### PR TITLE
fix(kv): make --max-ctx a virtual ceiling, grow KV ring lazily (#25)

### DIFF
--- a/crates/rmlx-core/src/error.rs
+++ b/crates/rmlx-core/src/error.rs
@@ -116,6 +116,21 @@ pub enum Error {
         /// The configured hard cap (in tokens), from `RMLX_KV_MAX_SEQ_HARD_CAP`.
         cap: i32,
     },
+
+    /// Prefill requested a sequence length above the per-cache virtual
+    /// ceiling. The ceiling is the resolved `--max-ctx` (a virtual cap, not an
+    /// eager allocation): the KV ring grows lazily up to it. Raised before any
+    /// allocation past the ceiling so an over-long prompt is rejected cleanly
+    /// instead of growing the ring beyond the operator-declared context bound.
+    #[error(
+        "kv prefill request exceeds max-ctx ceiling: requested={requested}, ceiling={ceiling}"
+    )]
+    KvCeilingExceeded {
+        /// The needed sequence length (in tokens) that triggered the guard.
+        requested: i32,
+        /// The configured virtual ceiling (in tokens), from `--max-ctx`.
+        ceiling: i32,
+    },
 }
 
 /// The allocation phase in which an [`Error::Oom`] was raised.

--- a/crates/rmlx-kv-quant/src/kvcache/core.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/core.rs
@@ -198,6 +198,10 @@ impl KvCache {
             flash_max_seq: 0,
             flash_filled: 0,
             fused_qk_shadow: None,
+            // Intentional: hydrated/restored caches resume with `in_prefill: false`
+            // and never re-enter the prefill grow path, so the ceiling guard is
+            // not needed. Callers that want to re-attach a ceiling after hydration
+            // can chain `.with_max_seq_ceiling(n)` explicitly.
             max_seq_ceiling: None,
         }
     }
@@ -236,6 +240,14 @@ impl KvCache {
     /// what lets a server started with a large `--max-ctx` serve short requests
     /// at full speed: short requests pay only for what they fill, while the
     /// ceiling still bounds the maximum context.
+    ///
+    /// **Scope: non-rotating (global-attention / dense) layers only.**
+    /// Rotating SWA layers return early from `update()` via the `self.rotating`
+    /// branch before reaching `ensure_prefill_capacity`, so the ceiling is never
+    /// consulted for them. This is correct by construction: SWA layers are
+    /// window-bounded (e.g. 512 or 1024 tokens), so no ceiling guard is needed.
+    /// Per-arch correctness holds because every wired architecture has at least
+    /// one global-attention layer that does enforce the ceiling.
     ///
     /// `ceiling <= 0` is treated as "no ceiling" and clears it.
     #[must_use]

--- a/crates/rmlx-kv-quant/src/kvcache/core.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/core.rs
@@ -111,6 +111,15 @@ pub struct KvCache {
     // subsequent decode token. See
     // `docs/research/fused-qk-storage-design.md`.
     pub(super) fused_qk_shadow: Option<FusedQkShadow>,
+    /// Virtual ceiling on the lazily-grown prefill ring, in tokens.
+    ///
+    /// `None` = no ceiling (grow until `RMLX_KV_MAX_SEQ_HARD_CAP` or memory).
+    /// `Some(c)` = the resolved `--max-ctx`: the ring starts small and grows
+    /// lazily (power-of-two doubling) only up to `c`. A prefill that would need
+    /// more than `c` tokens is rejected with [`rmlx_core::Error::KvCeilingExceeded`]
+    /// before any allocation, instead of paying the long-context working-set
+    /// tax on every short request. Set via [`KvCache::with_max_seq_ceiling`].
+    pub(super) max_seq_ceiling: Option<i32>,
 }
 
 impl KvCache {
@@ -189,6 +198,7 @@ impl KvCache {
             flash_max_seq: 0,
             flash_filled: 0,
             fused_qk_shadow: None,
+            max_seq_ceiling: None,
         }
     }
 
@@ -212,7 +222,26 @@ impl KvCache {
             flash_max_seq: 0,
             flash_filled: 0,
             fused_qk_shadow: None,
+            max_seq_ceiling: None,
         }
+    }
+
+    /// Set the virtual ceiling on lazy prefill-ring growth (the resolved
+    /// `--max-ctx`), in tokens.
+    ///
+    /// The ring is allocated lazily at its starting `max_seq` and grows by
+    /// power-of-two doubling up to this ceiling (never past it). A prefill that
+    /// would need more than `ceiling` tokens is rejected with
+    /// [`rmlx_core::Error::KvCeilingExceeded`] before any allocation. This is
+    /// what lets a server started with a large `--max-ctx` serve short requests
+    /// at full speed: short requests pay only for what they fill, while the
+    /// ceiling still bounds the maximum context.
+    ///
+    /// `ceiling <= 0` is treated as "no ceiling" and clears it.
+    #[must_use]
+    pub fn with_max_seq_ceiling(mut self, ceiling: i32) -> Self {
+        self.max_seq_ceiling = if ceiling > 0 { Some(ceiling) } else { None };
+        self
     }
 
     /// Construct a KV cache, optionally as a rotating ring buffer for SWA layers.
@@ -311,6 +340,15 @@ impl KvCache {
     #[cfg(test)]
     pub fn decode_fp16_k_for_test(&self) -> Option<&Array> {
         self.decode_fp16_k.as_ref()
+    }
+
+    /// Test-only accessor: the `max_seq` currently recorded on the active
+    /// storage variant (the allocated ring capacity). Used by the issue-#25
+    /// lazy-grow / ceiling tests to assert the ring grew lazily rather than
+    /// pre-allocating to the ceiling.
+    #[cfg(test)]
+    pub fn storage_max_seq_for_test(&self) -> i32 {
+        super::update::storage_max_seq(&self.storage)
     }
 
     /// Test-only accessor: borrow the internal `decode_fp16_v` Option.

--- a/crates/rmlx-kv-quant/src/kvcache/prefill_grow_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/prefill_grow_tests.rs
@@ -154,6 +154,121 @@ fn update_prefill_raw_rejects_grow_on_resumed_cache() {
     );
 }
 
+/// Issue #25: a large `max_seq_ceiling` does NOT pre-allocate the ring.
+///
+/// The ring must start at its small initial `max_seq` and grow lazily up to
+/// the ceiling. Build a cache with a tiny initial `max_seq=128` and a large
+/// ceiling of 140_000 (the issue's oversized `--max-ctx`), then prefill 192
+/// tokens. The buffer must end up sized to the lazy power-of-two (256), NOT to
+/// the ceiling — proving the short request pays only for what it fills.
+#[test]
+fn ceiling_does_not_pre_allocate_ring() {
+    let device = Device::Cpu;
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::None, TEST_INITIAL_MAX_SEQ)
+        .with_max_seq_ceiling(140_000);
+    cache.enter_prefill();
+
+    let chunk_shape = [1_i32, TEST_KV_H, TEST_CHUNK, TEST_HEAD_DIM];
+    let n_chunk: usize = chunk_shape.iter().map(|&d| d as usize).product();
+    for step in 0..3_u32 {
+        let k = f32_arr(&vec![0.1_f32 * (step as f32 + 1.0); n_chunk], &chunk_shape);
+        let v = f32_arr(&vec![0.2_f32 * (step as f32 + 1.0); n_chunk], &chunk_shape);
+        cache
+            .update(&k, &v, device)
+            .expect("lazy grow under ceiling");
+    }
+
+    assert_eq!(cache.offset(), 192, "offset tracks filled length");
+    // The ring grew only to the next pow2 ≥ 192 = 256 — NOT to 140_000.
+    assert_eq!(
+        cache.storage_max_seq_for_test(),
+        256,
+        "ring grows lazily to the doubling boundary, not the ceiling",
+    );
+
+    cache.exit_prefill(device).expect("exit_prefill");
+}
+
+/// Issue #25: lazy grow is clamped to the ceiling, never past it.
+///
+/// With initial `max_seq=128` and ceiling=200, a 192-token prefill would
+/// normally double to 256, but the ceiling clamps the allocation to exactly
+/// 200. The request still fits (192 <= 200) and completes.
+#[test]
+fn grow_clamps_to_ceiling() {
+    let device = Device::Cpu;
+    let mut cache =
+        KvCache::with_quant_max_seq(KvQuant::None, TEST_INITIAL_MAX_SEQ).with_max_seq_ceiling(200);
+    cache.enter_prefill();
+
+    let chunk_shape = [1_i32, TEST_KV_H, TEST_CHUNK, TEST_HEAD_DIM];
+    let n_chunk: usize = chunk_shape.iter().map(|&d| d as usize).product();
+    for _ in 0..3_u32 {
+        let k = f32_arr(&vec![0.1_f32; n_chunk], &chunk_shape);
+        let v = f32_arr(&vec![0.2_f32; n_chunk], &chunk_shape);
+        cache.update(&k, &v, device).expect("lazy grow to ceiling");
+    }
+
+    assert_eq!(cache.offset(), 192);
+    assert_eq!(
+        cache.storage_max_seq_for_test(),
+        200,
+        "doubled size (256) clamped down to the 200-token ceiling",
+    );
+
+    cache.exit_prefill(device).expect("exit_prefill");
+}
+
+/// Issue #25: a prefill that exceeds the ceiling is rejected with a typed
+/// error before any allocation past the ceiling.
+///
+/// Initial `max_seq=128`, ceiling=150. A single 200-token chunk needs more
+/// than the ceiling and must error with `KvCeilingExceeded` rather than grow.
+#[test]
+fn prefill_over_ceiling_is_rejected() {
+    let device = Device::Cpu;
+    let mut cache =
+        KvCache::with_quant_max_seq(KvQuant::None, TEST_INITIAL_MAX_SEQ).with_max_seq_ceiling(150);
+    cache.enter_prefill();
+
+    let chunk_shape = [1_i32, TEST_KV_H, 200, TEST_HEAD_DIM];
+    let n_chunk: usize = chunk_shape.iter().map(|&d| d as usize).product();
+    let k = f32_arr(&vec![0.5_f32; n_chunk], &chunk_shape);
+    let v = f32_arr(&vec![0.7_f32; n_chunk], &chunk_shape);
+
+    let err = cache
+        .update(&k, &v, device)
+        .expect_err("prefill over ceiling must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("exceeds max-ctx ceiling"),
+        "unexpected error: {msg}",
+    );
+}
+
+/// A zero/negative ceiling is treated as "no ceiling" — unbounded lazy grow.
+#[test]
+fn non_positive_ceiling_means_unbounded() {
+    let device = Device::Cpu;
+    let mut cache =
+        KvCache::with_quant_max_seq(KvQuant::None, TEST_INITIAL_MAX_SEQ).with_max_seq_ceiling(0);
+    cache.enter_prefill();
+
+    // 300 > 128 initial cap; with no ceiling it grows to 512 as usual.
+    let chunk_shape = [1_i32, TEST_KV_H, 300, TEST_HEAD_DIM];
+    let n_chunk: usize = chunk_shape.iter().map(|&d| d as usize).product();
+    let k = f32_arr(&vec![0.5_f32; n_chunk], &chunk_shape);
+    let v = f32_arr(&vec![0.7_f32; n_chunk], &chunk_shape);
+    cache
+        .update(&k, &v, device)
+        .expect("unbounded grow with non-positive ceiling");
+
+    assert_eq!(cache.offset(), 300);
+    assert_eq!(cache.storage_max_seq_for_test(), 512);
+
+    cache.exit_prefill(device).expect("exit_prefill");
+}
+
 /// `next_pow2_seq` rounds correctly for a representative spread.
 ///
 /// Pins the local helper so future refactors don't silently regress to

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -704,6 +704,24 @@ impl KvCache {
             }
         }
 
+        // Virtual ceiling: the resolved `--max-ctx`. The ring grows lazily up
+        // to it; a prefill needing more is rejected before any allocation so a
+        // server started with a large ceiling pays no long-context tax on short
+        // requests. Checked after the env hard cap (both bound the same axis).
+        if let Some(ceiling) = self.max_seq_ceiling {
+            if needed_seq > ceiling {
+                tracing::warn!(
+                    requested = needed_seq,
+                    ceiling,
+                    "KV max-ctx ceiling exceeded — rejecting prefill request"
+                );
+                return Err(Error::KvCeilingExceeded {
+                    requested: needed_seq,
+                    ceiling,
+                });
+            }
+        }
+
         let current_max_seq = storage_max_seq(&self.storage);
         if needed_seq <= current_max_seq {
             return Ok(());
@@ -734,8 +752,14 @@ impl KvCache {
 
         // Grow to next power-of-two ≥ needed. Doubling avoids per-chunk
         // churn during multi-chunk prefill while keeping the buffer within
-        // a single doubling of the request.
-        let new_max_seq = next_pow2_seq(needed_seq);
+        // a single doubling of the request. When a virtual ceiling is set,
+        // clamp the doubled size to it (never allocate past `--max-ctx`):
+        // `needed_seq <= ceiling` is guaranteed by the reject check above, so
+        // the clamped capacity still fits the request.
+        let new_max_seq = match self.max_seq_ceiling {
+            Some(ceiling) => next_pow2_seq(needed_seq).min(ceiling),
+            None => next_pow2_seq(needed_seq),
+        };
 
         tracing::info!(
             from = current_max_seq,
@@ -4781,6 +4805,9 @@ impl KvCache {
             // branching simply drops it; the next decode dispatch on the
             // cloned cache will reallocate from the bf16 prefix.
             fused_qk_shadow: None,
+            // Preserve the virtual ceiling across a branch clone so the cloned
+            // cache enforces the same --max-ctx bound on further prefill.
+            max_seq_ceiling: self.max_seq_ceiling,
         })
     }
 
@@ -6133,7 +6160,7 @@ pub(super) fn next_pow2_seq(needed: i32) -> i32 {
 }
 
 /// Read the `max_seq` recorded on whichever `KvStorage` variant is active.
-fn storage_max_seq(storage: &KvStorage) -> i32 {
+pub(super) fn storage_max_seq(storage: &KvStorage) -> i32 {
     match storage {
         KvStorage::K8V4 { max_seq, .. } => *max_seq,
         KvStorage::K8V8 { max_seq, .. } => *max_seq,

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -348,9 +348,8 @@ pub fn generate_greedy(
     // Derive the initial ring size and the virtual ceiling (issue #25):
     // `--max-ctx` is a ceiling the ring grows lazily up to, not an eager
     // allocation. `initial_max_seq` is the small lazy start; `max_seq_ceiling`
-    // caps growth and rejects over-long prompts. `max_seq` keeps its name as
-    // the value the cache is first built with.
-    let (max_seq, max_seq_ceiling) =
+    // caps growth and rejects over-long prompts.
+    let (initial_max_seq, max_seq_ceiling) =
         kv_max_seq_and_ceiling(max_ctx_override, model.cfg.max_position_embeddings as i32);
 
     // ------------------------------------------------------------------
@@ -740,7 +739,7 @@ pub fn generate_greedy(
                         LAYER_ADAPTIVE_TAIL_N,
                         LAYER_ADAPTIVE_HEAD_N,
                     );
-                    KvCache::with_quant_max_seq_window(q, max_seq, window)
+                    KvCache::with_quant_max_seq_window(q, initial_max_seq, window)
                         .with_max_seq_ceiling(max_seq_ceiling)
                         .with_layer_idx(i)
                 })

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -40,10 +40,12 @@ use rmlx_mlx::{argmax, Array, Device, Dtype};
 use tracing::info_span;
 
 use crate::constraint::ConstraintEngine;
-use crate::kv_cache::{kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N};
+use crate::kv_cache::{
+    kv_max_seq_and_ceiling, kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N,
+};
 use crate::prompt_cache::PromptCacheEntry as _;
 use crate::sampler::{apply_mask_argmax, TokenLogprobs};
-use rmlx_kv_quant::{KvCache, KvQuant, KV_MAX_SEQ_DEFAULT};
+use rmlx_kv_quant::{KvCache, KvQuant};
 
 use super::model::Gemma4Text;
 use super::prompt_cache::{ensure_prompt_cache, store_kv_cache_bytes, Gemma4Entry, PROMPT_CACHE};
@@ -343,16 +345,13 @@ pub fn generate_greedy(
         })
     };
 
-    // Derive max_seq (used for cache miss allocation and may be needed in
-    // prefix path for entering prefill).
-    let max_seq = max_ctx_override.unwrap_or_else(|| {
-        let mpe = model.cfg.max_position_embeddings as i32;
-        if mpe <= 0 || mpe > KV_MAX_SEQ_DEFAULT {
-            KV_MAX_SEQ_DEFAULT
-        } else {
-            mpe
-        }
-    });
+    // Derive the initial ring size and the virtual ceiling (issue #25):
+    // `--max-ctx` is a ceiling the ring grows lazily up to, not an eager
+    // allocation. `initial_max_seq` is the small lazy start; `max_seq_ceiling`
+    // caps growth and rejects over-long prompts. `max_seq` keeps its name as
+    // the value the cache is first built with.
+    let (max_seq, max_seq_ceiling) =
+        kv_max_seq_and_ceiling(max_ctx_override, model.cfg.max_position_embeddings as i32);
 
     // ------------------------------------------------------------------
     // Helper: decode loop — shared across exact-hit / prefix-hit / miss paths.
@@ -741,7 +740,9 @@ pub fn generate_greedy(
                         LAYER_ADAPTIVE_TAIL_N,
                         LAYER_ADAPTIVE_HEAD_N,
                     );
-                    KvCache::with_quant_max_seq_window(q, max_seq, window).with_layer_idx(i)
+                    KvCache::with_quant_max_seq_window(q, max_seq, window)
+                        .with_max_seq_ceiling(max_seq_ceiling)
+                        .with_layer_idx(i)
                 })
                 .collect();
             (fresh, prompt_ids, false)

--- a/crates/rmlx-models/src/kv_cache/mod.rs
+++ b/crates/rmlx-models/src/kv_cache/mod.rs
@@ -135,6 +135,55 @@ pub fn kv_quant_for_layer(
     }
 }
 
+/// Resolve `(initial_max_seq, ceiling)` for a request from `--max-ctx`.
+///
+/// This is the shared policy that makes `--max-ctx` a **virtual ceiling**
+/// rather than an eager allocation, fixing the short-prompt decode penalty
+/// (issue #25): a server started with a large `--max-ctx` must serve short
+/// requests at full speed by growing the KV ring lazily up to the ceiling,
+/// not by allocating the whole ceiling up front.
+///
+/// - `initial_max_seq` is what the per-layer `KvCache` is *first* sized to.
+///   It is always the small lazy default ([`rmlx_kv_quant::KV_MAX_SEQ_DEFAULT`]),
+///   capped by the ceiling so a sub-default ceiling is honoured. The codec's
+///   power-of-two grow path ([`KvCache::ensure_prefill_capacity`]) takes it
+///   from there up to the ceiling as the prompt fills.
+/// - `ceiling` is the resolved bound: `min(max_ctx_override, mpe)` when an
+///   override is given, else `min(mpe, KV_MAX_SEQ_DEFAULT)` — the same chain
+///   the server's `effective_max_ctx` uses, so the per-cache ceiling and the
+///   per-request prompt-length guard agree. `mpe <= 0` means the arch does not
+///   expose `max_position_embeddings`; treat it as "unknown" and ignore it.
+///
+/// Wire it in an arch `generate` as:
+/// ```ignore
+/// let (initial_max_seq, ceiling) = kv_max_seq_and_ceiling(max_ctx_override, mpe);
+/// KvCache::with_quant_max_seq(q, initial_max_seq).with_max_seq_ceiling(ceiling)
+/// ```
+#[must_use]
+pub fn kv_max_seq_and_ceiling(max_ctx_override: Option<i32>, mpe: i32) -> (i32, i32) {
+    let default = rmlx_kv_quant::KV_MAX_SEQ_DEFAULT;
+    let ceiling = match max_ctx_override {
+        Some(n) if n > 0 => {
+            if mpe > 0 {
+                n.min(mpe)
+            } else {
+                n
+            }
+        }
+        _ => {
+            if mpe > 0 {
+                mpe.min(default)
+            } else {
+                default
+            }
+        }
+    };
+    // Start the ring at the lazy default, but never above the ceiling (a
+    // sub-default ceiling must not be pre-grown past).
+    let initial_max_seq = default.min(ceiling);
+    (initial_max_seq, ceiling)
+}
+
 // ── KvCacheBuilder ────────────────────────────────────────────────────────────
 
 /// Returns the appropriate `KvQuant` default for a named architecture.

--- a/crates/rmlx-models/src/kv_cache/mod.rs
+++ b/crates/rmlx-models/src/kv_cache/mod.rs
@@ -153,6 +153,9 @@ pub fn kv_quant_for_layer(
 ///   the server's `effective_max_ctx` uses, so the per-cache ceiling and the
 ///   per-request prompt-length guard agree. `mpe <= 0` means the arch does not
 ///   expose `max_position_embeddings`; treat it as "unknown" and ignore it.
+/// - `max_ctx_override = Some(n)` where `n <= 0` is treated as "unset" (falls
+///   through to the arch-default path) and emits a `warn!` event so the caller
+///   can diagnose unexpected zero/negative values from config parsing.
 ///
 /// Wire it in an arch `generate` as:
 /// ```ignore
@@ -170,7 +173,20 @@ pub fn kv_max_seq_and_ceiling(max_ctx_override: Option<i32>, mpe: i32) -> (i32, 
                 n
             }
         }
-        _ => {
+        Some(n) => {
+            // n <= 0: treat as unset; log so the caller can diagnose
+            // unexpected zero/negative values from CLI or config parsing.
+            tracing::warn!(
+                max_ctx_override = n,
+                "max_ctx_override <= 0 treated as unset; using arch default"
+            );
+            if mpe > 0 {
+                mpe.min(default)
+            } else {
+                default
+            }
+        }
+        None => {
             if mpe > 0 {
                 mpe.min(default)
             } else {

--- a/crates/rmlx-models/src/kv_cache/tests.rs
+++ b/crates/rmlx-models/src/kv_cache/tests.rs
@@ -5,8 +5,8 @@
 #[allow(clippy::module_inception)]
 mod tests {
     use super::super::{
-        kv_quant_for_ctx, kv_quant_for_layer, lookup_layer_calibration, KvCacheBuilder,
-        LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N,
+        kv_max_seq_and_ceiling, kv_quant_for_ctx, kv_quant_for_layer, lookup_layer_calibration,
+        KvCacheBuilder, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N,
     };
     use rmlx_kv_quant::kvcache::KvCache;
     use rmlx_kv_quant::storage::KvStorage;
@@ -1704,5 +1704,61 @@ mod tests {
             entry.is_some(),
             "3-component query should match via 3-prefix (guard is < 3, not <= 3)"
         );
+    }
+
+    // ── Issue #25: kv_max_seq_and_ceiling policy ──────────────────────────────
+
+    /// A large `--max-ctx` becomes a ceiling, NOT the initial ring size.
+    ///
+    /// The ring must start at the lazy default while the ceiling carries the
+    /// operator's `--max-ctx` (clamped to mpe). This is the core fix: a 140k
+    /// override on a 262k-mpe model starts the ring at 4096, ceiling 140k.
+    #[test]
+    fn ceiling_large_override_starts_lazy() {
+        let (initial, ceiling) = kv_max_seq_and_ceiling(Some(140_000), 262_144);
+        assert_eq!(initial, KV_MAX_SEQ_DEFAULT, "ring starts at lazy default");
+        assert_eq!(ceiling, 140_000, "ceiling = override (under mpe)");
+    }
+
+    /// `--max-ctx` is clamped to the model's positional capacity.
+    #[test]
+    fn ceiling_override_clamped_to_mpe() {
+        let (initial, ceiling) = kv_max_seq_and_ceiling(Some(500_000), 131_072);
+        assert_eq!(initial, KV_MAX_SEQ_DEFAULT);
+        assert_eq!(ceiling, 131_072, "ceiling never exceeds mpe");
+    }
+
+    /// A sub-default ceiling must also cap the initial ring (don't pre-grow
+    /// past a small ceiling).
+    #[test]
+    fn ceiling_below_default_caps_initial() {
+        let (initial, ceiling) = kv_max_seq_and_ceiling(Some(2048), 131_072);
+        assert_eq!(initial, 2048, "initial capped at the sub-default ceiling");
+        assert_eq!(ceiling, 2048);
+    }
+
+    /// No override: ceiling falls back to `min(mpe, default)`, initial = that.
+    #[test]
+    fn ceiling_no_override_uses_mpe_default_chain() {
+        // mpe above default → clamp to default.
+        let (initial, ceiling) = kv_max_seq_and_ceiling(None, 131_072);
+        assert_eq!(initial, KV_MAX_SEQ_DEFAULT);
+        assert_eq!(ceiling, KV_MAX_SEQ_DEFAULT);
+        // mpe below default → use mpe.
+        let (initial, ceiling) = kv_max_seq_and_ceiling(None, 2048);
+        assert_eq!(initial, 2048);
+        assert_eq!(ceiling, 2048);
+    }
+
+    /// Unknown mpe (arch reports 0) is ignored; override stands alone.
+    #[test]
+    fn ceiling_unknown_mpe_ignored() {
+        let (initial, ceiling) = kv_max_seq_and_ceiling(Some(64_000), 0);
+        assert_eq!(initial, KV_MAX_SEQ_DEFAULT);
+        assert_eq!(ceiling, 64_000, "no mpe clamp when mpe unknown");
+        // No override + unknown mpe → bare default.
+        let (initial, ceiling) = kv_max_seq_and_ceiling(None, 0);
+        assert_eq!(initial, KV_MAX_SEQ_DEFAULT);
+        assert_eq!(ceiling, KV_MAX_SEQ_DEFAULT);
     }
 }

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -2270,10 +2270,10 @@ pub fn generate_greedy(
     let prefill_t0 = Instant::now();
 
     // Derive initial ring size + virtual ceiling (issue #25): `--max-ctx` is a
-    // ceiling the ring grows lazily up to, not an eager allocation. `max_seq`
-    // is the small lazy start; `max_seq_ceiling` caps growth + rejects over-long
-    // prompts.
-    let (max_seq, max_seq_ceiling) =
+    // ceiling the ring grows lazily up to, not an eager allocation.
+    // `initial_max_seq` is the small lazy start; `max_seq_ceiling` caps growth
+    // and rejects over-long prompts.
+    let (initial_max_seq, max_seq_ceiling) =
         kv_max_seq_and_ceiling(max_ctx_override, model.cfg.max_position_embeddings as i32);
 
     // Allocate one KvCache per decoder layer using the selected quant mode.
@@ -2288,7 +2288,7 @@ pub fn generate_greedy(
                 LAYER_ADAPTIVE_TAIL_N,
                 LAYER_ADAPTIVE_HEAD_N,
             );
-            KvCache::with_quant_max_seq(q, max_seq)
+            KvCache::with_quant_max_seq(q, initial_max_seq)
                 .with_max_seq_ceiling(max_seq_ceiling)
                 .with_layer_idx(i)
         })

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -64,13 +64,15 @@ use tracing::{debug, info};
 
 use crate::calibration_sink::CalibrationSink;
 use crate::constraint::ConstraintEngine;
-use crate::kv_cache::{kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N};
+use crate::kv_cache::{
+    kv_max_seq_and_ceiling, kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N,
+};
 use crate::prompt_cache::{
     chained_block_hashes_seeded, ArchPromptCache, PromptCacheEntry, ReusePolicy, SpillSink,
     SsdHydrate, BLOCK_TOKENS, FNV_OFFSET,
 };
 use crate::sampler::{apply_mask_argmax, TokenLogprobs};
-use rmlx_kv_quant::{KvCache, KvQuant, KV_MAX_SEQ_DEFAULT};
+use rmlx_kv_quant::{KvCache, KvQuant};
 use rmlx_kv_ssd::{HydratedBlock, SpillJob, SsdHydrator, SsdSpiller};
 
 /// capture top-`k` logprobs for an already-chosen token.
@@ -2267,15 +2269,12 @@ pub fn generate_greedy(
     // Path B (Miss): full re-prefill from scratch.
     let prefill_t0 = Instant::now();
 
-    // Derive max_seq: user override wins; otherwise derive from mpe, capped at KV_MAX_SEQ_DEFAULT.
-    let max_seq = max_ctx_override.unwrap_or_else(|| {
-        let mpe = model.cfg.max_position_embeddings as i32;
-        if mpe <= 0 || mpe > KV_MAX_SEQ_DEFAULT {
-            KV_MAX_SEQ_DEFAULT
-        } else {
-            mpe
-        }
-    });
+    // Derive initial ring size + virtual ceiling (issue #25): `--max-ctx` is a
+    // ceiling the ring grows lazily up to, not an eager allocation. `max_seq`
+    // is the small lazy start; `max_seq_ceiling` caps growth + rejects over-long
+    // prompts.
+    let (max_seq, max_seq_ceiling) =
+        kv_max_seq_and_ceiling(max_ctx_override, model.cfg.max_position_embeddings as i32);
 
     // Allocate one KvCache per decoder layer using the selected quant mode.
     // Force K8V8 for boundary layers (first head_n + last tail_n).
@@ -2289,7 +2288,9 @@ pub fn generate_greedy(
                 LAYER_ADAPTIVE_TAIL_N,
                 LAYER_ADAPTIVE_HEAD_N,
             );
-            KvCache::with_quant_max_seq(q, max_seq).with_layer_idx(i)
+            KvCache::with_quant_max_seq(q, max_seq)
+                .with_max_seq_ceiling(max_seq_ceiling)
+                .with_layer_idx(i)
         })
         .collect();
 

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -30,9 +30,11 @@ use rmlx_core::error::Result;
 use rmlx_mlx::{argmax, Array, Device, Dtype};
 
 use crate::constraint::ConstraintEngine;
-use crate::kv_cache::{kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N};
+use crate::kv_cache::{
+    kv_max_seq_and_ceiling, kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N,
+};
 use crate::sampler::{apply_mask_argmax, TokenLogprobs};
-use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache, KV_MAX_SEQ_DEFAULT};
+use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 
 use super::model::Qwen3_5MoeText;
 use super::prompt_cache::{
@@ -914,14 +916,11 @@ pub fn generate_greedy(
         return Ok(steps);
     }
 
-    let max_seq = max_ctx_override.unwrap_or_else(|| {
-        let mpe = model.cfg.max_position_embeddings as i32;
-        if mpe <= 0 || mpe > KV_MAX_SEQ_DEFAULT {
-            KV_MAX_SEQ_DEFAULT
-        } else {
-            mpe
-        }
-    });
+    // Issue #25: `--max-ctx` is a virtual ceiling the KV ring grows lazily up
+    // to, not an eager allocation. `max_seq` is the lazy start; `max_seq_ceiling`
+    // caps growth and rejects over-long prompts.
+    let (max_seq, max_seq_ceiling) =
+        kv_max_seq_and_ceiling(max_ctx_override, model.cfg.max_position_embeddings as i32);
     // 64-token chunks keep GDN ts < 256 threshold → sequential MSL kernel, no lazy graph explosion.
     // 2048-token chunks (e0231a4) trigger gated_delta_prefill_ops at ts=2048 → ~1.47M lazy nodes
     // across 30 GDN layers → Metal GPU watchdog timeout.
@@ -960,7 +959,9 @@ pub fn generate_greedy(
                 LAYER_ADAPTIVE_TAIL_N,
                 LAYER_ADAPTIVE_HEAD_N,
             );
-            KvCache::with_quant_max_seq(q, max_seq).with_layer_idx(i)
+            KvCache::with_quant_max_seq(q, max_seq)
+                .with_max_seq_ceiling(max_seq_ceiling)
+                .with_layer_idx(i)
         })
         .collect();
     let mut lin_caches: Vec<LinearAttnCache> = (0..model.cfg.num_hidden_layers)

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -917,9 +917,9 @@ pub fn generate_greedy(
     }
 
     // Issue #25: `--max-ctx` is a virtual ceiling the KV ring grows lazily up
-    // to, not an eager allocation. `max_seq` is the lazy start; `max_seq_ceiling`
-    // caps growth and rejects over-long prompts.
-    let (max_seq, max_seq_ceiling) =
+    // to, not an eager allocation. `initial_max_seq` is the lazy start;
+    // `max_seq_ceiling` caps growth and rejects over-long prompts.
+    let (initial_max_seq, max_seq_ceiling) =
         kv_max_seq_and_ceiling(max_ctx_override, model.cfg.max_position_embeddings as i32);
     // 64-token chunks keep GDN ts < 256 threshold → sequential MSL kernel, no lazy graph explosion.
     // 2048-token chunks (e0231a4) trigger gated_delta_prefill_ops at ts=2048 → ~1.47M lazy nodes
@@ -959,7 +959,7 @@ pub fn generate_greedy(
                 LAYER_ADAPTIVE_TAIL_N,
                 LAYER_ADAPTIVE_HEAD_N,
             );
-            KvCache::with_quant_max_seq(q, max_seq)
+            KvCache::with_quant_max_seq(q, initial_max_seq)
                 .with_max_seq_ceiling(max_seq_ceiling)
                 .with_layer_idx(i)
         })

--- a/crates/rmlx-server/src/retry.rs
+++ b/crates/rmlx-server/src/retry.rs
@@ -144,6 +144,10 @@ pub fn classify(err: &RmlxError) -> RetryClass {
         // request is structurally too large for the current process limits;
         // replaying would hit the same cap. Fatal.
         RmlxError::KvHardCapExceeded { .. } => RetryClass::Fatal,
+        // KV prefill request above the resolved `--max-ctx` virtual ceiling.
+        // The prompt exceeds the operator-declared context bound; replaying
+        // would hit the same ceiling. Fatal (same class as the hard cap).
+        RmlxError::KvCeilingExceeded { .. } => RetryClass::Fatal,
         // Non-exhaustive catch-all: future variants default to Fatal.
         _ => RetryClass::Fatal,
     }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -71,7 +71,7 @@ mutually exclusive.
 | `--cache-type-v` / `--ctv` | string | — | Per-side codec for the V (value) tensor. Mutually exclusive with `--kv-quant`. |
 | `--kv-bits` | float | — | Bit-width alias (integer or fractional, e.g. `4`, `3.5`). Mutually exclusive with `--kv-quant` and `--cache-type-*`. See KV-bits mapping below. |
 | `--kv-group-size` | usize | 64 | Group size for `--kv-bits`. Requires `--kv-bits`. |
-| `--max-ctx` | u32 | (from model) | KV cache buffer token capacity. Derives from `max_position_embeddings` capped at 4096 when unset. Must be ≥ 256 when set. |
+| `--max-ctx` | u32 | (from model) | **Virtual ceiling** on context length, in tokens — NOT an eager allocation. The KV ring starts small (`KV_MAX_SEQ_DEFAULT = 4096`) and grows lazily up to this ceiling as the prompt fills; prompts over the ceiling are rejected. Short requests on a large-`--max-ctx` server thus decode at full speed (no long-context working-set tax — see `docs/KV_CACHE.md` §4.6). Derives from `max_position_embeddings` capped at 4096 when unset. Must be ≥ 256 when set. |
 | `--idle-timeout-secs` | string | `15m` | Idle time before the model is unloaded. Accepts an integer count of seconds (`30`, `900`) OR a Go-style duration (`30s`, `15m`, `2h`, `24h`). Negative (`-1`) pins the model forever; `0` unloads after each response. Per-request override on **native** routes only (`POST /v1/models/{id}/load` body field `keep_alive`); OpenAI/Anthropic compat routes do not parse the field but still reset the timer on use. **Interaction with the single-MLX claim file:** the timer never bypasses the claim — when TTL fires it unloads the slot in-process; the cross-process claim file (`/tmp/rmlx.<port>.claim`) remains held for the lifetime of the `rmlx serve` process. |
 | `--prompt-cache-slots` | usize | 4 | Number of prompt-cache slots for multi-slot prefix matching. Set to `1` for legacy single-slot exact-match behaviour. |
 | `--draft-model` | path | — | Path to a draft model for speculative decoding. Requires `--draft-kind`. |
@@ -192,7 +192,7 @@ rmlx chat --model /path/to/snapshot --device cpu --kv-quant k8v4
 | `--cache-type-v` / `--ctv` | string | — | Per-side V codec. Mutually exclusive with `--kv-quant`. |
 | `--kv-bits` | float | — | Bit-width alias. Mutually exclusive with `--kv-quant` and `--cache-type-*`. |
 | `--kv-group-size` | usize | 64 | Group size for `--kv-bits`. Requires `--kv-bits`. |
-| `--max-ctx` | u32 | (from model) | KV cache buffer token capacity. Must be ≥ 256 when set. |
+| `--max-ctx` | u32 | (from model) | **Virtual ceiling** on context length, in tokens (not an eager allocation): the KV ring grows lazily up to it, prompts over it are rejected. See `docs/KV_CACHE.md` §4.6. Must be ≥ 256 when set. |
 
 ---
 
@@ -219,7 +219,7 @@ rmlx info --model /path/to/snapshot --probe-smoke
 | `--cache-type-v` / `--ctv` | string | — | Per-side V codec. Mutually exclusive with `--kv-quant`. |
 | `--kv-bits` | float | — | Bit-width alias. Mutually exclusive with `--kv-quant` and `--cache-type-*`. |
 | `--kv-group-size` | usize | 64 | Group size for `--kv-bits`. |
-| `--max-ctx` | u32 | (from model) | KV cache buffer token capacity. Must be ≥ 256 when set. |
+| `--max-ctx` | u32 | (from model) | **Virtual ceiling** on context length, in tokens (not an eager allocation): the KV ring grows lazily up to it, prompts over it are rejected. See `docs/KV_CACHE.md` §4.6. Must be ≥ 256 when set. |
 | `--list-cache-types` | bool flag | off | Print the full §D1 KV codec table and exit. No model load. |
 
 ---

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -155,9 +155,10 @@ rejected as `UnsupportedCombo`. `q2_g64` is V-side only and pure 2-bit K is
 
 Prefill chunks accumulate into a per-layer `[B, kv_h, max_seq, head_dim]`
 raw buffer (`KvCache::prefill_raw_k/v`) before quantisation in
-`exit_prefill`. The initial `max_seq` comes from the model's
-`max_position_embeddings` or, when absent, `KV_MAX_SEQ_DEFAULT = 4096`
-(see `crates/rmlx-kv-quant/src/quant.rs`).
+`exit_prefill`. The **initial** `max_seq` is always the small lazy default
+`KV_MAX_SEQ_DEFAULT = 4096` (capped at the ceiling — see §4.6), regardless of
+`--max-ctx`; the buffer grows from there to fit the prompt. The grow path
+(below) takes it up to the resolved `--max-ctx` ceiling.
 
 Before this fix the buffer was sized once at cache construction and never
 grew. If a prompt exceeded `max_seq`, the chunked-prefill loop wrote at
@@ -173,7 +174,9 @@ at the top of every call. When `needed_seq > storage.max_seq`:
 
 1. Allocate a fresh `[B, kv_h, new_max_seq, head_dim]` buffer where
    `new_max_seq = next_pow2_seq(needed_seq)` (power-of-two ≥ needed,
-   clamped to `2^30`).
+   clamped to `2^30`). When a virtual ceiling is set (§4.6), the doubled
+   size is additionally clamped down to the ceiling, so the ring never
+   allocates past `--max-ctx`.
 2. Copy the filled prefix `[..prev_offset]` from the old buffer into
    the new one with `slice_update`.
 3. Bump `max_seq` on the active `KvStorage` variant so the downstream
@@ -200,6 +203,47 @@ on the prefill sequence length. When set to a positive integer:
 
 The env var is resolved once at process start (`OnceLock`); changes
 during the process lifetime are ignored.
+
+## 4.6 `--max-ctx` is a virtual ceiling (lazy grow)
+
+`--max-ctx N` is a **virtual ceiling**, not an eager allocation. Both
+`rmlx serve` and `rmlx baseline` start the KV ring at the lazy default
+(`KV_MAX_SEQ_DEFAULT = 4096`, capped at the ceiling) and grow it by the
+power-of-two policy above **up to** the ceiling as the prompt fills. A short
+request on a server started with a large `--max-ctx` therefore pays only for
+what it fills — it does **not** carry a multi-GB-to-tens-of-GB resident KV
+cache sized to the ceiling.
+
+> **Why this matters (issue #25).** Decode speed tracks the *allocated* ring
+> capacity, not the *filled* length: an oversized resident KV sitting next to
+> the weights starves decode bandwidth/locality. Eagerly sizing the ring to
+> `--max-ctx` cost short requests ~20-25% decode TPS (e.g. gemma-4-e2b 4k:
+> ~95 TPS oversized vs ~117 TPS right-sized). Lazy grow removes the tax; the
+> only cost is an occasional realloc+copy when a request crosses a doubling
+> boundary (amortised O(1), rare).
+
+### Mechanism
+
+* The resolved ceiling is `min(--max-ctx, max_position_embeddings)` when an
+  override is given, else `min(max_position_embeddings, KV_MAX_SEQ_DEFAULT)`.
+  Computed once per request by `rmlx_models::kv_cache::kv_max_seq_and_ceiling`,
+  which returns `(initial_max_seq, ceiling)`. This is the same chain the
+  server's `effective_max_ctx` uses for the per-request prompt-length guard,
+  so cache ceiling and request guard agree.
+* The ceiling is recorded on each `KvCache` via
+  `KvCache::with_max_seq_ceiling(ceiling)` (field `max_seq_ceiling`). It is
+  preserved across branch clones (`try_deep_clone`).
+* `ensure_prefill_capacity` rejects a prefill that needs more than the
+  ceiling with `Error::KvCeilingExceeded { requested, ceiling }` **before**
+  any allocation, and clamps grown allocations to the ceiling. The server
+  route additionally rejects over-long prompts up front
+  (`effective_max_ctx_for`), so this engine-level guard is defense-in-depth
+  (and the sole guard for the CLI `baseline`/`chat` paths).
+* `ceiling <= 0` means "no ceiling" — unbounded lazy grow (bounded only by
+  `RMLX_KV_MAX_SEQ_HARD_CAP` / unified memory).
+
+SWA / rotating layers are unaffected: their bf16 ring is sized to the
+`sliding_window`, never to `max_seq`, so they carry no long-context tax.
 
 ## 5. Hard invariants
 


### PR DESCRIPTION
## Summary

Fixes #25. `rmlx serve --max-ctx N` no longer eagerly allocates the per-layer KV ring to `N`. `--max-ctx` is now a **virtual ceiling**: the prefill ring starts at the lazy default (4096) and grows by power-of-two doubling up to the ceiling, matching what `rmlx baseline` already did. Over-ceiling prompts are rejected cleanly. Removes the ~20-25% short-prompt decode penalty that oversized-`--max-ctx` servers paid.

## Root cause

Each arch's `generate` passed `max_ctx_override.unwrap_or(default)` straight into `KvCache::with_quant_max_seq[_window]`, so serve (`--max-ctx 140000`) allocated `prefill_raw_k/v` as `[B,kv_h,140000,head_dim]` on first prefill and the lazy grow path never fired. The attention read already slices to the filled `new_offset`, so the penalty was working-set / memory-bandwidth pressure from the oversized resident ring.

## Changes

- `rmlx-kv-quant`: `KvCache.max_seq_ceiling` + `with_max_seq_ceiling()`; `ensure_prefill_capacity` rejects over-ceiling prefill and clamps grown size to the ceiling; ceiling preserved across `try_deep_clone`.
- `rmlx-models`: shared policy helper `kv_max_seq_and_ceiling(max_ctx_override, mpe)`; wired into Gemma4 / Qwen3 (Bonsai) / Qwen3.5-MoE (Qwen3.6) generate paths.
- `rmlx-core`: `Error::KvCeilingExceeded`; `rmlx-server` retry classifies it `Fatal`.
- Docs: `docs/KV_CACHE.md` §4.6 (virtual-ceiling / lazy-grow), `docs/CLI.md` `--max-ctx` rows.

## Real-model proof (gemma-4-e2b-it-mxfp8, kv=none)

| path | max_ctx | decode TPS |
|---|---|---|
| oversized (before fix) | 140000 | ~95 |
| oversized (after fix) | 140000 | **133.0** |
| right-sized | 6144 | 129.6 |

Grow trace on oversized server: `KV prefill buffer grow from=4096 to=8192 needed_seq=4608` (lazy, not eager 140000). Over-ceiling prompt (8329 tok, ceiling 6144) → `HTTP 400 context_length_exceeded`.

## Tests

New `prefill_grow_tests.rs` (lazy-start, ceiling-clamp, over-ceiling reject, unbounded) + `kv_cache` policy tests (override/mpe/unknown-mpe branches). Full workspace: 806 pass. `make lint` / `make build` / `make fmt-check` clean.

## Scope note

Wired for the three test-target families (Gemma4, Qwen3/Bonsai, Qwen3.5-MoE). Other archs keep prior eager behavior (additive change, gated on `max_seq_ceiling.is_some()`) — low-risk follow-up to extend. Ceiling reject is enforced on global-attention layers; rotating SWA layers are window-bounded (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)