### PR TITLE
feat(kv): per-request KV-quant + max-ctx hot-swap on resident model (#26)

### DIFF
--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -414,6 +414,42 @@ pub enum KvQuant {
 }
 
 impl KvQuant {
+    /// Issue #26: stable per-codec salt for namespacing the in-RAM
+    /// prompt/prefix cache key by KV codec.
+    ///
+    /// A single resident model can serve requests under different KV codecs
+    /// (hot-swap, no weight reload). The cached K/V bytes are codec-specific —
+    /// a prefix cached under `None` (bf16) must NOT serve a `K8V4` request. The
+    /// prompt-cache block-hash chain is salted with this value (XOR'd into the
+    /// FNV seed, the same mixing the SSD `layout_key` uses), so two requests
+    /// with the same tokens but different codecs produce disjoint digest
+    /// streams and occupy distinct cache slots — no cross-codec serve.
+    ///
+    /// The salt is a deterministic FNV-1a-64 hash over the codec's canonical
+    /// [`Display`](std::fmt::Display) string (`"none"`, `"k8v4"`,
+    /// `"mixed_k8g64_v4g64"`, …), so it is stable across runs and covers every
+    /// variant — including payload-bearing ones (`Mixed`, `RotK`, `RotorK*Asym`)
+    /// whose payload is part of the Display form. Two codecs render to the same
+    /// string iff they are byte-identical, so the salt is collision-free across
+    /// the enum.
+    #[must_use]
+    pub fn cache_key_salt(&self) -> u64 {
+        // FNV-1a-64 over the canonical Display bytes. Constants are the
+        // standard offset basis / prime — self-contained here because
+        // `rmlx-kv-quant` does not (and must not) depend on `rmlx-kv-ssd`,
+        // where the prompt-cache FNV constants live. The *values* match by
+        // construction (same standard FNV-1a-64 constants).
+        const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+        const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+        let label = self.to_string();
+        let mut h = FNV_OFFSET;
+        for byte in label.as_bytes() {
+            h ^= u64::from(*byte);
+            h = h.wrapping_mul(FNV_PRIME);
+        }
+        h
+    }
+
     /// True for the Mixed-machinery hot path (Mixed + RotK), which dispatches
     /// through `mx.quantize` 3-tuples + `mixed_quantized_sdpa`.
     pub fn uses_mixed_path(&self) -> bool {

--- a/crates/rmlx-kv-quant/src/quant_tests.rs
+++ b/crates/rmlx-kv-quant/src/quant_tests.rs
@@ -153,3 +153,72 @@ fn rotk_cli_form_parses() {
     // And the Display round-trip.
     assert_eq!(q.to_string(), "rot_k_v4g64");
 }
+
+/// Issue #26: `cache_key_salt` must be collision-free across distinct codecs so
+/// the codec-partitioned prompt-cache key never conflates two codecs. Two
+/// distinct `KvQuant` values (including payload-bearing variants that differ
+/// only by bit-width / group size) must produce distinct salts; the same value
+/// must produce the same salt (determinism).
+#[test]
+fn cache_key_salt_is_unique_and_deterministic() {
+    let cases: &[KvQuant] = &[
+        KvQuant::None,
+        KvQuant::K8V4,
+        KvQuant::K8V8,
+        KvQuant::Planar,
+        KvQuant::K8VTurbo3,
+        KvQuant::Mixed {
+            k_bits: 8,
+            v_bits: 4,
+            k_group_size: 64,
+            v_group_size: 64,
+        },
+        KvQuant::Mixed {
+            k_bits: 8,
+            v_bits: 8,
+            k_group_size: 128,
+            v_group_size: 128,
+        },
+        KvQuant::RotK {
+            v_bits: 4,
+            v_group_size: 64,
+        },
+        KvQuant::RotorK3Asym {
+            v_bits: 4,
+            v_group_size: 64,
+        },
+    ];
+    // Determinism: same value → same salt.
+    for &q in cases {
+        assert_eq!(
+            q.cache_key_salt(),
+            q.cache_key_salt(),
+            "{q:?} cache_key_salt must be deterministic"
+        );
+    }
+    // Uniqueness: every distinct pair must differ.
+    for (i, &a) in cases.iter().enumerate() {
+        for &b in &cases[i + 1..] {
+            assert_ne!(
+                a.cache_key_salt(),
+                b.cache_key_salt(),
+                "{a:?} and {b:?} must have distinct cache_key_salts (codec partitioning)"
+            );
+        }
+    }
+    // The two Mixed variants above differ only by bit-width/group size — their
+    // salts must still diverge (payload is part of the codec identity).
+    let m1 = KvQuant::Mixed {
+        k_bits: 8,
+        v_bits: 4,
+        k_group_size: 64,
+        v_group_size: 64,
+    };
+    let m2 = KvQuant::Mixed {
+        k_bits: 8,
+        v_bits: 8,
+        k_group_size: 128,
+        v_group_size: 128,
+    };
+    assert_ne!(m1.cache_key_salt(), m2.cache_key_salt());
+}

--- a/crates/rmlx-kv-quant/src/quant_tests.rs
+++ b/crates/rmlx-kv-quant/src/quant_tests.rs
@@ -161,6 +161,7 @@ fn rotk_cli_form_parses() {
 /// must produce the same salt (determinism).
 #[test]
 fn cache_key_salt_is_unique_and_deterministic() {
+    // when adding a KvQuant variant, add it here
     let cases: &[KvQuant] = &[
         KvQuant::None,
         KvQuant::K8V4,

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -167,19 +167,29 @@ pub fn generate_greedy(
     // image prompts bypass the prompt cache. The cached K/V is keyed by
     // token ids only; an image prompt's K/V depends on the scattered vision
     // features, so it must never be reused for (or saved under) a token-id key.
+    // Issue #26: codec-partitioned prompt-cache key. The query digest stream is
+    // salted by `FNV_OFFSET ^ layout_key ^ codec_salt(kv_quant)` — identical to
+    // the push seed below — so a slot stored under a different KV codec never
+    // matches this request (no cross-codec serve), and codecs coexist as
+    // distinct slots rather than thrash-evicting one another. On a single-codec
+    // RAM-only run (layout_key=0, constant codec) this is byte-identical to the
+    // legacy un-salted stream for this codec.
+    let cache_seed = crate::prompt_cache::FNV_OFFSET
+        ^ crate::gemma4::prompt_cache::active_layout_key()
+        ^ kv_quant.cache_key_salt();
     let lookup: CacheLookup = if image_prefill.is_some() {
         CacheLookup::Miss
     } else {
         PROMPT_CACHE.with_inner_mut(|guard| {
             let cache = guard.as_mut().unwrap();
-            let mut raw_match = cache.find_best_prefix(prompt_ids);
+            let mut raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
             // on a RAM miss, try to serve the longest cached block-aligned
             // prefix from the SSD tier (no-op when no SSD source is attached —
             // tier OFF). A hydrate hit promotes the block into RAM; re-run
             // find_best_prefix so the promoted slot is matched (and quant-checked)
             // by the normal path below.
             if raw_match.is_none() && cache.hydrate_from_ssd(prompt_ids).is_some() {
-                raw_match = cache.find_best_prefix(prompt_ids);
+                raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
             }
             // Plan §D8 / Task 11.5: the snapshot is only safe to reuse when the
             // stored `KvQuant` discriminant matches the runtime quant for this
@@ -974,12 +984,19 @@ pub fn generate_greedy(
                             // layout_key)` row the hydrator will reconstruct. When
                             // the SSD tier is OFF, `active_layout_key()` returns 0 and the
                             // seed collapses to `FNV_OFFSET` — legacy un-salted digests.
+                            // Issue #26: salt the stored digest stream by the
+                            // active KV codec too, so the push seed matches the
+                            // codec-partitioned query seed in `find_best_prefix`
+                            // above. Stacks with `layout_key` (XOR) exactly like
+                            // the SSD-tier salt.
                             let lk = crate::gemma4::prompt_cache::active_layout_key();
                             cache.push(Gemma4Entry {
                                 prompt_token_ids: prompt_ids.to_vec(),
                                 block_hashes: crate::prompt_cache::chained_block_hashes_seeded(
                                     prompt_ids,
-                                    crate::prompt_cache::FNV_OFFSET ^ lk,
+                                    crate::prompt_cache::FNV_OFFSET
+                                        ^ lk
+                                        ^ kv_quant.cache_key_salt(),
                                 ),
                                 kv_caches: kvs,
                                 first_id: last_id,

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -171,9 +171,11 @@ pub fn generate_greedy(
     // salted by `FNV_OFFSET ^ layout_key ^ codec_salt(kv_quant)` — identical to
     // the push seed below — so a slot stored under a different KV codec never
     // matches this request (no cross-codec serve), and codecs coexist as
-    // distinct slots rather than thrash-evicting one another. On a single-codec
-    // RAM-only run (layout_key=0, constant codec) this is byte-identical to the
-    // legacy un-salted stream for this codec.
+    // distinct slots rather than thrash-evicting one another. On a RAM-only run
+    // (layout_key=0) the push and query seeds are equal (`FNV_OFFSET ^
+    // codec_salt`), so same-codec hits still land; digests differ from the
+    // pre-#26 stream by the constant codec salt, harmless because the cache is
+    // rebuilt per process.
     let cache_seed = crate::prompt_cache::FNV_OFFSET
         ^ crate::gemma4::prompt_cache::active_layout_key()
         ^ kv_quant.cache_key_salt();

--- a/crates/rmlx-models/src/gemma4/prompt_cache.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache.rs
@@ -197,7 +197,10 @@ impl SsdHydrate<Gemma4Entry> for SsdHydrator {
             kv_caches,
             lin_caches: _,
         } = block;
-        let block_hashes = chained_block_hashes_seeded(&prompt_ids, FNV_OFFSET ^ self.layout_key());
+        let block_hashes = chained_block_hashes_seeded(
+            &prompt_ids,
+            FNV_OFFSET ^ self.layout_key() ^ self.kv_quant().cache_key_salt(),
+        );
         Ok(Some(Gemma4Entry {
             prompt_token_ids: prompt_ids,
             block_hashes,

--- a/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
@@ -3,7 +3,7 @@ use crate::prompt_cache::PromptCache;
 use rmlx_kv_quant::KvQuant;
 
 fn entry_with(kv_caches: Vec<KvCache>, ids: Vec<u32>) -> Gemma4Entry {
-    let block_hashes = crate::prompt_cache::chained_block_hashes(&ids);
+    let block_hashes = rmlx_kv_ssd::chained_block_hashes(&ids);
     Gemma4Entry {
         prompt_token_ids: ids,
         block_hashes,
@@ -19,7 +19,7 @@ fn entry_with_quant(
     ids: Vec<u32>,
     kv_quant: Option<KvQuant>,
 ) -> Gemma4Entry {
-    let block_hashes = crate::prompt_cache::chained_block_hashes(&ids);
+    let block_hashes = rmlx_kv_ssd::chained_block_hashes(&ids);
     Gemma4Entry {
         prompt_token_ids: ids,
         block_hashes,
@@ -85,14 +85,16 @@ fn kv_quant_mismatch_evicts_and_misses() {
     cache.push(entry);
 
     let runtime_quant = KvQuant::K8V4;
-    let (slot_idx, _) = cache.find_best_prefix(&prompt_ids).expect("block hit");
+    let (slot_idx, _) = cache
+        .find_best_prefix(&prompt_ids, FNV_OFFSET)
+        .expect("block hit");
     let entry_quant = cache.slots[slot_idx].entry.kv_quant;
     assert!(entry_quant != Some(runtime_quant));
     cache.evict_slot(slot_idx);
 
     assert_eq!(cache.slots.len(), 0);
     assert_eq!(cache.stats().evictions, 1);
-    assert!(cache.find_best_prefix(&prompt_ids).is_none());
+    assert!(cache.find_best_prefix(&prompt_ids, FNV_OFFSET).is_none());
 }
 
 /// BACKWARD-COMPAT path: stored `None` — treated as MISMATCH.
@@ -117,7 +119,9 @@ fn kv_quant_legacy_none_evicts_and_misses() {
     cache.push(entry);
 
     let runtime_quant = KvQuant::K8V8;
-    let (slot_idx, _) = cache.find_best_prefix(&prompt_ids).expect("block hit");
+    let (slot_idx, _) = cache
+        .find_best_prefix(&prompt_ids, FNV_OFFSET)
+        .expect("block hit");
     assert!(cache.slots[slot_idx].entry.kv_quant != Some(runtime_quant));
     cache.evict_slot(slot_idx);
     assert_eq!(cache.slots.len(), 0);
@@ -145,7 +149,9 @@ fn kv_quant_match_hits_no_eviction() {
     let mut cache: PromptCache<Gemma4Entry> = PromptCache::new(4);
     cache.push(entry);
 
-    let (slot_idx, _) = cache.find_best_prefix(&prompt_ids).expect("block hit");
+    let (slot_idx, _) = cache
+        .find_best_prefix(&prompt_ids, FNV_OFFSET)
+        .expect("block hit");
     assert_eq!(cache.slots[slot_idx].entry.kv_quant, Some(KvQuant::K8V8));
     assert_eq!(cache.slots.len(), 1);
     assert_eq!(cache.stats().evictions, 0);

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -62,9 +62,12 @@ use rmlx_kv_ssd::{SsdHydrator, SsdSpiller};
 // every in-crate `crate::prompt_cache::FNV_OFFSET` / `BLOCK_TOKENS` /
 // `chained_block_hashes_seeded` / `SsdHydrate` import path byte-identically.
 pub(crate) use rmlx_kv_ssd::{
-    chained_block_hashes, chained_block_hashes_seeded, SsdHydrate, BLOCK_TOKENS, FNV_OFFSET,
-    FNV_PRIME,
+    chained_block_hashes_seeded, SsdHydrate, BLOCK_TOKENS, FNV_OFFSET, FNV_PRIME,
 };
+// `chained_block_hashes` (the un-seeded form) is no longer used by this module
+// directly — `find_best_prefix` now always salts with a caller-supplied seed
+// (issue #26). It is still consumed by sibling `#[path]` test modules and by
+// `gemma4::prompt_cache`, which import it directly from `rmlx_kv_ssd`.
 
 /// Default RAM cap for the prompt cache (2 GiB).
 pub(crate) const DEFAULT_MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
@@ -471,8 +474,19 @@ impl<E: PromptCacheEntry> PromptCache<E> {
         clippy::indexing_slicing,
         reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
     )]
-    pub(crate) fn find_best_prefix(&mut self, prompt_ids: &[u32]) -> Option<(usize, usize)> {
-        let want = chained_block_hashes(prompt_ids);
+    pub(crate) fn find_best_prefix(
+        &mut self,
+        prompt_ids: &[u32],
+        seed: u64,
+    ) -> Option<(usize, usize)> {
+        // Issue #26: `seed` salts the query digest stream so it partitions by
+        // the same `(layout_key, codec)` the push side seeds with. Different
+        // KV codecs (or SSD layouts) for the same tokens produce disjoint
+        // digest streams and never match each other's slots — the codec
+        // namespacing that lets a resident model serve multiple KV codecs
+        // without cross-serving cached KV. Pass `FNV_OFFSET` for the legacy
+        // un-salted stream (RAM-only, single-codec, layout_key=0).
+        let want = chained_block_hashes_seeded(prompt_ids, seed);
 
         let (best_idx, best_blocks) = match self.prefix_index_kind {
             // Linear path is byte-identical to the pre-scan;

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use rmlx_core::error::Result;
+use rmlx_kv_ssd::chained_block_hashes;
 
 // ── chained_block_hashes_seeded ────────────────────────────────────
 
@@ -40,6 +41,19 @@ struct TestEntry {
 impl TestEntry {
     fn new(ids: Vec<u32>) -> Self {
         let hashes = chained_block_hashes(&ids);
+        TestEntry {
+            ids,
+            hashes,
+            truncated_to: std::cell::Cell::new(None),
+        }
+    }
+
+    /// Issue #26: build an entry whose block-hash chain is salted with an
+    /// explicit `seed` (the `FNV_OFFSET ^ layout_key ^ codec_salt` the
+    /// production push uses). Lets the codec-partition test store a slot under
+    /// one codec seed and query under another.
+    fn new_seeded(ids: Vec<u32>, seed: u64) -> Self {
+        let hashes = chained_block_hashes_seeded(&ids, seed);
         TestEntry {
             ids,
             hashes,
@@ -105,13 +119,13 @@ fn hit_miss_counters_three_requests() {
     let mut cache: PromptCache<TestEntry> = PromptCache::new(4);
 
     // --- Request 1: cold miss (cache empty) ---
-    let r1 = cache.find_best_prefix(&prompt_a);
+    let r1 = cache.find_best_prefix(&prompt_a, FNV_OFFSET);
     assert!(r1.is_none(), "r1 should be a miss");
     // Populate cache so subsequent requests can hit.
     cache.push(TestEntry::new(prompt_a.clone()));
 
     // --- Request 2: full-prompt block hit (same prompt) ---
-    let r2 = cache.find_best_prefix(&prompt_a);
+    let r2 = cache.find_best_prefix(&prompt_a, FNV_OFFSET);
     assert!(r2.is_some(), "r2 should be a hit");
     let (_, blocks_2) = r2.unwrap();
     assert_eq!(blocks_2, 2, "full hit must cover all 2 blocks");
@@ -119,7 +133,7 @@ fn hit_miss_counters_three_requests() {
     // --- Request 3: partial prefix hit (one extra full block of new ids) ---
     let mut prompt_b = prompt_a.clone();
     prompt_b.extend(1000..1000 + BLOCK_TOKENS as u32);
-    let r3 = cache.find_best_prefix(&prompt_b);
+    let r3 = cache.find_best_prefix(&prompt_b, FNV_OFFSET);
     assert!(r3.is_some(), "r3 should be a partial prefix hit");
     let (_, blocks_3) = r3.unwrap();
     assert_eq!(
@@ -162,7 +176,7 @@ fn short_prefix_treated_as_miss() {
 
     // Query with the same short prompt — no full block stored, so there is
     // nothing to match: must be a miss.
-    let result = cache.find_best_prefix(&short_prompt);
+    let result = cache.find_best_prefix(&short_prompt, FNV_OFFSET);
     assert!(
         result.is_none(),
         "shared prefix < one 256-token block must be treated as a miss"
@@ -197,11 +211,11 @@ fn lru_bump_on_hit_determines_eviction_order() {
     assert_eq!(cache.slots.len(), 3);
 
     // Hit B — B becomes MRU.
-    let hit_b = cache.find_best_prefix(&ids_b);
+    let hit_b = cache.find_best_prefix(&ids_b, FNV_OFFSET);
     assert!(hit_b.is_some(), "B must hit");
 
     // Hit C — C becomes MRU.
-    let hit_c = cache.find_best_prefix(&ids_c);
+    let hit_c = cache.find_best_prefix(&ids_c, FNV_OFFSET);
     assert!(hit_c.is_some(), "C must hit");
 
     // Push D — slot count cap triggers, A must be evicted (smallest seq).
@@ -313,7 +327,7 @@ fn long_prompt_block_aligned_partial_hit() {
     prompt_b.extend(9000..9000 + BLOCK_TOKENS as u32);
     assert_eq!(prompt_b.len(), 16 * BLOCK_TOKENS);
 
-    let r = cache.find_best_prefix(&prompt_b);
+    let r = cache.find_best_prefix(&prompt_b, FNV_OFFSET);
     assert!(r.is_some(), "must hit on the shared 15-block prefix");
     let (slot_idx, block_count) = r.unwrap();
     assert_eq!(block_count, 15, "must match exactly 15 leading blocks");
@@ -365,7 +379,7 @@ fn block_level_counters_partial_and_full() {
     partial_prompt.extend(9000..9000 + BLOCK_TOKENS as u32);
     assert_eq!(partial_prompt.len(), 16 * BLOCK_TOKENS);
 
-    let r_a = cache.find_best_prefix(&partial_prompt);
+    let r_a = cache.find_best_prefix(&partial_prompt, FNV_OFFSET);
     assert!(r_a.is_some(), "(a) must be a hit");
     let (_, blocks_a) = r_a.unwrap();
     assert_eq!(blocks_a, 15, "(a) 15 blocks matched");
@@ -387,7 +401,7 @@ fn block_level_counters_partial_and_full() {
     // The want vector for this prompt has 17 hashes; cache has 16.
     // Matched = 16 (full match of stored entry), unmatched = 1.
     // Because best_blocks (16) < want_blocks (17) → still a partial_hit.
-    let r_b = cache.find_best_prefix(&full_prompt);
+    let r_b = cache.find_best_prefix(&full_prompt, FNV_OFFSET);
     assert!(r_b.is_some(), "(b) must be a hit");
     let (_, blocks_b) = r_b.unwrap();
     assert_eq!(blocks_b, 16, "(b) 16 blocks matched");
@@ -402,7 +416,7 @@ fn block_level_counters_partial_and_full() {
 
     // Build a truly full match (same 16-block prompt, no extension).
     // want_blocks == 16, best_blocks == 16 → NOT partial.
-    let r_b2 = cache.find_best_prefix(&base);
+    let r_b2 = cache.find_best_prefix(&base, FNV_OFFSET);
     assert!(r_b2.is_some(), "(b2) must be a hit");
     let (_, blocks_b2) = r_b2.unwrap();
     assert_eq!(blocks_b2, 16, "(b2) 16 blocks matched");
@@ -419,7 +433,7 @@ fn block_level_counters_partial_and_full() {
     // (c) Total miss: use an unrelated 4-block prompt with completely
     // different token ids (offset by 100000 to avoid any block collision).
     let miss_prompt: Vec<u32> = (100000..100000 + 4 * BLOCK_TOKENS as u32).collect();
-    let r_c = cache.find_best_prefix(&miss_prompt);
+    let r_c = cache.find_best_prefix(&miss_prompt, FNV_OFFSET);
     assert!(r_c.is_none(), "(c) must be a miss");
 
     let s = cache.stats();
@@ -460,7 +474,7 @@ fn exact_hit_clone_preserves_prompt_identity() {
     cache.push(TestEntry::new(prompt.clone()));
 
     let (idx, blocks) = cache
-        .find_best_prefix(&prompt)
+        .find_best_prefix(&prompt, FNV_OFFSET)
         .expect("identical prompt must hit");
     assert_eq!(blocks, 2, "full prompt covers both blocks");
     // Exact-hit gate at the call site: stored ids == request ids.
@@ -634,7 +648,10 @@ fn ssd_hydrate_populates_ram_and_bumps_counter() {
     }));
 
     // RAM miss (cache empty).
-    assert!(cache.find_best_prefix(&prompt).is_none(), "cold RAM miss");
+    assert!(
+        cache.find_best_prefix(&prompt, FNV_OFFSET).is_none(),
+        "cold RAM miss"
+    );
     assert_eq!(cache.stats().ssd_hits, 0);
 
     // Hydrate from SSD → promoted into RAM, counter bumped.
@@ -644,7 +661,7 @@ fn ssd_hydrate_populates_ram_and_bumps_counter() {
     assert_eq!(cache.slots.len(), 1, "one slot now populated");
 
     // The hydrated entry is now served by find_best_prefix.
-    let r = cache.find_best_prefix(&prompt);
+    let r = cache.find_best_prefix(&prompt, FNV_OFFSET);
     assert!(
         r.is_some(),
         "find_best_prefix must serve the hydrated entry"
@@ -659,7 +676,7 @@ fn ssd_hydrate_populates_ram_and_bumps_counter() {
 fn no_ssd_source_is_inert() {
     let prompt: Vec<u32> = make_ids(2 * BLOCK_TOKENS);
     let mut cache: PromptCache<TestEntry> = PromptCache::new(4);
-    assert!(cache.find_best_prefix(&prompt).is_none());
+    assert!(cache.find_best_prefix(&prompt, FNV_OFFSET).is_none());
     assert!(
         cache.hydrate_from_ssd(&prompt).is_none(),
         "no SSD source → always a miss"
@@ -715,7 +732,9 @@ fn partial_hit_truncates_to_matched_block_boundary() {
     // Request shares first 3 blocks, then diverges.
     let mut req = cached[..3 * BLOCK_TOKENS].to_vec();
     req.extend(50_000..50_000 + BLOCK_TOKENS as u32);
-    let (idx, blocks) = cache.find_best_prefix(&req).expect("3-block prefix hit");
+    let (idx, blocks) = cache
+        .find_best_prefix(&req, FNV_OFFSET)
+        .expect("3-block prefix hit");
     assert_eq!(blocks, 3, "exactly 3 leading blocks match");
 
     let mut cloned = cache.slots[idx].entry.deep_clone().unwrap();
@@ -821,7 +840,7 @@ fn arch_cache_with_inner_mut_round_trip() {
     // Second-call observability: the pushed entry is reachable.
     let hit_blocks = arch.with_inner_mut(|g| {
         let cache = g.as_mut().unwrap();
-        cache.find_best_prefix(&ids).map(|(_, b)| b)
+        cache.find_best_prefix(&ids, FNV_OFFSET).map(|(_, b)| b)
     });
     assert_eq!(hit_blocks, Some(2), "pushed entry must hit on full prompt");
     // Deep-clone semantics: clone the slot and verify tokens identical.
@@ -895,7 +914,7 @@ fn exact_only_policy_forces_partial_match_to_miss_semantics() {
     // the full-token-equality check fails, the lookup MUST be Miss.
     let outcome = arch.with_inner_mut(|g| {
         let cache = g.as_mut().unwrap();
-        let m = cache.find_best_prefix(&req);
+        let m = cache.find_best_prefix(&req, FNV_OFFSET);
         match m {
             Some((slot_idx, _b)) => {
                 let exact = cache.slots[slot_idx].entry.prompt_token_ids() == req.as_slice();
@@ -911,5 +930,70 @@ fn exact_only_policy_forces_partial_match_to_miss_semantics() {
     assert_eq!(
         outcome, "miss",
         "ExactOnly policy must force non-exact matches to Miss semantics"
+    );
+}
+
+/// Issue #26 — codec-partitioned prefix-cache key (the anti-cross-serve guard).
+///
+/// A prefix cached under one KV codec must NOT be served to a request running a
+/// different codec — the cached K/V bytes are codec-specific. The production
+/// push/query seed is `FNV_OFFSET ^ layout_key ^ codec_salt(kv_quant)`; here we
+/// store a slot under codec A's seed and assert that a query under codec A's
+/// seed HITS (same codec → reuse) while a query under codec B's seed MISSES
+/// (cross-codec → no serve), even though the token ids are byte-identical. This
+/// is the namespacing that lets a resident model serve multiple codecs without
+/// conflating their caches.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: PromptCache slots populated by construction just above each lookup"
+)]
+fn codec_partitioned_key_blocks_cross_codec_serve() {
+    use rmlx_kv_quant::KvQuant;
+
+    // Two distinct codecs → two distinct salts → two distinct seeds.
+    let seed_a = FNV_OFFSET ^ KvQuant::None.cache_key_salt();
+    let seed_b = FNV_OFFSET ^ KvQuant::K8V4.cache_key_salt();
+    assert_ne!(seed_a, seed_b, "distinct codecs must yield distinct seeds");
+
+    // Identical 2-block prompt for both codecs.
+    let prompt: Vec<u32> = make_ids(2 * BLOCK_TOKENS);
+
+    let mut cache: PromptCache<TestEntry> = PromptCache::new(4);
+    // Store the slot under codec A's seed (mirrors the production push).
+    cache.push(TestEntry::new_seeded(prompt.clone(), seed_a));
+
+    // 1. Same-codec query (seed A) → HIT (full 2-block prefix).
+    let hit_a = cache.find_best_prefix(&prompt, seed_a);
+    assert!(
+        hit_a.is_some(),
+        "same-codec query must hit the codec-A slot"
+    );
+    assert_eq!(hit_a.unwrap().1, 2, "full 2-block prefix must match");
+
+    // 2. Cross-codec query (seed B) → MISS, even though the tokens are
+    //    identical. The codec-B digest stream is disjoint from codec-A's, so
+    //    the codec-A slot is never matched → no cross-serve of mismatched KV.
+    let miss_b = cache.find_best_prefix(&prompt, seed_b);
+    assert!(
+        miss_b.is_none(),
+        "cross-codec query must MISS the codec-A slot (anti-cross-serve guard)"
+    );
+
+    // 3. Coexistence: pushing the same prompt under codec B adds a *second*
+    //    slot rather than colliding, and each codec now hits its own slot.
+    cache.push(TestEntry::new_seeded(prompt.clone(), seed_b));
+    assert_eq!(
+        cache.slots.len(),
+        2,
+        "both codecs coexist as distinct slots"
+    );
+    assert!(
+        cache.find_best_prefix(&prompt, seed_a).is_some(),
+        "codec-A query still hits its own slot"
+    );
+    assert!(
+        cache.find_best_prefix(&prompt, seed_b).is_some(),
+        "codec-B query hits its own slot"
     );
 }

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -997,3 +997,133 @@ fn codec_partitioned_key_blocks_cross_codec_serve() {
         "codec-B query hits its own slot"
     );
 }
+
+// ── SSD hydrate seed symmetry (issue #26 reviewer fix) ────────────────────
+//
+// Regression guard for the SSD hydrate path fixed in the review of #26:
+// `SsdHydrate<E>` impls must build the hydrated entry's `block_hashes` with
+// `FNV_OFFSET ^ layout_key ^ kv_quant.cache_key_salt()` — the same seed the
+// RAM push and `find_best_prefix` query use.  If the codec salt is omitted
+// from the hydrate seed, `find_best_prefix` can never match a hydrated entry
+// on SSD-active runs (non-zero `layout_key`) → guaranteed prefix MISS despite
+// a valid on-disk block.
+
+/// A mock `SsdHydrate<TestEntry>` whose returned entry uses the fully-salted
+/// seed (`FNV_OFFSET ^ layout_key ^ codec_salt`), mirroring the corrected
+/// production impls.
+struct MockHydrateSalted {
+    ids: Vec<u32>,
+    layout_key: u64,
+    codec_salt: u64,
+}
+
+impl SsdHydrate<TestEntry> for MockHydrateSalted {
+    fn hydrate(&self, _prompt_ids: &[u32]) -> rmlx_core::error::Result<Option<TestEntry>> {
+        let seed = FNV_OFFSET ^ self.layout_key ^ self.codec_salt;
+        let hashes = chained_block_hashes_seeded(&self.ids, seed);
+        Ok(Some(TestEntry {
+            ids: self.ids.clone(),
+            hashes,
+            truncated_to: std::cell::Cell::new(None),
+        }))
+    }
+}
+
+/// Same as above but uses only `FNV_OFFSET ^ layout_key` (codec salt
+/// omitted) — reproduces the pre-fix bug so we can confirm it misses.
+struct MockHydrateUnsalted {
+    ids: Vec<u32>,
+    layout_key: u64,
+}
+
+impl SsdHydrate<TestEntry> for MockHydrateUnsalted {
+    fn hydrate(&self, _prompt_ids: &[u32]) -> rmlx_core::error::Result<Option<TestEntry>> {
+        let seed = FNV_OFFSET ^ self.layout_key;
+        let hashes = chained_block_hashes_seeded(&self.ids, seed);
+        Ok(Some(TestEntry {
+            ids: self.ids.clone(),
+            hashes,
+            truncated_to: std::cell::Cell::new(None),
+        }))
+    }
+}
+
+/// Issue #26 review — SSD hydrate seed must include the codec salt.
+///
+/// With a non-zero `layout_key` and a non-trivial codec salt:
+/// 1. A hydrated entry built with the **full** seed (`FNV_OFFSET ^
+///    layout_key ^ codec_salt`) is found by a same-seed `find_best_prefix`
+///    query (corrected behavior — HIT).
+/// 2. A hydrated entry built with the **unsalted** seed (`FNV_OFFSET ^
+///    layout_key`, codec salt omitted) is NOT found by the same-codec
+///    query (pre-fix bug — MISS, here tested as the negative case to confirm
+///    the fix is load-bearing).
+/// 3. A correct hydrated entry is NOT found by a different-codec query
+///    (cross-codec isolation still holds).
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: values established by construction"
+)]
+fn ssd_hydrate_seed_symmetry_with_nonzero_layout_key() {
+    use rmlx_kv_quant::KvQuant;
+
+    // Non-zero layout_key to exercise the SSD-active code path.
+    let layout_key: u64 = 0xdead_beef_0000_0001;
+    let codec_a = KvQuant::K8V4;
+    let codec_b = KvQuant::K8V8;
+    let codec_salt_a = codec_a.cache_key_salt();
+    let codec_salt_b = codec_b.cache_key_salt();
+    assert_ne!(
+        codec_salt_a, codec_salt_b,
+        "codecs must have distinct salts"
+    );
+
+    let full_seed_a = FNV_OFFSET ^ layout_key ^ codec_salt_a;
+
+    // 2-block prompt.
+    let prompt_ids: Vec<u32> = make_ids(2 * BLOCK_TOKENS);
+
+    // ── Case 1: corrected hydrate (salted) → same-codec query HITs ──────────
+    let mut cache_correct: PromptCache<TestEntry> = PromptCache::new(4);
+    cache_correct.set_ssd_source(Box::new(MockHydrateSalted {
+        ids: prompt_ids.clone(),
+        layout_key,
+        codec_salt: codec_salt_a,
+    }));
+    let before = cache_correct.find_best_prefix(&prompt_ids, full_seed_a);
+    assert!(before.is_none(), "RAM empty before hydrate");
+    let promoted = cache_correct.hydrate_from_ssd(&prompt_ids);
+    assert!(promoted.is_some(), "mock SSD source must hydrate");
+    let after = cache_correct.find_best_prefix(&prompt_ids, full_seed_a);
+    assert!(
+        after.is_some(),
+        "salted hydrated entry must be found by same-codec query (corrected behavior)"
+    );
+    assert_eq!(after.unwrap().1, 2, "full 2-block prefix must match");
+
+    // ── Case 2: pre-fix hydrate (unsalted seed) → same-codec query MISSes ───
+    // This is the negative case that would have silently re-prefilled before
+    // the fix.  The hydrated entry's hashes are built from
+    // `FNV_OFFSET ^ layout_key` but the query uses `full_seed_a`
+    // (`FNV_OFFSET ^ layout_key ^ codec_salt_a`) → disjoint streams → MISS.
+    let mut cache_broken: PromptCache<TestEntry> = PromptCache::new(4);
+    cache_broken.set_ssd_source(Box::new(MockHydrateUnsalted {
+        ids: prompt_ids.clone(),
+        layout_key,
+    }));
+    cache_broken.hydrate_from_ssd(&prompt_ids);
+    let after_broken = cache_broken.find_best_prefix(&prompt_ids, full_seed_a);
+    assert!(
+        after_broken.is_none(),
+        "pre-fix (unsalted) hydrated entry must NOT be found by salted query (negative case)"
+    );
+
+    // ── Case 3: corrected hydrate under codec A → different-codec query MISSes
+    let full_seed_b = FNV_OFFSET ^ layout_key ^ codec_salt_b;
+    let cross_codec = cache_correct.find_best_prefix(&prompt_ids, full_seed_b);
+    assert!(
+        cross_codec.is_none(),
+        "codec-A hydrated entry must not cross-serve a codec-B query"
+    );
+}

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -1936,14 +1936,19 @@ pub fn generate_greedy(
         "qwen3 ArchPromptCache must use ReusePolicy::ExactOnly",
     );
 
+    // Issue #26: codec-partitioned prompt-cache key — see gemma4/generate/mod.rs
+    // for the full rationale. The query digest stream is salted by
+    // `FNV_OFFSET ^ layout_key ^ codec_salt(kv_quant)` (matches the push seed),
+    // so a slot stored under a different KV codec never cross-serves.
+    let cache_seed = FNV_OFFSET ^ qwen3_active_layout_key() ^ kv_quant.cache_key_salt();
     let lookup: CacheLookup = QWEN3_PROMPT_CACHE.with_inner_mut(|guard| {
         let cache = guard.as_mut().unwrap();
-        let mut raw_match = cache.find_best_prefix(prompt_ids);
+        let mut raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
         // on a RAM miss, try the SSD tier (no-op when no source attached
         // — tier OFF). A hit promotes the block into RAM; re-run find_best_prefix
         // so the promoted slot is matched + quant-checked by the path below.
         if raw_match.is_none() && cache.hydrate_from_ssd(prompt_ids).is_some() {
-            raw_match = cache.find_best_prefix(prompt_ids);
+            raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
         }
         // Plan §D8 / Task 11.5: stored `KvQuant` must match runtime; on
         // mismatch evict + warn + degrade to Miss. See `gemma4/generate.rs`
@@ -2476,10 +2481,14 @@ pub fn generate_greedy(
             // the clone, which shares the same buffers — so materializing here makes that eval a no-op.
             match kv_snapshot.iter().try_for_each(|c| c.eval_for_spill()) {
                 Ok(()) => {
-                    // salt chained walk with the active layout_key. When tier
-                    // is OFF, `active_layout_key()` returns 0 ⇒ legacy un-salted.
+                    // salt chained walk with the active layout_key + KV codec
+                    // (issue #26). When tier is OFF and the codec is constant,
+                    // this is the legacy stream for that codec.
                     let lk = qwen3_active_layout_key();
-                    let block_hashes = chained_block_hashes_seeded(prompt_ids, FNV_OFFSET ^ lk);
+                    let block_hashes = chained_block_hashes_seeded(
+                        prompt_ids,
+                        FNV_OFFSET ^ lk ^ kv_quant.cache_key_salt(),
+                    );
                     // Capture the first-token logprobs at the OpenAI ceiling so
                     // a later exact-hit replays a true logprob (truncated to its own
                     // `top_logprobs_k`) regardless of whether THIS request asked for

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -274,7 +274,10 @@ impl SsdHydrate<Qwen3Entry> for SsdHydrator {
             kv_caches,
             lin_caches: _, // pure-attention arch has no GDN state
         } = block;
-        let block_hashes = chained_block_hashes_seeded(&prompt_ids, FNV_OFFSET ^ self.layout_key());
+        let block_hashes = chained_block_hashes_seeded(
+            &prompt_ids,
+            FNV_OFFSET ^ self.layout_key() ^ self.kv_quant().cache_key_salt(),
+        );
         Ok(Some(Qwen3Entry {
             prompt_token_ids: prompt_ids,
             block_hashes,

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -179,14 +179,20 @@ pub fn generate_greedy(
          partial-prefix reuse is unsafe for GDN lin_caches",
     );
 
+    // Issue #26: codec-partitioned prompt-cache key — see gemma4/generate/mod.rs
+    // for the full rationale. Query digest stream salted by
+    // `FNV_OFFSET ^ layout_key ^ codec_salt(kv_quant)` (matches the push seed).
+    let cache_seed = crate::prompt_cache::FNV_OFFSET
+        ^ crate::qwen3_5_moe::prompt_cache::active_layout_key()
+        ^ kv_quant.cache_key_salt();
     let lookup: CacheLookup = PROMPT_CACHE.with_inner_mut(|guard| {
         let cache = guard.as_mut().unwrap();
-        let mut raw_match = cache.find_best_prefix(prompt_ids);
+        let mut raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
         // on a RAM miss, try the SSD tier (no-op when no source attached
         // — tier OFF). A hit promotes the block into RAM; re-run find_best_prefix
         // so the promoted slot is matched + quant-checked by the path below.
         if raw_match.is_none() && cache.hydrate_from_ssd(prompt_ids).is_some() {
-            raw_match = cache.find_best_prefix(prompt_ids);
+            raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
         }
         // Plan §D8 / Task 11.5: stored `KvQuant` must match runtime; on
         // mismatch evict + warn + degrade to Miss. See `gemma4/generate.rs`
@@ -1126,7 +1132,9 @@ pub fn generate_greedy(
                                 prompt_token_ids: prompt_ids.to_vec(),
                                 block_hashes: crate::prompt_cache::chained_block_hashes_seeded(
                                     prompt_ids,
-                                    crate::prompt_cache::FNV_OFFSET ^ lk,
+                                    crate::prompt_cache::FNV_OFFSET
+                                        ^ lk
+                                        ^ kv_quant.cache_key_salt(),
                                 ),
                                 kv_caches: kvs,
                                 lin_caches: lins,

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -709,7 +709,9 @@ pub fn generate_greedy(
                                     prompt_token_ids: prompt_ids.to_vec(),
                                     block_hashes: crate::prompt_cache::chained_block_hashes_seeded(
                                         prompt_ids,
-                                        crate::prompt_cache::FNV_OFFSET ^ lk,
+                                        crate::prompt_cache::FNV_OFFSET
+                                            ^ lk
+                                            ^ kv_quant.cache_key_salt(),
                                     ),
                                     kv_caches: kvs,
                                     lin_caches: lins,

--- a/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
@@ -179,7 +179,10 @@ impl SsdHydrate<Qwen35MoeEntry> for SsdHydrator {
             kv_caches,
             lin_caches,
         } = block;
-        let block_hashes = chained_block_hashes_seeded(&prompt_ids, FNV_OFFSET ^ self.layout_key());
+        let block_hashes = chained_block_hashes_seeded(
+            &prompt_ids,
+            FNV_OFFSET ^ self.layout_key() ^ self.kv_quant().cache_key_salt(),
+        );
         Ok(Some(Qwen35MoeEntry {
             prompt_token_ids: prompt_ids,
             block_hashes,

--- a/crates/rmlx-models/src/qwen3_5_moe/tests.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/tests.rs
@@ -25,7 +25,8 @@ use super::{
 use super::decoder_layer::AttnBlock;
 use super::layers::{embed_lookup, Embedding};
 use super::prompt_cache::Qwen35MoeEntry;
-use crate::prompt_cache::{chained_block_hashes, PromptCache, BLOCK_TOKENS};
+use crate::prompt_cache::{PromptCache, BLOCK_TOKENS};
+use rmlx_kv_ssd::chained_block_hashes;
 
 fn paro_model_dir() -> Option<std::path::PathBuf> {
     std::env::var_os("RMLX_TEST_MODEL_QWEN36_PARO").map(std::path::PathBuf::from)
@@ -171,7 +172,9 @@ fn prompt_cache_lookup_miss_empty() {
     let mut cache: PromptCache<Qwen35MoeEntry> = PromptCache::new(4);
     let ids = vec![1u32, 2, 3, 4];
     assert!(
-        cache.find_best_prefix(&ids).is_none(),
+        cache
+            .find_best_prefix(&ids, crate::prompt_cache::FNV_OFFSET)
+            .is_none(),
         "empty cache must return None"
     );
 }
@@ -193,7 +196,7 @@ fn prompt_cache_lookup_hit_prefix() {
     let mut new_prompt: Vec<u32> = (0..BLOCK_TOKENS as u32).collect();
     new_prompt.extend(10_000..10_000 + BLOCK_TOKENS as u32);
 
-    let result = cache.find_best_prefix(&new_prompt);
+    let result = cache.find_best_prefix(&new_prompt, crate::prompt_cache::FNV_OFFSET);
     assert!(result.is_some(), "cache must return a prefix hit");
     let (slot_idx, block_count) = result.unwrap();
     assert_eq!(slot_idx, 0, "slot index must be 0");
@@ -211,7 +214,9 @@ fn prompt_cache_lookup_miss_below_threshold() {
 
     let query: Vec<u32> = (1..=10).chain(800..1000u32).collect();
     assert!(
-        cache.find_best_prefix(&query).is_none(),
+        cache
+            .find_best_prefix(&query, crate::prompt_cache::FNV_OFFSET)
+            .is_none(),
         "shared prefix < one 256-token block must return None"
     );
 }
@@ -240,7 +245,7 @@ fn prompt_cache_fifo_eviction() {
 
     // Slot A is gone — its exact prompt no longer matches any block.
     let query_a = make_ids(0);
-    let r = cache.find_best_prefix(&query_a);
+    let r = cache.find_best_prefix(&query_a, crate::prompt_cache::FNV_OFFSET);
     assert!(
         r.is_none(),
         "evicted slot A must not produce a match; got {r:?}"
@@ -248,7 +253,7 @@ fn prompt_cache_fifo_eviction() {
 
     // Slot C must match its own 2-block prompt exactly.
     let query_c = make_ids(2);
-    let rc = cache.find_best_prefix(&query_c);
+    let rc = cache.find_best_prefix(&query_c, crate::prompt_cache::FNV_OFFSET);
     assert!(rc.is_some(), "slot C must match its own prompt");
     let (_, blocks) = rc.unwrap();
     assert_eq!(blocks, 2, "slot C shares both blocks with its own prompt");
@@ -297,7 +302,7 @@ fn prompt_cache_identical_prompt_is_exact_not_partial() {
 
     // Re-request the SAME prompt (regenerate / identical retry).
     let (slot_idx, block_count) = cache
-        .find_best_prefix(&prompt)
+        .find_best_prefix(&prompt, crate::prompt_cache::FNV_OFFSET)
         .expect("identical prompt must hit");
 
     // The fixed callsite predicate: full token-level equality => EXACT.

--- a/crates/rmlx-models/src/qwen3_tests.rs
+++ b/crates/rmlx-models/src/qwen3_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
-use crate::prompt_cache::{chained_block_hashes, PromptCache};
+use crate::prompt_cache::PromptCache;
+use rmlx_kv_ssd::chained_block_hashes;
 
 /// Unit test: per-head q_norm shape is preserved.
 ///
@@ -299,7 +300,7 @@ fn qwen3_ssd_hydrate_promotes_entry_into_ram() {
     }));
 
     // Before hydrate: RAM miss.
-    let before = cache.find_best_prefix(&prompt_ids);
+    let before = cache.find_best_prefix(&prompt_ids, FNV_OFFSET);
     assert!(before.is_none(), "RAM must be empty before hydrate");
 
     // Hydrate from mock SSD.
@@ -316,7 +317,7 @@ fn qwen3_ssd_hydrate_promotes_entry_into_ram() {
     assert_eq!(cache.stats().ssd_hits, 1, "ssd_hits counter must be bumped");
 
     // After hydrate: RAM hit.
-    let after = cache.find_best_prefix(&prompt_ids);
+    let after = cache.find_best_prefix(&prompt_ids, FNV_OFFSET);
     assert!(
         after.is_some(),
         "promoted entry must be findable in RAM after hydrate"

--- a/crates/rmlx-server/src/anthropic/route.rs
+++ b/crates/rmlx-server/src/anthropic/route.rs
@@ -538,6 +538,10 @@ pub(crate) async fn messages(
         thinking_end_token: None,
         // C5 Slice A: set below, after FIFO admission acquires the permit.
         gpu_admission: None,
+        // Issue #26: the Anthropic Messages surface does not expose per-request
+        // KV-config overrides (stricter wire spec); always launch default here.
+        kv_quant_override: None,
+        max_ctx_override: None,
         // Anthropic route has no multimodal content-part extraction yet.
         images: vec![],
         audio_b64: vec![],

--- a/crates/rmlx-server/src/engine/gemma4.rs
+++ b/crates/rmlx-server/src/engine/gemma4.rs
@@ -483,14 +483,27 @@ impl Generator for Gemma4Generator {
         let req_images = req.images.clone();
         let vision = self.vision.clone();
         let mm_cache = self.mm_cache.clone();
-        let kv_quant_user_explicit = self.kv_quant_user_explicit;
+        // Issue #26: a per-request `kv_quant` override hot-swaps the KV codec on
+        // the resident model. When present it takes precedence over the launch
+        // `--kv-quant` (explicit or auto) and over the per-ctx auto policy —
+        // exactly like a startup-explicit flag, but scoped to this one request.
+        // The prefix/prompt cache key is namespaced by codec downstream, so a
+        // codec switch never serves mismatched cached KV.
+        let req_kv_quant_override = req.kv_quant_override;
+        let kv_quant_user_explicit = self.kv_quant_user_explicit || req_kv_quant_override.is_some();
         let lock = Arc::clone(&self._lock);
         // Per-request ctx-based KV mode selection in auto mode.
         // When the user gave an explicit `--kv-quant <mode>` flag at startup,
         // honour it for every request. In auto mode, override the arch-resolved
         // default with `kv_quant_for_ctx(prompt_len)` so long-ctx requests
         // automatically use a quant mode suited to that context length.
-        let kv_quant_override = if self.kv_quant_user_explicit {
+        let kv_quant_override = if let Some(rq) = req_kv_quant_override {
+            tracing::info!(
+                ?rq,
+                "generate: per-request KV-quant override active (issue #26)"
+            );
+            Some(rq)
+        } else if self.kv_quant_user_explicit {
             self.kv_quant_override
         } else if matches!(
             self.model.as_ref(),
@@ -511,7 +524,16 @@ impl Generator for Gemma4Generator {
             );
             Some(ctx_quant)
         };
-        let max_ctx_override = self.max_ctx_override;
+        // Issue #26: a per-request `max_ctx` re-sizes the KV-ring virtual
+        // ceiling for this request only (#25 lazy-grow path); `None` keeps the
+        // launch `--max-ctx`. No weight touch — a ring realloc only.
+        let max_ctx_override = req.max_ctx_override.or(self.max_ctx_override);
+        if req.max_ctx_override.is_some() {
+            tracing::info!(
+                max_ctx = ?req.max_ctx_override,
+                "generate: per-request max-ctx override active (issue #26)"
+            );
+        }
         // F2: capture effective_max_ctx for drainer MetricEvent.ctx_max field.
         let effective_max_ctx_val = self.effective_max_ctx as i64;
         // N2: route handler sets effective_prompt_cache_slots = base + active_sessions

--- a/crates/rmlx-server/src/engine/helpers.rs
+++ b/crates/rmlx-server/src/engine/helpers.rs
@@ -129,6 +129,37 @@ pub(crate) fn resolve_kv_quant_for_load(
     }
 }
 
+/// Issue #26: parse a per-request `kv_quant` string into an optional override.
+///
+/// Mirrors the `--kv-quant` CLI grammar (`crate`-external
+/// `rmlx_cli::commands::parse::parse_kv_quant`) so a request field and the
+/// launch flag accept identical strings:
+/// - `"auto"` → `Ok(None)` — fall through to the generator's per-arch/per-ctx
+///   auto policy (NOT the launch explicit value).
+/// - `"mixed"` → the canonical `Mixed{k8,v4,g64}` short alias.
+/// - everything else → `<KvQuant as FromStr>::from_str` (`none`/`bf16`,
+///   `k8v4`, `k8v8`, `planar`, `mixed_k<kb>g<kg>_v<vb>g<vg>`, …).
+///
+/// Returns the parse error string (no `--kv-quant:` prefix) so the route layer
+/// can wrap it in a clean HTTP 400 `invalid_request_error`.
+pub(crate) fn parse_request_kv_quant(s: &str) -> Result<Option<rmlx_kv_quant::KvQuant>, String> {
+    use rmlx_kv_quant::KvQuant;
+    use std::str::FromStr;
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("auto") {
+        return Ok(None);
+    }
+    if s.eq_ignore_ascii_case("mixed") {
+        return Ok(Some(KvQuant::Mixed {
+            k_bits: 8,
+            v_bits: 4,
+            k_group_size: 64,
+            v_group_size: 64,
+        }));
+    }
+    KvQuant::from_str(s).map(Some).map_err(|e| e.to_string())
+}
+
 // ── tool-marker allowlist ────────────────────────────────────────────────────
 
 /// A5.6: whether a special-token surface form is one of the Gemma-4

--- a/crates/rmlx-server/src/engine/mod.rs
+++ b/crates/rmlx-server/src/engine/mod.rs
@@ -49,7 +49,7 @@ pub use types::{
 
 // ── Crate-internal re-exports ─────────────────────────────────────────────────
 
-pub(crate) use helpers::record_ttft_and_prefill;
+pub(crate) use helpers::{parse_request_kv_quant, record_ttft_and_prefill};
 
 // ── Test-visible re-exports ───────────────────────────────────────────────────
 

--- a/crates/rmlx-server/src/engine/speculative.rs
+++ b/crates/rmlx-server/src/engine/speculative.rs
@@ -571,8 +571,16 @@ impl Generator for SpeculativeGenerator {
         let prompt_tokens = req.prompt_tokens.clone();
         let n_tokens = req.max_tokens as usize;
         let lock = Arc::clone(&self._lock);
+        // Issue #26: per-request `kv_quant` override wins over the launch
+        // default (explicit or per-ctx auto), scoped to this request only.
         // Same ctx-based auto selection as Gemma4Generator.
-        let kv_quant_override = if self.kv_quant_user_explicit {
+        let kv_quant_override = if let Some(rq) = req.kv_quant_override {
+            tracing::info!(
+                ?rq,
+                "speculative generate: per-request KV-quant override active (issue #26)"
+            );
+            Some(rq)
+        } else if self.kv_quant_user_explicit {
             self.kv_quant_override
         } else {
             let ctx_quant = rmlx_models::kv_cache::kv_quant_for_ctx(prompt_tokens.len());
@@ -583,7 +591,8 @@ impl Generator for SpeculativeGenerator {
             );
             Some(ctx_quant)
         };
-        let max_ctx_override = self.max_ctx_override;
+        // Issue #26: per-request max-ctx ceiling override (#25 lazy-grow path).
+        let max_ctx_override = req.max_ctx_override.or(self.max_ctx_override);
         // F2: capture effective_max_ctx for drainer MetricEvent.ctx_max field.
         let effective_max_ctx_val = self.effective_max_ctx as i64;
         // N2: use effective_prompt_cache_slots override if set by route handler.

--- a/crates/rmlx-server/src/engine/tests.rs
+++ b/crates/rmlx-server/src/engine/tests.rs
@@ -27,6 +27,8 @@ fn sample_req() -> GenerationRequest {
         thinking_start_token: None,
         thinking_end_token: None,
         gpu_admission: None,
+        kv_quant_override: None,
+        max_ctx_override: None,
         images: vec![],
         audio_b64: vec![],
     }
@@ -735,4 +737,62 @@ fn registry_exposes_new_ops() {
             "{op} direction"
         );
     }
+}
+
+// ── Issue #26: per-request KV-config override parsing ──────────────────────────
+
+/// `parse_request_kv_quant` mirrors the `--kv-quant` CLI grammar: `"auto"` →
+/// `None` (fall through to the generator's per-arch/per-ctx default), canonical
+/// codec strings → the matching `KvQuant`, `"mixed"` → the canonical short
+/// alias, and a malformed string → `Err` (the route maps this to HTTP 400).
+#[test]
+fn parse_request_kv_quant_maps_strings() {
+    use rmlx_kv_quant::KvQuant;
+
+    // "auto" → None (defer to launch/auto policy).
+    assert_eq!(parse_request_kv_quant("auto"), Ok(None));
+    // Case-insensitive + whitespace-tolerant.
+    assert_eq!(parse_request_kv_quant("  AUTO "), Ok(None));
+
+    // Canonical codec strings round-trip to the right variant.
+    assert_eq!(parse_request_kv_quant("none"), Ok(Some(KvQuant::None)));
+    assert_eq!(parse_request_kv_quant("bf16"), Ok(Some(KvQuant::None)));
+    assert_eq!(parse_request_kv_quant("k8v4"), Ok(Some(KvQuant::K8V4)));
+    assert_eq!(parse_request_kv_quant("k8v8"), Ok(Some(KvQuant::K8V8)));
+    assert_eq!(parse_request_kv_quant("planar"), Ok(Some(KvQuant::Planar)));
+
+    // "mixed" → the canonical Mixed{k8,v4,g64} short alias.
+    assert_eq!(
+        parse_request_kv_quant("mixed"),
+        Ok(Some(KvQuant::Mixed {
+            k_bits: 8,
+            v_bits: 4,
+            k_group_size: 64,
+            v_group_size: 64,
+        }))
+    );
+
+    // Garbage → Err (route layer returns HTTP 400).
+    assert!(parse_request_kv_quant("definitely-not-a-codec").is_err());
+}
+
+/// Default-when-absent: the override fields on a freshly built request are
+/// `None`, so the generator falls through to its launch default (zero
+/// regression for requests that omit `kv_quant` / `max_ctx`).
+#[test]
+fn generation_request_overrides_default_none() {
+    let req = sample_req();
+    assert_eq!(req.kv_quant_override, None);
+    assert_eq!(req.max_ctx_override, None);
+}
+
+/// A per-request override is carried verbatim on the `GenerationRequest` so the
+/// generator's `generate()` can prefer it over the launch default.
+#[test]
+fn generation_request_carries_overrides() {
+    let mut req = sample_req();
+    req.kv_quant_override = Some(rmlx_kv_quant::KvQuant::K8V4);
+    req.max_ctx_override = Some(8192);
+    assert_eq!(req.kv_quant_override, Some(rmlx_kv_quant::KvQuant::K8V4));
+    assert_eq!(req.max_ctx_override, Some(8192));
 }

--- a/crates/rmlx-server/src/engine/types.rs
+++ b/crates/rmlx-server/src/engine/types.rs
@@ -407,6 +407,20 @@ pub struct GenerationRequest {
     /// unit-test / non-route paths that never went through admission.
     pub gpu_admission: Option<GpuAdmission>,
 
+    /// Issue #26: per-request KV-quant codec override. `Some(q)` switches the
+    /// per-request cache builder to codec `q` on the resident model (no weight
+    /// reload); `None` falls through to the generator's launch default
+    /// (`--kv-quant`, or the auto per-ctx policy). The prefix/prompt cache key
+    /// is namespaced by codec, so a `none`-codec cached prefix never serves a
+    /// quantized-KV request and vice-versa.
+    pub kv_quant_override: Option<rmlx_kv_quant::KvQuant>,
+
+    /// Issue #26: per-request max-context ceiling override. `Some(n)` re-sizes
+    /// the KV-ring virtual ceiling for this request only (the ring still grows
+    /// lazily, #25); `None` uses the generator's launch `--max-ctx`. No weight
+    /// touch — a ring realloc only.
+    pub max_ctx_override: Option<i32>,
+
     // multimodal content parts extracted from `user` message Parts.
     // will pass these into the vision/audio towers. The decode loop
     // currently ignores them — text-only requests stay byte-identical.

--- a/crates/rmlx-server/src/openai/chat.rs
+++ b/crates/rmlx-server/src/openai/chat.rs
@@ -213,6 +213,34 @@ pub(crate) async fn chat_completions(
             return bad_request("presence_penalty must be in [-2.0, 2.0]");
         }
     }
+    // Issue #26: per-request KV-cache config hot-swap. Parse `kv_quant` /
+    // `max_ctx` overrides up front so a malformed codec string rejects with a
+    // clean 400 before any tokenization or model-load work. `None` (omitted)
+    // → fall through to the generator's launch default (zero regression).
+    let req_kv_quant_override = match req.kv_quant.as_deref() {
+        Some(s) => match crate::engine::parse_request_kv_quant(s) {
+            Ok(v) => v,
+            Err(e) => {
+                state.error_counts.increment(ApiErrorCategory::BadRequest);
+                return bad_request(&format!("kv_quant: {e}"));
+            }
+        },
+        None => None,
+    };
+    if let Some(c) = req.max_ctx {
+        if c <= 0 {
+            state.error_counts.increment(ApiErrorCategory::BadRequest);
+            return bad_request("max_ctx must be > 0");
+        }
+    }
+    let req_max_ctx_override = req.max_ctx;
+    if req_kv_quant_override.is_some() || req_max_ctx_override.is_some() {
+        tracing::info!(
+            kv_quant = ?req_kv_quant_override,
+            max_ctx = ?req_max_ctx_override,
+            "chat_completions: per-request KV-config override (issue #26)"
+        );
+    }
     // logprobs / top_logprobs validation (OpenAI semantics).
     // - `top_logprobs` requires `logprobs:true` (else 400).
     // - `top_logprobs` must be in 0..=20.
@@ -937,6 +965,10 @@ pub(crate) async fn chat_completions(
         thinking_end_token,
         // C5 Slice A: set below, after FIFO admission acquires the permit.
         gpu_admission: None,
+        // Issue #26: per-request KV-config overrides threaded to the cache
+        // builder (None = launch default).
+        kv_quant_override: req_kv_quant_override,
+        max_ctx_override: req_max_ctx_override,
         // multimodal content-part extraction.
         images: req_images,
         audio_b64: req_audio_b64,
@@ -971,7 +1003,14 @@ pub(crate) async fn chat_completions(
     // Slot=None (cold-start race) or NotReadyGenerator default → usize::MAX,
     // letting the existing 503 path catch real runtime overflows there.
     {
-        let effective_max_ctx = state.effective_max_ctx_for(&req.model);
+        // Issue #26: when a per-request `max_ctx` override is present, the guard
+        // ceiling is the requested value (the engine sizes the KV-ring virtual
+        // ceiling to it, #25), not the load-time `--max-ctx`. The engine clamps
+        // by the model's max_position_embeddings during cache build, so an
+        // over-mpe request is bounded there; this guard only prevents a runaway
+        // prompt from bottoming out as a 503 / zero-token response.
+        let effective_max_ctx = req_max_ctx_override
+            .map_or_else(|| state.effective_max_ctx_for(&req.model), |n| n as usize);
         let prompt_len = gen_req.prompt_tokens.len();
         if prompt_len > effective_max_ctx {
             state

--- a/crates/rmlx-server/src/openai/request.rs
+++ b/crates/rmlx-server/src/openai/request.rs
@@ -501,6 +501,21 @@ pub struct ChatCompletionsRequest {
     #[serde(default)]
     pub thinking_end_token: Option<String>,
 
+    // Issue #26: per-request KV-cache config hot-swap on a resident model.
+    // These let a single `rmlx serve` process (weights loaded once) switch the
+    // KV codec and context ceiling per request — no weight reload. `None`
+    // (omitted) preserves the launch-default behavior exactly (zero regression).
+    /// Per-request KV-quant codec override (e.g. `"none"`, `"k8v4"`, `"k8v8"`,
+    /// `"planar"`, `"auto"`). `"auto"` selects the per-arch/per-ctx default.
+    /// `None` (omitted) uses the server's launch `--kv-quant`. Parsed with the
+    /// same grammar as the `--kv-quant` CLI flag.
+    #[serde(default)]
+    pub kv_quant: Option<String>,
+    /// Per-request max-context ceiling override (KV ring grows lazily up to this
+    /// ceiling, #25). `None` (omitted) uses the server's launch `--max-ctx`.
+    #[serde(default)]
+    pub max_ctx: Option<i32>,
+
     // Stage 2+ features — accepted & ignored with a debug log.
     // Explicitly reject only fields that indicate unsafe injection intent.
     /// Catch-all for unknown request fields; debug-logged and ignored.

--- a/crates/rmlx-server/src/retry.rs
+++ b/crates/rmlx-server/src/retry.rs
@@ -254,6 +254,10 @@ pub struct RequestPlan {
     pub images: Vec<String>,
     /// Base64-encoded audio payloads attached to this request.
     pub audio_b64: Vec<String>,
+    /// Issue #26: per-request KV-quant codec override (`None` = launch default).
+    pub kv_quant_override: Option<rmlx_kv_quant::KvQuant>,
+    /// Issue #26: per-request max-ctx ceiling override (`None` = launch default).
+    pub max_ctx_override: Option<i32>,
 }
 
 impl RequestPlan {
@@ -288,6 +292,8 @@ impl RequestPlan {
             thinking_end_token: req.thinking_end_token.clone(),
             images: req.images.clone(),
             audio_b64: req.audio_b64.clone(),
+            kv_quant_override: req.kv_quant_override,
+            max_ctx_override: req.max_ctx_override,
         }
     }
 
@@ -334,6 +340,8 @@ impl RequestPlan {
             gpu_admission: None,
             images: self.images.clone(),
             audio_b64: self.audio_b64.clone(),
+            kv_quant_override: self.kv_quant_override,
+            max_ctx_override: self.max_ctx_override,
         }
     }
 }

--- a/crates/rmlx-server/src/retry_tests.rs
+++ b/crates/rmlx-server/src/retry_tests.rs
@@ -140,6 +140,8 @@ fn req_with_temp(temperature: f32) -> GenerationRequest {
         thinking_start_token: None,
         thinking_end_token: None,
         gpu_admission: None,
+        kv_quant_override: None,
+        max_ctx_override: None,
         images: vec![],
         audio_b64: vec![],
     }
@@ -261,6 +263,8 @@ fn make_initial_req(prompt: Vec<u32>, max_tokens: u32) -> GenerationRequest {
         thinking_start_token: None,
         thinking_end_token: None,
         gpu_admission: None,
+        kv_quant_override: None,
+        max_ctx_override: None,
         images: vec![],
         audio_b64: vec![],
     }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -106,6 +106,14 @@ mutually exclusive.
 | `--planar-fused-qk` | `on \| off` | `on` | Route pre-softmax QK over PlanarQuant-packed K (`KvStorage::PlanarK`) through the `planar_fused_qk` MSL kernel instead of dequant+SDPA. Decode-step only (prefill chunks fall through to the legacy path). No effect on any non-PlanarK cache. **No env fallback — CLI-only**; tests do not need an env lock. See `docs/KV_QUANT.md` §"Fused-QK kernels". |
 | `--prefix-index` | `linear \| radix` | `linear` | Longest-prefix index strategy for the prompt cache. `linear` is O(slots × n\_blocks); `radix` is O(n\_blocks). |
 
+> **Per-request override (issue #26).** `--kv-quant` and `--max-ctx` set the
+> **launch defaults**. On a running server, the OpenAI route accepts per-request
+> `kv_quant` / `max_ctx` fields that override them for one request without
+> reloading weights — one resident model can serve multiple KV codecs / context
+> ceilings. Requests that omit the fields use these launch defaults. See
+> `docs/SERVER.md` § "Per-request KV-config hot-swap". `--kv-ssd-cache-gb` stays
+> launch-fixed (SSD live reconfig deferred — `docs/SSD_TIER.md`).
+
 **KV-bits mapping** (`--kv-bits` + `--kv-group-size`):
 
 | `--kv-bits` | Result |

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -245,6 +245,17 @@ cache sized to the ceiling.
 SWA / rotating layers are unaffected: their bf16 ring is sized to the
 `sliding_window`, never to `max_seq`, so they carry no long-context tax.
 
+### Per-request `max_ctx` override (issue #26)
+
+Because the ceiling is resolved **per request** (`kv_max_seq_and_ceiling`), it
+can be overridden per request without reloading weights. The OpenAI route
+accepts an optional `max_ctx` field that supplies the override for that one
+request (else the launch `--max-ctx`); the server's `context_length_exceeded`
+prompt-length guard uses the per-request ceiling when present. This pairs with
+the per-request KV-codec hot-swap (also issue #26) so a resident model can sweep
+`(codec × ctx)` cells with no reload. See `docs/SERVER.md` § "Per-request
+KV-config hot-swap".
+
 ## 5. Hard invariants
 
 These are enforced by the resolver. Violation exits with code 78

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -120,6 +120,20 @@ of the active `KvQuant`: they use `RotatingState` (a ring-buffer bf16 path
 ported from mlx-lm's `RotatingKVCache`). `mlx-lm.to_quantized` raises
 `NotImplementedError` for rotating caches; rMLX matches that behaviour.
 
+### Per-request hot-swap (issue #26)
+
+The `KvQuant` for a request is **not** tied to the model load. A running
+`rmlx serve` accepts a per-request `kv_quant` field (OpenAI route) that selects
+the codec for that one request — weights stay resident, only the KV cache is
+rebuilt. This means one resident model can serve `none`, `k8v4`, `k8v8`, … back
+to back with no reload. The override threads down to the same per-request cache
+builder the per-ctx `auto` policy already used; absent → launch `--kv-quant`.
+
+The prompt/prefix cache is **partitioned by codec** so a switch can never serve
+mismatched cached K/V — `KvQuant::cache_key_salt()` is XOR'd into the
+block-hash seed alongside the SSD `layout_key`. See `docs/PROMPT_CACHE.md`
+§ "Codec namespacing" and `docs/SERVER.md` § "Per-request KV-config hot-swap".
+
 ---
 
 ## Storage variants — summary table

--- a/docs/PROMPT_CACHE.md
+++ b/docs/PROMPT_CACHE.md
@@ -94,6 +94,38 @@ is retained for tests and for backward-compat verification.
 The SSD index also stores `(hash, layout_key)` as a composite primary key,
 providing defence-in-depth against hash collisions across layouts.
 
+### Codec namespacing (issue #26)
+
+A single resident model can serve requests under **different KV codecs**
+(per-request `kv_quant` hot-swap, no weight reload — see `docs/SERVER.md`).
+Because cached K/V bytes are codec-specific, a prefix cached under `none` (bf16)
+**must not** serve a `k8v4` request. The block-hash seed therefore folds in a
+per-codec salt as well:
+
+```
+seed = FNV_OFFSET ^ layout_key ^ kv_quant.cache_key_salt()
+```
+
+`KvQuant::cache_key_salt()` is a stable FNV-1a-64 hash over the codec's
+canonical `Display` string (`"none"`, `"k8v4"`, `"mixed_k8g64_v4g64"`, …), so it
+covers every variant including payload-bearing ones (`Mixed`, `RotK`,
+`RotorK*Asym`). Both the push side (storing a slot) and the
+[`find_best_prefix`](#find_best_prefix-lookup) query side salt with the same
+value, so two requests with identical tokens but different codecs produce
+**disjoint digest streams** and occupy **distinct cache slots**. A codec switch
+is a clean cross-codec miss — the other codec's slot survives and is reusable
+again under its own codec, rather than being thrash-evicted.
+
+On a single-codec RAM-only run (`layout_key = 0`, constant codec) the salt is a
+constant XOR for every request, so hit/miss behaviour is identical to the legacy
+stream for that codec — zero regression.
+
+> The SSD `layout_key` already mixes `kv_quant` into its hash, so on an
+> SSD-active run the codec is salted twice (`layout_key` *and*
+> `cache_key_salt`); the extra XOR is harmless (still a deterministic salt) and
+> keeps the RAM-only path correct, where `layout_key = 0` would otherwise leave
+> the codec un-partitioned.
+
 ---
 
 ## Per-arch caches
@@ -180,10 +212,16 @@ re-installed from the recorded `attach` params.
 ## `find_best_prefix` lookup
 
 ```
-find_best_prefix(prompt_ids) -> Option<(slot_index, matched_blocks)>
+find_best_prefix(prompt_ids, seed) -> Option<(slot_index, matched_blocks)>
 ```
 
-1. Compute chained block hashes for `prompt_ids`.
+The `seed` (issue #26) is the `FNV_OFFSET ^ layout_key ^ codec_salt` the caller
+also uses on the push side, so the query digest stream partitions by
+`(layout, codec)` — a slot stored under a different KV codec or SSD layout never
+matches. Pass the bare `FNV_OFFSET` for the legacy un-salted stream (RAM-only,
+single-codec, `layout_key = 0`).
+
+1. Compute chained block hashes for `prompt_ids` using `seed`.
 2. Scan all slots (Linear path) or query the radix tree (Radix path).
 3. For each slot count how many leading block digests match.
 4. Return `Some((best_slot_index, best_block_count))` where

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -186,6 +186,8 @@ Expired requests return HTTP 408 `timeout`.
 | `stream_options` | object | `{include_usage:true}` appends a usage chunk before `[DONE]`. |
 | `enable_thinking` | bool | `false` suppresses the open `<think>` block on Qwen3-family models. |
 | `thinking_budget` | u32 | Cap the reasoning channel at N tokens. |
+| `kv_quant` | string | **Issue #26 — per-request KV-codec hot-swap.** Override the KV-cache codec for this request on the resident model, no weight reload. Accepts the same grammar as the `--kv-quant` CLI flag (`"none"`/`"bf16"`, `"k8v4"`, `"k8v8"`, `"planar"`, `"mixed"`, `"mixed_k<kb>g<kg>_v<vb>g<vg>"`, …). `"auto"` selects the per-arch/per-ctx default. Omitted → the server's launch `--kv-quant`. A malformed codec string returns HTTP 400 `invalid_request_error`. |
+| `max_ctx` | i32 | **Issue #26 — per-request context-ceiling override.** Re-size the KV-ring virtual ceiling (lazy-grow, #25) for this request only; must be `> 0`. Omitted → the server's launch `--max-ctx`. No weight touch — a ring realloc only. |
 | `logit_bias` | object | Token-id (string key) → logit bias (float). |
 | `frequency_penalty` | f32 | |
 | `presence_penalty` | f32 | |
@@ -195,6 +197,36 @@ Expired requests return HTTP 408 `timeout`.
 
 Unknown fields are accepted, debug-logged, and discarded. Fields that indicate
 injection intent are explicitly rejected.
+
+### Per-request KV-config hot-swap (issue #26)
+
+`kv_quant` and `max_ctx` change the **KV cache** for one request without
+reloading the model weights. Weights are read-only during decode; the KV cache
+(codec, ring size) is built per request, so a config switch only rebuilds the
+cache — the resident weights stay put. This lets a single `rmlx serve` process
+sweep KV codecs / context ceilings, or pick a KV policy per request (aggressive
+quant for a 128k request, `none` for a short chat) with zero downtime.
+
+- **Precedence.** A per-request `kv_quant` wins over the launch `--kv-quant`
+  (explicit or `auto`) and over the per-ctx auto policy — exactly like a
+  startup-explicit flag, but scoped to the one request. `"auto"` defers to the
+  generator's per-arch/per-ctx default. Absent → launch default (byte-identical
+  to pre-#26 behavior; zero regression).
+- **Codec-partitioned prefix cache.** The prompt/prefix cache key is namespaced
+  by KV codec, so a prefix cached under one codec **never** serves a request
+  running a different codec (the cached K/V bytes are codec-specific). Two
+  codecs for the same tokens occupy **distinct** cache slots and coexist — a
+  codec switch is a clean cross-codec miss, not a thrash-eviction. See
+  `docs/PROMPT_CACHE.md` § "Codec namespacing".
+- **`max_ctx`** re-sizes the KV-ring virtual ceiling (#25 lazy-grow) for the
+  request; the engine clamps it by the model's `max_position_embeddings` during
+  cache build. The `context_length_exceeded` prompt-length guard uses the
+  per-request ceiling when the override is present.
+- **Single-MLX claim is unaffected** — one model stays resident throughout.
+- **Anthropic `/v1/messages`** does not expose these fields (stricter wire
+  spec); it always uses the launch default.
+- **Deferred:** live SSD-tier reconfiguration (per-request `kv_ssd` toggle) is
+  **not** implemented — see `docs/SSD_TIER.md` § "Live reconfiguration (deferred)".
 
 **Non-streaming response** (`stream:false`):
 

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -216,8 +216,9 @@ The codec partitioning that #26 added to the **RAM** prompt cache
 (`KvQuant::cache_key_salt()` XOR'd into the block-hash seed) composes correctly
 with `layout_key`: on an SSD-active run the seed mixes both, so RAM slots are
 codec-partitioned even though the SSD tier itself remains single-codec for the
-resident lifetime. A live SSD reconfiguration is a well-scoped follow-up:
-per-namespace tier teardown/attach driven by a control-plane setter.
+resident lifetime. A live SSD reconfiguration is a well-scoped follow-up
+(tracked in issue #30): per-namespace tier teardown/attach driven by a
+control-plane drain+reattach setter.
 
 ---
 

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -196,6 +196,29 @@ under one KV layout cannot collide with the same block cached under another.
 `layout_key`) at `attach_at_load` before the index is opened, so operators can
 correlate log rows with the active layout during debugging.
 
+## Live reconfiguration (deferred — issue #26)
+
+Issue #26 makes the KV **codec** and **context ceiling** per-request hot-swappable
+on a resident model (see `docs/SERVER.md` § "Per-request KV-config hot-swap").
+The SSD tier is **deliberately excluded** from that per-request surface and stays
+launch-fixed (`--kv-ssd-cache-gb`, attached once at `attach_at_load`).
+
+**Why deferred.** The tier is wired into the prompt cache via a per-namespace
+spiller + hydrator keyed by `(namespace, layout_key)`, opened against an on-disk
+`ssd_index` and `.kvb` block files at load. A per-request SSD toggle would need
+to tear down and re-attach that per-namespace tier (close/reopen the index,
+respawn the spiller, re-key the hydrator) mid-flight — architecturally heavy and
+orthogonal to the read-only-weights insight that makes codec/ctx hot-swap cheap.
+The per-request codec/ctx override delivers the issue's core benefit (resident
+multi-KV sweeps, per-request KV policy) without it.
+
+The codec partitioning that #26 added to the **RAM** prompt cache
+(`KvQuant::cache_key_salt()` XOR'd into the block-hash seed) composes correctly
+with `layout_key`: on an SSD-active run the seed mixes both, so RAM slots are
+codec-partitioned even though the SSD tier itself remains single-codec for the
+resident lifetime. A live SSD reconfiguration is a well-scoped follow-up:
+per-namespace tier teardown/attach driven by a control-plane setter.
+
 ---
 
 ## Hydrate Path (RAM Miss → SSD Load → Promote)


### PR DESCRIPTION
## Summary

Addresses #26. A running `rmlx serve` can now switch **KV codec** and **context ceiling** per request with **no weight reload** — load the weights once, sweep/switch KV-quant and max-ctx against the resident model. The prefix/prompt cache is **codec-partitioned** so a config switch can never serve mismatched cached KV.

Weights are read-only during decode; the KV cache (codec, ring size) is built per request. This wires that independence through to the request surface.

## What landed

- **Per-request overrides** — OpenAI request extension fields `kv_quant` (string, same grammar as `--kv-quant`; `"auto"` → per-arch/per-ctx default; malformed → HTTP 400) and `max_ctx` (i32). Override wins over the launch global; **absent → exact prior behavior (zero regression)**. Threaded through `GenerationRequest` and `RequestPlan` (so retry replay rebuilds the same cache). Anthropic route keeps launch defaults.
- **Codec-partitioned prefix cache** — `KvQuant::cache_key_salt()` (FNV-1a-64 over the codec `Display`) XOR'd into the block-hash seed at **all four** seed sites (RAM push, query, SSD hydrate, HydratedTail push), alongside the existing SSD `layout_key`. Different codecs → disjoint digest streams → coexisting slots, clean cross-codec miss, no thrash-eviction. RAM-only single-codec runs behave as before (push==query seed).
- Builds on the merged #25 lazy-grow: per-request `max_ctx` is just a per-request ceiling, trivially correct.

## SSD axis — deferred (tracked in #30)

Per-request SSD-tier toggle is **not** a low-risk mirror of the KV-quant override: the KV override is a seed-salt on one global cache, whereas the SSD tier is stateful global machinery (an `SsdHydrator` with an open SQLite index handle + an `SsdSpiller` drain thread, both bound to a fixed `layout_key`/`kv_quant` at `attach_at_load`). A true toggle forces mid-flight global-tier teardown/reattach, risking the index PK partitioning and the cross-restart canary. Filed as **#30** (control-plane drain+reattach setter) and documented in `docs/SSD_TIER.md`.

## Real-model proof (gemma-4-e2b-it-mxfp8, single load)

- Request A `kv=none` → "Red/Yellow/Blue"; Request B `kv=k8v4` same prompt → identical, **no restart** (`grep -c 'loading model via arch dispatch'` = 1 across all requests).
- **Anti-cross-serve**: prompt under `none` populates the prefix cache (miss → repeat HIT); same prompt under `k8v4` is a MISS with no eviction (namespacing, not flush) → each codec is served its own correct KV.
- Per-request `max_ctx` 512 and 8192 both correct on the resident model, ring grows lazily (#25 path), still one load span.
- Bad codec → HTTP 400 `invalid_request_error`; absent override → normal default serve.

## Tests

- `codec_partitioned_key_blocks_cross_codec_serve` — proves cross-codec MISS + two-slot coexistence + each-codec-hits-own-slot.
- `ssd_hydrate_seed_symmetry_with_nonzero_layout_key` — locks the SSD-hydrate seed symmetry (salted hydrate HIT, unsalted MISS, cross-codec MISS).
- `cache_key_salt_is_unique_and_deterministic`, request-override parse/precedence tests.
- Full: rmlx-models 538 pass, rmlx-kv-quant 272 pass, rmlx-server suite pass. `make build` / `make lint` / `cargo fmt` clean.

## Docs

`docs/SERVER.md` (per-request KV-config hot-swap field), `docs/KV_QUANT.md`, `docs/KV_CACHE.md`, `docs/PROMPT_CACHE.md` (codec namespacing of the prefix key), `docs/CLI.md`, `docs/SSD_TIER.md` (deferral → #30).

Built on #25 (lazy KV-ring grow). Follow-up: #30 (SSD live reconfiguration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)