### PR TITLE
chore(release): 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to rMLX are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-06-06
+
+Bug-fix + dependency-maintenance release.
+
+### Added
+
+- `rmlx baseline --max-prompt-tokens <N>` — the prompt-truncation cap (previously
+  a hardcoded 65536) is now configurable, enabling ≥128k-context baselines
+  (validated `>= 1`). (#11)
+
+### Fixed
+
+- Eagle3 speculative decode crashed mid-generation on Qwen3-MoE
+  (`slice_update` zero-length KV dim). The drafter KV cache is now sized to the
+  verifier context limit instead of a hardcoded 4096. (#8)
+- SSD KV-tier spill failed with `no Stream(gpu, N) in current thread` and skipped
+  persisting blocks. KV/lin caches are now materialized on the inference thread
+  before the prompt-cache store, so the drain thread's eval is a no-op. Applies
+  to qwen3.5-moe, qwen3, and gemma4. (#10)
+
+### Changed
+
+- Dependency bumps: `bindgen` 0.72 (FFI codegen — golden-token-verified
+  behaviorally identical), `sha2` 0.11, `actions/checkout` 6, and a minor/patch
+  group (`serde_json`, `tokio`, `minijinja`, `chrono`, `uuid`).
+
 ## [0.1.0] - 2026-06-06
 
 First release. Native, single-binary [MLX](https://github.com/ml-explore/mlx)
@@ -39,4 +65,5 @@ inference + conversion backend for Apple Silicon — no Python at runtime.
 - Speculative drafters validated against their verifiers: Qwen 3.6 MTP sidecar
   and the Gemma 4 assistant drafter.
 
+[0.1.1]: https://github.com/Pushkinist/rMLX/releases/tag/v0.1.1
 [0.1.0]: https://github.com/Pushkinist/rMLX/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,7 +1879,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmlx-audio"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "miniz_oxide",
  "rmlx-core",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "libc",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-kv-quant"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rmlx-core",
  "rmlx-mlx",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-kv-ssd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rmlx-core",
  "rmlx-kv-quant",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-loader"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "memmap2",
  "rayon",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-metrics"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "csv",
  "regex-lite",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-mlx"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bindgen",
  "rmlx-core",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-models"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "image",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-quant"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "rmlx-core",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rmlx-core",
  "rmlx-mlx",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cut **0.1.1** — bug-fix + dependency-maintenance release.

Single-source version bump (`[workspace.package].version` 0.1.0 → 0.1.1) + Cargo.lock + CHANGELOG.

## Included since 0.1.0
**Fixed**
- Eagle3 speculative decode crash on Qwen3-MoE (#8)
- SSD spill GPU-stream / block persistence (#10)

**Added**
- `rmlx baseline --max-prompt-tokens` (#11)

**Changed (deps)**
- bindgen 0.72 (golden-token-verified identical), sha2 0.11, actions/checkout 6, minor/patch group

## Post-merge release steps (local — hosted CI can't build the Metal artifact)
`make tag` → push `v0.1.1` → `make release-package` → `gh release create` + binary → `make release-sha` → formula bump → `make tap-sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)