### PR TITLE
fix(kv-ssd): spill + restore bf16 K/V payload for KvQuant::None layers

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/core.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/core.rs
@@ -137,6 +137,20 @@ impl KvCache {
         &self.storage
     }
 
+    /// Borrow the live bf16 decode K/V buffers, if both are present.
+    ///
+    /// For a [`KvStorage::None`] cache these are the *only* place the live K/V
+    /// resides (the storage buffer is geometry-only), so the SSD spill path
+    /// reads them here to persist the bf16 prefix. Returns `None` when either
+    /// buffer is unset (a never-filled cache, or a hydrated SWA layer whose
+    /// rotating ring was never serialised) — those layers spill geometry-only.
+    pub fn decode_fp16_kv(&self) -> Option<(&Array, &Array)> {
+        match (&self.decode_fp16_k, &self.decode_fp16_v) {
+            (Some(k), Some(v)) => Some((k, v)),
+            _ => None,
+        }
+    }
+
     /// Set the model-side layer index on this cache.
     ///
     /// Call this in the arch builder loop immediately after `with_quant_max_seq`
@@ -161,6 +175,26 @@ impl KvCache {
     /// test in `rmlx-kv-ssd` to verify the `write_caches` positional contract.
     pub fn layer_idx(&self) -> usize {
         self.layer_idx
+    }
+
+    /// Seed the bf16 decode K/V buffers on a hydrated [`KvStorage::None`] cache.
+    ///
+    /// `KvStorage::None` (the unquantised bf16 path) keeps its live K/V in
+    /// [`Self::decode_fp16_k`] / [`Self::decode_fp16_v`] off the storage buffer,
+    /// so [`Self::from_storage`] alone reconstructs an *empty* cache for that
+    /// variant. The SSD hydrate path persists the bf16 prefix alongside the
+    /// geometry and restores it here so an exact-hit replay reads the real K/V
+    /// instead of zeros. bf16 round-trips exactly, so the seeded buffers match
+    /// the pre-spill values bit-for-bit.
+    ///
+    /// `k` / `v` are head-major `[B, kv_h, seq, head_dim]`, matching the layout
+    /// `exit_prefill` materialises. The `offset` set by [`Self::from_storage`]
+    /// already reflects `seq`, so no further bookkeeping is needed.
+    #[must_use]
+    pub fn with_decode_fp16_seed(mut self, k: Array, v: Array) -> Self {
+        self.decode_fp16_k = Some(k);
+        self.decode_fp16_v = Some(v);
+        self
     }
 
     /// Rebuild a `KvCache` from a reconstructed [`KvStorage`] (SSD

--- a/crates/rmlx-kv-ssd/src/block_io.rs
+++ b/crates/rmlx-kv-ssd/src/block_io.rs
@@ -699,6 +699,13 @@ fn write_layer(
             // a hydrated SWA layer whose rotating ring was never serialised) this
             // falls back to geometry-only "none" — those layers hold no payload.
             if let Some((k, v)) = none_bf16 {
+                // `seq` is taken as the buffer's filled length. The spill
+                // contract requires the None-path `decode_fp16_k` to be
+                // compacted to `offset` (the state `exit_prefill` leaves it in:
+                // sliced to `[B, kv_h, offset, D]`). A decode-expanded buffer
+                // grown to the `max_seq` ceiling with a zeroed tail must never
+                // reach here, or that tail would be persisted as live KV and the
+                // reconstructed offset would be wrong.
                 let seq = k.shape().get(2).copied().unwrap_or(0);
                 out.push((format!("l{idx}.k.bf16"), OwnedTensor::from_array(k)?));
                 out.push((format!("l{idx}.v.bf16"), OwnedTensor::from_array(v)?));

--- a/crates/rmlx-kv-ssd/src/block_io.rs
+++ b/crates/rmlx-kv-ssd/src/block_io.rs
@@ -84,6 +84,16 @@ use rmlx_kv_quant::storage::{
 };
 use rmlx_kv_quant::KvQuant;
 
+/// Per-layer off-storage bf16 K/V seed restored on hydrate. `Some` only for a
+/// `KvQuant::None` layer whose live K/V lived on the parent `KvCache`
+/// (`decode_fp16_{k,v}`); `None` for every quantised variant (their K/V is
+/// inside the reconstructed `KvStorage`).
+type NoneBf16Seed = Option<(Array, Array)>;
+
+/// Result of [`KvBlockReader::hydrate`]: per-layer storages, per-layer
+/// off-storage bf16 seeds, and the linear-attn recurrent caches.
+type HydratedLayers = (Vec<KvStorage>, Vec<NoneBf16Seed>, Vec<LinearAttnCache>);
+
 // ── Metadata keys ───────────────────────────────────────────────────────────
 
 const META_MODEL_ID: &str = "model_id";
@@ -297,7 +307,34 @@ pub fn write_caches(
     lin_caches: &[LinearAttnCache],
 ) -> Result<()> {
     let layers: Vec<&KvStorage> = kv_caches.iter().map(KvCache::storage).collect();
-    serialize_block_refs(path, device, model_id, kv_quant, &layers, lin_caches)
+    let none_bf16 = none_bf16_payloads(kv_caches)?;
+    serialize_block_refs(
+        path, device, model_id, kv_quant, &layers, &none_bf16, lin_caches,
+    )
+}
+
+/// Collect the live bf16 K/V buffers of every [`KvStorage::None`] layer, so the
+/// spill writer can persist the unquantised prefix that lives off the storage
+/// buffer (on `KvCache::decode_fp16_{k,v}`). Element `i` is `Some` only for a
+/// `None`-storage layer that actually holds a filled bf16 pair; all other
+/// layers (quantised storage, or an unfilled / SWA-hydrated `None`) are `None`
+/// and spill via their existing geometry-only path.
+fn none_bf16_payloads(kv_caches: &[KvCache]) -> Result<Vec<NoneBf16Seed>> {
+    kv_caches
+        .iter()
+        .map(|c| {
+            if matches!(c.storage(), KvStorage::None { .. }) {
+                match c.decode_fp16_kv() {
+                    // Ref-count clone only (mlx-c is COW); host materialisation
+                    // happens later in `OwnedTensor::from_array`.
+                    Some((k, v)) => Ok(Some((k.try_clone()?, v.try_clone()?))),
+                    None => Ok(None),
+                }
+            } else {
+                Ok(None)
+            }
+        })
+        .collect()
 }
 
 /// Timed variant of [`write_caches`] for SSD-tier spill observability.
@@ -320,7 +357,10 @@ pub(crate) fn write_caches_timed(
     lin_caches: &[LinearAttnCache],
 ) -> Result<(u64, u64, u64)> {
     let layers: Vec<&KvStorage> = kv_caches.iter().map(KvCache::storage).collect();
-    serialize_block_refs_timed(path, device, model_id, kv_quant, &layers, lin_caches)
+    let none_bf16 = none_bf16_payloads(kv_caches)?;
+    serialize_block_refs_timed(
+        path, device, model_id, kv_quant, &layers, &none_bf16, lin_caches,
+    )
 }
 
 /// Reconstruct a KV block as `Vec<KvCache>` (+ optional GDN linear state) from
@@ -384,17 +424,26 @@ fn read_caches_inner(
     let dur_read_us = t_read.elapsed().as_micros() as u64;
 
     let t_dequant = Instant::now();
-    let (storages, lin_caches) = reader.hydrate(model_id, kv_quant, device)?;
+    let (storages, none_bf16, lin_caches) = reader.hydrate(model_id, kv_quant, device)?;
     let offset = reader.seq_len()?;
     let dur_dequant_us = t_dequant.elapsed().as_micros() as u64;
 
     let t_finalize = Instant::now();
     // `layer_idx` is reconstructed positionally: assumes `kv_caches` was
-    // layer-ordered at spill — see `write_caches` contract.
+    // layer-ordered at spill — see `write_caches` contract. A `None`-storage
+    // layer that carried an off-storage bf16 prefix re-seeds the decode buffers
+    // so an exact-hit replay reads the real K/V instead of zeros.
     let kv_caches: Vec<KvCache> = storages
         .into_iter()
+        .zip(none_bf16)
         .enumerate()
-        .map(|(layer_idx, s)| KvCache::from_storage(s, kv_quant, offset, layer_idx))
+        .map(|(layer_idx, (s, bf16))| {
+            let cache = KvCache::from_storage(s, kv_quant, offset, layer_idx);
+            match bf16 {
+                Some((k, v)) => cache.with_decode_fp16_seed(k, v),
+                None => cache,
+            }
+        })
         .collect();
     let dur_finalize_us = t_finalize.elapsed().as_micros() as u64;
 
@@ -418,19 +467,27 @@ fn serialize_block(
     linear: &[LinearAttnCache],
 ) -> Result<()> {
     let refs: Vec<&KvStorage> = layers.iter().collect();
-    serialize_block_refs(path, device, model_id, kv_quant, &refs, linear)
+    // Storage-only callers (the `KvBlockWriter` struct path used by tests)
+    // carry no off-storage bf16 — None layers serialize geometry-only.
+    serialize_block_refs(path, device, model_id, kv_quant, &refs, &[], linear)
 }
 
 /// Shared serialization core over a slice of storage references.
+///
+/// `none_bf16[i]`, when `Some`, holds the off-storage bf16 `(K, V)` of a
+/// [`KvStorage::None`] layer (from `KvCache::decode_fp16_{k,v}`); an empty
+/// slice means "no off-storage payload for any layer" (the struct-writer path).
 fn serialize_block_refs(
     path: &Path,
     device: Device,
     model_id: &str,
     kv_quant: KvQuant,
     layers: &[&KvStorage],
+    none_bf16: &[NoneBf16Seed],
     linear: &[LinearAttnCache],
 ) -> Result<()> {
-    serialize_block_refs_timed(path, device, model_id, kv_quant, layers, linear).map(|_| ())
+    serialize_block_refs_timed(path, device, model_id, kv_quant, layers, none_bf16, linear)
+        .map(|_| ())
 }
 
 /// Timed serialization core — splits the work into a tensor-build phase
@@ -443,6 +500,7 @@ fn serialize_block_refs_timed(
     model_id: &str,
     kv_quant: KvQuant,
     layers: &[&KvStorage],
+    none_bf16: &[NoneBf16Seed],
     linear: &[LinearAttnCache],
 ) -> Result<(u64, u64, u64)> {
     use std::time::Instant;
@@ -458,7 +516,8 @@ fn serialize_block_refs_timed(
 
     let mut max_seq_len = 0i32;
     for (idx, storage) in layers.iter().enumerate() {
-        let (geom, seq) = write_layer(idx, storage, device, &mut tensors)?;
+        let bf16 = none_bf16.get(idx).and_then(Option::as_ref);
+        let (geom, seq) = write_layer(idx, storage, bf16, device, &mut tensors)?;
         meta.insert(geom_key(idx), geom);
         max_seq_len = max_seq_len.max(seq);
     }
@@ -501,6 +560,7 @@ fn serialize_block_refs_timed(
 fn write_layer(
     idx: usize,
     storage: &KvStorage,
+    none_bf16: Option<&(Array, Array)>,
     device: Device,
     out: &mut Vec<(String, OwnedTensor)>,
 ) -> Result<(String, i32)> {
@@ -631,7 +691,24 @@ fn write_layer(
             Ok((geom_kv(tag, *max_seq, k_shape(k.as_ref())), seq))
         }
         KvStorage::None { max_seq } => {
-            Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0))
+            // KvQuant::None keeps its live K/V as bf16 on the parent KvCache
+            // (`decode_fp16_{k,v}`), not in the storage buffer. When the spill
+            // path supplies that pair, persist it under `l{idx}.{k,v}.bf16` and
+            // tag the layer "none_bf16" so hydrate re-seeds the decode buffers
+            // (bf16 round-trips exactly). With no pair (a never-filled cache, or
+            // a hydrated SWA layer whose rotating ring was never serialised) this
+            // falls back to geometry-only "none" — those layers hold no payload.
+            if let Some((k, v)) = none_bf16 {
+                let seq = k.shape().get(2).copied().unwrap_or(0);
+                out.push((format!("l{idx}.k.bf16"), OwnedTensor::from_array(k)?));
+                out.push((format!("l{idx}.v.bf16"), OwnedTensor::from_array(v)?));
+                Ok((
+                    format!("{{\"tag\":\"none_bf16\",\"max_seq\":{max_seq}}}"),
+                    seq,
+                ))
+            } else {
+                Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0))
+            }
         }
         KvStorage::Mixed { state, max_seq } => write_mixed(idx, state, *max_seq, out),
         KvStorage::Paged {
@@ -1866,7 +1943,7 @@ impl KvBlockReader {
         expected_model_id: &str,
         expected_kv_quant: KvQuant,
         device: Device,
-    ) -> Result<(Vec<KvStorage>, Vec<LinearAttnCache>)> {
+    ) -> Result<HydratedLayers> {
         let header = self.header()?;
         let st = self.parse()?;
 
@@ -1893,9 +1970,21 @@ impl KvBlockReader {
             .map_err(|e| BlockIoError::Header(format!("bad n_layers: {e}")))?;
 
         let mut layers = Vec::with_capacity(n_layers);
+        let mut none_bf16: Vec<NoneBf16Seed> = Vec::with_capacity(n_layers);
         for idx in 0..n_layers {
             let geom = read_meta(&header, &geom_key(idx))?;
             layers.push(read_layer(&st, idx, &geom, device)?);
+            // For a "none_bf16" layer (KvQuant::None spill that carried the
+            // off-storage bf16 prefix), restore the K/V pair so the caller can
+            // re-seed the parent KvCache's decode buffers. All other tags hold
+            // their K/V inside the reconstructed KvStorage and have no bf16 seed.
+            if geom_tag(&geom) == "none_bf16" {
+                let k = tensor_req(&st, &format!("l{idx}.k.bf16"))?;
+                let v = tensor_req(&st, &format!("l{idx}.v.bf16"))?;
+                none_bf16.push(Some((k, v)));
+            } else {
+                none_bf16.push(None);
+            }
         }
 
         let n_linear: usize = header
@@ -1912,7 +2001,7 @@ impl KvBlockReader {
             linear.push(lac);
         }
 
-        Ok((layers, linear))
+        Ok((layers, none_bf16, linear))
     }
 }
 
@@ -2037,7 +2126,10 @@ fn read_layer(st: &SafeTensors<'_>, idx: usize, geom: &str, device: Device) -> R
                 bits: 3,
             })
         }
-        "none" => Ok(KvStorage::None {
+        // Both tags reconstruct geometry-only None storage. The "none_bf16"
+        // variant additionally carries an off-storage bf16 K/V prefix, read in
+        // `hydrate` and re-seeded onto the parent KvCache by the caller.
+        "none" | "none_bf16" => Ok(KvStorage::None {
             max_seq: geom_i32(geom, "max_seq")?,
         }),
         "mixed" => read_mixed(st, idx, geom),

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -588,7 +588,7 @@ fn roundtrip_variant(name: &str, quant: KvQuant) {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _lin) = reader.hydrate(MODEL_ID, quant, device).unwrap();
+    let (rebuilt, _bf16, _lin) = reader.hydrate(MODEL_ID, quant, device).unwrap();
     assert_eq!(rebuilt.len(), 1, "{name}: layer count");
 
     // Dequant K from the rebuilt storage and compare to the pre-write dequant.
@@ -824,7 +824,7 @@ fn roundtrip_planar3() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _lin) = reader.hydrate(MODEL_ID, KvQuant::Planar3, device).unwrap();
+    let (rebuilt, _bf16, _lin) = reader.hydrate(MODEL_ID, KvQuant::Planar3, device).unwrap();
     assert_eq!(rebuilt.len(), 1, "planar3: layer count");
 
     // Assert bits=3 is preserved through the round-trip.
@@ -916,7 +916,7 @@ fn roundtrip_k8vturbo3_tcq() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::K8VTurbo3Tcq, device)
         .unwrap();
     assert_eq!(rebuilt.len(), 1, "layer count");
@@ -983,7 +983,7 @@ fn roundtrip_k8vturbo2_v_codes_byte_identical() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::K8VTurbo2, device)
         .unwrap();
     assert_eq!(rebuilt.len(), 1, "layer count");
@@ -1048,7 +1048,7 @@ fn roundtrip_rot_k_tq4v() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _lin) = reader.hydrate(MODEL_ID, KvQuant::RotKTq4V, device).unwrap();
+    let (rebuilt, _bf16, _lin) = reader.hydrate(MODEL_ID, KvQuant::RotKTq4V, device).unwrap();
     assert_eq!(rebuilt.len(), 1, "layer count");
 
     // K codes round-trip: dequant must be bit-identical.
@@ -1116,7 +1116,7 @@ fn roundtrip_iso3() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _lin) = reader.hydrate(MODEL_ID, KvQuant::Iso3, device).unwrap();
+    let (rebuilt, _bf16, _lin) = reader.hydrate(MODEL_ID, KvQuant::Iso3, device).unwrap();
     assert_eq!(rebuilt.len(), 1, "iso3: layer count");
 
     // All four V-side buffers must be byte/value-identical after round-trip.
@@ -1233,7 +1233,7 @@ fn roundtrip_iso4() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _lin) = reader.hydrate(MODEL_ID, KvQuant::Iso4, device).unwrap();
+    let (rebuilt, _bf16, _lin) = reader.hydrate(MODEL_ID, KvQuant::Iso4, device).unwrap();
     assert_eq!(rebuilt.len(), 1, "iso4: layer count");
 
     let (v_codes_after, v_scales_after, v_quats_after, v_norms_after) = match &rebuilt[0] {
@@ -1348,7 +1348,7 @@ fn roundtrip_rotor3() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _lin) = reader.hydrate(MODEL_ID, KvQuant::Rotor3, device).unwrap();
+    let (rebuilt, _bf16, _lin) = reader.hydrate(MODEL_ID, KvQuant::Rotor3, device).unwrap();
     assert_eq!(rebuilt.len(), 1, "rotor3: layer count");
 
     let (v_codes_after, v_scales_after, v_norms_after, v_rotors_after) = match &rebuilt[0] {
@@ -1458,7 +1458,7 @@ fn roundtrip_rotor4() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _lin) = reader.hydrate(MODEL_ID, KvQuant::Rotor4, device).unwrap();
+    let (rebuilt, _bf16, _lin) = reader.hydrate(MODEL_ID, KvQuant::Rotor4, device).unwrap();
     assert_eq!(rebuilt.len(), 1, "rotor4: layer count");
 
     let (v_codes_after, v_scales_after, v_norms_after, v_rotors_after) = match &rebuilt[0] {
@@ -1547,8 +1547,111 @@ fn roundtrip_none() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader.hydrate(MODEL_ID, KvQuant::None, device).unwrap();
+    let (rebuilt, _bf16, _) = reader.hydrate(MODEL_ID, KvQuant::None, device).unwrap();
     assert!(matches!(rebuilt[0], KvStorage::None { max_seq: 4096 }));
+    let _ = std::fs::remove_file(&path);
+}
+
+/// `KvQuant::None` keeps its live K/V as bf16 on the parent `KvCache`
+/// (`decode_fp16_{k,v}`), off the geometry-only `KvStorage::None` buffer. The
+/// spill path must persist that bf16 prefix and hydrate must re-seed it, or an
+/// exact-hit SSD replay reads zeros and decodes garbage.
+///
+/// This drives the REAL `write_caches` (spill bridge) + `read_caches` (hydrate
+/// bridge) on disk — not the storage-only `KvBlockWriter` struct path — so the
+/// `KvCache::decode_fp16_{k,v}` capture/restore seam is exercised end-to-end.
+/// Uses `kv_h > 1` and two layers so a head-axis or per-layer scramble would
+/// surface. bf16 round-trips bit-exact, so the assert is exact equality.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "test assertion: a missing bf16 seed is exactly the failure this test must surface, so a panic with the diagnostic message is the intended outcome"
+)]
+fn roundtrip_none_bf16_payload_via_spill_hydrate() {
+    let device = Device::Cpu;
+    // [B, kv_h, S, D] with kv_h > 1 so a head-axis transpose would be caught.
+    let shape = [1i32, 8, 32, 128];
+    let n: usize = shape.iter().map(|&x| x as usize).product();
+
+    // Two None-storage layers, each with a distinct bf16 K/V pair. bf16 cast up
+    // front so the round-trip is bit-exact (the cache stores exactly these
+    // buffers; no quantisation is applied on the None path).
+    let mut kv_caches = Vec::new();
+    let mut want: Vec<(Vec<f32>, Vec<f32>)> = Vec::new();
+    for layer in 0..2u64 {
+        let k_bf16 = arr(&lcg(n, 0x511 ^ layer), &shape)
+            .astype(Dtype::Bf16, device)
+            .unwrap();
+        let v_bf16 = arr(&lcg(n, 0x9A7 ^ layer), &shape)
+            .astype(Dtype::Bf16, device)
+            .unwrap();
+        // Reference values read back through bf16 so equality is exact.
+        let k_ref = to_vec(&k_bf16.astype(Dtype::F32, device).unwrap());
+        let v_ref = to_vec(&v_bf16.astype(Dtype::F32, device).unwrap());
+        want.push((k_ref, v_ref));
+
+        let cache = KvCache::with_quant_max_seq(KvQuant::None, 4096)
+            .with_layer_idx(layer as usize)
+            .with_decode_fp16_seed(k_bf16, v_bf16);
+        kv_caches.push(cache);
+    }
+
+    let path = tmp_path("none_bf16");
+    write_caches(&path, device, MODEL_ID, KvQuant::None, &kv_caches, &[]).unwrap();
+
+    // Sanity: the spilled file must carry real K/V tensors, not geometry-only.
+    let reader = KvBlockReader::open(&path).unwrap();
+    let (rebuilt, bf16_seeds, _lin) = reader.hydrate(MODEL_ID, KvQuant::None, device).unwrap();
+    assert_eq!(rebuilt.len(), 2, "layer count");
+    for layer in 0..2 {
+        assert!(
+            matches!(rebuilt[layer], KvStorage::None { .. }),
+            "layer {layer} reconstructs as None storage"
+        );
+        let (k_hyd, v_hyd) = bf16_seeds[layer]
+            .as_ref()
+            .expect("None layer must carry a restored bf16 K/V seed");
+        let k_got = to_vec(&k_hyd.astype(Dtype::F32, device).unwrap());
+        let v_got = to_vec(&v_hyd.astype(Dtype::F32, device).unwrap());
+        assert_eq!(
+            k_got, want[layer].0,
+            "layer {layer} K bf16 must round-trip exactly"
+        );
+        assert_eq!(
+            v_got, want[layer].1,
+            "layer {layer} V bf16 must round-trip exactly"
+        );
+    }
+
+    // And the full bridge re-seeds the parent KvCache: a hydrated None cache
+    // must expose the restored bf16 K/V via `decode_fp16_kv`, with `offset`
+    // set to the spilled seq length (32 tokens) so decode resumes at the right
+    // position.
+    let (hydrated, _lin) = read_caches(&path, device, MODEL_ID, KvQuant::None).unwrap();
+    assert_eq!(hydrated.len(), 2, "bridge layer count");
+    for layer in 0..2 {
+        assert_eq!(
+            hydrated[layer].offset(),
+            shape[2],
+            "layer {layer} offset must equal spilled seq_len"
+        );
+        let (k_hyd, v_hyd) = hydrated[layer]
+            .decode_fp16_kv()
+            .expect("hydrated None cache must carry bf16 decode K/V");
+        let k_got = to_vec(&k_hyd.astype(Dtype::F32, device).unwrap());
+        let v_got = to_vec(&v_hyd.astype(Dtype::F32, device).unwrap());
+        assert_eq!(k_got, want[layer].0, "layer {layer} bridge K mismatch");
+        assert_eq!(v_got, want[layer].1, "layer {layer} bridge V mismatch");
+    }
+
     let _ = std::fs::remove_file(&path);
 }
 
@@ -1602,7 +1705,7 @@ fn roundtrip_paged() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader.hydrate(MODEL_ID, KvQuant::K8V4, device).unwrap();
+    let (rebuilt, _bf16, _) = reader.hydrate(MODEL_ID, KvQuant::K8V4, device).unwrap();
     let after = dequant_k(&rebuilt[0], device);
     assert_eq!(before.len(), after.len(), "paged K length");
     let max_err = before
@@ -1651,7 +1754,7 @@ fn roundtrip_linear_attn() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (_layers, rebuilt_lin) = reader.hydrate(MODEL_ID, KvQuant::None, device).unwrap();
+    let (_layers, _bf16, rebuilt_lin) = reader.hydrate(MODEL_ID, KvQuant::None, device).unwrap();
     assert_eq!(rebuilt_lin.len(), 1, "linear cache count");
     assert_eq!(
         to_vec(rebuilt_lin[0].conv_state.as_ref().unwrap()),
@@ -1729,7 +1832,7 @@ fn c3_k8v4_hydrate_round_trip_no_panic() {
     write_caches(&path, device, MODEL_ID, KvQuant::K8V4, &[c], &[]).unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader.hydrate(MODEL_ID, KvQuant::K8V4, device).unwrap();
+    let (rebuilt, _bf16, _) = reader.hydrate(MODEL_ID, KvQuant::K8V4, device).unwrap();
     let storage = rebuilt.into_iter().next().unwrap();
 
     let mut cache = KvCache::from_storage(storage, KvQuant::K8V4, 300, 0);
@@ -1776,7 +1879,7 @@ fn c2_planar_hydrate_round_trip_no_panic() {
     write_caches(&path, device, MODEL_ID, KvQuant::Planar, &[c], &[]).unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader.hydrate(MODEL_ID, KvQuant::Planar, device).unwrap();
+    let (rebuilt, _bf16, _) = reader.hydrate(MODEL_ID, KvQuant::Planar, device).unwrap();
     let storage = rebuilt.into_iter().next().unwrap();
 
     let mut cache = KvCache::from_storage(storage, KvQuant::Planar, 300, 0);
@@ -1861,7 +1964,7 @@ fn roundtrip_k8vturbo2tcq() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::K8VTurbo2Tcq, device)
         .unwrap();
     assert_eq!(rebuilt.len(), 1, "layer count");
@@ -1953,7 +2056,7 @@ fn roundtrip_iso_sym_3() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader.hydrate(MODEL_ID, KvQuant::Iso3Sym, device).unwrap();
+    let (rebuilt, _bf16, _) = reader.hydrate(MODEL_ID, KvQuant::Iso3Sym, device).unwrap();
     assert_eq!(rebuilt.len(), 1, "iso_sym_3: layer count");
 
     let (k_codes_after, v_codes_after) = match &rebuilt[0] {
@@ -2020,7 +2123,7 @@ fn roundtrip_iso_sym_4() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader.hydrate(MODEL_ID, KvQuant::Iso4Sym, device).unwrap();
+    let (rebuilt, _bf16, _) = reader.hydrate(MODEL_ID, KvQuant::Iso4Sym, device).unwrap();
     assert_eq!(rebuilt.len(), 1);
 
     let (k_codes_after, v_codes_after) = match &rebuilt[0] {
@@ -2076,7 +2179,7 @@ fn roundtrip_iso_k_only_3() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::IsoKOnly3, device)
         .unwrap();
     assert_eq!(rebuilt.len(), 1);
@@ -2129,7 +2232,7 @@ fn roundtrip_iso_k_only_4() {
         .unwrap();
 
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::IsoKOnly4, device)
         .unwrap();
     assert_eq!(rebuilt.len(), 1);
@@ -2172,7 +2275,7 @@ fn roundtrip_rotor_sym_3_no_qjl() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::Rotor3Sym, device)
         .unwrap();
     let (k_codes_after, use_qjl_after) = match &rebuilt[0] {
@@ -2217,7 +2320,7 @@ fn roundtrip_rotor_sym_3_qjl() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::Rotor3Sym, device)
         .unwrap();
     let (k_codes_after, qjl_codes_after, use_qjl_after) = match &rebuilt[0] {
@@ -2255,7 +2358,7 @@ fn roundtrip_rotor_sym_4_qjl() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::Rotor4Sym, device)
         .unwrap();
     let (k_codes_after, use_qjl_after) = match &rebuilt[0] {
@@ -2281,7 +2384,7 @@ fn roundtrip_rotor_sym_4_no_qjl() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::Rotor4Sym, device)
         .unwrap();
     let use_qjl_after = match &rebuilt[0] {
@@ -2314,7 +2417,7 @@ fn roundtrip_rotor_k3_asym_v4_g64() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader.hydrate(MODEL_ID, kq, device).unwrap();
+    let (rebuilt, _bf16, _) = reader.hydrate(MODEL_ID, kq, device).unwrap();
     assert_eq!(rebuilt.len(), 1);
     let (vb_after, vg_after) = match &rebuilt[0] {
         KvStorage::RotorKAsym3 {
@@ -2359,7 +2462,7 @@ fn roundtrip_rotor_k4_asym_v3_g64() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader.hydrate(MODEL_ID, kq, device).unwrap();
+    let (rebuilt, _bf16, _) = reader.hydrate(MODEL_ID, kq, device).unwrap();
     assert_eq!(rebuilt.len(), 1);
     let (vb_after, vg_after) = match &rebuilt[0] {
         KvStorage::RotorKAsym4 {
@@ -2397,7 +2500,7 @@ fn roundtrip_rotor_k_only_3_qjl() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::RotorKOnly3, device)
         .unwrap();
     let use_qjl_after = match &rebuilt[0] {
@@ -2422,7 +2525,7 @@ fn roundtrip_rotor_k_only_3_no_qjl() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::RotorKOnly3, device)
         .unwrap();
     let use_qjl_after = match &rebuilt[0] {
@@ -2449,7 +2552,7 @@ fn roundtrip_rotor_k_only_4_qjl() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::RotorKOnly4, device)
         .unwrap();
     let use_qjl_after = match &rebuilt[0] {
@@ -2474,7 +2577,7 @@ fn roundtrip_rotor_k_only_4_no_qjl() {
         .write(&path, device)
         .unwrap();
     let reader = KvBlockReader::open(&path).unwrap();
-    let (rebuilt, _) = reader
+    let (rebuilt, _bf16, _) = reader
         .hydrate(MODEL_ID, KvQuant::RotorKOnly4, device)
         .unwrap();
     let use_qjl_after = match &rebuilt[0] {

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -367,13 +367,31 @@ or `BlockIoError::KvQuantMismatch` — never a silently-wrong cache.
 | `K8V4` | `l{i}.k.codes` `l{i}.k.scales` `l{i}.v.codes` `l{i}.v.scales` |
 | `K8V8` | same as K8V4 (V is also q8_0) |
 | `Planar` | K8V4 tensors plus `l{i}.v.rotations` |
-| `None` | geometry only — bf16 K/V live on the parent KvCache, not storage |
+| `None` (filled bf16) | `l{i}.k.bf16` `l{i}.v.bf16` — the off-storage bf16 prefix; geom tag `none_bf16` |
+| `None` (no payload) | geometry only, geom tag `none` — see note below |
 | `Mixed` | `l{i}.k.codes` `l{i}.k.scales` `l{i}.k.biases` + V equivalents |
 | `Paged` | gathered contiguous codes/scales/rotations + page geometry metadata |
 | `LinearAttn` | `l{i}.conv_state` + `l{i}.delta_state` (recurrent state, whole, never truncated) |
 
 The round trip is byte-exact on codes. GDN state has no sequence axis and is
 serialized in full.
+
+#### `None` payload spill (bf16)
+
+`KvStorage::None` (the `--kv-quant none` path) does **not** hold its live K/V in
+the storage buffer — the bf16 K/V live on the parent `KvCache`
+(`decode_fp16_{k,v}`, the same buffers `exit_prefill` seeds). The spill bridge
+(`write_caches`) reads those buffers and, when present, persists them under
+`l{i}.k.bf16` / `l{i}.v.bf16` with the geometry tag `none_bf16`. On hydrate the
+reader restores the pair and re-seeds the reconstructed cache via
+`KvCache::with_decode_fp16_seed`, so an exact-hit SSD replay reads the real K/V.
+bf16 round-trips bit-for-bit, so the restored prefix equals the pre-spill value.
+
+A `None` layer with **no** bf16 pair (a never-filled cache, or a hydrated SWA
+layer whose rotating ring was never serialised) falls back to the geometry-only
+`none` tag and re-prefills its prefix on reuse — it carries no spillable payload.
+This is the distinguishing signal: presence of `decode_fp16_{k,v}` means real KV
+exists and must travel; absence means there is nothing to persist.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes the SSD-tier spill of `KvQuant::None` layers. Previously a none-storage block was serialized geometry-only (`{"tag":"none","max_seq":…}`) with no K/V tensors, so a hydrated exact-hit decoded against empty caches (garbage / all-sentinel output).

For the none path the live bf16 K/V lives in `KvCache::decode_fp16_{k,v}` (off the codec storage buffer). The spill bridge now persists that pair under `l{i}.{k,v}.bf16` with geom tag `none_bf16`, and hydrate restores it via the new `KvCache::with_decode_fp16_seed`. bf16 round-trips bit-exact.

## Changes

- `crates/rmlx-kv-quant/src/kvcache/core.rs` — `decode_fp16_kv()` (read) + `with_decode_fp16_seed(k, v)` (hydrate re-seed).
- `crates/rmlx-kv-ssd/src/block_io.rs` — capture/serialize/restore the none bf16 payload through the write→serialize→`write_layer` and `hydrate`→`read_caches` paths; documented the `seq == filled offset` spill invariant.
- `docs/SSD_TIER.md` — `none_bf16` tensor layout + payload-vs-geometry rule.

## Proof

- New default-gate test `roundtrip_none_bf16_payload_via_spill_hydrate` drives the **real on-disk** `write_caches` spill + `read_caches`/`hydrate` for two `kv_h=8` None layers and asserts bit-exact bf16 K/V restore with consistent `offset`.
- Real-model (Qwen3-dense, `--kv-quant none`, SSD tier, exact-256 prompt, temp 0): pre-fix the hydrated exact-hit emits empty-KV garbage; post-fix the KV is restored (52 bf16 tensors, hydrate fired in logs) and output is structured.

## Compatibility

Old `.kvb` blocks tagged `none` (geometry-only) still hydrate as empty (prior behavior); only the new `none_bf16` tag triggers the payload reads. Non-None codec spill/hydrate paths are unchanged.

## Note

The residual first-token incoherence on an SSD exact-hit (a sentinel `first_id=0` is replayed because the spilled block does not store the first decode token) is a **separate, codec-agnostic** bug affecting all KV quants and architectures — tracked in #87, not this PR. This PR's KV-payload restoration is proven correct independently (bit-exact round-trip).

Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
