### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-10
+
+Gemma 4 decode is now competitive with mlx-lm across the whole family, Gemma 4
+speculative decoding (MTP) works end to end, the KV ring grows lazily with
+per-request KV / context hot-swap, KV-cache metrics report live sizes, and the
+env-var surface is cleaned up — **breaking** for shell configs that set removed
+vars directly (see Removed).
+
+### Added
+
+- **Per-request KV-quant + `--max-ctx` hot-swap** on a resident model — switch
+  the KV codec or context ceiling per request without reloading the model. (#26)
+- **Per-layer KV net-benefit estimator** — warns when a KV codec costs more
+  resident bytes than it saves on a given layer mix (general across arches). (#34)
+- Five env-var-only knobs promoted to proper `--flag` / `env=` pairs (the flag
+  always takes precedence): `--log-cap-mb`, `--yarn-factor`,
+  `--yarn-original-max`, `--session-cache-max-sessions`, `--prompts-dir`.
+
+### Fixed
+
+- **Gemma 4 speculative (MTP) functional end to end.** Dispatch routes
+  `--draft-kind mtp` by draft arch family and rejects a plain-`gemma4` draft
+  cleanly (#23); the assistant SWA mask uses array mode instead of the rejected
+  additive mode (#24); a verify-step SWA mask off-by-one in both the producer
+  and consumer branches is fixed (#32); and the loader supports both assistant
+  LM-head variants — sparse centroid-routed (e2b/e4b) and plain tied-head
+  (26b/31b) (#49). All four Gemma 4 sizes load and run coherent under MTP.
+- **Gemma 4 decode kept bf16 end to end.** `gelu_tanh` f32 constants plus the
+  embed / per-layer scales no longer promote the dense activation stream to f32
+  (#44), and the MoE router's strong-f32 root-size scalar no longer leaks f32
+  into the routing weights and the downstream KV (#51). Net: e2b/e4b beat mlx-lm
+  decode, 26b-a4b MoE closed from −10…−28 % to −4…+1 %, and global `--kv-quant
+  none` KV is halved (bf16) on every model.
+- **`--max-ctx` is a virtual ceiling** — the KV ring grows on demand, so a high
+  ceiling no longer penalizes small-prompt decode. (#25)
+- **Rotation / K-only KV codecs** precompile their MSL kernels at load and are
+  truthfully classified Metal vs CPU (no silent host-CPU fallback). (#36)
+- **Qwen3.6-MoE SSD-hydrated prefix skips prefill** via a hydrated-tail path — a
+  cache hit no longer re-runs the full prefill. (#9)
+- **Live KV-cache metrics** — `kv_cache_bytes` reports the real resident size
+  (was always 0) and counts the filled prefix, not the `--max-ctx` ceiling.
+  (#33, #39)
+
+### Performance
+
+- **MoE prefill ~4× faster** on gemma4-26b and Qwen3.5-MoE via sorted-index
+  expert gather (contiguous per-expert access in `gather_qmm`) — 26b 128k cold
+  TTFT ~403 s → ~117 s. (#46)
+
+### Tested
+
+- Falsified the 6× SWA-KV claim: windowed SWA KV is window-bounded, not
+  full-context (#35, #40).
+- Full Gemma 4 and Qwen 3.6 KV × context bench matrices (per-model decode /
+  TTFT / KV-size across all codecs) recorded under `docs/models/`.
+
 ### Changed
 
 - **Env-var surface cleanup** (`chore/env-var-cleanup`). Five previously
@@ -27,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   vars (`RMLX_HOME`, `RMLX_METRICS_DB`), all five newly-promoted flag-envs,
   audio path vars, `RMLX_MM_CACHE_BYTES`, `RMLX_SESSION_CACHE_MAX_SESSIONS`,
   draft compat keys, and prefill chunk tuning.
+- Dependency bumps: `safetensors` 0.4 → 0.7, `symphonia` 0.5 → 0.6.
 
 ### Removed
 
@@ -120,6 +177,7 @@ inference + conversion backend for Apple Silicon — no Python at runtime.
 - Speculative drafters validated against their verifiers: Qwen 3.6 MTP sidecar
   and the Gemma 4 assistant drafter.
 
-[Unreleased]: https://github.com/Pushkinist/rMLX/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/Pushkinist/rMLX/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.0
 [0.1.1]: https://github.com/Pushkinist/rMLX/releases/tag/v0.1.1
 [0.1.0]: https://github.com/Pushkinist/rMLX/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,7 +1892,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmlx-audio"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "miniz_oxide",
  "rmlx-core",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-cli"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "libc",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-kv-quant"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "rmlx-core",
  "rmlx-mlx",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-kv-ssd"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "rmlx-core",
  "rmlx-kv-quant",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-loader"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "memmap2",
  "rayon",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-metrics"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "csv",
  "regex-lite",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-mlx"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bindgen",
  "rmlx-core",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-models"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "image",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-quant"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "rmlx-core",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-runtime"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "rmlx-core",
  "rmlx-mlx",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-server"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release **0.2.0**. Bumps `[workspace.package].version` 0.1.1 → 0.2.0 + CHANGELOG `[0.2.0]`.

Highlights since v0.1.1 (23 commits): Gemma 4 decode now competitive with mlx-lm across the family (#44/#51), Gemma 4 speculative MTP functional end to end (#23/#24/#32/#49), lazy-grow KV ring + per-request KV/ctx hot-swap (#25/#26), MoE prefill ~4× (#46), live KV-cache metrics (#33/#39), env-var surface cleanup (**breaking** — see Removed).

`make ci` green locally. Tag + binary + Homebrew follow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)