### PR TITLE
refactor(server): prompt-cache stats dispatch through Architecture::cache_stats

### DIFF
--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -1204,6 +1204,26 @@ impl Architecture {
         }
     }
 
+    /// Prompt-cache stats for the arch's shared PromptCache, when it has one.
+    ///
+    /// Reads the arch-specific global static that `generate_greedy` writes after
+    /// each generation call.  Returns `None` for architectures that do not yet
+    /// maintain a shared PromptCache (Qwen2, BitNet, Laguna, Qwen3VlMoe).
+    #[allow(
+        clippy::wildcard_enum_match_arm,
+        reason = "archs without a shared PromptCache fall through to None"
+    )]
+    pub fn cache_stats(&self) -> Option<crate::CacheStats> {
+        match self {
+            Architecture::Gemma4(_) | Architecture::Gemma3(_) => {
+                crate::gemma4::gemma4_cache_stats()
+            }
+            Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::qwen3_5_moe_cache_stats(),
+            Architecture::Qwen3(_) => crate::qwen3::read_cache_stats(),
+            _ => None,
+        }
+    }
+
     /// Actual on-device KV-cache bytes used by the most recent `generate_greedy`
     /// call on this architecture.
     ///

--- a/crates/rmlx-server/src/engine/arch_generator.rs
+++ b/crates/rmlx-server/src/engine/arch_generator.rs
@@ -395,24 +395,8 @@ impl Generator for ArchGenerator {
         self.effective_max_ctx
     }
 
-    #[allow(
-        clippy::wildcard_enum_match_arm,
-        reason = "wildcard arm is the correct fallthrough for unsupported arch/quant/error variants"
-    )]
     fn cache_stats(&self) -> Option<rmlx_models::CacheStats> {
-        // Dispatch to the arch-specific global static based on the loaded arch.
-        match self.model.as_ref() {
-            rmlx_models::arch::Architecture::Gemma4(_)
-            | rmlx_models::arch::Architecture::Gemma3(_) => {
-                rmlx_models::gemma4::gemma4_cache_stats()
-            }
-            rmlx_models::arch::Architecture::Qwen3_5Moe(_) => {
-                rmlx_models::qwen3_5_moe::qwen3_5_moe_cache_stats()
-            }
-            rmlx_models::arch::Architecture::Qwen3(_) => rmlx_models::qwen3::read_cache_stats(),
-            // Other archs don't use the shared PromptCache (yet).
-            _ => None,
-        }
+        self.model.cache_stats()
     }
 
     #[allow(
@@ -1023,17 +1007,7 @@ impl Generator for ArchGenerator {
             // since we are outside generate_greedy at this point).
             // F6/L18: also emit via SPSC drainer for SQLite persistence.
             {
-                use rmlx_models::arch::Architecture;
-                let cs_opt = match model.as_ref() {
-                    Architecture::Gemma4(_) | Architecture::Gemma3(_) => {
-                        rmlx_models::gemma4::gemma4_cache_stats()
-                    }
-                    Architecture::Qwen3_5Moe(_) => {
-                        rmlx_models::qwen3_5_moe::qwen3_5_moe_cache_stats()
-                    }
-                    Architecture::Qwen3(_) => rmlx_models::qwen3::read_cache_stats(),
-                    _ => None,
-                };
+                let cs_opt = model.cache_stats();
                 if let Some(cs) = cs_opt {
                     let total = cs.hits + cs.misses;
                     let hit_rate = if total == 0 {


### PR DESCRIPTION
## What
The server (`arch_generator.rs`) switched on model arch in TWO places to fetch prompt-cache stats — a model-agnosticism leak (the server shouldn't know arch internals).

## Fix
Add `Architecture::cache_stats(&self) -> Option<CacheStats>` in rmlx-models (same arch→fn mapping: Gemma4/Gemma3→`gemma4_cache_stats`, Qwen3_5Moe→`qwen3_5_moe_cache_stats`, Qwen3→`read_cache_stats`, else `None`). The server's `impl Generator::cache_stats` and the post-generation tracing block both delegate to `model.cache_stats()`. The `#[allow(wildcard_enum_match_arm)]` moved onto the new method. `SpeculativeGenerator` (hardcoded Gemma4 verifier, not an arch dispatch) left as-is.

Zero behavior change — both original matches were identical; reviewer confirmed downstream `Option` consumption byte-identical. `make check`/`make lint` clean, `rmlx-models`+`rmlx-server` 1121 tests passed. Rust-reviewer (Opus): clean APPROVE.

Plan: Task 9a (Phase C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)