### PR TITLE
refactor(models): qwen3.rs uses Array::from_{i32,f32}_slice per FFI.md

### DIFF
--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -1,8 +1,6 @@
 // LOC-exempt: full Qwen3 forward + loader + prompt-cache + decode driver in one
 // arch module; shrinks across the model-agnostic refactor phases (decode loop
 // already extracted) and lands under the soft cap as later phases continue.
-// unsafe_code: mlx-rs Array zero-copy view — slice::from_raw_parts byte-reinterpret for Array::from_bytes
-#![allow(unsafe_code)]
 
 //! Qwen3 text-only forward pass.
 //!
@@ -1575,9 +1573,7 @@ impl Qwen3Text {
     ) -> Result<Array> {
         let seq = ids.len();
         let ids_i32: Vec<i32> = ids.iter().map(|&x| x as i32).collect();
-        let ids_bytes =
-            unsafe { std::slice::from_raw_parts(ids_i32.as_ptr().cast::<u8>(), seq * 4) };
-        let ids_arr = Array::from_bytes(ids_bytes, &[seq as i32], Dtype::I32)?;
+        let ids_arr = Array::from_i32_slice(&ids_i32, &[seq as i32])?;
         self.forward_arr(&ids_arr, seq as i32, caches, device)
     }
 
@@ -1594,9 +1590,7 @@ impl Qwen3Text {
     ) -> Result<Array> {
         let seq = ids.len();
         let ids_i32: Vec<i32> = ids.iter().map(|&x| x as i32).collect();
-        let ids_bytes =
-            unsafe { std::slice::from_raw_parts(ids_i32.as_ptr().cast::<u8>(), seq * 4) };
-        let ids_arr = Array::from_bytes(ids_bytes, &[seq as i32], Dtype::I32)?;
+        let ids_arr = Array::from_i32_slice(&ids_i32, &[seq as i32])?;
         self.forward_arr_with_sink(&ids_arr, seq as i32, caches, Some(sink), device)
     }
 
@@ -1709,9 +1703,7 @@ impl Qwen3Text {
             ));
         }
         let ids_i32: Vec<i32> = ids.iter().map(|&x| x as i32).collect();
-        let ids_bytes =
-            unsafe { std::slice::from_raw_parts(ids_i32.as_ptr().cast::<u8>(), seq * 4) };
-        let ids_arr = Array::from_bytes(ids_bytes, &[seq as i32], Dtype::I32)?;
+        let ids_arr = Array::from_i32_slice(&ids_i32, &[seq as i32])?;
         let h = self.embed_tokens.forward(&ids_arr, device)?;
         let mut h = h.reshape(&[1, seq as i32, self.cfg.hidden_size as i32], device)?;
         for (i, layer) in self.layers.iter().enumerate() {

--- a/crates/rmlx-models/src/qwen3_tests.rs
+++ b/crates/rmlx-models/src/qwen3_tests.rs
@@ -21,14 +21,11 @@ fn qwen3_per_head_qnorm_shape() {
     let n = (batch * seq * n_heads * head_dim) as usize;
 
     let data: Vec<f32> = (0..n).map(|i| (i as f32) * 0.1).collect();
-    let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), n * 4) };
-    let x = Array::from_bytes(bytes, &[batch, seq, n_heads, head_dim], Dtype::F32)
-        .expect("build input tensor");
+    let x =
+        Array::from_f32_slice(&data, &[batch, seq, n_heads, head_dim]).expect("build input tensor");
 
     let w_data: Vec<f32> = vec![1.0_f32; head_dim as usize];
-    let w_bytes =
-        unsafe { std::slice::from_raw_parts(w_data.as_ptr().cast::<u8>(), w_data.len() * 4) };
-    let w = Array::from_bytes(w_bytes, &[head_dim], Dtype::F32).expect("build weight");
+    let w = Array::from_f32_slice(&w_data, &[head_dim]).expect("build weight");
 
     let norm = RmsNorm {
         weight: w,


### PR DESCRIPTION
## What
`qwen3.rs` hand-rolled 3 `unsafe { slice::from_raw_parts(ids_i32 → u8, seq*4) }` + `Array::from_bytes(.., I32)` blocks — the pattern `docs/FFI.md` says to replace with `Array::from_i32_slice`.

## Fix
The 3 token-id sites → `Array::from_i32_slice(&ids_i32, &[seq as i32])`. `from_i32_slice` is the identical inlined copy (now confined to the rmlx-mlx FFI module). Shapes unchanged → bit-identical Arrays. Removing qwen3.rs's module-level `#![allow(unsafe_code)]` + header note exposed 2 F32 `from_raw_parts` blocks in the companion `qwen3_tests.rs` (a `#[path]` child inheriting the allow) → converted to `Array::from_f32_slice` (required for `make lint` under workspace `unsafe_code = "deny"`). Untouched: the scalar `off_bytes` `from_bytes` and `max_abs_from_bytes` (not reinterprets).

`grep from_raw_parts` → 0 in both files; zero `unsafe` remains; `make lint` clean; `cargo test -p rmlx-models` 587 passed; `make model-check` 624 passed. Rust-reviewer (Opus): clean APPROVE.

Plan: Task 13b (Phase D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)