### PR TITLE
refactor(server): arch-pinned auto-KV default dispatches through Architecture

### DIFF
--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -1248,6 +1248,23 @@ impl Architecture {
         }
     }
 
+    /// Arch-pinned auto-KV default, when the arch must not take the
+    /// ctx-based quant policy. `None` = use the normal auto policy.
+    #[allow(
+        clippy::wildcard_enum_match_arm,
+        reason = "only archs with a measured quantized-KV degradation pin a default"
+    )]
+    pub fn preferred_auto_kv(&self) -> Option<rmlx_kv_quant::KvQuant> {
+        match self {
+            // Qwen3-VL-MoE degrades under quantized KV (K8V4/K8V8) — both
+            // text and image decode go incoherent on this 4-bit checkpoint.
+            // Pin its auto default to bf16 (None) rather than the ctx-based
+            // quant policy.
+            Architecture::Qwen3VlMoe(_) => Some(rmlx_kv_quant::KvQuant::None),
+            _ => None,
+        }
+    }
+
     /// Smoke probe verdict -- delegates to gemma4::classify_smoke for now.
     pub fn classify_smoke(steps: &[crate::decode_loop::ProbeStep]) -> SmokeVerdict {
         crate::gemma4::classify_smoke(steps)

--- a/crates/rmlx-server/src/engine/arch_generator.rs
+++ b/crates/rmlx-server/src/engine/arch_generator.rs
@@ -489,16 +489,9 @@ impl Generator for ArchGenerator {
             Some(rq)
         } else if self.kv_quant_user_explicit {
             self.kv_quant_override
-        } else if matches!(
-            self.model.as_ref(),
-            rmlx_models::arch::Architecture::Qwen3VlMoe(_)
-        ) {
-            // Qwen3-VL-MoE degrades under quantized KV (K8V4/K8V8) — both
-            // text and image decode go incoherent on this 4-bit checkpoint.
-            // Pin its auto default to the arch-resolved bf16 (None) rather than
-            // the ctx-based quant policy.
-            tracing::info!("generate: Qwen3-VL-MoE auto-KV pinned to bf16 (None)");
-            Some(rmlx_kv_quant::KvQuant::None)
+        } else if let Some(pin) = self.model.preferred_auto_kv() {
+            tracing::info!(?pin, "generate: arch pinned auto-KV default");
+            Some(pin)
         } else {
             let ctx_quant = rmlx_models::kv_cache::kv_quant_for_ctx(prompt_tokens.len());
             tracing::info!(


### PR DESCRIPTION
## What
The server's `kv_quant_override` chain had an `else if matches!(arch, Qwen3VlMoe)` branch pinning Qwen3-VL-MoE auto-KV to bf16 — arch knowledge baked into the server.

## Fix
Move it into `Architecture::preferred_auto_kv(&self) -> Option<KvQuant>` (Qwen3VlMoe → `Some(None)`, else `None`). The server branch becomes `else if let Some(pin) = self.model.preferred_auto_kv()`. The ctx-based `else` arm is byte-identical; the arch rationale comment moved into the method.

Predicate-equivalent (third arm fires iff Qwen3-VL-MoE; pinned value unchanged; all other archs fall through to the ctx branch as before). Only observable delta is the tracing message (now generic `"arch pinned auto-KV default"` with a `?pin` field; old string has zero parsers in the repo). `make check`/`make lint` clean, `rmlx-models`+`rmlx-server` 1121 tests passed. Rust-reviewer (Opus): clean APPROVE.

Plan: Task 9c (Phase C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)