### PR TITLE
fix(metrics): kv_cache_bytes reports live-inference KV (filled prefix, ceiling-independent) (#39)

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/core.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/core.rs
@@ -363,6 +363,18 @@ impl KvCache {
         super::update::storage_max_seq(&self.storage)
     }
 
+    /// Test-only mutator: plant pre-allocated bf16 decode K/V buffers (sized to
+    /// a capacity that may exceed the filled length) and set the filled
+    /// `offset`. Lets `resident_bytes` tests reproduce the on-device case where
+    /// the bf16 decode mirror is allocated to the max-context ceiling but only
+    /// `offset` positions hold live K/V.
+    #[cfg(test)]
+    pub fn inject_decode_fp16_for_test(&mut self, k: Array, v: Array, offset: i32) {
+        self.decode_fp16_k = Some(k);
+        self.decode_fp16_v = Some(v);
+        self.offset = offset;
+    }
+
     /// Test-only accessor: borrow the internal `decode_fp16_v` Option.
     ///
     /// Used by tests to assert the bf16 V seed stays live even when the K seed

--- a/crates/rmlx-kv-quant/src/kvcache/resident_bytes_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/resident_bytes_tests.rs
@@ -142,6 +142,47 @@ fn resident_bytes_scales_with_seq() {
     );
 }
 
+/// When the bf16 decode buffer is over-allocated to a ceiling capacity larger
+/// than the filled length (the on-device case: the mirror is sized to
+/// max-context but only `offset` positions hold live K/V), `resident_bytes`
+/// must report only the *filled* prefix — not the whole ceiling allocation.
+///
+/// This is the live-inference-KV accounting fix: a ceiling-sized buffer must
+/// not inflate the reported KV (e.g. an 8192-capacity buffer holding 4096 live
+/// positions reports half the bytes a naive shape × dtype sum would).
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test — panics are the intended failure mode"
+)]
+fn ceiling_sized_decode_buffer_counts_filled_prefix_only() {
+    const B: i32 = 1;
+    const KV_H: i32 = 2;
+    const D: i32 = 64;
+    const CAPACITY: i32 = 8192; // allocated ceiling
+    const FILLED: i32 = 4096; // live positions
+
+    // Plant K/V buffers allocated to CAPACITY but only FILLED positions live.
+    let k = bf16_zeros(B, KV_H, CAPACITY, D);
+    let v = bf16_zeros(B, KV_H, CAPACITY, D);
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::None, CAPACITY);
+    cache.inject_decode_fp16_for_test(k, v, FILLED);
+
+    // Expected: 2 buffers × B × kv_h × FILLED × D × 2 bytes — NOT CAPACITY.
+    let expected_filled = 2 * B as u64 * KV_H as u64 * FILLED as u64 * D as u64 * 2;
+    let naive_capacity = 2 * B as u64 * KV_H as u64 * CAPACITY as u64 * D as u64 * 2;
+    assert_eq!(
+        cache.resident_bytes(),
+        expected_filled,
+        "resident_bytes must count only the filled prefix, not the ceiling capacity"
+    );
+    assert!(
+        cache.resident_bytes() < naive_capacity,
+        "filled-prefix count must be strictly less than the ceiling-capacity sum \
+         (the inflation the live-KV accounting fix removes)"
+    );
+}
+
 /// Two separately populated `KvCache` instances (simulating two model
 /// layers) sum correctly.
 #[test]

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -2397,29 +2397,37 @@ impl KvCache {
         kv_bytes + seed_bytes
     }
 
-    /// Actual on-device bytes held by this KV cache at the current call-site.
+    /// Live-inference KV resident bytes held by this cache at the call-site.
     ///
-    /// Returns the sum of every buffer currently allocated on this cache:
+    /// Reports the bytes of the K/V that actually serves decode — the *filled*
+    /// prefix of each buffer, not its pre-allocated capacity. The bf16 decode
+    /// mirrors (`decode_fp16_k/v`) are sized to the max-context ceiling, so the
+    /// seq-scaled buffers are counted by their filled length (`offset`,
+    /// clamped to the buffer's capacity) rather than the whole allocation.
+    /// This keeps the figure consistent across contexts and configurations so
+    /// bytes-per-KV-token is comparable: a run with a large ceiling no longer
+    /// reports more KV than its active cache. Sums:
     ///
     /// - **Quantized storage** (`KvStorage::resident_bytes`): packed codes,
-    ///   scales, rotation buffers, etc. for all codec variants. Returns 0 for
+    ///   scales, rotation buffers, etc. for all codec variants. Already
+    ///   compacted to the filled length at `exit_prefill`. Returns 0 for
     ///   `KvStorage::None` (bf16 buffers live in `decode_fp16_k/v` below).
     /// - **fp16 decode seeds** (`decode_fp16_k`, `decode_fp16_v`): warm-TTFT
     ///   bf16 mirrors present on quantized paths; also the sole storage for
-    ///   `KvStorage::None` (bf16).
+    ///   `KvStorage::None` (bf16). Counted by filled length, not capacity.
     /// - **Rotating SWA ring** (`rotating`): pre-allocated bf16 `[B, kv_h,
-    ///   window, D]` buffer used by SWA layers, sized to the sliding window.
+    ///   window, D]` buffer used by SWA layers; counted by filled length
+    ///   (≤ the sliding window).
     /// - **TurboFlash head-major buffers** (`flash_k_codes/scales`,
     ///   `flash_v_codes/scales`): lazy copy of the K/V cache in head-major
     ///   layout for the TurboFlash MSL SDPA kernel.
     /// - **Fused-QK shadow** (`fused_qk_shadow`): head-major K shadow used by
     ///   fused-QK dispatch (q8, turbo3/4-sym, iso3/4-sym, rotor3/4-sym, …).
     ///
-    /// Unlike [`approx_bytes`], this does **not** use a formula: it reads the
-    /// actual `Array` shape × dtype from every live buffer. For GPU-backed
-    /// codecs this reflects the paged allocation size, which is rounded up to
-    /// the nearest page; for CPU-backed codecs (IsoQuant, RotorQuant) it is
-    /// the exact heap bytes of the backing `Vec`s.
+    /// Unlike [`approx_bytes`], the per-position size comes from the actual
+    /// `Array` shape × dtype of each live buffer (picking up per-layer head_dim
+    /// differences, e.g. windowed vs full-attention layers), scaled by the
+    /// filled length rather than a quant-bit formula.
     ///
     /// Returns 0 when the cache has never been used (`offset == 0` and no
     /// buffers are allocated). Safe to call at any point — no FFI eval, no
@@ -2432,24 +2440,57 @@ impl KvCache {
             n * a.dtype().itemsize() as u64
         }
 
-        // 1. Quantized storage (codec-specific buffers; None → 0).
+        // Helper: bytes of the *filled* prefix of a `[B, kv_h, seq, D]` decode
+        // buffer. These per-position mirrors are pre-allocated to the
+        // max-context ceiling (full `max_seq`) and compacted to the filled
+        // length only after `exit_prefill`/decode reclaim — so the same config
+        // reports different totals depending on when the metric is read. Only
+        // `offset` positions ever hold live K/V that decode reads. Counting the
+        // whole ceiling-sized buffer inflates the live-inference KV total and
+        // makes bytes-per-KV-token incomparable across contexts (a run with a
+        // high ceiling reports far more than its active cache). Scale by the
+        // filled length, using each buffer's real per-position size (shape ×
+        // dtype, so per-layer head_dim and dtype are picked up), so the figure
+        // is the KV that serves decode regardless of read timing.
+        #[inline]
+        #[allow(
+            clippy::indexing_slicing,
+            reason = "indices 0..=3 are bounds-checked by the `s.len() != 4` early return above"
+        )]
+        fn filled_seq_bytes(a: &Array, filled: u64) -> u64 {
+            let s = a.shape();
+            if s.len() != 4 {
+                return ab(a);
+            }
+            let per_pos = s[0] as u64 * s[1] as u64 * s[3] as u64 * a.dtype().itemsize() as u64;
+            let cap = s[2] as u64;
+            per_pos * filled.min(cap)
+        }
+
+        let offset = self.offset.max(0) as u64;
+
+        // 1. Quantized storage (codec-specific buffers; None → 0). Already
+        //    compacted to the filled length at `exit_prefill`.
         let mut total = self.storage.resident_bytes();
 
         // 2. fp16 decode seeds (KvQuant::None bf16 storage lives here too).
+        //    Count only the filled prefix, not the ceiling-sized allocation.
         if let Some(ref k) = self.decode_fp16_k {
-            total += ab(k);
+            total += filled_seq_bytes(k, offset);
         }
         if let Some(ref v) = self.decode_fp16_v {
-            total += ab(v);
+            total += filled_seq_bytes(v, offset);
         }
 
-        // 3. Rotating SWA ring buffer (bf16, sized to sliding window).
+        // 3. Rotating SWA ring buffer (bf16, sized to the sliding window). The
+        //    ring holds at most `window` live positions; early in a sequence
+        //    only `offset` are filled. Both are already ≤ the window allocation.
         if let Some(ref rot) = self.rotating {
             if let Some(ref k) = rot.keys {
-                total += ab(k);
+                total += filled_seq_bytes(k, offset);
             }
             if let Some(ref v) = rot.values {
-                total += ab(v);
+                total += filled_seq_bytes(v, offset);
             }
         }
 

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -288,6 +288,33 @@ are not currently routed through the ring (mlx-lm's reference keeps SWA bf16
 too — `RotatingKVCache.to_quantized` raises), but the SWA layers are bf16 by
 default (§5.7), so the bound applies on every shipping SWA configuration.
 
+### `resident_bytes` counts the live-inference KV (filled prefix, not ceiling)
+
+`KvCache::resident_bytes()` reports the bytes of the K/V that **actually serves
+decode** — the *filled* prefix of each buffer, not its pre-allocated capacity.
+This matters because the per-position decode mirrors (`decode_fp16_k/v`, and the
+sole bf16/f32 storage on the `KvQuant::None` path) are allocated to the
+`--max-ctx` ceiling and only compacted to the filled length *after*
+`exit_prefill` / decode-time reclaim. Naively summing the whole allocation made
+the same `(model, prompt, KV quant)` cell report different totals depending on
+when the metric was read (ceiling vs compacted), and made `kv_cache_bytes`
+depend on the chosen ceiling rather than the prompt — so a high `--max-ctx`
+inflated the reported KV even for a short prompt.
+
+To keep the figure consistent and comparable for bytes-per-KV-token /
+tokens-per-KV-GB, the seq-scaled buffers are counted by their filled length
+(`offset`, clamped to the buffer capacity) at each buffer's real per-position
+size (shape × dtype, so per-layer head_dim differences — e.g. the windowed
+layers' `head_dim` vs the full-attention layers' larger `head_dim` — and the
+real decode dtype are both picked up). Quantized storage is already compacted at
+`exit_prefill`, so it is counted as-is. The windowed ring is already bounded to
+the window (above), so clamping is a no-op once the ring has filled.
+
+The prompt-cache snapshot (a deep clone of every layer cache, held per slot in
+the arch prompt cache) is **never** part of this sum — the store sites iterate
+only the active decode caches. So `kv_cache_bytes` means live-inference KV on
+every arch, with or without a prompt-cache snapshot resident.
+
 ### Per-request `max_ctx` override (issue #26)
 
 Because the ceiling is resolved **per request** (`kv_max_seq_and_ceiling`), it

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -341,7 +341,7 @@ Source of truth for `observations.metric`, `.unit`, `.direction`. Add to this ta
 | `model_load_ms`       | `ms`    | `lower_better`  | Wall time from `serve` start to "ready" log line.                       |
 | `peak_rss_mb`         | `mb`    | `lower_better`  | Peak resident set during the run.                                       |
 | `metal_peak_alloc_mb` | `mb`    | `lower_better`  | Peak Metal device allocation (from `mx.metal.get_peak_memory()`).       |
-| `kv_cache_bytes`      | `bytes` | `lower_better`  | Actual on-device KV-cache allocation at end of generation (packed codes + scales + rotation/residual buffers; reads real Array sizes via `KvCache::resident_bytes`). |
+| `kv_cache_bytes`      | `bytes` | `lower_better`  | Live-inference KV resident bytes at end of generation: the *filled* prefix of the cache that actually serves decode (packed codes + scales + rotation/residual buffers, plus the per-position bf16/f32 decode buffers scaled to the filled length). Reads real Array shapes × dtype via `KvCache::resident_bytes`, but counts only `offset` positions of the seq-scaled buffers — the bf16/f32 decode mirrors are pre-allocated to the `--max-ctx` ceiling, so counting the whole allocation would inflate the figure and make bytes-per-KV-token depend on the ceiling rather than the prompt. Excludes any prompt-cache snapshot clone (held separately, never summed). |
 | `tps_per_gb_ram`      | `ratio` | `higher_better` | `decode_tps_warm / peak_rss_gb` — runtime efficiency.                   |
 | `task_pass_at_1`      | `ratio` | `higher_better` | Quality probe pass rate (CBB-style). 0.0–1.0.                           |
 | `prompt_cache_block_hits`        | `count` | `higher_better` | Cumulative 256-tok blocks served from a cached prefix.   |


### PR DESCRIPTION
Closes #39.

## Problem
`kv_cache_bytes` read ~2× the active-cache theory and varied with `--max-ctx` rather than the prompt.

## Diagnosis (named cause falsified)
The prompt-cache snapshot hypothesis is **false** — the snapshot is a separate `Entry` in `PROMPT_CACHE`, never in the `caches.iter().map(resident_bytes)` sum. The real cause: `KvCache::resident_bytes()` summed the **full ceiling-sized** decode buffers. On `--kv-quant none` the global `decode_fp16_k/v` are pre-allocated to the `--max-ctx` ceiling and compacted only after decode reclaim, so the metric depended on the ceiling + read-timing, not the filled length (e.g. 8192-ceiling at a 4410-token prompt → 1.85×). The rotating SWA ring was already correctly bounded.

## Fix (reporting-only, model-agnostic)
`filled_seq_bytes(array, filled)` in `crates/rmlx-kv-quant/src/kvcache/update.rs` counts a 4-D `[B,kv_h,seq,D]` seq-scaled buffer as `per_pos(B·kv_h·D·itemsize) × min(offset, capacity)` — the filled prefix, reading the array's **real dtype**, clamped to capacity for a wrapped ring. Applied to `decode_fp16_k/v` and the rotating ring K/V. Quant `storage` (already compacted at `exit_prefill`), TurboFlash, and fused-QK shadow are unchanged. No KV allocation or decode-numerics change — `kv_cache_bytes` now means "live-inference KV resident bytes" consistently across archs/quants/ceilings.

## Proof
- Real model (e2b, `--kv-quant none`, `release-perf`): 4k 113.2→**66.9 MB** (theory 66.8), 16k 314.6→**239.9** (239.8), 64k 872.7 unchanged (ceiling==prompt). Ceiling-independent: same 4k prompt → 66.9 MB at ceilings 5120/8192/16384.
- Unit: `ceiling_sized_decode_buffer_counts_filled_prefix_only` (cap 8192 / filled 4096 → counts 4096, fails on a full-shape revert). `rmlx-kv-quant`/`-models`/`-cli` suite green (1037 passed); #35 windowed flat-bound + #33 accounting still pass. `cargo fmt` + `make lint` + `check-no-inline-tests` clean.

Docs: `docs/METRICS_DB.md` + `docs/KV_CACHE.md` — filled-prefix semantics.

Note: the None-path decode KV is **f32**, not bf16 — so the issue's bf16-based "37/129/436 MB theory" was 2× low; the true active KV is ~67/240/873 MB. The f32-vs-bf16 buffer dtype is a real *allocation* question (potential memory reduction), separate from this reporting fix, left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)