### PR TITLE
refactor(mlx): cache pad constant-mode CString like other mode strings

### DIFF
--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -236,6 +236,7 @@ static CSTR_MXFP4: std::sync::OnceLock<std::ffi::CString> = std::sync::OnceLock:
 static CSTR_NVFP4: std::sync::OnceLock<std::ffi::CString> = std::sync::OnceLock::new();
 static CSTR_ARRAY: std::sync::OnceLock<std::ffi::CString> = std::sync::OnceLock::new();
 static CSTR_CAUSAL: std::sync::OnceLock<std::ffi::CString> = std::sync::OnceLock::new();
+static CSTR_CONSTANT: std::sync::OnceLock<std::ffi::CString> = std::sync::OnceLock::new();
 static CSTR_EMPTY: std::sync::OnceLock<std::ffi::CString> = std::sync::OnceLock::new();
 
 /// Return a `&'static CStr` for a known mode string, or a heap-allocated `CString`.
@@ -284,6 +285,11 @@ pub(crate) fn mode_to_cstr(
         "causal" => Ok(Cow::Borrowed(
             CSTR_CAUSAL
                 .get_or_init(|| CString::new("causal").expect("causal cstr"))
+                .as_c_str(),
+        )),
+        "constant" => Ok(Cow::Borrowed(
+            CSTR_CONSTANT
+                .get_or_init(|| CString::new("constant").expect("constant cstr"))
                 .as_c_str(),
         )),
         "" => Ok(Cow::Borrowed(

--- a/crates/rmlx-mlx/src/ops/shape.rs
+++ b/crates/rmlx-mlx/src/ops/shape.rs
@@ -49,14 +49,10 @@ pub fn conv2d(
 
 /// Pad `a` along the given `axes` with per-axis `(low, high)` zero padding
 /// (constant mode, pad value 0). `low`/`high` line up with `axes` by index.
-#[allow(
-    clippy::expect_used,
-    reason = "CString::new on a hardcoded ASCII literal — interior NUL is impossible"
-)]
 pub fn pad(a: &Array, axes: &[i32], low: &[i32], high: &[i32], device: Device) -> Result<Array> {
     install_error_handler();
     let zero = scalar_f32(0.0);
-    let mode = std::ffi::CString::new("constant").expect("constant cstr");
+    let mode = crate::mode_to_cstr("constant", "pad")?;
     let mut res = unsafe { sys::mlx_array_new() };
     let status = unsafe {
         with_stream(device, |s| {


### PR DESCRIPTION
## What
`pad` heap-allocated `CString::new("constant").expect(...)` on every call to pass the pad mode to `sys::mlx_pad`, inconsistent with the crate's `OnceLock<CString>` mode-string cache.

## Fix
Reuse the existing `mode_to_cstr(mode, ctx) -> Result<Cow<'static, CStr>>` helper (one cache, not two): add a `"constant"` arm + a `CSTR_CONSTANT` static, mirroring the existing `affine`/`causal`/… arms. `pad` now calls `mode_to_cstr("constant", "pad")?` and drops its per-call `expect` + `#[allow(clippy::expect_used)]`. The "constant" path returns `Cow::Borrowed(&'static CStr)` — zero-alloc, no UAF.

## Validation
`cargo test -p rmlx-mlx ops` 4 passed; `cargo clippy -p rmlx-mlx --all-targets -D warnings` clean. Rust-reviewer (Opus): clean APPROVE.

Plan: Task 6 (Phase B). Phase B complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)