### PR TITLE
fix(gemma4): keep MoE router/expert stream bf16 — close 26b-a4b decode gap

### DIFF
--- a/crates/rmlx-models/src/gemma4/layers/moe.rs
+++ b/crates/rmlx-models/src/gemma4/layers/moe.rs
@@ -134,7 +134,11 @@ impl Gemma4Router {
         // mlx-lm: `mx.fast.rms_norm(x, self.scale * self._root_size, self.eps)`.
         // The `scale * root_size` could be baked at load-time (sub-1% gain);
         // keeping per-call to preserve weight tying with checkpoint.
-        let rs = scalar_f32(self.root_size);
+        // Cast the root-size scalar to the activation dtype first: a strong-f32
+        // scalar would promote `scaled_weight` (and thus the RMSNorm output, the
+        // expert scores, and the routing weights) to f32, leaking f32 into the
+        // MoE residual stream — keep the stream in the model dtype (bf16).
+        let rs = scalar_f32(self.root_size).astype(x.dtype(), device)?;
         let scaled_weight = multiply(&self.scale, &rs, device)?;
         let x_normed = rms_norm(x, Some(&scaled_weight), self.eps, device)?;
 


### PR DESCRIPTION
Fixes #50. The Gemma4 MoE router scaled its RMSNorm weight by a strong-f32 root-size scalar, leaking f32 into the whole MoE residual stream (the same f32-stream class #44 fixed for the dense path). One-line `.astype(x.dtype())` (the #44 embed_scale idiom) keeps the stream bf16.

**Proven** on gemma-4-26b-a4b-it-mxfp8 (release-perf, `--kv-quant none`):
- dtype probe: `h2_expert` / `h_sum` / `routing_weights` F32 → Bf16
- decode: 4k 63.9→**73.3** (+14.6%, parity vs mlx-lm 74), 32k ~50→**54.6**, 64k 38.7→**45.7** (+18%); gap vs mlx-lm −11…−20% → −1…−9%
- coherent temp=0 output; `make ci` green; blind rust-review clean

Scope: gemma4 MoE only (26b) — dense e2b/e4b/31b skip `moe_block` entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)