### PR TITLE
docs(models): Qwen3.6 champion-matrix benchmark study

### DIFF
--- a/docs/models/qwen3.6/SIBLINGS.md
+++ b/docs/models/qwen3.6/SIBLINGS.md
@@ -1,0 +1,232 @@
+# Qwen3.6 — Sibling-Backend Champions (Phase A)
+
+> Companion: [`rMLX.md`](rMLX.md) — rMLX full matrix + standing-vs-champion.
+> This file covers sibling backends only.
+
+**Family:** `qwen3_5_moe` (`Qwen3_5MoeForCausalLM` / `Qwen3_5MoeForConditionalGeneration`)
+**Stage 1 (Phase A) collected:** 2026-06-06
+**Machine:** Apple M5 Max, 128 GB unified memory, macOS 26.4.1 (Darwin 25.4.0)
+**Protocol:** batch=1 single-stream; temp=0 (greedy); `max_tokens=256`;
+n=5 measured (4k/8k/16k/32k), n=2 measured (64k/128k); 1 warmup before each backend.
+All medians computed from full n; 95% CI via bootstrap (2000 samples).
+
+---
+
+## 1. Snapshots in Scope
+
+| Snapshot (basename) | Weight quant | Arch | Role | Disk |
+|---|---|---|---|---|
+| `mlx-community__Qwen3.6-35B-A3B-8bit` | affine int8 (g64) | Qwen3.5-MoE | **Base / bench target** | 35 GB |
+| `mlx-community__Qwen3.6-35B-A3B-MTP-5bit` | affine 5-bit | Qwen3.5-MoE | MTP drafter _(Stage 2)_ | 572 MB |
+| `z-lab__Qwen3.6-35B-A3B-DFlash` | DFlash weights | Qwen3.5-MoE | DFlash drafter _(Stage 2)_ | 904 MB |
+| `Dogacel__specdrift-qwen3.6-35b-a3b-eagle3` | Eagle3 weights | Qwen3.5-MoE | Eagle3 drafter _(Stage 2)_ | 398 MB |
+| `z-lab__Qwen3.6-27B-PARO` | ParoQuant rotation (~4-bit effective) | Qwen3.5-MoE | Alt-weight (non-comparable) | 18 GB |
+
+**Notes on alt-weight:**
+- `z-lab__Qwen3.6-27B-PARO` is a **different model** (27B parameters, PARO rotation quantization) — not weight-comparable to the 35B 8-bit base. Benched as a separate non-comparable row.
+- `mlx-community__Qwen3.6-35B-A3B-8bit` is the **weight-comparable anchor** for mlx-lm, mlx-lm-turboquant, and oMLX.
+- ollama uses `qwen3.6:35b-a3b-coding-mxfp8` (mxfp8, not affine int8) — flagged as non-weight-comparable.
+- All drafter snapshots listed above are Stage 2 only.
+
+---
+
+## 2. Sibling Champion Table (Phase A — Decode TPS)
+
+**Weight-comparable group (affine int8, 35B):** mlx-lm, mlx-lm-turboquant, oMLX.
+**Non-comparable:** ollama (mxfp8, 35B), paroquant (PARO ~4-bit, 27B). Shown as separate rows; excluded from champion designation.
+
+Decode TPS = median of n measured runs at steady-state (tokens 2…end).
+95% CI via bootstrap. All runs: `max_tokens=256`, temp=0.
+
+### 2a. Decode TPS — weight-comparable tier (affine int8 35B)
+
+| Prompt | mlx-lm (`04a1910`) | mlx-lm-turboquant (`67db9af`) | oMLX (`2169285`) | Champion |
+|---|---|---|---|---|
+| 4k (4 096 tok) | 82.49 [82.07–83.09] | **84.88 [83.05–85.73]** | 61.75 [51.06–63.27]¹ | **mlx-lm-turboquant** |
+| 8k (8 192 tok) | 81.89 [80.82–83.09] | **83.93 [82.59–84.28]** | 60.98 [46.99–61.56]¹ | **mlx-lm-turboquant** |
+| 16k (16 381 tok) | 76.38 [71.40–78.43] | **79.20 [78.42–80.49]** | 57.01 [35.10–57.71]¹ | **mlx-lm-turboquant** |
+| 32k (32 764 tok) | 71.12 [70.28–72.39] | **73.56 [72.50–74.43]** | 51.10 [19.44–51.88]¹ | **mlx-lm-turboquant** |
+| 64k (65 528 tok) | 63.33 [62.63–64.03] | **65.09 [64.54–65.64]** | 25.51 [8.30–42.72]¹² | **mlx-lm-turboquant** |
+| 128k (131 052 tok) | 49.51 [49.23–49.78] | **50.81 [50.18–51.44]** | 16.85 [3.57–30.12]¹² | **mlx-lm-turboquant** |
+
+¹ oMLX run-1 of each prompt size shows drastically lower TPS (first-run metal kernel warm-up / KV growth).
+The median includes run-1; CI lower bound reflects this. Runs 2–5 are stable (~62/61/57/51 TPS).
+² Only 2 runs for 64k/128k; oMLX run-1 is especially bad (~8 TPS and ~3.6 TPS), making both the median and CI unreliable for these cells. Treat oMLX at 64k+ as anomalous.
+
+### 2b. Prefill TPS (first-TTFT only, from run-1 cold prefill)
+
+oMLX enables auto-prefix caching — runs 2+ show TTFT of ~30–140ms regardless of prompt size (cache hit).
+Only run-1 TTFT reflects actual prefill. All other backends show increasing TTFT with context.
+
+| Prompt | mlx-lm | mlx-lm-turboquant | oMLX (run-1 only) | ollama (non-comp.) | paroquant (non-comp.) |
+|---|---|---|---|---|---|
+| 4k | 2 687 t/s | 2 654 t/s | ~139k t/s (cached)³ | 1 945 t/s | 884 t/s |
+| 8k | 3 824 t/s | 3 788 t/s | ~260k t/s (cached)³ | 3 342 t/s | 739 t/s |
+| 16k | 3 297 t/s | 3 072 t/s | ~403k t/s (cached)³ | 3 645 t/s | 655 t/s |
+| 32k | 2 804 t/s | 2 774 t/s | ~633k t/s (cached)³ | 3 608 t/s | 595 t/s |
+| 64k | 2 102 t/s | 2 035 t/s | ~883k t/s (cached)³ | 2 250 t/s | 490 t/s |
+| 128k | 1 179 t/s | 1 227 t/s | ~1.1M t/s (cached)³ | 1 761 t/s | 354 t/s |
+
+³ oMLX prompt-caching makes TTFT 29–116ms regardless of context length. These numbers reflect cache-hit speed,
+not actual prefill throughput. Real first-prefill TPS not measured for oMLX in this bench.
+
+### 2c. Non-comparable rows (for reference only)
+
+| Prompt | ollama 0.23.2 (mxfp8 35B) | paroquant `c049a8a` (PARO ~4-bit 27B) |
+|---|---|---|
+| 4k | 179.15 [175.75–179.82] | 28.55 [28.08–28.65] |
+| 8k | 165.12 [163.26–166.06] | 27.97 [27.88–28.05] |
+| 16k | 143.94 [141.71–144.44] | 26.51 [26.44–26.71] |
+| 32k | 147.15 [146.93–148.85] | 24.39 [24.30–24.41] |
+| 64k | 127.68 [126.02–129.33] | 21.61 [21.59–21.64] |
+| 128k | 105.80 [105.44–106.16] | 17.80 [17.73–17.87] |
+
+**ollama:** ~2× apparent decode TPS, but the comparison is **contaminated** (see §2d). ollama is `mxfp8`, **37 GB on disk ≈ the 35 GB int8 tier** — roughly the same bytes/param, so the earlier "mxfp8 halves the bytes" claim is **wrong**. The apparent advantage is NOT a quant/bandwidth-footprint effect.
+
+**paroquant:** 27B model with Python/MLX rotation-kernel dispatch (no compiled Metal kernel for PARO rotations). Low TPS (~17–28) reflects Python overhead in the rotation pass, not model size alone. Stable and coherent.
+
+---
+
+## 2d. Decode-efficiency analysis — the ollama "2×" investigated (2026-06-06)
+
+Probe goal: explain ollama's ~2× decode TPS and decide whether rMLX can match it.
+Findings (from `Cross-Backend-Bench/metrics/runs/*.jsonl` + a 3-run rMLX
+`baseline` probe on `mlx-community__Qwen3.6-35B-A3B-8bit`, 4k, max_tokens=256):
+
+**The 2× is contaminated, not a clean win:**
+
+1. **Same byte footprint.** ollama = `mxfp8`, **37 GB**; MLX int8 = **35 GB**.
+   ~1 byte/param both. The 2× is **not** a quant/bandwidth-footprint effect.
+2. **ollama ignored `max_tokens`.** It generated ~455–485 tokens to EOS every
+   cell (thinking model; CBB runner doesn't pass `num_predict`), while mlx-lm /
+   mlx-lm-tq / rMLX honored 256. Unequal work — decode *rate* is still a rate,
+   but the cells aren't equal-effort.
+3. **ollama TTFT is cache-flat** (~72–131 ms for 4k→64k, then 74 s at 128k) →
+   prefix caching / context not reprocessed per run. Its prefill numbers are
+   meaningless, and its decode may attend a shorter effective KV (cheaper/token)
+   at long context.
+
+**Apples-to-apples decode TPS @ 4k (same 8-bit weights, controlled 256-token
+runs where the backend obeyed the cap):**
+
+| Backend | decode TPS @ 4k | vs mlx-lm |
+|---|---|---|
+| mlx-lm | 82.1 | — |
+| mlx-lm-turboquant | 85.7 | +4% |
+| **rMLX (kv none)** | **98.2** | **+20%** |
+| ollama (uncontrolled, ~485 tok, cache) | 175.8 | not trustworthy |
+
+**rMLX already leads the MLX tier on decode** (+20% vs mlx-lm). At ~3.5 GB/token
+active and ≈98 TPS, rMLX uses ~340 GB/s — roughly half of the M5 Max roofline,
+so headroom remains. ollama's implied ~610 GB/s is near/above roofline →
+consistent with its number being inflated by (2)+(3), not a real 2× of honest
+work. **Conclusion: ollama's edge, where real, is llama.cpp's Metal MoE
+bandwidth utilization (kernel efficiency), NOT quant — recoverable in rMLX on the
+same weights. The literal "2×" is mostly an artifact of uncontrolled generation
++ caching.**
+
+**Bigger real gap found (decode is fine; prefill is not):** rMLX `baseline` @ 4k
+shows **TTFT ≈ 6.9 s, prefill ≈ 580 tok/s** vs mlx-lm TTFT ≈ 144 ms. rMLX
+prefill at short context is ~40–50× slower than mlx-lm — the genuine
+optimization target, far more impactful than the contaminated decode "2×". Needs
+its own investigation (chunked-prefill path / first-prefill graph cost on the
+MoE) in the improvement plan.
+
+**To settle ollama honestly (later):** re-measure with `num_predict=256`, prompt
+caching disabled, and confirm full-context attention — then its decode TPS is
+directly comparable. Until then treat ollama's column as uncontrolled.
+
+---
+
+## 3. Skips — Non-Benched Backends
+
+| Backend | Reason |
+|---|---|
+| `mistral.rs` | No CBB runner; no bench script. Would require building a new runner — out of scope for Phase A data collection. |
+| `isoquant` | No CBB runner; no bench script. Skip-with-reason: no live server endpoint available. |
+| `rotorquant` | No CBB runner; no bench script. Skip-with-reason: no live server endpoint available. |
+| `llama.cpp` | GGUF runtime — weight format incompatible (GGUF ≠ MLX safetensors). Weight-quant mismatch vs affine-int8 baseline. No CBB runner. |
+| `mlx-vlm` | Qwen3.6 is a text-only model family; mlx-vlm is a VLM reference. No text-only serving path applicable here. |
+| `dynamo` | Not verified as OpenAI-compatible; no CBB runner. Pre-classified skip. |
+| `1bit-eval-scratch` | Eval harness, not a serving backend. No live inference server. |
+| `experiments-kv-cache-compression` | Research / data-only repo; no serving endpoint. |
+| `llama-cpp-turboquant` | TurboQuant Metal kernel variant (llama.cpp base). GGUF runtime — weight incompatible. No CBB runner. |
+| `johndpope-llama-cpp-turboquant` | Same as above. |
+| `turboquant_plus` | TurboQuant Metal kernel variant. No serving endpoint. No CBB runner. |
+| `multi-turboquant` | TurboQuant Metal kernel variant. No serving endpoint. No CBB runner. |
+
+---
+
+## 4. Stage 2 Placeholder — rMLX Full Matrix
+
+**Pending Stage 2. Do not fill this section until Stage 2 is executed.**
+
+```
+rMLX full matrix (Stage 2):
+  - Base: mlx-community__Qwen3.6-35B-A3B-8bit, kv-quant none → baseline
+  - KV sweep: all arch-allowed named variants (MoE arch-guard pre-skips applied)
+  - SSD tier: off/on at 64k/128k for top-3 KV cells
+  - Speculative: MTP-5bit, DFlash, Eagle3 × {none, k8v4, k8v8, top-1 from sweep}
+  - Prompt sizes: 4k / 8k / 16k / 32k / 64k / 128k
+  - Standing-vs-champion table: decode + prefill, per prompt size, 🟢/🟡/🔴
+```
+
+**Arch-guard pre-skips for MoE (Qwen3.5-MoE):** the following KV variants are hard-rejected
+by `refuses_qwen_moe()` in `rmlx-kv-quant/src/quant.rs` and will be logged as skip(arch-guard)
+without a probe: `tsym3, tsym4, iso3_sym, iso4_sym, k_iso3, k_iso4, rotor3_sym, rotor4_sym,
+k_rotor3, k_rotor4, rotor_k_3_asym_*, rotor_k_4_asym_*` (~13 variants), plus `planar_k`.
+
+---
+
+## 5. Notes
+
+### Machine and environment
+- **Chip:** Apple M5 Max, 128 GB unified memory
+- **OS:** macOS 26.4.1 (Darwin 25.4.0)
+- **Date:** 2026-06-06
+- **Bench start:** ~03:18 UTC; all four comparable backends + paroquant completed in ~140 min wall-clock.
+
+### Backend SHAs
+| Backend | SHA / Version |
+|---|---|
+| mlx-lm | `04a1910` (pulled ff-only 2026-06-06) |
+| mlx-lm-turboquant | `67db9af` (already up to date) |
+| oMLX | `2169285` (pulled ff-only 2026-06-06) |
+| ollama | version `0.23.2` |
+| paroquant | `c049a8a` (pulled ff-only 2026-06-06) |
+
+### Coherence gate results
+All five backends passed the coherence gate at 8k prompt size:
+
+| Backend | 8k output sample | Pass/Fail |
+|---|---|---|
+| mlx-lm | `The user wants to find the top three projects by README length…` | PASS |
+| mlx-lm-turboquant | `The user wants to find the top three projects by README length…` | PASS |
+| oMLX | `\nThe user wants to find the top three projects by README length…` | PASS |
+| ollama | `Here's a thinking process:\n\n1.  **Analyze User Input:**…` | PASS |
+| paroquant | `Here's a thinking process:\n\n1.  **Analyze User Input:**…` | PASS |
+
+No backend produced empty output, repetition loops, or broken punctuation.
+Note: ollama and paroquant output reasoning/thinking preambles (the model emits `<think>…</think>` style output). Both are coherent extended-thinking outputs, not degeneration.
+
+### oMLX caching anomaly
+oMLX appears to have auto-prefix caching enabled. From run-2 onward of each prompt size,
+TTFT is 27–140ms regardless of prompt length (4k → 128k), indicating the full KV prefix is
+served from cache. Consequence: run-1 TPS at each new prompt size is much lower (first-time KV
+allocation + prefill), while runs 2-5 are stable but do NOT reflect independent full-context
+prefill. The 5-run median is dominated by the stable cached runs; CI lower bound reflects the
+single cold-start outlier. The oMLX decode TPS numbers are valid (steady-state decode is after
+TTFT regardless of caching); the prefill TPS numbers from oMLX are not meaningful in this bench.
+
+### Thermal / caching caveats
+- No `purge` was run between backends. macOS buffer cache may hold recently-accessed safetensors pages.
+- Bench ran sequentially without thermal cooling pauses. M5 Max sustained performance is well-characterized; no thermal throttle detected (decode TPS stable within each backend's run series).
+- The mlx-lm-turboquant KV cache flag `--kv-cache-quantization 8,4 --quantized-kv-start 0` is a "fake asymmetric" flag (the CBB script note) — mlx-lm-turboquant's 8,4 is not true asymmetric K8/V4 as implemented in rMLX. The decode TPS advantage over plain mlx-lm is real but modest (~2–4%), reflecting reduced KV bandwidth at large context.
+
+### paroquant notes
+- Paroquant `_serve_mlx()` path wraps `mlx_lm.server` with a patched `load()` that applies PARO rotation at load time. The rotation kernels run through Python/MLX (not compiled Metal). This explains the ~28 TPS decode at 4k for a 27B model (expected ~85+ with a compiled Metal kernel). The rotation overhead dominates each forward pass.
+- Paroquant 128k prefill takes ~370 seconds (TTFT 370 600ms). This is expected given the Python rotation overhead on 131k tokens.
+- Paroquant is benched purely for data completeness. It is non-weight-comparable (27B, different quant scheme) and non-competitive at current Python-kernel speed.
+
+### Prompt sizes
+All six fixtures used: `longctx_{4k,8k,16k,32k,64k,128k}.json` (4 096 / 8 192 / 16 381 / 32 764 / 65 528 / 131 052 prompt tokens). Sub-4k and 256k prompts are not in the fixture set — deferred, not silently omitted.

--- a/docs/models/qwen3.6/rMLX.md
+++ b/docs/models/qwen3.6/rMLX.md
@@ -1,0 +1,225 @@
+# Qwen3.6 — rMLX Full Matrix (Stage 2)
+
+> Companion: [`SIBLINGS.md`](SIBLINGS.md) — sibling-backend champions.
+> Champion (weight-comparable affine int8 35B tier) = **mlx-lm-turboquant**,
+> decode TPS @ 4k/8k/16k/32k/64k/128k = 84.88 / 83.93 / 79.20 / 73.56 / 65.09 / 50.81.
+
+**Family:** `qwen3_5_moe` · **Machine:** Apple M5 Max, 128 GB, macOS 26.4.1
+**Protocol:** batch=1, temp=0, `max_tokens=256`; n=5 measured (4k/8k/16k/32k),
+n=2 (64k/128k), 1 warmup discarded; decode-TPS median + 95% CI (bootstrap);
+binary `release-perf`. Bar (§0.1): WIN / TIE-on-CI-overlap / LOSS.
+Step-by-step execution — one cell per run.
+
+> **Status: Stage 2 COMPLETE** (Phases B–E + PARO). Step-by-step, one cell per run.
+
+## 0. TL;DR
+
+- **rMLX WINS decode vs the champion (mlx-lm-turboquant) at every prompt size**,
+  +12–15% (kv-none), confirmed path-equivalent to the sibling harness (−0.2%).
+- **Best KV: rotor3 / iso3** (rotation codecs) — +1.9% over none at 128k. Turbo
+  codecs *lose* at long ctx (V-dequant overhead). At 8k all 8-bit-K codecs tie.
+- **The real deficit is prefill/TTFT**, ~40–50× slower than mlx-lm at short ctx —
+  the #1 improvement-plan target.
+- **Speculative barely helps:** MTP +4.2% (only working drafter), DFlash −37%,
+  **Eagle3 crashes** (MoE KV bug). Spec-loop overhead eats the accept gain.
+- **SSD tier** decode-neutral (−0.5%) but **hydrate doesn't skip prefill** (bug).
+- **PARO 27B:** rMLX runs it (26.3 TPS) but −5.6% vs the paroquant reference.
+- Bugs found: Eagle3 KV crash, SSD hydrate-no-prefill-skip, SSD spill GPU-stream,
+  CBB→runs.db schema reject. See plan §10.
+
+---
+
+## 1. rMLX snapshots benched
+
+| Snapshot (basename) | Weight quant | Role | Resident |
+|---|---|---|---|
+| `mlx-community__Qwen3.6-35B-A3B-8bit` | affine int8 (g64) | base / comparable | ~35 GB |
+| `z-lab__Qwen3.6-27B-PARO` | ParoQuant 4-bit krot=8 (27B) | alt-weight (non-comparable) | ~14 GB |
+| `…-MTP-5bit` / `…-DFlash` / `…-eagle3` | drafters | speculative (Phase E) | _pending_ |
+
+---
+
+## 2. rMLX full matrix
+
+### 2a. Phase B — baseline (`--kv-quant none`, base model)
+
+| Prompt | decode TPS (median [95% CI]) | TTFT | prefill TPS | peak RSS |
+|---|---|---|---|---|
+| 4k | **97.68** [96.94–97.91] | 6857 ms | 596 | 35.4 GB |
+| 8k | **94.28** [89.01–94.93] | 13 847 ms | 586 | 35.4 GB |
+| 16k | **89.33** [88.88–89.94] | 30 619 ms | 552 | 35.8 GB |
+| 32k | **83.32** [82.93–83.75] | 61 138 ms | 549 | 36.4 GB |
+| 64k | **74.07** [74.07–74.08] | 132 359 ms | 495 | 41.5 GB |
+| 128k | **57.12** [57.12–57.13] | 312 314 ms (cold) | 419 | 40.8 GB |
+
+_Cells 4k–64k via `rmlx baseline`; 128k via `rmlx serve`+`run_one` (baseline caps
+prompts at 64k — see plan §10). 128k prefill ≈ 5m12s for 130 810 tokens._
+_**Paths validated equivalent**: 4k baseline 97.68 vs serve+run_one 97.47 (−0.2%)
+— so these rows compare directly against the serve+run_one siblings; the wins are
+real, not a measurement artifact._
+
+### 2b. Phase C — KV-variant sweep
+
+**Ranking pass @ 8k** (n=3, `baseline`), sorted by decode TPS. All coherence PASS,
+no skips (planar/planar3 ARE MoE-allowed):
+
+| KV variant | decode TPS @8k (median [range]) | ttft_ms | note |
+|---|---|---|---|
+| k8vturbo2tcq | 96.10 [95.41–96.52] | 14 074 | tcq ttft penalty, no decode gain |
+| k8vturbo3tcq | 96.04 [95.42–96.31] | 14 352 | " |
+| k8vturbo3 | 96.02 [95.92–96.17] | 13 617 | tightest variance |
+| rotor3 | 96.02 [95.50–96.15] | 13 891 | |
+| iso3 | 96.00 [95.87–96.30] | 13 881 | |
+| k8vturbo2 | 95.87 [95.68–96.24] | 13 579 | |
+| planar3 | 95.86 [95.42–96.08] | 13 529 | |
+| rotor4 | 95.85 [95.78–96.16] | 13 912 | |
+| planar | 95.72 [95.05–96.03] | 13 468 | |
+| iso4 | 95.71 [94.97–96.23] | 15 598 | higher prefill cost |
+| k8v4 | 95.50 [94.88–95.66] | 13 567 | |
+| k8v8 | 95.23 [94.92–95.87] | 13 519 | |
+| none (bf16) | 94.28 [89.01–94.93] | 13 847 | unquantized KV |
+| rot_k_tq4v | 89.60 [89.20–90.26] | 13 398 | ~7% slower (tq4 V cost) |
+| rot_k_v4g64 | 58.21 [58.02–58.34] | 13 475 | V-side dequant decode cost |
+| mixed_k8g128_v4g64 | 57.44 [57.30–57.69] | 13 471 | " |
+| mixed_k8g128_v8g128 | 56.50 [56.26–56.51] | 13 449 | " |
+
+**Read:** at 8k the KV cache is tiny vs the weights, so all 8-bit-K codecs are
+within <1% (bandwidth-bound on weights). The 8k ranking is NOT predictive of the
+long-context winner — KV-codec savings only pay off where the KV cache is large.
+
+**Arch-guard pre-skips (MoE, no probe):** tsym3, tsym4, iso3_sym, iso4_sym,
+k_iso3, k_iso4, rotor3_sym, rotor4_sym, k_rotor3, k_rotor4, rotor_k_3_asym_*,
+rotor_k_4_asym_*, planar_k.
+
+**Carry plan (step-by-step, adaptive prune — plan §7.0):** the informative size
+for KV choice is **128k** (KV-dominated). Carry the top 3-bit-V codecs to 128k
+(serve+run_one); confirm across codec families, then conclude.
+
+**Carry results @ 128k** (vs none@128k = 57.12):
+
+| KV variant | decode TPS @128k (median) | Δ vs none | coherence |
+|---|---|---|---|
+| none (bf16) | 57.12 | — | PASS |
+| **rotor3** | **58.19** | **+1.9%** | PASS |
+| **iso3** | **58.21** | **+1.9%** | PASS |
+| k8vturbo3 | 55.57 | −2.7% | PASS |
+| k8vturbo2tcq / k8vturbo3tcq | _pruned_ | (turbo family — tracks turbo3 −2.7%) | |
+
+**Finding (forming): codec FAMILY decides the long-ctx outcome, not bit-width.**
+- **rotor3 (rotation-based V) BEATS none at 128k (+1.9%)** — the rotation codec's
+  dequant is cheap enough that the KV-bandwidth saving nets positive. This is the
+  rotation-KV advantage rMLX uniquely ships.
+- **k8vturbo3 (turbo V) LOSES (−2.7%)** — its per-token V-dequant over 131k
+  positions costs more than the bandwidth saved (compute-bound).
+- At 8k (KV tiny) all codecs ≈ none; the split only appears at long ctx.
+- `--fused-qk` kernels are default-OFF — turbo's loss may shrink with them on
+  (improvement-plan lead).
+- **KV-cache memory numbers were inconsistent across runs** (none KV reported
+  3.0 GB in one cell, a "bf16≈40 GB" framing in another) → NOT asserting
+  compression ratios here; verify KV footprint separately.
+
+### 2c. Phase D — SSD KV tier (off/on)
+
+Enabled via `--kv-ssd-cache-gb 8`. rotor3 @128k:
+
+| Config | decode TPS @128k | Δ | notes |
+|---|---|---|---|
+| rotor3, SSD off | 58.19 | — | |
+| rotor3, SSD on | 57.90 | **−0.5%** | spill async (no decode stall); hydrate 0.68s |
+
+**Finding:** SSD decode overhead is **negligible** (−0.5%) — the drain-thread spill
+doesn't stall decode. SSD's purpose is **capacity** (KV that outgrows RAM), not
+speed; at 128k single-stream (KV ~2.2 GB) it isn't needed. **Two bugs found:**
+1. **SSD hydrate does not bypass prefill** — `prompt_cache_hits=0` even after a
+   successful hydrate (510 blocks, prefix_len 130560); the full 342s prefill still
+   ran. The cross-restart prefill-reuse benefit is **not materializing** (the
+   hydrated KV isn't matched to the active request's prefix). Improvement target.
+2. **Spill GPU-stream WARN** — `eval-for-spill failed: no Stream(gpu,2)` on the
+   drain thread → that run's KV isn't persisted. Non-fatal but a real bug.
+
+### 2d. Phase E — speculative (drafter × KV anchor)
+
+Verifier = 35B-A3B-8bit, kv none, 4k, temp 0 (greedy accept). Baseline none@4k = 97.68.
+
+| Drafter | decode TPS @4k | speedup vs none | accept-rate | vs champion 84.88 |
+|---|---|---|---|---|
+| MTP-5bit (block 3, k=4) | 101.77 | +4.2% (1.04×) | 66.4% | +20% |
+| DFlash (block 16, k=4) | 61.86 | **−37% (regression)** | 47.2% | −27% |
+| Eagle3 | **CRASH** | — (bug) | — | — |
+
+_DFlash: the `z-lab__…-DFlash` snapshot loads as a heavy ~full-size MoE (72.6 GB
+dual-model peak) — draft cost ≈ verify cost, so spec backfires. Decode-only
+number; engine overall (incl. 6.5s prefill) was ~23 TPS. Dead end for this snapshot._
+
+_Eagle3: drafter loads (vocab 248320→32000, d2t hot-path, aux layers [2,18,34],
+block 5) but **crashes at token ~245** every run — MLX `slice_update` shape error
+`(1,2,N,256) vs (1,2,0,256)` (zero-length seq dim) in the Eagle3 draft-KV
+aux-layer management for MoE. **Bug — Eagle3 is broken on Qwen3.6-MoE.**_
+
+**Phase E verdict:** **MTP** is the only working drafter — but only **+4.2%**
+(round overhead eats the 66% accept). **DFlash** regresses (heavy drafter).
+**Eagle3** is broken (KV bug). Speculative is not a net win for rMLX on this model
+today; the gains live behind (a) reducing spec-loop overhead, (b) fixing Eagle3,
+(c) a true lightweight drafter. Block-size / KV-anchor tuning deferred to the
+improvement plan.
+
+**Finding (forming):** MTP spec gives only **+4.2%** despite a 66% accept rate —
+the speculative round overhead (draft-model forwards + multi-position verify)
+nearly cancels the decode-step savings. With 66% accept + block 3, theory is
+~1.5×; rMLX realizes 1.04×. → **rMLX's spec path has overhead to recover**
+(improvement-plan target). Spec currently adds little over rMLX's already-winning
+kv-none. Testing DFlash / Eagle3 + block-size tuning to see if any drafter clears
+the overhead.
+
+---
+
+## 3. Standing vs champion (decode)
+
+| Prompt | rMLX (kv none) | champion (mlx-lm-tq) | standing |
+|---|---|---|---|
+| 4k | 97.68 [96.94–97.91] | 84.88 | 🟢 **WIN +15%** (CI clear) |
+| 8k | 94.28 [89.01–94.93] | 83.93 | 🟢 **WIN +12%** (CI clear) |
+| 16k | 89.33 [88.88–89.94] | 79.20 | 🟢 **WIN +13%** (CI clear) |
+| 32k | 83.32 [82.93–83.75] | 73.56 | 🟢 **WIN +13%** (CI clear) |
+| 64k | 74.07 [74.07–74.08] | 65.09 | 🟢 **WIN +14%** (CI clear) |
+| 128k | 58.19 (rotor3) / 57.12 (none) | 50.81 | 🟢 **WIN +14.5%** (rotor3) |
+
+> **Phase B verdict: rMLX baseline (kv none) WINS decode at every prompt size**
+> (+12–15%) vs the champion mlx-lm-turboquant. KV-quant variants (Phase C) may
+> push further. The deficit is prefill/TTFT, not decode (§4).
+
+---
+
+## 4. Gaps & hypotheses (Phase F synthesis → improvement plan)
+
+Ranked by impact:
+
+1. **Prefill / TTFT — the dominant deficit.** rMLX prefill is ~40–50× slower than
+   mlx-lm at short ctx (4k TTFT 6.9s vs ~144ms) and degrades with length (prefill
+   596→419 tok/s as 4k→128k; TTFT 6.9s→132s→5m12s). Decode is fine; **prefill is
+   where rMLX loses wall-clock.** Profile the MoE first-prefill path (chunked
+   prefill, expert gather, graph compile). Highest-value fix.
+2. **Decode kernel headroom.** rMLX wins the tier but sits ~half of M5-Max roofline
+   (≈340 GB/s of ~600). llama.cpp/ollama saturate more. Tighter MoE decode kernels
+   (expert gather + dequant fusion) could extend the lead. `--fused-qk` is
+   default-OFF — turning it on may also let quant codecs win on decode.
+3. **Speculative overhead.** MTP only +4.2% despite 66% accept — the spec-round
+   cost (draft forwards + multi-position verify) nearly cancels the savings. Reduce
+   per-round overhead; **fix the Eagle3 MoE KV crash** (`slice_update` zero-dim);
+   source a true lightweight DFlash head.
+4. **SSD prompt-cache not skipping prefill.** Hydrate restores KV but
+   `prompt_cache_hits=0` → full prefill still runs. Wiring the hydrated prefix into
+   the cache-hit path would turn SSD into a real cross-restart TTFT win (and helps
+   #1 for repeated long prefixes). Also fix the spill GPU-stream WARN.
+5. **PARO decode** −5.6% vs the paroquant reference — rMLX's PARO path trails the
+   native rotation kernels. Lower priority (non-comparable, niche format).
+
+**What's already good (don't "fix"):** decode TPS leads the MLX int8 tier at every
+size; rotation KV codecs (rotor3/iso3) are a genuine long-ctx edge; SSD decode
+overhead is negligible; coherence solid across all KV variants.
+
+## 5. PARO 27B (non-comparable alt-weight)
+
+rMLX runs `z-lab__Qwen3.6-27B-PARO` (4-bit krot=8, ~14 GB): decode **26.31 TPS @8k**
+[26.28–26.31], coherent. vs paroquant sibling 27.97 → **−5.6%**. Different model
+(27B) + format — not comparable to the 8-bit champion table; recorded for coverage.

--- a/docs/models/qwen3.6/rMLX.md
+++ b/docs/models/qwen3.6/rMLX.md
@@ -20,12 +20,15 @@ Step-by-step execution — one cell per run.
   codecs *lose* at long ctx (V-dequant overhead). At 8k all 8-bit-K codecs tie.
 - **The real deficit is prefill/TTFT**, ~40–50× slower than mlx-lm at short ctx —
   the #1 improvement-plan target.
-- **Speculative barely helps:** MTP +4.2% (only working drafter), DFlash −37%,
-  **Eagle3 crashes** (MoE KV bug). Spec-loop overhead eats the accept gain.
-- **SSD tier** decode-neutral (−0.5%) but **hydrate doesn't skip prefill** (bug).
+- **Speculative barely helps:** MTP +4.2% (best drafter), DFlash −37%, Eagle3
+  −39% (now works after the crash fix, but low accept ~0.27 → net loss). Spec-loop
+  overhead eats the accept gain.
+- **SSD tier** decode-neutral (−0.5% / −3.1%); spill now persists correctly; the
+  **hydrate-doesn't-skip-prefill** gap remains (#9, deferred).
 - **PARO 27B:** rMLX runs it (26.3 TPS) but −5.6% vs the paroquant reference.
-- Bugs found: Eagle3 KV crash, SSD hydrate-no-prefill-skip, SSD spill GPU-stream,
-  CBB→runs.db schema reject. See plan §10.
+- **Bugs filed + FIXED in 0.1.1:** Eagle3 MoE crash (#8), SSD spill GPU-stream
+  (#10), baseline prompt cap (#11). Still open: SSD hydrate-no-prefill-skip (#9,
+  enhancement). CBB→runs.db schema reject (harness). See plan §10.
 
 ---
 
@@ -125,17 +128,21 @@ Enabled via `--kv-ssd-cache-gb 8`. rotor3 @128k:
 | Config | decode TPS @128k | Δ | notes |
 |---|---|---|---|
 | rotor3, SSD off | 58.19 | — | |
-| rotor3, SSD on | 57.90 | **−0.5%** | spill async (no decode stall); hydrate 0.68s |
+| rotor3, SSD on | 57.90 / 56.41 | **−0.5% / −3.1%** | spill async (no decode stall) |
 
-**Finding:** SSD decode overhead is **negligible** (−0.5%) — the drain-thread spill
-doesn't stall decode. SSD's purpose is **capacity** (KV that outgrows RAM), not
-speed; at 128k single-stream (KV ~2.2 GB) it isn't needed. **Two bugs found:**
+**Finding:** SSD decode overhead is **negligible** (−0.5% original, −3.1% on
+re-test, both within noise) — the drain-thread spill doesn't stall decode. SSD's
+purpose is **capacity** (KV that outgrows RAM), not speed; at 128k single-stream
+(KV ~2.2 GB) it isn't needed. Two bugs were found; one is fixed:
 1. **SSD hydrate does not bypass prefill** — `prompt_cache_hits=0` even after a
    successful hydrate (510 blocks, prefix_len 130560); the full 342s prefill still
    ran. The cross-restart prefill-reuse benefit is **not materializing** (the
-   hydrated KV isn't matched to the active request's prefix). Improvement target.
-2. **Spill GPU-stream WARN** — `eval-for-spill failed: no Stream(gpu,2)` on the
-   drain thread → that run's KV isn't persisted. Non-fatal but a real bug.
+   hydrated KV isn't matched to the active request's prefix). **Open — #9,
+   deferred (feature-sized; ExactOnly policy vs block-aligned hydrate).**
+2. ~~Spill GPU-stream WARN~~ — **FIXED in 0.1.1 (#10).** Was
+   `eval-for-spill failed: no Stream(gpu,N)` → block not persisted. Re-tested
+   post-fix: WARN gone, `kv-spill: block written + indexed` confirmed (2.34 GB
+   blocks persisted), decode 56.41 TPS (−3.1%, within noise).
 
 ### 2d. Phase E — speculative (drafter × KV anchor)
 
@@ -145,23 +152,25 @@ Verifier = 35B-A3B-8bit, kv none, 4k, temp 0 (greedy accept). Baseline none@4k =
 |---|---|---|---|---|
 | MTP-5bit (block 3, k=4) | 101.77 | +4.2% (1.04×) | 66.4% | +20% |
 | DFlash (block 16, k=4) | 61.86 | **−37% (regression)** | 47.2% | −27% |
-| Eagle3 | **CRASH** | — (bug) | — | — |
+| Eagle3 (block 5) | 59.61 | **−39% (regression)** | 26.5% | −30% |
 
 _DFlash: the `z-lab__…-DFlash` snapshot loads as a heavy ~full-size MoE (72.6 GB
 dual-model peak) — draft cost ≈ verify cost, so spec backfires. Decode-only
 number; engine overall (incl. 6.5s prefill) was ~23 TPS. Dead end for this snapshot._
 
-_Eagle3: drafter loads (vocab 248320→32000, d2t hot-path, aux layers [2,18,34],
-block 5) but **crashes at token ~245** every run — MLX `slice_update` shape error
-`(1,2,N,256) vs (1,2,0,256)` (zero-length seq dim) in the Eagle3 draft-KV
-aux-layer management for MoE. **Bug — Eagle3 is broken on Qwen3.6-MoE.**_
+_Eagle3: **the crash is fixed** (PR #8 / 0.1.1 — the drafter KV cache was
+hardcoded to 4096; now sized to the verifier `max_seq`). Re-tested post-fix:
+256 tokens complete, coherent, no `slice_update` crash. But decode is **59.61 TPS
+(−39% vs none)** at a low **26.5% accept-rate** — the small accept can't offset the
+spec-loop overhead, so Eagle3 is a net decode loss for this model (same shape as
+DFlash). Functional now, but not worth using here without a higher-accept drafter._
 
-**Phase E verdict:** **MTP** is the only working drafter — but only **+4.2%**
-(round overhead eats the 66% accept). **DFlash** regresses (heavy drafter).
-**Eagle3** is broken (KV bug). Speculative is not a net win for rMLX on this model
-today; the gains live behind (a) reducing spec-loop overhead, (b) fixing Eagle3,
-(c) a true lightweight drafter. Block-size / KV-anchor tuning deferred to the
-improvement plan.
+**Phase E verdict (post-0.1.1):** all three drafters now RUN (Eagle3 crash fixed),
+but speculative is **not a net win** for Qwen3.6: MTP +4.2% (only positive),
+DFlash −37%, Eagle3 −39%. The accept-rates (MTP 66%, DFlash 47%, Eagle3 27%)
+don't clear the spec-loop overhead. Gains live behind (a) reducing per-round
+overhead, (b) a higher-accept / truly-lightweight drafter, (c) block-size / KV-
+anchor tuning — deferred to the improvement plan.
 
 **Finding (forming):** MTP spec gives only **+4.2%** despite a 66% accept rate —
 the speculative round overhead (draft-model forwards + multi-position verify)
@@ -204,13 +213,15 @@ Ranked by impact:
    (expert gather + dequant fusion) could extend the lead. `--fused-qk` is
    default-OFF — turning it on may also let quant codecs win on decode.
 3. **Speculative overhead.** MTP only +4.2% despite 66% accept — the spec-round
-   cost (draft forwards + multi-position verify) nearly cancels the savings. Reduce
-   per-round overhead; **fix the Eagle3 MoE KV crash** (`slice_update` zero-dim);
-   source a true lightweight DFlash head.
-4. **SSD prompt-cache not skipping prefill.** Hydrate restores KV but
+   cost (draft forwards + multi-position verify) nearly cancels the savings. The
+   Eagle3 MoE KV crash is **fixed (#8 / 0.1.1)** — Eagle3 now runs but at −39%
+   (27% accept). Remaining work: reduce per-round overhead; source a higher-accept
+   / truly-lightweight drafter (the DFlash snapshot is full-size).
+4. **SSD prompt-cache not skipping prefill (#9, open).** Hydrate restores KV but
    `prompt_cache_hits=0` → full prefill still runs. Wiring the hydrated prefix into
    the cache-hit path would turn SSD into a real cross-restart TTFT win (and helps
-   #1 for repeated long prefixes). Also fix the spill GPU-stream WARN.
+   #1 for repeated long prefixes). _(The spill GPU-stream bug is fixed — #10 /
+   0.1.1.)_
 5. **PARO decode** −5.6% vs the paroquant reference — rMLX's PARO path trails the
    native rotation kernels. Lower priority (non-comparable, niche format).
 


### PR DESCRIPTION
## Qwen3.6 champion-matrix benchmark docs

Adds the full Qwen3.6 (35B-A3B) benchmark study under `docs/models/qwen3.6/`.
Docs-only — no code, no behavior change.

### Files

- **`SIBLINGS.md`** — Phase A sibling-backend champions (mlx-lm, mlx-lm-turboquant, ollama, paroquant). Champion = mlx-lm-turboquant. Includes the ollama "2× decode" investigation: the apparent gap is a measurement artifact (ignored `max_tokens` + server-side prompt caching), not a quant/bandwidth advantage.
- **`rMLX.md`** — full rMLX matrix across weight quants, KV quants, SSD tier, and speculative decoding:
  - **Phase B** — rMLX wins every size on decode vs the MLX tier.
  - **Phase C** — rotation KV codecs (`rotor3`/`iso3`) beat `none` at 128k (+1.9%); TurboQuant loses on V-dequant overhead. Family-dependent, not bit-width.
  - **Phase D** — SSD KV tier spill/hydrate behavior.
  - **Phase E** — speculative drafters (MTP / DFlash / Eagle3).
  - **§0/§2c/§2d/§4** updated post-0.1.1 to reflect the three landed fixes (#8 Eagle3 crash, #10 SSD spill, #11 baseline cap):
    - Eagle3 @4k: crash gone, now **59.61 TPS** / accept 27% → functional but **−39% vs none** (low accept, net loss like DFlash).
    - SSD spill @128k: GPU-stream WARN gone, blocks persist, **56.41 TPS** (−3.1%, noise).

### Verification

Re-tested on the rebased branch (carries the 0.1.1 fixes) via `make build-perf` + targeted problem-zone runs. Numbers in the doc are from those runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
