### PR TITLE
refactor(kv-quant): shared fused-QK setup scaffold; q8 ports first

### DIFF
--- a/crates/rmlx-kv-quant/src/fused_qk_common.rs
+++ b/crates/rmlx-kv-quant/src/fused_qk_common.rs
@@ -1,0 +1,135 @@
+//! Shared scaffold for the fused-QK MSL dispatchers (q8, turbo-k3, turbo-k4,
+//! iso). Validates geometry, prepares the Q/mask/scale/dims device arrays,
+//! and computes the launch grid. Codec-specific parts (codes/sideband
+//! reshapes, kernel handle, input order beyond the common prefix) stay in
+//! each `*_fused_qk_msl.rs`.
+
+use rmlx_core::error::{Error, Result};
+use rmlx_mlx::{Array, Device, Dtype};
+
+/// Validated, device-ready common inputs for one fused-QK dispatch.
+pub(crate) struct FusedQkSetup {
+    /// `[b * n_q_heads * head_dim]` f32, eval'd.
+    pub q_f32: Array,
+    /// `[b * n_q_heads * kv_seq]` f32 mask, or a 1-element dummy. Eval'd.
+    pub mask_flat: Array,
+    /// `[1]` f32 attention scale. Eval'd.
+    pub scale_arr: Array,
+    /// `[5]` u32: `[head_dim, kv_seq, kv_h, heads_per_kv, has_mask]`. Eval'd.
+    pub dims_arr: Array,
+    pub n_q_heads: i32,
+    /// `b * n_q_heads * kv_seq` — the flat output length.
+    pub out_total: i64,
+    pub grid_x: i32,
+    pub grid_y: i32,
+    /// 1 when an additive mask was supplied, 0 for the dummy mask — surfaced
+    /// so each dispatcher can log it uniformly on its trace event.
+    pub has_mask: u32,
+}
+
+/// Validate geometry and build the codec-independent device arrays.
+/// `label` names the calling dispatcher in error messages.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "mirrors the dispatcher signatures 1:1"
+)]
+pub(crate) fn build_fused_qk_setup(
+    label: &str,
+    query: &Array,
+    additive_mask: Option<&Array>,
+    b: i32,
+    kv_h: i32,
+    kv_seq: i32,
+    head_dim: i32,
+    heads_per_kv: i32,
+    scale: f32,
+    device: Device,
+) -> Result<FusedQkSetup> {
+    if head_dim != 128 && head_dim != 256 {
+        return Err(Error::Quant(format!(
+            "{label}: head_dim={head_dim} not supported \
+             (only 128 and 256 are wired; legacy dequant+SDPA path handles other dims)"
+        )));
+    }
+    if heads_per_kv <= 0 {
+        return Err(Error::Quant(format!(
+            "{label}: heads_per_kv must be > 0, got {heads_per_kv}"
+        )));
+    }
+    if b <= 0 || kv_seq <= 0 || kv_h <= 0 {
+        return Err(Error::Quant(format!(
+            "{label}: b={b}, kv_h={kv_h}, kv_seq={kv_seq} must all be > 0"
+        )));
+    }
+    let n_q_heads = kv_h * heads_per_kv;
+
+    let q_total: i64 = i64::from(b) * i64::from(n_q_heads) * i64::from(head_dim);
+    let q_flat = query.reshape(&[q_total as i32], device)?;
+    let q_f32 = if q_flat.dtype() == Dtype::F32 {
+        q_flat
+    } else {
+        q_flat.astype(Dtype::F32, device)?
+    };
+
+    let (mask_flat, has_mask) = if let Some(m) = additive_mask {
+        let mask_total: i64 = i64::from(b) * i64::from(n_q_heads) * i64::from(kv_seq);
+        let m_f = if m.dtype() == Dtype::F32 {
+            m.reshape(&[mask_total as i32], device)?
+        } else {
+            m.astype(Dtype::F32, device)?
+                .reshape(&[mask_total as i32], device)?
+        };
+        (m_f, 1u32)
+    } else {
+        let zero_bytes = [0u8; 4];
+        let dummy = Array::from_bytes(&zero_bytes, &[1], Dtype::F32)
+            .map_err(|e| Error::Mlx(format!("{label} dummy mask: {e}")))?;
+        (dummy, 0u32)
+    };
+
+    let scale_arr = {
+        let bytes = scale.to_le_bytes();
+        Array::from_bytes(&bytes, &[1], Dtype::F32)?
+    };
+
+    let dims_vals: [u32; 5] = [
+        head_dim as u32,
+        kv_seq as u32,
+        kv_h as u32,
+        heads_per_kv as u32,
+        has_mask,
+    ];
+    // LE byte assembly — no pointer reinterpret needed, drops the historic
+    // 4x-cloned unsafe block.
+    let mut dims_bytes = [0u8; 20];
+    for (chunk, v) in dims_bytes.chunks_exact_mut(4).zip(dims_vals.iter()) {
+        chunk.copy_from_slice(&v.to_le_bytes());
+    }
+    let dims_arr = Array::from_bytes(&dims_bytes, &[5], Dtype::U32)?;
+
+    q_f32.eval()?;
+    mask_flat.eval()?;
+    scale_arr.eval()?;
+    dims_arr.eval()?;
+
+    let out_total: i64 = i64::from(b) * i64::from(n_q_heads) * i64::from(kv_seq);
+    let grid_x: i64 = i64::from(kv_seq) * i64::from(head_dim);
+    let grid_y: i64 = i64::from(b) * i64::from(n_q_heads);
+    if grid_x > i64::from(i32::MAX) || grid_y > i64::from(i32::MAX) {
+        return Err(Error::Quant(format!(
+            "{label}: grid dimensions exceed i32::MAX (x={grid_x}, y={grid_y})"
+        )));
+    }
+
+    Ok(FusedQkSetup {
+        q_f32,
+        mask_flat,
+        scale_arr,
+        dims_arr,
+        n_q_heads,
+        out_total,
+        grid_x: grid_x as i32,
+        grid_y: grid_y as i32,
+        has_mask,
+    })
+}

--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -41,6 +41,7 @@
 pub(crate) mod test_utils;
 
 pub mod clifford;
+pub(crate) mod fused_qk_common;
 pub mod iso_fused_qk_msl;
 pub mod isoquant;
 pub mod isoquant_msl;

--- a/crates/rmlx-kv-quant/src/q8_fused_qk_msl.rs
+++ b/crates/rmlx-kv-quant/src/q8_fused_qk_msl.rs
@@ -57,10 +57,6 @@
 //! Not required — q8 is K-side 8-bit, so the Qwen-MoE 4-bit A.y guard
 //! does not apply.  Both K8V4 and K8V8 are accepted on every architecture.
 
-// unsafe_code: dims buffer byte cast — slice::from_raw_parts over a fixed
-// u32 array for MSL kernel input. SAFETY justified at each use site.
-#![allow(unsafe_code)]
-
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 
@@ -234,119 +230,56 @@ pub fn q8_fused_qk_sdpa(
     scale: f32,
     device: Device,
 ) -> Result<Array> {
-    if head_dim != 128 && head_dim != 256 {
-        return Err(Error::Quant(format!(
-            "q8_fused_qk_sdpa: head_dim={head_dim} not supported \
-             (only 128 and 256 are wired; legacy dequant+SDPA path handles other dims)"
-        )));
-    }
+    let setup = crate::fused_qk_common::build_fused_qk_setup(
+        "q8_fused_qk_sdpa",
+        query,
+        additive_mask,
+        b,
+        kv_h,
+        kv_seq,
+        head_dim,
+        heads_per_kv,
+        scale,
+        device,
+    )?;
+
     if !(head_dim as usize).is_multiple_of(Q8_GROUP_SIZE) {
         return Err(Error::Quant(format!(
             "q8_fused_qk_sdpa: invariant: head_dim={head_dim} must be a multiple of \
              Q8_GROUP_SIZE={Q8_GROUP_SIZE}"
         )));
     }
-    if heads_per_kv <= 0 {
-        return Err(Error::Quant(format!(
-            "q8_fused_qk_sdpa: heads_per_kv must be > 0, got {heads_per_kv}"
-        )));
-    }
-    if b <= 0 || kv_seq <= 0 || kv_h <= 0 {
-        return Err(Error::Quant(format!(
-            "q8_fused_qk_sdpa: b={b}, kv_h={kv_h}, kv_seq={kv_seq} must all be > 0"
-        )));
-    }
-    let n_q_heads = kv_h * heads_per_kv;
-
-    let q_total: i64 = i64::from(b) * i64::from(n_q_heads) * i64::from(head_dim);
-    let q_flat = query.reshape(&[q_total as i32], device)?;
-    let q_f32 = if q_flat.dtype() == Dtype::F32 {
-        q_flat
-    } else {
-        q_flat.astype(Dtype::F32, device)?
-    };
 
     let tok_count: i64 = i64::from(b) * i64::from(kv_h) * i64::from(kv_seq);
     let codes_total: i64 = tok_count * i64::from(head_dim) / 4;
     let scales_total: i64 = tok_count * i64::from(head_dim) / (Q8_GROUP_SIZE as i64);
     let codes_flat = k_codes.reshape(&[codes_total as i32], device)?;
     let scales_flat = k_scales.reshape(&[scales_total as i32], device)?;
-
-    let (mask_flat, has_mask) = if let Some(m) = additive_mask {
-        let mask_total: i64 = i64::from(b) * i64::from(n_q_heads) * i64::from(kv_seq);
-        let m_f = if m.dtype() == Dtype::F32 {
-            m.reshape(&[mask_total as i32], device)?
-        } else {
-            m.astype(Dtype::F32, device)?
-                .reshape(&[mask_total as i32], device)?
-        };
-        (m_f, 1u32)
-    } else {
-        let zero_bytes = [0u8; 4];
-        let dummy = Array::from_bytes(&zero_bytes, &[1], Dtype::F32)
-            .map_err(|e| Error::Mlx(format!("q8_fused_qk dummy mask: {e}")))?;
-        (dummy, 0u32)
-    };
-
-    let scale_arr = {
-        let bytes = scale.to_le_bytes();
-        Array::from_bytes(&bytes, &[1], Dtype::F32)?
-    };
-    let dims_vals: [u32; 5] = [
-        head_dim as u32,
-        kv_seq as u32,
-        kv_h as u32,
-        heads_per_kv as u32,
-        has_mask,
-    ];
-    let dims_arr = {
-        // SAFETY: `dims_vals` is a stack array of 5 `u32`; reinterpreting the
-        // pointer as `&[u8]` of length 20 is safe — `u32` has no alignment
-        // requirement stricter than `u8`, every bit pattern is valid for
-        // `u8`, and `Array::from_bytes` copies the bytes before this scope
-        // ends, so no escaping pointer.
-        let bytes: &[u8] =
-            unsafe { std::slice::from_raw_parts(dims_vals.as_ptr().cast::<u8>(), 5 * 4) };
-        Array::from_bytes(bytes, &[5], Dtype::U32)?
-    };
-
-    q_f32.eval()?;
     codes_flat.eval()?;
     scales_flat.eval()?;
-    mask_flat.eval()?;
-    scale_arr.eval()?;
-    dims_arr.eval()?;
 
     let kernel = qk_kernel()?;
     let mut invoke = MetalKernelInvoke::new();
-    invoke.add_input(&q_f32)?;
+    invoke.add_input(&setup.q_f32)?;
     invoke.add_input(&codes_flat)?;
     invoke.add_input(&scales_flat)?;
-    invoke.add_input(&mask_flat)?;
-    invoke.add_input(&scale_arr)?;
-    invoke.add_input(&dims_arr)?;
+    invoke.add_input(&setup.mask_flat)?;
+    invoke.add_input(&setup.scale_arr)?;
+    invoke.add_input(&setup.dims_arr)?;
 
-    let out_total: i64 = i64::from(b) * i64::from(n_q_heads) * i64::from(kv_seq);
-    invoke.add_output_shape(&[out_total as i32], Dtype::F32)?;
+    invoke.add_output_shape(&[setup.out_total as i32], Dtype::F32)?;
 
-    let grid_x: i64 = i64::from(kv_seq) * i64::from(head_dim);
-    let grid_y: i64 = i64::from(b) * i64::from(n_q_heads);
-    if grid_x > i64::from(i32::MAX) || grid_y > i64::from(i32::MAX) {
-        return Err(Error::Quant(format!(
-            "q8_fused_qk_sdpa: grid dimensions exceed i32::MAX (x={grid_x}, y={grid_y})"
-        )));
-    }
-    invoke.set_grid(grid_x as i32, grid_y as i32, 1)?;
+    invoke.set_grid(setup.grid_x, setup.grid_y, 1)?;
     invoke.set_thread_group(head_dim, 1, 1)?;
 
     Q8_FUSED_QK_DISPATCHES.fetch_add(1, Ordering::Relaxed);
     tracing::trace!(
         b,
-        n_q_heads,
+        n_q_heads = setup.n_q_heads,
         kv_h,
         kv_seq,
         head_dim,
-        has_mask,
+        has_mask = setup.has_mask,
         "q8_fused_qk_sdpa: dispatch"
     );
 
@@ -358,7 +291,7 @@ pub fn q8_fused_qk_sdpa(
     }
     let out_flat = outputs.remove(0);
 
-    out_flat.reshape(&[b, n_q_heads, 1, kv_seq], device)
+    out_flat.reshape(&[b, setup.n_q_heads, 1, kv_seq], device)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What
~110-145 LOC were repeated verbatim across the 4 fused-QK MSL dispatchers (q8, turbo_k3, turbo_k4, iso): geometry guards, Q flatten+f32 cast, mask handling, scale array, a byte-identical **unsafe** `dims_arr` pointer-cast, and grid math. A past `dims` change missed one copy.

## Fix
New `fused_qk_common.rs`: `build_fused_qk_setup` → `FusedQkSetup` holds the validated, device-ready common inputs. q8 ports first (so the module is never dead code); Tasks 12b-12d port the other 3. The shared scaffold **eliminates the unsafe block** — `dims_arr` is now built with LE byte assembly (`to_le_bytes` + `chunks_exact_mut` → `Array::from_bytes`), byte-identical to the old pointer reinterpret on Apple Silicon (LE). q8's now-dead `#![allow(unsafe_code)]` removed. `has_mask` is surfaced on `FusedQkSetup` so each dispatcher logs it uniformly on its trace event.

Zero behavior change for q8: kernel `add_input` order (q, codes, scales, mask, scale, dims), denominators, grid/thread-group/output-shape/final-reshape all unchanged. q8's `Q8_GROUP_SIZE` guard stays at the q8 site.

`cargo test -p rmlx-kv-quant q8_fused` CPU 2 passed; **GPU `--ignored` 5/5 passed** on Metal (confirms identical attention output). `make lint` clean (no unsafe in either file). Rust-reviewer (Opus): APPROVE (LE assembly proven byte-identical; add_input order byte-identical; scope limited to 3 files).

Plan: Task 12a (Phase D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)