### PR TITLE
fix(speculative): route --draft-kind mtp by draft arch family, reject plain-gemma4 cleanly (#23)

### DIFF
--- a/crates/rmlx-core/src/error.rs
+++ b/crates/rmlx-core/src/error.rs
@@ -131,6 +131,21 @@ pub enum Error {
         /// The configured virtual ceiling (in tokens), from `--max-ctx`.
         ceiling: i32,
     },
+
+    /// A `--draft-model` + `--draft-kind` combination is structurally
+    /// unsupported. Raised at load (before first inference) when the draft
+    /// model's detected architecture family cannot back the requested draft
+    /// kind — e.g. a plain `Gemma4ForConditionalGeneration` snapshot passed
+    /// with `--draft-kind mtp`, which has no MTP sidecar head and is not the
+    /// dedicated Gemma4 assistant drafter. The message names the detected
+    /// family and the correct alternative so the operator can fix the flags
+    /// instead of seeing an unrelated loader error leak from the wrong path.
+    #[error("unsupported speculative pairing: {reason}")]
+    SpeculativePairing {
+        /// Human-readable explanation naming the detected draft arch and the
+        /// correct alternative (e.g. the required assistant snapshot).
+        reason: String,
+    },
 }
 
 /// The allocation phase in which an [`Error::Oom`] was raised.

--- a/crates/rmlx-server/src/engine/speculative.rs
+++ b/crates/rmlx-server/src/engine/speculative.rs
@@ -24,6 +24,61 @@ use super::helpers::{
 use super::think::ThinkSplitter;
 use super::types::{GenerationRequest, GenerationToken, ModelLoadConfig};
 
+// ── MTP draft dispatch ────────────────────────────────────────────────────────
+
+/// Which drafter loader an `--draft-kind mtp` draft model routes to, decided by
+/// the draft's detected architecture family (never a substring leak).
+///
+/// `--draft-kind mtp` historically fronted two structurally different loaders:
+/// the Qwen3.5-MoE MTP sidecar head (`MtpDrafter`) and the Gemma4 assistant
+/// drafter (`Gemma4AssistantDrafter`). A draft whose family backs neither must
+/// be rejected at load — see issue #23: a plain `Gemma4ForConditionalGeneration`
+/// snapshot used to fall through to the Qwen3.5 sidecar loader and leak a
+/// confusing `text_config missing num_experts` error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MtpDraftFamily {
+    /// Dedicated Gemma4 assistant drafter snapshot (`gemma4_assistant`).
+    Gemma4Assistant,
+    /// Qwen3.5-MoE MTP sidecar head (`qwen3_5_mtp`).
+    Qwen35Mtp,
+    /// Family that cannot back an MTP draft — reject with a typed error.
+    Unsupported,
+}
+
+/// Classify an `--draft-kind mtp` draft by its `architectures[0]` and
+/// `model_type`. Both fields are checked because mlx-community snapshots set the
+/// family on one or the other depending on the export tool.
+fn classify_mtp_draft(arch: &str, model_type: &str) -> MtpDraftFamily {
+    if model_type == "gemma4_assistant" || arch.contains("Gemma4Assistant") {
+        MtpDraftFamily::Gemma4Assistant
+    } else if model_type == "qwen3_5_mtp" || arch == "qwen3_5_mtp" {
+        MtpDraftFamily::Qwen35Mtp
+    } else {
+        MtpDraftFamily::Unsupported
+    }
+}
+
+/// Build the actionable rejection message for an unsupported MTP draft family.
+/// A plain Gemma4 model gets a family-specific hint pointing at the assistant
+/// snapshot; everything else gets the generic "no MTP sidecar for this family"
+/// message. Never leaks the Qwen3.5 loader's internal error.
+fn mtp_reject_reason(arch: &str, model_type: &str) -> String {
+    if arch.contains("Gemma4") || model_type.contains("gemma4") {
+        format!(
+            "draft model architecture '{arch}' is a plain Gemma4 model, which has no MTP sidecar \
+             head and cannot be used with --draft-kind mtp; a Gemma4 MTP draft requires the \
+             dedicated Gemma4 assistant snapshot (e.g. *-it-assistant-bf16), not a plain \
+             Gemma4ForConditionalGeneration checkpoint"
+        )
+    } else {
+        format!(
+            "draft model architecture '{arch}' (model_type '{model_type}') is not a supported \
+             --draft-kind mtp family; MTP supports the Qwen3.5-MoE sidecar head (qwen3_5_mtp) and \
+             the Gemma4 assistant drafter (gemma4_assistant)"
+        )
+    }
+}
+
 // ── SpeculativeGenerator ──────────────────────────────────────────────────────
 
 /// Generator backed by a (verifier, draft) pair under
@@ -201,92 +256,102 @@ impl SpeculativeGenerator {
         // real checkpoint — reuse the verifier snapshot for the dispatcher's
         // draft slot so the struct is valid and the legacy two-model spec path
         // still serves. The MTP loop, when enabled, ignores that draft slot.
-        let (dispatcher, mtp_drafter, mtp_assistant, dflash_drafter, eagle3_drafter) =
-            if matches!(draft_kind, Some(rmlx_models::DraftKind::Eagle3)) {
-                // the `--draft-model` is a standalone EAGLE-3 drafter (not
-                // a full model), so it cannot go through `load_speculative`. Load
-                // the verifier once for the dispatcher, the EAGLE-3 drafter
-                // separately, and reuse the verifier snapshot for the dispatcher's
-                // draft slot so the struct is valid (the EAGLE-3 round-loop ignores
-                // it).
-                tracing::info!(
-                    draft = %draft_dir.display(),
-                    "SpeculativeGenerator: EAGLE-3 drafter — loading drafter"
-                );
-                let dispatcher = rmlx_models::SpeculativeDispatcher::load_speculative(
-                    verifier_dir,
-                    verifier_dir,
-                    device,
-                )?;
-                let hidden_size = dispatcher.verifier.hidden_size();
-                let vocab_size = dispatcher.verifier.vocab_size();
-                let drafter = rmlx_models::speculative::eagle3::Eagle3Drafter::load(
-                    draft_dir,
-                    hidden_size,
-                    vocab_size,
-                    &eos_ids,
-                    device,
-                )?;
-                (
-                    dispatcher,
-                    None,
-                    None,
-                    None,
-                    Some(Arc::new(Mutex::new(drafter))),
-                )
-            } else if matches!(draft_kind, Some(rmlx_models::DraftKind::DFlash)) {
-                // the `--draft-model` is a standalone DFlash drafter (not a
-                // full model), so it cannot go through `load_speculative`. Load the
-                // verifier once for the dispatcher, the DFlash drafter separately,
-                // and reuse the verifier snapshot for the dispatcher's draft slot
-                // so the struct is valid (the DFlash round-loop ignores it).
-                tracing::info!(
-                    draft = %draft_dir.display(),
-                    "SpeculativeGenerator: DFlash drafter — loading drafter"
-                );
-                let dispatcher = rmlx_models::SpeculativeDispatcher::load_speculative(
-                    verifier_dir,
-                    verifier_dir,
-                    device,
-                )?;
-                let hidden_size = dispatcher.verifier.hidden_size();
-                let drafter = rmlx_models::speculative::dflash::DFlashDrafter::load(
-                    draft_dir,
-                    hidden_size,
-                    device,
-                )?;
-                (
-                    dispatcher,
-                    None,
-                    None,
-                    Some(Arc::new(Mutex::new(drafter))),
-                    None,
-                )
-            } else if matches!(draft_kind, Some(rmlx_models::DraftKind::Mtp)) {
-                tracing::info!(
-                    draft = %draft_dir.display(),
-                    "SpeculativeGenerator: MTP drafter — loading sidecar head"
-                );
-                let dispatcher = rmlx_models::SpeculativeDispatcher::load_speculative(
-                    verifier_dir,
-                    verifier_dir,
-                    device,
-                )?;
-                let hidden_size = dispatcher.verifier.hidden_size();
-                // Detect the MTP sidecar family from the draft config.json.
-                let draft_cfg = rmlx_loader::load_config(draft_dir)
-                    .map_err(|e| Error::Other(format!("load_config (draft): {e}")))?;
-                let draft_model_type = draft_cfg
-                    .extras
-                    .get("model_type")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let is_assistant = draft_model_type == "gemma4_assistant"
-                    || draft_cfg
-                        .architectures
-                        .iter()
-                        .any(|a| a.contains("Gemma4Assistant"));
-                if is_assistant {
+        let (dispatcher, mtp_drafter, mtp_assistant, dflash_drafter, eagle3_drafter) = if matches!(
+            draft_kind,
+            Some(rmlx_models::DraftKind::Eagle3)
+        ) {
+            // the `--draft-model` is a standalone EAGLE-3 drafter (not
+            // a full model), so it cannot go through `load_speculative`. Load
+            // the verifier once for the dispatcher, the EAGLE-3 drafter
+            // separately, and reuse the verifier snapshot for the dispatcher's
+            // draft slot so the struct is valid (the EAGLE-3 round-loop ignores
+            // it).
+            tracing::info!(
+                draft = %draft_dir.display(),
+                "SpeculativeGenerator: EAGLE-3 drafter — loading drafter"
+            );
+            let dispatcher = rmlx_models::SpeculativeDispatcher::load_speculative(
+                verifier_dir,
+                verifier_dir,
+                device,
+            )?;
+            let hidden_size = dispatcher.verifier.hidden_size();
+            let vocab_size = dispatcher.verifier.vocab_size();
+            let drafter = rmlx_models::speculative::eagle3::Eagle3Drafter::load(
+                draft_dir,
+                hidden_size,
+                vocab_size,
+                &eos_ids,
+                device,
+            )?;
+            (
+                dispatcher,
+                None,
+                None,
+                None,
+                Some(Arc::new(Mutex::new(drafter))),
+            )
+        } else if matches!(draft_kind, Some(rmlx_models::DraftKind::DFlash)) {
+            // the `--draft-model` is a standalone DFlash drafter (not a
+            // full model), so it cannot go through `load_speculative`. Load the
+            // verifier once for the dispatcher, the DFlash drafter separately,
+            // and reuse the verifier snapshot for the dispatcher's draft slot
+            // so the struct is valid (the DFlash round-loop ignores it).
+            tracing::info!(
+                draft = %draft_dir.display(),
+                "SpeculativeGenerator: DFlash drafter — loading drafter"
+            );
+            let dispatcher = rmlx_models::SpeculativeDispatcher::load_speculative(
+                verifier_dir,
+                verifier_dir,
+                device,
+            )?;
+            let hidden_size = dispatcher.verifier.hidden_size();
+            let drafter = rmlx_models::speculative::dflash::DFlashDrafter::load(
+                draft_dir,
+                hidden_size,
+                device,
+            )?;
+            (
+                dispatcher,
+                None,
+                None,
+                Some(Arc::new(Mutex::new(drafter))),
+                None,
+            )
+        } else if matches!(draft_kind, Some(rmlx_models::DraftKind::Mtp)) {
+            tracing::info!(
+                draft = %draft_dir.display(),
+                "SpeculativeGenerator: MTP drafter — loading sidecar head"
+            );
+            let dispatcher = rmlx_models::SpeculativeDispatcher::load_speculative(
+                verifier_dir,
+                verifier_dir,
+                device,
+            )?;
+            let hidden_size = dispatcher.verifier.hidden_size();
+            // Route by the draft model's detected architecture family — never
+            // by a substring leak. `--draft-kind mtp` covers two distinct
+            // drafter loaders, and a third (non-MTP) family must be rejected
+            // cleanly rather than falling through to the Qwen3.5 sidecar
+            // loader (which would leak a confusing `text_config missing
+            // num_experts` error for a draft that has no MoE config at all).
+            let draft_cfg = rmlx_loader::load_config(draft_dir)
+                .map_err(|e| Error::Other(format!("load_config (draft): {e}")))?;
+            let draft_arch = draft_cfg.architectures.first().map_or("", String::as_str);
+            let draft_model_type = draft_cfg
+                .extras
+                .get("model_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            match classify_mtp_draft(draft_arch, draft_model_type) {
+                MtpDraftFamily::Gemma4Assistant => {
+                    tracing::info!(
+                        draft = %draft_dir.display(),
+                        arch = draft_arch,
+                        model_type = draft_model_type,
+                        "SpeculativeGenerator: MTP dispatch — Gemma4 assistant drafter"
+                    );
                     let drafter =
                         rmlx_models::speculative::gemma4_assistant::Gemma4AssistantDrafter::load(
                             draft_dir,
@@ -294,7 +359,14 @@ impl SpeculativeGenerator {
                             device,
                         )?;
                     (dispatcher, None, Some(Arc::new(drafter)), None, None)
-                } else {
+                }
+                MtpDraftFamily::Qwen35Mtp => {
+                    tracing::info!(
+                        draft = %draft_dir.display(),
+                        arch = draft_arch,
+                        model_type = draft_model_type,
+                        "SpeculativeGenerator: MTP dispatch — Qwen3.5 MTP sidecar"
+                    );
                     let drafter = rmlx_models::speculative::mtp::MtpDrafter::load(
                         draft_dir,
                         hidden_size,
@@ -308,14 +380,25 @@ impl SpeculativeGenerator {
                         None,
                     )
                 }
-            } else {
-                let dispatcher = rmlx_models::SpeculativeDispatcher::load_speculative(
-                    verifier_dir,
-                    draft_dir,
-                    device,
-                )?;
-                (dispatcher, None, None, None, None)
-            };
+                MtpDraftFamily::Unsupported => {
+                    let reason = mtp_reject_reason(draft_arch, draft_model_type);
+                    tracing::error!(
+                        draft = %draft_dir.display(),
+                        arch = draft_arch,
+                        model_type = draft_model_type,
+                        "SpeculativeGenerator: MTP dispatch — rejecting unsupported draft family"
+                    );
+                    return Err(Error::SpeculativePairing { reason });
+                }
+            }
+        } else {
+            let dispatcher = rmlx_models::SpeculativeDispatcher::load_speculative(
+                verifier_dir,
+                draft_dir,
+                device,
+            )?;
+            (dispatcher, None, None, None, None)
+        };
 
         let tk_path = verifier_dir.join("tokenizer.json");
         let tokenizer = tokenizers::Tokenizer::from_file(&tk_path)
@@ -980,3 +1063,7 @@ impl Generator for SpeculativeGenerator {
         Box::pin(token_stream)
     }
 }
+
+#[cfg(test)]
+#[path = "speculative_tests.rs"]
+mod speculative_tests;

--- a/crates/rmlx-server/src/engine/speculative.rs
+++ b/crates/rmlx-server/src/engine/speculative.rs
@@ -48,10 +48,26 @@ enum MtpDraftFamily {
 /// Classify an `--draft-kind mtp` draft by its `architectures[0]` and
 /// `model_type`. Both fields are checked because mlx-community snapshots set the
 /// family on one or the other depending on the export tool.
+///
+/// Empty-config fall-through: when BOTH `arch` AND `model_type` are absent/empty
+/// we treat the snapshot as a Qwen3.5 MTP sidecar. Real-world Qwen3.6 MTP
+/// sidecars (e.g. `mlx-community/Qwen3.6-35B-A3B-MTP-5bit`) carry
+/// `model_type=qwen3_5_mtp` but an absent `architectures` array — the downstream
+/// `MtpDrafter::load` (mtp.rs:~288) only warns on a mismatch and proceeds by
+/// tensor names. The issue #23 fix targets *populated* foreign families
+/// (e.g. `Gemma4ForConditionalGeneration`), not blanks.
 fn classify_mtp_draft(arch: &str, model_type: &str) -> MtpDraftFamily {
     if model_type == "gemma4_assistant" || arch.contains("Gemma4Assistant") {
         MtpDraftFamily::Gemma4Assistant
-    } else if model_type == "qwen3_5_mtp" || arch == "qwen3_5_mtp" {
+    } else if arch.contains("qwen3_5_mtp") || model_type.contains("qwen3_5_mtp") {
+        // `arch` checked via substring to tolerate minor variant suffixes; same
+        // token (`qwen3_5_mtp`) is what real Qwen3.6 MTP sidecars carry in
+        // `model_type` (arch field absent in those snapshots).
+        MtpDraftFamily::Qwen35Mtp
+    } else if arch.is_empty() && model_type.is_empty() {
+        // Both fields absent: legacy fall-through to Qwen3.5 MTP sidecar loader,
+        // which warns and proceeds by tensor names. A populated foreign family
+        // (e.g. plain Gemma4) is caught by the Unsupported arm below.
         MtpDraftFamily::Qwen35Mtp
     } else {
         MtpDraftFamily::Unsupported

--- a/crates/rmlx-server/src/engine/speculative_tests.rs
+++ b/crates/rmlx-server/src/engine/speculative_tests.rs
@@ -14,10 +14,39 @@ fn qwen35_mtp_sidecar_routes_to_mtp_drafter() {
         classify_mtp_draft("qwen3_5_mtp", "qwen3_5_mtp"),
         MtpDraftFamily::Qwen35Mtp
     );
-    // model_type alone is sufficient (some exports leave architectures empty).
+    // model_type alone is sufficient — real Qwen3.6-35B-A3B-MTP-5bit has no
+    // `architectures` array; only `model_type=qwen3_5_mtp` is set.
     assert_eq!(
         classify_mtp_draft("", "qwen3_5_mtp"),
         MtpDraftFamily::Qwen35Mtp
+    );
+}
+
+#[test]
+fn qwen35_mtp_substring_match() {
+    // arch substring: tolerate minor variant suffixes in the arch string.
+    assert_eq!(
+        classify_mtp_draft("qwen3_5_mtp_head_v2", ""),
+        MtpDraftFamily::Qwen35Mtp,
+        "arch substring containing qwen3_5_mtp should route to Qwen35Mtp"
+    );
+    // model_type substring: same tolerance on model_type side.
+    assert_eq!(
+        classify_mtp_draft("", "qwen3_5_mtp_variant"),
+        MtpDraftFamily::Qwen35Mtp,
+        "model_type substring containing qwen3_5_mtp should route to Qwen35Mtp"
+    );
+}
+
+#[test]
+fn empty_config_falls_through_to_qwen35_mtp() {
+    // Both fields absent: legacy blank-config snapshot. The downstream
+    // MtpDrafter::load warns and proceeds by tensor names — this must NOT
+    // be rejected as Unsupported (regression from issue #23 fix scope).
+    assert_eq!(
+        classify_mtp_draft("", ""),
+        MtpDraftFamily::Qwen35Mtp,
+        "blank arch+model_type must fall through to Qwen35Mtp, not Unsupported"
     );
 }
 

--- a/crates/rmlx-server/src/engine/speculative_tests.rs
+++ b/crates/rmlx-server/src/engine/speculative_tests.rs
@@ -1,0 +1,86 @@
+//! Unit tests for the `--draft-kind mtp` arch-family dispatch (issue #23).
+//!
+//! These cover the pure classifier `classify_mtp_draft` and the rejection
+//! message builder `mtp_reject_reason` — the load-time routing decision that
+//! keeps a plain Gemma4 draft from falling through to the Qwen3.5 MTP sidecar
+//! loader (which would leak a `text_config missing num_experts` error).
+
+use super::{classify_mtp_draft, mtp_reject_reason, MtpDraftFamily};
+
+#[test]
+fn qwen35_mtp_sidecar_routes_to_mtp_drafter() {
+    // mlx-community Qwen3.5 MTP sidecars carry arch == model_type == qwen3_5_mtp.
+    assert_eq!(
+        classify_mtp_draft("qwen3_5_mtp", "qwen3_5_mtp"),
+        MtpDraftFamily::Qwen35Mtp
+    );
+    // model_type alone is sufficient (some exports leave architectures empty).
+    assert_eq!(
+        classify_mtp_draft("", "qwen3_5_mtp"),
+        MtpDraftFamily::Qwen35Mtp
+    );
+}
+
+#[test]
+fn gemma4_assistant_routes_to_assistant_drafter() {
+    // Dedicated assistant snapshot: model_type gemma4_assistant.
+    assert_eq!(
+        classify_mtp_draft("Gemma4Assistant", "gemma4_assistant"),
+        MtpDraftFamily::Gemma4Assistant
+    );
+    // architectures-substring path (some exports set arch, not model_type).
+    assert_eq!(
+        classify_mtp_draft("Gemma4AssistantForCausalLM", ""),
+        MtpDraftFamily::Gemma4Assistant
+    );
+}
+
+#[test]
+fn plain_gemma4_draft_is_unsupported_not_qwen_fallthrough() {
+    // The issue #23 case: a plain dense Gemma4 model must NOT classify as the
+    // Qwen3.5 MTP sidecar (which would leak `num_experts`); it is Unsupported.
+    assert_eq!(
+        classify_mtp_draft("Gemma4ForConditionalGeneration", ""),
+        MtpDraftFamily::Unsupported
+    );
+}
+
+#[test]
+fn unrelated_family_is_unsupported() {
+    assert_eq!(
+        classify_mtp_draft("Qwen3ForCausalLM", ""),
+        MtpDraftFamily::Unsupported
+    );
+}
+
+#[test]
+fn plain_gemma4_reject_reason_points_at_assistant_snapshot() {
+    let reason = mtp_reject_reason("Gemma4ForConditionalGeneration", "");
+    // Must name the family and the actionable alternative.
+    assert!(
+        reason.contains("Gemma4"),
+        "reason names the family: {reason}"
+    );
+    assert!(
+        reason.contains("assistant"),
+        "reason points at the assistant snapshot: {reason}"
+    );
+    // Must NOT mention the leaked Qwen3.5 internal error.
+    assert!(
+        !reason.contains("num_experts"),
+        "reason must not leak the Qwen3.5 loader error: {reason}"
+    );
+}
+
+#[test]
+fn non_gemma_reject_reason_is_generic_and_clean() {
+    let reason = mtp_reject_reason("Qwen3ForCausalLM", "qwen3");
+    assert!(
+        reason.contains("Qwen3ForCausalLM"),
+        "names the arch: {reason}"
+    );
+    assert!(
+        !reason.contains("num_experts"),
+        "reason must not leak the Qwen3.5 loader error: {reason}"
+    );
+}

--- a/crates/rmlx-server/src/retry.rs
+++ b/crates/rmlx-server/src/retry.rs
@@ -148,6 +148,10 @@ pub fn classify(err: &RmlxError) -> RetryClass {
         // The prompt exceeds the operator-declared context bound; replaying
         // would hit the same ceiling. Fatal (same class as the hard cap).
         RmlxError::KvCeilingExceeded { .. } => RetryClass::Fatal,
+        // Unsupported `--draft-model` + `--draft-kind` pairing. Structural
+        // misconfiguration detected at load; replaying would hit the same
+        // rejection. Fatal.
+        RmlxError::SpeculativePairing { .. } => RetryClass::Fatal,
         // Non-exhaustive catch-all: future variants default to Fatal.
         _ => RetryClass::Fatal,
     }

--- a/crates/rmlx-server/src/retry_tests.rs
+++ b/crates/rmlx-server/src/retry_tests.rs
@@ -91,6 +91,24 @@ fn classify_io_is_fatal() {
     assert_eq!(classify(&err), RetryClass::Fatal);
 }
 
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only string construction; no fallible ops"
+)]
+fn classify_speculative_pairing_is_fatal() {
+    // SpeculativePairing is emitted when --draft-kind mtp is given an
+    // incompatible draft snapshot (e.g. plain Gemma4 fed to the Qwen MTP
+    // loader). Retrying would hit the same rejection — must be Fatal, not
+    // Migratable.
+    let err = E::SpeculativePairing {
+        reason: "draft model architecture 'Gemma4ForConditionalGeneration' is not a supported \
+                 --draft-kind mtp family"
+            .to_owned(),
+    };
+    assert_eq!(classify(&err), RetryClass::Fatal);
+}
+
 // ── is_replayable() ──────────────────────────────────────────────────────
 
 fn req_with_temp(temperature: f32) -> GenerationRequest {

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -641,8 +641,12 @@ the embedding sequence similarly to image tokens.
 
 **Speculative decoding fully wired for Gemma4.** `forward_seq_last_k_with_cache`,
 `forward_hidden_states`, `forward_hidden_states_shared_kv`, `apply_final_norm`,
-`logits_from_hidden`, `embed_token_raw` all implemented. Supports the MTP head
-drafter and the Gemma4-assistant MTP path.
+`logits_from_hidden`, `embed_token_raw` all implemented. The Gemma4 spec path is
+the **assistant drafter** (`Gemma4AssistantDrafter`), selected with
+`--draft-kind mtp` and a dedicated `*-it-assistant-bf16` draft snapshot. A plain
+`Gemma4ForConditionalGeneration` model is **not** a valid `--draft-kind mtp`
+draft (no MTP sidecar head) and is rejected at load — see `docs/SPECULATIVE.md`
+§"`--draft-kind mtp` dispatch" and issue #23.
 
 ### Weight quantization
 

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -434,13 +434,35 @@ respectively.
 `--draft-kind none` is not a valid value; to disable speculative decoding omit
 `--draft-model` and `--draft-kind` entirely.
 
+### `--draft-kind mtp` dispatch (arch-family routing)
+
+`--draft-kind mtp` fronts **two structurally different drafter loaders**, and
+the serve layer (`engine::speculative::classify_mtp_draft`) routes by the draft
+model's **detected architecture family** (`architectures[0]` and `model_type`),
+never a substring guess:
+
+| Draft family (`model_type` / `architectures[0]`) | Drafter loaded | Notes |
+|---|---|---|
+| `qwen3_5_mtp` | `MtpDrafter` (Qwen3.5/3.6-MoE sidecar head) | The MTP head reuses the verifier's embedding, LM head, and one Qwen3.5-MoE decoder layer. |
+| `gemma4_assistant` / `Gemma4Assistant*` | `Gemma4AssistantDrafter` | The dedicated `*-it-assistant-bf16` snapshot — a small Gemma4 decoder stack that reads the verifier's own K/V cache. |
+| anything else (incl. plain `Gemma4ForConditionalGeneration`) | **rejected at load** | Typed `Error::SpeculativePairing`; for a plain Gemma4 draft the message points at the assistant snapshot. |
+
+A **plain Gemma4 model** (`Gemma4ForConditionalGeneration`, e.g.
+`gemma-4-e2b-it-mxfp8`) is **not** a valid `--draft-kind mtp` draft: it has no
+MTP sidecar head and is not the assistant drafter. Passing one is rejected at
+load with an actionable error rather than falling through to the Qwen3.5
+sidecar loader (which previously leaked a confusing `text_config missing
+num_experts` error — issue #23). Use the `*-it-assistant-bf16` assistant
+snapshot for Gemma4 speculative decoding.
+
 ### Example invocations
 
 ```text
-# Two-model Gemma4 speculative (31B verifier + E2B draft):
+# Gemma4 assistant speculative (verifier + dedicated assistant drafter):
+# the draft MUST be the *-assistant-bf16 snapshot, NOT a plain Gemma4 model.
 rmlx serve \
-  --model   /path/to/gemma-4-31b-mxfp8 \
-  --draft-model /path/to/gemma-4-e2b-mxfp8 \
+  --model   /path/to/gemma-4-e2b-it-mxfp8 \
+  --draft-model /path/to/gemma-4-E2B-it-assistant-bf16 \
   --draft-kind  mtp \
   --draft-block-size 6
 


### PR DESCRIPTION
## Summary

Fixes #23. `--draft-kind mtp` selected the drafter via a `"Gemma4Assistant"` substring check, so a plain `Gemma4ForConditionalGeneration` draft fell through to the Qwen3.5-MoE `MtpDrafter` and failed at first inference with `text_config missing num_experts` (a dense Gemma4 has no `num_experts`). The documented two-model Gemma4 spec setup was unreachable; the error leaked a Qwen-specific field for a Gemma draft.

## Fix — route by detected arch family

New `classify_mtp_draft` → `MtpDraftFamily` keys on the draft's `architectures[0]` / `model_type` (the same fields the downstream loader uses):
- `Gemma4Assistant` → `Gemma4AssistantDrafter` (the now-working #24 path)
- `qwen3_5_mtp` (substring-tolerant) **or** blank/absent config → `MtpDrafter` (preserves the legacy warn-and-load-by-tensor-names behavior)
- any other *populated* family (e.g. plain Gemma4) → typed `Error::SpeculativePairing { reason }`, classified `Fatal` in retry — no Qwen `num_experts` leak

### Route-vs-reject decision

**Reject** for plain Gemma4 + `mtp`: it has no MTP sidecar head and is not the assistant snapshot, so there is no cheap correct route through the MTP branch (a true Gemma4 self-spec MTP would be a new feature). The error message points the operator at the assistant snapshot. Plain Gemma4 verifier+draft can still use the generic two-model path by omitting `--draft-kind`.

## Real-model proof

1. **Misroute repro** (31b verifier + e2b draft, `--draft-kind mtp`): before → HTTP 500 `text_config missing num_experts`; after → typed error naming the assistant-snapshot requirement, no `num_experts` leak.
2. **Valid assistant pairing** (e2b verifier + E2B-it-assistant-bf16 draft): still routes to `Gemma4AssistantDrafter`, decodes (the #24 path).
3. **Qwen3.6-MoE MTP** (Qwen3.6-35B-A3B-8bit + MTP-5bit, blank `architectures` / `model_type=qwen3_5_mtp`): still routes to `MtpDrafter`, 17 tokens.

## Tests

`speculative_tests.rs` (8): per-family routing, blank-config→Qwen fall-through, substring Qwen match, plain-gemma4 + unrelated rejection, reject-reason content. `retry_tests.rs`: `SpeculativePairing → Fatal`. `make build` / `make lint` / `cargo fmt` clean.

## Docs

`docs/SPECULATIVE.md` — `--draft-kind mtp` dispatch family table + corrected the misleading plain-Gemma4 example. `docs/MODELS.md` — Gemma4 assistant-draft requirement.

Related: #24 (assistant SDPA decode fix — the path this routes a valid pairing to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)