### PR TITLE
fix(gemma4-spec): assistant drafter SDPA uses array mask mode, not invalid "additive" (#24)

### DIFF
--- a/crates/rmlx-mlx/src/fast_ops.rs
+++ b/crates/rmlx-mlx/src/fast_ops.rs
@@ -265,13 +265,16 @@ pub fn rope_with_freqs(
 /// `scale`: 1/sqrt(head_dim) or 1.0 (Gemma4 uses 1.0).
 /// `mask`: optional causal mask array (bf16 or f32 additive mask) or None.
 ///
-/// `mask_mode`: MLX's string hint for mask type.
+/// `mask_mode`: MLX's string hint for mask type. mlx-c accepts ONLY these
+/// values (the Metal kernel rejects anything else, incl. `"additive"`):
 /// - `"causal"`: use internal causal masking (fastest).
-/// - `"additive"`: caller supplies an additive mask in `mask_arr`.
+/// - `"array"`: caller supplies an explicit mask in `mask_arr` — an additive
+///   bias (0 = allowed, large-negative = masked) whose dtype promotes with
+///   Q/K/V. This is how additive / sliding-window masks are passed.
 /// - `""` (empty): no mask.
 ///
-/// When mask_mode is "causal", `mask_arr` is ignored. When "additive", `mask_arr`
-/// must be a valid array.
+/// When mask_mode is `"causal"` or `""`, `mask_arr` is ignored. When `"array"`,
+/// `mask_arr` must be a valid array.
 ///
 /// Wraps `mlx_fast_scaled_dot_product_attention`.
 pub fn scaled_dot_product_attention(

--- a/crates/rmlx-models/src/speculative/gemma4_assistant.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant.rs
@@ -39,7 +39,9 @@
 //! Unbatched, B=1, greedy (temp=0). Stochastic temp>0 is deferred (the host
 //! sampler slots in at the round-loop level - ). Full-attention masks
 //! are `None` (B=1 no-padding); sliding-attention layers get an additive
-//! bidirectional-window bias when the verifier KV exceeds the window. The
+//! bidirectional-window bias (passed via mlx-c SDPA `"array"` mode, matching
+//! the verifier SWA path — there is no `"additive"` mode) when the verifier KV
+//! exceeds the window. The
 //! `position_ids` are held constant across draft steps (`query_offset =
 //! kv_offset`), mirroring `draft_block`'s single-position multi-token generator.
 
@@ -233,10 +235,12 @@ impl Gemma4AssistantDrafter {
             }
         };
 
-        let (mode, mask_arr) = match mask {
-            Some(m) => ("additive", Some(m)),
-            None => ("", None),
-        };
+        // mlx-c SDPA accepts only "causal" / "array" / "" for mask_mode; the
+        // additive window-bias mask is supplied via "array" with the bias as
+        // mask_arr (mirrors the verifier SWA path in gemma4::layers, NOT a
+        // distinct "additive" mode string — that value is rejected by the
+        // Metal kernel, see fast_ops::scaled_dot_product_attention docs).
+        let (mode, mask_arr) = swa_sdpa_mode(mask);
         let attn = scaled_dot_product_attention(&q, sk, sv, 1.0, mode, mask_arr, self.device)?;
         let attn = attn.transpose(&[0, 2, 1, 3], self.device)?;
         let attn = attn.reshape(&[1, 1, (self.n_heads * layer.head_dim) as i32], self.device)?;
@@ -314,20 +318,38 @@ impl Gemma4AssistantDrafter {
         if kv_len <= window && q_off < window && (kv_len - (q_off + query_len)) < window {
             return Ok(None);
         }
+        // Masked cells use -1e30 (not f32::NEG_INFINITY) to match the verifier
+        // SWA mask builders (crate::layers::build_swa_*): a fully-masked softmax
+        // row over -inf yields NaN, whereas a large finite penalty stays well-
+        // conditioned. The bias is converted to Bf16 below so its dtype promotes
+        // with the bf16 Q/K/V (mlx-c SDPA "array" mode requires this).
         let mut bias = vec![0.0f32; (query_len * kv_len) as usize];
         for qi in 0..query_len {
             let q = q_off + qi;
             for ki in 0..kv_len {
                 let dist = q - ki;
                 if !(dist > -window && dist < window) {
-                    bias[(qi * kv_len + ki) as usize] = f32::NEG_INFINITY;
+                    bias[(qi * kv_len + ki) as usize] = -1e30;
                 }
             }
         }
         let bytes =
             unsafe { std::slice::from_raw_parts(bias.as_ptr().cast::<u8>(), bias.len() * 4) };
         let arr = Array::from_bytes(bytes, &[1, 1, query_len, kv_len], Dtype::F32)?;
-        Ok(Some(arr))
+        Ok(Some(arr.astype(Dtype::Bf16, self.device)?))
+    }
+}
+
+/// Select the mlx-c SDPA `(mask_mode, mask_arr)` for a drafter attention layer.
+///
+/// The additive window-bias mask (when present) goes through the `"array"`
+/// mode — mlx-c rejects a bespoke `"additive"` mode string (valid values are
+/// `"causal"`, `"array"`, `""`). `None` (full-attention or window-covers-all)
+/// uses the empty mode. Verifier-faithful: see `gemma4::layers::build_attn_mask`.
+fn swa_sdpa_mode(mask: Option<&Array>) -> (&'static str, Option<&Array>) {
+    match mask {
+        Some(m) => ("array", Some(m)),
+        None => ("", None),
     }
 }
 
@@ -887,3 +909,7 @@ fn slice_kv_len(kv: &(Array, Array), keep: i32, device: Device) -> Result<(Array
     };
     Ok((do_slice(&kv.0)?, do_slice(&kv.1)?))
 }
+
+#[cfg(test)]
+#[path = "gemma4_assistant_tests.rs"]
+mod tests;

--- a/crates/rmlx-models/src/speculative/gemma4_assistant_tests.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant_tests.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+// ---------------------------------------------------------------------------
+// Mask-mode selection (issue #24: "additive" is NOT a valid mlx-c mode).
+// ---------------------------------------------------------------------------
+
+/// The mlx-c Metal SDPA kernel accepts only these mask_mode strings. A drafter
+/// layer must never emit anything else (the old "additive" string aborted every
+/// decode step).
+const KERNEL_ACCEPTED_MODES: [&str; 3] = ["causal", "array", ""];
+
+#[test]
+fn windowed_layer_uses_array_mode() {
+    // A present window-bias mask routes through "array" (NOT "additive").
+    let bias = make_bias();
+    let (mode, arr) = swa_sdpa_mode(Some(&bias));
+    assert_eq!(mode, "array");
+    assert!(arr.is_some());
+    assert!(KERNEL_ACCEPTED_MODES.contains(&mode));
+}
+
+#[test]
+fn global_or_covered_layer_uses_empty_mode() {
+    // Full-attention layers (and sliding layers whose window covers all KV)
+    // pass no mask: empty mode, no array.
+    let (mode, arr) = swa_sdpa_mode(None);
+    assert_eq!(mode, "");
+    assert!(arr.is_none());
+    assert!(KERNEL_ACCEPTED_MODES.contains(&mode));
+}
+
+#[test]
+fn no_additive_mode_ever_emitted() {
+    // Regression guard for issue #24: neither branch may select "additive".
+    let bias = make_bias();
+    for m in [swa_sdpa_mode(Some(&bias)).0, swa_sdpa_mode(None).0] {
+        assert_ne!(
+            m, "additive",
+            "issue #24: mlx-c rejects mask_mode 'additive'"
+        );
+        assert!(KERNEL_ACCEPTED_MODES.contains(&m));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Window-bias values — pure mirror of build_swa_mask's banded loop.
+// ---------------------------------------------------------------------------
+
+/// Pure mirror of the additive bidirectional-window bias built in
+/// `build_swa_mask`. Locks the value convention: 0.0 in-window, -1e30 out of
+/// window (NOT f32::NEG_INFINITY — a fully-masked softmax row over -inf is NaN,
+/// matching the verifier `crate::layers::build_swa_*` builders).
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bias sized query_len*kv_len; (qi,ki) loop bounds keep the index in range"
+)]
+fn window_bias(q_off: i32, query_len: i32, kv_len: i32, window: i32) -> Vec<f32> {
+    let mut bias = vec![0.0f32; (query_len * kv_len) as usize];
+    for qi in 0..query_len {
+        let q = q_off + qi;
+        for ki in 0..kv_len {
+            let dist = q - ki;
+            if !(dist > -window && dist < window) {
+                bias[(qi * kv_len + ki) as usize] = -1e30;
+            }
+        }
+    }
+    bias
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "test fixture: tiny constant-shape array, failure is a test bug"
+)]
+fn make_bias() -> Array {
+    let data = window_bias(0, 1, 4, 2);
+    let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), data.len() * 4) };
+    Array::from_bytes(bytes, &[1, 1, 1, 4], Dtype::F32).expect("bias array")
+}
+
+// Exact bit-pattern compare avoids the float_cmp lint while still asserting
+// the precise constants the kernel sees (these cells are assigned literals).
+fn allowed(v: f32) -> bool {
+    v.to_bits() == 0.0f32.to_bits()
+}
+fn masked(v: f32) -> bool {
+    v.to_bits() == (-1e30f32).to_bits()
+}
+
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "fixed-shape bias [1,1,1,6]; indices are in-bounds by construction"
+)]
+fn bias_masks_outside_window_with_finite_penalty() {
+    // window=2, query at offset 5, kv_len 6: keys within (q-window, q+window)
+    // exclusive are allowed (0.0), the rest get -1e30.
+    let bias = window_bias(5, 1, 6, 2);
+    // q=5: dist = 5-ki. allowed when -2 < dist < 2 => ki in {4,5} (dist 1,0).
+    assert!(allowed(bias[4]));
+    assert!(allowed(bias[5]));
+    // ki=3 -> dist 2 (not < window) => masked. ki=0 far past => masked.
+    assert!(masked(bias[3]));
+    assert!(masked(bias[0]));
+    // No -inf / NaN anywhere (NaN-avoidance invariant vs f32::NEG_INFINITY).
+    assert!(bias.iter().all(|v| v.is_finite()));
+}
+
+#[test]
+fn bias_all_allowed_when_window_covers_kv() {
+    // window large enough to cover every key => all-zero bias.
+    let bias = window_bias(0, 1, 4, 64);
+    assert!(bias.iter().all(|v| allowed(*v)));
+}

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -333,7 +333,12 @@ Per draft step:
    verifier hidden width and `D` is the draft hidden width).
 4. Run the 4-layer decoder stack using the shared K/V from the verifier's most
    recent forward pass. Sliding layers receive an additive bidirectional-window
-   bias mask when the KV length exceeds the sliding window.
+   bias mask when the KV length exceeds the sliding window. That bias is passed
+   to SDPA via mlx-c's `"array"` mask mode (masked cells use a large finite
+   penalty `-1e30`, bias cast to the bf16 Q/K/V dtype) — the same convention as
+   the verifier SWA path (`gemma4::layers::build_attn_mask`). mlx-c does **not**
+   accept an `"additive"` mode string; using it aborts every decode step
+   (fixed, issue #24).
 5. Apply `norm` (final RMSNorm), then `post_projection` (`D -> B`) to produce
    the `last_hidden` for the next step.
 6. Pick the next token via the **centroid-routed sparse LM head**


### PR DESCRIPTION
## Summary

Fixes #24. The Gemma4 assistant speculative drafter crashed on **every** decode step: its sliding-window attention passed `mask_mode = "additive"` to `scaled_dot_product_attention`, which the mlx-c Metal SDPA kernel rejects (`mask_mode must be 'causal', 'array' or ''`). TTFT was produced but **0 decode tokens** — Gemma4 speculative decode was unusable.

## Root cause

`crates/rmlx-models/src/speculative/gemma4_assistant.rs` selected the literal mode string `"additive"` for windowed layers. mlx-c accepts only `causal` / `array` / `''`; the additive window-bias must be supplied via `array` mode with the bias as the mask array. The non-draft verifier path already does exactly this.

## Fix

- `swa_sdpa_mode` helper routes the window-bias through `("array", Some(mask))` for windowed layers and `("", None)` for single-query global-attention decode (matches the verifier's `pick_attn_mask_mode`).
- Masked fill value `f32::NEG_INFINITY` → `-1e30` cast to bf16 — byte-identical to the verifier mask builders (`layers/mask.rs`), NaN-safe, dtype-promotes cleanly with bf16 Q/K/V.
- Corrected the false `"additive"` claim in the SDPA FFI docstring (`crates/rmlx-mlx/src/fast_ops.rs`).

## Real-model proof (e2b verifier + E2B-it-assistant-bf16 draft)

- Before: 0 decode tokens, `scaled_dot_product_attention: Invalid mask_mode additive` on first decode.
- After: **24 / 26 decode tokens**, coherent output, HTTP 200, `grep -c additive` on server log = 0. accept_rate 0.18, TTFT 93 ms, ~71 end-to-end TPS through the spec loop.

(Low accept_rate is a separate draft-quality/block-size question, out of scope here — the path now decodes correctly.)

## Tests

New `gemma4_assistant_tests.rs` (sibling, no inline mod): mask-mode selection windowed vs global + bias-value convention. `make build` / `make lint` (clippy -D warnings) / `cargo fmt` clean.

## Docs

`docs/SPECULATIVE.md` Gemma4-assistant step corrected to array-mode SWA mask; FFI docstring corrected.

Related: #23 (two-model dispatch misroute — independent, addressed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)