### PR TITLE
chore(deps): migrate symphonia 0.5 -> 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,12 +116,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,7 +231,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -250,12 +244,6 @@ dependencies = [
  "shlex",
  "syn",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1565,7 +1553,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1593,7 +1581,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1720,7 +1708,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1864,7 +1852,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2127,7 +2115,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2173,7 +2161,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2242,7 +2230,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2443,9 +2431,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "symphonia"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+checksum = "1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-mp3",
@@ -2457,21 +2445,20 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+checksum = "350f1f2f2e19ad4dd315db94304d1eb361b29af070681f94e51b8fdaad769546"
 dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-codec-pcm"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+checksum = "50baee168f0e9dcf6ba7fc06e8b57eb62072a4490cc7cf13af77e72baae5d328"
 dependencies = [
  "log",
  "symphonia-core",
@@ -2479,22 +2466,23 @@ dependencies = [
 
 [[package]]
 name = "symphonia-core"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+checksum = "95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1"
 dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
+ "bitflags",
  "bytemuck",
  "lazy_static",
  "log",
+ "num-complex",
+ "smallvec",
 ]
 
 [[package]]
 name = "symphonia-format-riff"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+checksum = "17424452a777666d3eaf09a5c651029b15b6a333812fcc5b5474f2a3f0cff3f0"
 dependencies = [
  "extended",
  "log",
@@ -2504,13 +2492,14 @@ dependencies = [
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+checksum = "a31acf5cd623398a6208e2225d18f4b20f761c55098a796a5247ad516a4a8681"
 dependencies = [
- "encoding_rs",
  "lazy_static",
  "log",
+ "regex-lite",
+ "smallvec",
  "symphonia-core",
 ]
 
@@ -3114,7 +3103,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3372,7 +3361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ rustfft = "6.4"
 # mp3  — MPEG Layer 3 codec (symphonia-bundle-mp3/mp3).
 # default-features=false drops AIFF/OGG/FLAC/AAC/MKV/ADPCM from the default
 # registry so only the three features we need are compiled in.
-symphonia = { version = "0.5", default-features = false, features = ["wav", "pcm", "mp3"] }
+symphonia = { version = "0.6", default-features = false, features = ["wav", "pcm", "mp3"] }
 
 # Testing
 tempfile = "3"

--- a/crates/rmlx-audio/Cargo.toml
+++ b/crates/rmlx-audio/Cargo.toml
@@ -25,8 +25,8 @@ symphonia    = { workspace = true }
 # (used by rmlx-models for LLM tokenization). No new transitive deps added.
 tokenizers   = { workspace = true }
 # miniz_oxide: inflate (DEFLATE decompress) for reading .npz (ZIP+deflate) archives.
-# Already a transitive dep via symphonia → flate2. Pinned to the workspace-resolved
-# version to avoid pulling a second copy. No new transitive deps added.
+# symphonia 0.5 brought this in transitively via flate2; symphonia 0.6 dropped
+# flate2, so miniz_oxide is now a direct dep here. Still no new transitive crates.
 miniz_oxide  = "0.8"
 
 [dev-dependencies]

--- a/crates/rmlx-audio/src/wav.rs
+++ b/crates/rmlx-audio/src/wav.rs
@@ -24,13 +24,11 @@
 use std::io::Cursor;
 
 use symphonia::core::{
-    audio::SampleBuffer,
-    codecs::DecoderOptions,
+    codecs::audio::AudioDecoderOptions,
     errors::Error as SymphoniaError,
-    formats::FormatOptions,
+    formats::{probe::Hint, FormatOptions, TrackType},
     io::{MediaSourceStream, MediaSourceStreamOptions},
     meta::MetadataOptions,
-    probe::Hint,
 };
 use thiserror::Error;
 use tracing::{debug, instrument};
@@ -86,43 +84,52 @@ impl WavDecoder {
         let cursor = Cursor::new(bytes.to_vec());
         let mss = MediaSourceStream::new(Box::new(cursor), MediaSourceStreamOptions::default());
 
-        let probed = symphonia::default::get_probe()
-            .format(
+        let mut reader = symphonia::default::get_probe()
+            .probe(
                 &Hint::new(),
                 mss,
-                &FormatOptions::default(),
-                &MetadataOptions::default(),
+                FormatOptions::default(),
+                MetadataOptions::default(),
             )
             .map_err(|e| WavError::Probe(e.to_string()))?;
 
-        let mut reader = probed.format;
-
-        let track = reader.default_track().ok_or(WavError::NoTrack)?;
+        let track = reader
+            .default_track(TrackType::Audio)
+            .ok_or(WavError::NoTrack)?;
 
         let track_id = track.id;
-        let codec_params = track.codec_params.clone();
+        let audio_params = track
+            .codec_params
+            .as_ref()
+            .and_then(|cp| cp.audio())
+            .ok_or(WavError::NoTrack)?
+            .clone();
 
-        let sample_rate = codec_params
+        let sample_rate = audio_params
             .sample_rate
             .ok_or_else(|| WavError::Decode("missing sample_rate in codec params".to_owned()))?;
 
-        let n_channels = codec_params
+        let n_channels = audio_params
             .channels
+            .as_ref()
             .map_or(1, symphonia::core::audio::Channels::count)
             .max(1);
 
         debug!(sample_rate, n_channels, "WAV track selected");
 
-        let mut decoder = symphonia::default::get_codecs()
-            .make(&codec_params, &DecoderOptions::default())
+        let reg_entry = symphonia::default::get_codecs()
+            .get_audio_decoder(audio_params.codec)
+            .ok_or_else(|| WavError::Decode("no decoder for audio codec".to_owned()))?;
+        let mut decoder = (reg_entry.factory)(&audio_params, &AudioDecoderOptions::default())
             .map_err(|e| WavError::Decode(e.to_string()))?;
 
         let mut interleaved: Vec<f32> = Vec::new();
-        let mut sample_buf: Option<SampleBuffer<f32>> = None;
+        let mut frame_buf: Vec<f32> = Vec::new();
 
         loop {
             let packet = match reader.next_packet() {
-                Ok(p) => p,
+                Ok(Some(p)) => p,
+                Ok(None) => break,
                 Err(SymphoniaError::IoError(ref e))
                     if e.kind() == std::io::ErrorKind::UnexpectedEof =>
                 {
@@ -134,7 +141,7 @@ impl WavDecoder {
                 }
             };
 
-            if packet.track_id() != track_id {
+            if packet.track_id != track_id {
                 continue;
             }
 
@@ -147,11 +154,9 @@ impl WavDecoder {
                 Err(e) => return Err(WavError::Decode(e.to_string())),
             };
 
-            let spec = *decoded.spec();
-            let sb = sample_buf
-                .get_or_insert_with(|| SampleBuffer::<f32>::new(decoded.capacity() as u64, spec));
-            sb.copy_interleaved_ref(decoded);
-            interleaved.extend_from_slice(sb.samples());
+            // copy_to_vec_interleaved resizes + overwrites frame_buf, so no clear() needed.
+            decoded.copy_to_vec_interleaved::<f32>(&mut frame_buf);
+            interleaved.extend_from_slice(&frame_buf);
         }
 
         if interleaved.is_empty() {

--- a/crates/rmlx-models/src/audio_io.rs
+++ b/crates/rmlx-models/src/audio_io.rs
@@ -22,8 +22,11 @@
 use std::io::Cursor;
 
 use symphonia::core::{
-    audio::SampleBuffer, codecs::DecoderOptions, errors::Error as SymphoniaError,
-    formats::FormatOptions, io::MediaSourceStream, meta::MetadataOptions, probe::Hint,
+    codecs::audio::AudioDecoderOptions,
+    errors::Error as SymphoniaError,
+    formats::{probe::Hint, FormatOptions, TrackType},
+    io::MediaSourceStream,
+    meta::MetadataOptions,
 };
 use tracing::{debug, instrument, warn};
 
@@ -44,48 +47,58 @@ pub fn decode_audio_bytes(bytes: &[u8]) -> Result<(Vec<f32>, u32), String> {
     let mss = MediaSourceStream::new(Box::new(cursor), Default::default());
 
     // Probe: let symphonia detect the container type.
-    let probed = symphonia::default::get_probe()
-        .format(
+    let mut reader = symphonia::default::get_probe()
+        .probe(
             &Hint::new(),
             mss,
-            &FormatOptions::default(),
-            &MetadataOptions::default(),
+            FormatOptions::default(),
+            MetadataOptions::default(),
         )
         .map_err(|e| format!("audio probe failed: {e}"))?;
 
-    let mut reader = probed.format;
-
     // Pick the first default/best audio track.
     let track = reader
-        .default_track()
+        .default_track(TrackType::Audio)
         .ok_or_else(|| "no audio track found".to_owned())?;
 
     let track_id = track.id;
-    let codec_params = track.codec_params.clone();
+    let audio_params = track
+        .codec_params
+        .as_ref()
+        .and_then(|cp| cp.audio())
+        .ok_or_else(|| "no audio codec parameters".to_owned())?
+        .clone();
 
-    let sample_rate = codec_params
+    let sample_rate = audio_params
         .sample_rate
         .ok_or_else(|| "codec params missing sample_rate".to_owned())?;
 
-    let n_channels = codec_params.channels.map_or(1, |c| c.count()).max(1);
+    let n_channels = audio_params
+        .channels
+        .as_ref()
+        .map_or(1, |c| c.count())
+        .max(1);
 
     debug!(
         sample_rate,
         n_channels, track_id, "audio track selected for decode"
     );
 
-    let mut decoder = symphonia::default::get_codecs()
-        .make(&codec_params, &DecoderOptions::default())
+    let reg_entry = symphonia::default::get_codecs()
+        .get_audio_decoder(audio_params.codec)
+        .ok_or_else(|| "no decoder registered for audio codec".to_owned())?;
+    let mut decoder = (reg_entry.factory)(&audio_params, &AudioDecoderOptions::default())
         .map_err(|e| format!("failed to create audio decoder: {e}"))?;
 
     // Accumulate interleaved f32 samples from all packets.
     let mut interleaved: Vec<f32> = Vec::new();
-    let mut sample_buf: Option<SampleBuffer<f32>> = None;
+    let mut frame_buf: Vec<f32> = Vec::new();
 
     loop {
         let packet = match reader.next_packet() {
-            Ok(p) => p,
+            Ok(Some(p)) => p,
             // End of stream is the normal termination signal.
+            Ok(None) => break,
             Err(SymphoniaError::IoError(ref e))
                 if e.kind() == std::io::ErrorKind::UnexpectedEof =>
             {
@@ -97,7 +110,7 @@ pub fn decode_audio_bytes(bytes: &[u8]) -> Result<(Vec<f32>, u32), String> {
             }
         };
 
-        if packet.track_id() != track_id {
+        if packet.track_id != track_id {
             continue;
         }
 
@@ -110,14 +123,10 @@ pub fn decode_audio_bytes(bytes: &[u8]) -> Result<(Vec<f32>, u32), String> {
             Err(e) => return Err(format!("audio decode error: {e}")),
         };
 
-        // Lazily allocate the sample buffer on the first decoded frame so we
-        // know the exact capacity needed.
-        let spec = *decoded.spec();
-        let sb = sample_buf
-            .get_or_insert_with(|| SampleBuffer::<f32>::new(decoded.capacity() as u64, spec));
-
-        sb.copy_interleaved_ref(decoded);
-        interleaved.extend_from_slice(sb.samples());
+        // Copy decoded audio as interleaved f32, converting sample format as needed.
+        // copy_to_vec_interleaved resizes + overwrites frame_buf, so no clear() needed.
+        decoded.copy_to_vec_interleaved::<f32>(&mut frame_buf);
+        interleaved.extend_from_slice(&frame_buf);
     }
 
     if interleaved.is_empty() {


### PR DESCRIPTION
## Migrate symphonia 0.5 → 0.6

Major bump with a reworked decode/format API (supersedes dependabot #4).
Adapted both audio-decode consumers — `rmlx-audio/src/wav.rs` and
`rmlx-models/src/audio_io.rs` — to the 0.6 surface (6 distinct API changes):

| 0.5 | 0.6 |
|---|---|
| `get_probe().format(...)` → `probed.format` | `.probe(...)` returns the `FormatReader` directly; `FormatOptions`/`MetadataOptions` by value |
| `default_track()` | `default_track(TrackType::Audio)` |
| `track.codec_params` (value) | `Option<CodecParameters>`; `.audio()` → `AudioCodecParameters` |
| `get_codecs().make(...)` | `get_audio_decoder(codec).factory(...)` + `AudioDecoderOptions` |
| `SampleBuffer<f32>` + `copy_interleaved_ref` | `copy_to_vec_interleaved::<f32>(&mut frame_buf)` (resizes + overwrites) |
| `next_packet() -> Result<Packet>` | `Result<Option<Packet>>` → `Ok(None) => break` |
| `packet.track_id()` (method) | `packet.track_id` (field) |

symphonia 0.6 dropped `flate2`; updated the `rmlx-audio/Cargo.toml` comment
accordingly (miniz_oxide is now the direct dep). Lockfile drops `arrayvec` +
`bitflags v1`.

### Proof — decode correctness is byte-level
- `rmlx-audio`: **45 passed**. `round_trip_440hz` synthesizes a 440 Hz sine,
  encodes to PCM-16 WAV, decodes, and asserts each sample within **1e-4**;
  `silence_round_trip` asserts decoded silence within **1e-6**. Both pass →
  0.6 produces bit-equivalent PCM.
- `rmlx-models` audio_io: **11 passed** (the get_probe/get_codecs path).
- `make lint` clean. rust-reviewer: no correctness findings (verified
  `copy_to_vec_interleaved` resizes+overwrites, EOS arms reachable, no PCM
  divergence). Dropped a redundant `frame_buf.clear()` it flagged.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
