### PR TITLE
chore(deps): migrate safetensors 0.4 -> 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,7 +981,20 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2178,10 +2203,11 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safetensors"
-version = "0.4.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
 dependencies = [
+ "hashbrown 0.16.1",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ toml       = "0.8"
 
 # I/O
 memmap2     = "0.9"
-safetensors = "0.4"
+safetensors = "0.7"
 
 # Image decode + resize for the jina-v4 Qwen2.5-VL image front-end
 # (user-approved 2026-05-19). Scoped to the only two

--- a/crates/rmlx-kv-ssd/src/block_io.rs
+++ b/crates/rmlx-kv-ssd/src/block_io.rs
@@ -485,7 +485,7 @@ fn serialize_block_refs_timed(
     // ── Phase 2: write to disk ────────────────────────────────────────────────
     let t_write = Instant::now();
     let refs: Vec<(String, &OwnedTensor)> = tensors.iter().map(|(n, t)| (n.clone(), t)).collect();
-    safetensors::serialize_to_file(refs, &Some(meta), path)
+    safetensors::serialize_to_file(refs, Some(meta), path)
         .map_err(|e| Error::Mlx(format!("KV block serialize: {e}")))?;
     let dur_write_us = t_write.elapsed().as_micros() as u64;
 


### PR DESCRIPTION
## Migrate safetensors 0.4 → 0.7

Breaking major bump (supersedes dependabot #5). The only API break that
touches this codebase is `serialize_to_file`: safetensors 0.7 takes the
metadata `Option<HashMap<String,String>>` **by value** instead of
`&Option<HashMap>` (upstream dropped the `&Option` anti-pattern, hf/safetensors#617).

### Change
- `Cargo.toml`: `safetensors = "0.4"` → `"0.7"`.
- `crates/rmlx-kv-ssd/src/block_io.rs:488`: `serialize_to_file(refs, &Some(meta), path)` → `serialize_to_file(refs, Some(meta), path)`. `meta` is not read after this call — no use-after-move.
- `Cargo.lock`: adds transitive deps `hashbrown 0.16`, `foldhash 0.2`, `allocator-api2 0.2` (safetensors 0.7's new hashmap impl).

All `safetensors::Dtype` match sites are wildcard-guarded, so 0.7's new
`Complex64` variant is absorbed with no change.

### Proof — weight-loader + KV-serialize dep, so correctness is byte-level
- `rmlx-kv-ssd`: **74 passed** (block_io round-trip exercises `serialize_to_file` + `SafeTensors::deserialize`, hydrate, ssd_index).
- `rmlx-loader`: **122 passed** (deserialize, dtype, calibration).
- Golden-token oracle (exact-token weight-load proof — divergent byte parsing ⇒ divergent tokens): **bonsai 4/4, gemma4 1/1, qwen3 2/2** RAN + PASS.
- `make lint` clean; rust-reviewer: no findings (by-value move correct).

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
