### PR TITLE
refactor(server): KV byte reporting dispatches through Architecture::kv_cache_bytes

### DIFF
--- a/crates/rmlx-server/src/engine/arch_generator.rs
+++ b/crates/rmlx-server/src/engine/arch_generator.rs
@@ -399,22 +399,8 @@ impl Generator for ArchGenerator {
         self.model.cache_stats()
     }
 
-    #[allow(
-        clippy::wildcard_enum_match_arm,
-        reason = "wildcard arm is the correct fallthrough for unsupported arch/quant/error variants"
-    )]
     fn kv_cache_bytes(&self) -> u64 {
-        match self.model.as_ref() {
-            rmlx_models::arch::Architecture::Gemma4(_)
-            | rmlx_models::arch::Architecture::Gemma3(_) => {
-                rmlx_models::gemma4::gemma4_kv_cache_bytes()
-            }
-            rmlx_models::arch::Architecture::Qwen3_5Moe(_) => {
-                rmlx_models::qwen3_5_moe::qwen3_5_moe_kv_cache_bytes()
-            }
-            rmlx_models::arch::Architecture::Qwen3(_) => rmlx_models::qwen3::read_kv_cache_bytes(),
-            _ => 0,
-        }
+        self.model.kv_cache_bytes()
     }
 
     fn load_phases(&self) -> Option<rmlx_models::LoadPhases> {
@@ -1106,17 +1092,7 @@ impl Generator for ArchGenerator {
             // boundary — no lock contention with inference at this point.
             // F6/L18: also emit via SPSC drainer for SQLite persistence.
             {
-                use rmlx_models::arch::Architecture;
-                let kv_bytes = match model.as_ref() {
-                    Architecture::Gemma4(_) | Architecture::Gemma3(_) => {
-                        rmlx_models::gemma4::gemma4_kv_cache_bytes()
-                    }
-                    Architecture::Qwen3_5Moe(_) => {
-                        rmlx_models::qwen3_5_moe::qwen3_5_moe_kv_cache_bytes()
-                    }
-                    Architecture::Qwen3(_) => rmlx_models::qwen3::read_kv_cache_bytes(),
-                    _ => 0,
-                };
+                let kv_bytes = model.kv_cache_bytes();
                 // Reuse `kv_quant_label` so payload-bearing
                 // variants (RotorK*Asym, Mixed, RotK) render with their full
                 // tag (e.g. `rotor_k_3_asym_v8_g128`). Previously this match


### PR DESCRIPTION
## What
The server had TWO arch-dispatch matches computing KV-cache bytes (`impl Generator::kv_cache_bytes` + an inline tracing block) — a model-agnosticism leak, and they duplicated logic that already lived (in better form) in `Architecture::kv_cache_bytes()`.

## Fix
Both server sites delegate to the pre-existing exhaustive `self.model.kv_cache_bytes()` method. The `#[allow(wildcard_enum_match_arm)]` and a block-scoped `use Architecture` are dropped.

### Behavior note — Gemma3 telemetry refinement
The old server match grouped `Gemma4 | Gemma3 => gemma4_kv_cache_bytes()`. The blessed method maps `Gemma3 => 0` (Gemma3's generate path never calls `store_kv_cache_bytes`, so the Gemma4 global would read 0 — or a **stale Gemma4 value** if both were loaded in one process). After delegation, a Gemma3 model reports KV bytes = 0, which is strictly more correct (kills a cross-model stale telemetry leak). Reporting value only, not inference. All other arches map identically to the old match.

`make check`/`make lint` clean, `rmlx-server` 536 + `rmlx-models` 585 passed. Rust-reviewer (Opus): clean APPROVE (adjudicated the Gemma3 change sound).

Plan: Task 9b (Phase C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)