### PR TITLE
fix(release): sync_tap.sh commits as noreply identity

### DIFF
--- a/scripts/release/sync_tap.sh
+++ b/scripts/release/sync_tap.sh
@@ -26,14 +26,15 @@ else
 fi
 
 mkdir -p "$TAP_DIR/Formula"
-cp "$SRC" "$TAP_DIR/Formula/rmlx.rb"
+cp -f "$SRC" "$TAP_DIR/Formula/rmlx.rb"
 
 ( cd "$TAP_DIR"
   git add Formula/rmlx.rb
   if git diff --cached --quiet; then
     echo "==> tap already up to date"
   else
-    git commit -q -m "rmlx ${VER}"
+    # GitHub email-privacy push block — must commit as the noreply identity, not the operator's global git identity.
+    git -c user.name="Pushkinist" -c user.email="4850452+Pushkinist@users.noreply.github.com" commit -q -m "rmlx ${VER}"
     git push -q
     echo "==> pushed Formula/rmlx.rb (rmlx ${VER}) to $TAP_REPO"
   fi


### PR DESCRIPTION
## Fix: tap-sync commits as the project noreply identity

`scripts/release/sync_tap.sh` committed the synced Homebrew formula into the
tap repo using whatever git identity was globally configured. When the
operator's global identity uses a real email, GitHub's email-privacy setting
rejects the push (`push declined due to email privacy restrictions`), forcing
a manual hand-sync.

### Change (shell only, 3 lines)
- Commit into the tap clone now sets the project GitHub noreply identity
  explicitly via `git -c user.name=… -c user.email=…`, so it works regardless
  of the operator's global git config (no global-config mutation, no side
  effects). Sets both author and committer.
- `cp -f` to force-overwrite the formula past any interactive `cp -i` alias.

All pre-existing logic untouched (`set -euo pipefail`, awk VER extraction,
mktemp/clone, skip-if-unchanged guard).

### Proof
Ran the script against a throwaway local tap repo (`sync_tap.sh /tmp/faketap`)
and inspected the resulting commit:

```
git log -1 --format='author=%ae committer=%ce'
author=4850452+Pushkinist@users.noreply.github.com committer=4850452+Pushkinist@users.noreply.github.com
```

`bash -n` clean. Reviewed: `git -c` correctly sets both author + committer; `+`
in the noreply email needs no escaping inside double quotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
