### PR TITLE
chore: repo setup for open contribution

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Something broke — wrong output, crash, load failure, perf regression.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. rMLX is Apple-Silicon-only — please confirm you're
+        on an M-series Mac. For security issues, **do not** file here; see
+        [SECURITY.md](../blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, what you got.
+      placeholder: Loaded model X, sent request Y, got incoherent output / crash / …
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Exact command / request. Minimal is best.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: Model snapshot
+      description: e.g. mlx-community__gemma-4-e4b-it-mxfp8
+    validations:
+      required: true
+  - type: input
+    id: arch
+    attributes:
+      label: Architecture
+      description: From config.json, e.g. Gemma4ForConditionalGeneration
+  - type: input
+    id: quant
+    attributes:
+      label: Weight / KV quant
+      description: e.g. mxfp8 weights, K8V8 KV
+  - type: input
+    id: version
+    attributes:
+      label: rMLX version / commit
+      description: "`rmlx --version` or git SHA"
+    validations:
+      required: true
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version + chip
+      description: e.g. macOS 15.4, M3 Max, 64 GB
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: From .rmlx/logs/. Run with --log debug if useful.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Pushkinist/rMLX/security/advisories/new
+    about: Report security issues privately — do not open a public issue.
+  - name: Question / usage help
+    url: https://github.com/Pushkinist/rMLX/discussions
+    about: Ask in Discussions instead of filing a bug.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature / model request
+description: A new model arch, quant format, API surface, or capability.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep scope in mind: rMLX is Apple-Silicon, no-Python, MLX-format only.
+        Not in scope: GGUF, training / fine-tune, non-Apple backends.
+  - type: textarea
+    id: request
+    attributes:
+      label: What would you like
+      description: The capability, model arch, or quant format.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why
+      description: Use case. What does it unblock?
+    validations:
+      required: true
+  - type: input
+    id: refs
+    attributes:
+      label: References
+      description: Model card, paper, upstream impl, mlx-lm reference, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- Keep it surgical. Match existing style. No drive-by refactors. -->
+
+## What & why
+
+<!-- One or two sentences. Link the issue if any (Closes #N). -->
+
+## Changes
+
+-
+
+## Checklist
+
+- [ ] `make ci` green locally (fmt + clippy + test + deny + audit)
+- [ ] Tests added/updated in sibling `*_tests.rs` (no inline `#[cfg(test)] mod`)
+- [ ] Docs/`CLAUDE.md` updated if behavior or layout changed
+- [ ] **Model-touching change:** regression smoke run — Gemma4, Qwen3.6, Bonsai
+      still serve at best-known KV quant, decode TPS within ±1% (N/A otherwise)
+- [ ] No new `Cargo.toml` dependency without justification
+
+## Notes for reviewer
+
+<!-- Tradeoffs, follow-ups, anything non-obvious. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot — keep cargo deps current, grouped into one PR per run to cut noise.
+# Pairs with the Security tab's grouped security updates. Weekly cadence.
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "chore(ci)"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.
+
+In short: be respectful, assume good faith, no harassment. Unacceptable behavior
+includes insults, personal or political attacks, and unwelcome attention.
+
+Maintainers may remove, edit, or reject comments, commits, code, and issues that
+violate this code, and may ban contributors for repeated or severe violations.
+
+## Reporting
+
+Report violations privately to the maintainers via GitHub — open a
+[private report](https://github.com/Pushkinist/rMLX/security/advisories/new) or
+contact [@Pushkinist](https://github.com/Pushkinist). All reports are reviewed
+and kept confidential.
+
+Full text: https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to rMLX
+
+Thanks for your interest. rMLX is a Rust-native, single-binary MLX inference +
+conversion backend for Apple Silicon. A few things up front:
+
+- **Apple Silicon only.** Metal first. No CUDA, no ROCm, no x86 SIMD. You need a
+  real Apple-Silicon Mac to build and test — GitHub-hosted macOS runners have no
+  usable Metal device, so the full suite runs on hardware, not in hosted CI.
+- **No Python at runtime.** One `cargo build --release` is the artifact.
+- **MLX-format only.** GGUF is out of scope.
+- **No training.** Quant / format conversion is in scope; fine-tune / fuse /
+  lora-merge is not.
+
+## Prerequisites
+
+- macOS on Apple Silicon (M-series).
+- Rust (MSRV **1.95**, edition 2021) — `rustup` recommended.
+- MLX C bindings: `brew install mlx-c` (pulls `mlx`). The build links the
+  `libmlxc` / `libmlx` dylibs from the Homebrew prefix.
+
+## Build & test
+
+```sh
+make build          # cargo build --workspace --release
+make check          # fast cargo check
+make test           # workspace tests (needs a Metal GPU)
+make ci             # fmt-check + clippy + test + deny + audit  ← pre-PR gate
+```
+
+`make ci` must be green before you open a PR. The per-commit hook runs the fast
+checks; `cargo audit` / `cargo deny` are gated behind `make ci` (or
+`pre-commit run --hook-stage manual`).
+
+Model-touching changes: see the regression-bench discipline in
+[`CLAUDE.md`](CLAUDE.md). At minimum the three test-target families (Gemma4,
+Qwen3.6, Bonsai) must still serve, each at its best-known KV quant, within ±1%
+of the recorded decode TPS.
+
+## Workflow
+
+1. Branch from `main` (`feat/…`, `fix/…`, `chore/…`).
+2. Keep changes surgical — match existing style, no drive-by refactors.
+3. Tests live in sibling `*_tests.rs` files (no inline `#[cfg(test)] mod`
+   blocks — `make check-no-inline-tests` enforces this).
+4. `make ci` green locally.
+5. Open a PR into `main`. Fill in the PR template.
+
+`main` is protected: changes land via PR with CI green, not direct pushes.
+
+## Commit messages
+
+Conventional-Commits style: `type(scope): summary`
+(`feat`, `fix`, `perf`, `docs`, `test`, `chore`, `refactor`).
+
+## Project layout
+
+Workspace crates under `crates/rmlx-*`. Subsystem docs under `docs/` (see the
+documentation map in [`CLAUDE.md`](CLAUDE.md)). Read the relevant doc before
+touching a subsystem.
+
+## License
+
+By contributing you agree your work is dual-licensed under
+**MIT OR Apache-2.0**, matching the project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported versions
+
+rMLX is pre-1.0. Security fixes land on the latest released version only.
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | ✅        |
+| < 0.1.0 | ❌        |
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security problems.**
+
+Use GitHub's [private vulnerability reporting](https://github.com/Pushkinist/rMLX/security/advisories/new)
+(Security → Report a vulnerability). That opens a private advisory only the
+maintainers can see.
+
+Please include:
+
+- affected version / commit,
+- a minimal reproduction (model arch / quant / request if relevant),
+- impact and any known workaround.
+
+You can expect an initial acknowledgement within a few days. Once a fix is
+ready, we coordinate a release and credit the reporter (unless anonymity is
+requested).
+
+## Scope
+
+rMLX is an Apple-Silicon-only, no-Python inference backend. In scope: the HTTP
+server surface (OpenAI / Anthropic-compatible routes), model loading,
+quantization codecs, and the FFI bridge. Out of scope: vulnerabilities in
+upstream MLX / mlx-c, or in models you choose to load.

--- a/scripts/release/source_sha256.sh
+++ b/scripts/release/source_sha256.sh
@@ -22,13 +22,12 @@ VER=$(awk -F'"' '/^version = /{print $2; exit}' Cargo.toml)
 URL="https://github.com/${OWNER_REPO}/archive/refs/tags/v${VER}.tar.gz"
 echo "==> fetching $URL" >&2
 
-# gh-authenticated fetch works for private repos; falls back to plain curl.
-if command -v gh >/dev/null 2>&1; then
-  SHA=$(gh api "repos/${OWNER_REPO}/tarball/v${VER}" 2>/dev/null | shasum -a 256 | awk '{print $1}')
-else
-  SHA=$(curl -fsSL "$URL" | shasum -a 256 | awk '{print $1}')
-fi
-[ -n "$SHA" ] || { echo "error: failed to compute sha256 (tag v${VER} reachable?)"; exit 1; }
+# MUST hash the exact `archive/refs/tags/...tar.gz` the formula `url` downloads.
+# NOTE: `gh api .../tarball/...` returns a DIFFERENT tarball (different prefix /
+# packing) with a different sha — do not use it here. The repo must be public
+# (Homebrew downloads anonymously), so a plain curl of the archive URL is right.
+SHA=$(curl -fsSL "$URL" | shasum -a 256 | awk '{print $1}')
+[ -n "$SHA" ] || { echo "error: failed to compute sha256 (tag v${VER} public + reachable?)"; exit 1; }
 
 echo "sha256: $SHA"
 


### PR DESCRIPTION
Opens rMLX for a normal branch → PR contribution flow now that 0.1.0 is out.

## Commits
1. **fix(release):** `source_sha256.sh` hashes the `archive/refs/tags/*.tar.gz`
   URL the Homebrew formula actually downloads — not `gh api .../tarball`, which
   returns a different tarball with a different sha. (Bug found live during the
   0.1.0 go-live; main never had the fix.)
2. **chore:** contributor + community health files:
   - `SECURITY.md` — private vulnerability reporting policy.
   - `CONTRIBUTING.md` — Apple-Silicon build deps, `make ci` gate, workflow,
     regression-smoke expectation.
   - `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1.
   - `.github/ISSUE_TEMPLATE/` — structured bug + feature forms (model / arch /
     quant / macOS fields); `config.yml` routes security → private reporting,
     questions → Discussions.
   - `.github/PULL_REQUEST_TEMPLATE.md` — ci-green + regression-smoke checklist.
   - `.github/dependabot.yml` — weekly grouped cargo + github-actions updates.

## Notes
- `config.yml` links to **Discussions** — enable Discussions in repo settings or
  that contact link 404s.
- Hosted CI (`ci.yml`) runs fmt + clippy + a best-effort release build; the full
  test suite needs real Metal hardware (documented in the workflow).