### PR TITLE
docs(kv-quant): k-only iso/rotor decode cost, iso memory truth, planar3 warm note

### DIFF
--- a/docs/E2E_TEST_PLAN.md
+++ b/docs/E2E_TEST_PLAN.md
@@ -107,7 +107,7 @@ Bonsai facts that drive legality:
 - `head_dim = 128` → divisible by 4 (Iso quaternion) and 32 (Planar) — all
   rotation codecs are shape-legal.
 - dense `Qwen3ForCausalLM` (not `Qwen3_5MoeForConditionalGeneration`) →
-  `refuses_qwen_moe()` codecs (`*Sym`, `IsoKOnly*`, `RotorKOnly*`,
+  `k_below_8bit()` codecs (`*Sym`, `IsoKOnly*`, `RotorKOnly*`,
   `RotorK*Asym`, `PlanarK`) are all LEGAL here.
 - `max_position_embeddings = 65536` via YARN → 8k NIAH is well within band.
 
@@ -354,7 +354,7 @@ extend: add more `[[case]]` rows with `model = "GEMMA4_E4B"` / `"GEMMA4_26B"` /
 `k8vturbo2`, `planar3`, `iso3/4`, `rotor3/4`, …; Qwen3.6: `iso4`, `rotor3/4`,
 `mixed_k8g64_v4g64`, …, all K≥8).
 Each new golden auto-records on first run (`RMLX_E2E_REGEN_GOLDEN=1` to refresh).
-The Qwen-MoE illegal-codec surface (every `refuses_qwen_moe()` variant) can be
+The Qwen-MoE illegal-codec surface (every `k_below_8bit()` variant) can be
 swept with additional `serve_refused` rows.
 
 ## Files

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -562,7 +562,14 @@ because per-pair rotation+scale compresses correlated pairs extremely well even 
 
 **CLI**: `--kv-quant planar3`; or `--ctk q8_g128 --ctv planar_3`; or `--kv-preset planar3`.
 
-**Smoke-probe status**: CPU codec verified; GPU MSL kernels implemented (GPU tests `#[ignore]` until Metal context available).
+**Smoke-probe status**: CPU codec verified; the V3 **quantize** kernel
+(`planar_quantize_v3_gpu`) is **precompiled at load** via
+`precompile::warm_v_side`, so a first `--kv-quant planar3` request pays no
+Metal cold-compile stall on the prefill V-encode path (the separate
+`planar_dequantize_v3_gpu` kernel still cold-compiles lazily on first cache
+read). The GPU round-trip test `planar_v3_msl_roundtrip_within_tolerance`
+exists and passes but is `#[ignore]`-gated (needs a local Metal context — run
+with `cargo test -p rmlx-kv-quant --release -- --ignored`).
 
 ---
 
@@ -881,7 +888,7 @@ disaster path on Qwen MoE. `--kv-quant tsym4` on a
 `Qwen3_5MoeForConditionalGeneration` checkpoint is rejected at resolve-time
 by `validate_resolved` with `ResolveError::QwenMoeKBitsTooLow(4)` (exit 78,
 same surface as the existing Mixed K<8 rejection). The helper
-`KvQuant::refuses_qwen_moe()` returns `true` for this variant — extend the
+`KvQuant::k_below_8bit()` returns `true` for this variant — extend the
 helper when adding any future sub-8-bit-K codec.
 
 `KvCacheBuilder::resolve_default` never returns `TurboSym4` for any arch.
@@ -977,7 +984,7 @@ K-head error through softmax). `--kv-quant planar_k` and
 `Qwen3VLMoeForConditionalGeneration` are rejected at resolve-time by
 `validate_resolved` with the dedicated `ResolveError::QwenMoePlanarKRejected`
 (distinct from `QwenMoeKBitsTooLow` so the K-side disaster surface is
-preserved in the diagnostic). The helper `KvQuant::refuses_qwen_moe()`
+preserved in the diagnostic). The helper `KvQuant::k_below_8bit()`
 returns `true` for this variant — extend the helper when adding any future
 sub-8-bit-K codec.
 
@@ -1385,6 +1392,14 @@ where `*` is the **Hamilton product** and `v ∈ ℝ⁴` is treated as a quatern
 
 **Dequantize:** unpack → centroid lookup → rescale → inverse rotate → renorm.
 
+**Memory truth.** iso stores, per 4-element group, a packed code word, an
+f32 scale, and a 4×f32 quaternion, plus one f32 norm per token — ≈772 B per
+token per kv_head at head_dim=128 versus 256 B for bf16. **iso3/iso4 are
+net-NEGATIVE on memory at head_dim ≤ 256**; they are research codecs for
+quality experiments, not size wins. The resolve-time net-negative warn
+(`estimated_resident_bytes_per_layer` models the quaternion + norm sidebands
+exactly) accounts for these sidebands.
+
 **`head_dim % 4 == 0` constraint.** iso3 operates in groups of 4. Any
 `head_dim` not divisible by 4 is rejected at encode/decode time with
 `IsoQuantError::HeadDimNotMultipleOf4`.
@@ -1746,7 +1761,7 @@ the SDPA path and the SSD writer/reader tensor names (`l{idx}.k.*` vs
 
 **A.y Qwen MoE arch guard (mandatory).** K-side ≤4-bit on Qwen MoE is the
 PPL-disaster zone (218 → 8641 on Q4_K_M baseline; 7:1 GQA amplifies K-head
-error through softmax). All four variants extend `KvQuant::refuses_qwen_moe()`
+error through softmax). All four variants are flagged by `KvQuant::k_below_8bit()`
 and `cache_type::validate_resolved` routes them through the dedicated
 `ResolveError::QwenMoeIsoKRejected { variant }` error, which quotes the
 offending variant by name. `KvCacheBuilder::resolve_default` never returns
@@ -1767,6 +1782,17 @@ bf16 buffer on first decode step.
 **Status.** CPU-only on the hot path. The iso3 MSL kernel could in principle
 be reused on the K axis (it is axis-agnostic), but on-disk and SDPA paths use
 the CPU dequant fallback; an MSL re-wiring is a deferred follow-up.
+
+**Decode-cost caveat.** `QuantIsoK3`/`QuantIsoK4` have no GPU-resident code
+mirror on the live decode path: the CPU `dequant()` re-materializes every
+accumulated block each step and the reconstructed K prefix is re-uploaded to
+the GPU via `Array::from_bytes` — an O(kv_seq) per-step cost that grows
+monotonically with context. (A `dequant_gpu` mirror exists but is gated behind
+`gpu_resident_iso_enabled()`, hardcoded `false` in `rmlx-kv-quant/src/lib.rs`,
+so it does not run.) The short-prompt anchors elsewhere in this doc (warm-TTFT
+masks the cost after step 1) do not show it; long-prompt decode does (k_iso3
+Bonsai ~59 TPS vs iso3_sym ~142). The GPU mirror is deferred until a bench arm
+shows a win on a FusedQkShadow-incompatible path.
 
 **Cosine empirical floors.** Measured on the LCG fixture at
 `head_dim=128, n_rows=16, TEST_SEED` (see `quant_iso_k{,4}_tests.rs`):
@@ -1834,6 +1860,15 @@ siblings (K-side ≤4-bit on Qwen MoE is the PPL-disaster path). The error's
 **SDPA**: the K rotor codec dequants to bf16 (existing `RotorKOnly{3,4}` K
 path); the affine V codec dequants to bf16 (existing `K8V4` V path); then
 `scaled_dot_product_attention` runs.
+
+**Decode-cost caveat.** Like the iso K-side codecs, the rotor K-side codecs
+have no GPU-resident code mirror: with the default `--rotor-qjl on`, each
+decode step re-decodes the full K prefix on the CPU (and re-encodes the newly
+appended token), applies an O(head_dim²)-per-cached-token QJL score
+correction, then re-uploads the K prefix — an O(kv_seq) per-step cost that the
+short-prompt anchors mask but long-prompt decode exposes. The fused-QK fast path (which would avoid the
+per-step marshaling) is reachable only with `--rotor-qjl off` and is
+default-OFF; see the Fused-QK status below.
 
 **Fused-QK status:** the 6 rotor variants (`Rotor3Sym`, `Rotor4Sym`,
 `RotorKOnly3`, `RotorKOnly4`, `RotorK3Asym`, `RotorK4Asym`) are wired into
@@ -1919,7 +1954,7 @@ is validated; the QJL wiring did not change the storage shape.
 
 **A.y Qwen MoE arch guard (mandatory).** K-side ≤4-bit on Qwen MoE is the
 PPL-disaster zone (218 → 8641 on Q4_K_M baseline; 7:1 GQA amplifies K-head
-error through softmax). All four variants extend `KvQuant::refuses_qwen_moe()`
+error through softmax). All four variants are flagged by `KvQuant::k_below_8bit()`
 and `cache_type::validate_resolved` routes them through
 `ResolveError::QwenMoeRotorKRejected { variant }`, which quotes the offending
 variant by name. Error message verbatim:

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -160,6 +160,19 @@ Recorded per `(codec, model)` cell. A.y-excluded combos (e.g. K8VTurbo3 K-side �
 
 `—` = cell not measured yet. SKIP marks A.y-rejected combos.
 
+**Why `k_iso*` / `k_rotor*` trail their `*_sym` siblings.** Counter-intuitively
+the K-only variants (bf16 V) decode *slower* than the fully-symmetric ones on
+Bonsai (e.g. k_iso3 59 vs iso3_sym 142, k_rotor3 45 vs rotor3_sym 145). The
+K-side iso/rotor codecs have no GPU-resident code mirror on the live decode
+path: the CPU `dequant()` re-materializes the full K prefix each step and the
+result is re-uploaded via `Array::from_bytes` (rotor additionally applies an
+O(head_dim²)-per-token QJL score correction under the default `--rotor-qjl
+on`), an O(kv_seq) per-step cost the `*_sym` path amortizes through its
+warm-TTFT bf16 seed. (The `dequant_gpu` mirror is gated off by
+`gpu_resident_iso_enabled()`.) These anchors are
+short-prompt; the gap widens with context. See `docs/KV_QUANT.md` "iso/rotor
+K-side variants" and `gpu_resident_iso_enabled` in `rmlx-kv-quant/src/lib.rs`.
+
 Each new codec: invoke `scripts/bench_codec_cell.sh --kv-quant <codec> --model <model>` per cell (3 cells per codec, A.y-excluded skipped), then append to this table.
 
 **Champions regen**: regenerate `BENCHMARK_CHAMPIONS.md` via `rmlx metrics export --markdown` after each cell lands. If that command is unavailable, manual fallback: hand-edit `BENCHMARK_CHAMPIONS.md` with cell + recorded TPS, cite source CSV row.

--- a/docs/models/qwen3.6/SIBLINGS.md
+++ b/docs/models/qwen3.6/SIBLINGS.md
@@ -172,7 +172,7 @@ rMLX full matrix (Stage 2):
 ```
 
 **Arch-guard pre-skips for MoE (Qwen3.5-MoE):** the following KV variants are hard-rejected
-by `refuses_qwen_moe()` in `rmlx-kv-quant/src/quant.rs` and will be logged as skip(arch-guard)
+by `k_below_8bit()` in `rmlx-kv-quant/src/quant.rs` and will be logged as skip(arch-guard)
 without a probe: `tsym3, tsym4, iso3_sym, iso4_sym, k_iso3, k_iso4, rotor3_sym, rotor4_sym,
 k_rotor3, k_rotor4, rotor_k_3_asym_*, rotor_k_4_asym_*` (~13 variants), plus `planar_k`.
 


### PR DESCRIPTION
## What
Documentation-truth pass for the iso/rotor KV codecs (Phase E, Task 14a).

## KV_QUANT.md
- **iso/rotor K-side decode-cost caveat**: the K-only codecs have no GPU-resident mirror on the live path — CPU `dequant()` re-materializes the full K prefix each step + re-uploads via `Array::from_bytes` (O(kv_seq)/step); rotor adds an O(head_dim²)/token QJL correction under default `--rotor-qjl on`. The `dequant_gpu` mirror is gated off by `gpu_resident_iso_enabled()` (hardcoded `false`). Short-prompt anchors mask it; long-prompt exposes it.
- **iso memory truth**: iso stores per 4-elem group a code word + f32 scale + 4×f32 quaternion, +1 f32 norm/token ≈ 772 B/token/kv_head @hd128 vs 256 B bf16 → **iso3/iso4 are net-NEGATIVE on memory**; the resolve-time warn (`estimated_resident_bytes_per_layer`) models the sidebands exactly.
- **planar3 warm note**: the V3 quantize kernel is precompiled at load via `warm_v_side` (no prefill cold-compile stall); the dequant kernel still cold-compiles lazily; the `--ignored` GPU round-trip test exists.

## PERF_BASELINE.md
Footnote explaining why `k_iso*`/`k_rotor*` trail their `*_sym` siblings (59 vs 142, 45 vs 145 on Bonsai) — the K-side per-step CPU re-materialization, matching the cell-table figures.

## Rename propagation
Updated stale `refuses_qwen_moe()` → `k_below_8bit()` references (renamed in #64) across KV_QUANT.md, E2E_TEST_PLAN.md, SIBLINGS.md.

Rust-reviewer (Opus) doc-truth pass verified every claim against code; flagged 3 mechanism-precision issues (dequant_gpu vs live dequant, planar3 quantize-only warm, rotor re-decode-not-re-encode) — all corrected here.

Plan: Task 14a (Phase E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)