### PR TITLE
fix(speculative): size Eagle3 drafter KV cache to verifier max_seq (closes #8)

### DIFF
--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -327,8 +327,14 @@ impl Eagle3Drafter {
     }
 
     /// Reset the drafter's KV cache between generations.
-    pub fn reset(&mut self) {
-        self.cache = KvCache::with_quant(KvQuant::None);
+    ///
+    /// `max_seq` must cover the full generation horizon:
+    /// `prompt_len + max_new_tokens`. The drafter cache advances by
+    /// `accepted + 1` tokens per round; using `KV_MAX_SEQ_DEFAULT = 4096`
+    /// here would overflow on any prompt whose length + target exceeds 4096,
+    /// causing a silent MLX `slice_update` broadcast failure at the boundary.
+    pub fn reset(&mut self, max_seq: i32) {
+        self.cache = KvCache::with_quant_max_seq(KvQuant::None, max_seq);
     }
 
     /// Trained / configured block ceiling.
@@ -871,7 +877,13 @@ pub fn eagle3_generate_greedy(
         .map(|_| LinearAttnCache::new())
         .collect();
 
-    drafter.reset();
+    // Size the drafter KV cache to the verifier context limit
+    // (max_position_embeddings, capped to KV_MAX_SEQ_DEFAULT, or --max-ctx).
+    // This matches the verifier caches so the drafter cannot overflow before
+    // the verifier does — fixing the prior hardcoded 4096 that crashed once
+    // prompt + emitted tokens exceeded it (zero-length slice_update range in
+    // update_decode_fp16, broadcast-shape panic).
+    drafter.reset(max_seq);
 
     let mut total_draft = 0usize;
     let mut total_accept = 0usize;

--- a/crates/rmlx-models/src/speculative/eagle3/tests.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/tests.rs
@@ -621,3 +621,91 @@ fn mismatch_only_at_bonus_full_pos_eq_n_draft() {
         "bonus mismatch must not influence full_pos (out of range)"
     );
 }
+
+// -----------------------------------------------------------------------
+// KV-cache sizing regression test.
+//
+// Guards the fix in `Eagle3Drafter::reset`: the drafter cache must be sized
+// to the verifier's context limit (max_seq), not a hardcoded 4096. Prior to
+// the fix, once prompt + emitted tokens exceeded 4096 the decode path hit a
+// zero-width `slice_update` range (prev_offset >= max_seq with a live
+// buffer), producing a broadcast-shape panic.
+// -----------------------------------------------------------------------
+
+/// Regression: a `KvCache` built via `KvCache::with_quant_max_seq(KvQuant::None, 8192)`
+/// must successfully process decode steps whose cumulative offset surpasses
+/// 4096 (the former hardcoded cap).
+///
+/// The test mirrors what `Eagle3Drafter::reset(max_seq)` does, then drives
+/// the same update path that crashed: prefill to 4090, then decode past 4096.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test tensors + KvCache are built by construction in this fn; the unwrapped Results are infallible by setup"
+)]
+fn eagle3_drafter_cache_sized_from_max_seq_decodes_past_4096() {
+    use rmlx_kv_quant::{KvCache, KvQuant};
+    use rmlx_mlx::{Array, Device, Dtype};
+
+    const B: i32 = 1;
+    const KV_H: i32 = 2;
+    const HEAD_DIM: i32 = 8;
+    // Prefill to just below 4096; decode steps will push offset above it.
+    const PREFILL_SEQ: i32 = 4090;
+    // Decode this many single-token steps — step 7 puts offset at 4097.
+    const DECODE_STEPS: i32 = 10;
+
+    let device = Device::Cpu;
+
+    // Build the cache the same way reset() does (KvQuant::None, max_seq=8192).
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::None, 8192);
+
+    // Helper: allocate a tiny f32 array for K or V.
+    let make_arr = |seq: i32, fill: f32| -> Array {
+        let shape = [B, KV_H, seq, HEAD_DIM];
+        let n: usize = shape.iter().map(|&d| d as usize).product();
+        let data = vec![fill; n];
+        // SAFETY: f32 is 4-byte LE on Apple Silicon (CLAUDE.md hard rule 1).
+        let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), n * 4) };
+        Array::from_bytes(bytes, &shape, Dtype::F32).unwrap()
+    };
+
+    // Prefill phase: feed PREFILL_SEQ tokens.
+    cache.enter_prefill();
+    let k_pre = make_arr(PREFILL_SEQ, 0.1);
+    let v_pre = make_arr(PREFILL_SEQ, 0.2);
+    cache.update(&k_pre, &v_pre, device).unwrap();
+    cache.exit_prefill(device).unwrap();
+
+    assert_eq!(
+        cache.offset(),
+        PREFILL_SEQ,
+        "offset must equal PREFILL_SEQ after prefill"
+    );
+
+    // Decode phase: single-token steps. Each step increments offset by 1.
+    // Steps 1-6 stay at or below 4096; step 7 reaches 4097.
+    // With the old max_seq=4096 hardcode, step 7 panicked here.
+    for step in 1..=DECODE_STEPS {
+        let k_dec = make_arr(1, 0.01 * step as f32);
+        let v_dec = make_arr(1, 0.02 * step as f32);
+        cache.update(&k_dec, &v_dec, device).unwrap_or_else(|e| {
+            panic!(
+                "decode step {step} (offset {}) failed: {e}",
+                PREFILL_SEQ + step
+            )
+        });
+        assert_eq!(
+            cache.offset(),
+            PREFILL_SEQ + step,
+            "offset must advance by 1 each decode step"
+        );
+    }
+
+    // Final offset must be 4100 (4090 + 10), comfortably past 4096.
+    assert_eq!(
+        cache.offset(),
+        PREFILL_SEQ + DECODE_STEPS,
+        "cache must decode past 4096 without error"
+    );
+}


### PR DESCRIPTION
Closes #8.

## Problem
Eagle3 speculative decode crashed reproducibly at ~token 245:
`slice_update: Shapes (1,2,2,256) and (1,2,0,256) cannot be broadcast`.

## Root cause
`Eagle3Drafter::reset()` built the drafter `KvCache` with the default `KV_MAX_SEQ_DEFAULT` (4096). The `KvQuant::None` decode path is **non-growing**, so once `prompt_len + emitted_tokens` exceeded 4096 the drafter offset hit `max_seq`; MLX clamped the `slice_update` stop index to 4096 (an empty `seq=0` target range), and the broadcast against the 1–2 token data tensor failed. Deterministic: a ~3854-token prompt crashes at +245 tokens (= 4099 > 4096). MTP/DFlash use separate `reset()` paths and are unaffected.

## Fix
`reset()` takes `max_seq` and sizes the drafter cache via `with_quant_max_seq(KvQuant::None, max_seq)`, passing the same `max_seq` already computed for the verifier caches. The drafter's per-round transient peak is strictly one row below the verifier's, so the verifier's bound is sufficient (no off-by-block risk). Two lines, one file.

## Verification
- GPU: 256-token requests now complete with **no** `slice_update` crash, coherent output (Eagle3 spec runs end-to-end; accept-rate is a separate perf matter).
- Regression test drives a `KvQuant::None` decode past 4096 (the exact crash path).
- 29 eagle3 unit tests pass; `make lint` / `cargo fmt --check` clean.

Reviewed by rust-reviewer: correct, minimal, single-caller, mergeable; both LOW findings (comment accuracy, regression test) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)