### PR TITLE
fix(mlx): free in_vec when output-name conversion fails in MetalKernel::new

### DIFF
--- a/crates/rmlx-mlx/src/metal_kernel.rs
+++ b/crates/rmlx-mlx/src/metal_kernel.rs
@@ -97,7 +97,12 @@ impl MetalKernel {
 
         // Build mlx_vector_string for input_names and output_names.
         let in_vec = strings_to_vec_string(input_names)?;
-        let out_vec = strings_to_vec_string(output_names)?;
+        let out_vec = strings_to_vec_string(output_names).inspect_err(|_e| {
+            // SAFETY: in_vec was created just above, is not aliased, and is not
+            // used after this free — release it so the output-name failure path
+            // does not leak the input handle.
+            unsafe { sys::mlx_vector_string_free(in_vec) };
+        })?;
 
         // SAFETY: all CStrings are valid NUL-terminated strings; vectors were
         // created above and are valid for the duration of this call.
@@ -367,6 +372,10 @@ fn strings_to_vec_string(names: &[&str]) -> Result<sys::mlx_vector_string> {
     let vec = unsafe { sys::mlx_vector_string_new() };
     for &s in names {
         let cs = CString::new(s).map_err(|_| {
+            // SAFETY: vec was created above and is not aliased; free it before
+            // returning so the NUL-byte path does not leak the handle (mirrors
+            // the append_value-failure free below).
+            unsafe { sys::mlx_vector_string_free(vec) };
             Error::Mlx(format!(
                 "strings_to_vec_string: string '{s}' contains a NUL byte"
             ))

--- a/crates/rmlx-mlx/src/metal_kernel_tests.rs
+++ b/crates/rmlx-mlx/src/metal_kernel_tests.rs
@@ -60,6 +60,16 @@ fn metal_kernel_add_one_gpu() {
     }
 }
 
+/// A NUL byte in an output name must return Err (not panic) — a regression
+/// guard for the leak-free error paths in `new` and `strings_to_vec_string`
+/// (this asserts the `Err` contract those frees depend on; it cannot itself
+/// observe a leak).
+#[test]
+fn new_rejects_nul_in_output_name() {
+    let r = MetalKernel::new("k", "", "kernel void k() {}", &["inp"], &["out\0bad"]);
+    assert!(r.is_err());
+}
+
 /// Kernel registration with bad source should not panic.
 ///
 /// MLX may defer compilation to first dispatch, so the error may surface


### PR DESCRIPTION
## What
`MetalKernel::new` built two `mlx_vector_string` FFI handles (`in_vec`, `out_vec`). These handles own heap memory with no Rust Drop guard. If the second `strings_to_vec_string(output_names)?` failed (e.g. a NUL byte in an output name), the `?` returned early and `in_vec` leaked.

## Fix
- Free `in_vec` on the output-name failure via `.inspect_err(|_e| unsafe { sys::mlx_vector_string_free(in_vec) })?` — propagates the same error, frees exactly once on the Err path only.
- Sibling leak (caught in review): `strings_to_vec_string`'s NUL-byte path allocated its own `vec` then returned `Err` without freeing it — now frees via `.map_err`, mirroring the existing `append_value`-failure free. The function is leak-free on all paths.

## Test
`new_rejects_nul_in_output_name` pins the `Err` contract the frees depend on (the leak itself isn't observable from safe code). `cargo test -p rmlx-mlx metal_kernel` 3 passed; `make lint` clean.

Rust-reviewer (Opus): clean APPROVE — both handles freed exactly once on every error path, no double-free/UAF.

Plan: Task 5 (Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)