### PR TITLE
refactor(kv-quant): rename refuses_qwen_moe to k_below_8bit

### DIFF
--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -462,14 +462,16 @@ impl KvQuant {
         matches!(self, KvQuant::RotKTq4V)
     }
 
-    /// True for KV codecs that put K below 8-bit, which is catastrophic on
-    /// Qwen MoE (PPL 218 → 8641 per CLAUDE.md). Used by `validate_resolved` to
-    /// hard-reject explicit `--kv-quant tsym4` on a Qwen MoE arch. `K8V4` /
-    /// `K8V8` / `Planar` / `K8VTurbo3` keep K at 8-bit and are NOT included.
+    /// True for KV codecs that store K below 8 bits. Sub-8-bit K is
+    /// catastrophic on high-GQA architectures (measured: Qwen MoE PPL
+    /// 218 → 8641). `validate_resolved` in `rmlx-models` decides which
+    /// archs reject these codecs — this predicate only names the codec
+    /// property. `K8V4` / `K8V8` / `Planar` / `K8VTurbo3` keep K at
+    /// 8-bit and are NOT included.
     ///
-    /// `PlanarK` is guarded separately via a dedicated `QwenMoePlanarKRejected`
-    /// error (Contract A.y) before this check runs.
-    pub fn refuses_qwen_moe(&self) -> bool {
+    /// `PlanarK` is guarded separately (dedicated resolve error) before
+    /// this check runs.
+    pub fn k_below_8bit(&self) -> bool {
         matches!(
             self,
             KvQuant::TurboSym3

--- a/crates/rmlx-models/src/kv_cache/cache_type.rs
+++ b/crates/rmlx-models/src/kv_cache/cache_type.rs
@@ -1556,7 +1556,7 @@ pub fn validate_resolved(arch_class: &str, kq: &KvQuant) -> Result<(), ResolveEr
         }
         // Contract A.y — IsoQuant K-side codecs are surfaced via a
         // dedicated error so the diagnostic names the variant. Runs BEFORE the
-        // generic `refuses_qwen_moe → QwenMoeKBitsTooLow(4)` fallthrough.
+        // generic `k_below_8bit → QwenMoeKBitsTooLow(4)` fallthrough.
         if matches!(
             kq,
             KvQuant::Iso3Sym | KvQuant::Iso4Sym | KvQuant::IsoKOnly3 | KvQuant::IsoKOnly4
@@ -1593,7 +1593,7 @@ pub fn validate_resolved(arch_class: &str, kq: &KvQuant) -> Result<(), ResolveEr
         }
         // Contract A.y — TurboSym3 (symmetric WHT-3 K+V) is K-side
         // 3-bit on Qwen MoE — rejected with a dedicated error so the diagnostic
-        // names the variant. Runs after rotor guard and before `refuses_qwen_moe`.
+        // names the variant. Runs after rotor guard and before `k_below_8bit`.
         if matches!(kq, KvQuant::TurboSym3) {
             tracing::warn!(
                 arch = arch_class,
@@ -1608,7 +1608,7 @@ pub fn validate_resolved(arch_class: &str, kq: &KvQuant) -> Result<(), ResolveEr
         // the PPL-218→8641 disaster path on Qwen MoE (CLAUDE.md hard rule 6).
         // Surface as `QwenMoeKBitsTooLow(4)` so the error class is uniform with
         // the existing Mixed K<8 rejection — same exit code, same hint text.
-        if kq.refuses_qwen_moe() {
+        if kq.k_below_8bit() {
             tracing::warn!(
                 arch = arch_class,
                 kv_quant = ?kq,


### PR DESCRIPTION
## What
`KvQuant::refuses_qwen_moe()` baked an arch name into the codec-leaf crate (`rmlx-kv-quant`), violating the CLAUDE.md dep-graph rule that the codec leaf must not carry arch names. The actual property is: K stored below 8 bits (catastrophic PPL on high-GQA archs).

## Fix
Rename to `k_below_8bit()`, doc rewritten to lead with the codec property (Qwen MoE PPL 218→8641 kept only as a measured example). `validate_resolved` in `rmlx-models` still decides which archs reject these codecs. The `QwenMoe*Rejected`/`QwenMoeKBitsTooLow` error variants stay (operator-visible; separate tracked item).

Match-arm body byte-identical (all 12 flagged variants verified K<8bit; K8V4/K8V8/Planar/K8VTurbo3 correctly excluded). Gate `grep refuses_qwen_moe crates/` → zero hits. `make check`/`make lint` clean, `rmlx-kv-quant` 295 + `rmlx-models kv_cache` 183 passed. Rust-reviewer (Opus): clean APPROVE.

Plan: Task 8 (Phase C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)