### PR TITLE
docs(kv-quant): codec comments describe properties, arch names demoted to examples

### DIFF
--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -66,9 +66,9 @@ pub enum KvQuant {
     /// Eliminates the per-step full dequantize that dominates the rMLX k8v4
     /// hot path (decode-step audit).
     ///
-    /// Currently wired for `Qwen3ForCausalLM` only (Bonsai-2bit) via
-    /// `KvCacheBuilder::resolve_default`; other archs continue to use their
-    /// existing per-arch defaults.
+    /// The codec is arch-agnostic; the auto policy currently selects it only
+    /// for `Qwen3ForCausalLM` (Bonsai-2bit) via `KvCacheBuilder::resolve_default`
+    /// as an example consumer — other archs keep their existing per-arch defaults.
     Mixed {
         /// K quantization bit-width.
         k_bits: u8,

--- a/crates/rmlx-kv-quant/src/rotating.rs
+++ b/crates/rmlx-kv-quant/src/rotating.rs
@@ -9,7 +9,7 @@
 //! attention reads at most `max_size` tokens — no per-step trimming, no per-step
 //! window mask.
 //!
-//! Used by Gemma3/Gemma4 SWA layers in **bf16-KV mode only**.
+//! Used by SWA layers (e.g. Gemma3/Gemma4) in **bf16-KV mode only**.
 //! Quantized SWA layers stay on the existing full-size [`KvStorage`] codec
 //! paths; mlx-lm's reference also keeps RotatingKVCache as bf16
 //! (`to_quantized` raises `NotImplementedError`).


### PR DESCRIPTION
## What
Comment-hygiene fix (Phase E, Task 14b / F20): two codec comments in the leaf `rmlx-kv-quant` crate stated arch coupling as a definition.

## Fix
- `rotating.rs`: "Used by Gemma3/Gemma4 SWA layers" → "Used by SWA layers (e.g. Gemma3/Gemma4)" — arch names are examples, not the definition.
- `quant.rs` `Mixed` doc: lead with "the codec is arch-agnostic"; `Qwen3ForCausalLM`/Bonsai is the *current example consumer* of the auto policy, not a definitional coupling.

Per the plan, the example-geometry comments in `sdpa.rs`/`core.rs` are NOT swept (examples are allowed; only normative-arch-coupling comments are fixed). Comment-only — `make check`/`make lint` clean.

Plan: Task 14b (Phase E). Phase E complete — all plan tasks landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)