### PR TITLE
fix(quant): f16 negative subnormal no longer decodes to -0.0

### DIFF
--- a/crates/rmlx-quant/src/awq.rs
+++ b/crates/rmlx-quant/src/awq.rs
@@ -224,8 +224,11 @@ pub fn f16_bits_to_f32(bits: u16) -> f32 {
         if mantissa == 0 {
             return f32::from_bits(sign);
         }
-        // Subnormal: scale by 2^(1-15-10) = 2^(-24).
-        return f32::from_bits(sign) * (mantissa as f32) * (1.0 / 16777216.0);
+        // Subnormal: scale by 2^(1-15-10) = 2^(-24). The sign must be applied
+        // as a factor of ±1.0 — multiplying by f32::from_bits(sign) (±0.0)
+        // collapses every subnormal to a signed zero.
+        let sign_f = if bits >> 15 != 0 { -1.0_f32 } else { 1.0_f32 };
+        return sign_f * (mantissa as f32) * (1.0 / 16777216.0);
     } else if exp == 31 {
         // Inf or NaN.
         return f32::from_bits(sign | 0x7F800000 | (mantissa << 13));

--- a/crates/rmlx-quant/src/awq_tests.rs
+++ b/crates/rmlx-quant/src/awq_tests.rs
@@ -198,3 +198,18 @@ fn quantize_f16_affine_int4_matches_python() {
         );
     }
 }
+
+#[test]
+fn f16_subnormal_negative_decodes_nonzero() {
+    // 0x8001 = sign=1, exp=0, mantissa=1 → -1 * 2^-24
+    let neg = f16_bits_to_f32(0x8001);
+    assert_eq!(neg, -(1.0 / 16777216.0));
+    // 0x83FF = largest negative subnormal: -1023 * 2^-24
+    let neg_max = f16_bits_to_f32(0x83FF);
+    assert_eq!(neg_max, -1023.0 / 16777216.0);
+    // Positive subnormal unchanged.
+    assert_eq!(f16_bits_to_f32(0x0001), 1.0 / 16777216.0);
+    // Signed zeros preserved.
+    assert_eq!(f16_bits_to_f32(0x0000).to_bits(), 0.0_f32.to_bits());
+    assert_eq!(f16_bits_to_f32(0x8000).to_bits(), (-0.0_f32).to_bits());
+}


### PR DESCRIPTION
## What
`f16_bits_to_f32` in `crates/rmlx-quant/src/awq.rs` decoded every negative f16 subnormal to `-0.0`: the sign was applied via `f32::from_bits(sign)` (= ±0.0) and IEEE `-0.0 * x == -0.0` collapses the result.

## Fix
Apply the sign as a ±1.0 factor (`sign_f = if bits >> 15 != 0 { -1.0 } else { 1.0 }`). The `mantissa == 0` zero branch is untouched, so signed zeros are still preserved.

## Test
New `f16_subnormal_negative_decodes_nonzero` (red→green): negative subnormals (`0x8001`, `0x83FF`), positive subnormal unchanged, and both signed zeros preserved. Whole `rmlx-quant` crate green (59 tests).

Plan: Task 1 (Phase A) of docs/superpowers/plans/2026-06-12-deep-analysis-remediation.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)