### PR TITLE
perf(moe): sorted-index expert gather at prefill — ~4x on gemma4-26b + qwen3.5-moe (#46)

### DIFF
--- a/crates/rmlx-mlx/src/ops/arith.rs
+++ b/crates/rmlx-mlx/src/ops/arith.rs
@@ -58,6 +58,20 @@ pub fn divide(a: &Array, b: &Array, device: Device) -> Result<Array> {
     Ok(Array { inner: res })
 }
 
+/// Element-wise floor division: `floor(a / b)`. Broadcasts. Integer-exact for
+/// integer inputs (unlike `divide`, which promotes to float).
+pub fn floor_divide(a: &Array, b: &Array, device: Device) -> Result<Array> {
+    install_error_handler();
+    let mut res = unsafe { sys::mlx_array_new() };
+    let status = unsafe {
+        with_stream(device, |s| {
+            sys::mlx_floor_divide(&raw mut res, a.inner, b.inner, s)
+        })
+    };
+    unsafe { check_status(status, "floor_divide") }?;
+    Ok(Array { inner: res })
+}
+
 /// Element-wise subtraction: `a - b`. Broadcasts.
 pub fn subtract(a: &Array, b: &Array, device: Device) -> Result<Array> {
     install_error_handler();

--- a/crates/rmlx-mlx/src/ops/matmul.rs
+++ b/crates/rmlx-mlx/src/ops/matmul.rs
@@ -191,9 +191,26 @@ pub fn quantize(
     bits: i32,
     device: Device,
 ) -> Result<(Array, Array, Array)> {
+    quantize_mode(x, group_size, bits, "affine", device)
+}
+
+/// Quantize with an explicit MLX codec mode (`"affine"`, `"mxfp8"`,
+/// `"mxfp4"`, `"nvfp4"`).
+///
+/// Same 3-tuple as [`quantize`]; the no-bias codecs (`mxfp*`/`nvfp4`) still
+/// return a `biases` array (MLX emits a placeholder) — callers that pass
+/// `None` biases to [`quantized_matmul`] / [`gather_qmm`] simply ignore it.
+/// [`quantize`] is the `"affine"` specialization.
+pub fn quantize_mode(
+    x: &Array,
+    group_size: i32,
+    bits: i32,
+    mode: &str,
+    device: Device,
+) -> Result<(Array, Array, Array)> {
     install_error_handler();
 
-    let mode_cstr = mode_to_cstr("affine", "quantize")?;
+    let mode_cstr = mode_to_cstr(mode, "quantize")?;
 
     let gs = sys::mlx_optional_int {
         value: group_size,
@@ -230,12 +247,14 @@ pub fn quantize(
     let extract_result = (|| -> Result<(Array, Array, Array)> {
         unsafe { check_status(status, "quantize") }?;
 
-        // Verify the vector has 3 entries (codes, scales, biases).
+        // Affine emits 3 entries (codes, scales, biases); the mxfp*/nvfp4
+        // codecs emit 2 (codes, scales) — biases is then left as the
+        // default-constructed empty array, which the caller discards.
         // SAFETY: vec_res is a valid mlx_vector_array on success.
         let len = unsafe { sys::mlx_vector_array_size(vec_res) };
-        if len != 3 {
+        if len != 2 && len != 3 {
             return Err(Error::Mlx(format!(
-                "quantize: expected 3-element vector_array, got {len}"
+                "quantize: expected 2- or 3-element vector_array, got {len}"
             )));
         }
 
@@ -253,10 +272,12 @@ pub fn quantize(
                 sys::mlx_vector_array_get(&raw mut scales, vec_res, 1),
                 "quantize: get scales",
             )?;
-            check_status(
-                sys::mlx_vector_array_get(&raw mut biases, vec_res, 2),
-                "quantize: get biases",
-            )?;
+            if len == 3 {
+                check_status(
+                    sys::mlx_vector_array_get(&raw mut biases, vec_res, 2),
+                    "quantize: get biases",
+                )?;
+            }
         }
         Ok((
             Array { inner: codes },

--- a/crates/rmlx-mlx/src/ops/mod.rs
+++ b/crates/rmlx-mlx/src/ops/mod.rs
@@ -30,9 +30,9 @@ mod shape;
 pub use activation::{gelu, gelu_tanh, silu, softmax, softmax_precise, tanh};
 pub use arith::{
     add, argmax, argpartition, argsort, broadcast_to, clip, concatenate, divide, exp, expand_dims,
-    greater_equal, log, log1p, max_axis, multiply, negative, repeat_axis, scalar_f32, scatter_add,
-    sigmoid, softplus, sqrt, stack_axis, subtract, sum_axis, sum_axis_keepdims, take_along_axis,
-    topk, where_cond, zeros,
+    floor_divide, greater_equal, log, log1p, max_axis, multiply, negative, repeat_axis, scalar_f32,
+    scatter_add, sigmoid, softplus, sqrt, stack_axis, subtract, sum_axis, sum_axis_keepdims,
+    take_along_axis, topk, where_cond, zeros,
 };
 pub use matmul::{dequantize, gather_qmm, matmul, quantize, quantized_matmul};
 pub use shape::{arange, conv1d, conv2d, conv_transpose1d, cos, maximum, pad, sin, tril};

--- a/crates/rmlx-mlx/src/ops/mod.rs
+++ b/crates/rmlx-mlx/src/ops/mod.rs
@@ -34,7 +34,7 @@ pub use arith::{
     scatter_add, sigmoid, softplus, sqrt, stack_axis, subtract, sum_axis, sum_axis_keepdims,
     take_along_axis, topk, where_cond, zeros,
 };
-pub use matmul::{dequantize, gather_qmm, matmul, quantize, quantized_matmul};
+pub use matmul::{dequantize, gather_qmm, matmul, quantize, quantize_mode, quantized_matmul};
 pub use shape::{arange, conv1d, conv2d, conv_transpose1d, cos, maximum, pad, sin, tril};
 
 // ---------------------------------------------------------------------------

--- a/crates/rmlx-models/src/gemma4/layers/moe.rs
+++ b/crates/rmlx-models/src/gemma4/layers/moe.rs
@@ -5,13 +5,18 @@
 
 use rmlx_core::error::Result;
 use rmlx_mlx::{
-    argpartition, expand_dims, multiply, rms_norm, scalar_f32, softmax, sum_axis, take_along_axis,
-    Array, Device, Dtype,
+    argpartition, argsort, expand_dims, floor_divide, multiply, rms_norm, scalar_f32, softmax,
+    sum_axis, take_along_axis, Array, Device, Dtype,
 };
 
 use crate::layers::{Linear, RmsNorm};
 
 use super::kernels::{geglu_fused, pli_gelu_fused};
+
+/// Flattened `n_tokens * top_k` count at or above which the expert dispatch
+/// sorts indices for contiguous per-expert access (prefill). Below it (decode,
+/// single token) the simple broadcast path is cheaper. Matches mlx-lm SwitchGLU.
+const SORT_DISPATCH_THRESHOLD: i32 = 64;
 
 #[allow(missing_debug_implementations)]
 pub(crate) struct PerLayerInput {
@@ -195,13 +200,32 @@ impl Gemma4Experts {
         routing_weights: &Array,
         device: Device,
     ) -> Result<Array> {
+        let s = expert_indices.shape();
+        let n_tokens = s[0];
+        let tk = s[1];
+
+        // Multi-token (prefill) fast path: sort the flattened expert indices so
+        // each expert's rows are contiguous, then dispatch gather_qmm with
+        // sorted_indices=true and scatter the outputs back. Contiguous expert
+        // access lets the gathered-matmul kernel run each expert as one dense
+        // block instead of scattered per-token gathers. Mirrors mlx-lm
+        // SwitchGLU (threshold `indices.size >= 64`). Decode (n_tokens=1,
+        // tk*1 < 64) keeps the simple broadcast path below.
+        if n_tokens * tk >= SORT_DISPATCH_THRESHOLD {
+            return self.forward_sorted(x, expert_indices, routing_weights, device);
+        }
+
         // Expand x: [n, hidden] -> [n, 1, 1, hidden]
         let xe = expand_dims(x, -2, device)?; // [n, 1, hidden]
         let xe = expand_dims(&xe, -2, device)?; // [n, 1, 1, hidden]
 
         // gate: [n, tk, 1, inter]; up: same.
-        let gate_raw = self.gate_proj.gather_forward(&xe, expert_indices, device)?;
-        let up_raw = self.up_proj.gather_forward(&xe, expert_indices, device)?;
+        let gate_raw = self
+            .gate_proj
+            .gather_forward(&xe, expert_indices, false, device)?;
+        let up_raw = self
+            .up_proj
+            .gather_forward(&xe, expert_indices, false, device)?;
 
         let s = gate_raw.shape();
         let gate_3d = gate_raw.reshape(&[s[0], s[1], s[3]], device)?;
@@ -216,7 +240,9 @@ impl Gemma4Experts {
 
         // Re-expand for down_proj.
         let gd = expand_dims(&gated, -2, device)?; // [n, tk, 1, inter]
-        let out_raw = self.down_proj.gather_forward(&gd, expert_indices, device)?;
+        let out_raw = self
+            .down_proj
+            .gather_forward(&gd, expert_indices, false, device)?;
         let s = out_raw.shape();
         let out_3d = out_raw.reshape(&[s[0], s[1], s[3]], device)?; // [n, tk, hidden]
 
@@ -225,6 +251,78 @@ impl Gemma4Experts {
         let out_scaled = multiply(&out_3d, &rw, device)?;
 
         // Sum over top_k: [n, hidden].
+        sum_axis(&out_scaled, 1, device)
+    }
+
+    /// Sorted-dispatch expert forward for the multi-token (prefill) case.
+    ///
+    /// Sorts the flattened `[n*tk]` expert indices ascending, gathers the
+    /// matching x rows into expert-contiguous order, runs the three gathered
+    /// quantized matmuls with `sorted_indices=true`, then scatters the result
+    /// back to token order. Math is identical to the broadcast path; only the
+    /// memory-access order into the expert weights changes.
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "bounds established by construction: index buffers sized from x/indices shapes"
+    )]
+    fn forward_sorted(
+        &self,
+        x: &Array,
+        expert_indices: &Array,
+        routing_weights: &Array,
+        device: Device,
+    ) -> Result<Array> {
+        let s = expert_indices.shape();
+        let n_tokens = s[0];
+        let tk = s[1];
+        let total = n_tokens * tk;
+        let hidden = x.shape()[1];
+
+        // order = argsort(flat_indices); inv_order = argsort(order).
+        let flat_idx = expert_indices.reshape(&[total], device)?;
+        let order = argsort(&flat_idx, device)?.astype(Dtype::I32, device)?;
+        let inv_order = argsort(&order, device)?.astype(Dtype::I32, device)?;
+
+        // Sorted expert ids: [total]. take(flat_idx, order).
+        let sorted_idx = flat_idx.take(&order, 0, device)?;
+
+        // Sorted token rows: token = order // tk; gather x rows -> [total, hidden].
+        let tk_arr = scalar_f32(tk as f32).astype(Dtype::I32, device)?;
+        let tok_of_order = floor_divide(&order, &tk_arr, device)?;
+        let x_sorted = x.take(&tok_of_order, 0, device)?; // [total, hidden]
+
+        // Shape for gather_qmm: x [total, 1, hidden] aligns its leading `total`
+        // dim with the 1-D `rhs_indices [total]` (element-wise expert per row).
+        let xe = expand_dims(&x_sorted, -2, device)?; // [total, 1, hidden]
+
+        let gate_raw = self
+            .gate_proj
+            .gather_forward(&xe, &sorted_idx, true, device)?; // [total, 1, inter]
+        let up_raw = self
+            .up_proj
+            .gather_forward(&xe, &sorted_idx, true, device)?;
+
+        let s = gate_raw.shape();
+        let gate_2d = gate_raw.reshape(&[s[0], s[2]], device)?; // [total, inter]
+        let s = up_raw.shape();
+        let up_2d = up_raw.reshape(&[s[0], s[2]], device)?;
+
+        let gated = geglu_fused(&gate_2d, &up_2d, device)?; // [total, inter]
+
+        let gd = expand_dims(&gated, -2, device)?; // [total, 1, inter]
+        let out_raw = self
+            .down_proj
+            .gather_forward(&gd, &sorted_idx, true, device)?; // [total, 1, hidden]
+        let s = out_raw.shape();
+        let out_2d = out_raw.reshape(&[s[0], s[2]], device)?; // [total, hidden]
+
+        // Scatter back to token order, then reshape to [n, tk, hidden].
+        let out_unsorted = out_2d.take(&inv_order, 0, device)?; // [total, hidden]
+        let out_3d = out_unsorted.reshape(&[n_tokens, tk, hidden], device)?;
+
+        // Scale by routing weights and sum over top_k: [n, hidden].
+        let rw = expand_dims(routing_weights, -1, device)?;
+        let out_scaled = multiply(&out_3d, &rw, device)?;
         sum_axis(&out_scaled, 1, device)
     }
 }
@@ -242,6 +340,7 @@ impl Linear {
         &self,
         x: &Array,
         rhs_indices: &Array,
+        sorted_indices: bool,
         device: Device,
     ) -> Result<Array> {
         match self {
@@ -290,7 +389,7 @@ impl Linear {
                 *group_size,
                 *bits,
                 mode.as_str(),
-                false,
+                sorted_indices,
                 device,
             ),
             // PARO layers do not appear as MoE expert projections in Gemma4 PARO (dense MoE path

--- a/crates/rmlx-models/src/gemma4/layers/moe.rs
+++ b/crates/rmlx-models/src/gemma4/layers/moe.rs
@@ -214,7 +214,23 @@ impl Gemma4Experts {
         if n_tokens * tk >= SORT_DISPATCH_THRESHOLD {
             return self.forward_sorted(x, expert_indices, routing_weights, device);
         }
+        self.forward_broadcast(x, expert_indices, routing_weights, device)
+    }
 
+    /// Broadcast (per-token gather) expert forward. Used for the decode /
+    /// single-token case; also the equivalence reference for `forward_sorted`
+    /// (the two produce mathematically identical output for any routing).
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "bounds established by construction: index buffers sized from x/indices shapes"
+    )]
+    fn forward_broadcast(
+        &self,
+        x: &Array,
+        expert_indices: &Array,
+        routing_weights: &Array,
+        device: Device,
+    ) -> Result<Array> {
         // Expand x: [n, hidden] -> [n, 1, 1, hidden]
         let xe = expand_dims(x, -2, device)?; // [n, 1, hidden]
         let xe = expand_dims(&xe, -2, device)?; // [n, 1, 1, hidden]
@@ -420,3 +436,7 @@ pub(crate) struct Gemma4MoeBlock {
     pub(crate) post_ffn_norm_2: RmsNorm,
     pub(crate) pre_ffn_norm_2: RmsNorm,
 }
+
+#[cfg(test)]
+#[path = "moe_tests.rs"]
+mod moe_tests;

--- a/crates/rmlx-models/src/gemma4/layers/moe_tests.rs
+++ b/crates/rmlx-models/src/gemma4/layers/moe_tests.rs
@@ -1,0 +1,205 @@
+//! Permutation-equivalence tests for `Gemma4Experts`.
+//!
+//! The sorted-dispatch prefill path (`forward_sorted`) reorders the flattened
+//! `[n*tk]` expert indices, gathers x rows into expert-contiguous order, runs
+//! the gathered quantized matmuls with `sorted_indices=true`, then scatters
+//! back. The whole safety argument is "sorted path == broadcast path" for
+//! *any* routing. A single greedy A/B is weak (greedy argmax tolerates small
+//! logit noise), so these tests lock the equivalence directly on the two
+//! internal paths with adversarial routing: duplicate experts, heavily skewed
+//! distributions, and token counts on both sides of the
+//! `SORT_DISPATCH_THRESHOLD` (64) boundary.
+//!
+//! These exercise the real production path (`Linear::Quantized` →
+//! `gather_qmm`), which is Metal-only — hence `#[ignore]`. Run with
+//! `cargo test -p rmlx-models --lib gemma4::layers::moe -- --ignored`.
+//! (The single-MLX claim file must be free.)
+
+use super::{Gemma4Experts, Linear};
+use crate::layers::QuantMode;
+use rmlx_mlx::{quantize_mode, Array, Device, Dtype};
+
+const DEV: Device = Device::Gpu;
+// mxfp8: matches the real Gemma4 expert tensor format (no biases). The
+// gemma4 gather path passes `None` biases — affine would error here.
+const GROUP_SIZE: i32 = 32;
+const BITS: i32 = 8;
+
+struct Lcg(u64);
+
+impl Lcg {
+    fn next_f32(&mut self) -> f32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        let bits = (self.0 >> 40) as u32;
+        (bits as f32 / (1u32 << 23) as f32) - 1.0
+    }
+    fn next_u(&mut self, modulo: u32) -> u32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        ((self.0 >> 33) as u32) % modulo
+    }
+}
+
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: from_bytes on a fixed-size in-memory buffer cannot fail"
+)]
+fn f32_arr(data: &[f32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|x| x.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::F32).unwrap()
+}
+
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: from_bytes on a fixed-size in-memory buffer cannot fail"
+)]
+fn i32_arr(data: &[i32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|x| x.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::I32).unwrap()
+}
+
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: CPU eval + to_bytes on a materialized array cannot fail"
+)]
+fn to_vec(a: &Array) -> Vec<f32> {
+    let f = a.astype(Dtype::F32, Device::Cpu).unwrap();
+    f.eval().unwrap();
+    f.to_bytes()
+        .unwrap()
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+        .collect()
+}
+
+/// Quantize a `[ne, out, in]` f32 weight into an mxfp8 `Linear::Quantized`.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: quantize on a valid bf16 GPU array cannot fail"
+)]
+fn quant_linear(data: &[f32], shape: &[i32]) -> Linear {
+    let w = f32_arr(data, shape).astype(Dtype::Bf16, DEV).unwrap();
+    // mxfp8 → biases dropped (the gemma4 gather passes `None`).
+    let (weight, scales, _biases) = quantize_mode(&w, GROUP_SIZE, BITS, "mxfp8", DEV).unwrap();
+    Linear::Quantized {
+        weight,
+        scales,
+        biases: None,
+        group_size: GROUP_SIZE,
+        bits: BITS,
+        mode: QuantMode::Mxfp8,
+    }
+}
+
+/// gate/up: [ne, inter, hidden]; down: [ne, hidden, inter].
+fn make_experts(rng: &mut Lcg, ne: i32, hidden: i32, inter: i32) -> Gemma4Experts {
+    let gate: Vec<f32> = (0..ne * inter * hidden)
+        .map(|_| rng.next_f32() * 0.1)
+        .collect();
+    let up: Vec<f32> = (0..ne * inter * hidden)
+        .map(|_| rng.next_f32() * 0.1)
+        .collect();
+    let down: Vec<f32> = (0..ne * hidden * inter)
+        .map(|_| rng.next_f32() * 0.1)
+        .collect();
+    Gemma4Experts {
+        gate_proj: quant_linear(&gate, &[ne, inter, hidden]),
+        up_proj: quant_linear(&up, &[ne, inter, hidden]),
+        down_proj: quant_linear(&down, &[ne, hidden, inter]),
+    }
+}
+
+/// Random routing: `mode` 0 = uniform-with-duplicates, 1 = skewed onto {0,1}.
+fn make_routing(rng: &mut Lcg, n: i32, tk: i32, ne: i32, mode: u8) -> (Array, Array) {
+    let mut idx = Vec::with_capacity((n * tk) as usize);
+    for _ in 0..n {
+        for _ in 0..tk {
+            let e = if mode == 1 {
+                if rng.next_u(10) < 8 {
+                    (rng.next_u(2)) as i32
+                } else {
+                    rng.next_u(ne as u32) as i32
+                }
+            } else {
+                rng.next_u(ne as u32) as i32
+            };
+            idx.push(e);
+        }
+    }
+    let w: Vec<f32> = (0..n * tk).map(|_| 0.5 + rng.next_f32() * 0.25).collect();
+    (i32_arr(&idx, &[n, tk]), f32_arr(&w, &[n, tk]))
+}
+
+#[allow(
+    clippy::unwrap_used,
+    reason = "test: forward paths on valid GPU arrays cannot fail under matching shapes"
+)]
+fn assert_paths_match(n: i32, tk: i32, ne: i32, hidden: i32, inter: i32, mode: u8, seed: u64) {
+    const ATOL: f32 = 0.06;
+    const RTOL: f32 = 0.03;
+    let mut rng = Lcg(seed);
+    let experts = make_experts(&mut rng, ne, hidden, inter);
+    let xdata: Vec<f32> = (0..n * hidden).map(|_| rng.next_f32()).collect();
+    let x = f32_arr(&xdata, &[n, hidden])
+        .astype(Dtype::Bf16, DEV)
+        .unwrap();
+    let (idx, w) = make_routing(&mut rng, n, tk, ne, mode);
+    let w = w.astype(Dtype::Bf16, DEV).unwrap();
+
+    let bc = experts.forward_broadcast(&x, &idx, &w, DEV).unwrap();
+    let sorted = experts.forward_sorted(&x, &idx, &w, DEV).unwrap();
+
+    let bc_v = to_vec(&bc);
+    let so_v = to_vec(&sorted);
+    assert_eq!(bc_v.len(), so_v.len(), "shape mismatch");
+    // Both paths run the identical gather_qmm/geglu sequence; only the row
+    // order into the expert weights differs. Equivalence is exact in real
+    // arithmetic and exact-up-to-accumulation-reorder under bf16. Assert
+    // numpy-`allclose`-style (atol + rtol*|b|): atol absorbs the bf16 reorder
+    // floor on near-zero elements, rtol the proportional drift on large ones.
+    // A real index/scatter bug produces order-1 divergence on many elements,
+    // far above this envelope.
+    let mut worst = 0.0f32;
+    for (a, b) in bc_v.iter().zip(&so_v) {
+        let allowed = ATOL + RTOL * b.abs();
+        worst = worst.max((a - b).abs() - allowed);
+    }
+    assert!(
+        worst <= 0.0,
+        "sorted vs broadcast diverge beyond atol+rtol*|b| by {worst} (n={n} tk={tk} ne={ne} mode={mode})"
+    );
+}
+
+/// Below the 64 threshold (n*tk = 32): paths must agree.
+#[test]
+#[ignore = "needs Metal device + single-MLX claim (gather_qmm is GPU-only)"]
+fn sorted_eq_broadcast_below_threshold() {
+    assert_paths_match(8, 4, 8, 256, 512, 0, 0xC0FFEE);
+}
+
+/// Above the 64 threshold (n*tk = 256), uniform routing with duplicates.
+#[test]
+#[ignore = "needs Metal device + single-MLX claim (gather_qmm is GPU-only)"]
+fn sorted_eq_broadcast_above_threshold() {
+    assert_paths_match(64, 4, 8, 256, 512, 0, 0xBADBEEF);
+}
+
+/// Skewed routing: many tokens collapse onto experts {0,1}. Stresses the
+/// sorted-contiguous-block path where one expert owns a long run of rows.
+#[test]
+#[ignore = "needs Metal device + single-MLX claim (gather_qmm is GPU-only)"]
+fn sorted_eq_broadcast_skewed() {
+    assert_paths_match(64, 4, 8, 256, 512, 1, 0x5EED);
+}
+
+/// Heavy top_k with a small expert pool → guaranteed duplicates per token.
+#[test]
+#[ignore = "needs Metal device + single-MLX claim (gather_qmm is GPU-only)"]
+fn sorted_eq_broadcast_many_dup() {
+    assert_paths_match(32, 8, 4, 256, 512, 1, 0xABCD1234);
+}

--- a/crates/rmlx-models/src/qwen3_5_moe/layers.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/layers.rs
@@ -141,6 +141,7 @@ impl Linear {
         &self,
         x: &Array,
         rhs_indices: &Array,
+        sorted_indices: bool,
         device: Device,
     ) -> Result<Array> {
         match self {
@@ -201,7 +202,7 @@ impl Linear {
                 *group_size,
                 *bits,
                 mode,
-                false,
+                sorted_indices,
                 device,
             ),
         }

--- a/crates/rmlx-models/src/qwen3_5_moe/moe.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/moe.rs
@@ -55,7 +55,23 @@ impl SwitchMlp {
         if n_tokens * tk >= SORT_DISPATCH_THRESHOLD {
             return self.forward_sorted(x, expert_indices, routing_weights, device);
         }
+        self.forward_broadcast(x, expert_indices, routing_weights, device)
+    }
 
+    /// Broadcast (per-token gather) expert forward. Used for the decode /
+    /// single-token case; also the equivalence reference for `forward_sorted`.
+    /// Result is mathematically identical to `forward_sorted` for any input.
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "bounds established by construction: index buffers sized from x/indices shapes"
+    )]
+    fn forward_broadcast(
+        &self,
+        x: &Array,
+        expert_indices: &Array,
+        routing_weights: &Array,
+        device: Device,
+    ) -> Result<Array> {
         // Expand x: [n, hidden] -> [n, 1, 1, hidden].
         let xe = expand_dims(x, -2, device)?;
         let xe = expand_dims(&xe, -2, device)?;
@@ -283,3 +299,7 @@ impl DenseMlp {
         self.down_proj.forward(&gated, device)
     }
 }
+
+#[cfg(test)]
+#[path = "moe_tests.rs"]
+mod moe_tests;

--- a/crates/rmlx-models/src/qwen3_5_moe/moe.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/moe.rs
@@ -10,11 +10,16 @@
 #![allow(clippy::struct_field_names)]
 use rmlx_core::error::Result;
 use rmlx_mlx::{
-    add, argpartition, divide, expand_dims, multiply, sigmoid, silu, softmax, sum_axis,
-    take_along_axis, Array, Device, Dtype,
+    add, argpartition, argsort, divide, expand_dims, floor_divide, multiply, scalar_f32, sigmoid,
+    silu, softmax, sum_axis, take_along_axis, Array, Device, Dtype,
 };
 
 use super::layers::Linear;
+
+/// Flattened `n_tokens * top_k` count at or above which the expert dispatch
+/// sorts indices for contiguous per-expert access (prefill). Below it (decode,
+/// single token) the simple broadcast path is cheaper. Matches mlx-lm SwitchGLU.
+const SORT_DISPATCH_THRESHOLD: i32 = 64;
 
 #[allow(missing_debug_implementations)]
 pub(super) struct SwitchMlp {
@@ -39,12 +44,28 @@ impl SwitchMlp {
         routing_weights: &Array,
         device: Device,
     ) -> Result<Array> {
+        let s = expert_indices.shape();
+        let n_tokens = s[0];
+        let tk = s[1];
+
+        // Multi-token (prefill) fast path: sort the flattened expert indices so
+        // each expert's rows are contiguous, then dispatch gather_qmm with
+        // sorted_indices=true and scatter the outputs back. Decode (single
+        // token) keeps the simple broadcast path below. Mirrors mlx-lm SwitchGLU.
+        if n_tokens * tk >= SORT_DISPATCH_THRESHOLD {
+            return self.forward_sorted(x, expert_indices, routing_weights, device);
+        }
+
         // Expand x: [n, hidden] -> [n, 1, 1, hidden].
         let xe = expand_dims(x, -2, device)?;
         let xe = expand_dims(&xe, -2, device)?;
 
-        let gate_raw = self.gate_proj.gather_forward(&xe, expert_indices, device)?;
-        let up_raw = self.up_proj.gather_forward(&xe, expert_indices, device)?;
+        let gate_raw = self
+            .gate_proj
+            .gather_forward(&xe, expert_indices, false, device)?;
+        let up_raw = self
+            .up_proj
+            .gather_forward(&xe, expert_indices, false, device)?;
 
         // Squeeze singleton: [n, tk, 1, inter] -> [n, tk, inter].
         let gs = gate_raw.shape();
@@ -56,7 +77,9 @@ impl SwitchMlp {
 
         // Re-expand for down_proj: [n, tk, inter] -> [n, tk, 1, inter].
         let gd = expand_dims(&gated, -2, device)?;
-        let out_raw = self.down_proj.gather_forward(&gd, expert_indices, device)?;
+        let out_raw = self
+            .down_proj
+            .gather_forward(&gd, expert_indices, false, device)?;
         let os = out_raw.shape();
         let out_3d = out_raw.reshape(&[os[0], os[1], os[3]], device)?;
 
@@ -64,6 +87,73 @@ impl SwitchMlp {
         let rw = expand_dims(routing_weights, -1, device)?;
         let out_scaled = multiply(&out_3d, &rw, device)?;
 
+        sum_axis(&out_scaled, 1, device)
+    }
+
+    /// Sorted-dispatch expert forward for the multi-token (prefill) case.
+    ///
+    /// Sorts the flattened `[n*tk]` expert indices ascending, gathers the
+    /// matching x rows into expert-contiguous order, runs the three gathered
+    /// quantized matmuls with `sorted_indices=true`, then scatters the result
+    /// back to token order. Math is identical to the broadcast path; only the
+    /// memory-access order into the expert weights changes.
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "bounds established by construction: index buffers sized from x/indices shapes"
+    )]
+    fn forward_sorted(
+        &self,
+        x: &Array,
+        expert_indices: &Array,
+        routing_weights: &Array,
+        device: Device,
+    ) -> Result<Array> {
+        let s = expert_indices.shape();
+        let n_tokens = s[0];
+        let tk = s[1];
+        let total = n_tokens * tk;
+        let hidden = x.shape()[1];
+
+        let flat_idx = expert_indices.reshape(&[total], device)?;
+        let order = argsort(&flat_idx, device)?.astype(Dtype::I32, device)?;
+        let inv_order = argsort(&order, device)?.astype(Dtype::I32, device)?;
+        let sorted_idx = flat_idx.take(&order, 0, device)?;
+
+        // token = order // tk; gather x rows -> [total, hidden].
+        let tk_arr = scalar_f32(tk as f32).astype(Dtype::I32, device)?;
+        let tok_of_order = floor_divide(&order, &tk_arr, device)?;
+        let x_sorted = x.take(&tok_of_order, 0, device)?;
+
+        // x [total, 1, hidden] aligns its leading dim with rhs_indices [total].
+        let xe = expand_dims(&x_sorted, -2, device)?;
+
+        let gate_raw = self
+            .gate_proj
+            .gather_forward(&xe, &sorted_idx, true, device)?; // [total, 1, inter]
+        let up_raw = self
+            .up_proj
+            .gather_forward(&xe, &sorted_idx, true, device)?;
+
+        let gs = gate_raw.shape();
+        let gate_2d = gate_raw.reshape(&[gs[0], gs[2]], device)?; // [total, inter]
+        let us = up_raw.shape();
+        let up_2d = up_raw.reshape(&[us[0], us[2]], device)?;
+        let gate = silu(&gate_2d, device)?;
+        let gated = multiply(&gate, &up_2d, device)?;
+
+        let gd = expand_dims(&gated, -2, device)?; // [total, 1, inter]
+        let out_raw = self
+            .down_proj
+            .gather_forward(&gd, &sorted_idx, true, device)?; // [total, 1, hidden]
+        let os = out_raw.shape();
+        let out_2d = out_raw.reshape(&[os[0], os[2]], device)?; // [total, hidden]
+
+        // Scatter back to token order, then [n, tk, hidden].
+        let out_unsorted = out_2d.take(&inv_order, 0, device)?;
+        let out_3d = out_unsorted.reshape(&[n_tokens, tk, hidden], device)?;
+
+        let rw = expand_dims(routing_weights, -1, device)?;
+        let out_scaled = multiply(&out_3d, &rw, device)?;
         sum_axis(&out_scaled, 1, device)
     }
 }

--- a/crates/rmlx-models/src/qwen3_5_moe/moe_tests.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/moe_tests.rs
@@ -1,0 +1,192 @@
+//! Permutation-equivalence tests for the Qwen3.5-MoE `SwitchMlp`.
+//!
+//! Same contract as the Gemma4 MoE tests: the sorted-dispatch prefill path
+//! (`forward_sorted`) must produce outputs identical to the broadcast path
+//! (`forward_broadcast`) for *any* routing. The sorted path permutes the
+//! flattened `[n*tk]` expert indices, gathers/scatters x rows, and runs the
+//! gathered quantized matmuls with `sorted_indices=true`. A single greedy A/B
+//! is weak, so these tests assert equivalence directly on the two internal
+//! paths with duplicate experts, skewed distributions, and token counts on
+//! both sides of the `SORT_DISPATCH_THRESHOLD` (64).
+//!
+//! Exercises the real production path (`Linear::Quantized` → `gather_qmm`),
+//! which is Metal-only — hence `#[ignore]`. Run with
+//! `cargo test -p rmlx-models --lib qwen3_5_moe::moe -- --ignored`.
+
+use super::{Linear, SwitchMlp};
+use rmlx_mlx::{quantize, Array, Device, Dtype};
+
+const DEV: Device = Device::Gpu;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+struct Lcg(u64);
+
+impl Lcg {
+    fn next_f32(&mut self) -> f32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        let bits = (self.0 >> 40) as u32;
+        (bits as f32 / (1u32 << 23) as f32) - 1.0
+    }
+    fn next_u(&mut self, modulo: u32) -> u32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        ((self.0 >> 33) as u32) % modulo
+    }
+}
+
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: from_bytes on a fixed-size in-memory buffer cannot fail"
+)]
+fn f32_arr(data: &[f32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|x| x.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::F32).unwrap()
+}
+
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: from_bytes on a fixed-size in-memory buffer cannot fail"
+)]
+fn i32_arr(data: &[i32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|x| x.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::I32).unwrap()
+}
+
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: CPU eval + to_bytes on a materialized array cannot fail"
+)]
+fn to_vec(a: &Array) -> Vec<f32> {
+    let f = a.astype(Dtype::F32, Device::Cpu).unwrap();
+    f.eval().unwrap();
+    f.to_bytes()
+        .unwrap()
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+        .collect()
+}
+
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: quantize on a valid bf16 GPU array cannot fail"
+)]
+fn quant_linear(data: &[f32], shape: &[i32]) -> Linear {
+    let w = f32_arr(data, shape).astype(Dtype::Bf16, DEV).unwrap();
+    let (weight, scales, biases) = quantize(&w, GROUP_SIZE, BITS, DEV).unwrap();
+    Linear::Quantized {
+        weight,
+        scales,
+        biases: Some(biases),
+        group_size: GROUP_SIZE,
+        bits: BITS,
+        mode: "affine".to_string(),
+    }
+}
+
+/// gate/up: [ne, inter, hidden]; down: [ne, hidden, inter].
+fn make_switch(rng: &mut Lcg, ne: i32, hidden: i32, inter: i32) -> SwitchMlp {
+    let gate: Vec<f32> = (0..ne * inter * hidden)
+        .map(|_| rng.next_f32() * 0.1)
+        .collect();
+    let up: Vec<f32> = (0..ne * inter * hidden)
+        .map(|_| rng.next_f32() * 0.1)
+        .collect();
+    let down: Vec<f32> = (0..ne * hidden * inter)
+        .map(|_| rng.next_f32() * 0.1)
+        .collect();
+    SwitchMlp {
+        gate_proj: quant_linear(&gate, &[ne, inter, hidden]),
+        up_proj: quant_linear(&up, &[ne, inter, hidden]),
+        down_proj: quant_linear(&down, &[ne, hidden, inter]),
+    }
+}
+
+fn make_routing(rng: &mut Lcg, n: i32, tk: i32, ne: i32, mode: u8) -> (Array, Array) {
+    let mut idx = Vec::with_capacity((n * tk) as usize);
+    for _ in 0..n {
+        for _ in 0..tk {
+            let e = if mode == 1 {
+                if rng.next_u(10) < 8 {
+                    (rng.next_u(2)) as i32
+                } else {
+                    rng.next_u(ne as u32) as i32
+                }
+            } else {
+                rng.next_u(ne as u32) as i32
+            };
+            idx.push(e);
+        }
+    }
+    let w: Vec<f32> = (0..n * tk).map(|_| 0.5 + rng.next_f32() * 0.25).collect();
+    (i32_arr(&idx, &[n, tk]), f32_arr(&w, &[n, tk]))
+}
+
+#[allow(
+    clippy::unwrap_used,
+    reason = "test: forward paths on valid GPU arrays cannot fail under matching shapes"
+)]
+fn assert_paths_match(n: i32, tk: i32, ne: i32, hidden: i32, inter: i32, mode: u8, seed: u64) {
+    const ATOL: f32 = 0.06;
+    const RTOL: f32 = 0.03;
+    let mut rng = Lcg(seed);
+    let switch = make_switch(&mut rng, ne, hidden, inter);
+    let xdata: Vec<f32> = (0..n * hidden).map(|_| rng.next_f32()).collect();
+    let x = f32_arr(&xdata, &[n, hidden])
+        .astype(Dtype::Bf16, DEV)
+        .unwrap();
+    let (idx, w) = make_routing(&mut rng, n, tk, ne, mode);
+    let w = w.astype(Dtype::Bf16, DEV).unwrap();
+
+    let bc = switch.forward_broadcast(&x, &idx, &w, DEV).unwrap();
+    let sorted = switch.forward_sorted(&x, &idx, &w, DEV).unwrap();
+
+    let bc_v = to_vec(&bc);
+    let so_v = to_vec(&sorted);
+    assert_eq!(bc_v.len(), so_v.len(), "shape mismatch");
+    // Both paths run the identical gather_qmm/silu/multiply sequence; only the
+    // row order into the expert weights differs. Equivalence is exact in real
+    // arithmetic and exact-up-to-accumulation-reorder under bf16 int4. Assert
+    // numpy-`allclose`-style (atol + rtol*|b|): atol absorbs the bf16 reorder
+    // floor on near-zero elements, rtol the proportional drift on large ones.
+    // A real index/scatter bug produces order-1 divergence on many elements,
+    // far above this envelope.
+    let mut worst = 0.0f32;
+    for (a, b) in bc_v.iter().zip(&so_v) {
+        let allowed = ATOL + RTOL * b.abs();
+        worst = worst.max((a - b).abs() - allowed);
+    }
+    assert!(
+        worst <= 0.0,
+        "sorted vs broadcast diverge beyond atol+rtol*|b| by {worst} (n={n} tk={tk} ne={ne} mode={mode})"
+    );
+}
+
+#[test]
+#[ignore = "needs Metal device + single-MLX claim (gather_qmm is GPU-only)"]
+fn sorted_eq_broadcast_below_threshold() {
+    assert_paths_match(8, 4, 8, 256, 512, 0, 0xC0FFEE);
+}
+
+#[test]
+#[ignore = "needs Metal device + single-MLX claim (gather_qmm is GPU-only)"]
+fn sorted_eq_broadcast_above_threshold() {
+    assert_paths_match(64, 4, 8, 256, 512, 0, 0xBADBEEF);
+}
+
+#[test]
+#[ignore = "needs Metal device + single-MLX claim (gather_qmm is GPU-only)"]
+fn sorted_eq_broadcast_skewed() {
+    assert_paths_match(64, 4, 8, 256, 512, 1, 0x5EED);
+}
+
+#[test]
+#[ignore = "needs Metal device + single-MLX claim (gather_qmm is GPU-only)"]
+fn sorted_eq_broadcast_many_dup() {
+    assert_paths_match(32, 8, 4, 256, 512, 1, 0xABCD1234);
+}

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -323,6 +323,11 @@ Text only. No vision or audio tower.
   prompts in windows to avoid GPU command-buffer timeout on Qwen3.6-MoE at
   n > ~1 000 tokens.
 - **Thinking mode and prompt cache.** Both active.
+- **Sorted-index expert gather at prefill.** Same optimization as Gemma4-26b:
+  when `n_tokens*top_k ≥ 64`, the routed expert indices are sorted for
+  contiguous per-expert access, the three `gather_qmm` calls run with
+  `sorted_indices=true`, and the outputs are scattered back. Decode keeps the
+  broadcast path. Mirrors mlx-lm `SwitchGLU`.
 
 ### Known limitations
 
@@ -691,7 +696,18 @@ Text, image, and audio input. rMLX implements all three towers:
 - **SWA + FullAttention alternation** with dual RoPE theta.
 - **Cross-layer KV sharing** (`num_kv_shared_layers`).
 - **K=V weight sharing** for full-attention layers on 26B/31B.
-- **Sparse MoE** on 26B (dense + sparse block per layer).
+- **Sparse MoE** on 26B (dense + sparse block per layer). The expert dispatch
+  uses **sorted-index gather** at prefill: when the flattened `n_tokens*top_k`
+  count is ≥ 64 (multi-token prefill), the routed expert indices are sorted so
+  each expert's rows are contiguous, the three gathered quantized matmuls run
+  with `sorted_indices=true`, and the outputs are scattered back to token order.
+  Contiguous per-expert access lets the gathered-matmul kernel run each expert
+  as one dense block instead of scattered per-token gathers — a ~4× prefill
+  speedup on 26B at 4k/16k/32k. Decode (single token, count < 64) keeps the
+  simple broadcast path. Mirrors mlx-lm `SwitchGLU`. The remaining ~1.6× gap to
+  mlx-lm prefill is inherent: Gemma4-26b runs a **dense MLP and the sparse
+  experts in parallel every layer** plus three extra MoE RMSNorms, so it does
+  strictly more per-layer work than a pure-MoE model.
 - **Conformer audio encoder** with SSCP subsampling.
 - **Gemma4-assistant MTP drafter.** The sidecar MTP head reads the verifier's
   pre-final-norm hidden state via `forward_hidden_states_shared_kv`, which also


### PR DESCRIPTION
## Problem
`gemma4-26b-a4b` (MoE) prefilled at ~dense-model speed — ~10× slower than the mlx-lm sibling. The original "computes all experts at prefill" hypothesis was **refuted** (the MoE already uses sparse top-k `gather_qmm`); the real cause was found by re-baselining + A/B.

## Root cause
MoE expert dispatch called MLX `gather_qmm` with `sorted_indices=false` and **no index sort**, so every prefill token's expert access was unordered — defeating the gathered-matmul kernel's contiguous-per-expert block path. mlx-lm's `SwitchGLU` sorts the indices when `indices.size >= 64` ("sort so different experts are accessed in order"). The `>= 64` threshold also explains why only *prefill* was slow: decode (`top_k`=8 rows < 64) skips the sort in both backends, so decode was already at parity.

## Fix (general — Gemma4-26b AND Qwen3.5-MoE)
A sorted-dispatch path: sort the flattened `[n*top_k]` expert indices, gather token rows (`order / top_k` via a new integer `floor_divide`), run the 3 `gather_qmm` calls with `sorted_indices=true`, scatter back via the exact inverse permutation. Threshold 64, matching mlx-lm. Decode keeps the broadcast path. The same fix lands on Qwen3.5-MoE (shared inefficiency).

`#44`'s bf16 stream had already lifted 26b prefill ~1.6× (329→528 tok/s); this closes most of the rest.

## Results (release-perf, real 26b)
- **Prefill ~4×:** 16k 464→**1856 tok/s**; TTFT@32k 90.8s→22.3s. Now ~0.6× of mlx-lm (was ~0.14×).
- **Output byte-identical** pre/post (greedy).
- **Correctness locked:** permutation-equivalence unit tests on both arches (`forward_sorted` ≡ `forward_broadcast`, allclose) covering duplicate/skewed experts + both sides of the 64 threshold; mutation-checked (a wrong inverse permutation makes them fail).
- A blind review verified the sort→gather→scatter is a **provably-correct inverse** (identical math to the broadcast path).
- **Regression clean:** Gemma4-e2b 127.5 / e4b 78.8, Qwen3.6 prefill coherent + decode 99.2 (≥~97 anchor), Bonsai 112.1 — all coherent.
- `make build-perf` / `make lint` / `cargo fmt --check` / `make check-no-inline-tests` clean.

## Note
Remaining ~1.6× to mlx-lm is inherent (gemma4-26b runs a dense MLP + sparse experts in parallel every layer + 3 extra MoE norms) — not chased. `laguna` / `qwen3_vl_moe` carry the same latent unsorted-gather pattern (out of the test-target set; left as a follow-up).

Resolves #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
