### PR TITLE
fix(cli): make baseline prompt cap configurable via --max-prompt-tokens (closes #11)

### DIFF
--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -135,7 +135,8 @@ pub(crate) fn compute_phase_timing(
 /// Record a performance baseline for the given model snapshot.
 ///
 /// Steps:
-/// 1. Parse device, read prompt file, tokenize, truncate to MAX_PROMPT_TOKENS.
+/// 1. Parse device, read prompt file, tokenize, truncate to `max_prompt_tokens`
+///    (CLI-configurable; defaults to `MAX_PROMPT_TOKENS`).
 /// 2. `arch::load_model` -- capture `load_ms`.
 /// 3. `arch.generate_greedy` -- per-token `step_fn` callback captures wall-clock
 /// so prefill (TTFT) and steady-state decode are timed SEPARATELY.
@@ -157,6 +158,7 @@ pub(crate) fn run_baseline(
     prompt_label: &str,
     kv_quant_override: Option<rmlx_kv_quant::KvQuant>,
     max_ctx_override: Option<i32>,
+    max_prompt_tokens: usize,
     sink: &EventRecorder,
     record_args: Option<BaselineRecordArgs<'_>>,
 ) -> anyhow::Result<()> {
@@ -187,14 +189,14 @@ pub(crate) fn run_baseline(
 
     let mut prompt_ids: Vec<u32> = encoding.get_ids().to_vec();
 
-    // Truncate to MAX_PROMPT_TOKENS (CPU forward time is O(N^2)).
-    if prompt_ids.len() > MAX_PROMPT_TOKENS {
+    // Truncate to `max_prompt_tokens` (CLI-configurable; CPU forward time is O(N^2)).
+    if prompt_ids.len() > max_prompt_tokens {
         warn!(
             original = prompt_ids.len(),
-            cap = MAX_PROMPT_TOKENS,
+            cap = max_prompt_tokens,
             "baseline: prompt truncated to cap"
         );
-        prompt_ids.truncate(MAX_PROMPT_TOKENS);
+        prompt_ids.truncate(max_prompt_tokens);
     }
     let prompt_token_count = prompt_ids.len();
 

--- a/crates/rmlx-cli/src/commands/mod.rs
+++ b/crates/rmlx-cli/src/commands/mod.rs
@@ -19,8 +19,8 @@ pub(crate) use info::run_info;
 pub(crate) use kv_calibrate::run_kv_calibrate;
 pub(crate) use parse::{
     acquire_claim_for_device, build_cache_type_spec, parse_device, parse_kv_bits_combo,
-    parse_kv_bits_fractional, parse_kv_preset, parse_kv_quant, parse_max_ctx, resolve_model_flags,
-    resolve_preset_arg,
+    parse_kv_bits_fractional, parse_kv_preset, parse_kv_quant, parse_max_ctx,
+    parse_max_prompt_tokens, resolve_model_flags, resolve_preset_arg,
 };
 pub(crate) use profile::run_profile_list;
 pub(crate) use serve::run_serve;

--- a/crates/rmlx-cli/src/commands/parse.rs
+++ b/crates/rmlx-cli/src/commands/parse.rs
@@ -402,6 +402,14 @@ pub(crate) fn resolve_kv_quant(
     final_kv_quant
 }
 
+/// Reject a zero `--max-prompt-tokens`; `truncate(0)` would empty the prompt.
+pub(crate) fn parse_max_prompt_tokens(v: usize) -> anyhow::Result<usize> {
+    if v == 0 {
+        return Err(anyhow::anyhow!("--max-prompt-tokens must be >= 1, got 0"));
+    }
+    Ok(v)
+}
+
 /// Parse the `--max-ctx` flag value into an optional `i32` override.
 ///
 /// `None` → no override (arch derives from `max_position_embeddings`, capped at 4096).

--- a/crates/rmlx-cli/src/commands/parse_tests.rs
+++ b/crates/rmlx-cli/src/commands/parse_tests.rs
@@ -286,6 +286,19 @@ fn fractional_group_size_zero_rejected() {
     );
 }
 
+// ── parse_max_prompt_tokens ──────────────────────────────────────
+
+#[test]
+fn parse_max_prompt_tokens_rejects_zero() {
+    let err = parse_max_prompt_tokens(0).unwrap_err();
+    assert!(err.to_string().contains(">= 1"), "{err}");
+}
+
+#[test]
+fn parse_max_prompt_tokens_accepts_one() {
+    assert_eq!(parse_max_prompt_tokens(1).unwrap(), 1);
+}
+
 // ── resolve_model_flags fractional dispatch ─────────────────────
 // Integer path via resolve_model_flags with f32 must match exactly.
 

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -105,9 +105,9 @@ use commands::parse::KvPresetArg;
 use commands::serve::{FusedQkMode, PlanarFlashDecodeMode, SparseAttnMode, TurboFlashMode};
 use commands::{
     acquire_claim_for_device, build_cache_type_spec, parse_device, parse_kv_bits_combo,
-    parse_kv_bits_fractional, parse_kv_preset, parse_kv_quant, parse_max_ctx, resolve_model_flags,
-    resolve_preset_arg, run_baseline, run_healthcheck, run_info, run_kv_calibrate, run_ppl,
-    run_serve,
+    parse_kv_bits_fractional, parse_kv_preset, parse_kv_quant, parse_max_ctx,
+    parse_max_prompt_tokens, resolve_model_flags, resolve_preset_arg, run_baseline,
+    run_healthcheck, run_info, run_kv_calibrate, run_ppl, run_serve,
 };
 
 /// Long-help body shared by `--cache-type-k` / `--cache-type-v` on every
@@ -911,6 +911,12 @@ enum Cmd {
         /// set.
         #[arg(long, visible_alias = "ctx-max")]
         max_ctx: Option<u32>,
+        /// Truncate the tokenized prompt to at most this many tokens (CPU forward
+        /// is O(N^2), so a cap guards against pathological bench times). Defaults
+        /// to the built-in cap; raise it to bench longer contexts (e.g. 128k).
+        /// Must be >= 1.
+        #[arg(long, value_name = "N", default_value_t = commands::baseline::MAX_PROMPT_TOKENS)]
+        max_prompt_tokens: usize,
         /// Free-form label stamped into the metrics record's `notes` column
         /// (used by the bench harness to group cells under a campaign name).
         #[arg(long)]
@@ -1700,9 +1706,11 @@ fn main() -> Result<()> {
             kv_bits,
             kv_group_size,
             max_ctx,
+            max_prompt_tokens,
             label: bench_label,
             record,
         } => {
+            let max_prompt_tokens = parse_max_prompt_tokens(max_prompt_tokens)?;
             // --kv-preset pre-resolution. resolve_preset_arg runs the
             // auto-selector for KvPresetArg::Auto.
             let (dev, kv_quant_resolved, max_ctx_override) = if let Some(preset_arg) = kv_preset {
@@ -1820,6 +1828,7 @@ fn main() -> Result<()> {
                 &label_str,
                 Some(kv_quant_resolved),
                 max_ctx_override,
+                max_prompt_tokens,
                 &sink,
                 record_args,
             )?;


### PR DESCRIPTION
Closes #11.

## Problem
`rmlx baseline` truncated the tokenized prompt to a hardcoded `MAX_PROMPT_TOKENS = 65536` — `--prompt-tokens 131072` was silently cut to 64k (only a WARN). `--max-ctx` raises the KV buffer but not this prompt cap, so ≥128k contexts could not be benched via `baseline`.

## Change
- Add `--max-prompt-tokens <N>` to the `baseline` subcommand (default `65536`, byte-equivalent to prior behavior). Threaded through `run_baseline`; used at the truncation site instead of the const.
- Validate `>= 1` via `parse_max_prompt_tokens` (mirrors the existing `parse_max_ctx` precedent), run as the **first** statement in the `Cmd::Baseline` arm so `0` is rejected before any model I/O / GPU claim.
- Unit tests for the validator (zero rejected, one accepted).

## Verification
- `cargo build -p rmlx-cli` green; `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.
- `--help` shows the flag; `--max-prompt-tokens 0` errors with "must be >= 1".
- `cargo test -p rmlx-cli parse_max_prompt_tokens` — 2/2 pass.
- Default unchanged → no behavior change for existing `baseline` runs.

Reviewed by the rust-reviewer (3 passes); all findings (unenforced `>=1`, help-text drift, missing test) resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)