### PR TITLE
fix(server): adaptive prefill-chunk fallback resolves the loaded arch, not gemma4

### DIFF
--- a/crates/rmlx-cli/src/commands/serve.rs
+++ b/crates/rmlx-cli/src/commands/serve.rs
@@ -1173,11 +1173,25 @@ pub(crate) fn run_serve(
         // Must happen after AppState is built but before accepting connections.
         // Mutates state.admission_controller and spawns the background tick task.
         if adaptive_admission {
+            // Resolve the primary model's prefill-chunk arch key from the registry
+            // (the per-model config class name, mapped to a module-style key). The
+            // controller's prefill-chunk fallback is process-wide; with a single
+            // --model there is exactly one entry. Empty string → conservative
+            // FALLBACK chunk, never the oversized gemma4 default.
+            let prefill_arch = state
+                .registry
+                .list()
+                .first()
+                .map_or("", |e| {
+                    rmlx_models::prefill_chunk::module_key_for_class(&e.arch)
+                })
+                .to_owned();
             let ctrl = rmlx_server::ControllerHandle::new(
                 rmlx_server::ControllerConfig::new(
                     ttft_target_ms, // M2: flag --ttft-target-ms maps to step_target_ms
                     itl_target_ms,
                     max_queue_depth.max(1),
+                    prefill_arch,
                 )
                 .with_adaptive_prefill_chunk(adaptive_prefill_chunk),
                 state.metrics.clone(),

--- a/crates/rmlx-models/src/prefill_chunk.rs
+++ b/crates/rmlx-models/src/prefill_chunk.rs
@@ -99,6 +99,26 @@ pub fn prefill_chunk_for(arch: &str) -> usize {
     arch_default(arch).unwrap_or(FALLBACK)
 }
 
+/// Map a config `architectures[0]` class name (e.g. `"Qwen3ForCausalLM"`) to
+/// the module-style key understood by [`prefill_chunk_for`]. Unknown classes
+/// return `""`, which `prefill_chunk_for` resolves to the conservative
+/// `FALLBACK` chunk — never the oversized gemma4 default.
+pub fn module_key_for_class(arch_class: &str) -> &'static str {
+    match arch_class {
+        "Gemma4ForConditionalGeneration" | "Gemma4UnifiedForConditionalGeneration" => "gemma4",
+        "Gemma3ForConditionalGeneration" => "gemma3",
+        "Qwen2ForCausalLM" => "qwen2",
+        "Qwen3ForCausalLM" => "qwen3",
+        "LagunaForCausalLM" => "laguna",
+        "Qwen3_5MoeForConditionalGeneration" | "Qwen3_5ForConditionalGeneration" => "qwen3_5_moe",
+        "BitNetForCausalLM" => "bitnet",
+        // Qwen3VLMoe (single-shot prefill, no `prefill_chunk_for` call) and any
+        // unsupported class: no dedicated prefill-chunk row, fall through to
+        // FALLBACK (safe, conservative).
+        _ => "",
+    }
+}
+
 fn arch_default(arch: &str) -> Option<usize> {
     match arch {
         "qwen3" => Some(256),

--- a/crates/rmlx-models/src/prefill_chunk_tests.rs
+++ b/crates/rmlx-models/src/prefill_chunk_tests.rs
@@ -20,6 +20,66 @@ fn defaults_match_recommendations() {
 }
 
 #[test]
+fn module_key_for_class_maps_supported_classes() {
+    // Each supported config `architectures[0]` class maps to the same
+    // module-style key its own generate path passes to `prefill_chunk_for`.
+    assert_eq!(
+        module_key_for_class("Gemma4ForConditionalGeneration"),
+        "gemma4"
+    );
+    assert_eq!(
+        module_key_for_class("Gemma4UnifiedForConditionalGeneration"),
+        "gemma4"
+    );
+    assert_eq!(
+        module_key_for_class("Gemma3ForConditionalGeneration"),
+        "gemma3"
+    );
+    assert_eq!(module_key_for_class("Qwen2ForCausalLM"), "qwen2");
+    assert_eq!(module_key_for_class("Qwen3ForCausalLM"), "qwen3");
+    assert_eq!(module_key_for_class("LagunaForCausalLM"), "laguna");
+    assert_eq!(
+        module_key_for_class("Qwen3_5MoeForConditionalGeneration"),
+        "qwen3_5_moe"
+    );
+    assert_eq!(
+        module_key_for_class("Qwen3_5ForConditionalGeneration"),
+        "qwen3_5_moe"
+    );
+    assert_eq!(module_key_for_class("BitNetForCausalLM"), "bitnet");
+
+    // Unknown / single-shot-prefill classes → "" → FALLBACK chunk, never the
+    // oversized gemma4 default.
+    assert_eq!(
+        module_key_for_class("Qwen3VLMoeForConditionalGeneration"),
+        ""
+    );
+    assert_eq!(module_key_for_class("JinaEmbeddingsV4Model"), "");
+    assert_eq!(module_key_for_class("TotallyUnknownArch"), "");
+}
+
+#[test]
+fn module_key_resolves_to_arch_default_chunk() {
+    // The class→key→chunk chain lands on the arch's known default. Racy w.r.t.
+    // env vars; only assert when no global override is set.
+    if env::var("RMLX_PREFILL_CHUNK").is_ok() {
+        return;
+    }
+    // qwen3_5_moe's small conservative chunk must win over gemma4's 512 default.
+    let key = module_key_for_class("Qwen3_5MoeForConditionalGeneration");
+    assert_eq!(prefill_chunk_for(key), 64);
+    assert_eq!(
+        prefill_chunk_for(module_key_for_class("Gemma4ForConditionalGeneration")),
+        512
+    );
+    // Unknown class resolves through "" to FALLBACK, not gemma4's 512.
+    assert_eq!(
+        prefill_chunk_for(module_key_for_class("TotallyUnknownArch")),
+        FALLBACK
+    );
+}
+
+#[test]
 fn unknown_arch_falls_back() {
     // Env-var path may override; only assert pure default behaviour.
     if env::var("RMLX_PREFILL_CHUNK").is_ok() || env::var("RMLX_PREFILL_CHUNK_BOGUS").is_ok() {

--- a/crates/rmlx-server/src/admission.rs
+++ b/crates/rmlx-server/src/admission.rs
@@ -329,6 +329,10 @@ pub struct ControllerConfig {
     /// Initial (and minimum) queue depth. Equals the static `--max-queue-depth`
     /// passed at startup. The controller never goes below `MIN_QUEUE_DEPTH` (1).
     pub initial_queue_depth: usize,
+    /// Module-style arch key of the loaded model (`"gemma4"`, `"qwen3_5_moe"`, …),
+    /// used to resolve the arch's prefill-chunk default when no runtime override
+    /// is active. Empty string → conservative FALLBACK chunk.
+    pub arch: String,
     /// When `true`, the controller also adjusts the process-wide prefill
     /// chunk size via `rmlx_models::prefill_chunk::set_prefill_chunk`.
     ///
@@ -341,11 +345,19 @@ pub struct ControllerConfig {
 
 impl ControllerConfig {
     /// Construct a new `ControllerConfig` with `adaptive_prefill_chunk = false`.
-    pub fn new(step_target_ms: u64, itl_target_ms: u64, initial_queue_depth: usize) -> Self {
+    ///
+    /// `arch` is the module-style key of the loaded model (see [`ControllerConfig::arch`]).
+    pub fn new(
+        step_target_ms: u64,
+        itl_target_ms: u64,
+        initial_queue_depth: usize,
+        arch: String,
+    ) -> Self {
         Self {
             step_target_ms,
             itl_target_ms,
             initial_queue_depth,
+            arch,
             adaptive_prefill_chunk: false,
         }
     }
@@ -595,7 +607,7 @@ impl ControllerHandle {
     fn tick_prefill_chunk(&self, est_itl: f64, itl_target: f64) {
         let mut g = self.inner.lock();
         let current = rmlx_models::prefill_chunk::runtime_override()
-            .unwrap_or_else(|| rmlx_models::prefill_chunk::prefill_chunk_for("gemma4"));
+            .unwrap_or_else(|| rmlx_models::prefill_chunk::prefill_chunk_for(&g.config.arch));
 
         let reason = if est_itl > itl_target {
             g.prefill_chunk_overload_ticks += 1;

--- a/crates/rmlx-server/src/admission_tests.rs
+++ b/crates/rmlx-server/src/admission_tests.rs
@@ -111,7 +111,8 @@ fn decision_reason_as_str_stable() {
 
 fn make_controller(ttft_ms: u64, itl_ms: u64, init_depth: usize) -> ControllerHandle {
     ControllerHandle::new(
-        ControllerConfig::new(ttft_ms, itl_ms, init_depth),
+        // Timing-logic tests assume the historical gemma4 prefill-chunk default.
+        ControllerConfig::new(ttft_ms, itl_ms, init_depth, "gemma4".to_owned()),
         None, // no DB in unit tests
     )
 }
@@ -297,7 +298,8 @@ fn prefill_chunk_global_state_serial() {
         rmlx_models::prefill_chunk::set_prefill_chunk(initial_chunk);
 
         let ctrl = ControllerHandle::new(
-            ControllerConfig::new(500, 50, 4).with_adaptive_prefill_chunk(true),
+            ControllerConfig::new(500, 50, 4, "gemma4".to_owned())
+                .with_adaptive_prefill_chunk(true),
             None,
         );
 
@@ -332,7 +334,8 @@ fn prefill_chunk_global_state_serial() {
         rmlx_models::prefill_chunk::set_prefill_chunk(initial_chunk);
 
         let ctrl = ControllerHandle::new(
-            ControllerConfig::new(500, 10, 8).with_adaptive_prefill_chunk(true),
+            ControllerConfig::new(500, 10, 8, "gemma4".to_owned())
+                .with_adaptive_prefill_chunk(true),
             None,
         );
 
@@ -384,6 +387,53 @@ fn prefill_chunk_global_state_serial() {
             rmlx_models::prefill_chunk::runtime_override(),
             Some(sentinel),
             "C: runtime override must not change when adaptive_prefill_chunk is off"
+        );
+        rmlx_models::prefill_chunk::set_prefill_chunk(0);
+    }
+
+    // Scenario D: the prefill-chunk fallback honors the loaded model's arch, not
+    // the hardcoded gemma4 default. With `arch = "qwen3_5_moe"` the controller's
+    // `current` starts from that arch's default (64), so the first overload lower
+    // sets an override <= 64. Under the old hardcoded-"gemma4" bug `current` would
+    // have started at 512, so the first lower would land at 256 > 64 — the bound
+    // below discriminates the two. Note: `arch_default` MUST be captured BEFORE
+    // driving the controller, while the override is cleared — `prefill_chunk_for`
+    // returns the runtime override (highest precedence) once one is set, so reading
+    // it after the lower would self-corrupt the bound.
+    {
+        // No runtime override → tick_prefill_chunk reads the arch default.
+        rmlx_models::prefill_chunk::set_prefill_chunk(0);
+        // Capture the true arch default (=64) before any lower pollutes the global.
+        let arch_default = rmlx_models::prefill_chunk::prefill_chunk_for("qwen3_5_moe");
+
+        let ctrl = ControllerHandle::new(
+            ControllerConfig::new(500, 10, 8, "qwen3_5_moe".to_owned())
+                .with_adaptive_prefill_chunk(true),
+            None,
+        );
+
+        // Drive overload (step_ms >> itl_target) to trigger a lower after HOLD_TICKS.
+        for tokens in [10u64, 20, 30, 40, 50, 60, 70, 80] {
+            ctrl.record_step(&StepMetrics {
+                prompt_tokens: tokens,
+                decode_kv_bytes: 0,
+                queue_depth: 1,
+                queue_wait_ms: 0,
+                step_ms: 50, // >> 10 ms target
+            });
+        }
+        for _ in 0..HOLD_TICKS {
+            ctrl.tick_force();
+        }
+
+        // The lower must have set an override; it must start from the qwen3_5_moe
+        // default (64), not gemma4's 512.
+        let resolved = rmlx_models::prefill_chunk::runtime_override()
+            .expect("D: overload must lower the chunk and set a runtime override");
+        assert!(
+            resolved <= arch_default,
+            "D: first lower must start from qwen3_5_moe default ({arch_default}=64), \
+             not gemma4's 512; got {resolved}"
         );
         rmlx_models::prefill_chunk::set_prefill_chunk(0);
     }


### PR DESCRIPTION
## What
The adaptive admission controller's prefill-chunk fallback was hardcoded `prefill_chunk_for("gemma4")` (=512). On a non-gemma4 model (e.g. Qwen3.5-MoE, default 64) the controller started 8× too large — a documented Metal-watchdog risk.

## Fix
Thread the loaded model's arch through `ControllerConfig`:
- New `module_key_for_class(arch_class) -> &'static str` in rmlx-models maps config class names → `prefill_chunk_for` module keys (rmlx-models owns both vocabularies). Every supported class cross-checked against that arch's own generate-path string; Qwen3VLMoe/Jina (no `prefill_chunk_for` call) → `""` → conservative FALLBACK.
- `ControllerConfig` gains `arch: String` (4th `new()` param); `tick_prefill_chunk` resolves `prefill_chunk_for(&g.config.arch)` (runtime-override path unchanged, checked first).
- Serve passes the primary model's arch via `registry.list().first().arch` (BTreeMap → deterministic; empty → `""` → FALLBACK; never panics).

## Tests
- Two pure-mapping tests (class → key → arch default).
- Admission Scenario D: with `arch="qwen3_5_moe"`, the first overload lower starts from 64 (not 512). **Proven to discriminate the bug** — reverting the fallback to `"gemma4"` makes it FAIL with `got 256` (512→256 > 64); the fix passes (64→32).

`make check`/`make lint` clean; `rmlx-server` admission 23 + `rmlx-models` prefill_chunk 8 + 1123 workspace tests passed. Rust-reviewer (Opus) approved the code; flagged the original test as non-discriminating → fixed + empirically verified red/green. Adaptive-admission is opt-in, so no perf-canary impact.

Plan: Task 10 (Phase C). Phase C complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)