### PR TITLE
fix(metrics): report live KV-cache size (kv_cache_bytes was always 0) (#33)

### DIFF
--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -416,7 +416,6 @@ pub(crate) fn run_baseline(
         ("baseline_prefill_tps", "tok/s", prefill_tps),
         ("baseline_prompt_tokens", "count", prompt_token_count as f64),
         ("baseline_peak_rss_mb", "MB", rss_mb),
-        ("baseline_kv_cache_bytes", "bytes", kv_cache_bytes as f64),
     ];
 
     for (op, unit, value) in metrics_data {
@@ -430,6 +429,22 @@ pub(crate) fn run_baseline(
             notes: &notes_truncated,
         })
         .map_err(|e| anyhow::anyhow!("metrics record {op}: {e}"))?;
+    }
+
+    // Emit kv_cache_bytes only when non-zero (un-wired archs return 0; omitting
+    // them matches the `build_run_record` gate and prevents a spurious
+    // "measured 0-byte KV" row in the events table).
+    if kv_cache_bytes > 0 {
+        sink.record(&rmlx_metrics::events::Measurement {
+            model_path: &abs_path_str,
+            quant_mode: &quant_mode,
+            stage: "baseline",
+            op: "baseline_kv_cache_bytes",
+            value_unit: "bytes",
+            value: kv_cache_bytes as f64,
+            notes: &notes_truncated,
+        })
+        .map_err(|e| anyhow::anyhow!("metrics record baseline_kv_cache_bytes: {e}"))?;
     }
 
     // -- Append to metrics/baseline.csv ---------------------------------------

--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -291,6 +291,10 @@ pub(crate) fn run_baseline(
         )
         .map_err(|e| anyhow::anyhow!("generate_greedy: {e}"))?;
     let generate_elapsed = ts_generate_start.elapsed();
+    // Read actual on-device KV-cache bytes from the arch-specific static that
+    // `generate_greedy` writes via `store_kv_cache_bytes`.  Returns 0 for
+    // architectures that do not yet maintain that static.
+    let kv_cache_bytes: u64 = model.kv_cache_bytes();
     // Drop the span guard explicitly so the span closes (and its elapsed_ms is
     // emitted to the JSONL log) right here — before the summary println below.
     drop(_decode_span_guard);
@@ -412,6 +416,7 @@ pub(crate) fn run_baseline(
         ("baseline_prefill_tps", "tok/s", prefill_tps),
         ("baseline_prompt_tokens", "count", prompt_token_count as f64),
         ("baseline_peak_rss_mb", "MB", rss_mb),
+        ("baseline_kv_cache_bytes", "bytes", kv_cache_bytes as f64),
     ];
 
     for (op, unit, value) in metrics_data {
@@ -523,6 +528,7 @@ pub(crate) fn run_baseline(
             rss_mb,
             n_generated,
             &preview_64,
+            kv_cache_bytes,
         )?;
         let path = write_buffer_record(&record)?;
         info!(path = %path.display(), "baseline: wrote §8.5 ingest record");
@@ -654,6 +660,7 @@ fn build_run_record(
     rss_mb: f64,
     n_generated: usize,
     preview_first_64: &str,
+    kv_cache_bytes: u64,
 ) -> anyhow::Result<serde_json::Value> {
     // Identity: namespace + model name from the snapshot directory basename.
     let snapshot_str = model_path
@@ -711,15 +718,20 @@ fn build_run_record(
 
     // `decode_tps_warm` now carries the prefill-EXCLUDED steady-state number;
     // `overall_tps` keeps the combined prefill+decode value; `prefill_tps` is
-    // prompt throughput.
-    let metrics = serde_json::json!([
-        { "name": "decode_tps_warm", "value": decode_tps },
-        { "name": "overall_tps",     "value": overall_tps },
-        { "name": "prefill_tps",     "value": prefill_tps },
-        { "name": "ttft_warm_ms",    "value": ttft_ms },
-        { "name": "model_load_ms",   "value": load_ms },
-        { "name": "peak_rss_mb",     "value": rss_mb },
-    ]);
+    // prompt throughput.  `kv_cache_bytes` is omitted when 0 (arch not yet
+    // wired) so the RunRecord schema stays backward-compatible.
+    let mut metrics = vec![
+        serde_json::json!({ "name": "decode_tps_warm", "value": decode_tps }),
+        serde_json::json!({ "name": "overall_tps",     "value": overall_tps }),
+        serde_json::json!({ "name": "prefill_tps",     "value": prefill_tps }),
+        serde_json::json!({ "name": "ttft_warm_ms",    "value": ttft_ms }),
+        serde_json::json!({ "name": "model_load_ms",   "value": load_ms }),
+        serde_json::json!({ "name": "peak_rss_mb",     "value": rss_mb }),
+    ];
+    if kv_cache_bytes > 0 {
+        metrics.push(serde_json::json!({ "name": "kv_cache_bytes", "value": kv_cache_bytes }));
+    }
+    let metrics = serde_json::Value::Array(metrics);
 
     Ok(serde_json::json!({
         "backend": "rmlx",

--- a/crates/rmlx-kv-quant/src/kvcache/mod.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/mod.rs
@@ -27,8 +27,8 @@
 //!   [`KvCache::update_and_sdpa_k8v4_flash`], [`KvCache::update`].
 //! - Lifecycle: [`KvCache::enter_prefill`], [`KvCache::exit_prefill`],
 //!   [`KvCache::reset`], [`KvCache::truncate_to`].
-//! - Diagnostics: [`KvCache::approx_bytes`], [`KvCache::offset`],
-//!   [`KvCache::seq_len`].
+//! - Diagnostics: [`KvCache::approx_bytes`], [`KvCache::resident_bytes`],
+//!   [`KvCache::offset`], [`KvCache::seq_len`].
 //!
 //! # See also
 //!
@@ -76,6 +76,11 @@ mod prefill_grow_tests;
 #[cfg(test)]
 #[path = "rotor3_layer_idx_tests.rs"]
 mod rotor3_layer_idx_tests;
+
+// resident_bytes: actual on-device byte accounting.
+#[cfg(test)]
+#[path = "resident_bytes_tests.rs"]
+mod resident_bytes_tests;
 
 pub use core::KvCache;
 pub use fused_qk_dispatch::fused_qk_total_dispatch_count;

--- a/crates/rmlx-kv-quant/src/kvcache/resident_bytes_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/resident_bytes_tests.rs
@@ -1,0 +1,183 @@
+//! Unit tests for [`KvCache::resident_bytes`].
+//!
+//! All tests run on `Device::Cpu` — no GPU required.  They verify that
+//! `resident_bytes()` returns the actual allocated buffer size, not a formula
+//! estimate, and that empty (unpopulated) caches return 0.
+//!
+//! The GPU-backed quantised paths (K8V4, TurboSym, etc.) are exercised in the
+//! integration test suite under `crates/rmlx-kv-quant/tests/` where a Metal
+//! GPU is available.  The CPU-level invariants tested here are:
+//!
+//! 1. A freshly constructed cache → `resident_bytes() == 0`.
+//! 2. After manually populating `decode_fp16_k/v` → bytes match `shape ×
+//!    itemsize` exactly.
+//! 3. Two independently populated layers sum correctly.
+//! 4. `KvStorage::None` contributes 0; only `KvCache::decode_fp16_k/v` are
+//!    counted.
+
+use super::core::KvCache;
+use crate::KvQuant;
+use rmlx_mlx::{Array, Device, Dtype};
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/// Build a `[B, kv_h, seq, D]` fp16 Array filled with zeros on CPU.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper — panic on failure is the desired outcome"
+)]
+fn bf16_zeros(b: i32, kv_h: i32, seq: i32, d: i32) -> Array {
+    let n = (b * kv_h * seq * d) as usize;
+    // bf16 = 2 bytes per element; zero-fill.
+    let bytes = vec![0u8; n * 2];
+    Array::from_bytes(&bytes, &[b, kv_h, seq, d], Dtype::Bf16).unwrap()
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+/// A freshly constructed `KvCache` has no buffers → `resident_bytes` is 0.
+#[test]
+fn fresh_cache_is_zero() {
+    let cache = KvCache::with_quant_max_seq(KvQuant::None, 512);
+    assert_eq!(
+        cache.resident_bytes(),
+        0,
+        "freshly constructed cache must report 0 resident bytes"
+    );
+}
+
+/// A K8V4 cache (quantised variant) also starts at 0 before any generate.
+#[test]
+fn fresh_k8v4_cache_is_zero() {
+    let cache = KvCache::with_quant_max_seq(KvQuant::K8V4, 512);
+    assert_eq!(
+        cache.resident_bytes(),
+        0,
+        "pre-generate K8V4 cache must report 0 resident bytes"
+    );
+}
+
+/// After injecting a bf16 K seed into `decode_fp16_k`, the bytes reported
+/// equal `B × kv_h × seq × head_dim × 2` (bf16 = 2 bytes/elem).
+///
+/// `resident_bytes` must read the actual Array shape, not a stored formula.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test — panics are the intended failure mode"
+)]
+fn none_quant_with_seed_reports_actual_bytes() {
+    const B: i32 = 1;
+    const KV_H: i32 = 8;
+    const SEQ: i32 = 64;
+    const D: i32 = 128;
+
+    // Build the cache and plant a bf16 K seed directly into decode_fp16_k.
+    // We use the helper method that the prefill exit path uses internally
+    // (`inject_fp16_seeds_for_test` isn't public, so we round-trip through
+    // a minimal prefill instead).
+
+    // Allocate a raw K/V pair, then force the cache into a populated-seed
+    // state by running a minimal CPU prefill + exit_prefill.
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::None, 512);
+    let device = Device::Cpu;
+
+    // Construct a dummy K/V prefill block (1 batch, KV_H heads, SEQ tokens, D dims).
+    let k = bf16_zeros(B, KV_H, SEQ, D);
+    let v = bf16_zeros(B, KV_H, SEQ, D);
+
+    // enter_prefill / update / exit_prefill to populate decode_fp16_k/v.
+    cache.enter_prefill();
+    cache
+        .update(&k, &v, device)
+        .expect("update must succeed on CPU for KvQuant::None");
+    cache
+        .exit_prefill(device)
+        .expect("exit_prefill must succeed on CPU for KvQuant::None");
+
+    // For KvQuant::None the bf16 seed is stored on decode_fp16_k/v.
+    // Expected: 2 buffers × B × kv_h × seq × head_dim × 2 bytes.
+    let expected = 2 * B as u64 * KV_H as u64 * SEQ as u64 * D as u64 * 2;
+    assert_eq!(
+        cache.resident_bytes(),
+        expected,
+        "resident_bytes after prefill must equal 2 × B × kv_h × seq × D × 2 (bf16)"
+    );
+}
+
+/// `resident_bytes` grows proportionally when the sequence length doubles.
+/// This pins the linear relationship: bytes ∝ seq.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test — panics are the intended failure mode"
+)]
+fn resident_bytes_scales_with_seq() {
+    const B: i32 = 1;
+    const KV_H: i32 = 4;
+    const D: i32 = 64;
+    let device = Device::Cpu;
+
+    let run = |seq: i32| -> u64 {
+        let mut cache = KvCache::with_quant_max_seq(KvQuant::None, 512);
+        let k = bf16_zeros(B, KV_H, seq, D);
+        let v = bf16_zeros(B, KV_H, seq, D);
+        cache.enter_prefill();
+        cache.update(&k, &v, device).unwrap();
+        cache.exit_prefill(device).unwrap();
+        cache.resident_bytes()
+    };
+
+    let bytes_32 = run(32);
+    let bytes_64 = run(64);
+    assert_eq!(
+        bytes_64,
+        bytes_32 * 2,
+        "resident_bytes must scale linearly with seq (64 = 2 × 32)"
+    );
+    // Absolute value: 2 bufs × B=1 × kv_h=4 × seq=64 × D=64 × 2 bytes (bf16) = 65_536.
+    assert_eq!(
+        bytes_64, 65_536_u64,
+        "absolute byte count for seq=64 must be exact (2 × 1 × 4 × 64 × 64 × 2)"
+    );
+}
+
+/// Two separately populated `KvCache` instances (simulating two model
+/// layers) sum correctly.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test — panics are the intended failure mode"
+)]
+fn layer_sum_is_additive() {
+    const B: i32 = 1;
+    const KV_H: i32 = 4;
+    const SEQ: i32 = 32;
+    const D: i32 = 64;
+    let device = Device::Cpu;
+
+    let make_cache = || -> KvCache {
+        let mut cache = KvCache::with_quant_max_seq(KvQuant::None, 256);
+        let k = bf16_zeros(B, KV_H, SEQ, D);
+        let v = bf16_zeros(B, KV_H, SEQ, D);
+        cache.enter_prefill();
+        cache.update(&k, &v, device).unwrap();
+        cache.exit_prefill(device).unwrap();
+        cache
+    };
+
+    let layer0 = make_cache();
+    let layer1 = make_cache();
+    let per_layer = layer0.resident_bytes();
+    assert!(
+        per_layer > 0,
+        "per-layer bytes must be non-zero after prefill"
+    );
+
+    let total: u64 = [layer0, layer1].iter().map(KvCache::resident_bytes).sum();
+    assert_eq!(
+        total,
+        per_layer * 2,
+        "sum across two identical layers must equal 2 × per-layer"
+    );
+}

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -2397,6 +2397,91 @@ impl KvCache {
         kv_bytes + seed_bytes
     }
 
+    /// Actual on-device bytes held by this KV cache at the current call-site.
+    ///
+    /// Returns the sum of every buffer currently allocated on this cache:
+    ///
+    /// - **Quantized storage** (`KvStorage::resident_bytes`): packed codes,
+    ///   scales, rotation buffers, etc. for all codec variants. Returns 0 for
+    ///   `KvStorage::None` (bf16 buffers live in `decode_fp16_k/v` below).
+    /// - **fp16 decode seeds** (`decode_fp16_k`, `decode_fp16_v`): warm-TTFT
+    ///   bf16 mirrors present on quantized paths; also the sole storage for
+    ///   `KvStorage::None` (bf16).
+    /// - **Rotating SWA ring** (`rotating`): pre-allocated bf16 `[B, kv_h,
+    ///   window, D]` buffer used by SWA layers, sized to the sliding window.
+    /// - **TurboFlash head-major buffers** (`flash_k_codes/scales`,
+    ///   `flash_v_codes/scales`): lazy copy of the K/V cache in head-major
+    ///   layout for the TurboFlash MSL SDPA kernel.
+    /// - **Fused-QK shadow** (`fused_qk_shadow`): head-major K shadow used by
+    ///   fused-QK dispatch (q8, turbo3/4-sym, iso3/4-sym, rotor3/4-sym, …).
+    ///
+    /// Unlike [`approx_bytes`], this does **not** use a formula: it reads the
+    /// actual `Array` shape × dtype from every live buffer. For GPU-backed
+    /// codecs this reflects the paged allocation size, which is rounded up to
+    /// the nearest page; for CPU-backed codecs (IsoQuant, RotorQuant) it is
+    /// the exact heap bytes of the backing `Vec`s.
+    ///
+    /// Returns 0 when the cache has never been used (`offset == 0` and no
+    /// buffers are allocated). Safe to call at any point — no FFI eval, no
+    /// data read, no mutation.
+    pub fn resident_bytes(&self) -> u64 {
+        // Helper: bytes of a single Array without FFI eval.
+        #[inline]
+        fn ab(a: &Array) -> u64 {
+            let n: u64 = a.shape().iter().map(|&d| d as u64).product();
+            n * a.dtype().itemsize() as u64
+        }
+
+        // 1. Quantized storage (codec-specific buffers; None → 0).
+        let mut total = self.storage.resident_bytes();
+
+        // 2. fp16 decode seeds (KvQuant::None bf16 storage lives here too).
+        if let Some(ref k) = self.decode_fp16_k {
+            total += ab(k);
+        }
+        if let Some(ref v) = self.decode_fp16_v {
+            total += ab(v);
+        }
+
+        // 3. Rotating SWA ring buffer (bf16, sized to sliding window).
+        if let Some(ref rot) = self.rotating {
+            if let Some(ref k) = rot.keys {
+                total += ab(k);
+            }
+            if let Some(ref v) = rot.values {
+                total += ab(v);
+            }
+        }
+
+        // 4. TurboFlash head-major K/V buffers (lazy; only for K8V4 path).
+        if let Some(ref c) = self.flash_k_codes {
+            total += ab(c);
+        }
+        if let Some(ref s) = self.flash_k_scales {
+            total += ab(s);
+        }
+        if let Some(ref c) = self.flash_v_codes {
+            total += ab(c);
+        }
+        if let Some(ref s) = self.flash_v_scales {
+            total += ab(s);
+        }
+
+        // 5. Fused-QK shadow (head-major K shadow for fused-QK MSL kernels).
+        if let Some(ref shadow) = self.fused_qk_shadow {
+            total += ab(&shadow.k_codes);
+            total += ab(&shadow.k_scales);
+            if let Some(ref norms) = shadow.sideband_norms {
+                total += ab(norms);
+            }
+            if let Some(ref table) = shadow.sideband_rotor_table {
+                total += ab(table);
+            }
+        }
+
+        total
+    }
+
     /// Reset the cache to an empty state (offset → 0, buffers zeroed).
     pub fn reset(&mut self) {
         if let Some(ref mut rot) = self.rotating {

--- a/crates/rmlx-kv-quant/src/paged/alloc.rs
+++ b/crates/rmlx-kv-quant/src/paged/alloc.rs
@@ -55,6 +55,26 @@ impl PageSlab {
         self.page_tokens * self.elems_per_token
     }
 
+    /// Actual on-device bytes across all allocated pages in this slab.
+    ///
+    /// Counts only allocated (initialised) pages — `pool[i].is_some()` up to
+    /// `next_free`. Each page holds `page_tokens * elems_per_token` elements at
+    /// `dtype.itemsize()` bytes each. Pages that are allocated but not yet fully
+    /// written count their full allocation.
+    pub(super) fn resident_bytes(&self) -> u64 {
+        #[allow(
+            clippy::indexing_slicing,
+            reason = "next_free is monotonically bounded by pool.len() by construction"
+        )]
+        let allocated_pages = self.pool[..self.next_free]
+            .iter()
+            .filter(|p| p.is_some())
+            .count() as u64;
+        let elems_per_page = self.page_elems() as u64;
+        let item_bytes = self.dtype.itemsize() as u64;
+        allocated_pages * elems_per_page * item_bytes
+    }
+
     /// Allocate the next free physical page, initialize it to zeros on `device`.
     /// Returns the physical page ID.
     #[allow(

--- a/crates/rmlx-kv-quant/src/paged/ops.rs
+++ b/crates/rmlx-kv-quant/src/paged/ops.rs
@@ -193,6 +193,11 @@ impl PagedKStorage {
         self.scales.reset();
     }
 
+    /// Actual on-device bytes across all allocated pages (codes + scales slabs).
+    pub fn resident_bytes(&self) -> u64 {
+        self.codes.resident_bytes() + self.scales.resident_bytes()
+    }
+
     #[allow(
         clippy::indexing_slicing,
         reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
@@ -382,6 +387,11 @@ impl PagedVStorage {
         }
         self.codes.reset();
         self.scales.reset();
+    }
+
+    /// Actual on-device bytes across all allocated pages (codes + scales slabs).
+    pub fn resident_bytes(&self) -> u64 {
+        self.codes.resident_bytes() + self.scales.resident_bytes()
     }
 
     #[allow(
@@ -604,6 +614,11 @@ impl PagedPlanarVStorage {
         self.codes.reset();
         self.scales.reset();
         self.rotations.reset();
+    }
+
+    /// Actual on-device bytes across all allocated pages (codes + scales + rotations slabs).
+    pub fn resident_bytes(&self) -> u64 {
+        self.codes.resident_bytes() + self.scales.resident_bytes() + self.rotations.resident_bytes()
     }
 
     #[allow(

--- a/crates/rmlx-kv-quant/src/storage/kv_storage.rs
+++ b/crates/rmlx-kv-quant/src/storage/kv_storage.rs
@@ -1686,13 +1686,21 @@ impl KvStorage {
 ///
 /// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32) — sized to
 /// `gpu_capacity`, not just `offset`. CPU path: `codes` (u8) + `scales` (f32).
+///
+/// NOTE: After an SSD-hydrate init the GPU mirror is live (`gpu_codes_buf =
+/// Some`) *and* the pre-hydration CPU `codes`/`scales` are still resident in
+/// RAM (the hydrate upload path never clears them). Both allocations are
+/// counted.
 fn quant_k_bytes(qk: Option<&QuantK>) -> u64 {
     let Some(qk) = qk else {
         return 0;
     };
     if let Some(ref codes) = qk.gpu_codes_buf {
         let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
-        array_nbytes(codes) + scales_bytes
+        // Add any coexisting CPU residual (pre-hydration data not cleared on
+        // GPU-mirror init; see `QuantK::append_inner` hydrated-init block).
+        let cpu_residual = qk.codes.len() as u64 + qk.scales.len() as u64 * 4;
+        array_nbytes(codes) + scales_bytes + cpu_residual
     } else {
         // CPU path: codes = Vec<u8>, scales = Vec<f32>
         qk.codes.len() as u64 + qk.scales.len() as u64 * 4
@@ -1704,13 +1712,23 @@ fn quant_k_bytes(qk: Option<&QuantK>) -> u64 {
 /// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32). CPU path: sum of
 /// `TurboBlocks` — each block has `codes: Vec<u8>` (1 B/elem) and
 /// `scales: Vec<f32>` (4 B/elem).
+///
+/// NOTE: After an SSD-hydrate init the GPU mirror is live and the pre-hydration
+/// CPU `blocks` are still resident in RAM. Both are counted.
 fn quant_v_bytes(qv: Option<&QuantV>) -> u64 {
     let Some(qv) = qv else {
         return 0;
     };
     if let Some(ref codes) = qv.gpu_codes_buf {
         let scales_bytes = qv.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
-        array_nbytes(codes) + scales_bytes
+        // Add any coexisting CPU residual (pre-hydration blocks not cleared on
+        // GPU-mirror init; see `QuantV::append_inner` hydrated-init block).
+        let cpu_residual: u64 = qv
+            .blocks
+            .iter()
+            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
+            .sum();
+        array_nbytes(codes) + scales_bytes + cpu_residual
     } else {
         // CPU path: TurboBlocks — codes: Vec<u8>, scales: Vec<f32>
         qv.blocks
@@ -1725,6 +1743,9 @@ fn quant_v_bytes(qv: Option<&QuantV>) -> u64 {
 /// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32) +
 /// `gpu_rotations_buf` (u32). CPU path: sum of `PlanarBlocks` — each has
 /// `codes: Vec<u8>` (1 B), `scales: Vec<f32>` (4 B), `rotations: Vec<u8>` (1 B).
+///
+/// NOTE: After an SSD-hydrate init the GPU mirror is live and the pre-hydration
+/// CPU `blocks` are still resident in RAM. Both are counted.
 fn quant_planar_v_bytes(qv: Option<&QuantPlanarV>) -> u64 {
     let Some(qv) = qv else {
         return 0;
@@ -1732,7 +1753,14 @@ fn quant_planar_v_bytes(qv: Option<&QuantPlanarV>) -> u64 {
     if let Some(ref codes) = qv.gpu_codes_buf {
         let scales_bytes = qv.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
         let rot_bytes = qv.gpu_rotations_buf.as_ref().map_or(0, array_nbytes);
-        array_nbytes(codes) + scales_bytes + rot_bytes
+        // Add any coexisting CPU residual (pre-hydration blocks not cleared on
+        // GPU-mirror init; see `QuantPlanarV::append` hydrated-init block).
+        let cpu_residual: u64 = qv
+            .blocks
+            .iter()
+            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4 + b.rotations.len() as u64)
+            .sum();
+        array_nbytes(codes) + scales_bytes + rot_bytes + cpu_residual
     } else {
         qv.blocks
             .iter()
@@ -1744,6 +1772,9 @@ fn quant_planar_v_bytes(qv: Option<&QuantPlanarV>) -> u64 {
 /// PlanarQuant K buffer (`QuantPlanarK`), used for `PlanarK` variant.
 ///
 /// Same buffer layout as `QuantPlanarV` — GPU or CPU with codes/scales/rotations.
+///
+/// NOTE: After an SSD-hydrate init the GPU mirror is live and the pre-hydration
+/// CPU `blocks` are still resident in RAM. Both are counted.
 fn quant_planar_k_bytes(qk: Option<&QuantPlanarK>) -> u64 {
     let Some(qk) = qk else {
         return 0;
@@ -1751,7 +1782,14 @@ fn quant_planar_k_bytes(qk: Option<&QuantPlanarK>) -> u64 {
     if let Some(ref codes) = qk.gpu_codes_buf {
         let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
         let rot_bytes = qk.gpu_rotations_buf.as_ref().map_or(0, array_nbytes);
-        array_nbytes(codes) + scales_bytes + rot_bytes
+        // Add any coexisting CPU residual (pre-hydration blocks not cleared on
+        // GPU-mirror init; see `QuantPlanarK::append` hydrated-init block).
+        let cpu_residual: u64 = qk
+            .blocks
+            .iter()
+            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4 + b.rotations.len() as u64)
+            .sum();
+        array_nbytes(codes) + scales_bytes + rot_bytes + cpu_residual
     } else {
         qk.blocks
             .iter()
@@ -1779,13 +1817,23 @@ fn mixed_kv_state_bytes(state: &crate::mixed_quant::MixedKvState) -> u64 {
 ///
 /// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32).
 /// CPU path: sum of `TurboBlocks`.
+///
+/// NOTE: After an SSD-hydrate init the GPU mirror is live and the pre-hydration
+/// CPU `blocks` are still resident in RAM. Both are counted.
 fn quant_k_turbo3_bytes(qk: Option<&QuantKTurbo3>) -> u64 {
     let Some(qk) = qk else {
         return 0;
     };
     if let Some(ref codes) = qk.gpu_codes_buf {
         let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
-        array_nbytes(codes) + scales_bytes
+        // Add any coexisting CPU residual (pre-hydration blocks not cleared on
+        // GPU-mirror init; see `QuantKTurbo3::append` hydrated-init block).
+        let cpu_residual: u64 = qk
+            .blocks
+            .iter()
+            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
+            .sum();
+        array_nbytes(codes) + scales_bytes + cpu_residual
     } else {
         qk.blocks
             .iter()
@@ -1797,13 +1845,23 @@ fn quant_k_turbo3_bytes(qk: Option<&QuantKTurbo3>) -> u64 {
 /// TurboQuant 4-bit K buffer (`QuantKTurbo4`).
 ///
 /// Same buffer layout as `QuantKTurbo3` — GPU codes/scales or CPU TurboBlocks.
+///
+/// NOTE: After an SSD-hydrate init the GPU mirror is live and the pre-hydration
+/// CPU `blocks` are still resident in RAM. Both are counted.
 fn quant_k_turbo4_bytes(qk: Option<&QuantKTurbo4>) -> u64 {
     let Some(qk) = qk else {
         return 0;
     };
     if let Some(ref codes) = qk.gpu_codes_buf {
         let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
-        array_nbytes(codes) + scales_bytes
+        // Add any coexisting CPU residual (pre-hydration blocks not cleared on
+        // GPU-mirror init; see `QuantKTurbo4::append` hydrated-init block).
+        let cpu_residual: u64 = qk
+            .blocks
+            .iter()
+            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
+            .sum();
+        array_nbytes(codes) + scales_bytes + cpu_residual
     } else {
         qk.blocks
             .iter()
@@ -1818,6 +1876,11 @@ fn quant_k_turbo4_bytes(qk: Option<&QuantKTurbo4>) -> u64 {
 /// `gpu_scales_buf` (f32) + `gpu_norms_buf` (f32). CPU path: sum of
 /// `IsoBlocks` — each has `codes: Vec<u32>` (4 B), `scales: Vec<f32>` (4 B),
 /// `quaternions: Vec<f32>` (4 B), `norms: Vec<f32>` (4 B).
+///
+/// NOTE: `QuantIsoV3::gpu_offset` advances independently from `blocks` when
+/// CPU-only blocks are also appended, e.g. after an SSD-hydrate fallback
+/// (see `quant_iso_v.rs` field doc on `gpu_offset`). Both GPU-mirror and any
+/// coexisting CPU `blocks` are resident simultaneously, so both are counted.
 fn quant_iso_v3_bytes(qv: Option<&QuantIsoV3>) -> u64 {
     let Some(qv) = qv else {
         return 0;
@@ -1826,7 +1889,20 @@ fn quant_iso_v3_bytes(qv: Option<&QuantIsoV3>) -> u64 {
     if let Some(ref codes) = qv.gpu_codes_buf {
         let scales_bytes = qv.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
         let norms_bytes = qv.gpu_norms_buf.as_ref().map_or(0, array_nbytes);
-        return array_nbytes(codes) + scales_bytes + norms_bytes;
+        // Add any coexisting CPU residual (blocks can be non-empty under a live
+        // GPU mirror after an SSD-hydrate fallback — gpu_offset advances
+        // independently; CPU blocks remain resident).
+        let cpu_residual: u64 = qv
+            .blocks
+            .iter()
+            .map(|b| {
+                b.codes.len() as u64 * 4
+                    + b.scales.len() as u64 * 4
+                    + b.quaternions.len() as u64 * 4
+                    + b.norms.len() as u64 * 4
+            })
+            .sum();
+        return array_nbytes(codes) + scales_bytes + norms_bytes + cpu_residual;
     }
     // CPU path.
     qv.blocks

--- a/crates/rmlx-kv-quant/src/storage/kv_storage.rs
+++ b/crates/rmlx-kv-quant/src/storage/kv_storage.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::match_same_arms, clippy::too_many_lines)]
 
 use rmlx_core::error::Result;
+use rmlx_mlx::Array;
 
 use super::{
     QuantIsoK3, QuantIsoK4, QuantIsoV3, QuantIsoV4, QuantK, QuantKTurbo3, QuantKTurbo4,
@@ -21,6 +22,18 @@ use super::{
 };
 use crate::paged::{PagedKStorage, PagedPlanarVStorage, PagedVStorage};
 use crate::KvQuant;
+
+// ── Byte-accounting helper ────────────────────────────────────────────────────
+
+/// Actual on-device bytes for a single `Array` — shape product × dtype item size.
+///
+/// Works entirely from array metadata (no FFI eval, no data read). Returns 0
+/// for zero-dimensional or empty arrays. Used by [`KvStorage::resident_bytes`].
+#[inline]
+fn array_nbytes(a: &Array) -> u64 {
+    let n: u64 = a.shape().iter().map(|&d| d as u64).product();
+    n * a.dtype().itemsize() as u64
+}
 
 /// Layout tag for symmetric TurboQuant 3-bit K + turbo3 V.
 ///
@@ -1541,4 +1554,412 @@ impl KvStorage {
             },
         })
     }
+
+    /// Actual on-device byte footprint of the quantized storage buffers.
+    ///
+    /// Sums the bytes of every allocated buffer in the storage variant:
+    /// - For GPU-backed variants (`QuantK`, `QuantV`, `QuantPlanarV`, …):
+    ///   actual `Array` shape × dtype item-size (allocated at `gpu_capacity`,
+    ///   not just filled tokens — the allocator uses power-of-two pages).
+    /// - For CPU-backed variants (`IsoBlocks`, `RotorBlocks`, …):
+    ///   sum of all `Vec` element sizes in bytes.
+    /// - `KvStorage::None` returns **0**: its buffers live on the parent
+    ///   `KvCache::decode_fp16_k/v` and are counted by `KvCache::resident_bytes`.
+    ///
+    /// Does **not** count the warm-TTFT fp16 decode-seed buffers
+    /// (`KvCache::decode_fp16_k/v`) — those are tallied separately in
+    /// [`KvCache::resident_bytes`] for all quantized variants.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "exhaustive match over all KvStorage variants — LOC-exempt: KvStorage has 30 variants; each arm is a one-to-three line byte summation that cannot be factored further without losing explicitness"
+    )]
+    pub fn resident_bytes(&self) -> u64 {
+        match self {
+            // ── Unquantised (bf16) ─────────────────────────────────────────────
+            // Buffers live on KvCache::decode_fp16_k/v; nothing extra here.
+            KvStorage::None { .. } => 0,
+
+            // ── K8V8 (K = q8_0, V = q8_0; V uses QuantK not QuantV) ─────────
+            KvStorage::K8V8 { k, v, .. } => quant_k_bytes(k.as_ref()) + quant_k_bytes(v.as_ref()),
+
+            // ── K8V4 / K8VTurbo* (K = q8_0, V = TurboQuant) ─────────────────
+            KvStorage::K8V4 { k, v, .. }
+            | KvStorage::K8VTurbo3 { k, v, .. }
+            | KvStorage::K8VTurbo3Tcq { k, v, .. }
+            | KvStorage::K8VTurbo2 { k, v, .. }
+            | KvStorage::K8VTurbo2Tcq { k, v, .. } => {
+                quant_k_bytes(k.as_ref()) + quant_v_bytes(v.as_ref())
+            }
+
+            // ── Planar (K=q8, V=PlanarQuant) ─────────────────────────────────
+            KvStorage::Planar { k, v, .. } => {
+                quant_k_bytes(k.as_ref()) + quant_planar_v_bytes(v.as_ref())
+            }
+
+            // ── PlanarK (K=PlanarQuant, V=bf16 on KvCache) ───────────────────
+            KvStorage::PlanarK { k, .. } => quant_planar_k_bytes(k.as_ref()),
+
+            // ── Mixed (MLX mx.quantize 3-tuples, opt. RotK) ───────────────────
+            KvStorage::Mixed { state, .. } => mixed_kv_state_bytes(state),
+
+            // ── RotKTq4V (rotated-K 3-tuple + TurboQuant V4) ─────────────────
+            KvStorage::RotKTq4V { k_state, v, .. } => {
+                mixed_kv_state_bytes(k_state) + quant_v_bytes(v.as_ref())
+            }
+
+            // ── Symmetric Turbo (K=TurboK3/4, V=TurboV) ─────────────────────
+            KvStorage::TurboSym3 { k, v, .. } => {
+                quant_k_turbo3_bytes(k.as_ref()) + quant_v_bytes(v.as_ref())
+            }
+            KvStorage::TurboSym4 { k, v, .. } => {
+                quant_k_turbo4_bytes(k.as_ref()) + quant_v_bytes(v.as_ref())
+            }
+
+            // ── IsoQuant V (K=q8, V=Iso3/4) ──────────────────────────────────
+            KvStorage::IsoV3 { k, v, .. } => {
+                quant_k_bytes(k.as_ref()) + quant_iso_v3_bytes(v.as_ref())
+            }
+            KvStorage::IsoV4 { k, v, .. } => {
+                quant_k_bytes(k.as_ref()) + quant_iso_v4_bytes(v.as_ref())
+            }
+
+            // ── IsoQuant Sym (K=IsoK3/4, V=IsoV3/4) ─────────────────────────
+            KvStorage::IsoSym3 { k, v, .. } => {
+                quant_iso_k3_bytes(k.as_ref()) + quant_iso_v3_bytes(v.as_ref())
+            }
+            KvStorage::IsoSym4 { k, v, .. } => {
+                quant_iso_k4_bytes(k.as_ref()) + quant_iso_v4_bytes(v.as_ref())
+            }
+
+            // ── IsoKOnly (K=Iso3/4, V=bf16 on KvCache) ───────────────────────
+            KvStorage::IsoKOnly3 { k, .. } => quant_iso_k3_bytes(k.as_ref()),
+            KvStorage::IsoKOnly4 { k, .. } => quant_iso_k4_bytes(k.as_ref()),
+
+            // ── RotorV (K=q8, V=Rotor3/4) ────────────────────────────────────
+            KvStorage::RotorV3 { k, v, .. } => {
+                quant_k_bytes(k.as_ref()) + quant_rotor_v3_bytes(v.as_ref())
+            }
+            KvStorage::RotorV4 { k, v, .. } => {
+                quant_k_bytes(k.as_ref()) + quant_rotor_v4_bytes(v.as_ref())
+            }
+
+            // ── RotorSym (K=RotorK3/4, V=RotorV3/4) ─────────────────────────
+            KvStorage::RotorSym3 { k, v, .. } => {
+                quant_rotor_k3_bytes(k.as_ref()) + quant_rotor_v3_bytes(v.as_ref())
+            }
+            KvStorage::RotorSym4 { k, v, .. } => {
+                quant_rotor_k4_bytes(k.as_ref()) + quant_rotor_v4_bytes(v.as_ref())
+            }
+
+            // ── RotorKOnly (K=RotorK3/4, V=bf16 on KvCache) ─────────────────
+            KvStorage::RotorKOnly3 { k, .. } => quant_rotor_k3_bytes(k.as_ref()),
+            KvStorage::RotorKOnly4 { k, .. } => quant_rotor_k4_bytes(k.as_ref()),
+
+            // ── RotorKAsym (K=RotorK3/4, V=affine QuantV) ────────────────────
+            KvStorage::RotorKAsym3 { k, v, .. } => {
+                quant_rotor_k3_bytes(k.as_ref()) + quant_v_bytes(v.as_ref())
+            }
+            KvStorage::RotorKAsym4 { k, v, .. } => {
+                quant_rotor_k4_bytes(k.as_ref()) + quant_v_bytes(v.as_ref())
+            }
+
+            // ── Paged (block-table KV, --paged-kv path) ───────────────────────
+            KvStorage::Paged {
+                k, v_k8, v_planar, ..
+            } => {
+                let k_bytes = k.as_ref().map_or(0, PagedKStorage::resident_bytes);
+                // v_k8 / v_planar are Box-wrapped; closure used to deref through Box.
+                let vk8_bytes = v_k8.as_ref().map_or(0, |s| s.resident_bytes());
+                let vp_bytes = v_planar.as_ref().map_or(0, |s| s.resident_bytes());
+                k_bytes + vk8_bytes + vp_bytes
+            }
+        }
+    }
+}
+
+// ── Per-type byte-counting helpers ────────────────────────────────────────────
+//
+// Each function accepts an `Option<&T>` (None = storage not yet populated →
+// returns 0) and sums the actual buffer bytes for that codec type.
+
+/// Affine q8_0 K buffer (`QuantK`).
+///
+/// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32) — sized to
+/// `gpu_capacity`, not just `offset`. CPU path: `codes` (u8) + `scales` (f32).
+fn quant_k_bytes(qk: Option<&QuantK>) -> u64 {
+    let Some(qk) = qk else {
+        return 0;
+    };
+    if let Some(ref codes) = qk.gpu_codes_buf {
+        let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
+        array_nbytes(codes) + scales_bytes
+    } else {
+        // CPU path: codes = Vec<u8>, scales = Vec<f32>
+        qk.codes.len() as u64 + qk.scales.len() as u64 * 4
+    }
+}
+
+/// TurboQuant V buffer (`QuantV`), used for K8V4 / K8V8 / K8VTurbo* / RotorKAsym.
+///
+/// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32). CPU path: sum of
+/// `TurboBlocks` — each block has `codes: Vec<u8>` (1 B/elem) and
+/// `scales: Vec<f32>` (4 B/elem).
+fn quant_v_bytes(qv: Option<&QuantV>) -> u64 {
+    let Some(qv) = qv else {
+        return 0;
+    };
+    if let Some(ref codes) = qv.gpu_codes_buf {
+        let scales_bytes = qv.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
+        array_nbytes(codes) + scales_bytes
+    } else {
+        // CPU path: TurboBlocks — codes: Vec<u8>, scales: Vec<f32>
+        qv.blocks
+            .iter()
+            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
+            .sum()
+    }
+}
+
+/// PlanarQuant V buffer (`QuantPlanarV`), used for `Planar` variant.
+///
+/// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32) +
+/// `gpu_rotations_buf` (u32). CPU path: sum of `PlanarBlocks` — each has
+/// `codes: Vec<u8>` (1 B), `scales: Vec<f32>` (4 B), `rotations: Vec<u8>` (1 B).
+fn quant_planar_v_bytes(qv: Option<&QuantPlanarV>) -> u64 {
+    let Some(qv) = qv else {
+        return 0;
+    };
+    if let Some(ref codes) = qv.gpu_codes_buf {
+        let scales_bytes = qv.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
+        let rot_bytes = qv.gpu_rotations_buf.as_ref().map_or(0, array_nbytes);
+        array_nbytes(codes) + scales_bytes + rot_bytes
+    } else {
+        qv.blocks
+            .iter()
+            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4 + b.rotations.len() as u64)
+            .sum()
+    }
+}
+
+/// PlanarQuant K buffer (`QuantPlanarK`), used for `PlanarK` variant.
+///
+/// Same buffer layout as `QuantPlanarV` — GPU or CPU with codes/scales/rotations.
+fn quant_planar_k_bytes(qk: Option<&QuantPlanarK>) -> u64 {
+    let Some(qk) = qk else {
+        return 0;
+    };
+    if let Some(ref codes) = qk.gpu_codes_buf {
+        let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
+        let rot_bytes = qk.gpu_rotations_buf.as_ref().map_or(0, array_nbytes);
+        array_nbytes(codes) + scales_bytes + rot_bytes
+    } else {
+        qk.blocks
+            .iter()
+            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4 + b.rotations.len() as u64)
+            .sum()
+    }
+}
+
+/// MLX mx.quantize 3-tuple state (`MixedKvState`).
+///
+/// Each `MixedTuple` has three `Array`s: codes (u32), scales (bf16/f32), biases
+/// (bf16/f32). Also includes the optional per-layer Hadamard rotation matrix
+/// (`k_rotation`: `Array`).
+fn mixed_kv_state_bytes(state: &crate::mixed_quant::MixedKvState) -> u64 {
+    fn tuple_bytes(t: &crate::mixed_quant::MixedTuple) -> u64 {
+        array_nbytes(&t.codes) + array_nbytes(&t.scales) + array_nbytes(&t.biases)
+    }
+    let k_bytes = state.keys.as_ref().map_or(0, tuple_bytes);
+    let v_bytes = state.values.as_ref().map_or(0, tuple_bytes);
+    let rot_bytes = state.k_rotation.as_ref().map_or(0, array_nbytes);
+    k_bytes + v_bytes + rot_bytes
+}
+
+/// TurboQuant 3-bit K buffer (`QuantKTurbo3`).
+///
+/// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32).
+/// CPU path: sum of `TurboBlocks`.
+fn quant_k_turbo3_bytes(qk: Option<&QuantKTurbo3>) -> u64 {
+    let Some(qk) = qk else {
+        return 0;
+    };
+    if let Some(ref codes) = qk.gpu_codes_buf {
+        let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
+        array_nbytes(codes) + scales_bytes
+    } else {
+        qk.blocks
+            .iter()
+            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
+            .sum()
+    }
+}
+
+/// TurboQuant 4-bit K buffer (`QuantKTurbo4`).
+///
+/// Same buffer layout as `QuantKTurbo3` — GPU codes/scales or CPU TurboBlocks.
+fn quant_k_turbo4_bytes(qk: Option<&QuantKTurbo4>) -> u64 {
+    let Some(qk) = qk else {
+        return 0;
+    };
+    if let Some(ref codes) = qk.gpu_codes_buf {
+        let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
+        array_nbytes(codes) + scales_bytes
+    } else {
+        qk.blocks
+            .iter()
+            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
+            .sum()
+    }
+}
+
+/// IsoQuant 3-bit V buffer (`QuantIsoV3`).
+///
+/// GPU path (when `gpu_resident_iso` gate enabled): `gpu_codes_buf` (u32) +
+/// `gpu_scales_buf` (f32) + `gpu_norms_buf` (f32). CPU path: sum of
+/// `IsoBlocks` — each has `codes: Vec<u32>` (4 B), `scales: Vec<f32>` (4 B),
+/// `quaternions: Vec<f32>` (4 B), `norms: Vec<f32>` (4 B).
+fn quant_iso_v3_bytes(qv: Option<&QuantIsoV3>) -> u64 {
+    let Some(qv) = qv else {
+        return 0;
+    };
+    // GPU path (crate-private fields accessed from within the same crate).
+    if let Some(ref codes) = qv.gpu_codes_buf {
+        let scales_bytes = qv.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
+        let norms_bytes = qv.gpu_norms_buf.as_ref().map_or(0, array_nbytes);
+        return array_nbytes(codes) + scales_bytes + norms_bytes;
+    }
+    // CPU path.
+    qv.blocks
+        .iter()
+        .map(|b| {
+            b.codes.len() as u64 * 4
+                + b.scales.len() as u64 * 4
+                + b.quaternions.len() as u64 * 4
+                + b.norms.len() as u64 * 4
+        })
+        .sum()
+}
+
+/// IsoQuant 4-bit V buffer (`QuantIsoV4`, CPU-only).
+fn quant_iso_v4_bytes(qv: Option<&QuantIsoV4>) -> u64 {
+    qv.map_or(0, |q| {
+        q.blocks
+            .iter()
+            .map(|b| {
+                b.codes.len() as u64 * 4
+                    + b.scales.len() as u64 * 4
+                    + b.quaternions.len() as u64 * 4
+                    + b.norms.len() as u64 * 4
+            })
+            .sum()
+    })
+}
+
+/// IsoQuant 3-bit K buffer (`QuantIsoK3`, CPU-only). Same layout as IsoV3 blocks.
+fn quant_iso_k3_bytes(qk: Option<&QuantIsoK3>) -> u64 {
+    qk.map_or(0, |q| {
+        q.blocks
+            .iter()
+            .map(|b| {
+                b.codes.len() as u64 * 4
+                    + b.scales.len() as u64 * 4
+                    + b.quaternions.len() as u64 * 4
+                    + b.norms.len() as u64 * 4
+            })
+            .sum()
+    })
+}
+
+/// IsoQuant 4-bit K buffer (`QuantIsoK4`, CPU-only). Same block layout.
+fn quant_iso_k4_bytes(qk: Option<&QuantIsoK4>) -> u64 {
+    qk.map_or(0, |q| {
+        q.blocks
+            .iter()
+            .map(|b| {
+                b.codes.len() as u64 * 4
+                    + b.scales.len() as u64 * 4
+                    + b.quaternions.len() as u64 * 4
+                    + b.norms.len() as u64 * 4
+            })
+            .sum()
+    })
+}
+
+/// Rotor3 V buffer (`QuantRotorV3`, CPU-only).
+///
+/// Includes the static per-layer rotor table (`rotors: Vec<f32>`, 4 B each)
+/// and the per-token `RotorBlocks` payload: `codes: Vec<u32>` (4 B),
+/// `scales: Vec<f32>` (4 B), `norms: Vec<f32>` (4 B).
+fn quant_rotor_v3_bytes(qv: Option<&QuantRotorV3>) -> u64 {
+    qv.map_or(0, |q| {
+        let rotor_bytes = q.rotors.len() as u64 * 4;
+        let block_bytes: u64 = q
+            .blocks
+            .iter()
+            .map(|b| {
+                b.codes.len() as u64 * 4 + b.scales.len() as u64 * 4 + b.norms.len() as u64 * 4
+            })
+            .sum();
+        rotor_bytes + block_bytes
+    })
+}
+
+/// Rotor4 V buffer (`QuantRotorV4`, CPU-only). Same layout as RotorV3.
+fn quant_rotor_v4_bytes(qv: Option<&QuantRotorV4>) -> u64 {
+    qv.map_or(0, |q| {
+        let rotor_bytes = q.rotors.len() as u64 * 4;
+        let block_bytes: u64 = q
+            .blocks
+            .iter()
+            .map(|b| {
+                b.codes.len() as u64 * 4 + b.scales.len() as u64 * 4 + b.norms.len() as u64 * 4
+            })
+            .sum();
+        rotor_bytes + block_bytes
+    })
+}
+
+/// Rotor3 K buffer (`QuantRotorK3`, CPU-only).
+///
+/// Includes: static `rotors: Vec<f32>` (4 B), optional QJL projection matrix
+/// `qjl_s_matrix: Vec<f32>` (4 B), and per-token `RotorKBlocks`:
+/// `codes: Vec<u32>` (4 B), `scales: Vec<f32>` (4 B), `norms: Vec<f32>` (4 B),
+/// `qjl_codes: Vec<u8>` (1 B), `qjl_norms: Vec<f32>` (4 B).
+fn quant_rotor_k3_bytes(qk: Option<&QuantRotorK3>) -> u64 {
+    qk.map_or(0, |q| {
+        let rotor_bytes = q.rotors.len() as u64 * 4;
+        let qjl_mat_bytes = q.qjl_s_matrix.as_ref().map_or(0, |m| m.len() as u64 * 4);
+        let block_bytes: u64 = q
+            .blocks
+            .iter()
+            .map(|b| {
+                b.codes.len() as u64 * 4
+                    + b.scales.len() as u64 * 4
+                    + b.norms.len() as u64 * 4
+                    + b.qjl_codes.len() as u64
+                    + b.qjl_norms.len() as u64 * 4
+            })
+            .sum();
+        rotor_bytes + qjl_mat_bytes + block_bytes
+    })
+}
+
+/// Rotor4 K buffer (`QuantRotorK4`, CPU-only). Same layout as RotorK3.
+fn quant_rotor_k4_bytes(qk: Option<&QuantRotorK4>) -> u64 {
+    qk.map_or(0, |q| {
+        let rotor_bytes = q.rotors.len() as u64 * 4;
+        let qjl_mat_bytes = q.qjl_s_matrix.as_ref().map_or(0, |m| m.len() as u64 * 4);
+        let block_bytes: u64 = q
+            .blocks
+            .iter()
+            .map(|b| {
+                b.codes.len() as u64 * 4
+                    + b.scales.len() as u64 * 4
+                    + b.norms.len() as u64 * 4
+                    + b.qjl_codes.len() as u64
+                    + b.qjl_norms.len() as u64 * 4
+            })
+            .sum();
+        rotor_bytes + qjl_mat_bytes + block_bytes
+    })
 }

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -1196,6 +1196,27 @@ impl Architecture {
         }
     }
 
+    /// Actual on-device KV-cache bytes used by the most recent `generate_greedy`
+    /// call on this architecture.
+    ///
+    /// Reads the arch-specific prompt-cache static that `generate_greedy` writes
+    /// via `store_kv_cache_bytes` at the end of every generate call.  Returns 0
+    /// for architectures that do not yet maintain that static (Qwen2, BitNet,
+    /// Laguna, Qwen3VlMoe).
+    pub fn kv_cache_bytes(&self) -> u64 {
+        match self {
+            Architecture::Gemma4(_) | Architecture::Gemma3(_) => {
+                crate::gemma4::gemma4_kv_cache_bytes()
+            }
+            Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::qwen3_5_moe_kv_cache_bytes(),
+            Architecture::Qwen3(_) => crate::qwen3::read_kv_cache_bytes(),
+            Architecture::Qwen2(_)
+            | Architecture::Laguna(_)
+            | Architecture::Qwen3VlMoe(_)
+            | Architecture::BitNet(_) => 0,
+        }
+    }
+
     /// Smoke probe verdict -- delegates to gemma4::classify_smoke for now.
     pub fn classify_smoke(steps: &[crate::gemma4::ProbeStep]) -> SmokeVerdict {
         crate::gemma4::classify_smoke(steps)

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -1205,9 +1205,12 @@ impl Architecture {
     /// Laguna, Qwen3VlMoe).
     pub fn kv_cache_bytes(&self) -> u64 {
         match self {
-            Architecture::Gemma4(_) | Architecture::Gemma3(_) => {
-                crate::gemma4::gemma4_kv_cache_bytes()
-            }
+            Architecture::Gemma4(_) => crate::gemma4::gemma4_kv_cache_bytes(),
+            // NOTE: Gemma3 has its own generate path (`crate::gemma3::generate_greedy`)
+            // that does NOT call `store_kv_cache_bytes`, so `gemma4_kv_cache_bytes()`
+            // always returns 0 (or the last Gemma4 value if both were loaded in the
+            // same process). Gemma3 KV byte reporting is not yet wired.
+            Architecture::Gemma3(_) => 0,
             Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::qwen3_5_moe_kv_cache_bytes(),
             Architecture::Qwen3(_) => crate::qwen3::read_kv_cache_bytes(),
             Architecture::Qwen2(_)

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -627,7 +627,7 @@ pub fn generate_greedy(
                 }
             }
  // N16: store KV-cache bytes at decode-loop end before returning.
-            let kv_bytes_macro: u64 = kv_caches.iter().map(|c| c.approx_bytes()).sum();
+            let kv_bytes_macro: u64 = kv_caches.iter().map(|c| c.resident_bytes()).sum();
             store_kv_cache_bytes(kv_bytes_macro);
         }};
     }
@@ -1315,7 +1315,7 @@ pub fn generate_greedy(
        );
 
     // N16: store KV-cache bytes for the /metrics/cache endpoint.
-    let kv_bytes: u64 = caches.iter().map(|c| c.approx_bytes()).sum();
+    let kv_bytes: u64 = caches.iter().map(|c| c.resident_bytes()).sum();
     store_kv_cache_bytes(kv_bytes);
 
     Ok(steps)

--- a/crates/rmlx-models/src/gemma4/prompt_cache.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache.rs
@@ -137,7 +137,7 @@ impl PromptCacheEntry for Gemma4Entry {
     }
 
     fn kv_bytes(&self) -> u64 {
-        self.kv_caches.iter().map(KvCache::approx_bytes).sum()
+        self.kv_caches.iter().map(KvCache::resident_bytes).sum()
     }
 }
 

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -187,7 +187,7 @@ impl PromptCacheEntry for Qwen3Entry {
     }
 
     fn kv_bytes(&self) -> u64 {
-        self.kv_caches.iter().map(|c| c.approx_bytes()).sum()
+        self.kv_caches.iter().map(|c| c.resident_bytes()).sum()
     }
 }
 
@@ -2268,7 +2268,7 @@ pub fn generate_greedy(
         // Store KV-cache bytes on exact-hit path (mirrors the Miss path store at
         // the prefill snapshot block below). Once per generate call, after decode.
         {
-            let kv_bytes: u64 = kv_caches.iter().map(|c| c.approx_bytes()).sum();
+            let kv_bytes: u64 = kv_caches.iter().map(|c| c.resident_bytes()).sum();
             QWEN3_PROMPT_CACHE.store_kv_cache_bytes(kv_bytes);
         }
         return Ok(steps);
@@ -2468,7 +2468,7 @@ pub fn generate_greedy(
     // We clone the post-prefill KV caches (refcount bump, no data copy) before
     // the decode loop starts writing new decode-step K/V into them.
     {
-        let kv_bytes: u64 = caches.iter().map(|c| c.approx_bytes()).sum();
+        let kv_bytes: u64 = caches.iter().map(|c| c.resident_bytes()).sum();
         QWEN3_PROMPT_CACHE.store_kv_cache_bytes(kv_bytes);
         let cloned_caches: Result<Vec<KvCache>> =
             caches.iter().map(|c| c.try_deep_clone()).collect();

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -532,7 +532,7 @@ pub fn generate_greedy(
             }
         }
         // N16: store KV-cache bytes (KV + linear-attn state) for /metrics/cache.
-        let kv_bytes: u64 = kv_caches.iter().map(|c| c.approx_bytes()).sum::<u64>()
+        let kv_bytes: u64 = kv_caches.iter().map(|c| c.resident_bytes()).sum::<u64>()
             + lin_caches.iter().map(|c| c.approx_bytes()).sum::<u64>();
         store_kv_cache_bytes(kv_bytes);
         return Ok(steps);
@@ -918,7 +918,7 @@ pub fn generate_greedy(
             }
         }
 
-        let kv_bytes: u64 = kv_caches.iter().map(|c| c.approx_bytes()).sum::<u64>()
+        let kv_bytes: u64 = kv_caches.iter().map(|c| c.resident_bytes()).sum::<u64>()
             + lin_caches.iter().map(|c| c.approx_bytes()).sum::<u64>();
         store_kv_cache_bytes(kv_bytes);
         return Ok(steps);
@@ -1429,7 +1429,7 @@ pub fn generate_greedy(
     );
 
     // N16: store KV-cache bytes (KV + linear-attn state) for /metrics/cache.
-    let kv_bytes: u64 = kv_caches.iter().map(|c| c.approx_bytes()).sum::<u64>()
+    let kv_bytes: u64 = kv_caches.iter().map(|c| c.resident_bytes()).sum::<u64>()
         + lin_caches.iter().map(|c| c.approx_bytes()).sum::<u64>();
     store_kv_cache_bytes(kv_bytes);
 

--- a/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
@@ -113,7 +113,7 @@ impl PromptCacheEntry for Qwen35MoeEntry {
     }
 
     fn kv_bytes(&self) -> u64 {
-        let kv: u64 = self.kv_caches.iter().map(|c| c.approx_bytes()).sum();
+        let kv: u64 = self.kv_caches.iter().map(|c| c.resident_bytes()).sum();
         let lin: u64 = self.lin_caches.iter().map(|c| c.approx_bytes()).sum();
         kv + lin
     }

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -805,7 +805,9 @@ independently and so reflects the dropped buffer. Residency reclaimed for Bonsai
 (`num_kv_heads=8`, `head_dim=128`, 36 layers): 288 MiB @ 4k ctx, 576 MiB @ 8k,
 1152 MiB @ 16k (= `seq × kv_h × head_dim × 2 B × n_layers`). Pinned by
 `warm_ttft_cross_codec_tests::iso_k_only3_quant_at_decode` (asserts
-the seed is **absent** and `approx_bytes` drops).
+the seed is **absent** and `approx_bytes` drops). `resident_bytes` is the
+preferred diagnostic in metrics paths — it reads actual buffer sizes rather
+than re-deriving from shape fields.
 
 ### Decision: keep warm-TTFT universal
 

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -120,6 +120,17 @@ of the active `KvQuant`: they use `RotatingState` (a ring-buffer bf16 path
 ported from mlx-lm's `RotatingKVCache`). `mlx-lm.to_quantized` raises
 `NotImplementedError` for rotating caches; rMLX matches that behaviour.
 
+**Byte accounting.** Two methods report KV-cache size:
+
+- `KvCache::approx_bytes()` — formula-based estimate using stored shape fields.
+  Used for SWA ring sizing and internal shape guards. Can return 0 when shape
+  fields are absent (e.g. before the first prefill).
+- `KvCache::resident_bytes()` — actual on-device allocation: reads the real
+  `Array` shape × `dtype.itemsize()` for every GPU buffer, and `Vec.len()`
+  for CPU codec blocks. Covers packed codes, scales, zero-points, and optional
+  rotation/residual buffers. This is the value recorded in `kv_cache_bytes`
+  metrics observations and returned by `rmlx baseline`.
+
 ### Per-request hot-swap (issue #26)
 
 The `KvQuant` for a request is **not** tied to the model load. A running

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -341,7 +341,7 @@ Source of truth for `observations.metric`, `.unit`, `.direction`. Add to this ta
 | `model_load_ms`       | `ms`    | `lower_better`  | Wall time from `serve` start to "ready" log line.                       |
 | `peak_rss_mb`         | `mb`    | `lower_better`  | Peak resident set during the run.                                       |
 | `metal_peak_alloc_mb` | `mb`    | `lower_better`  | Peak Metal device allocation (from `mx.metal.get_peak_memory()`).       |
-| `kv_cache_bytes`      | `bytes` | `lower_better`  | KV cache footprint at end of generation.                                |
+| `kv_cache_bytes`      | `bytes` | `lower_better`  | Actual on-device KV-cache allocation at end of generation (packed codes + scales + rotation/residual buffers; reads real Array sizes via `KvCache::resident_bytes`). |
 | `tps_per_gb_ram`      | `ratio` | `higher_better` | `decode_tps_warm / peak_rss_gb` — runtime efficiency.                   |
 | `task_pass_at_1`      | `ratio` | `higher_better` | Quality probe pass rate (CBB-style). 0.0–1.0.                           |
 | `prompt_cache_block_hits`        | `count` | `higher_better` | Cumulative 256-tok blocks served from a cached prefix.   |


### PR DESCRIPTION
Closes #33.

## Problem
`kv_cache_bytes` in observation records was **always 0** — the engine never reported live KV-cache size, so KV codecs could not be ranked on memory/compression (the axis they exist for). Only decode TPS was observable, making every codec look like a no-op on small-KV architectures.

## Fix (model-agnostic)
- New `KvStorage::resident_bytes()` — exhaustive match over all 28 storage variants, summing **actual on-device bytes** (GPU `Array` shape×itemsize + CPU `Vec` len×elem): packed codes + scales + zero-points + rotation/residual/norm buffers. Quantized variants report their packed size, not the dequantized-equivalent.
- `KvCache::resident_bytes()` — sums quantized storage + fp16 decode seeds + rotating SWA ring + TurboFlash + fused-QK shadow, no double-counting.
- Paged variants (`PageSlab`/`PagedKStorage`/`PagedVStorage`/`PagedPlanarVStorage`) report allocated-page bytes.
- `Architecture::kv_cache_bytes()` arch-agnostic dispatch (Gemma4 / Qwen3 / Qwen3.5-MoE wired; un-wired archs return 0 explicitly).
- Wired into `rmlx baseline` metrics + the §8.5 RunRecord; zero values gated out so "un-wired" never reads as "measured 0 bytes".

Review-follow-up commit: GPU arms now also count coexisting CPU `blocks` (resident after an SSD-hydrate fallback), and the in-process metric is gated on `>0` to match the RunRecord.

## Proof
- Unit: `rmlx-kv-quant` 277 pass, `rmlx-models` 542 pass; `cargo fmt` + `make lint` clean.
- Real model (Gemma4 e2b, `release-perf`): `kv_cache_bytes` = 62.9 MB @ 894 tok → 113.2 MB @ 4410 tok — non-zero and monotonic with KV length (was always 0). Decode coherent. (k8v4 65.5 MB > none 62.9 MB at 894 tok confirms SWA codec framing overhead exceeds savings on small windows — separate issue #34.)

Docs: `KV_QUANT.md`, `KV_CACHE.md`, `METRICS_DB.md` updated with the byte-accounting semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)