### PR TITLE
refactor(kv-quant): iso fused-QK dispatcher uses the shared scaffold

### DIFF
--- a/crates/rmlx-kv-quant/src/iso_fused_qk_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_fused_qk_msl.rs
@@ -82,10 +82,6 @@
 //!   sandwich** (`q̄ * r`, not `q̄ * r * q`).
 //! * [`crate::isoquant::iso_decode_fast`] — CPU reference (Rust).
 
-// unsafe_code: dims buffer byte cast — slice::from_raw_parts over a fixed
-// u32 array for MSL kernel input. SAFETY justified at each use site.
-#![allow(unsafe_code)]
-
 use std::fmt::Write as _;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
@@ -369,37 +365,25 @@ pub fn iso_fused_qk_sdpa<const BITS: u8>(
             "iso_fused_qk_sdpa: unsupported BITS={BITS} (only 3 and 4)"
         )));
     }
-    if head_dim != 128 && head_dim != 256 {
-        return Err(Error::Quant(format!(
-            "iso_fused_qk_sdpa: head_dim={head_dim} not supported \
-             (only 128 and 256 are wired; legacy dequant+SDPA path handles other dims)"
-        )));
-    }
     if !(head_dim as usize).is_multiple_of(ISO_GROUP_SIZE) {
         return Err(Error::Quant(format!(
             "iso_fused_qk_sdpa: invariant: head_dim={head_dim} must be a multiple of \
              ISO_GROUP_SIZE={ISO_GROUP_SIZE}"
         )));
     }
-    if heads_per_kv <= 0 {
-        return Err(Error::Quant(format!(
-            "iso_fused_qk_sdpa: heads_per_kv must be > 0, got {heads_per_kv}"
-        )));
-    }
-    if b <= 0 || kv_seq <= 0 || kv_h <= 0 {
-        return Err(Error::Quant(format!(
-            "iso_fused_qk_sdpa: b={b}, kv_h={kv_h}, kv_seq={kv_seq} must all be > 0"
-        )));
-    }
-    let n_q_heads = kv_h * heads_per_kv;
 
-    let q_total: i64 = i64::from(b) * i64::from(n_q_heads) * i64::from(head_dim);
-    let q_flat = query.reshape(&[q_total as i32], device)?;
-    let q_f32 = if q_flat.dtype() == Dtype::F32 {
-        q_flat
-    } else {
-        q_flat.astype(Dtype::F32, device)?
-    };
+    let setup = crate::fused_qk_common::build_fused_qk_setup(
+        "iso_fused_qk_sdpa",
+        query,
+        additive_mask,
+        b,
+        kv_h,
+        kv_seq,
+        head_dim,
+        heads_per_kv,
+        scale,
+        device,
+    )?;
 
     let tok_count: i64 = i64::from(b) * i64::from(kv_h) * i64::from(kv_seq);
     // iso: 1 u32 word per group of 4 (both BITS=3 and BITS=4 fit in one word).
@@ -409,77 +393,23 @@ pub fn iso_fused_qk_sdpa<const BITS: u8>(
     let codes_flat = k_codes.reshape(&[codes_total as i32], device)?;
     let scales_flat = k_scales.reshape(&[scales_total as i32], device)?;
     let norms_flat = k_norms.reshape(&[norms_total as i32], device)?;
-
-    let (mask_flat, has_mask) = if let Some(m) = additive_mask {
-        let mask_total: i64 = i64::from(b) * i64::from(n_q_heads) * i64::from(kv_seq);
-        let m_f = if m.dtype() == Dtype::F32 {
-            m.reshape(&[mask_total as i32], device)?
-        } else {
-            m.astype(Dtype::F32, device)?
-                .reshape(&[mask_total as i32], device)?
-        };
-        (m_f, 1u32)
-    } else {
-        let zero_bytes = [0u8; 4];
-        let dummy = Array::from_bytes(&zero_bytes, &[1], Dtype::F32)
-            .map_err(|e| Error::Mlx(format!("iso_fused_qk dummy mask: {e}")))?;
-        (dummy, 0u32)
-    };
-
-    let scale_arr = {
-        let bytes = scale.to_le_bytes();
-        Array::from_bytes(&bytes, &[1], Dtype::F32)?
-    };
-    let dims_vals: [u32; 5] = [
-        head_dim as u32,
-        kv_seq as u32,
-        kv_h as u32,
-        heads_per_kv as u32,
-        has_mask,
-    ];
-    let dims_arr = {
-        // SAFETY: `dims_vals` is a stack array of 5 `u32`; reinterpreting the
-        // pointer as `&[u8]` of length 20 is safe — `u32` has no alignment
-        // requirement stricter than `u8`, every bit pattern is valid for
-        // `u8`, and `Array::from_bytes` copies the bytes before this scope
-        // ends, so no escaping pointer.
-        let bytes: &[u8] =
-            unsafe { std::slice::from_raw_parts(dims_vals.as_ptr().cast::<u8>(), 5 * 4) };
-        Array::from_bytes(bytes, &[5], Dtype::U32)?
-    };
-
-    q_f32.eval()?;
     codes_flat.eval()?;
     scales_flat.eval()?;
     norms_flat.eval()?;
-    mask_flat.eval()?;
-    scale_arr.eval()?;
-    dims_arr.eval()?;
 
     let kernel = iso_qk_kernel(BITS)?;
     let mut invoke = MetalKernelInvoke::new();
-    invoke.add_input(&q_f32)?;
+    invoke.add_input(&setup.q_f32)?;
     invoke.add_input(&codes_flat)?;
     invoke.add_input(&scales_flat)?;
     invoke.add_input(&norms_flat)?;
-    invoke.add_input(&mask_flat)?;
-    invoke.add_input(&scale_arr)?;
-    invoke.add_input(&dims_arr)?;
+    invoke.add_input(&setup.mask_flat)?;
+    invoke.add_input(&setup.scale_arr)?;
+    invoke.add_input(&setup.dims_arr)?;
 
-    let out_total: i64 = i64::from(b) * i64::from(n_q_heads) * i64::from(kv_seq);
-    invoke.add_output_shape(&[out_total as i32], Dtype::F32)?;
+    invoke.add_output_shape(&[setup.out_total as i32], Dtype::F32)?;
 
-    // `set_grid` expects TOTAL threads (not threadgroup count): the Metal
-    // dispatcher divides grid by threadgroup to obtain threadgroup count per
-    // axis.  Mirrors turbo_k3 / turbo_k4 / q8 patterns.
-    let grid_x: i64 = i64::from(kv_seq) * i64::from(head_dim);
-    let grid_y: i64 = i64::from(b) * i64::from(n_q_heads);
-    if grid_x > i64::from(i32::MAX) || grid_y > i64::from(i32::MAX) {
-        return Err(Error::Quant(format!(
-            "iso_fused_qk_sdpa: grid dimensions exceed i32::MAX (x={grid_x}, y={grid_y})"
-        )));
-    }
-    invoke.set_grid(grid_x as i32, grid_y as i32, 1)?;
+    invoke.set_grid(setup.grid_x, setup.grid_y, 1)?;
     invoke.set_thread_group(head_dim, 1, 1)?;
 
     if BITS == 3 {
@@ -490,11 +420,11 @@ pub fn iso_fused_qk_sdpa<const BITS: u8>(
     tracing::trace!(
         bits = BITS,
         b,
-        n_q_heads,
+        n_q_heads = setup.n_q_heads,
         kv_h,
         kv_seq,
         head_dim,
-        has_mask,
+        has_mask = setup.has_mask,
         "iso_fused_qk_sdpa: dispatch"
     );
 
@@ -506,7 +436,7 @@ pub fn iso_fused_qk_sdpa<const BITS: u8>(
     }
     let out_flat = outputs.remove(0);
 
-    out_flat.reshape(&[b, n_q_heads, 1, kv_seq], device)
+    out_flat.reshape(&[b, setup.n_q_heads, 1, kv_seq], device)
 }
 
 // ── `FusedQkFn`-compatible shims ──────────────────────────────────────────────


### PR DESCRIPTION
## What
Final fused-QK dispatcher ported to the shared `build_fused_qk_setup` scaffold (#70), completing the 12a–12d extraction. iso has an extra `norms_flat` quaternion sideband input — kept in its exact byte-identical 4th position (q, codes, scales, **norms**, mask, scale, dims).

## Preserved (codec-specific)
iso's `codes_total = tok_count*head_dim/ISO_GROUP_SIZE`, `scales_total`, `norms_total` formulas, the iso3/iso4 dispatch-counter `const BITS` selection, the `head_dim % 4 == 0` invariant — all unchanged. Unsafe `dims_arr` cast eliminated (−70 lines). The non-fused default path is untouched.

## Validation
- CPU `iso_fused` 5 passed; **GPU `--ignored` 10/10 passed** on Metal; whole crate 295 passed; `make lint` clean. Rust-reviewer (Opus): clean APPROVE (norms position + denominators + dims byte-identical/equivalent vs HEAD).
- **Perf gate (12a–12d extraction)**: `scripts/perf_canary.sh` A/B'd this branch vs main on the same machine. Absolute TPS ran below the `docs/PERF_BASELINE.md` anchors on **both** branches (thermal from a long session), so the dip is environmental, not code. Branch-vs-main, default path: Bonsai −0.6%, Gemma4-e4b −2.3%, Qwen3.6 +2.5% — all within run-to-run noise, mixed signs (no directional regression). The canary never dispatches fused-QK (auto→OFF), and the GPU round-trip tests prove the fused-QK output is byte-identical via the scaffold, so the extraction is perf-neutral by construction.

Plan: Task 12d (Phase D). Fused-QK scaffold extraction (12a–12d) complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)