### PR TITLE
refactor(models): mask.rs uses Array::from_f32_slice per FFI.md

### DIFF
--- a/crates/rmlx-models/src/layers/mask.rs
+++ b/crates/rmlx-models/src/layers/mask.rs
@@ -1,8 +1,5 @@
 //! Attention mask builders for causal, chunked-prefill, and SWA forward passes.
 
-// unsafe_code: Array::from_bytes uses slice::from_raw_parts for byte reinterpretation.
-#![allow(unsafe_code)]
-
 use rmlx_core::error::Result;
 use rmlx_mlx::{Array, Device, Dtype};
 
@@ -59,9 +56,7 @@ pub fn build_chunked_prefill_mask(offset: i32, new_seq: i32, device: Device) -> 
         }
     }
 
-    let bytes: &[u8] =
-        unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), data.len() * 4) };
-    let mask_f32 = Array::from_bytes(bytes, &[1, 1, rows as i32, cols as i32], Dtype::F32)?;
+    let mask_f32 = Array::from_f32_slice(&data, &[1, 1, rows as i32, cols as i32])?;
     // Convert to BF16 to match Q/K/V dtype (MLX requires mask dtype to promote to output).
     mask_f32.astype(Dtype::Bf16, device)
 }
@@ -112,9 +107,7 @@ pub fn build_swa_prefill_mask(
         }
     }
 
-    let bytes: &[u8] =
-        unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), data.len() * 4) };
-    let mask_f32 = Array::from_bytes(bytes, &[1, 1, rows as i32, cols as i32], Dtype::F32)?;
+    let mask_f32 = Array::from_f32_slice(&data, &[1, 1, rows as i32, cols as i32])?;
     mask_f32.astype(Dtype::Bf16, device)
 }
 
@@ -148,9 +141,7 @@ pub fn build_swa_decode_mask(
         *cell = 0.0;
     }
 
-    let bytes: &[u8] =
-        unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), data.len() * 4) };
-    let mask_f32 = Array::from_bytes(bytes, &[1, 1, 1, cols as i32], Dtype::F32)?;
+    let mask_f32 = Array::from_f32_slice(&data, &[1, 1, 1, cols as i32])?;
     let mask_bf16 = mask_f32.astype(Dtype::Bf16, device)?;
     Ok(Some(mask_bf16))
 }


### PR DESCRIPTION
## What
`layers/mask.rs` hand-rolled 3 `unsafe { slice::from_raw_parts(f32 → u8, len*4) }` + `Array::from_bytes(.., F32)` blocks — exactly the pattern `docs/FFI.md` says callers must replace with `Array::from_f32_slice`.

## Fix
All 3 sites → `Array::from_f32_slice(&data, &[shape])`. `from_f32_slice` is the identical inlined body (same `from_raw_parts`+`from_bytes`), now confined to the rmlx-mlx FFI module (where unsafe is policy-scoped). Shapes unchanged → bit-identical Arrays, zero behavior change. File's `#![allow(unsafe_code)]` + stale header note removed (no unsafe remains).

`grep from_raw_parts mask.rs` → 0; `make lint` clean; `make model-check` 624 passed. Rust-reviewer (Opus): clean APPROVE (byte-identical, no unsafe, no orphaned imports).

Plan: Task 13a (Phase D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)