### PR TITLE
fix(models): pre-eval KV caches before prompt-cache store — SSD spill cross-thread eval (closes #10)

### DIFF
--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -956,34 +956,49 @@ pub fn generate_greedy(
         let kv_snap: rmlx_core::error::Result<Vec<_>> =
             caches.iter().map(|c| c.try_deep_clone()).collect();
         if let Ok(kvs) = kv_snap {
-            PROMPT_CACHE.with_inner_mut(|guard| {
-                if let Some(cache) = guard.as_mut() {
-                    // salt the chained walk with the active layout_key so
-                    // an entry that later spills lands under the same `(hash,
-                    // layout_key)` row the hydrator will reconstruct. When
-                    // the SSD tier is OFF, `active_layout_key()` returns 0 and the
-                    // seed collapses to `FNV_OFFSET` — legacy un-salted digests.
-                    let lk = crate::gemma4::prompt_cache::active_layout_key();
-                    cache.push(Gemma4Entry {
-                        prompt_token_ids: prompt_ids.to_vec(),
-                        block_hashes: crate::prompt_cache::chained_block_hashes_seeded(
-                            prompt_ids,
-                            crate::prompt_cache::FNV_OFFSET ^ lk,
-                        ),
-                        kv_caches: kvs,
-                        first_id: last_id,
-                        first_piece: piece.clone(),
-                        kv_quant: Some(kv_quant),
+            // Materialize GPU arrays on the current inference thread before
+            // storing in the prompt cache.  Each spawn_blocking request runs
+            // on its own tokio thread with its own Metal GPU stream.  If these
+            // lazy arrays are evicted on a *different* inference thread later,
+            // that thread's eval_for_spill would fail with "There is no
+            // Stream(gpu, N) in current thread".  Pre-eval here makes eval()
+            // a no-op from any future thread.
+            // The drain thread's spill() refcount-clones these arrays (no new graph) and evals
+            // the clone, which shares the same buffers — so materializing here makes that eval a no-op.
+            match kvs.iter().try_for_each(|c| c.eval_for_spill()) {
+                Ok(()) => {
+                    PROMPT_CACHE.with_inner_mut(|guard| {
+                        if let Some(cache) = guard.as_mut() {
+                            // salt the chained walk with the active layout_key so
+                            // an entry that later spills lands under the same `(hash,
+                            // layout_key)` row the hydrator will reconstruct. When
+                            // the SSD tier is OFF, `active_layout_key()` returns 0 and the
+                            // seed collapses to `FNV_OFFSET` — legacy un-salted digests.
+                            let lk = crate::gemma4::prompt_cache::active_layout_key();
+                            cache.push(Gemma4Entry {
+                                prompt_token_ids: prompt_ids.to_vec(),
+                                block_hashes: crate::prompt_cache::chained_block_hashes_seeded(
+                                    prompt_ids,
+                                    crate::prompt_cache::FNV_OFFSET ^ lk,
+                                ),
+                                kv_caches: kvs,
+                                first_id: last_id,
+                                first_piece: piece.clone(),
+                                kv_quant: Some(kv_quant),
+                            });
+                            tracing::debug!(
+                                prompt_len = prompt_ids.len(),
+                                token_id = last_id,
+                                n_slots = cache.slots.len(),
+                                cache_path = if is_prefix { "prefix" } else { "miss" },
+                                "gemma4 generate_greedy: full-prompt snapshot saved"
+                            );
+                        }
                     });
-                    tracing::debug!(
-                        prompt_len = prompt_ids.len(),
-                        token_id = last_id,
-                        n_slots = cache.slots.len(),
-                        cache_path = if is_prefix { "prefix" } else { "miss" },
-                        "gemma4 generate_greedy: full-prompt snapshot saved"
-                    );
                 }
-            });
+                Err(e) => tracing::warn!(error = %e,
+                    "gemma4 generate_greedy: pre-eval of KV caches failed, skipping prompt cache store"),
+            }
         }
     }
 

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -2456,41 +2456,57 @@ pub fn generate_greedy(
         let cloned_caches: Result<Vec<KvCache>> =
             caches.iter().map(|c| c.try_deep_clone()).collect();
         if let Ok(kv_snapshot) = cloned_caches {
-            // salt chained walk with the active layout_key. When tier
-            // is OFF, `active_layout_key()` returns 0 ⇒ legacy un-salted.
-            let lk = qwen3_active_layout_key();
-            let block_hashes = chained_block_hashes_seeded(prompt_ids, FNV_OFFSET ^ lk);
-            // Capture the first-token logprobs at the OpenAI ceiling so
-            // a later exact-hit replays a true logprob (truncated to its own
-            // `top_logprobs_k`) regardless of whether THIS request asked for
-            // logprobs. `logits_flat` is already host-evaluated above; this is
-            // one extra host log-softmax + top-k per cache store (per unique
-            // prompt), not per token.
-            let first_logprobs = capture_logprobs(&logits_flat, &top, PROMPT_CACHE_LOGPROBS_K);
-            let entry = Qwen3Entry {
-                prompt_token_ids: prompt_ids.to_vec(),
-                block_hashes,
-                kv_caches: kv_snapshot,
-                first_id: last_id,
-                first_piece: tokenizer
-                    .id_to_token(last_id)
-                    .unwrap_or_else(|| format!("<unk:{last_id}>")),
-                first_logprobs,
-                kv_quant: Some(kv_quant),
-            };
-            QWEN3_PROMPT_CACHE.with_inner_mut(|guard| {
-                if let Some(cache) = guard.as_mut() {
-                    cache.push(entry);
-                    let stats = cache.stats();
-                    tracing::debug!(
-                        prompt_len = prompt_ids.len(),
-                        cache_hits = stats.hits,
-                        cache_misses = stats.misses,
-                        cache_bytes = stats.bytes,
-                        "qwen3 generate_greedy: pushed snapshot to prompt cache (miss path)"
-                    );
+            // Materialize GPU arrays on the current inference thread before
+            // storing in the prompt cache.  Each spawn_blocking request runs
+            // on its own tokio thread with its own Metal GPU stream.  If these
+            // lazy arrays are evicted on a *different* inference thread later,
+            // that thread's eval_for_spill would fail with "There is no
+            // Stream(gpu, N) in current thread".  Pre-eval here makes eval()
+            // a no-op from any future thread.
+            // The drain thread's spill() refcount-clones these arrays (no new graph) and evals
+            // the clone, which shares the same buffers — so materializing here makes that eval a no-op.
+            match kv_snapshot.iter().try_for_each(|c| c.eval_for_spill()) {
+                Ok(()) => {
+                    // salt chained walk with the active layout_key. When tier
+                    // is OFF, `active_layout_key()` returns 0 ⇒ legacy un-salted.
+                    let lk = qwen3_active_layout_key();
+                    let block_hashes = chained_block_hashes_seeded(prompt_ids, FNV_OFFSET ^ lk);
+                    // Capture the first-token logprobs at the OpenAI ceiling so
+                    // a later exact-hit replays a true logprob (truncated to its own
+                    // `top_logprobs_k`) regardless of whether THIS request asked for
+                    // logprobs. `logits_flat` is already host-evaluated above; this is
+                    // one extra host log-softmax + top-k per cache store (per unique
+                    // prompt), not per token.
+                    let first_logprobs =
+                        capture_logprobs(&logits_flat, &top, PROMPT_CACHE_LOGPROBS_K);
+                    let entry = Qwen3Entry {
+                        prompt_token_ids: prompt_ids.to_vec(),
+                        block_hashes,
+                        kv_caches: kv_snapshot,
+                        first_id: last_id,
+                        first_piece: tokenizer
+                            .id_to_token(last_id)
+                            .unwrap_or_else(|| format!("<unk:{last_id}>")),
+                        first_logprobs,
+                        kv_quant: Some(kv_quant),
+                    };
+                    QWEN3_PROMPT_CACHE.with_inner_mut(|guard| {
+                        if let Some(cache) = guard.as_mut() {
+                            cache.push(entry);
+                            let stats = cache.stats();
+                            tracing::debug!(
+                                prompt_len = prompt_ids.len(),
+                                cache_hits = stats.hits,
+                                cache_misses = stats.misses,
+                                cache_bytes = stats.bytes,
+                                "qwen3 generate_greedy: pushed snapshot to prompt cache (miss path)"
+                            );
+                        }
+                    });
                 }
-            });
+                Err(e) => tracing::warn!(error = %e,
+                    "qwen3 generate_greedy: pre-eval of KV caches failed, skipping prompt cache store"),
+            }
         }
     }
 

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -649,31 +649,50 @@ pub fn generate_greedy(
         let kv_snap: Result<Vec<_>> = kv_caches.iter().map(|c| c.try_deep_clone()).collect();
         let lin_snap: Result<Vec<_>> = lin_caches.iter().map(|c| c.try_deep_clone()).collect();
         if let (Ok(kvs), Ok(lins)) = (kv_snap, lin_snap) {
-            PROMPT_CACHE.with_inner_mut(|guard| {
-                if let Some(cache) = guard.as_mut() {
-                    // salt chained walk with the active layout_key. When
-                    // tier is OFF, helper returns 0 ⇒ legacy un-salted digests.
-                    let lk = crate::qwen3_5_moe::prompt_cache::active_layout_key();
-                    cache.push(Qwen35MoeEntry {
-                        prompt_token_ids: prompt_ids.to_vec(),
-                        block_hashes: crate::prompt_cache::chained_block_hashes_seeded(
-                            prompt_ids,
-                            crate::prompt_cache::FNV_OFFSET ^ lk,
-                        ),
-                        kv_caches: kvs,
-                        lin_caches: lins,
-                        first_id: last_id,
-                        first_piece: piece.clone(),
-                        kv_quant: Some(kv_quant),
+            // Materialize GPU arrays on the current inference thread before
+            // storing in the prompt cache.  Each spawn_blocking request runs
+            // on its own tokio thread, which has its own Metal GPU stream
+            // (registered by ensure_gpu_default_stream() in arch::generate_greedy).
+            // If these lazy arrays are stored as-is and later evicted on a
+            // *different* inference thread (a subsequent request), that thread's
+            // eval_for_spill call will fail with "There is no Stream(gpu, N) in
+            // current thread" because stream N is only registered here.
+            // Pre-eval on this thread makes eval() a no-op from any future thread.
+            match kvs
+                .iter()
+                .try_for_each(|c| c.eval_for_spill())
+                .and_then(|()| lins.iter().try_for_each(|c| c.eval_for_spill()))
+            {
+                Ok(()) => {
+                    PROMPT_CACHE.with_inner_mut(|guard| {
+                        if let Some(cache) = guard.as_mut() {
+                            // salt chained walk with the active layout_key. When
+                            // tier is OFF, helper returns 0 ⇒ legacy un-salted digests.
+                            let lk = crate::qwen3_5_moe::prompt_cache::active_layout_key();
+                            cache.push(Qwen35MoeEntry {
+                                prompt_token_ids: prompt_ids.to_vec(),
+                                block_hashes: crate::prompt_cache::chained_block_hashes_seeded(
+                                    prompt_ids,
+                                    crate::prompt_cache::FNV_OFFSET ^ lk,
+                                ),
+                                kv_caches: kvs,
+                                lin_caches: lins,
+                                first_id: last_id,
+                                first_piece: piece.clone(),
+                                kv_quant: Some(kv_quant),
+                            });
+                            tracing::debug!(
+                                prompt_len = prompt_ids.len(),
+                                token_id = last_id,
+                                n_slots = cache.slots.len(),
+                                "qwen3_5moe generate_greedy: prompt cache MISS — saved snapshot"
+                            );
+                        }
                     });
-                    tracing::debug!(
-                        prompt_len = prompt_ids.len(),
-                        token_id = last_id,
-                        n_slots = cache.slots.len(),
-                        "qwen3_5moe generate_greedy: prompt cache MISS — saved snapshot"
-                    );
                 }
-            });
+                Err(e) => tracing::warn!(error = %e,
+                    "qwen3_5moe generate_greedy: pre-eval of KV/lin caches failed, skipping prompt cache store"),
+            }
         }
     }
 


### PR DESCRIPTION
Closes #10.

## Problem
SSD spill logged `eval-for-spill failed: no Stream(gpu, N) in current thread` and **skipped persisting the block** → cross-restart KV persistence silently incomplete.

## Root cause
KV/lin cache arrays stored in the process-global prompt cache are **lazy GPU arrays bound to the inference thread's Metal stream**. When a later request (a different `spawn_blocking` thread) evicts + spills that entry, MLX cannot access the originating thread's stream, so `Array::eval` fails.

## Fix
Materialize the cloned KV/lin snapshots via `eval_for_spill()` **on the inference thread**, before pushing them into the prompt cache. The drain thread's `spill()` refcount-clones those arrays (no new graph) and evals the clone, which shares the now-materialized buffers — so the cross-thread eval is a no-op. On eval failure, skip the store and log the error (a cache miss is always safe; re-prefill is the fallback).

Applied to all three arches with a real `SpillSink` — **qwen3.5-moe, qwen3, gemma4** — identical root cause (qwen3.5-moe also evals its linear-attn caches).

## Performance
Only materializes the post-prefill KV snapshot the decode loop is about to read anyway — one GPU sync per *cache-store* (miss path), **never per token**. No steady-state decode impact.

## Verification
- `make build-perf` green; `make lint` / `cargo fmt --check` / `cargo test -p rmlx-models` clean.
- GPU repro: triggered spills at 8k/32k/64k → `eval-for-spill failed` WARN **gone**, `kv-spill: block written + indexed` present, output coherent.

Reviewed by rust-reviewer: no CRITICAL/HIGH; correct, in-scope, mergeable. Optional NITs (FFI error now logged; comments tightened) applied. Helper-extraction deliberately skipped per the simplicity tenet (3 simple arch-local blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)