### PR TITLE
refactor(models): arch modules import ProbeStep from decode_loop, not gemma4

### DIFF
--- a/crates/rmlx-cli/examples/fused_qk_realmodel_probe.rs
+++ b/crates/rmlx-cli/examples/fused_qk_realmodel_probe.rs
@@ -109,7 +109,7 @@ fn main() -> anyhow::Result<()> {
     let mut first_cb_s: Option<f64> = None;
     let mut last_cb_s: f64 = 0.0;
 
-    let mut step_fn = |_step: &rmlx_models::gemma4::ProbeStep| -> Option<u32> {
+    let mut step_fn = |_step: &rmlx_models::ProbeStep| -> Option<u32> {
         let elapsed = ts_start.elapsed().as_secs_f64();
         if first_cb_s.is_none() {
             first_cb_s = Some(elapsed);

--- a/crates/rmlx-cli/examples/returning_kv_realmodel_probe.rs
+++ b/crates/rmlx-cli/examples/returning_kv_realmodel_probe.rs
@@ -116,7 +116,7 @@ fn main() -> anyhow::Result<()> {
     let mut first_cb_s: Option<f64> = None;
     let mut last_cb_s: f64 = 0.0;
 
-    let mut step_fn = |_step: &rmlx_models::gemma4::ProbeStep| -> Option<u32> {
+    let mut step_fn = |_step: &rmlx_models::ProbeStep| -> Option<u32> {
         let elapsed = ts_start.elapsed().as_secs_f64();
         if first_cb_s.is_none() {
             first_cb_s = Some(elapsed);

--- a/crates/rmlx-cli/src/bin/qwen36_diag.rs
+++ b/crates/rmlx-cli/src/bin/qwen36_diag.rs
@@ -111,7 +111,7 @@ fn main() -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("load tokenizer: {e}"))?;
 
     let mut ids: Vec<u32> = Vec::with_capacity(n_gen);
-    let mut step_fn = |s: &rmlx_models::gemma4::ProbeStep| -> Option<u32> {
+    let mut step_fn = |s: &rmlx_models::ProbeStep| -> Option<u32> {
         ids.push(s.token_id);
         None
     };

--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -264,7 +264,7 @@ pub(crate) fn run_baseline(
     // Per-token callback wall-clocks (elapsed seconds since generate-start).
     let mut first_cb_s: Option<f64> = None;
     let mut last_cb_s: f64 = 0.0;
-    let mut step_timing = |_step: &rmlx_models::gemma4::ProbeStep| -> Option<u32> {
+    let mut step_timing = |_step: &rmlx_models::ProbeStep| -> Option<u32> {
         let elapsed = ts_generate_start.elapsed().as_secs_f64();
         if first_cb_s.is_none() {
             first_cb_s = Some(elapsed);

--- a/crates/rmlx-cli/src/commands/info.rs
+++ b/crates/rmlx-cli/src/commands/info.rs
@@ -452,10 +452,10 @@ pub(crate) fn run_info(
 
         // -- stdout output -------------------------------------------------------
         let verdict_str = match &verdict {
-            rmlx_models::gemma4::SmokeVerdict::Ok => "ok",
-            rmlx_models::gemma4::SmokeVerdict::BrokenPunctLoop { .. } => "broken_punct_loop",
-            rmlx_models::gemma4::SmokeVerdict::BrokenNan { .. } => "broken_nan",
-            rmlx_models::gemma4::SmokeVerdict::Inconclusive { .. } => "inconclusive",
+            rmlx_models::SmokeVerdict::Ok => "ok",
+            rmlx_models::SmokeVerdict::BrokenPunctLoop { .. } => "broken_punct_loop",
+            rmlx_models::SmokeVerdict::BrokenNan { .. } => "broken_nan",
+            rmlx_models::SmokeVerdict::Inconclusive { .. } => "inconclusive",
         };
 
         println!("smoke_probe: {verdict_str}");
@@ -480,10 +480,10 @@ pub(crate) fn run_info(
             .map(|s| s.max_abs_logit)
             .fold(0.0_f32, f32::max);
         let verdict_code: f64 = match &verdict {
-            rmlx_models::gemma4::SmokeVerdict::Ok => 0.0,
-            rmlx_models::gemma4::SmokeVerdict::BrokenPunctLoop { .. } => 1.0,
-            rmlx_models::gemma4::SmokeVerdict::BrokenNan { .. } => 2.0,
-            rmlx_models::gemma4::SmokeVerdict::Inconclusive { .. } => 3.0,
+            rmlx_models::SmokeVerdict::Ok => 0.0,
+            rmlx_models::SmokeVerdict::BrokenPunctLoop { .. } => 1.0,
+            rmlx_models::SmokeVerdict::BrokenNan { .. } => 2.0,
+            rmlx_models::SmokeVerdict::Inconclusive { .. } => 3.0,
         };
 
         sink.record(&Measurement {
@@ -524,8 +524,8 @@ pub(crate) fn run_info(
         // Exit 1 on broken snapshot.
         let is_broken = matches!(
             verdict,
-            rmlx_models::gemma4::SmokeVerdict::BrokenPunctLoop { .. }
-                | rmlx_models::gemma4::SmokeVerdict::BrokenNan { .. }
+            rmlx_models::SmokeVerdict::BrokenPunctLoop { .. }
+                | rmlx_models::SmokeVerdict::BrokenNan { .. }
         );
         return Ok(is_broken);
     }

--- a/crates/rmlx-cli/tests/smoke_probe.rs
+++ b/crates/rmlx-cli/tests/smoke_probe.rs
@@ -132,8 +132,7 @@ fn smoke_probe_gemma4_mxfp8_is_clean() {
     assert!(
         matches!(
             verdict,
-            rmlx_models::gemma4::SmokeVerdict::Ok
-                | rmlx_models::gemma4::SmokeVerdict::Inconclusive { .. }
+            rmlx_models::SmokeVerdict::Ok | rmlx_models::SmokeVerdict::Inconclusive { .. }
         ),
         "expected Ok or Inconclusive verdict for known-clean snapshot, got {verdict:?}"
     );

--- a/crates/rmlx-models/src/arch/loader.rs
+++ b/crates/rmlx-models/src/arch/loader.rs
@@ -378,7 +378,7 @@ pub fn run_smoke_probe(
     device: Device,
     kv_quant: Option<rmlx_kv_quant::KvQuant>,
     max_ctx_override: Option<i32>,
-) -> Result<crate::gemma4::SmokeVerdict> {
+) -> Result<crate::decode_loop::SmokeVerdict> {
     let model = load_model(model_dir, device, &LoadOpts::default())?;
 
     // Resolve BOS token id from tokenizer_config.json.

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -31,8 +31,9 @@ use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{Array, Device};
 
 use crate::bitnet::BitNetText;
+use crate::decode_loop::SmokeVerdict;
 use crate::gemma3::Gemma3Text;
-use crate::gemma4::{Gemma4Text, SmokeVerdict};
+use crate::gemma4::Gemma4Text;
 use crate::laguna::LagunaText;
 use crate::qwen2::Qwen2Text;
 use crate::qwen3::Qwen3Text;
@@ -845,7 +846,7 @@ impl Architecture {
         max_ctx_override: Option<i32>,
         prompt_cache_slots: usize,
         eos_ids: &'a [u32],
-        step_fn: &'a mut dyn FnMut(&crate::gemma4::ProbeStep) -> Option<u32>,
+        step_fn: &'a mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
         // A6.2: optional sampler constraint. `None` = unmasked argmax (the
         // hot path; identical to pre-A6.2 behaviour). `Some(_)` enables the
         // masked branch in each arch's `argmax` call sites; in A6.2 the only
@@ -869,7 +870,7 @@ impl Architecture {
         // to the trailing-20 window before each `apply_penalties` call.
         penalty_cfg: &'a crate::sampler::PenaltyConfig,
         token_history: &'a mut Vec<u32>,
-    ) -> Result<Vec<crate::gemma4::ProbeStep>> {
+    ) -> Result<Vec<crate::decode_loop::ProbeStep>> {
         use crate::kv_cache::KvCacheBuilder;
         use rmlx_kv_quant::KvQuant;
         // Resolve the effective quant: explicit override wins; otherwise ask the builder.
@@ -1080,13 +1081,13 @@ impl Architecture {
         eos_ids: &'a [u32],
         // The per-request borrows share `'a`: the shared decode loop stores
         // them together in one `DecodeCtx<'a>` for the duration of the call.
-        step_fn: &'a mut dyn FnMut(&crate::gemma4::ProbeStep) -> Option<u32>,
+        step_fn: &'a mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
         constraint: Option<&'a mut dyn crate::ConstraintEngine>,
         sampler_cfg: &'a crate::sampler::SamplerConfig,
         rng: &'a mut crate::sampler::Pcg32,
         penalty_cfg: &'a crate::sampler::PenaltyConfig,
         token_history: &'a mut Vec<u32>,
-    ) -> Result<Vec<crate::gemma4::ProbeStep>> {
+    ) -> Result<Vec<crate::decode_loop::ProbeStep>> {
         use crate::kv_cache::KvCacheBuilder;
         use rmlx_kv_quant::KvQuant;
         match self {
@@ -1228,7 +1229,7 @@ impl Architecture {
     }
 
     /// Smoke probe verdict -- delegates to gemma4::classify_smoke for now.
-    pub fn classify_smoke(steps: &[crate::gemma4::ProbeStep]) -> SmokeVerdict {
+    pub fn classify_smoke(steps: &[crate::decode_loop::ProbeStep]) -> SmokeVerdict {
         crate::gemma4::classify_smoke(steps)
     }
 }

--- a/crates/rmlx-models/src/bitnet/generate.rs
+++ b/crates/rmlx-models/src/bitnet/generate.rs
@@ -47,14 +47,14 @@ pub fn generate_greedy(
     kv_quant: rmlx_kv_quant::KvQuant,
     max_ctx_override: Option<i32>,
     eos_ids: &[u32],
-    step_fn: &mut dyn FnMut(&crate::gemma4::ProbeStep) -> Option<u32>,
+    step_fn: &mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
     mut constraint: Option<&mut dyn ConstraintEngine>,
     sampler_cfg: &crate::sampler::SamplerConfig,
     rng: &mut crate::sampler::Pcg32,
     penalty_cfg: &crate::sampler::PenaltyConfig,
     token_history: &mut Vec<u32>,
-) -> Result<Vec<crate::gemma4::ProbeStep>> {
-    use crate::gemma4::ProbeStep;
+) -> Result<Vec<crate::decode_loop::ProbeStep>> {
+    use crate::decode_loop::ProbeStep;
 
     tracing::info!(
         arch = "BitNetForCausalLM",

--- a/crates/rmlx-models/src/gemma3/generate.rs
+++ b/crates/rmlx-models/src/gemma3/generate.rs
@@ -118,7 +118,7 @@ pub fn generate_greedy<'a>(
     // The shared `DecodeCtx` bundles every per-request borrow under one
     // lifetime, so these references share `'a` (a `&mut dyn` trait-object
     // reborrow is invariant and cannot be re-unified once split).
-    step_fn: &'a mut dyn FnMut(&crate::gemma4::ProbeStep) -> Option<u32>,
+    step_fn: &'a mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
     // A6.2: optional sampler constraint. See gemma4::generate_greedy.
     mut constraint: Option<&'a mut dyn ConstraintEngine>,
     // A7.2: sampling config + per-request RNG. `temperature <= 0.0` keeps the
@@ -134,8 +134,8 @@ pub fn generate_greedy<'a>(
     // (image prompts are one-shot) and prefill runs from the embeds in one
     // forward instead of chunked token-id forwards.
     image_prefill: Option<Array>,
-) -> Result<Vec<crate::gemma4::ProbeStep>> {
-    use crate::gemma4::ProbeStep;
+) -> Result<Vec<crate::decode_loop::ProbeStep>> {
+    use crate::decode_loop::ProbeStep;
 
     tracing::info!(
         arch = "Gemma3ForConditionalGeneration",

--- a/crates/rmlx-models/src/laguna/generate.rs
+++ b/crates/rmlx-models/src/laguna/generate.rs
@@ -101,7 +101,7 @@ pub fn generate_greedy(
     kv_quant: rmlx_kv_quant::KvQuant,
     max_ctx_override: Option<i32>,
     eos_ids: &[u32],
-    step_fn: &mut dyn FnMut(&crate::gemma4::ProbeStep) -> Option<u32>,
+    step_fn: &mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
     // A6.2: optional sampler constraint. See gemma4::generate_greedy.
     mut constraint: Option<&mut dyn ConstraintEngine>,
     // A7.2: sampling config + per-request RNG. See gemma3::generate_greedy.
@@ -110,8 +110,8 @@ pub fn generate_greedy(
     // A7.3: logit-penalty configuration + per-request token history.
     penalty_cfg: &crate::sampler::PenaltyConfig,
     token_history: &mut Vec<u32>,
-) -> Result<Vec<crate::gemma4::ProbeStep>> {
-    use crate::gemma4::ProbeStep;
+) -> Result<Vec<crate::decode_loop::ProbeStep>> {
+    use crate::decode_loop::ProbeStep;
 
     tracing::info!(
         arch = "LagunaForCausalLM",

--- a/crates/rmlx-models/src/lib.rs
+++ b/crates/rmlx-models/src/lib.rs
@@ -65,6 +65,7 @@ pub mod ssd_tier;
 
 pub use arch::{is_arch_supported, read_load_phases, LoadPhases};
 pub use constraint::{ConstraintEngine, NoOpConstraint};
+pub use decode_loop::{ProbeStep, SmokeVerdict};
 // The flat `rmlx_models::{KvCache, KvQuant, LinearAttnCache,
 // write_caches, set_ssd_*}` re-exports were dropped. Codec types live at
 // `rmlx_kv_quant::*`, SSD-tier hooks + `write_caches` at `rmlx_kv_ssd::*`.

--- a/crates/rmlx-models/src/qwen2/generate.rs
+++ b/crates/rmlx-models/src/qwen2/generate.rs
@@ -101,7 +101,7 @@ pub fn generate_greedy(
     kv_quant: rmlx_kv_quant::KvQuant,
     max_ctx_override: Option<i32>,
     eos_ids: &[u32],
-    step_fn: &mut dyn FnMut(&crate::gemma4::ProbeStep) -> Option<u32>,
+    step_fn: &mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
     // A6.2: optional sampler constraint. See gemma4::generate_greedy.
     mut constraint: Option<&mut dyn ConstraintEngine>,
     // A7.2: sampling config + per-request RNG. See gemma3::generate_greedy.
@@ -110,8 +110,8 @@ pub fn generate_greedy(
     // A7.3: logit-penalty configuration + per-request token history.
     penalty_cfg: &crate::sampler::PenaltyConfig,
     token_history: &mut Vec<u32>,
-) -> Result<Vec<crate::gemma4::ProbeStep>> {
-    use crate::gemma4::ProbeStep;
+) -> Result<Vec<crate::decode_loop::ProbeStep>> {
+    use crate::decode_loop::ProbeStep;
 
     tracing::info!(
         arch = "Qwen2ForCausalLM",

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -1809,7 +1809,7 @@ pub fn generate_greedy<'a>(
     max_ctx_override: Option<i32>,
     prompt_cache_slots: usize,
     eos_ids: &'a [u32],
-    step_fn: &'a mut dyn FnMut(&crate::gemma4::ProbeStep) -> Option<u32>,
+    step_fn: &'a mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
     // A6.2: optional sampler constraint. See gemma4::generate_greedy.
     // The shared `DecodeCtx` bundles every per-request borrow under one
     // lifetime, so these references share `'a` (a `&mut dyn` trait-object
@@ -1821,8 +1821,8 @@ pub fn generate_greedy<'a>(
     // A7.3: logit-penalty configuration + per-request token history.
     penalty_cfg: &'a crate::sampler::PenaltyConfig,
     token_history: &'a mut Vec<u32>,
-) -> Result<Vec<crate::gemma4::ProbeStep>> {
-    use crate::gemma4::ProbeStep;
+) -> Result<Vec<crate::decode_loop::ProbeStep>> {
+    use crate::decode_loop::ProbeStep;
 
     tracing::info!(
         arch = "Qwen3ForCausalLM",

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -67,7 +67,7 @@ pub fn generate_greedy<'a>(
     // The shared `DecodeCtx` bundles every per-request borrow under one
     // lifetime, so these references share `'a` (a `&mut dyn` trait-object
     // reborrow is invariant and cannot be re-unified once split).
-    step_fn: &'a mut dyn FnMut(&crate::gemma4::ProbeStep) -> Option<u32>,
+    step_fn: &'a mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
     mut constraint: Option<&'a mut dyn ConstraintEngine>,
     // A7.2: sampling config + per-request RNG. See gemma3::generate_greedy.
     sampler_cfg: &'a crate::sampler::SamplerConfig,
@@ -75,8 +75,8 @@ pub fn generate_greedy<'a>(
     // A7.3: logit-penalty configuration + per-request token history.
     penalty_cfg: &'a crate::sampler::PenaltyConfig,
     token_history: &'a mut Vec<u32>,
-) -> Result<Vec<crate::gemma4::ProbeStep>> {
-    use crate::gemma4::ProbeStep;
+) -> Result<Vec<crate::decode_loop::ProbeStep>> {
+    use crate::decode_loop::ProbeStep;
 
     tracing::info!(
         arch = "Qwen3_5MoeForConditionalGeneration",

--- a/crates/rmlx-models/src/qwen3_5_moe/tests.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/tests.rs
@@ -1387,7 +1387,7 @@ fn integration_paro_generate_greedy() {
         prompt_ids.len()
     );
     let mut report = String::new();
-    let mut step_fn = |step: &crate::gemma4::ProbeStep| -> Option<u32> {
+    let mut step_fn = |step: &crate::decode_loop::ProbeStep| -> Option<u32> {
         let line = format!(
             "step {} token_id={}\n",
             report.matches('\n').count(),
@@ -1810,7 +1810,7 @@ fn hydrated_tail_produces_identical_output() {
     let cold_tokens: Vec<u32> = {
         let mut rng = crate::sampler::Pcg32::new(sampler_cfg.seed_or_default());
         let mut token_history: Vec<u32> = Vec::new();
-        let mut step_fn = |_: &crate::gemma4::ProbeStep| -> Option<u32> { None };
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
         let steps = generate_greedy(
             &model,
             // Tokenizer is only needed for piece strings in ProbeStep; we can
@@ -1935,7 +1935,7 @@ fn hydrated_tail_produces_identical_output() {
     let warm_tokens: Vec<u32> = {
         let mut rng = crate::sampler::Pcg32::new(sampler_cfg.seed_or_default());
         let mut token_history: Vec<u32> = Vec::new();
-        let mut step_fn = |_: &crate::gemma4::ProbeStep| -> Option<u32> { None };
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
         let steps = generate_greedy(
             &model,
             &tokenizers::Tokenizer::from_file(model_dir.join("tokenizer.json"))
@@ -2014,7 +2014,7 @@ fn hydrated_tail_produces_identical_output() {
     let divergent_tokens: Vec<u32> = {
         let mut rng = crate::sampler::Pcg32::new(sampler_cfg.seed_or_default());
         let mut token_history: Vec<u32> = Vec::new();
-        let mut step_fn = |_: &crate::gemma4::ProbeStep| -> Option<u32> { None };
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
         let steps = generate_greedy(
             &model,
             &tokenizers::Tokenizer::from_file(model_dir.join("tokenizer.json"))
@@ -2188,7 +2188,7 @@ fn hydrated_exact_block_no_tail_not_placeholder() {
     let cold_tokens: Vec<u32> = {
         let mut rng = crate::sampler::Pcg32::new(sampler_cfg.seed_or_default());
         let mut token_history: Vec<u32> = Vec::new();
-        let mut step_fn = |_: &crate::gemma4::ProbeStep| -> Option<u32> { None };
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
         let steps = generate_greedy(
             &model,
             &tokenizers::Tokenizer::from_file(model_dir.join("tokenizer.json"))
@@ -2311,7 +2311,7 @@ fn hydrated_exact_block_no_tail_not_placeholder() {
     let warm_tokens: Vec<u32> = {
         let mut rng = crate::sampler::Pcg32::new(sampler_cfg.seed_or_default());
         let mut token_history: Vec<u32> = Vec::new();
-        let mut step_fn = |_: &crate::gemma4::ProbeStep| -> Option<u32> { None };
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
         let steps = generate_greedy(
             &model,
             &tokenizers::Tokenizer::from_file(model_dir.join("tokenizer.json"))
@@ -2465,7 +2465,7 @@ fn hydrated_tail_k8v8_equivalence() {
     let cold_tokens: Vec<u32> = {
         let mut rng = crate::sampler::Pcg32::new(sampler_cfg.seed_or_default());
         let mut token_history: Vec<u32> = Vec::new();
-        let mut step_fn = |_: &crate::gemma4::ProbeStep| -> Option<u32> { None };
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
         let steps = generate_greedy(
             &model,
             &tokenizers::Tokenizer::from_file(model_dir.join("tokenizer.json"))
@@ -2576,7 +2576,7 @@ fn hydrated_tail_k8v8_equivalence() {
     let warm_tokens: Vec<u32> = {
         let mut rng = crate::sampler::Pcg32::new(sampler_cfg.seed_or_default());
         let mut token_history: Vec<u32> = Vec::new();
-        let mut step_fn = |_: &crate::gemma4::ProbeStep| -> Option<u32> { None };
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
         let steps = generate_greedy(
             &model,
             &tokenizers::Tokenizer::from_file(model_dir.join("tokenizer.json"))

--- a/crates/rmlx-models/src/qwen3_vl_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_vl_moe/generate.rs
@@ -20,7 +20,7 @@ use rmlx_core::error::Result;
 use rmlx_mlx::{Array, Device, Dtype};
 
 use crate::constraint::ConstraintEngine;
-use crate::gemma4::ProbeStep;
+use crate::decode_loop::ProbeStep;
 use crate::sampler::{apply_mask_argmax, sample_token_array, Pcg32, PenaltyConfig, SamplerConfig};
 use rmlx_kv_quant::{KvCache, KvQuant};
 

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -612,7 +612,7 @@ pub fn walk_block_greedy(
     (accepted, new_tokens)
 }
 
-use crate::gemma4::ProbeStep;
+use crate::decode_loop::ProbeStep;
 
 /// Emit a single token through `step_fn` + the running `emitted` buffer.
 fn emit_step(

--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -118,7 +118,7 @@ use rmlx_mlx::{add, argmax, concatenate, rope, Array, Device};
 
 use super::dflash::DFlashRoundState;
 use crate::arch::Architecture;
-use crate::gemma4::ProbeStep;
+use crate::decode_loop::ProbeStep;
 use crate::layers::{Activation, Linear, Mlp, RmsNorm};
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache, KV_MAX_SEQ_DEFAULT};
 

--- a/crates/rmlx-models/src/speculative/gemma4_assistant.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant.rs
@@ -683,7 +683,7 @@ fn load_assistant(
 // Round-loop (greedy MTP, port of _mtp_rounds + _mtp_acceptance_walk)
 // ---------------------------------------------------------------------------
 
-use crate::gemma4::ProbeStep;
+use crate::decode_loop::ProbeStep;
 use crate::kv_cache::{KvCacheBuilder, ResolverSignals};
 use rmlx_kv_quant::{KvCache, KvQuant, KV_MAX_SEQ_DEFAULT};
 use std::time::Instant;

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -44,7 +44,7 @@ use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{argmax, Array, Device, Dtype};
 
 use crate::arch::{load_model, Architecture, LoadOpts};
-use crate::gemma4::ProbeStep;
+use crate::decode_loop::ProbeStep;
 use crate::kv_cache::KvCacheBuilder;
 pub use draft_kind::DraftKind;
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache, KV_MAX_SEQ_DEFAULT};

--- a/crates/rmlx-models/src/speculative/mtp.rs
+++ b/crates/rmlx-models/src/speculative/mtp.rs
@@ -568,7 +568,7 @@ pub fn walk_deferred_greedy(
     Ok((accepted, new_tokens))
 }
 
-use crate::gemma4::ProbeStep;
+use crate::decode_loop::ProbeStep;
 
 /// Emit a single token through `step_fn` + the running `emitted` buffer.
 fn emit_step(

--- a/crates/rmlx-models/tests/dflash_drafter_alignment.rs
+++ b/crates/rmlx-models/tests/dflash_drafter_alignment.rs
@@ -202,7 +202,7 @@ fn dflash_live_loop_emits_coherent() {
     let prompt_ids: Vec<u32> = enc.get_ids().to_vec();
 
     let mut emitted_ids: Vec<u32> = Vec::new();
-    let mut step_fn = |s: &rmlx_models::gemma4::ProbeStep| {
+    let mut step_fn = |s: &rmlx_models::ProbeStep| {
         emitted_ids.push(s.token_id);
         None
     };

--- a/crates/rmlx-models/tests/gemma4_mtp_drafter_alignment.rs
+++ b/crates/rmlx-models/tests/gemma4_mtp_drafter_alignment.rs
@@ -125,7 +125,7 @@ fn mtp_assistant_accept_rate_is_high() {
     // covers n_tokens in far fewer rounds. We assert the loop returns the full
     // budget AND the output is coherent prose.
     let mut emitted: Vec<u32> = Vec::new();
-    let mut step_fn = |s: &rmlx_models::gemma4::ProbeStep| {
+    let mut step_fn = |s: &rmlx_models::ProbeStep| {
         emitted.push(s.token_id);
         None
     };

--- a/crates/rmlx-runtime/src/decode_loop.rs
+++ b/crates/rmlx-runtime/src/decode_loop.rs
@@ -7,16 +7,16 @@
 //! refactor (chunked prefill + decode + decode-profile timers) is deferred
 //! until at least three archs have migrated to the runtime helpers
 //! provided here. Reason: the existing per-arch `generate_greedy` functions
-//! all return `crate::gemma4::ProbeStep` today, so introducing a
-//! `runtime::ProbeStep` and rewriting one arch's `generate_greedy` would
-//! force a cross-arch type rename that the task explicitly forbids
-//! ("no changes to non-migrated arches").
+//! all return `rmlx_models::ProbeStep` (defined in `rmlx_models::decode_loop`
+//! and re-exported at the crate root). Introducing a `runtime::ProbeStep`
+//! and rewriting one arch's `generate_greedy` would force a cross-arch type
+//! rename that the task explicitly forbids ("no changes to non-migrated arches").
 //!
 //! What is provided here right now:
 //! - [`ProbeStep`], [`SmokeVerdict`], [`DecodeProfile`] — runtime-native
 //!   types that future arches and the unified `generate_greedy` will use.
-//!   Structurally identical to `crate::gemma4::ProbeStep` /
-//!   `crate::gemma4::SmokeVerdict`. They co-exist for now and the gemma4
+//!   Structurally identical to `rmlx_models::ProbeStep` /
+//!   `rmlx_models::SmokeVerdict`. They co-exist for now and the models-crate
 //!   versions will be migrated to type aliases in a follow-up.
 //! - [`PREFILL_CHUNK`] — the standard 64-token prefill chunk size (Metal
 //!   watchdog safety margin).
@@ -38,8 +38,8 @@ pub const PREFILL_CHUNK: usize = 64;
 
 /// One record per autoregressive step.
 ///
-/// Mirrors [`rmlx_models::gemma4::ProbeStep`] field-for-field. Once all six
-/// arch graphs migrate to the runtime crate, the gemma4 version becomes a
+/// Mirrors [`rmlx_models::ProbeStep`] field-for-field. Once all six
+/// arch graphs migrate to the runtime crate, the models-crate version becomes a
 /// type alias.
 #[allow(
     clippy::exhaustive_structs,
@@ -58,7 +58,7 @@ pub struct ProbeStep {
 }
 
 /// Verdict returned by `classify_smoke`. Mirrors
-/// [`rmlx_models::gemma4::SmokeVerdict`] variant-for-variant.
+/// [`rmlx_models::SmokeVerdict`] variant-for-variant.
 #[allow(
     clippy::exhaustive_enums,
     reason = "closed dispatch enum — four smoke outcomes; adding an outcome requires updating classify_smoke and all verdict consumers"

--- a/crates/rmlx-server/src/engine/arch_generator.rs
+++ b/crates/rmlx-server/src/engine/arch_generator.rs
@@ -786,7 +786,7 @@ impl Generator for ArchGenerator {
             // the budget-unset path always returns `None` after a single
             // `Option`-discriminant + bool check, so the hot loop is
             // unchanged when no budget is set.
-            let mut step_fn = |s: &rmlx_models::gemma4::ProbeStep| -> Option<u32> {
+            let mut step_fn = |s: &rmlx_models::ProbeStep| -> Option<u32> {
                 // M30: record step arrival time for ITL computation.
                 // Instant::now() on macOS is a single rdtsc-equivalent syscall,
                 // ~3 ns; negligible vs the 8–15 ms decode step.

--- a/crates/rmlx-server/src/engine/image.rs
+++ b/crates/rmlx-server/src/engine/image.rs
@@ -229,14 +229,14 @@ pub(crate) fn run_qwen3vl_image(
     kv_quant_override: Option<rmlx_kv_quant::KvQuant>,
     eos_ids: &[u32],
     tokenizer: &tokenizers::Tokenizer,
-    step_fn: &mut dyn FnMut(&rmlx_models::gemma4::ProbeStep) -> Option<u32>,
+    step_fn: &mut dyn FnMut(&rmlx_models::ProbeStep) -> Option<u32>,
     constraint: Option<&mut dyn rmlx_models::ConstraintEngine>,
     sampler_cfg: &rmlx_models::SamplerConfig,
     rng: &mut rmlx_models::Pcg32,
     penalty_cfg: &rmlx_models::PenaltyConfig,
     token_history: &mut Vec<u32>,
     mm_cache: Option<&rmlx_models::multimodal_cache::MultimodalCache>,
-) -> rmlx_core::Result<Vec<rmlx_models::gemma4::ProbeStep>> {
+) -> rmlx_core::Result<Vec<rmlx_models::ProbeStep>> {
     let (vision, processor) = match vb {
         VisionBundle::Qwen3VlMoe { vision, processor } => (vision, processor),
         _ => {

--- a/crates/rmlx-server/src/engine/speculative.rs
+++ b/crates/rmlx-server/src/engine/speculative.rs
@@ -742,7 +742,7 @@ impl Generator for SpeculativeGenerator {
             // so `think_splitter` is `None` here and this always returns
             // `None`, but the wiring is symmetric for a future thinking
             // verifier (L36).
-            let mut step_fn = |s: &rmlx_models::gemma4::ProbeStep| -> Option<u32> {
+            let mut step_fn = |s: &rmlx_models::ProbeStep| -> Option<u32> {
                 // M30: record step arrival time for ITL computation.
                 timestamps_ref.push(Instant::now());
                 if *cancelled_ref {

--- a/crates/rmlx-server/src/openai/state.rs
+++ b/crates/rmlx-server/src/openai/state.rs
@@ -862,7 +862,7 @@ impl AppState {
             )
             .map_err(|e| format!("smoke probe error for '{model_id}': {e}"))?;
 
-            use rmlx_models::gemma4::SmokeVerdict;
+            use rmlx_models::SmokeVerdict;
             match &verdict {
                 SmokeVerdict::Ok | SmokeVerdict::Inconclusive { .. } => {
                     tracing::info!(model_id, ?verdict, "B5: smoke probe passed");


### PR DESCRIPTION
## What
Every non-gemma4 reference to `ProbeStep`/`SmokeVerdict` went through `crate::gemma4::` / `rmlx_models::gemma4::` — a foreign arch name leaking across the codebase for model-agnostic types.

## Fix
Migrate all 29 usage sites onto the arch-neutral path:
- Added `pub use decode_loop::{ProbeStep, SmokeVerdict};` to `rmlx-models/src/lib.rs` (external crates → `rmlx_models::ProbeStep`).
- Internal rmlx-models non-gemma4 sites → `crate::decode_loop::ProbeStep`.
- Split grouped imports surgically (e.g. `arch/mod.rs`: `Gemma4Text` stays on the gemma4 path, `SmokeVerdict` moves).
- rmlx-server/cli external sites → `rmlx_models::{ProbeStep,SmokeVerdict}`; stale prose doc-comments in rmlx-runtime updated.

The gemma4 re-export chain is unchanged (`gemma4::ProbeStep` is the *same* type via re-export — zero behavior change); removing it is a future follow-up. Gate `grep "gemma4::ProbeStep\|gemma4::SmokeVerdict" crates/ | grep -v gemma4/` → zero hits.

`make check`/`make lint` clean, `cargo test -p rmlx-models` 585 passed, rmlx-server/cli build clean. Rust-reviewer (Opus): clean APPROVE (surgical, no collateral, no behavior change).

Plan: Task 7b (Phase C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)