### PR TITLE
fix(kv): rotation/K-only KV codecs — load-time MSL precompile + truthful Metal/CPU classification (#36)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,12 +196,21 @@ Hard rules:
 - **Advisory: `make file-size-report`** prints files >1000 LOC. Non-failing.
   Also runs at the end of `make ci` (advisory, non-blocking).
 
+## Comments and identifiers (hard rule)
+
+Code comments, identifiers, log/error/reason strings must be **general** — never
+reference task/issue/PR/review numbers (`// #36 review:`, `// fix for #32`).
+Ticket traceability lives in git history, commit messages, and PR descriptions,
+not in source. A comment must still read correctly and be useful once the ticket
+is gone.
+
 ## Simplicity rules (hard)
 
 1. **Readability first.** Match existing style. Plain names. No clever macros, no trait towers, no premature generics.
 2. **No over-engineering.** Build what task needs. No speculative abstractions, no single-use traits, no "configurable" knobs that have one caller.
 3. **Straight-forward core backend.** Inference path is sequential, sync, explicit. Async only at HTTP/file-I/O boundaries (already in coding style above).
 4. **Inline beats premature factoring.** Extract to a function/module only when 2+ real callers exist. Three similar lines is better than a wrong abstraction.
+5. **No env-gated one-caller knobs.** Prefer a fixed default or a CLI flag with a real second caller. Env vars are invisible config — each is a support and repro burden. Keep the existing env surface minimal; new env vars need explicit justification (and are an "Ask before" item).
 
 ## Common commands (Makefile)
 
@@ -357,6 +366,7 @@ The build-by-failure rule is in §Hard rules rule 9 — do not duplicate it here
 - Removing a smoke-probe / safety check.
 - Bypassing the single-process claim file.
 - Deleting or truncating anything under `<RMLX_HOME>/metrics/` (the size-cap log rotation in `<RMLX_HOME>/logs/` is automatic and does not require asking).
+- Adding a new environment variable or runtime config knob.
 
 ## What "0.1.0 done" looks like
 

--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -55,6 +55,7 @@ pub mod planar_fused_qk;
 pub mod planar_fused_qk_msl;
 pub mod planarquant;
 pub mod planarquant_msl;
+pub mod precompile;
 pub mod q8;
 pub mod q8_fused_qk_msl;
 pub mod q8_msl;

--- a/crates/rmlx-kv-quant/src/precompile.rs
+++ b/crates/rmlx-kv-quant/src/precompile.rs
@@ -1,0 +1,205 @@
+//! Issue #36: deterministic load-time MSL precompile for KV codecs.
+//!
+//! Custom Metal kernels in this crate compile **lazily** — `MetalKernel::new`
+//! only registers the kernel; MLX compiles the MSL → Metal pipeline on the
+//! *first* `apply()` dispatch (see `docs/FFI.md` § `MetalKernel`). For KV codecs
+//! that dispatch a real Metal kernel on the hot path, that first dispatch lands
+//! inside the first user request — so the first forward pays a one-time shader
+//! cold-compile that a 1-token `"hi"` warmup never triggers (the codec kernels
+//! only fire on a real prefill encode). On large models this reads as a
+//! multi-second stall, and an orchestrator with a request-level timeout can
+//! misreport it as a load failure.
+//!
+//! This module warms those kernels at model-load / codec-attach time with one
+//! representative dispatch at a real shape, so the compile cost is paid during
+//! the deterministic preload window rather than on the first request.
+//!
+//! The warm is **general per-codec**, keyed off [`KvQuant::carries_msl`] — never
+//! an arch name. It is a no-op for `none` and for the CPU-hot-path codecs
+//! (iso / rotor families, see [`KvQuant::cpu_hot_path_reason`]) whose production
+//! encode + dequant run on CPU and therefore have no shader to warm.
+
+use rmlx_core::error::Result;
+use rmlx_mlx::{Array, Device, Dtype};
+
+use crate::KvQuant;
+
+/// Warm every Metal kernel a KV codec dispatches on its hot path, so the
+/// shader cold-compile is paid here (load time) instead of inside the first
+/// user request.
+///
+/// `head_dim` and `kv_heads` come from the model config so the warm dispatch
+/// uses the production shape (kernel template specialization is shape-aware).
+///
+/// Behaviour:
+/// - `device != Gpu` → no-op (CPU runs have no Metal pipeline to compile).
+/// - codec does not carry MSL (`none`) → no-op.
+/// - CPU-hot-path codec (iso / rotor) → no-op (its encode/dequant is CPU; the
+///   GPU encoder, when present, is opt-in via `RMLX_FUSED_QK` and not on the
+///   default path — warming it would not change the production first-forward).
+/// - otherwise → warm the shared q8_0 K-side kernels (every MSL-carrying KV
+///   codec quantizes K with q8_0) plus, where applicable, the codec's V-side
+///   GPU kernel.
+///
+/// Best-effort: a warm dispatch failure is logged at `warn!` and returns
+/// `Ok(())` — a failed precompile must not abort model load (the kernel will
+/// simply compile lazily on first use, the pre-#36 behaviour).
+#[allow(
+    clippy::cognitive_complexity,
+    reason = "linear sequence of early-return guards (device / carries_msl / cpu_hot_path / shape-alignment) plus two best-effort warm calls; splitting the guards into helpers would add indirection without reducing local complexity"
+)]
+pub fn precompile_kv_codec_msl(
+    kq: KvQuant,
+    head_dim: usize,
+    kv_heads: usize,
+    device: Device,
+) -> Result<()> {
+    if device != Device::Gpu {
+        return Ok(());
+    }
+    if !kq.carries_msl() {
+        tracing::debug!(kv_quant = %kq, "precompile_kv_codec_msl: codec carries no MSL — skip");
+        return Ok(());
+    }
+    if let Some(reason) = kq.cpu_hot_path_reason() {
+        tracing::debug!(
+            kv_quant = %kq,
+            reason,
+            "precompile_kv_codec_msl: CPU-hot-path codec — no shader to warm, skip"
+        );
+        return Ok(());
+    }
+
+    let kv_heads_i = kv_heads.max(1) as i32;
+    let head_dim_i = head_dim.max(1) as i32;
+    // q8_0 (the shared K-side kernel) requires total elements to be a multiple
+    // of its group size (128). TurboQuant/PlanarQuant V kernels group by 32 and
+    // additionally need `head_dim % 32 == 0`. Pick a token count that makes the
+    // per-(kv_head, head_dim) buffer a multiple of 128 so every warm dispatch is
+    // shape-legal; keep it tiny so load-time cost is the compile, not the data.
+    let per_token = kv_heads * head_dim.max(1);
+    let warm_tokens: i32 = if per_token == 0 {
+        128
+    } else {
+        // smallest n_tokens with (per_token * n_tokens) % 128 == 0, capped small.
+        let lcm = lcm_usize(per_token, 128);
+        (lcm / per_token).clamp(1, 32) as i32
+    };
+    let shape = [1, kv_heads_i, warm_tokens, head_dim_i];
+    let n: usize = shape.iter().map(|&d| d as usize).product();
+    if !n.is_multiple_of(128) {
+        // head_dim/kv_heads geometry can't be padded to a legal q8 group here;
+        // skip rather than dispatch an out-of-spec kernel.
+        tracing::debug!(
+            kv_quant = %kq, head_dim, kv_heads,
+            "precompile_kv_codec_msl: warm shape not group-aligned — skip (lazy compile on first use)"
+        );
+        return Ok(());
+    }
+
+    let t0 = std::time::Instant::now();
+    let warm = match Array::from_bytes(&vec![0u8; n * 2], &shape, Dtype::Bf16) {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::warn!(error = %e, kv_quant = %kq, "precompile_kv_codec_msl: warm array alloc failed — skipping");
+            return Ok(());
+        }
+    };
+
+    // K-side q8_0: shared by every MSL-carrying KV codec (K8V*/Planar*/Turbo*/
+    // RotKTq4V all quantize K with q8_0, group=128). Warm both directions.
+    if let Err(e) = warm_q8(&warm, device) {
+        tracing::warn!(error = %e, kv_quant = %kq, "precompile_kv_codec_msl: q8 K-side warm failed (non-fatal)");
+    }
+
+    // V-side codec kernel, where the codec dispatches one on the hot path.
+    if let Err(e) = warm_v_side(kq, &warm, device) {
+        tracing::warn!(error = %e, kv_quant = %kq, "precompile_kv_codec_msl: V-side warm failed (non-fatal)");
+    }
+
+    tracing::info!(
+        kv_quant = %kq,
+        head_dim,
+        kv_heads,
+        warm_ms = t0.elapsed().as_millis(),
+        "precompile_kv_codec_msl: MSL warm complete"
+    );
+    Ok(())
+}
+
+/// Warm the q8_0 quantize + dequantize Metal kernels by round-tripping a small
+/// array. Forces both pipelines to compile.
+fn warm_q8(warm: &Array, device: Device) -> Result<()> {
+    let (codes, scales) = crate::q8_msl::q8_quantize_gpu(warm, device)?;
+    codes.eval()?;
+    scales.eval()?;
+    let total: i32 = warm.shape().iter().product();
+    let recovered =
+        crate::q8_msl::q8_dequantize_gpu(&codes, &scales, &[total], Dtype::Bf16, device)?;
+    recovered.eval()?;
+    Ok(())
+}
+
+/// Least common multiple of two positive `usize`s (saturating; returns the
+/// product clamped to `usize::MAX` on overflow, which is harmless here because
+/// callers only use the ratio `lcm / a`).
+fn lcm_usize(a: usize, b: usize) -> usize {
+    if a == 0 || b == 0 {
+        return 0;
+    }
+    let g = gcd_usize(a, b);
+    (a / g).saturating_mul(b)
+}
+
+fn gcd_usize(mut a: usize, mut b: usize) -> usize {
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}
+
+/// Warm the V-side GPU kernel for codecs that dispatch one on the production
+/// hot path. Only the TurboQuant-4 and PlanarQuant-4 V kernels qualify today;
+/// other V codecs either share the q8 path (K8V8) or run their V encode on CPU.
+///
+/// The TurboQuant/PlanarQuant V kernels require `head_dim % 32 == 0`; when the
+/// warm buffer's last axis is not 32-aligned the V warm is skipped (the kernel
+/// will compile lazily on first real use, same as pre-#36).
+#[allow(
+    clippy::wildcard_enum_match_arm,
+    reason = "the wildcard arm is the contract: codecs whose V encode is q8 (K8V8), CPU-forced (turbo3/turbo2/tcq/planar3), or CPU-only (iso/rotor, skipped before this call) have no extra V shader to warm here. Exhaustive expansion would add a no-op arm per future variant for no semantic gain."
+)]
+fn warm_v_side(kq: KvQuant, warm: &Array, device: Device) -> Result<()> {
+    let head_dim = warm.shape().last().copied().unwrap_or(0);
+    if head_dim <= 0 || head_dim % 32 != 0 {
+        return Ok(());
+    }
+    match kq {
+        // tq4 V — K8V4 and RotKTq4V both encode V with TurboQuant 4-bit on GPU.
+        KvQuant::K8V4 | KvQuant::RotKTq4V => {
+            let (codes, scales) = crate::turboquant_msl::turbo_quantize_v4_gpu(warm, device)?;
+            codes.eval()?;
+            scales.eval()?;
+        }
+        // PlanarQuant-4 V — Planar codec encodes V with the Givens-rotation
+        // 4-bit kernel on GPU.
+        KvQuant::Planar => {
+            let (codes, scales, rotations) =
+                crate::planarquant_msl::planar_quantize_v4_gpu(warm, device)?;
+            codes.eval()?;
+            scales.eval()?;
+            rotations.eval()?;
+        }
+        // K8V8 V side reuses the q8 kernel already warmed above; all other
+        // MSL-carrying codecs run their V encode on CPU (turbo3/turbo2/tcq,
+        // planar3) so there is no extra V shader to warm here.
+        _ => {}
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "precompile_tests.rs"]
+mod precompile_tests;

--- a/crates/rmlx-kv-quant/src/precompile.rs
+++ b/crates/rmlx-kv-quant/src/precompile.rs
@@ -15,9 +15,13 @@
 //! the deterministic preload window rather than on the first request.
 //!
 //! The warm is **general per-codec**, keyed off [`KvQuant::carries_msl`] — never
-//! an arch name. It is a no-op for `none` and for the CPU-hot-path codecs
-//! (iso / rotor families, see [`KvQuant::cpu_hot_path_reason`]) whose production
-//! encode + dequant run on CPU and therefore have no shader to warm.
+//! an arch name. It is a no-op for `none` and for the CPU-hot-path codecs (the
+//! V-only iso / rotor families and QJL-on rotor-K, see
+//! [`KvQuant::cpu_hot_path_reason`]) whose production encode + dequant run on
+//! CPU and therefore have no q8 shader to warm here. The K-only iso / rotor
+//! codecs ARE Metal on the hot path but dispatch the iso/rotor MSL kernel for K
+//! (not the shared q8_0 K kernel this module warms), so they are also skipped
+//! ([`KvQuant::is_k_only_iso_rotor`]) and compile lazily on first prefill.
 
 use rmlx_core::error::Result;
 use rmlx_mlx::{Array, Device, Dtype};
@@ -34,9 +38,12 @@ use crate::KvQuant;
 /// Behaviour:
 /// - `device != Gpu` → no-op (CPU runs have no Metal pipeline to compile).
 /// - codec does not carry MSL (`none`) → no-op.
-/// - CPU-hot-path codec (iso / rotor) → no-op (its encode/dequant is CPU; the
-///   GPU encoder, when present, is opt-in via `RMLX_FUSED_QK` and not on the
-///   default path — warming it would not change the production first-forward).
+/// - CPU-hot-path codec (V-only iso / rotor, QJL-on rotor-K) → no-op (its
+///   encode/dequant is CPU; the GPU fused-QK encoder, when present, is opt-in
+///   via `RMLX_FUSED_QK` and not on the default path).
+/// - K-only iso / rotor codec (`is_k_only_iso_rotor`) → no-op here (Metal on the
+///   hot path, but its K kernel is the iso/rotor MSL kernel, not the shared q8_0
+///   K kernel this module warms; it compiles lazily on first prefill).
 /// - otherwise → warm the shared q8_0 K-side kernels (every MSL-carrying KV
 ///   codec quantizes K with q8_0) plus, where applicable, the codec's V-side
 ///   GPU kernel.
@@ -57,6 +64,14 @@ pub fn precompile_kv_codec_msl(
     if device != Device::Gpu {
         return Ok(());
     }
+    if head_dim == 0 {
+        // Degenerate config (arch did not report head_dim). The shape math
+        // below would build a 0-element warm array and dispatch q8 on an empty
+        // buffer — a silent, useless dispatch. Skip; the kernel compiles lazily
+        // on first real use.
+        tracing::debug!(kv_quant = %kq, "precompile_kv_codec_msl: skip — head_dim unknown (0)");
+        return Ok(());
+    }
     if !kq.carries_msl() {
         tracing::debug!(kv_quant = %kq, "precompile_kv_codec_msl: codec carries no MSL — skip");
         return Ok(());
@@ -66,6 +81,19 @@ pub fn precompile_kv_codec_msl(
             kv_quant = %kq,
             reason,
             "precompile_kv_codec_msl: CPU-hot-path codec — no shader to warm, skip"
+        );
+        return Ok(());
+    }
+    // K-only iso / rotor codecs are Metal on the hot path (so
+    // `cpu_hot_path_reason()` is `None`), but their K side is the iso/rotor MSL
+    // kernel, NOT the shared q8_0 K kernel that `warm_q8` below compiles. Warming
+    // q8 for them would compile the wrong shader and miss the real one; their
+    // iso/rotor K kernel compiles lazily on first prefill (the pre-#36 behaviour).
+    if kq.is_k_only_iso_rotor() {
+        tracing::debug!(
+            kv_quant = %kq,
+            "precompile_kv_codec_msl: K-only iso/rotor codec — K kernel is iso/rotor MSL, \
+             not q8; lazy-compile on first prefill, skip q8 warm"
         );
         return Ok(());
     }

--- a/crates/rmlx-kv-quant/src/precompile.rs
+++ b/crates/rmlx-kv-quant/src/precompile.rs
@@ -1,4 +1,4 @@
-//! Issue #36: deterministic load-time MSL precompile for KV codecs.
+//! Deterministic load-time MSL precompile for KV codecs.
 //!
 //! Custom Metal kernels in this crate compile **lazily** — `MetalKernel::new`
 //! only registers the kernel; MLX compiles the MSL → Metal pipeline on the
@@ -50,7 +50,7 @@ use crate::KvQuant;
 ///
 /// Best-effort: a warm dispatch failure is logged at `warn!` and returns
 /// `Ok(())` — a failed precompile must not abort model load (the kernel will
-/// simply compile lazily on first use, the pre-#36 behaviour).
+/// simply compile lazily on first use, the previous lazy-compile behaviour).
 #[allow(
     clippy::cognitive_complexity,
     reason = "linear sequence of early-return guards (device / carries_msl / cpu_hot_path / shape-alignment) plus two best-effort warm calls; splitting the guards into helpers would add indirection without reducing local complexity"
@@ -88,7 +88,7 @@ pub fn precompile_kv_codec_msl(
     // `cpu_hot_path_reason()` is `None`), but their K side is the iso/rotor MSL
     // kernel, NOT the shared q8_0 K kernel that `warm_q8` below compiles. Warming
     // q8 for them would compile the wrong shader and miss the real one; their
-    // iso/rotor K kernel compiles lazily on first prefill (the pre-#36 behaviour).
+    // iso/rotor K kernel compiles lazily on first prefill (lazy-compile path).
     if kq.is_k_only_iso_rotor() {
         tracing::debug!(
             kv_quant = %kq,
@@ -194,7 +194,7 @@ fn gcd_usize(mut a: usize, mut b: usize) -> usize {
 ///
 /// The TurboQuant/PlanarQuant V kernels require `head_dim % 32 == 0`; when the
 /// warm buffer's last axis is not 32-aligned the V warm is skipped (the kernel
-/// will compile lazily on first real use, same as pre-#36).
+/// will compile lazily on first real use, same as the lazy-compile path).
 #[allow(
     clippy::wildcard_enum_match_arm,
     reason = "the wildcard arm is the contract: codecs whose V encode is q8 (K8V8), CPU-forced (turbo3/turbo2/tcq/planar3), or CPU-only (iso/rotor, skipped before this call) have no extra V shader to warm here. Exhaustive expansion would add a no-op arm per future variant for no semantic gain."

--- a/crates/rmlx-kv-quant/src/precompile_tests.rs
+++ b/crates/rmlx-kv-quant/src/precompile_tests.rs
@@ -1,10 +1,10 @@
-//! Tests for issue #36 load-time MSL precompile + codec classification.
+//! Tests for load-time MSL precompile + codec classification.
 //!
 //! These are CPU-only / classification tests — they assert the precompile
 //! entrypoint is a no-op for `none` and for CPU-hot-path codecs, and that the
 //! `carries_msl` / `cpu_hot_path_reason` classifiers are internally consistent.
-//! The actual Metal warm dispatch is exercised by the on-device proof in the
-//! issue-#36 report, not here (no Metal context in unit tests).
+//! The actual Metal warm dispatch is exercised by the on-device smoke test
+//! (no Metal context in unit tests).
 
 use super::*;
 use rmlx_mlx::Device;
@@ -94,7 +94,7 @@ fn k_only_iso_families_are_metal_on_gpu() {
     // `IsoKOnly3/4` have NO bf16 decode-seed early-return: `update_iso_k_only_*`
     // dispatches the iso{3,4} MSL kernel every decode step on GPU. The verdict
     // must be `None` (Metal) — they must NOT be hard-rejected under
-    // RMLX_STRICT_METAL_KV. They are still skipped by the q8 precompile because
+    // They are still skipped by the q8 precompile because
     // their K kernel is iso MSL, not q8 (`is_k_only_iso_rotor`).
     for kq in [KvQuant::IsoKOnly3, KvQuant::IsoKOnly4] {
         assert!(

--- a/crates/rmlx-kv-quant/src/precompile_tests.rs
+++ b/crates/rmlx-kv-quant/src/precompile_tests.rs
@@ -1,0 +1,107 @@
+//! Tests for issue #36 load-time MSL precompile + codec classification.
+//!
+//! These are CPU-only / classification tests — they assert the precompile
+//! entrypoint is a no-op for `none` and for CPU-hot-path codecs, and that the
+//! `carries_msl` / `cpu_hot_path_reason` classifiers are internally consistent.
+//! The actual Metal warm dispatch is exercised by the on-device proof in the
+//! issue-#36 report, not here (no Metal context in unit tests).
+
+use super::*;
+use rmlx_mlx::Device;
+
+#[test]
+fn precompile_is_noop_on_cpu_device() {
+    // Device::Cpu → always a no-op, regardless of codec.
+    for kq in [
+        KvQuant::None,
+        KvQuant::K8V4,
+        KvQuant::Rotor3,
+        KvQuant::Iso3,
+        KvQuant::RotKTq4V,
+    ] {
+        assert!(
+            precompile_kv_codec_msl(kq, 256, 1, Device::Cpu).is_ok(),
+            "precompile on CPU device must be a no-op Ok for {kq}"
+        );
+    }
+}
+
+#[test]
+fn none_carries_no_msl() {
+    assert!(!KvQuant::None.carries_msl(), "bf16 KV carries no shader");
+    assert!(
+        KvQuant::None.cpu_hot_path_reason().is_none(),
+        "None is not a CPU-fallback codec — it is a no-op bf16 path"
+    );
+}
+
+#[test]
+fn metal_codecs_carry_msl_and_are_not_cpu_fallback() {
+    // Codecs whose hot path is genuinely Metal: carry MSL, not CPU-fallback.
+    for kq in [
+        KvQuant::K8V4,
+        KvQuant::K8V8,
+        KvQuant::Planar,
+        KvQuant::RotKTq4V,
+        KvQuant::TurboSym4,
+    ] {
+        assert!(kq.carries_msl(), "{kq} must carry MSL");
+        assert!(
+            kq.cpu_hot_path_reason().is_none(),
+            "{kq} runs on Metal — must NOT be flagged CPU-fallback"
+        );
+    }
+}
+
+#[test]
+fn iso_rotor_families_are_cpu_fallback_with_reason() {
+    // The issue-#36 target codecs: carry MSL (q8 K-side) yet run their codec
+    // encode/dequant on CPU — must report a reason.
+    for kq in [
+        KvQuant::Iso3,
+        KvQuant::Iso4,
+        KvQuant::Iso3Sym,
+        KvQuant::Iso4Sym,
+        KvQuant::IsoKOnly3,
+        KvQuant::IsoKOnly4,
+        KvQuant::Rotor3,
+        KvQuant::Rotor4,
+        KvQuant::Rotor3Sym,
+        KvQuant::Rotor4Sym,
+        KvQuant::RotorKOnly3,
+        KvQuant::RotorKOnly4,
+        KvQuant::RotorK3Asym {
+            v_bits: 8,
+            v_group_size: 128,
+        },
+        KvQuant::RotorK4Asym {
+            v_bits: 8,
+            v_group_size: 128,
+        },
+    ] {
+        assert!(
+            kq.carries_msl(),
+            "{kq} K-side is q8_0 MSL — carries_msl must be true"
+        );
+        assert!(
+            kq.cpu_hot_path_reason().is_some(),
+            "{kq} must be flagged as a CPU-hot-path codec"
+        );
+    }
+}
+
+#[test]
+fn precompile_skips_cpu_hot_path_codecs() {
+    // Even on a GPU device the precompile is a documented no-op for CPU-fallback
+    // codecs (nothing to warm). We can only assert the Ok contract off-device,
+    // but the skip branch is taken before any Metal dispatch, so this is safe to
+    // run without a Metal context: the function returns early on
+    // `cpu_hot_path_reason().is_some()` for these — but only after the device
+    // check. We therefore assert via the classifier, which the function consults.
+    for kq in [KvQuant::Rotor3, KvQuant::Iso3, KvQuant::IsoKOnly4] {
+        assert!(
+            kq.cpu_hot_path_reason().is_some(),
+            "{kq} drives the precompile skip branch"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/precompile_tests.rs
+++ b/crates/rmlx-kv-quant/src/precompile_tests.rs
@@ -92,10 +92,10 @@ fn v_only_iso_rotor_families_are_cpu_fallback_with_reason() {
 #[test]
 fn k_only_iso_families_are_metal_on_gpu() {
     // `IsoKOnly3/4` have NO bf16 decode-seed early-return: `update_iso_k_only_*`
-    // dispatches the iso{3,4} MSL kernel every decode step on GPU. The verdict
-    // must be `None` (Metal) — they must NOT be hard-rejected under
-    // They are still skipped by the q8 precompile because
-    // their K kernel is iso MSL, not q8 (`is_k_only_iso_rotor`).
+    // dispatches the iso{3,4} MSL kernel every decode step on GPU, so the verdict
+    // must be `None` (Metal) — not classified CPU-hot-path. They are still skipped
+    // by the q8 precompile because their K kernel is iso MSL, not q8
+    // (`is_k_only_iso_rotor`).
     for kq in [KvQuant::IsoKOnly3, KvQuant::IsoKOnly4] {
         assert!(
             kq.cpu_hot_path_reason().is_none(),

--- a/crates/rmlx-kv-quant/src/precompile_tests.rs
+++ b/crates/rmlx-kv-quant/src/precompile_tests.rs
@@ -54,22 +54,21 @@ fn metal_codecs_carry_msl_and_are_not_cpu_fallback() {
 }
 
 #[test]
-fn iso_rotor_families_are_cpu_fallback_with_reason() {
-    // The issue-#36 target codecs: carry MSL (q8 K-side) yet run their codec
-    // encode/dequant on CPU — must report a reason.
+fn v_only_iso_rotor_families_are_cpu_fallback_with_reason() {
+    // V-only iso / rotor codecs and the rotor-K-asym variants: `update_iso3*` /
+    // `update_rotor3*` early-return to the bf16 decode seed, so the iso/rotor
+    // encode that runs (at prefill) is CPU. They carry MSL (q8 K-side) but must
+    // report a CPU-hot-path reason. This is grounded in the dispatcher, not by
+    // fiat — flip the verdict and this test must flip with it.
     for kq in [
         KvQuant::Iso3,
         KvQuant::Iso4,
         KvQuant::Iso3Sym,
         KvQuant::Iso4Sym,
-        KvQuant::IsoKOnly3,
-        KvQuant::IsoKOnly4,
         KvQuant::Rotor3,
         KvQuant::Rotor4,
         KvQuant::Rotor3Sym,
         KvQuant::Rotor4Sym,
-        KvQuant::RotorKOnly3,
-        KvQuant::RotorKOnly4,
         KvQuant::RotorK3Asym {
             v_bits: 8,
             v_group_size: 128,
@@ -85,23 +84,92 @@ fn iso_rotor_families_are_cpu_fallback_with_reason() {
         );
         assert!(
             kq.cpu_hot_path_reason().is_some(),
-            "{kq} must be flagged as a CPU-hot-path codec"
+            "{kq} (V-only iso/rotor or rotor-K-asym) must be flagged as a CPU-hot-path codec"
         );
     }
 }
 
 #[test]
-fn precompile_skips_cpu_hot_path_codecs() {
-    // Even on a GPU device the precompile is a documented no-op for CPU-fallback
-    // codecs (nothing to warm). We can only assert the Ok contract off-device,
-    // but the skip branch is taken before any Metal dispatch, so this is safe to
-    // run without a Metal context: the function returns early on
-    // `cpu_hot_path_reason().is_some()` for these — but only after the device
-    // check. We therefore assert via the classifier, which the function consults.
-    for kq in [KvQuant::Rotor3, KvQuant::Iso3, KvQuant::IsoKOnly4] {
+fn k_only_iso_families_are_metal_on_gpu() {
+    // `IsoKOnly3/4` have NO bf16 decode-seed early-return: `update_iso_k_only_*`
+    // dispatches the iso{3,4} MSL kernel every decode step on GPU. The verdict
+    // must be `None` (Metal) — they must NOT be hard-rejected under
+    // RMLX_STRICT_METAL_KV. They are still skipped by the q8 precompile because
+    // their K kernel is iso MSL, not q8 (`is_k_only_iso_rotor`).
+    for kq in [KvQuant::IsoKOnly3, KvQuant::IsoKOnly4] {
+        assert!(
+            kq.cpu_hot_path_reason().is_none(),
+            "{kq} dispatches the iso K MSL kernel every decode step — must be Metal (None)"
+        );
+        assert!(
+            kq.is_k_only_iso_rotor(),
+            "{kq} is a K-only iso codec — precompile must skip the q8 warm for it"
+        );
+    }
+}
+
+#[test]
+#[allow(unsafe_code)]
+fn k_only_rotor_families_are_qjl_aware() {
+    // `RotorKOnly3/4` have NO bf16 early-return; the GPU K encode is gated on
+    // `!rotor_qjl_enabled()`. The verdict tracks the live QJL gate: QJL on (the
+    // default) → CPU (`Some`); QJL off → Metal (`None`). Drive both states via
+    // the same env the dispatcher reads, so the test is tied to the dispatcher.
+    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
+        .lock()
+        .expect("env lock poisoned");
+    // The codec identity (K-only rotor) is QJL-independent — assert it always.
+    for kq in [KvQuant::RotorKOnly3, KvQuant::RotorKOnly4] {
+        assert!(
+            kq.is_k_only_iso_rotor(),
+            "{kq} is a K-only rotor codec — precompile must skip the q8 warm for it"
+        );
+    }
+    // `rotor_qjl_enabled()` consults the CLI OnceLock before the env var; if a
+    // prior test in this process installed the CLI override the env toggle below
+    // is shadowed, so skip the QJL-state assertions (same pattern as
+    // `rotor_qjl_default_is_on`).
+    if crate::rotor_qjl::rotor_qjl_cli_is_set() {
+        return;
+    }
+    let prev = std::env::var("RMLX_ROTOR_QJL").ok();
+    for kq in [KvQuant::RotorKOnly3, KvQuant::RotorKOnly4] {
+        // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer.
+        unsafe { std::env::set_var("RMLX_ROTOR_QJL", "1") };
         assert!(
             kq.cpu_hot_path_reason().is_some(),
-            "{kq} drives the precompile skip branch"
+            "{kq} with QJL on must be a CPU-hot-path codec (QJL forces K append onto CPU)"
+        );
+        unsafe { std::env::set_var("RMLX_ROTOR_QJL", "off") };
+        assert!(
+            kq.cpu_hot_path_reason().is_none(),
+            "{kq} with QJL off dispatches the rotor K MSL kernel — must be Metal (None)"
+        );
+    }
+    // SAFETY: ROTOR_QJL_ENV_LOCK held.
+    match prev {
+        Some(p) => unsafe { std::env::set_var("RMLX_ROTOR_QJL", p) },
+        None => unsafe { std::env::remove_var("RMLX_ROTOR_QJL") },
+    }
+}
+
+#[test]
+fn precompile_skips_cpu_hot_path_codecs() {
+    // Even on a GPU device the precompile is a documented no-op for the V-only
+    // iso/rotor CPU-fallback codecs (nothing to warm). We can only assert the
+    // classifier off-device, which the function consults to take the skip branch.
+    for kq in [KvQuant::Rotor3, KvQuant::Iso3, KvQuant::Iso4Sym] {
+        assert!(
+            kq.cpu_hot_path_reason().is_some(),
+            "{kq} drives the precompile cpu_hot_path skip branch"
+        );
+    }
+    // K-only iso/rotor codecs are Metal (None from cpu_hot_path_reason) but the
+    // q8 precompile still skips them via `is_k_only_iso_rotor`.
+    for kq in [KvQuant::IsoKOnly3, KvQuant::IsoKOnly4] {
+        assert!(
+            kq.is_k_only_iso_rotor(),
+            "{kq} drives the precompile is_k_only_iso_rotor skip branch"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -542,7 +542,7 @@ impl KvQuant {
         }
     }
 
-    /// Issue #36: true when this codec dispatches at least one custom Metal
+    /// True when this codec dispatches at least one custom Metal
     /// (MSL) kernel on its production hot path, so its shaders pay a one-time
     /// cold-compile on first dispatch.
     ///
@@ -597,7 +597,7 @@ impl KvQuant {
         }
     }
 
-    /// Issue #36: `Some(reason)` when this codec runs its V (and, for the K-only
+    /// `Some(reason)` when this codec runs its V (and, for the K-only
     /// / symmetric variants, K) **encode + dequant on the CPU** on the default
     /// production hot path — i.e. it falls through to the dequant-then-SDPA
     /// legacy path with a host-side scalar codec rather than a Metal kernel.
@@ -620,10 +620,9 @@ impl KvQuant {
     ///   live [`crate::rotor_qjl::rotor_qjl_enabled`] gate so the verdict tracks
     ///   the dispatcher.
     ///
-    /// The `Some(reason)` cases are the issue-#36 30–60× first-forward slowdown
-    /// and the monotonic decode decay as KV grows. The reject under
-    /// `RMLX_STRICT_METAL_KV=1` keys off this verdict, so a `None` here MUST mean
-    /// a Metal kernel demonstrably dispatches on the hot path — never an
+    /// The `Some(reason)` cases are the source of the 30–60× first-forward
+    /// slowdown and the monotonic decode decay as KV grows. A `None` here MUST
+    /// mean a Metal kernel demonstrably dispatches on the hot path — never an
     /// assumption.
     ///
     /// Returns `None` for codecs whose hot path is genuinely Metal (q8_0 K +
@@ -633,7 +632,7 @@ impl KvQuant {
     /// Exhaustive on purpose (no wildcard) so a new variant must be classified.
     #[allow(
         clippy::match_same_arms,
-        reason = "the K-only iso arm returns None like the Metal arm but is kept separate on purpose: it is the load-bearing #36 honesty classification (a Metal kernel dispatches, distinct from the genuinely-Metal q8/turbo codecs and from the QJL-gated rotor arm). Merging it would erase the per-codec verdict this function exists to document."
+        reason = "the K-only iso arm returns None like the Metal arm but is kept separate to document the per-codec Metal-vs-CPU verdict this fn exists for: a Metal kernel dispatches for the K-only iso codec, distinct from the genuinely-Metal q8/turbo codecs and from the QJL-gated rotor arm. Merging the arms would erase that distinction."
     )]
     pub fn cpu_hot_path_reason(&self) -> Option<&'static str> {
         match self {
@@ -652,8 +651,7 @@ impl KvQuant {
             // dispatches the real iso{3,4} MSL encode kernel; IsoKOnly3 also runs
             // the iso3 MSL dequant kernel. This is a Metal hot path (a hybrid —
             // the dequant restages the growing prefix host-side each step — but a
-            // Metal kernel demonstrably dispatches, so it is NOT a CPU-only codec
-            // and must not be hard-rejected under RMLX_STRICT_METAL_KV).
+            // Metal kernel demonstrably dispatches, so it is NOT a CPU-only codec).
             KvQuant::IsoKOnly3 | KvQuant::IsoKOnly4 => None,
             // V-only rotor variants and the rotor-K-asym variants early-return to
             // the bf16 decode seed at decode (`decode_fp16_k.is_some()`), so the
@@ -873,8 +871,8 @@ impl KvQuant {
 
     /// Estimated **net byte saving** of running this codec versus plain bf16 on
     /// a single layer, given its attributes. Positive = the codec saves memory;
-    /// **negative = the codec costs more memory than bf16** (the issue #34
-    /// net-negative condition).
+    /// **negative = the codec costs more memory than bf16** (the net-negative
+    /// condition).
     ///
     /// `is_windowed` layers always run the bf16 rotating ring regardless of the
     /// codec flag (mlx-lm `RotatingKVCache.to_quantized` raises

--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -542,6 +542,122 @@ impl KvQuant {
         }
     }
 
+    /// Issue #36: true when this codec dispatches at least one custom Metal
+    /// (MSL) kernel on its production hot path, so its shaders pay a one-time
+    /// cold-compile on first dispatch.
+    ///
+    /// Used by [`crate::precompile::precompile_kv_codec_msl`] to decide whether
+    /// the load-time MSL warm should run (and to keep `none` off the warm path),
+    /// and by the resolve-time readiness logic to widen the first-serve window
+    /// only for shader-heavy codecs.
+    ///
+    /// **Important:** "carries MSL" is *not* the same as "runs entirely on
+    /// Metal". The iso / rotor families also return `true` here (their K-side is
+    /// q8_0 MSL and they ship V/K GPU encoders), yet their production V encode +
+    /// dequant run on **CPU** — see [`cpu_hot_path_reason`](Self::cpu_hot_path_reason).
+    /// The only codec with no MSL at all is `None` (raw bf16, `slice_update`).
+    ///
+    /// Exhaustive on purpose (no wildcard) so a new variant must be classified.
+    pub fn carries_msl(&self) -> bool {
+        match self {
+            // Raw bf16 KV: no quantization kernel, just slice_update on a bf16
+            // buffer. Nothing to cold-compile.
+            KvQuant::None => false,
+            // Everything else quantizes K with the q8_0 MSL kernel (or, for the
+            // Mixed/RotK family, MLX-native affine `mx.quantize`, itself a
+            // compiled Metal op) and therefore carries at least one shader.
+            KvQuant::K8V4
+            | KvQuant::K8V8
+            | KvQuant::Planar
+            | KvQuant::Planar3
+            | KvQuant::PlanarK
+            | KvQuant::Mixed { .. }
+            | KvQuant::RotK { .. }
+            | KvQuant::RotKTq4V
+            | KvQuant::K8VTurbo3
+            | KvQuant::K8VTurbo3Tcq
+            | KvQuant::K8VTurbo2
+            | KvQuant::K8VTurbo2Tcq
+            | KvQuant::TurboSym3
+            | KvQuant::TurboSym4
+            | KvQuant::Iso3
+            | KvQuant::Iso4
+            | KvQuant::Iso3Sym
+            | KvQuant::Iso4Sym
+            | KvQuant::IsoKOnly3
+            | KvQuant::IsoKOnly4
+            | KvQuant::Rotor3
+            | KvQuant::Rotor4
+            | KvQuant::Rotor3Sym
+            | KvQuant::Rotor4Sym
+            | KvQuant::RotorKOnly3
+            | KvQuant::RotorKOnly4
+            | KvQuant::RotorK3Asym { .. }
+            | KvQuant::RotorK4Asym { .. } => true,
+        }
+    }
+
+    /// Issue #36: `Some(reason)` when this codec runs its V (and, for the K-only
+    /// / symmetric variants, K) **encode + dequant on the CPU** on the default
+    /// production hot path — i.e. it falls through to the dequant-then-SDPA
+    /// legacy path with a host-side scalar codec rather than a Metal kernel.
+    ///
+    /// This is the honest Metal-vs-CPU verdict (CLAUDE.md hard rule 7). The
+    /// iso (quaternion SO(4)) and rotor (Clifford Cl(3,0)) families are CPU on
+    /// the default path: their `exit_prefill` encode calls the scalar
+    /// `QuantIso*/QuantRotor*::append` and decode dequantizes the growing prefix
+    /// on the host (`dequant() -> Vec<f32>`). A GPU fused-QK encoder exists for
+    /// the rotor family but is gated OFF by default (`RMLX_FUSED_QK`) and never
+    /// fires on the standard generate flow; the iso family has no wired GPU
+    /// encoder on the hot path at all. The consequence is the issue-#36
+    /// 30–60× first-forward slowdown and the monotonic decode decay as KV grows.
+    ///
+    /// Returns `None` for codecs whose hot path is genuinely Metal (q8_0 K +
+    /// tq4/planar/affine V, the Turbo/Mixed/RotK families).
+    ///
+    /// Exhaustive on purpose (no wildcard) so a new variant must be classified.
+    pub fn cpu_hot_path_reason(&self) -> Option<&'static str> {
+        match self {
+            KvQuant::Iso3
+            | KvQuant::Iso4
+            | KvQuant::Iso3Sym
+            | KvQuant::Iso4Sym
+            | KvQuant::IsoKOnly3
+            | KvQuant::IsoKOnly4 => Some(
+                "IsoQuant (quaternion SO(4)) V/K encode + dequant run on CPU on the \
+                 default hot path; no Metal kernel is wired into prefill/decode",
+            ),
+            KvQuant::Rotor3
+            | KvQuant::Rotor4
+            | KvQuant::Rotor3Sym
+            | KvQuant::Rotor4Sym
+            | KvQuant::RotorKOnly3
+            | KvQuant::RotorKOnly4
+            | KvQuant::RotorK3Asym { .. }
+            | KvQuant::RotorK4Asym { .. } => Some(
+                "RotorQuant (Clifford Cl(3,0)) V/K encode + dequant run on CPU on the \
+                 default hot path; the GPU fused-QK encoder is opt-in (RMLX_FUSED_QK) \
+                 and does not fire on the standard generate flow",
+            ),
+            // Genuinely Metal on the hot path (or no-op bf16): not a CPU codec.
+            KvQuant::None
+            | KvQuant::K8V4
+            | KvQuant::K8V8
+            | KvQuant::Planar
+            | KvQuant::Planar3
+            | KvQuant::PlanarK
+            | KvQuant::Mixed { .. }
+            | KvQuant::RotK { .. }
+            | KvQuant::RotKTq4V
+            | KvQuant::K8VTurbo3
+            | KvQuant::K8VTurbo3Tcq
+            | KvQuant::K8VTurbo2
+            | KvQuant::K8VTurbo2Tcq
+            | KvQuant::TurboSym3
+            | KvQuant::TurboSym4 => None,
+        }
+    }
+
     /// The `(k_bits, v_bits, k_group_size, v_group_size)` the Mixed state should
     /// be built with for this quant, or `None` for non-Mixed-path variants.
     ///

--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -602,43 +602,93 @@ impl KvQuant {
     /// production hot path — i.e. it falls through to the dequant-then-SDPA
     /// legacy path with a host-side scalar codec rather than a Metal kernel.
     ///
-    /// This is the honest Metal-vs-CPU verdict (CLAUDE.md hard rule 7). The
-    /// iso (quaternion SO(4)) and rotor (Clifford Cl(3,0)) families are CPU on
-    /// the default path: their `exit_prefill` encode calls the scalar
-    /// `QuantIso*/QuantRotor*::append` and decode dequantizes the growing prefix
-    /// on the host (`dequant() -> Vec<f32>`). A GPU fused-QK encoder exists for
-    /// the rotor family but is gated OFF by default (`RMLX_FUSED_QK`) and never
-    /// fires on the standard generate flow; the iso family has no wired GPU
-    /// encoder on the hot path at all. The consequence is the issue-#36
-    /// 30–60× first-forward slowdown and the monotonic decode decay as KV grows.
+    /// This is the honest Metal-vs-CPU verdict (CLAUDE.md hard rule 7),
+    /// grounded in the actual decode/prefill dispatch in
+    /// [`crate::kvcache`]'s `update_*` functions — not in assumptions:
+    ///
+    /// - **V-only iso / rotor** (`Iso3/4(/Sym)`, `Rotor3/4(/Sym)`,
+    ///   `RotorK{3,4}Asym`): `update_iso3*` / `update_rotor3*` early-return to
+    ///   the warm-TTFT bf16 decode seed (`decode_fp16_k.is_some()`) at decode,
+    ///   so the GPU iso/rotor branch is shadowed and the codec encode that does
+    ///   run (at prefill) is CPU → `Some(reason)`.
+    /// - **K-only iso** (`IsoKOnly3/4`): NO bf16 early-return — the iso K MSL
+    ///   kernel dispatches every decode step on GPU → `None` (Metal, hybrid:
+    ///   dequant restages host-side each step, but a Metal kernel runs).
+    /// - **K-only rotor** (`RotorKOnly3/4`): NO bf16 early-return; the GPU K
+    ///   encode is gated on `device == Gpu && !rotor_qjl_enabled()`. QJL ON
+    ///   (default) → CPU (`Some`); QJL OFF → Metal (`None`). This arm reads the
+    ///   live [`crate::rotor_qjl::rotor_qjl_enabled`] gate so the verdict tracks
+    ///   the dispatcher.
+    ///
+    /// The `Some(reason)` cases are the issue-#36 30–60× first-forward slowdown
+    /// and the monotonic decode decay as KV grows. The reject under
+    /// `RMLX_STRICT_METAL_KV=1` keys off this verdict, so a `None` here MUST mean
+    /// a Metal kernel demonstrably dispatches on the hot path — never an
+    /// assumption.
     ///
     /// Returns `None` for codecs whose hot path is genuinely Metal (q8_0 K +
-    /// tq4/planar/affine V, the Turbo/Mixed/RotK families).
+    /// tq4/planar/affine V, the Turbo/Mixed/RotK families, plus the K-only iso /
+    /// QJL-off rotor families above).
     ///
     /// Exhaustive on purpose (no wildcard) so a new variant must be classified.
+    #[allow(
+        clippy::match_same_arms,
+        reason = "the K-only iso arm returns None like the Metal arm but is kept separate on purpose: it is the load-bearing #36 honesty classification (a Metal kernel dispatches, distinct from the genuinely-Metal q8/turbo codecs and from the QJL-gated rotor arm). Merging it would erase the per-codec verdict this function exists to document."
+    )]
     pub fn cpu_hot_path_reason(&self) -> Option<&'static str> {
         match self {
-            KvQuant::Iso3
-            | KvQuant::Iso4
-            | KvQuant::Iso3Sym
-            | KvQuant::Iso4Sym
-            | KvQuant::IsoKOnly3
-            | KvQuant::IsoKOnly4 => Some(
-                "IsoQuant (quaternion SO(4)) V/K encode + dequant run on CPU on the \
-                 default hot path; no Metal kernel is wired into prefill/decode",
+            // V-only iso variants: the K side is GPU affine q8_0 and a GPU iso
+            // V encode/dequant branch EXISTS, but at the decode hot path
+            // `update_iso3*` early-returns to the warm-TTFT bf16 decode seed
+            // (`decode_fp16_k.is_some()`), so the GPU iso branch is shadowed;
+            // the iso V-encode that does run (at prefill) is CPU.
+            KvQuant::Iso3 | KvQuant::Iso4 | KvQuant::Iso3Sym | KvQuant::Iso4Sym => Some(
+                "IsoQuant (quaternion SO(4)) V-only: a GPU iso encode/dequant branch \
+                 exists but is shadowed by the bf16 decode seed; prefill V-encode runs \
+                 on CPU",
             ),
+            // K-only iso variants: NO bf16 decode-seed early-return — the iso K
+            // codec fires every decode step. On GPU, `update_iso_k_only_{3,4}`
+            // dispatches the real iso{3,4} MSL encode kernel; IsoKOnly3 also runs
+            // the iso3 MSL dequant kernel. This is a Metal hot path (a hybrid —
+            // the dequant restages the growing prefix host-side each step — but a
+            // Metal kernel demonstrably dispatches, so it is NOT a CPU-only codec
+            // and must not be hard-rejected under RMLX_STRICT_METAL_KV).
+            KvQuant::IsoKOnly3 | KvQuant::IsoKOnly4 => None,
+            // V-only rotor variants and the rotor-K-asym variants early-return to
+            // the bf16 decode seed at decode (`decode_fp16_k.is_some()`), so the
+            // rotor K codec only fires at prefill on CPU; the GPU fused-QK encoder
+            // is opt-in (RMLX_FUSED_QK) and does not fire on the standard flow.
             KvQuant::Rotor3
             | KvQuant::Rotor4
             | KvQuant::Rotor3Sym
             | KvQuant::Rotor4Sym
-            | KvQuant::RotorKOnly3
-            | KvQuant::RotorKOnly4
             | KvQuant::RotorK3Asym { .. }
             | KvQuant::RotorK4Asym { .. } => Some(
-                "RotorQuant (Clifford Cl(3,0)) V/K encode + dequant run on CPU on the \
-                 default hot path; the GPU fused-QK encoder is opt-in (RMLX_FUSED_QK) \
-                 and does not fire on the standard generate flow",
+                "RotorQuant (Clifford Cl(3,0)) encode + dequant run on CPU on the \
+                 default hot path (the bf16 decode seed shadows the GPU branch); the \
+                 GPU fused-QK encoder is opt-in (RMLX_FUSED_QK)",
             ),
+            // K-only rotor variants: NO bf16 decode-seed early-return — the rotor
+            // K codec fires every decode step. `update_rotor_k_only_{3,4}` gates
+            // the GPU K encode on `device == Gpu && !rotor_qjl_enabled()`:
+            //   - QJL ON (default): K append runs on CPU → CPU hot path.
+            //   - QJL OFF (`--rotor-qjl off`): `rotor{3,4}_gpu_append_into_k_blocks`
+            //     dispatches the per-codec rotor MSL encode kernel → Metal hot
+            //     path (hybrid: the dequant restages host-side each step, but a
+            //     Metal kernel dispatches), so it is NOT a CPU-only codec.
+            KvQuant::RotorKOnly3 | KvQuant::RotorKOnly4 => {
+                if crate::rotor_qjl::rotor_qjl_enabled() {
+                    Some(
+                        "RotorQuant (Clifford Cl(3,0)) K-only with QJL enabled \
+                         (rotor_qjl_enabled): the QJL residual forces the K append onto \
+                         CPU every decode step; disable QJL (--rotor-qjl off) to route \
+                         the rotor K encode through the Metal kernel",
+                    )
+                } else {
+                    None
+                }
+            }
             // Genuinely Metal on the hot path (or no-op bf16): not a CPU codec.
             KvQuant::None
             | KvQuant::K8V4
@@ -656,6 +706,21 @@ impl KvQuant {
             | KvQuant::TurboSym3
             | KvQuant::TurboSym4 => None,
         }
+    }
+
+    /// `true` for the K-only iso / rotor codecs whose K side dispatches the
+    /// iso/rotor MSL kernel (NOT the shared q8_0 K kernel) on the GPU hot path:
+    /// `IsoKOnly3/4`, `RotorKOnly3/4`. These return `None` from
+    /// [`cpu_hot_path_reason`](Self::cpu_hot_path_reason) (they are Metal on the
+    /// hot path, modulo the rotor-QJL gate) but are *not* q8-K codecs, so the
+    /// load-time q8 precompile must skip them — their K kernel compiles lazily on
+    /// first prefill. See [`crate::precompile::precompile_kv_codec_msl`].
+    #[must_use]
+    pub fn is_k_only_iso_rotor(&self) -> bool {
+        matches!(
+            self,
+            KvQuant::IsoKOnly3 | KvQuant::IsoKOnly4 | KvQuant::RotorKOnly3 | KvQuant::RotorKOnly4
+        )
     }
 
     /// The `(k_bits, v_bits, k_group_size, v_group_size)` the Mixed state should

--- a/crates/rmlx-kv-quant/src/rotor_qjl.rs
+++ b/crates/rmlx-kv-quant/src/rotor_qjl.rs
@@ -68,6 +68,14 @@ pub fn rotor_qjl_enabled() -> bool {
     }
 }
 
+/// `true` when the CLI override (`install_rotor_qjl`) has been installed in this
+/// process. Test-only helper: lets cross-module tests that toggle the env var
+/// detect the CLI shadow and skip the env-based assertions.
+#[cfg(test)]
+pub(crate) fn rotor_qjl_cli_is_set() -> bool {
+    ROTOR_QJL_CLI.get().is_some()
+}
+
 #[cfg(test)]
 #[path = "rotor_qjl_tests.rs"]
 mod rotor_qjl_tests;

--- a/crates/rmlx-models/src/kv_cache/cache_type.rs
+++ b/crates/rmlx-models/src/kv_cache/cache_type.rs
@@ -836,6 +836,28 @@ pub enum ResolveError {
         variant: String,
     },
 
+    /// Issue #36 — the resolved codec runs its KV encode + dequant on the CPU
+    /// on the default hot path (the iso / rotor families) and `RMLX_STRICT_METAL_KV=1`
+    /// is set, so the resolver refuses it rather than serving 30–60× slower than a
+    /// Metal codec. `reason` carries the per-family explanation
+    /// ([`KvQuant::cpu_hot_path_reason`]).
+    ///
+    /// Without the strict env-var these codecs are *not* rejected — they are
+    /// still functional and produce correct output — but `validate_resolved`
+    /// emits a loud structured `warn!` so the CPU cost is never silent.
+    #[error(
+        "KV codec '{variant}' has no Metal hot path on this build and \
+         RMLX_STRICT_METAL_KV=1 rejects CPU-only KV codecs: {reason}. \
+         Use a Metal codec (e.g. '--kv-quant k8v4', 'k8v8', 'planar', or \
+         'rot_k_tq4v'), or unset RMLX_STRICT_METAL_KV to run it on CPU."
+    )]
+    CpuOnlyKvCodec {
+        /// The KvQuant `Display` form that runs on CPU (e.g. `"rotor3"`, `"iso3"`).
+        variant: String,
+        /// The per-family reason from [`KvQuant::cpu_hot_path_reason`].
+        reason: &'static str,
+    },
+
     // The former `SharedKvIncompatibleWithMixed` variant was removed.
     // Gemma3 / Gemma4 cross-layer KV sharing now supports `Mixed` via
     // dequant-before-share in `KvCache::update_and_sdpa_returning_kv`,
@@ -1618,7 +1640,46 @@ pub fn validate_resolved(arch_class: &str, kq: &KvQuant) -> Result<(), ResolveEr
         }
     }
 
+    // Issue #36 — general (arch-agnostic) Metal-vs-CPU classification. Codecs
+    // whose KV encode + dequant run on the CPU on the default hot path (the
+    // iso / rotor families) are honestly surfaced here: a loud structured warn
+    // so the 30–60× cost is never silent, and a hard reject only under the
+    // opt-in `RMLX_STRICT_METAL_KV=1` (these codecs still produce correct
+    // output, so they are not rejected by default — only flagged).
+    if let Some(reason) = kq.cpu_hot_path_reason() {
+        if strict_metal_kv() {
+            tracing::warn!(
+                arch = arch_class,
+                kv_quant = %kq,
+                reason,
+                "rejecting CPU-only KV codec — RMLX_STRICT_METAL_KV=1"
+            );
+            return Err(ResolveError::CpuOnlyKvCodec {
+                variant: format!("{kq}"),
+                reason,
+            });
+        }
+        tracing::warn!(
+            arch = arch_class,
+            kv_quant = %kq,
+            reason,
+            "KV codec runs its encode + dequant on CPU on the default hot path — \
+             expect a slow first forward and decode that slows as KV grows. This is \
+             NOT a Metal kernel. Set RMLX_STRICT_METAL_KV=1 to reject CPU-only KV \
+             codecs, or pick a Metal codec (k8v4 / k8v8 / planar / rot_k_tq4v)."
+        );
+    }
+
     Ok(())
+}
+
+/// Issue #36 — whether the resolver should hard-reject CPU-only KV codecs.
+///
+/// Opt-in via `RMLX_STRICT_METAL_KV=1`. Default OFF: CPU codecs are functional
+/// (correct output, just slow) so they are warned-about, not rejected, unless
+/// the operator explicitly opts into a Metal-only policy.
+fn strict_metal_kv() -> bool {
+    matches!(std::env::var("RMLX_STRICT_METAL_KV").as_deref(), Ok("1"))
 }
 
 // ── resolve ───────────────────────────────────────────────────────────────────

--- a/crates/rmlx-models/src/kv_cache/cache_type.rs
+++ b/crates/rmlx-models/src/kv_cache/cache_type.rs
@@ -7,7 +7,7 @@
 //! Implemented: enum + parser + inline tests.
 //! Not yet: Resolver, ResolverContext, ResolveError.
 //!
-//! ## Codec-parameter audit (Task 1 findings — kept as ground truth)
+//! ## Codec-parameter audit (kept as ground truth)
 //!
 //! The claims below were verified by reading the source symbols listed in the
 //! "Symbol inspected" columns. No assumptions were carried forward from the
@@ -563,8 +563,8 @@ impl CacheType {
 /// Per-side KV cache type specification, holding one [`CacheType`] for K and
 /// one for V.
 ///
-/// Parsed from `--cache-type-k` / `--cache-type-v` (Task 12).
-/// Resolved to a concrete [`super::KvQuant`] by the resolver (Task 3).
+/// Parsed from `--cache-type-k` / `--cache-type-v`.
+/// Resolved to a concrete [`super::KvQuant`] by the resolver.
 #[allow(
     clippy::exhaustive_structs,
     reason = "internal closed struct — two codec fields (K, V); adding a side requires updating resolve() and all cache-type CLI parsing"
@@ -834,28 +834,6 @@ pub enum ResolveError {
     QwenMoeTurboKRejected {
         /// The KvQuant `Display` form that triggered the guard.
         variant: String,
-    },
-
-    /// Issue #36 — the resolved codec runs its KV encode + dequant on the CPU
-    /// on the default hot path (the iso / rotor families) and `RMLX_STRICT_METAL_KV=1`
-    /// is set, so the resolver refuses it rather than serving 30–60× slower than a
-    /// Metal codec. `reason` carries the per-family explanation
-    /// ([`KvQuant::cpu_hot_path_reason`]).
-    ///
-    /// Without the strict env-var these codecs are *not* rejected — they are
-    /// still functional and produce correct output — but `validate_resolved`
-    /// emits a loud structured `warn!` so the CPU cost is never silent.
-    #[error(
-        "KV codec '{variant}' has no Metal hot path on this build and \
-         RMLX_STRICT_METAL_KV=1 rejects CPU-only KV codecs: {reason}. \
-         Use a Metal codec (e.g. '--kv-quant k8v4', 'k8v8', 'planar', or \
-         'rot_k_tq4v'), or unset RMLX_STRICT_METAL_KV to run it on CPU."
-    )]
-    CpuOnlyKvCodec {
-        /// The KvQuant `Display` form that runs on CPU (e.g. `"rotor3"`, `"iso3"`).
-        variant: String,
-        /// The per-family reason from [`KvQuant::cpu_hot_path_reason`].
-        reason: &'static str,
     },
 
     // The former `SharedKvIncompatibleWithMixed` variant was removed.
@@ -1640,46 +1618,24 @@ pub fn validate_resolved(arch_class: &str, kq: &KvQuant) -> Result<(), ResolveEr
         }
     }
 
-    // Issue #36 — general (arch-agnostic) Metal-vs-CPU classification. Codecs
-    // whose KV encode + dequant run on the CPU on the default hot path (the
-    // iso / rotor families) are honestly surfaced here: a loud structured warn
-    // so the 30–60× cost is never silent, and a hard reject only under the
-    // opt-in `RMLX_STRICT_METAL_KV=1` (these codecs still produce correct
-    // output, so they are not rejected by default — only flagged).
+    // General (arch-agnostic) Metal-vs-CPU classification. Codecs whose KV
+    // encode + dequant run on the CPU on the default hot path (the iso / rotor
+    // families) are honestly surfaced here with a loud structured warn so the
+    // 30–60× cost is never silent. These codecs still produce correct output
+    // and are not rejected — only flagged.
     if let Some(reason) = kq.cpu_hot_path_reason() {
-        if strict_metal_kv() {
-            tracing::warn!(
-                arch = arch_class,
-                kv_quant = %kq,
-                reason,
-                "rejecting CPU-only KV codec — RMLX_STRICT_METAL_KV=1"
-            );
-            return Err(ResolveError::CpuOnlyKvCodec {
-                variant: format!("{kq}"),
-                reason,
-            });
-        }
         tracing::warn!(
             arch = arch_class,
             kv_quant = %kq,
             reason,
             "KV codec runs its encode + dequant on CPU on the default hot path — \
-             expect a slow first forward and decode that slows as KV grows. This is \
-             NOT a Metal kernel. Set RMLX_STRICT_METAL_KV=1 to reject CPU-only KV \
-             codecs, or pick a Metal codec (k8v4 / k8v8 / planar / rot_k_tq4v)."
+             expect a slow first forward and decode that slows as KV grows. \
+             This is NOT a Metal kernel. \
+             Pick a Metal codec (k8v4 / k8v8 / planar / rot_k_tq4v) to avoid this."
         );
     }
 
     Ok(())
-}
-
-/// Issue #36 — whether the resolver should hard-reject CPU-only KV codecs.
-///
-/// Opt-in via `RMLX_STRICT_METAL_KV=1`. Default OFF: CPU codecs are functional
-/// (correct output, just slow) so they are warned-about, not rejected, unless
-/// the operator explicitly opts into a Metal-only policy.
-fn strict_metal_kv() -> bool {
-    matches!(std::env::var("RMLX_STRICT_METAL_KV").as_deref(), Ok("1"))
 }
 
 // ── resolve ───────────────────────────────────────────────────────────────────
@@ -1687,7 +1643,7 @@ fn strict_metal_kv() -> bool {
 /// Resolve a user-supplied [`CacheTypeSpec`] against a [`ResolverContext`] and
 /// a base `auto` [`KvQuant`] (typically from `KvCacheBuilder::resolve_default`).
 ///
-/// Steps, in order (see plan Task 3 for the full spec):
+/// Steps, in order:
 /// 1. `head_dim` required (else `HeadDimUnknown`).
 /// 2. K-side rotation rejected (`KSideRotationCodec`).
 /// 3. Each non-`Auto` side checked for affine group-divisibility (§D6.1) and

--- a/crates/rmlx-models/src/kv_cache/cache_type_tests.rs
+++ b/crates/rmlx-models/src/kv_cache/cache_type_tests.rs
@@ -1268,6 +1268,56 @@ fn validate_resolved_non_moe_iso_k_side_passes() {
     }
 }
 
+/// Issue #36 — Metal-vs-CPU classification in `validate_resolved`.
+///
+/// Single test (no second test mutates `RMLX_STRICT_METAL_KV`) so the
+/// process-global env toggle is not racy under parallel test threads:
+/// - non-strict default: CPU-hot-path iso / rotor V-only codecs resolve `Ok`
+///   (warn-only, not rejected); Metal codecs resolve `Ok`.
+/// - strict (`RMLX_STRICT_METAL_KV=1`): iso / rotor V-only codecs hard-reject
+///   with `CpuOnlyKvCodec` naming the variant; Metal codecs still pass.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test intentionally asserts both Ok (unwrap) and the reject (unwrap_err)"
+)]
+#[allow(
+    clippy::wildcard_enum_match_arm,
+    reason = "test asserts the CpuOnlyKvCodec arm only; the catch-all panics on any other variant"
+)]
+fn validate_resolved_cpu_codec_classification() {
+    std::env::remove_var("RMLX_STRICT_METAL_KV");
+
+    // Non-strict: nothing is rejected.
+    for kq in [
+        KvQuant::Iso3,
+        KvQuant::Rotor3,
+        KvQuant::Iso4,
+        KvQuant::Rotor4,
+        KvQuant::K8V4,
+        KvQuant::Planar,
+        KvQuant::RotKTq4V,
+    ] {
+        validate_resolved("Gemma4ForConditionalGeneration", &kq)
+            .unwrap_or_else(|e| panic!("non-strict resolve must pass for {kq}: {e}"));
+    }
+
+    // Strict: CPU codecs reject; Metal codecs pass.
+    std::env::set_var("RMLX_STRICT_METAL_KV", "1");
+    for kq in [KvQuant::Iso3, KvQuant::Rotor3] {
+        let err = validate_resolved("Gemma4ForConditionalGeneration", &kq).unwrap_err();
+        match err {
+            ResolveError::CpuOnlyKvCodec { ref variant, .. } => {
+                assert_eq!(variant, &kq.to_string(), "must name the offending codec");
+            }
+            other => panic!("expected CpuOnlyKvCodec for {kq}, got {other:?}"),
+        }
+    }
+    validate_resolved("Gemma4ForConditionalGeneration", &KvQuant::K8V4).unwrap();
+    validate_resolved("Gemma4ForConditionalGeneration", &KvQuant::RotKTq4V).unwrap();
+    std::env::remove_var("RMLX_STRICT_METAL_KV");
+}
+
 /// Iso3Sym combo_to_kv_quant: (IsoK3, Iso3) maps to Iso3Sym.
 #[test]
 #[allow(

--- a/crates/rmlx-models/src/kv_cache/cache_type_tests.rs
+++ b/crates/rmlx-models/src/kv_cache/cache_type_tests.rs
@@ -52,8 +52,7 @@ fn kv_bitwidth_matrix_resolves() {
     // - 4-bit packs 8 vals/u32 → head_dim % 8 == 0 (128 OK).
     // - 3-bit packs 10 vals/u32 → head_dim % 10 == 0 → 128 is REJECTED;
     // needs a multiple of lcm(64,10)=320. This is a pre-existing rMLX
-    // guard (see `mlx_bit_packing_violation_q3_g64_on_unfriendly_head_dim`),
-    // not introduced by .
+    // guard (see `mlx_bit_packing_violation_q3_g64_on_unfriendly_head_dim`).
     // So 2/4 are asserted at head_dim=128 (Bonsai); 3 and the 3.5-bit
     // fractional endpoints (K3/V4) at head_dim=320.
     let arch = "Qwen3ForCausalLM";
@@ -1268,84 +1267,47 @@ fn validate_resolved_non_moe_iso_k_side_passes() {
     }
 }
 
-/// Issue #36 — Metal-vs-CPU classification in `validate_resolved`.
+/// Metal-vs-CPU classification in `validate_resolved` (warn-only).
 ///
-/// Single test (no second test mutates `RMLX_STRICT_METAL_KV`) so the
-/// process-global env toggle is not racy under parallel test threads:
-/// - non-strict default: CPU-hot-path iso / rotor V-only codecs resolve `Ok`
-///   (warn-only, not rejected); Metal codecs resolve `Ok`.
-/// - strict (`RMLX_STRICT_METAL_KV=1`): iso / rotor V-only codecs hard-reject
-///   with `CpuOnlyKvCodec` naming the variant; Metal codecs still pass.
+/// CPU-hot-path iso / rotor V-only codecs resolve `Ok` — the classifier emits
+/// a warn but never rejects. Metal codecs also resolve `Ok`.
 #[test]
 #[allow(
     clippy::unwrap_used,
-    reason = "test intentionally asserts both Ok (unwrap) and the reject (unwrap_err)"
-)]
-#[allow(
-    clippy::wildcard_enum_match_arm,
-    reason = "test asserts the CpuOnlyKvCodec arm only; the catch-all panics on any other variant"
+    reason = "test asserts Ok for all paths — unwrap surfaces an unexpected reject"
 )]
 fn validate_resolved_cpu_codec_classification() {
-    std::env::remove_var("RMLX_STRICT_METAL_KV");
-
-    // Non-strict: nothing is rejected.
+    // CPU-hot-path codecs (iso/rotor V-only families): warn-and-proceed,
+    // never rejected.
     for kq in [
         KvQuant::Iso3,
         KvQuant::Rotor3,
         KvQuant::Iso4,
         KvQuant::Rotor4,
-        KvQuant::K8V4,
-        KvQuant::Planar,
-        KvQuant::RotKTq4V,
     ] {
         validate_resolved("Gemma4ForConditionalGeneration", &kq)
-            .unwrap_or_else(|e| panic!("non-strict resolve must pass for {kq}: {e}"));
+            .unwrap_or_else(|e| panic!("CPU-hot-path codec must resolve Ok for {kq}: {e}"));
     }
 
-    // Strict: V-only iso/rotor CPU codecs reject; Metal codecs pass.
-    std::env::set_var("RMLX_STRICT_METAL_KV", "1");
-    for kq in [KvQuant::Iso3, KvQuant::Rotor3] {
-        let err = validate_resolved("Gemma4ForConditionalGeneration", &kq).unwrap_err();
-        match err {
-            ResolveError::CpuOnlyKvCodec { ref variant, .. } => {
-                assert_eq!(variant, &kq.to_string(), "must name the offending codec");
-            }
-            other => panic!("expected CpuOnlyKvCodec for {kq}, got {other:?}"),
-        }
+    // Metal codecs resolve Ok.
+    for kq in [KvQuant::K8V4, KvQuant::Planar, KvQuant::RotKTq4V] {
+        validate_resolved("Gemma4ForConditionalGeneration", &kq)
+            .unwrap_or_else(|e| panic!("Metal codec must resolve Ok for {kq}: {e}"));
     }
-    validate_resolved("Gemma4ForConditionalGeneration", &KvQuant::K8V4).unwrap();
-    validate_resolved("Gemma4ForConditionalGeneration", &KvQuant::RotKTq4V).unwrap();
-    // #36 review: K-only iso codecs dispatch the iso K MSL kernel every decode
-    // step — they are Metal (cpu_hot_path_reason None), so strict-metal must NOT
-    // reject them.
+
+    // K-only iso codecs dispatch the iso K MSL kernel every decode step — they
+    // are Metal (cpu_hot_path_reason returns None) and must resolve Ok.
     for kq in [KvQuant::IsoKOnly3, KvQuant::IsoKOnly4] {
         validate_resolved("Gemma4ForConditionalGeneration", &kq)
-            .unwrap_or_else(|e| panic!("strict-metal must accept K-only iso codec {kq}: {e}"));
+            .unwrap_or_else(|e| panic!("K-only iso codec must resolve Ok for {kq}: {e}"));
     }
-    // #36 review: rotor K-only is QJL-aware. Under this test's default process
-    // env (QJL on by default unless a sibling test set RMLX_ROTOR_QJL/CLI), the
-    // verdict equals `cpu_hot_path_reason().is_some()`. Rather than toggle the
-    // rotor-QJL process-global from here (it lives in rmlx-kv-quant with its own
-    // lock; the QJL-state matrix is unit-tested there in precompile_tests), assert
-    // the rmlx-models reject path is a faithful pass-through of the codec verdict:
-    // strict-metal rejects iff `cpu_hot_path_reason()` is `Some`.
+
+    // K-only rotor codec verdict is QJL-dependent; in either case
+    // validate_resolved must return Ok (no reject path).
     for kq in [KvQuant::RotorKOnly3, KvQuant::RotorKOnly4] {
-        let verdict_is_cpu = kq.cpu_hot_path_reason().is_some();
-        let res = validate_resolved("Gemma4ForConditionalGeneration", &kq);
-        if verdict_is_cpu {
-            match res.unwrap_err() {
-                ResolveError::CpuOnlyKvCodec { ref variant, .. } => {
-                    assert_eq!(variant, &kq.to_string(), "must name the offending codec");
-                }
-                other => panic!("QJL-on {kq}: expected CpuOnlyKvCodec, got {other:?}"),
-            }
-        } else {
-            res.unwrap_or_else(|e| {
-                panic!("QJL-off {kq} is Metal (None) — strict-metal must accept: {e}")
-            });
-        }
+        validate_resolved("Gemma4ForConditionalGeneration", &kq)
+            .unwrap_or_else(|e| panic!("K-only rotor codec must resolve Ok for {kq}: {e}"));
     }
-    std::env::remove_var("RMLX_STRICT_METAL_KV");
 }
 
 /// Iso3Sym combo_to_kv_quant: (IsoK3, Iso3) maps to Iso3Sym.

--- a/crates/rmlx-models/src/kv_cache/cache_type_tests.rs
+++ b/crates/rmlx-models/src/kv_cache/cache_type_tests.rs
@@ -1302,7 +1302,7 @@ fn validate_resolved_cpu_codec_classification() {
             .unwrap_or_else(|e| panic!("non-strict resolve must pass for {kq}: {e}"));
     }
 
-    // Strict: CPU codecs reject; Metal codecs pass.
+    // Strict: V-only iso/rotor CPU codecs reject; Metal codecs pass.
     std::env::set_var("RMLX_STRICT_METAL_KV", "1");
     for kq in [KvQuant::Iso3, KvQuant::Rotor3] {
         let err = validate_resolved("Gemma4ForConditionalGeneration", &kq).unwrap_err();
@@ -1315,6 +1315,36 @@ fn validate_resolved_cpu_codec_classification() {
     }
     validate_resolved("Gemma4ForConditionalGeneration", &KvQuant::K8V4).unwrap();
     validate_resolved("Gemma4ForConditionalGeneration", &KvQuant::RotKTq4V).unwrap();
+    // #36 review: K-only iso codecs dispatch the iso K MSL kernel every decode
+    // step — they are Metal (cpu_hot_path_reason None), so strict-metal must NOT
+    // reject them.
+    for kq in [KvQuant::IsoKOnly3, KvQuant::IsoKOnly4] {
+        validate_resolved("Gemma4ForConditionalGeneration", &kq)
+            .unwrap_or_else(|e| panic!("strict-metal must accept K-only iso codec {kq}: {e}"));
+    }
+    // #36 review: rotor K-only is QJL-aware. Under this test's default process
+    // env (QJL on by default unless a sibling test set RMLX_ROTOR_QJL/CLI), the
+    // verdict equals `cpu_hot_path_reason().is_some()`. Rather than toggle the
+    // rotor-QJL process-global from here (it lives in rmlx-kv-quant with its own
+    // lock; the QJL-state matrix is unit-tested there in precompile_tests), assert
+    // the rmlx-models reject path is a faithful pass-through of the codec verdict:
+    // strict-metal rejects iff `cpu_hot_path_reason()` is `Some`.
+    for kq in [KvQuant::RotorKOnly3, KvQuant::RotorKOnly4] {
+        let verdict_is_cpu = kq.cpu_hot_path_reason().is_some();
+        let res = validate_resolved("Gemma4ForConditionalGeneration", &kq);
+        if verdict_is_cpu {
+            match res.unwrap_err() {
+                ResolveError::CpuOnlyKvCodec { ref variant, .. } => {
+                    assert_eq!(variant, &kq.to_string(), "must name the offending codec");
+                }
+                other => panic!("QJL-on {kq}: expected CpuOnlyKvCodec, got {other:?}"),
+            }
+        } else {
+            res.unwrap_or_else(|e| {
+                panic!("QJL-off {kq} is Metal (None) — strict-metal must accept: {e}")
+            });
+        }
+    }
     std::env::remove_var("RMLX_STRICT_METAL_KV");
 }
 

--- a/crates/rmlx-server/src/engine/gemma4.rs
+++ b/crates/rmlx-server/src/engine/gemma4.rs
@@ -173,6 +173,24 @@ impl Gemma4Generator {
             },
         )?;
 
+        // Issue #36: deterministically warm the resolved KV codec's MSL kernels
+        // during this load (preload) window so the first user request does not
+        // pay a shader cold-compile. General per-codec (keyed off
+        // `KvQuant::carries_msl`); a no-op for `none`/affine and for the
+        // CPU-hot-path iso/rotor families (nothing to warm). Best-effort: a warm
+        // failure logs and proceeds (the kernel compiles lazily on first use).
+        if let Some(kq) = kv_quant_resolved {
+            // head_dim drives the kernel template / group alignment; a single
+            // KV head is enough to force every pipeline to compile (the warm
+            // buffer is `[1, 1, tokens, head_dim]`).
+            let head_dim = cfg.head_dim().unwrap_or(0);
+            if let Err(e) =
+                rmlx_kv_quant::precompile::precompile_kv_codec_msl(kq, head_dim, 1, device)
+            {
+                tracing::warn!(error = %e, kv_quant = %kq, "Gemma4Generator: KV codec MSL precompile failed (non-fatal)");
+            }
+        }
+
         let tk_path = model_dir.join("tokenizer.json");
         let tokenizer = tokenizers::Tokenizer::from_file(&tk_path)
             .map_err(|e| Error::Other(format!("load tokenizer: {e}")))?;

--- a/crates/rmlx-server/src/engine/gemma4.rs
+++ b/crates/rmlx-server/src/engine/gemma4.rs
@@ -173,9 +173,9 @@ impl Gemma4Generator {
             },
         )?;
 
-        // Issue #36: deterministically warm the resolved KV codec's MSL kernels
-        // during this load (preload) window so the first user request does not
-        // pay a shader cold-compile. General per-codec (keyed off
+        // Deterministically warm the resolved KV codec's MSL kernels during
+        // this load (preload) window so the first user request does not pay a
+        // shader cold-compile. General per-codec (keyed off
         // `KvQuant::carries_msl`); a no-op for `none`/affine and for the
         // CPU-hot-path iso/rotor families (nothing to warm). Best-effort: a warm
         // failure logs and proceeds (the kernel compiles lazily on first use).

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -433,6 +433,17 @@ input/output `mlx_vector_array` handles, dispatches via
 `mlx_fast_metal_kernel_apply`, extracts output `Array` handles, and returns
 them.
 
+**Lazy compile (issue #36).** `MetalKernel::new` only *registers* the kernel
+with MLX; the MSL → Metal pipeline compiles on the **first `apply()`
+dispatch**, not at `new`. For KV codecs this means the shader cold-compile lands
+inside the first user request unless it is warmed earlier. The KV layer warms
+its shader-heavy codecs at model-load time via
+`rmlx_kv_quant::precompile::precompile_kv_codec_msl` (one representative dispatch
+per codec kernel during the eager-preload window); see `docs/KV_QUANT.md`
+§ "Metal-vs-CPU hot path + load-time MSL precompile". The `gdn_warmup` in
+`rmlx-models::arch::loader` is the analogous warm for the GatedDeltaNet compiled
+graph.
+
 ### MSL source conventions
 
 The `source` parameter is the **body** of the kernel function. MLX wraps it

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -433,7 +433,7 @@ input/output `mlx_vector_array` handles, dispatches via
 `mlx_fast_metal_kernel_apply`, extracts output `Array` handles, and returns
 them.
 
-**Lazy compile (issue #36).** `MetalKernel::new` only *registers* the kernel
+**Lazy compile.** `MetalKernel::new` only *registers* the kernel
 with MLX; the MSL → Metal pipeline compiles on the **first `apply()`
 dispatch**, not at `new`. For KV codecs this means the shader cold-compile lands
 inside the first user request unless it is warmed earlier. The KV layer warms

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -212,6 +212,73 @@ block-hash seed alongside the SSD `layout_key`. See `docs/PROMPT_CACHE.md`
 | `Paged` | q8_0 per page | 128 | tq4 / q8_0 / planar per page | 32/128/32 | `PagedKStorage` + paged V | — |
 | `TurboSym3` | TurboQuant 3-bit | 32 | TurboQuant 3-bit | 32 | `QuantKTurbo3` + `QuantV{bits:3}` | 0.9807 (K empirical floor) |
 
+---
+
+## Metal-vs-CPU hot path + load-time MSL precompile (issue #36)
+
+Two orthogonal codec attributes drive startup behaviour. Both are exhaustive
+matches on `KvQuant` (`crates/rmlx-kv-quant/src/quant.rs`) — a new variant must
+be classified or the build fails.
+
+* **`KvQuant::carries_msl()`** — `true` when the codec dispatches at least one
+  custom Metal (MSL) kernel on its hot path (every codec except `none`, whose K
+  is q8_0 MSL or MLX-affine `mx.quantize`). MSL kernels in this crate compile
+  **lazily** — `MetalKernel::new` only registers; MLX compiles the pipeline on
+  the *first* `apply()` dispatch (see `docs/FFI.md` § `MetalKernel`). For a
+  shader-heavy codec that first dispatch lands inside the first user request, so
+  the first long-prompt forward pays a one-time shader cold-compile (a 1-token
+  `"hi"` warmup does not trigger it — the codec kernel only fires on a real
+  prefill encode).
+
+* **`KvQuant::cpu_hot_path_reason()`** — `Some(reason)` when the codec's KV
+  encode **and** dequant run on the **CPU** on the default hot path (the iso and
+  rotor families). These carry MSL on the K side (q8_0) yet route their V (and,
+  for the K-only / symmetric variants, K) encode through the scalar
+  `QuantIso*/QuantRotor*::append` at `exit_prefill` and dequantize the growing
+  prefix on the host (`dequant() -> Vec<f32>`) on every decode step. This is the
+  honest Metal-vs-CPU verdict (CLAUDE.md hard rule 7): it is the source of the
+  issue-#36 30–60× first-forward slowdown and the monotonic decode decay as KV
+  grows. The rotor family ships a GPU fused-QK encoder, but it is gated OFF by
+  default (`RMLX_FUSED_QK`) and never fires on the standard generate flow; the
+  iso family has no wired GPU encoder on the hot path at all.
+
+### Per-codec verdict
+
+| Codec family | Hot-path verdict | Notes |
+|---|---|---|
+| `none` | bf16, no kernel | nothing to compile |
+| `k8v4` / `k8v8` / `planar` / `planar3` / `planar_k` | **Metal** | q8_0 K + tq4 / planar V GPU kernels |
+| `mixed_*` / `rot_k_v*` / `rot_k_tq4v` | **Metal** | MLX-affine `mx.quantize` K + tq4/affine V (compiled Metal ops) |
+| `k8vturbo3` / `k8vturbo2` / `*tcq` / `tsym3` / `tsym4` | **Metal K**, CPU V (bounded) | K=q8_0 GPU; V CPU-forced by the −1 %/−2 % TPS gate, cost small |
+| `iso3` / `iso4` / `iso3_sym` / `iso4_sym` / `k_iso3` / `k_iso4` | **CPU** | quaternion SO(4) encode + dequant on host; no Metal hot path |
+| `rotor3` / `rotor4` / `rotor*_sym` / `k_rotor3` / `k_rotor4` / `rotor_k_*_asym_*` | **CPU** | Clifford Cl(3,0) encode + dequant on host; GPU encoder is `RMLX_FUSED_QK`-only |
+
+### Load-time precompile
+
+`rmlx_kv_quant::precompile::precompile_kv_codec_msl(kq, head_dim, kv_heads,
+device)` warms the kernels a codec carries with one representative GPU dispatch
+during model load (the eager-preload window), so the first user request is
+steady-state instead of paying a cold compile. It is **general per-codec**
+(keyed off `carries_msl()`, never an arch name): a no-op on CPU device, for
+`none`, and for the CPU-hot-path iso/rotor families (nothing to warm). It warms
+the shared q8_0 K-side kernels for every MSL codec, plus the tq4 / planar V
+kernel for `k8v4` / `rot_k_tq4v` / `planar`. Best-effort — a warm failure logs
+`warn!` and proceeds (the kernel then compiles lazily on first use, the
+pre-#36 behaviour). Wired into `Gemma4Generator::from_snapshot_with_id` (the
+single server-side generator factory all archs route through).
+
+### CPU-codec classification at resolve time
+
+`rmlx_models::kv_cache::validate_resolved` (alias `validate_resolved_kv_quant`)
+runs the arch-agnostic Metal-vs-CPU check after the Qwen-MoE guards. When the
+resolved codec is CPU-hot-path it emits a loud structured `warn!` naming the
+codec + reason so the cost is never silent. A hard reject (`ResolveError::
+CpuOnlyKvCodec`) fires **only** under the opt-in `RMLX_STRICT_METAL_KV=1` — these
+codecs still produce correct output, so the default is warn-and-proceed, not
+reject. Set `RMLX_STRICT_METAL_KV=1` for a Metal-only KV policy.
+
+---
+
 The `KvQuant::RotK { v_bits, v_group_size }` variant uses `KvStorage::Mixed`
 (same `MixedKvState` machinery) with the `rotate_k=true` flag set. It is
 listed under Mixed below.

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -120,13 +120,13 @@ of the active `KvQuant`: they use `RotatingState` (a ring-buffer bf16 path
 ported from mlx-lm's `RotatingKVCache`). `mlx-lm.to_quantized` raises
 `NotImplementedError` for rotating caches; rMLX matches that behaviour.
 
-### Per-layer net-benefit decision + net-negative warn (issue #34)
+### Per-layer net-benefit decision + net-negative warn
 
 Because SWA layers already run the bf16 ring (above), the per-layer
 quantization decision is implicit: **windowed layers are bf16, global
 (full-attention) layers are quantized**. The codec is a no-op on windowed
-layers and can never make them larger — the issue #34 "skip quant on tiny
-windowed layers" gate is therefore already satisfied by the rotating-ring
+layers and can never make them larger — the "skip quant on tiny windowed
+layers" condition is therefore already satisfied by the rotating-ring
 exemption, not by an extra gate.
 
 The residual net-negative is on the **global** layers. A quantized global
@@ -182,7 +182,7 @@ net-positive at large context and do not warn.
   rotation/residual buffers. This is the value recorded in `kv_cache_bytes`
   metrics observations and returned by `rmlx baseline`.
 
-### Per-request hot-swap (issue #26)
+### Per-request hot-swap
 
 The `KvQuant` for a request is **not** tied to the model load. A running
 `rmlx serve` accepts a per-request `kv_quant` field (OpenAI route) that selects
@@ -214,7 +214,7 @@ block-hash seed alongside the SSD `layout_key`. See `docs/PROMPT_CACHE.md`
 
 ---
 
-## Metal-vs-CPU hot path + load-time MSL precompile (issue #36)
+## Metal-vs-CPU hot path + load-time MSL precompile
 
 Two orthogonal codec attributes drive startup behaviour. Both are exhaustive
 matches on `KvQuant` (`crates/rmlx-kv-quant/src/quant.rs`) — a new variant must
@@ -247,7 +247,7 @@ be classified or the build fails.
     kernel). Hybrid — the dequant restages the growing prefix host-side and
     re-uploads via `Array::from_bytes` each step (a real, growing CPU cost) — but
     a Metal kernel demonstrably dispatches, so it is **not** "no Metal kernel",
-    and must not be hard-rejected under `RMLX_STRICT_METAL_KV`.
+    and must not be hard-rejected by the CPU-path classifier.
   * **K-only rotor** (`k_rotor3` / `k_rotor4`) → **QJL-dependent**. No bf16
     early-return; `update_rotor_k_only_{3,4}` gates the GPU K encode on
     `device == Gpu && !rotor_qjl_enabled()`. QJL **on** (default) → CPU
@@ -255,8 +255,8 @@ be classified or the build fails.
     `rotor{3,4}_gpu_append_into_k_blocks` Metal MSL encode (`None`). The verdict
     reads the live `rotor_qjl_enabled()` gate so it tracks the dispatcher.
 
-  The `Some` cases are the source of the issue-#36 30–60× first-forward slowdown
-  and the monotonic decode decay as KV grows.
+  The `Some` cases are the source of the 30–60× first-forward slowdown and the
+  monotonic decode decay as KV grows.
 
 ### Per-codec verdict
 
@@ -287,7 +287,7 @@ lazily on first prefill. It warms the shared q8_0 K-side kernels for every q8-K
 MSL codec, plus the tq4 / planar V kernel for `k8v4` / `rot_k_tq4v` / `planar`.
 Best-effort — a warm failure logs
 `warn!` and proceeds (the kernel then compiles lazily on first use, the
-pre-#36 behaviour). Wired into `Gemma4Generator::from_snapshot_with_id` (the
+previous lazy-compile behaviour). Wired into `Gemma4Generator::from_snapshot_with_id` (the
 single server-side generator factory all archs route through).
 
 ### CPU-codec classification at resolve time
@@ -295,13 +295,11 @@ single server-side generator factory all archs route through).
 `rmlx_models::kv_cache::validate_resolved` (alias `validate_resolved_kv_quant`)
 runs the arch-agnostic Metal-vs-CPU check after the Qwen-MoE guards. When the
 resolved codec is CPU-hot-path (`cpu_hot_path_reason()` is `Some`) it emits a
-loud structured `warn!` naming the codec + reason so the cost is never silent. A
-hard reject (`ResolveError::CpuOnlyKvCodec`) fires **only** under the opt-in
-`RMLX_STRICT_METAL_KV=1` — these codecs still produce correct output, so the
-default is warn-and-proceed, not reject. Because the reject keys off the verdict,
-the K-only iso (`k_iso3/4`) and QJL-off rotor (`k_rotor3/4`) codecs — Metal on
-the hot path — are **accepted** under strict-metal; only genuine CPU-hot-path
-codecs are rejected. Set `RMLX_STRICT_METAL_KV=1` for a Metal-only KV policy.
+loud structured `warn!` naming the codec + reason so the cost is never silent.
+These codecs still produce correct output — the classifier is warn-and-proceed
+only. The K-only iso (`k_iso3/4`) and QJL-off rotor (`k_rotor3/4`) codecs have
+`cpu_hot_path_reason() == None` (Metal on the hot path) and are unaffected by the
+warn.
 
 ---
 

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -231,16 +231,32 @@ be classified or the build fails.
   prefill encode).
 
 * **`KvQuant::cpu_hot_path_reason()`** — `Some(reason)` when the codec's KV
-  encode **and** dequant run on the **CPU** on the default hot path (the iso and
-  rotor families). These carry MSL on the K side (q8_0) yet route their V (and,
-  for the K-only / symmetric variants, K) encode through the scalar
-  `QuantIso*/QuantRotor*::append` at `exit_prefill` and dequantize the growing
-  prefix on the host (`dequant() -> Vec<f32>`) on every decode step. This is the
-  honest Metal-vs-CPU verdict (CLAUDE.md hard rule 7): it is the source of the
-  issue-#36 30–60× first-forward slowdown and the monotonic decode decay as KV
-  grows. The rotor family ships a GPU fused-QK encoder, but it is gated OFF by
-  default (`RMLX_FUSED_QK`) and never fires on the standard generate flow; the
-  iso family has no wired GPU encoder on the hot path at all.
+  encode + dequant run on the **CPU** on the default hot path. Grounded in the
+  actual decode/prefill dispatch in `crates/rmlx-kv-quant/src/kvcache/update.rs`,
+  not in assumptions (CLAUDE.md hard rule 7):
+
+  * **V-only iso / rotor** (`iso3/4(/sym)`, `rotor3/4(/sym)`,
+    `rotor_k_*_asym_*`) → **`Some`**. At decode, `update_iso3*` / `update_rotor3*`
+    early-return to the warm-TTFT bf16 decode seed (`decode_fp16_k.is_some()`),
+    so the GPU iso/rotor branch is shadowed; the codec encode that runs (at
+    prefill) is CPU. The rotor family's GPU fused-QK encoder is gated OFF by
+    default (`RMLX_FUSED_QK`).
+  * **K-only iso** (`k_iso3` / `k_iso4`) → **`None`** (Metal). No bf16
+    early-return: `update_iso_k_only_{3,4}` dispatches the `iso{3,4}` MSL encode
+    kernel every decode step on GPU (`k_iso3` also runs the iso3 MSL dequant
+    kernel). Hybrid — the dequant restages the growing prefix host-side and
+    re-uploads via `Array::from_bytes` each step (a real, growing CPU cost) — but
+    a Metal kernel demonstrably dispatches, so it is **not** "no Metal kernel",
+    and must not be hard-rejected under `RMLX_STRICT_METAL_KV`.
+  * **K-only rotor** (`k_rotor3` / `k_rotor4`) → **QJL-dependent**. No bf16
+    early-return; `update_rotor_k_only_{3,4}` gates the GPU K encode on
+    `device == Gpu && !rotor_qjl_enabled()`. QJL **on** (default) → CPU
+    (`Some`); QJL **off** (`--rotor-qjl off`) →
+    `rotor{3,4}_gpu_append_into_k_blocks` Metal MSL encode (`None`). The verdict
+    reads the live `rotor_qjl_enabled()` gate so it tracks the dispatcher.
+
+  The `Some` cases are the source of the issue-#36 30–60× first-forward slowdown
+  and the monotonic decode decay as KV grows.
 
 ### Per-codec verdict
 
@@ -250,8 +266,10 @@ be classified or the build fails.
 | `k8v4` / `k8v8` / `planar` / `planar3` / `planar_k` | **Metal** | q8_0 K + tq4 / planar V GPU kernels |
 | `mixed_*` / `rot_k_v*` / `rot_k_tq4v` | **Metal** | MLX-affine `mx.quantize` K + tq4/affine V (compiled Metal ops) |
 | `k8vturbo3` / `k8vturbo2` / `*tcq` / `tsym3` / `tsym4` | **Metal K**, CPU V (bounded) | K=q8_0 GPU; V CPU-forced by the −1 %/−2 % TPS gate, cost small |
-| `iso3` / `iso4` / `iso3_sym` / `iso4_sym` / `k_iso3` / `k_iso4` | **CPU** | quaternion SO(4) encode + dequant on host; no Metal hot path |
-| `rotor3` / `rotor4` / `rotor*_sym` / `k_rotor3` / `k_rotor4` / `rotor_k_*_asym_*` | **CPU** | Clifford Cl(3,0) encode + dequant on host; GPU encoder is `RMLX_FUSED_QK`-only |
+| `iso3` / `iso4` / `iso3_sym` / `iso4_sym` | **CPU** | bf16 decode seed shadows the GPU iso branch; prefill V-encode on host |
+| `k_iso3` / `k_iso4` | **Metal (hybrid)** | iso K MSL encode every decode step (`k_iso3` also MSL dequant); dequant restages prefix host-side per step. `cpu_hot_path_reason() == None` |
+| `rotor3` / `rotor4` / `rotor*_sym` / `rotor_k_*_asym_*` | **CPU** | bf16 decode seed shadows the GPU branch; GPU fused-QK encoder is `RMLX_FUSED_QK`-only |
+| `k_rotor3` / `k_rotor4` | **QJL-dependent** | QJL on (default) → CPU; QJL off (`--rotor-qjl off`) → rotor K MSL encode (Metal, hybrid). Verdict reads `rotor_qjl_enabled()` |
 
 ### Load-time precompile
 
@@ -259,10 +277,15 @@ be classified or the build fails.
 device)` warms the kernels a codec carries with one representative GPU dispatch
 during model load (the eager-preload window), so the first user request is
 steady-state instead of paying a cold compile. It is **general per-codec**
-(keyed off `carries_msl()`, never an arch name): a no-op on CPU device, for
-`none`, and for the CPU-hot-path iso/rotor families (nothing to warm). It warms
-the shared q8_0 K-side kernels for every MSL codec, plus the tq4 / planar V
-kernel for `k8v4` / `rot_k_tq4v` / `planar`. Best-effort — a warm failure logs
+(keyed off `carries_msl()`, never an arch name): a no-op on CPU device, when
+`head_dim` is unknown (`0`), for `none`, for the CPU-hot-path V-only iso/rotor
+families (nothing to warm), and for the K-only iso/rotor families
+(`is_k_only_iso_rotor()`) — those are Metal on the hot path but their K kernel is
+the iso/rotor MSL kernel, **not** the shared q8_0 K kernel this warm compiles, so
+warming q8 for them would compile the wrong shader; their K kernel compiles
+lazily on first prefill. It warms the shared q8_0 K-side kernels for every q8-K
+MSL codec, plus the tq4 / planar V kernel for `k8v4` / `rot_k_tq4v` / `planar`.
+Best-effort — a warm failure logs
 `warn!` and proceeds (the kernel then compiles lazily on first use, the
 pre-#36 behaviour). Wired into `Gemma4Generator::from_snapshot_with_id` (the
 single server-side generator factory all archs route through).
@@ -271,11 +294,14 @@ single server-side generator factory all archs route through).
 
 `rmlx_models::kv_cache::validate_resolved` (alias `validate_resolved_kv_quant`)
 runs the arch-agnostic Metal-vs-CPU check after the Qwen-MoE guards. When the
-resolved codec is CPU-hot-path it emits a loud structured `warn!` naming the
-codec + reason so the cost is never silent. A hard reject (`ResolveError::
-CpuOnlyKvCodec`) fires **only** under the opt-in `RMLX_STRICT_METAL_KV=1` — these
-codecs still produce correct output, so the default is warn-and-proceed, not
-reject. Set `RMLX_STRICT_METAL_KV=1` for a Metal-only KV policy.
+resolved codec is CPU-hot-path (`cpu_hot_path_reason()` is `Some`) it emits a
+loud structured `warn!` naming the codec + reason so the cost is never silent. A
+hard reject (`ResolveError::CpuOnlyKvCodec`) fires **only** under the opt-in
+`RMLX_STRICT_METAL_KV=1` — these codecs still produce correct output, so the
+default is warn-and-proceed, not reject. Because the reject keys off the verdict,
+the K-only iso (`k_iso3/4`) and QJL-off rotor (`k_rotor3/4`) codecs — Metal on
+the hot path — are **accepted** under strict-metal; only genuine CPU-hot-path
+codecs are rejected. Set `RMLX_STRICT_METAL_KV=1` for a Metal-only KV policy.
 
 ---
 


### PR DESCRIPTION
Closes #36.

## Problem
KV codecs carrying custom MSL shaders (rotation / QJL / K-only families) showed: first serve could exceed the readiness window (LOADFAIL), first real forward ran 30–60× slower than steady-state (a 1-token warmup did NOT trigger compile), some stayed slow with monotonic decode decay, and a few cells returned `success` with `decode_tps=0`. It was **undetermined** whether the slowness was one-time shader cold-compile or genuine CPU fallback.

## Diagnosis (resolved the open question)
On-device + dispatch tracing: the iso/rotor V-only families and QJL-on rotor-K run their encode/dequant **on the host** (Clifford/quaternion math; GPU branch shadowed by the warm-TTFT bf16 decode seed). Only `k8v4/k8v8/planar*/turbo*/tsym*/rot_k_tq4v` — and, on the GPU decode path, the **K-only iso** (`k_iso3/k_iso4`) and **QJL-off rotor-K** — dispatch real Metal kernels. The 30–60×/monotonic-decay is CPU codec cost scaling with model size + growing KV, not a shader compile (e2b is too small to exhibit it; the verdict is from the dispatch code, not a single model).

## Fix (general, model-agnostic — codec layer)
- **Load-time MSL precompile** (`rmlx-kv-quant::precompile`): warms a Metal codec's kernels with a representative dispatch during the synchronous preload window, so a legit compile folds into the operator's ready-wait instead of being misreported as LOADFAIL or stalling the first request. No-op for `none`, CPU device, CPU-hot-path codecs, and `head_dim==0`. Best-effort/non-fatal. Wired via `Gemma4Generator::from_snapshot_with_id` — the unified generator factory all archs route through.
- **Truthful per-codec Metal/CPU classifier** (`KvQuant::carries_msl()` + `cpu_hot_path_reason()`), grounded in the actual `update_*` dispatch: K-only iso → Metal (hybrid host-restage noted honestly), rotor-K → **QJL-aware** (`Some` when `rotor_qjl_enabled()`, else Metal), V-only iso/rotor → CPU (bf16-seed-shadowed). A one-shot structured `warn!` fires when the resolved codec runs its KV encode/dequant on the host — so it's never *silently* slow. Tests assert each verdict against the dispatcher (catch a future re-flip).

## Scope discipline (this PR also)
- **Removed the `RMLX_STRICT_METAL_KV` env var** + the opt-in hard-reject path (a one-caller config knob). Classification is warn-only now — codecs produce correct output, so we surface the cost, not break the selection.
- **Scrubbed ticket/issue/review numbers** from code comments, identifiers, and strings (general phrasing only).
- **CLAUDE.md**: added a hard rule against env-gated one-caller knobs (+ "Ask before / new env var") and a rule that comments/identifiers stay general (no ticket numbers in source).

## Proof
- Unit: full `rmlx-kv-quant`/`rmlx-models`/`rmlx-server` suite green (1382 passed); classifier tests tie each verdict to the real dispatcher incl. the QJL on/off matrix; `cargo fmt` + `make lint` + `check-no-inline-tests` clean.
- On-device (e2b, `release-perf`): precompile warms k8v4 (~6 ms), no LOADFAIL across rotor3/iso3/rot_k_tq4v/k8v4, CPU-hot-path codecs emit the warn and serve, clean codecs unaffected (ready ~3 s).

Docs: `docs/KV_QUANT.md` (per-codec Metal/CPU table + precompile + warn), `docs/FFI.md` (lazy-compile note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)