### PR TITLE
refactor(models): single read_raw_config helper replaces loader clones

### DIFF
--- a/crates/rmlx-models/src/gemma4/loader.rs
+++ b/crates/rmlx-models/src/gemma4/loader.rs
@@ -56,13 +56,7 @@ pub fn load_from_path(model_dir: &Path) -> Result<Gemma4Text> {
     let cfg_raw = load_config(model_dir)?;
 
     // Re-read config.json as raw JSON to capture per-tensor quant overrides.
-    let raw_json: serde_json::Value = {
-        let path = model_dir.join("config.json");
-        let data = std::fs::read(&path)
-            .map_err(|e| Error::Loader(format!("cannot read {}: {e}", path.display())))?;
-        serde_json::from_slice(&data)
-            .map_err(|e| Error::Loader(format!("malformed config.json: {e}")))?
-    };
+    let raw_json = crate::load_util::read_raw_config(model_dir)?;
     let raw_quant = raw_json.get("quantization");
 
     let cfg = Gemma4TextConfig::from_model_config(&cfg_raw, raw_quant)?;

--- a/crates/rmlx-models/src/gemma4/vision/mod.rs
+++ b/crates/rmlx-models/src/gemma4/vision/mod.rs
@@ -861,11 +861,7 @@ fn load_raw(shards: &ShardSet, name: &str) -> Result<Array> {
 /// Read top-level `quantization` (`group_size`, `bits`, `mode`) for the
 /// `embed_vision.embedding_projection` quantized Linear.
 fn read_quant_params(model_dir: &Path) -> Result<(i32, i32, crate::layers::QuantMode)> {
-    let path = model_dir.join("config.json");
-    let data = std::fs::read(&path)
-        .map_err(|e| Error::Loader(format!("cannot read {}: {e}", path.display())))?;
-    let v: serde_json::Value = serde_json::from_slice(&data)
-        .map_err(|e| Error::Loader(format!("malformed config.json: {e}")))?;
+    let v = crate::load_util::read_raw_config(model_dir)?;
     let q = v.get("quantization");
     let gs = q
         .and_then(|q| q.get("group_size"))

--- a/crates/rmlx-models/src/laguna/loader.rs
+++ b/crates/rmlx-models/src/laguna/loader.rs
@@ -32,13 +32,7 @@ pub fn load_from_path(model_dir: &Path) -> Result<LagunaText> {
 
     // Re-read config.json as raw JSON to extract inline quant overrides before
     // Serde struct-parsing drops unknown keys inside the quantization dict.
-    let raw_json: serde_json::Value = {
-        let path = model_dir.join("config.json");
-        let data = std::fs::read(&path)
-            .map_err(|e| Error::Loader(format!("cannot read {}: {e}", path.display())))?;
-        serde_json::from_slice(&data)
-            .map_err(|e| Error::Loader(format!("malformed config.json: {e}")))?
-    };
+    let raw_json = crate::load_util::read_raw_config(model_dir)?;
     let raw_quant = raw_json.get("quantization");
 
     let cfg = LagunaConfig::from_model_config(&cfg_raw, raw_quant)?;

--- a/crates/rmlx-models/src/load_util.rs
+++ b/crates/rmlx-models/src/load_util.rs
@@ -36,6 +36,16 @@ use tracing::debug;
 
 use crate::layers::{Embedding, Linear, QuantMode, QuantParams};
 
+/// Read `config.json` under `model_dir` as raw JSON, preserving all keys —
+/// including nested blocks (e.g. per-tensor `quantization` overrides) that
+/// typed config structs drop.
+pub(crate) fn read_raw_config(model_dir: &std::path::Path) -> Result<serde_json::Value> {
+    let path = model_dir.join("config.json");
+    let data = std::fs::read(&path)
+        .map_err(|e| Error::Loader(format!("cannot read {}: {e}", path.display())))?;
+    serde_json::from_slice(&data).map_err(|e| Error::Loader(format!("malformed config.json: {e}")))
+}
+
 /// Unified tensor fetch over a snapshot's shards.
 ///
 /// Index-first when an index is available (fast path); header-scan fallback for

--- a/crates/rmlx-models/src/qwen3_5_moe/loader.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/loader.rs
@@ -47,13 +47,7 @@ use super::moe::{DenseMlp, SharedExpert, SparseMoeBlock, SwitchMlp};
 pub fn load_from_path(model_dir: &Path) -> Result<Qwen3_5MoeText> {
     let cfg_raw = load_config(model_dir)?;
 
-    let raw_json: serde_json::Value = {
-        let path = model_dir.join("config.json");
-        let data = std::fs::read(&path)
-            .map_err(|e| Error::Loader(format!("cannot read {}: {e}", path.display())))?;
-        serde_json::from_slice(&data)
-            .map_err(|e| Error::Loader(format!("malformed config.json: {e}")))?
-    };
+    let raw_json = crate::load_util::read_raw_config(model_dir)?;
 
     let raw_quant = raw_json.get("quantization");
     let raw_text_config = raw_json.get("text_config");
@@ -291,13 +285,7 @@ pub fn load_from_path(model_dir: &Path) -> Result<Qwen3_5MoeText> {
 pub fn load_from_path_paro(model_dir: &Path) -> Result<Qwen3_5MoeText> {
     let cfg_raw = load_config(model_dir)?;
 
-    let raw_json: serde_json::Value = {
-        let path = model_dir.join("config.json");
-        let data = std::fs::read(&path)
-            .map_err(|e| Error::Loader(format!("cannot read {}: {e}", path.display())))?;
-        serde_json::from_slice(&data)
-            .map_err(|e| Error::Loader(format!("malformed config.json: {e}")))?
-    };
+    let raw_json = crate::load_util::read_raw_config(model_dir)?;
 
     let raw_text_config = raw_json.get("text_config");
     let raw_quant = None;

--- a/crates/rmlx-models/src/qwen3_vl_moe/loader.rs
+++ b/crates/rmlx-models/src/qwen3_vl_moe/loader.rs
@@ -35,13 +35,7 @@ use super::moe::{SparseMoeBlock, SwitchMlp};
 
 /// Load the full `Qwen3VlMoeConfig` from `config.json`.
 pub fn load_config_qwen3_vl(model_dir: &Path) -> Result<Qwen3VlMoeConfig> {
-    let raw_json: serde_json::Value = {
-        let path = model_dir.join("config.json");
-        let data = std::fs::read(&path)
-            .map_err(|e| Error::Loader(format!("cannot read {}: {e}", path.display())))?;
-        serde_json::from_slice(&data)
-            .map_err(|e| Error::Loader(format!("malformed config.json: {e}")))?
-    };
+    let raw_json = crate::load_util::read_raw_config(model_dir)?;
     let raw = raw_json
         .as_object()
         .ok_or_else(|| Error::Config("qwen3_vl_moe: config.json is not an object".into()))?;


### PR DESCRIPTION
## What
Six loaders re-read `config.json` as a raw `serde_json::Value` (to recover nested keys like per-tensor `quantization` overrides that typed config structs drop) via a verbatim-duplicated 6-line block.

## Fix
Extract `pub(crate) fn read_raw_config(model_dir: &Path) -> Result<serde_json::Value>` into `load_util.rs` (same error messages: `"cannot read {}"`, `"malformed config.json"`). Replace all clone sites:
- `gemma4/loader.rs`, `laguna/loader.rs`, `qwen3_5_moe/loader.rs` (×2: `load_from_path` + `load_from_path_paro`), `qwen3_vl_moe/loader.rs`
- `gemma4/vision/mod.rs::read_quant_params` — the same clone the original audit's "×5" missed (identical block); included to actually complete the dedup.

Each site keeps its local var name so downstream `.get(...)`/`.as_object()` is unchanged. Zero behavior change — the `?` simply moved from inside the block to the call site.

Gate `grep 'Error::Loader(format!("malformed config.json' | grep -v load_util` → zero. Typed-config parsers (gemma3/gemma4/jina_v4 — distinct message) and mtp (`Error::Model`) are a different pattern, left alone. `make model-check` + `make lint` clean. Rust-reviewer (Opus): clean APPROVE.

Plan: Task 11 (Phase D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)