### PR TITLE
fix(kv-quant): resident-bytes estimator models iso/rotor sidebands exactly

### DIFF
--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -807,13 +807,23 @@ impl KvQuant {
     /// the codec retains a bf16 decode seed via
     /// [`Self::feeds_bf16_k_at_decode`]) — never from an arch name.
     ///
-    /// Components per side:
-    /// - **Packed codes**: `seq * head_dim * code_bits / 8`.
-    /// - **Per-group scales**: one f32 per quantization group. K groups are
-    ///   128 elements (q8_0) or the K-side group; V groups are 32 (TurboQuant)
-    ///   or the affine group. A conservative single cadence of one f32 per 32
-    ///   elements is used for quantized sides (it never under-counts the q8_0
-    ///   K-side at group 128, which is the cheaper case).
+    /// Components per side, by layout family:
+    /// - **Generic (affine / turbo / planar)**: packed codes
+    ///   (`seq * head_dim * code_bits / 8`) + one f32 per 32-element group. A
+    ///   conservative single scale cadence of one f32 per 32 elements is used
+    ///   (it never under-counts the q8_0 K-side at group 128, the cheaper case).
+    /// - **iso (group 4)**: per 4-element group one code u32 + one f32 scale +
+    ///   four f32 quaternion, plus one f32 norm per token. The quaternion
+    ///   sideband dominates and makes an iso side *larger* than bf16 at
+    ///   `head_dim <= 256` — the generic cadence above underestimates it ~12×.
+    /// - **rotor (group 3)**: per 3-element group one code u32 + one f32 scale,
+    ///   plus one f32 norm per token. The static per-(layer, head) rotor table
+    ///   is not per-token and is omitted (estimate, not census).
+    ///
+    /// Only the side that actually carries the family codec uses its formula:
+    /// the V-only variants (`Iso3`/`Iso4`/`Rotor3`/`Rotor4`) keep an 8-bit
+    /// affine K, so their K side takes the generic path.
+    ///
     /// - **bf16 decode seed**: when [`Self::feeds_bf16_k_at_decode`] is true the
     ///   codec keeps a full `seq * head_dim * 2` bf16 mirror of **V** (always)
     ///   and **K** (unless it is a K-only re-quantize family). This is the
@@ -839,33 +849,96 @@ impl KvQuant {
             return elems.saturating_mul(2).saturating_mul(2);
         }
         let (k_bits, v_bits) = self.approx_code_bits();
-        // Per-side bytes: helper sizes one side (K or V) given its code bits and
-        // whether a parallel bf16 decode seed is retained for it.
-        //
-        // - **16-bit side (bf16-stored)**: the side IS a single bf16 buffer.
-        //   No separate codes vs seed — the bf16 buffer is both. Count it once.
-        // - **quantized side**: packed codes (`bits/8` bytes/elem) + one f32
-        //   per 32-element group (conservative scale cadence) + a bf16 decode
-        //   seed mirror *iff* this codec retains one (`retains_seed`).
-        let side_bytes = |bits: u32, retains_seed: bool| -> u64 {
+        let n_tokens = seq.saturating_mul(kv_heads);
+
+        // Per-side bytes for one quantized-or-bf16 side. Three layout families:
+        // - bf16 side (bits >= 16): one bf16 buffer, counted once.
+        // - iso (group 4): per 4-elem group 1 code u32 + 1 f32 scale + 4 f32
+        //   quaternion; plus 1 f32 norm per token. The quaternion sideband
+        //   dominates and makes iso larger than bf16 at head_dim <= 256.
+        // - rotor (group 3): per 3-elem group 1 code u32 + 1 f32 scale; plus
+        //   1 f32 norm per token. (Static per-(layer,head) rotor table is not
+        //   per-token and is omitted, consistent with estimate-not-census.)
+        // - everything else: dense pack bits/8 bytes/elem + one f32 scale per
+        //   32-elem group (the pre-existing conservative cadence).
+        let is_iso = matches!(
+            self,
+            KvQuant::Iso3
+                | KvQuant::Iso4
+                | KvQuant::Iso3Sym
+                | KvQuant::Iso4Sym
+                | KvQuant::IsoKOnly3
+                | KvQuant::IsoKOnly4
+        );
+        let is_rotor = matches!(
+            self,
+            KvQuant::Rotor3
+                | KvQuant::Rotor4
+                | KvQuant::Rotor3Sym
+                | KvQuant::Rotor4Sym
+                | KvQuant::RotorKOnly3
+                | KvQuant::RotorKOnly4
+                | KvQuant::RotorK3Asym { .. }
+                | KvQuant::RotorK4Asym { .. }
+        );
+        let side_bytes = |bits: u32, retains_seed: bool, side_uses_family: bool| -> u64 {
             if bits >= 16 {
-                // bf16 side: single buffer, counted once.
                 return elems.saturating_mul(2);
             }
-            let codes = elems.saturating_mul(u64::from(bits)) / 8;
-            let scales = (elems / 32).saturating_mul(4);
+            let stored = if side_uses_family && is_iso {
+                let groups = elems / 4;
+                groups
+                    .saturating_mul(4 + 4 + 16)
+                    .saturating_add(n_tokens.saturating_mul(4))
+            } else if side_uses_family && is_rotor {
+                // group size 3: per-token head_dim.div_ceil(3), NOT elems/3.
+                let groups = head_dim.div_ceil(3).saturating_mul(n_tokens);
+                groups
+                    .saturating_mul(4 + 4)
+                    .saturating_add(n_tokens.saturating_mul(4))
+            } else {
+                let codes = elems.saturating_mul(u64::from(bits)) / 8;
+                let scales = (elems / 32).saturating_mul(4);
+                codes.saturating_add(scales)
+            };
             let seed = if retains_seed {
                 elems.saturating_mul(2)
             } else {
                 0
             };
-            codes.saturating_add(scales).saturating_add(seed)
+            stored.saturating_add(seed)
         };
+        // Which side actually carries the iso/rotor encoding. V-only variants
+        // (Iso3/Iso4/Rotor3/Rotor4) keep an 8-bit AFFINE K -> generic path.
+        let k_uses_family = matches!(
+            self,
+            KvQuant::Iso3Sym
+                | KvQuant::Iso4Sym
+                | KvQuant::IsoKOnly3
+                | KvQuant::IsoKOnly4
+                | KvQuant::Rotor3Sym
+                | KvQuant::Rotor4Sym
+                | KvQuant::RotorKOnly3
+                | KvQuant::RotorKOnly4
+                | KvQuant::RotorK3Asym { .. }
+                | KvQuant::RotorK4Asym { .. }
+        );
+        let v_uses_family = matches!(
+            self,
+            KvQuant::Iso3
+                | KvQuant::Iso4
+                | KvQuant::Iso3Sym
+                | KvQuant::Iso4Sym
+                | KvQuant::Rotor3
+                | KvQuant::Rotor4
+                | KvQuant::Rotor3Sym
+                | KvQuant::Rotor4Sym
+        );
         // V seed is always retained by the warm-TTFT shortcut codecs (every
         // quant arm reads `decode_fp16_v` at decode). K seed is retained unless
         // this is a K-only re-quantize family (`feeds_bf16_k_at_decode == false`).
-        let k_bytes = side_bytes(k_bits, self.feeds_bf16_k_at_decode());
-        let v_bytes = side_bytes(v_bits, true);
+        let k_bytes = side_bytes(k_bits, self.feeds_bf16_k_at_decode(), k_uses_family);
+        let v_bytes = side_bytes(v_bits, true, v_uses_family);
         k_bytes.saturating_add(v_bytes)
     }
 

--- a/crates/rmlx-kv-quant/src/quant_tests.rs
+++ b/crates/rmlx-kv-quant/src/quant_tests.rs
@@ -271,15 +271,16 @@ fn global_layer_scratch_heavy_codec_is_net_negative_at_small_ctx() {
     );
 }
 
-/// A K-only re-quantize codec (no bf16 K seed) on a global layer at large
-/// context can be net-POSITIVE — proving the estimator distinguishes the
-/// seed-retaining families from the seed-free ones, generally.
+/// A seed-free K-only codec that carries a sideband-heavy family codec on K
+/// (iso quaternions) is net-NEGATIVE on memory: the per 4-element-group code +
+/// scale + 4×f32 quaternion, plus one f32 norm per token, exceeds the bf16 K it
+/// replaces — even though K's nominal code width is only 4 bits. This is the
+/// operator truth the resolve-time net-negative warn relies on; a naive
+/// bits-only model wrongly predicts a saving here. The only seed-free K-only
+/// codecs in the matrix (`IsoKOnly*`/`RotorKOnly*`) all carry such a sideband,
+/// so none of them actually save on a global layer.
 #[test]
-fn k_only_codec_can_be_net_positive_on_global_layer() {
-    // IsoKOnly4: feeds_bf16_k_at_decode() == false → no K seed retained.
-    // K stored 4-bit, V stored bf16 (no V codec). At large ctx the 4-bit K
-    // packed codes are smaller than the bf16 K it replaces, and there is no
-    // duplicate K seed, so the codec saves on the K side.
+fn k_only_iso_codec_is_net_negative_from_sidebands() {
     let saving = KvQuant::IsoKOnly4.estimated_net_saving_per_layer(
         16_384, // seq (large)
         128,    // head_dim
@@ -287,8 +288,8 @@ fn k_only_codec_can_be_net_positive_on_global_layer() {
         false,  // global
     );
     assert!(
-        saving > 0,
-        "IsoKOnly4 (no bf16 K seed) on a large global layer should save vs bf16; got {saving}"
+        saving < 0,
+        "IsoKOnly4 K carries the iso quaternion sideband (larger than bf16 K) → net-negative; got {saving}"
     );
 }
 
@@ -311,20 +312,21 @@ fn both_seed_codec_gets_more_negative_with_context() {
     );
 }
 
-/// A seed-free K-only codec crosses over: net-negative at tiny context (scales
-/// overhead dominates), net-positive once the 4-bit K codes save more than the
-/// scales cost. Proves the estimator captures a real per-codec crossover.
+/// The iso K-only codec's net cost scales with context: more tokens → more
+/// quaternion/norm sideband, so the saving grows MORE negative. There is no
+/// crossover — the sideband is a per-token overhead, not a fixed one, so it can
+/// never amortize away.
 #[test]
-fn seed_free_codec_improves_with_context_on_global_layer() {
+fn iso_k_only_codec_gets_more_negative_with_context() {
     let small = KvQuant::IsoKOnly4.estimated_net_saving_per_layer(64, 128, 8, false);
     let large = KvQuant::IsoKOnly4.estimated_net_saving_per_layer(16_384, 128, 8, false);
     assert!(
-        large > small,
-        "seed-free codec saving must improve with context: small={small} large={large}"
+        small < 0 && large < 0,
+        "iso K-only is net-negative at both contexts: small={small} large={large}"
     );
     assert!(
-        large > 0,
-        "seed-free K-only codec must be net-positive at large ctx; got {large}"
+        large < small,
+        "iso quaternion sideband is a per-token overhead → more negative with context: small={small} large={large}"
     );
 }
 
@@ -336,4 +338,69 @@ fn none_codec_zero_saving_vs_itself() {
     assert_eq!(bytes, 2 * 1024 * 128 * 8 * 2);
     let saving = KvQuant::None.estimated_net_saving_per_layer(1024, 128, 8, false);
     assert_eq!(saving, 0, "None vs bf16 baseline must net to 0");
+}
+
+/// The resident-bytes estimator must track the codec's ACTUAL stored bytes
+/// (codes + scales + sidebands), not just nominal code bits — otherwise the
+/// net-negative warn lies for sideband-heavy families (iso quaternions,
+/// rotor group-3 scale cadence).
+#[test]
+fn estimator_matches_actual_iso_rotor_encode_bytes() {
+    let head_dim = 128usize;
+    let seq = 64u64;
+    let kv_heads = 4u64;
+    let n_tokens = (seq * kv_heads) as usize;
+    let v: Vec<f32> = (0..n_tokens * head_dim)
+        .map(|i| ((i % 251) as f32) / 251.0 - 0.5)
+        .collect();
+
+    // iso3: actual stored bytes per side (codes + scales + quaternions + norms).
+    let (codes, scales, quats, norms) =
+        crate::isoquant::iso_encode_fast(&v, head_dim, 4, 3).unwrap();
+    let iso_side_actual = 4 * (codes.len() + scales.len() + quats.len() + norms.len()) as u64;
+
+    // Iso3Sym quantizes BOTH sides with the iso codec and retains bf16 seeds
+    // for both (warm-TTFT): estimate = 2*(side + seed).
+    let elems = seq * head_dim as u64 * kv_heads;
+    let seed = elems * 2;
+    let est = KvQuant::Iso3Sym.estimated_resident_bytes_per_layer(seq, head_dim as u64, kv_heads);
+    let expected = 2 * (iso_side_actual + seed);
+    let tol = expected / 10; // ±10%
+    assert!(
+        est.abs_diff(expected) <= tol,
+        "Iso3Sym estimate {est} not within 10% of actual {expected}"
+    );
+
+    // rotor3: per-token = n_groups*(code u32 + scale f32) + norm f32.
+    let n_groups = head_dim.div_ceil(crate::rotorquant::ROTOR3_GROUP_SIZE);
+    let rotors = vec![0.5f32; n_groups * 4];
+    let (r_codes, r_scales, r_norms) =
+        crate::rotorquant::rotor3_encode(&v, &rotors, head_dim).unwrap();
+    let rotor_side_actual = 4 * (r_codes.len() + r_scales.len() + r_norms.len()) as u64;
+    let est_r =
+        KvQuant::Rotor3Sym.estimated_resident_bytes_per_layer(seq, head_dim as u64, kv_heads);
+    let expected_r = 2 * (rotor_side_actual + seed);
+    let tol_r = expected_r / 10;
+    assert!(
+        est_r.abs_diff(expected_r) <= tol_r,
+        "Rotor3Sym estimate {est_r} not within 10% of actual {expected_r}"
+    );
+
+    // Net-saving must now be NEGATIVE for iso at head_dim=128.
+    let saving =
+        KvQuant::Iso3Sym.estimated_net_saving_per_layer(seq, head_dim as u64, kv_heads, false);
+    assert!(
+        saving < 0,
+        "iso3 must report net-negative at head_dim=128, got {saving}"
+    );
+
+    // V-only variants keep an 8-bit AFFINE K — their K side must take the
+    // generic codes+scales path, not the quaternion formula. Sym estimate
+    // (iso K) must be strictly larger than the V-only estimate (affine K).
+    let est_v_only =
+        KvQuant::Iso3.estimated_resident_bytes_per_layer(seq, head_dim as u64, kv_heads);
+    assert!(
+        est_v_only < est,
+        "Iso3 (affine K) estimate {est_v_only} must be below Iso3Sym (iso K) {est}"
+    );
 }

--- a/crates/rmlx-models/src/kv_cache/tests.rs
+++ b/crates/rmlx-models/src/kv_cache/tests.rs
@@ -1813,11 +1813,13 @@ mod tests {
         assert_eq!(saving, 0, "bf16 must never be net-negative against itself");
     }
 
-    /// A pure-global layer mix with a seed-free K-only codec at large context is
-    /// net-POSITIVE (no warn) — proving the decision is keyed on codec attrs,
-    /// not on the presence of windowed layers.
+    /// A pure-global layer mix with the seed-free iso K-only codec at large
+    /// context is net-NEGATIVE (warn fires) — the iso quaternion sideband on K
+    /// exceeds the bf16 K it replaces, so the codec costs memory even with no
+    /// windowed layers. Proves the decision is keyed on codec attrs (the K
+    /// sideband), not on the presence of windowed layers.
     #[test]
-    fn net_positive_no_warn_for_seed_free_codec_global_only() {
+    fn net_negative_warn_for_iso_k_only_codec_global_only() {
         // All-global mix (no windowed layers), large context.
         let layers: Vec<KvLayerShape> = (0..16)
             .map(|_| KvLayerShape {
@@ -1831,8 +1833,8 @@ mod tests {
         assert_eq!(n_global, 16);
         assert_eq!(n_win, 0);
         assert!(
-            saving > 0,
-            "IsoKOnly4 (no bf16 K seed) on a large all-global mix should save; got {saving}"
+            saving < 0,
+            "IsoKOnly4 K carries the iso quaternion sideband (larger than bf16 K) → net-negative even all-global; got {saving}"
         );
     }
 


### PR DESCRIPTION
## What
`KvQuant::estimated_resident_bytes_per_layer` modeled every quantized side as a generic group-32 dense pack, which ~12× **underestimates** the iso family (real per-4-elem-group layout: 1 code u32 + 1 f32 scale + 4 f32 quaternion, + 1 f32 norm/token) and underestimates rotor (group 3). Consequence: iso3/iso4 are actually net-**negative** on memory at typical head_dims, but the resolve-time net-negative `warn!` never fired.

## Fix
Exact per-family byte math for iso (group 4) and rotor (group 3); generic affine/turbo/planar path unchanged. Side gating via `k_uses_family`/`v_uses_family`: V-only `Iso3/Iso4/Rotor3/Rotor4` keep an 8-bit affine K (generic path); `*Sym` use the family codec on both sides; `*KOnly`/`*Asym` carry it on K.

A new ground-truth test (`estimator_matches_actual_iso_rotor_encode_bytes`) pins the estimate to the actual `iso_encode_fast`/`rotor3_encode` output lengths within ±10%, so the estimator can never drift from the codec.

## Test fallout (corrected, not masked)
Three pre-existing tests asserted `IsoKOnly4` is net-**positive** based on the now-falsified premise that its 4-bit K is a cheap generic pack. Ground truth: `IsoKOnly4` carries the iso quaternion sideband on K (`feeds_bf16_k_at_decode()==false`), no seed-free K-only codec has a cheap generic K (`PlanarK` retains a seed), so iso K-only is genuinely net-negative and grows more negative with context. The three tests are rewritten to assert the corrected physics.

`cargo test -p rmlx-kv-quant` 295 passed; `make model-check` 581 passed; `make lint` clean. Rust-reviewer (Opus) verified the per-family math bit-for-bit and confirmed the test rewrites are honest physics.

Plan: Task 3 (Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)