### PR TITLE
refactor(models): speculative/mod.rs uses Array::from_i32_slice per FFI.md

### DIFF
--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -1,6 +1,3 @@
-// unsafe_code: mlx-rs Array zero-copy view — slice::from_raw_parts byte-reinterpret for Array::from_bytes
-#![allow(unsafe_code)]
-
 //! Speculative decoding.
 //!
 //! Wraps a (verifier, draft) pair of `Architecture` instances.
@@ -1496,9 +1493,7 @@ fn draft_decode_n(
 
     // Step 0: feed all seed tokens at once (typical seed.len() = 1 or 2).
     let seed_i32: Vec<i32> = seed.iter().map(|&x| x as i32).collect();
-    let seed_bytes =
-        unsafe { std::slice::from_raw_parts(seed_i32.as_ptr().cast::<u8>(), seed.len() * 4) };
-    let mut y_arr = Array::from_bytes(seed_bytes, &[seed.len() as i32], Dtype::I32)?;
+    let mut y_arr = Array::from_i32_slice(&seed_i32, &[seed.len() as i32])?;
 
     let mut emitted_arrays: Vec<Array> = Vec::with_capacity(n);
     for _step_idx in 0..n {
@@ -1574,9 +1569,7 @@ fn draft_decode_n_stochastic(
     }
 
     let seed_i32: Vec<i32> = seed.iter().map(|&x| x as i32).collect();
-    let seed_bytes =
-        unsafe { std::slice::from_raw_parts(seed_i32.as_ptr().cast::<u8>(), seed.len() * 4) };
-    let mut y_arr = Array::from_bytes(seed_bytes, &[seed.len() as i32], Dtype::I32)?;
+    let mut y_arr = Array::from_i32_slice(&seed_i32, &[seed.len() as i32])?;
 
     let mut tokens: Vec<u32> = Vec::with_capacity(n);
     let mut q_dists: Vec<Vec<f32>> = Vec::with_capacity(n);


### PR DESCRIPTION
## What
`speculative/mod.rs` hand-rolled 2 `unsafe { slice::from_raw_parts(seed_i32 → u8, len*4) }` + `Array::from_bytes(.., I32)` blocks — the pattern `docs/FFI.md` says to replace with `Array::from_i32_slice`.

## Fix
Both seed sites → `Array::from_i32_slice(&seed_i32, &[seed.len() as i32])`; the dead `seed_bytes` intermediate removed. Shapes/dtype unchanged → bit-identical Arrays. mod.rs's `#![allow(unsafe_code)]` + header note removed: mod.rs now has zero unsafe, and every child module's `unsafe` is covered by its own declaring parent's allow (`gemma4_assistant.rs`, `eagle3/mod.rs`) — never by mod.rs — so removal exposes nothing to the workspace `unsafe_code = "deny"`.

The scalar `to_le_bytes` `from_bytes` site is untouched (not a reinterpret). eagle3/gemma4_assistant `from_raw_parts` deferred to Task 13d. `make lint` clean; `cargo test -p rmlx-models` 587 passed; `make model-check` 660 passed. Rust-reviewer (Opus): clean APPROVE (verified allow-coverage flows from declaring parent).

Plan: Task 13c (Phase D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)