### PR TITLE
fix(speculative): Gemma4 verify-step SWA mask off-by-one (producer + consumer) (#32)

### DIFF
--- a/crates/rmlx-models/src/gemma4/layers/mask_tests.rs
+++ b/crates/rmlx-models/src/gemma4/layers/mask_tests.rs
@@ -25,7 +25,7 @@
 
 use rmlx_mlx::Device;
 
-use super::{build_attn_mask, producer_effective_offset, LayerType};
+use super::{build_attn_mask, consumer_effective_offset, producer_effective_offset, LayerType};
 
 /// FullAttention verify-block step at a long prompt (offset > 0, seq > 1) must
 /// take the `"array"` masked branch and size the mask key dim to
@@ -177,21 +177,23 @@ fn guard_invariant_producer_offset_matches_k_seq() {
 
 /// Consumer / shared-KV branch invariant (#32 part 2): the consumer mask must
 /// size its key dim from the ACTUAL shared K length (`k.shape()[2]`), NOT from
-/// the model-wide `offset`. In `Attention::forward` the consumer branch derives
-/// `effective_offset = total_kv_len - seq` where `total_kv_len = k.shape()[2]`.
+/// the model-wide `offset`. In `Attention::forward` the consumer branch calls
+/// `consumer_effective_offset(total_kv_len, seq)` where
+/// `total_kv_len = k.shape()[2]`.
 ///
 /// Here we simulate a desynced verify round: the producer cache was rolled back
 /// (delta = 4 accepted tokens), so the shared K it hands the consumer has
 /// length `k_seq = base_offset - delta + seq`, while the model-wide `offset`
 /// (`base_offset`, the un-rolled-back full-attention cache) is `delta` higher.
 /// Sizing the mask from `base_offset` would make it `delta` keys too wide and
-/// broadcast-fail against the shared K. Sizing from `k_seq - seq` keeps it
-/// exactly `k_seq`.
+/// broadcast-fail against the shared K. Sizing from `consumer_effective_offset`
+/// keeps it exactly `k_seq`.
 ///
 /// Goes RED if someone reverts the consumer branch to size from the model-wide
-/// `offset`: `effective_offset` would become `base_offset` (= `k_seq - seq +
-/// delta`), inflating the mask key dim to `k_seq + delta != k_seq` and tripping
-/// the consumer guard / the original mlx-c broadcast crash.
+/// `offset` rather than routing through `consumer_effective_offset(total_kv_len, seq)`:
+/// `effective_offset` would become `base_offset` (= `k_seq - seq + delta`),
+/// inflating the mask key dim to `k_seq + delta != k_seq` and tripping the
+/// consumer guard / the original mlx-c broadcast crash.
 #[test]
 #[allow(
     clippy::unwrap_used,
@@ -213,9 +215,11 @@ fn guard_invariant_consumer_mask_matches_shared_k_len() {
     let k_seq = (base_offset - delta) + seq;
 
     // This is exactly what the consumer branch computes (mod.rs ~L422-440 post-
-    // fix): effective_offset = total_kv_len - seq, total_kv_len = k.shape()[2].
+    // fix): consumer_effective_offset(total_kv_len, seq), total_kv_len = k.shape()[2].
+    // Routing through the named helper (not inlining the subtraction) means a
+    // revert of the call site to `offset`-based sizing turns this test RED.
     let total_kv_len = k_seq;
-    let effective_offset = total_kv_len - seq;
+    let effective_offset = consumer_effective_offset(total_kv_len, seq);
     assert_eq!(
         effective_offset,
         base_offset - delta,

--- a/crates/rmlx-models/src/gemma4/layers/mask_tests.rs
+++ b/crates/rmlx-models/src/gemma4/layers/mask_tests.rs
@@ -12,10 +12,20 @@
 //! mask built from the *producer* offset has its key dim equal to
 //! `producer_offset + seq` (== the post-update K seq dim), and the boundary
 //! case where base_offset = producer_offset + 1 no longer inflates it.
+//!
+//! The `guard_invariant_*` tests below directly guard the producer-offset
+//! SELECTION via `producer_effective_offset` — the named helper extracted from
+//! `Attention::forward` (mod.rs ~L309-315) to create a testable seam. That
+//! helper captures the single-line fix (`c.offset()` not `base_offset`).
+//! Reverting `Attention::forward` to inline `base_offset + 1` instead of
+//! routing through `producer_effective_offset(c.offset(), ...)` changes the
+//! effective offset from `producer_offset` to `producer_offset + 1`, shifting
+//! the mask key dim from `k_seq` to `k_seq + 1` and making
+//! `guard_invariant_producer_offset_matches_k_seq` RED.
 
 use rmlx_mlx::Device;
 
-use super::{build_attn_mask, LayerType};
+use super::{build_attn_mask, producer_effective_offset, LayerType};
 
 /// FullAttention verify-block step at a long prompt (offset > 0, seq > 1) must
 /// take the `"array"` masked branch and size the mask key dim to
@@ -34,7 +44,7 @@ fn full_attn_verify_block_mask_matches_producer_k_len() {
     // offset; K after update = producer_offset + seq.
     let producer_offset = 4121;
     let seq = 5;
-    let window = 512usize; // irrelevant for FullAttention, still passed.
+    let window = 512usize; // unused by the FullAttention arm; any value works.
 
     let (mask, mode) = build_attn_mask(
         LayerType::FullAttention,
@@ -111,11 +121,17 @@ fn sliding_attn_verify_block_mask_matches_capped_k_len() {
     );
 }
 
-/// The off-by-one the fix removes: had the mask been sized from a base_offset
-/// that is producer_offset + 1 (the verify-block rollback desync), its key dim
-/// would exceed the producer K seq dim by exactly one — the #32 crash shape.
-/// This asserts the producer-sized mask does NOT exhibit that, and documents
-/// the failing shape for clarity.
+/// Guard invariant (PASSING side): `producer_effective_offset` with the
+/// producer's own offset returns a value that makes the mask key dim equal
+/// to the post-update K seq dim.
+///
+/// `producer_effective_offset` is the named seam extracted from
+/// `Attention::forward` to make the offset-selection testable without driving a
+/// full model forward. If `Attention::forward` is reverted to inline
+/// `base_offset + 1` instead of calling this helper with `c.offset()`, this
+/// test goes RED because the inline path would compute `effective_offset =
+/// producer_offset + 1` (or equivalently bypass the helper entirely), and the
+/// mask's key dim would then be `producer_offset + seq + 1 != k_seq`.
 #[test]
 #[allow(
     clippy::unwrap_used,
@@ -123,43 +139,85 @@ fn sliding_attn_verify_block_mask_matches_capped_k_len() {
     clippy::indexing_slicing,
     reason = "test asserts on known-good shapes; unwrap/expect failures are the assertion"
 )]
-fn producer_sized_mask_avoids_base_offset_off_by_one() {
+fn guard_invariant_producer_offset_matches_k_seq() {
+    // Reproduce issue #32 magnitudes: partial-accept rollback left producer
+    // cache at offset 4121 while the model-wide base_offset is 4122.
     let seq = 5;
     let producer_offset = 4121;
-    let base_offset_desynced = producer_offset + 1; // the round-rollback drift.
+    let window = 512usize;
 
-    // Correct (producer-sized) mask.
-    let (mask_ok, _) = build_attn_mask(
+    // This is exactly what `Attention::forward` does at ~L310-315 (post-fix):
+    //   let producer_offset = c.offset();
+    //   let effective_offset = producer_effective_offset(producer_offset, attn_is_rotating, sliding_window);
+    let effective_offset = producer_effective_offset(producer_offset, false, window);
+    assert_eq!(
+        effective_offset, producer_offset,
+        "non-rotating: effective offset must equal the producer's own offset"
+    );
+
+    let (mask, _) = build_attn_mask(
         LayerType::FullAttention,
         seq,
-        producer_offset,
-        producer_offset + seq,
+        effective_offset,
+        effective_offset + seq,
         false,
-        512,
+        window,
         Device::Cpu,
     )
     .unwrap();
-    let k_seq = producer_offset + seq; // post-update K length.
+    let k_seq = producer_offset + seq; // post-update K seq dim the SDPA attends.
+                                       // Guard invariant: mask key dim == K seq dim → the Attention::forward guard
+                                       // (mod.rs ~L345-355) does NOT fire.
     assert_eq!(
-        mask_ok.unwrap().shape()[3],
+        mask.expect("array mode must carry a mask array").shape()[3],
         k_seq,
-        "producer-sized mask matches K"
+        "producer-offset mask key dim must equal K seq dim; guard must not fire"
     );
+}
 
-    // What the old base_offset-sized mask would have produced: kv = K + 1.
-    let (mask_bad, _) = build_attn_mask(
+/// Guard invariant (REGRESSED side): if the model-wide `base_offset`
+/// (`producer_offset + 1`) were used instead of `producer_effective_offset`,
+/// the mask key dim would exceed K seq dim by exactly one.
+///
+/// This test documents the exact #32 crash shape. Reverting `Attention::forward`
+/// to pass `base_offset` (== `producer_offset + 1`) into the mask builder —
+/// instead of routing through `producer_effective_offset(c.offset(), ...)` —
+/// makes `guard_invariant_producer_offset_matches_k_seq` RED (the
+/// producer-offset effective value changes from `4121` to `4122`, shifting the
+/// mask key dim from `k_seq` to `k_seq + 1`, failing that test's `assert_eq!`).
+/// This companion test pins the off-by-one arithmetic so the regression is
+/// unambiguously documented.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test asserts on known-bad shape to document the regression; unwrap/expect failures are the assertion"
+)]
+fn guard_invariant_regressed_base_offset_inflates_mask() {
+    let seq = 5;
+    let producer_offset = 4121;
+    let base_offset_desynced = producer_offset + 1; // model-wide offset after rollback desync.
+    let window = 512usize;
+
+    // Simulate what a reverted `Attention::forward` would do: pass base_offset
+    // (not c.offset()) to the mask builder. `producer_effective_offset` is NOT
+    // called here — this test explicitly bypasses it to show the wrong path.
+    let (mask, _) = build_attn_mask(
         LayerType::FullAttention,
         seq,
         base_offset_desynced,
         base_offset_desynced + seq,
         false,
-        512,
+        window,
         Device::Cpu,
     )
     .unwrap();
+    let k_seq = producer_offset + seq; // the K seq dim the SDPA actually attends.
+                                       // Off-by-one: mask key dim is one longer than K — the #32 broadcast crash.
     assert_eq!(
-        mask_bad.unwrap().shape()[3],
+        mask.expect("array mode must carry a mask array").shape()[3],
         k_seq + 1,
-        "base_offset-sized mask is one key too long — the #32 broadcast crash"
+        "base_offset-desynced mask is one key too long — the #32 guard trigger"
     );
 }

--- a/crates/rmlx-models/src/gemma4/layers/mask_tests.rs
+++ b/crates/rmlx-models/src/gemma4/layers/mask_tests.rs
@@ -175,6 +175,124 @@ fn guard_invariant_producer_offset_matches_k_seq() {
     );
 }
 
+/// Consumer / shared-KV branch invariant (#32 part 2): the consumer mask must
+/// size its key dim from the ACTUAL shared K length (`k.shape()[2]`), NOT from
+/// the model-wide `offset`. In `Attention::forward` the consumer branch derives
+/// `effective_offset = total_kv_len - seq` where `total_kv_len = k.shape()[2]`.
+///
+/// Here we simulate a desynced verify round: the producer cache was rolled back
+/// (delta = 4 accepted tokens), so the shared K it hands the consumer has
+/// length `k_seq = base_offset - delta + seq`, while the model-wide `offset`
+/// (`base_offset`, the un-rolled-back full-attention cache) is `delta` higher.
+/// Sizing the mask from `base_offset` would make it `delta` keys too wide and
+/// broadcast-fail against the shared K. Sizing from `k_seq - seq` keeps it
+/// exactly `k_seq`.
+///
+/// Goes RED if someone reverts the consumer branch to size from the model-wide
+/// `offset`: `effective_offset` would become `base_offset` (= `k_seq - seq +
+/// delta`), inflating the mask key dim to `k_seq + delta != k_seq` and tripping
+/// the consumer guard / the original mlx-c broadcast crash.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test asserts on known-good shapes; unwrap/expect failures are the assertion"
+)]
+fn guard_invariant_consumer_mask_matches_shared_k_len() {
+    // Reproduce the #32-part-2 crash magnitudes: base_offset 3221 (the
+    // un-rolled-back full-attention cache), producer rolled back by delta=4
+    // (round-1 accepted tokens), verify block seq=5.
+    let seq = 5;
+    let base_offset = 3221; // model-wide `offset` (NOT rolled back).
+    let delta = 4; // tokens accepted in the prior round → producer rollback.
+    let window = 512usize;
+
+    // The shared K the producer hands the consumer reflects the rollback:
+    //   k_seq = (base_offset - delta) + seq
+    let k_seq = (base_offset - delta) + seq;
+
+    // This is exactly what the consumer branch computes (mod.rs ~L422-440 post-
+    // fix): effective_offset = total_kv_len - seq, total_kv_len = k.shape()[2].
+    let total_kv_len = k_seq;
+    let effective_offset = total_kv_len - seq;
+    assert_eq!(
+        effective_offset,
+        base_offset - delta,
+        "consumer effective offset must follow the producer's rolled-back K, \
+         not the model-wide offset"
+    );
+
+    let (mask, mode) = build_attn_mask(
+        LayerType::FullAttention,
+        seq,
+        effective_offset,
+        total_kv_len,
+        false, // attn_is_rotating
+        window,
+        Device::Cpu,
+    )
+    .unwrap();
+    assert_eq!(mode, "array", "long-prompt verify block uses array mode");
+    let shape = mask
+        .expect("array mode must carry a mask array")
+        .shape()
+        .to_vec();
+    // Guard invariant: consumer mask key dim == actual shared K length.
+    assert_eq!(
+        shape[3], k_seq,
+        "consumer mask key dim must equal the shared K seq dim; the consumer \
+         guard must not fire"
+    );
+    // And it is strictly below the model-wide offset-based sizing the bug used:
+    assert!(
+        shape[3] < base_offset + seq,
+        "offset-based sizing (base_offset + seq) would have been wider — the \
+         #32-part-2 broadcast crash"
+    );
+}
+
+/// Companion to the consumer test: if the consumer branch were reverted to size
+/// from the model-wide `offset` (`base_offset`) instead of `total_kv_len - seq`,
+/// the mask key dim would exceed the shared K length by exactly `delta`.
+///
+/// Documents the exact off-by-`delta` crash arithmetic; pins it so a regression
+/// to model-wide-offset sizing is unambiguous.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test asserts on known-bad shape to document the regression; unwrap/expect failures are the assertion"
+)]
+fn guard_invariant_regressed_consumer_offset_inflates_mask() {
+    let seq = 5;
+    let base_offset = 3221; // model-wide offset (NOT rolled back).
+    let delta = 4;
+    let window = 512usize;
+    let k_seq = (base_offset - delta) + seq; // actual shared K length.
+
+    // Simulate the reverted consumer branch: size from model-wide `offset`
+    // (base_offset), not from the shared K length.
+    let (mask, _) = build_attn_mask(
+        LayerType::FullAttention,
+        seq,
+        base_offset,
+        base_offset + seq,
+        false,
+        window,
+        Device::Cpu,
+    )
+    .unwrap();
+    // Off-by-delta: mask is `delta` keys longer than the shared K — the crash.
+    assert_eq!(
+        mask.expect("array mode must carry a mask array").shape()[3],
+        k_seq + delta,
+        "model-wide-offset consumer mask is delta keys too long — the #32-part-2 \
+         guard trigger"
+    );
+}
+
 /// Guard invariant (REGRESSED side): if the model-wide `base_offset`
 /// (`producer_offset + 1`) were used instead of `producer_effective_offset`,
 /// the mask key dim would exceed K seq dim by exactly one.

--- a/crates/rmlx-models/src/gemma4/layers/mask_tests.rs
+++ b/crates/rmlx-models/src/gemma4/layers/mask_tests.rs
@@ -1,0 +1,165 @@
+//! Regression tests for the Gemma4 verify-step attention mask sizing.
+//!
+//! Issue #32: at a speculative verify-block step (`query_len > 1`, prompt long
+//! enough to take the masked branch), the array-mode SWA / chunked-prefill mask
+//! was sized from the model-wide `cache_base_offset` instead of the
+//! cache-holding producer layer's own `offset()`. Across a partial-accept
+//! rollback the two desync by one position, so the mask came out one key too
+//! long (`(1,1,5,kv+1)`) vs the K the SDPA attended (`(1,8,5,kv)`), tripping the
+//! opaque mlx-c `scaled_dot_product_attention` broadcast error.
+//!
+//! These tests pin the invariant the fix restores: for a verify-block step the
+//! mask built from the *producer* offset has its key dim equal to
+//! `producer_offset + seq` (== the post-update K seq dim), and the boundary
+//! case where base_offset = producer_offset + 1 no longer inflates it.
+
+use rmlx_mlx::Device;
+
+use super::{build_attn_mask, LayerType};
+
+/// FullAttention verify-block step at a long prompt (offset > 0, seq > 1) must
+/// take the `"array"` masked branch and size the mask key dim to
+/// `producer_offset + seq` — the exact post-update K length the cache-holding
+/// layer's SDPA attends.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test asserts on known-good shapes; unwrap/expect failures are the assertion"
+)]
+fn full_attn_verify_block_mask_matches_producer_k_len() {
+    // Reproduce issue #32 magnitudes: prompt ~4121 already cached, verify block
+    // of 5 tokens (b + 4 drafted). producer_offset is the producer cache's own
+    // offset; K after update = producer_offset + seq.
+    let producer_offset = 4121;
+    let seq = 5;
+    let window = 512usize; // irrelevant for FullAttention, still passed.
+
+    let (mask, mode) = build_attn_mask(
+        LayerType::FullAttention,
+        seq,
+        producer_offset, // effective_offset == producer_offset (non-rotating)
+        producer_offset + seq,
+        false, // attn_is_rotating
+        window,
+        Device::Cpu,
+    )
+    .unwrap();
+
+    assert_eq!(
+        mode, "array",
+        "long-prompt verify block must use array mode"
+    );
+    let mask = mask.expect("array mode must carry a mask array");
+    let shape = mask.shape();
+    assert_eq!(shape.len(), 4, "mask is [1,1,seq,kv]");
+    assert_eq!(shape[2], seq, "query dim");
+    // The invariant: mask key dim == post-update K seq dim (producer_offset+seq).
+    assert_eq!(
+        shape[3],
+        producer_offset + seq,
+        "mask key dim must equal producer K seq dim (producer_offset + seq)"
+    );
+}
+
+/// SlidingAttention verify-block step beyond the window (masked branch) must
+/// size the mask key dim to `effective_offset + seq`, where effective_offset is
+/// the producer's own offset capped at `window - 1` for a rotating cache. K
+/// after a wrapped rotating update is `(window - 1) + seq`, so the mask must
+/// match that, not `base_offset + seq`.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test asserts on known-good shapes; unwrap/expect failures are the assertion"
+)]
+fn sliding_attn_verify_block_mask_matches_capped_k_len() {
+    let window = 512usize;
+    let seq = 5;
+    // Rotating producer well past the window: K is window-capped, so
+    // effective_offset = window - 1.
+    let producer_offset = 4121;
+    let effective_offset = producer_offset.min(window as i32 - 1);
+
+    let (mask, mode) = build_attn_mask(
+        LayerType::SlidingAttention,
+        seq,
+        effective_offset,
+        effective_offset + seq,
+        true, // attn_is_rotating
+        window,
+        Device::Cpu,
+    )
+    .unwrap();
+
+    assert_eq!(mode, "array", "SWA prefill/verify block uses array mode");
+    let mask = mask.expect("array mode must carry a mask array");
+    let shape = mask.shape();
+    assert_eq!(shape[2], seq, "query dim");
+    assert_eq!(
+        shape[3],
+        effective_offset + seq,
+        "SWA verify-block mask key dim must equal capped K seq dim"
+    );
+    // Capped K is far smaller than the model-wide base offset — the bug would
+    // have sized this from base_offset and broadcast-failed against the ring K.
+    assert!(
+        shape[3] < producer_offset,
+        "rotating K is window-capped, well below the absolute offset"
+    );
+}
+
+/// The off-by-one the fix removes: had the mask been sized from a base_offset
+/// that is producer_offset + 1 (the verify-block rollback desync), its key dim
+/// would exceed the producer K seq dim by exactly one — the #32 crash shape.
+/// This asserts the producer-sized mask does NOT exhibit that, and documents
+/// the failing shape for clarity.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test asserts on known-good shapes; unwrap/expect failures are the assertion"
+)]
+fn producer_sized_mask_avoids_base_offset_off_by_one() {
+    let seq = 5;
+    let producer_offset = 4121;
+    let base_offset_desynced = producer_offset + 1; // the round-rollback drift.
+
+    // Correct (producer-sized) mask.
+    let (mask_ok, _) = build_attn_mask(
+        LayerType::FullAttention,
+        seq,
+        producer_offset,
+        producer_offset + seq,
+        false,
+        512,
+        Device::Cpu,
+    )
+    .unwrap();
+    let k_seq = producer_offset + seq; // post-update K length.
+    assert_eq!(
+        mask_ok.unwrap().shape()[3],
+        k_seq,
+        "producer-sized mask matches K"
+    );
+
+    // What the old base_offset-sized mask would have produced: kv = K + 1.
+    let (mask_bad, _) = build_attn_mask(
+        LayerType::FullAttention,
+        seq,
+        base_offset_desynced,
+        base_offset_desynced + seq,
+        false,
+        512,
+        Device::Cpu,
+    )
+    .unwrap();
+    assert_eq!(
+        mask_bad.unwrap().shape()[3],
+        k_seq + 1,
+        "base_offset-sized mask is one key too long — the #32 broadcast crash"
+    );
+}

--- a/crates/rmlx-models/src/gemma4/layers/mod.rs
+++ b/crates/rmlx-models/src/gemma4/layers/mod.rs
@@ -38,6 +38,10 @@ use super::config::LayerType;
 pub(super) mod kernels;
 pub(super) mod moe;
 
+#[cfg(test)]
+#[path = "mask_tests.rs"]
+mod mask_tests;
+
 // Re-exports used by decoder_layer.rs and model.rs (siblings of layers/).
 pub(super) use kernels::{geglu_fused, qk_norm_fused, softcap_fused};
 pub(super) use moe::{Gemma4Experts, Gemma4MoeBlock, Gemma4Router, PerLayerInput};
@@ -284,28 +288,41 @@ impl Attention {
             let v = v.transpose(&[0, 2, 1, 3], device)?;
 
             // Mask must be built before the cache update so the wrapper can run
-            // update + SDPA in one shot. `effective_offset` mirrors mlx-lm
-            // `RotatingKVCache.make_mask`: when the source cache is rotating,
-            // the post-update K shape is capped at `min(max_size-1, prev_offset) + seq`.
-            // For non-rotating caches, K shape is `prev_offset + seq` — i.e.
-            // `offset + seq`.
-            let effective_offset = if attn_is_rotating {
-                offset.min(self.sliding_window as i32 - 1)
-            } else {
-                offset
-            };
-            let total_kv_len_pre = effective_offset + seq;
-            let (mask_holder_pre, mask_mode_pre) = build_attn_mask(
-                self.layer_type,
-                seq,
-                effective_offset,
-                total_kv_len_pre,
-                attn_is_rotating,
-                self.sliding_window,
-                device,
-            )?;
-
+            // update + SDPA in one shot. The mask's key dim MUST equal the
+            // post-update K seq dim the SDPA actually attends, otherwise mlx-c
+            // `scaled_dot_product_attention` rejects the broadcast (issue #32:
+            // mask `(1,1,5,kv+1)` vs scores `(1,8,5,kv)`).
+            //
+            // The post-update K length is `producer_offset + seq` (non-rotating)
+            // or the ring-capped `min(max_size-1, producer_offset) + seq`
+            // (rotating). `producer_offset` is the **cache-holding layer's own**
+            // `offset()`, which can drift from the model-wide `offset`
+            // (`cache_base_offset`, picked from the first full-attention cache)
+            // by one position across a speculative verify-block rollback: the
+            // rotating sliding cache that drives the round's `v_target` rolls
+            // back with no-op semantics once it wraps, desyncing its reported
+            // offset from the non-rotating producer. RoPE still uses the
+            // model-wide `offset` (absolute position); only the mask's key dim
+            // is bound to the producer's own K length. See
+            // `update_and_sdpa_returning_kv` (rotating short-circuit) for the
+            // sibling Mixed-path fix this generalises.
             if let Some(c) = cache {
+                let producer_offset = c.offset();
+                let effective_offset = if attn_is_rotating {
+                    producer_offset.min(self.sliding_window as i32 - 1)
+                } else {
+                    producer_offset
+                };
+                let total_kv_len_pre = effective_offset + seq;
+                let (mask_holder_pre, mask_mode_pre) = build_attn_mask(
+                    self.layer_type,
+                    seq,
+                    effective_offset,
+                    total_kv_len_pre,
+                    attn_is_rotating,
+                    self.sliding_window,
+                    device,
+                )?;
                 // Cache-holding layer: route through the shared-KV variant of
                 // the universal wrapper. Returns (out, k_full, v_full) so the
                 // accumulated K/V can be handed to downstream consumer layers
@@ -321,6 +338,21 @@ impl Attention {
                     mask_holder_pre.as_ref(),
                     device,
                 )?;
+                // Guard (issue #32): the array-mode mask's key dim must equal
+                // the K seq dim the SDPA just attended. A mismatch is a sizing
+                // bug, not user input — fail loudly here rather than let a
+                // later layer hit the opaque mlx-c broadcast error.
+                if let Some(mask) = mask_holder_pre.as_ref() {
+                    let mask_kv = mask.shape()[3];
+                    let k_seq = k_full.shape()[2];
+                    if mask_kv != k_seq {
+                        return Err(Error::Model(format!(
+                            "Gemma4 attention mask key dim {mask_kv} != K seq dim {k_seq} \
+                             (layer_type={:?}, seq={seq}, producer_offset={producer_offset})",
+                            self.layer_type
+                        )));
+                    }
+                }
                 attn_out_holder = Some(attn_out);
                 (
                     q,
@@ -329,8 +361,24 @@ impl Attention {
                     Some((k_full, v_full)),
                 )
             } else {
-                // No-cache forward (e.g. eval path with `caches: None`). Run
-                // SDPA directly on the freshly-computed K/V.
+                // No-cache forward (e.g. eval path with `caches: None`). The
+                // freshly-computed K is exactly `offset + seq` long, so size the
+                // mask from the model-wide `offset` directly.
+                let effective_offset = if attn_is_rotating {
+                    offset.min(self.sliding_window as i32 - 1)
+                } else {
+                    offset
+                };
+                let total_kv_len_pre = effective_offset + seq;
+                let (mask_holder_pre, mask_mode_pre) = build_attn_mask(
+                    self.layer_type,
+                    seq,
+                    effective_offset,
+                    total_kv_len_pre,
+                    attn_is_rotating,
+                    self.sliding_window,
+                    device,
+                )?;
                 let k_new = k.try_clone()?;
                 let v_new = v.try_clone()?;
                 let attn_out = scaled_dot_product_attention(

--- a/crates/rmlx-models/src/gemma4/layers/mod.rs
+++ b/crates/rmlx-models/src/gemma4/layers/mod.rs
@@ -422,12 +422,30 @@ impl Attention {
         let attn_out = if let Some(out) = attn_out_holder {
             out
         } else {
+            // Shared-KV consumer branch: K is fetched from the producer layer
+            // (`shared_kv`), not freshly projected here. Its seq dim
+            // (`k.shape()[2]`) is the ground truth for how many keys SDPA
+            // attends. Size the mask's key dim from that actual K length, NOT
+            // from the model-wide `offset` (#32 part 2): across a speculative
+            // partial-accept verify rollback the producer cache is rolled back
+            // while the model-wide `offset` (`cache_base_offset`, taken from the
+            // first full-attention cache that was NOT rolled back) is not, so
+            // `offset` can be one-or-more positions above the real K length.
+            // Sizing the band from `offset` then yields a mask one key too wide
+            // → the opaque mlx-c SDPA broadcast crash.
+            //
+            // `effective_offset = total_kv_len - seq` (K length minus the
+            // newly-projected query tokens) is the symmetric counterpart of the
+            // producer-branch `producer_effective_offset`. In the non-spec path
+            // (no rollback) `total_kv_len == offset + seq` exactly (rotating:
+            // `total_kv_len == offset.min(window-1) + seq`), so
+            // `total_kv_len - seq` reproduces the IDENTICAL effective offset the
+            // old `offset`-based sizing produced — including the rotating cap,
+            // which is already baked into the producer's K length. No regression
+            // on ordinary prefill/decode; the value only diverges (correctly)
+            // when a rollback desynced `offset` from the K it shares.
             let total_kv_len = k.shape()[2]; // [B, kv_heads, total_kv, D]
-            let effective_offset = if attn_is_rotating {
-                offset.min(self.sliding_window as i32 - 1)
-            } else {
-                offset
-            };
+            let effective_offset = total_kv_len - seq;
             let (mask_holder, mask_mode) = build_attn_mask(
                 self.layer_type,
                 seq,
@@ -437,6 +455,20 @@ impl Attention {
                 self.sliding_window,
                 device,
             )?;
+            // Guard (issue #32 part 2): the array-mode consumer mask's key dim
+            // must equal the K seq dim the SDPA is about to attend. Fail loudly
+            // on any future off-by-one rather than surfacing the opaque mlx-c
+            // broadcast error from a later frame.
+            if let Some(mask) = mask_holder.as_ref() {
+                let mask_kv = mask.shape()[3];
+                if mask_kv != total_kv_len {
+                    return Err(Error::Model(format!(
+                        "Gemma4 consumer/shared-KV mask key dim {mask_kv} != K seq dim \
+                         {total_kv_len} (layer_type={:?}, seq={seq}, offset={offset})",
+                        self.layer_type
+                    )));
+                }
+            }
             scaled_dot_product_attention(&q, &k, &v, 1.0, mask_mode, mask_holder.as_ref(), device)?
         };
         // [B, H, S, D] -> [B, S, H*D]

--- a/crates/rmlx-models/src/gemma4/layers/mod.rs
+++ b/crates/rmlx-models/src/gemma4/layers/mod.rs
@@ -445,7 +445,14 @@ impl Attention {
             // on ordinary prefill/decode; the value only diverges (correctly)
             // when a rollback desynced `offset` from the K it shares.
             let total_kv_len = k.shape()[2]; // [B, kv_heads, total_kv, D]
-            let effective_offset = total_kv_len - seq;
+            if total_kv_len < seq {
+                return Err(Error::Model(format!(
+                    "Gemma4 consumer/shared-KV K seq dim {total_kv_len} < query seq {seq} \
+                     (layer_type={:?}, offset={offset})",
+                    self.layer_type
+                )));
+            }
+            let effective_offset = consumer_effective_offset(total_kv_len, seq);
             let (mask_holder, mask_mode) = build_attn_mask(
                 self.layer_type,
                 seq,
@@ -504,6 +511,24 @@ pub(super) fn producer_effective_offset(
     } else {
         producer_offset
     }
+}
+
+/// Compute the effective mask offset for a **consumer / shared-KV branch**.
+///
+/// The consumer branch does not own a cache; it attends a shared K tensor
+/// handed from the producer layer. The K seq dim (`total_kv_len = k.shape()[2]`)
+/// is the ground truth. `total_kv_len - seq` is the effective offset: how many
+/// keys precede the newly-projected query tokens. In the non-spec path
+/// (`total_kv_len == offset + seq`) this reproduces the same value as the
+/// old `offset`-based sizing; it only diverges — correctly — when a
+/// partial-accept rollback desynced `offset` from the actual K length.
+///
+/// Extracted as a named helper symmetric to `producer_effective_offset` so
+/// `mask_tests::guard_invariant_consumer_*` can call it directly and go RED
+/// if the call site in `Attention::forward` is reverted to `offset`-based sizing.
+#[cfg_attr(test, allow(dead_code))]
+pub(super) fn consumer_effective_offset(total_kv_len: i32, seq: i32) -> i32 {
+    total_kv_len - seq
 }
 
 /// Build the per-step additive mask + mask-mode for Gemma4 attention.

--- a/crates/rmlx-models/src/gemma4/layers/mod.rs
+++ b/crates/rmlx-models/src/gemma4/layers/mod.rs
@@ -308,11 +308,11 @@ impl Attention {
             // sibling Mixed-path fix this generalises.
             if let Some(c) = cache {
                 let producer_offset = c.offset();
-                let effective_offset = if attn_is_rotating {
-                    producer_offset.min(self.sliding_window as i32 - 1)
-                } else {
-                    producer_offset
-                };
+                let effective_offset = producer_effective_offset(
+                    producer_offset,
+                    attn_is_rotating,
+                    self.sliding_window,
+                );
                 let total_kv_len_pre = effective_offset + seq;
                 let (mask_holder_pre, mask_mode_pre) = build_attn_mask(
                     self.layer_type,
@@ -446,6 +446,31 @@ impl Attention {
 
         let out = self.o_proj.forward(&attn_out, device)?;
         Ok((out, new_kv))
+    }
+}
+
+/// Compute the effective mask offset from a **producer cache's own offset**
+/// (not the model-wide `cache_base_offset`).
+///
+/// This is the single place that implements the #32 fix: at a speculative
+/// verify-block step the rotating sliding cache that drove the round's
+/// `v_target` can desync from the non-rotating full-attention producer by one
+/// position across a partial-accept rollback. Using the producer's `c.offset()`
+/// (not the model-wide `offset` argument) and capping it for rotating caches
+/// keeps the mask key dim equal to the post-update K seq dim.
+///
+/// Extracted as a named helper so the selection is covered by
+/// `mask_tests::guard_invariant_*` without requiring a full model forward pass.
+#[cfg_attr(test, allow(dead_code))]
+pub(super) fn producer_effective_offset(
+    producer_offset: i32,
+    attn_is_rotating: bool,
+    sliding_window: usize,
+) -> i32 {
+    if attn_is_rotating {
+        producer_offset.min(sliding_window as i32 - 1)
+    } else {
+        producer_offset
     }
 }
 

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -352,6 +352,27 @@ accepted position, obtained via `forward_hidden_states_shared_kv`. On partial
 accept, the verifier KV caches are truncated to the valid prefix length;
 the shared K/V is sliced accordingly before the next draft step.
 
+**Verify-step mask invariant (issue #32).** The verifier's multi-token verify
+forward (`forward_hidden_states_shared_kv` over `[b, draft…]`, `query_len > 1`)
+builds its SWA / chunked-prefill array mask in `gemma4::layers::Attention::
+forward`. The mask's key dim **must equal the post-update K seq dim** the SDPA
+attends, or mlx-c rejects the broadcast (`mask (1,1,5,kv+1)` vs scores
+`(1,8,5,kv)`). For a cache-holding producer layer the post-update K length is
+`producer_offset + seq` (non-rotating) or the ring-capped
+`min(window-1, producer_offset) + seq` (rotating), where `producer_offset` is
+the **cache-holding layer's own `KvCache::offset()`** — NOT the model-wide
+`cache_base_offset` (read from the first full-attention cache). Those two can
+desync by one position across a partial-accept verify-block rollback (the
+rotating sliding cache that drives `v_target` rolls back with no-op semantics
+once it wraps), so sizing the mask from `cache_base_offset` produced a mask one
+key too long only at non-trivial prompt lengths (window no longer covers the
+whole KV). RoPE still uses the model-wide absolute `offset`; only the mask's
+key dim is bound to the producer's own K. A guard in the producer branch fails
+loudly if `mask.shape()[3] != k_full.shape()[2]`. This is downstream of the
+issue-#24 `additive`→`array` mode fix, not a regression. The shared-KV consumer
+layers and the `draft_n` (`query_len == 1`) path already size their mask from
+the actual K (`k.shape()[2]`) and are unaffected.
+
 Weight layout (E2B sidecar, `model.*` prefix):
 
 | Tensor | Shape | Role |


### PR DESCRIPTION
Closes #32.

## Problem
Gemma4 MTP speculative decode (e2b verifier + assistant drafter, `--draft-kind mtp`) crashed in attention at non-trivial prompt lengths:
```
mlx: scaled_dot_product_attention: [broadcast_shapes] Shapes (1,1,5,kv+δ) and (1,8,5,kv) cannot be broadcast.
```
During a partial-accept verify round the producer cache is rolled back, but the SWA/chunked-prefill array mask was sized from the model-wide `cache_base_offset` (the un-rolled-back full-attention cache) instead of the K the SDPA actually attends → mask wider than K → broadcast crash. Length-dependent: only fires once the prompt is long enough to take the masked branch. Downstream of #24, not a regression.

## Fix (two symmetric halves of the same root cause)
`Attention::forward` in `crates/rmlx-models/src/gemma4/layers/mod.rs` — both mask-building branches now size from the actual resident K, not the model-wide offset:
- **Producer (cache-holding) branch** → sizes from the producer cache's own `KvCache::offset()` (rotating-capped), via extracted `producer_effective_offset`.
- **Consumer (shared-KV) branch** → sizes from the actual shared-K length: `consumer_effective_offset(total_kv_len, seq) = k.shape()[2] - seq`.
- Runtime **guards** on both branches assert `mask.shape()[3] == K.seq` and return `Error::Model` (not a panic) — any future off-by-one fails loudly instead of as an opaque mlx-c broadcast error.
- K-underflow guard (`total_kv_len < seq`) returns a clean `Error::Model`.
- RoPE keeps the absolute model-wide offset (positions are absolute); the mask is built in the resident-K frame, which is frame-invariant for the SWA band.

**No non-speculative regression** (verified in review): with no rollback, `k.shape()[2] - seq == offset` (non-rotating) and `== offset.min(window-1)` (rotating), so ordinary prefill/decode masks are byte-identical to before. The two only diverge across a speculative rollback — exactly the bug case. The no-cache eval branch (third mask site) cannot desync and is unchanged; the drafter already sizes from actual K.

## Proof
- Unit: `rmlx-models` 548 pass; 6 `mask_tests` incl. producer + consumer guard-invariant tests (go RED on a helper revert). `cargo fmt` + `make lint` + `check-no-inline-tests` clean.
- Real model (Gemma4 e2b verifier + assistant drafter, `--draft-kind mtp`, `release-perf`): the prior 4k-prompt crash is GONE — a 4645-token prompt with a partial-accept round (3/4) returns HTTP 200, coherent output, zero SDPA/guard errors in the log. (First fix proved partial — crash had moved producer→consumer; the consumer half closes it.)

Docs: `docs/SPECULATIVE.md` — Gemma4 verify-step mask invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)