### PR TITLE
fix(models): chunked_prefill exits prefill on every cache after a failure

### DIFF
--- a/crates/rmlx-models/src/decode_loop.rs
+++ b/crates/rmlx-models/src/decode_loop.rs
@@ -501,7 +501,11 @@ pub(crate) fn chunked_prefill(
         if let Err(e) = c.exit_prefill(device) {
             tracing::warn!(arch, error = %e, "prefill: exit_prefill quantization failed");
             prefill_ok = false;
-            break;
+            // No break: every cache entered prefill above and must run
+            // exit_prefill, even after a failure — skipping it leaves the
+            // remaining caches with un-finalized prefill state (no decode
+            // seed / un-quantized storage) that corrupts any later reuse of
+            // this Vec.
         }
     }
     if !prefill_ok || last_logits.is_none() {


### PR DESCRIPTION
## What
`chunked_prefill` calls `enter_prefill()` on **all** caches up front, but the exit loop `break`s on the first `exit_prefill` error — leaving `caches[i+1..]` with un-finalized prefill state (no decode seed / un-quantized storage). A later reuse of that `Vec<KvCache>` (prompt-cache slot, retry) then corrupts KV.

## Fix
Drop the `break` so every cache runs `exit_prefill` even after a failure. `prefill_ok = false` still propagates and the function still returns `Ok(None)` on failure — no silent success.

## Tests
`cargo test -p rmlx-models decode_loop` (10 passed) and `make model-check` (658 passed) green. Comment wording follows reviewer feedback (truthful about `in_prefill` vs storage finalization).

Plan: Task 2 (Phase A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)