### PR TITLE
fix(prompt-cache): recompute first token for SSD-hydrated exact-hit (drop sentinel replay)

### DIFF
--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -225,8 +225,18 @@ pub fn generate_greedy<'a>(
                 // tail-reprefill Prefix path, which produced wrong output here too
                 // (22 -> 0 tokens for an identical re-request). Full-equality
                 // reuse sidesteps truncation entirely (pre-C1 behaviour).
+                //
+                // A SSD-hydrated entry whose block-aligned prefix length equals
+                // `prompt_ids.len()` (prompt is an exact multiple of
+                // BLOCK_TOKENS → no tail) must NOT be served here: its
+                // `first_id` is the placeholder 0 set in `SsdHydrate::hydrate`,
+                // not a real decode token. The `!is_ssd_hydrated` guard drops it
+                // through to the block-partial / Miss arms, which re-prefill and
+                // recompute the real first token. Correctness over the micro-opt
+                // (mirrors the qwen3 / qwen3_5_moe Exact arm guards).
                 Some((slot_idx, _block_count))
-                    if cache.slots[slot_idx].entry.prompt_token_ids() == prompt_ids =>
+                    if !cache.slots[slot_idx].entry.is_ssd_hydrated()
+                        && cache.slots[slot_idx].entry.prompt_token_ids() == prompt_ids =>
                 {
                     let slot = &cache.slots[slot_idx].entry;
                     match slot.deep_clone() {
@@ -780,6 +790,7 @@ pub fn generate_greedy<'a>(
                                 first_id: last_id,
                                 first_piece: piece.clone(),
                                 kv_quant: Some(kv_quant),
+                                is_ssd_hydrated: false,
                             });
                             tracing::debug!(
                                 prompt_len = prompt_ids.len(),

--- a/crates/rmlx-models/src/gemma4/prompt_cache.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache.rs
@@ -56,6 +56,16 @@ pub(crate) struct Gemma4Entry {
     /// (Plan §D8 / Task 11.5). See the original commit comments for the
     /// `Option<None>` legacy-sentinel rationale.
     pub(crate) kv_quant: Option<KvQuant>,
+    /// True when this entry was reconstructed from the SSD tier and therefore
+    /// stores only the block-aligned prefix KV — `first_id` / `first_piece` are
+    /// placeholders, not a real decode token. The generate loop excludes such
+    /// an entry from the Exact fast path so it falls through to a re-prefill
+    /// that recomputes the real first token.
+    ///
+    /// MUST be set only in `SsdHydrate::hydrate`; never by the RAM-cache push
+    /// path. Do NOT use the `first_id == 0` heuristic as a substitute —
+    /// `<bos>` token id is 0 for some models.
+    pub(crate) is_ssd_hydrated: bool,
 }
 
 impl Gemma4Entry {
@@ -122,6 +132,7 @@ impl PromptCacheEntry for Gemma4Entry {
             first_id: self.first_id,
             first_piece: self.first_piece.clone(),
             kv_quant: self.kv_quant,
+            is_ssd_hydrated: self.is_ssd_hydrated,
         })
     }
 
@@ -135,6 +146,10 @@ impl PromptCacheEntry for Gemma4Entry {
 
     fn kv_quant(&self) -> Option<KvQuant> {
         self.kv_quant
+    }
+
+    fn is_ssd_hydrated(&self) -> bool {
+        self.is_ssd_hydrated
     }
 
     // Pure-attention arch: no GDN linear state.
@@ -173,6 +188,9 @@ impl SsdHydrate<Gemma4Entry> for SsdHydrator {
             first_id: 0,
             first_piece: String::new(),
             kv_quant: Some(self.kv_quant()),
+            // Block-aligned prefix only; the placeholder first_id must not be
+            // replayed — the generate loop re-prefills to recompute it.
+            is_ssd_hydrated: true,
         }))
     }
 }

--- a/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
@@ -11,6 +11,7 @@ fn entry_with(kv_caches: Vec<KvCache>, ids: Vec<u32>) -> Gemma4Entry {
         first_id: 0,
         first_piece: String::new(),
         kv_quant: Some(KvQuant::K8V8),
+        is_ssd_hydrated: false,
     }
 }
 
@@ -27,6 +28,7 @@ fn entry_with_quant(
         first_id: 0,
         first_piece: String::new(),
         kv_quant,
+        is_ssd_hydrated: false,
     }
 }
 

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -241,6 +241,24 @@ pub(crate) trait PromptCacheEntry: Sized {
     /// drive the generic spill path without per-arch field reach-in.
     fn kv_quant(&self) -> Option<KvQuant>;
 
+    /// True when this entry was reconstructed from the SSD tier rather than
+    /// produced by a live prefill.
+    ///
+    /// An SSD-hydrated entry restores only the block-aligned prefix KV — the
+    /// first decode token was never serialized, so `first_id` / `first_piece`
+    /// are placeholders (id 0). The exact-hit fast path MUST exclude such an
+    /// entry (`!entry.is_ssd_hydrated()`) so it falls through to a full
+    /// re-prefill that recomputes the real first token; replaying the
+    /// placeholder poisons generation (a sentinel "!" first token).
+    ///
+    /// Defaults to `false` (a normal RAM-cached entry). Arch entries that can
+    /// be hydrated from SSD override this to surface their stored flag. Do NOT
+    /// use a `first_id == 0` heuristic as a substitute — `<bos>` is id 0 for
+    /// some models.
+    fn is_ssd_hydrated(&self) -> bool {
+        false
+    }
+
     /// The entry's linear-attention recurrent caches (GDN layers).
     ///
     /// Pure-attention archs return `&[]`; hybrid archs (Qwen3.5-MoE) return

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -38,6 +38,7 @@ struct TestEntry {
     ids: Vec<u32>,
     hashes: Vec<u64>,
     truncated_to: std::cell::Cell<Option<usize>>,
+    is_ssd_hydrated: bool,
 }
 
 impl TestEntry {
@@ -47,6 +48,7 @@ impl TestEntry {
             ids,
             hashes,
             truncated_to: std::cell::Cell::new(None),
+            is_ssd_hydrated: false,
         }
     }
 
@@ -60,7 +62,15 @@ impl TestEntry {
             ids,
             hashes,
             truncated_to: std::cell::Cell::new(None),
+            is_ssd_hydrated: false,
         }
+    }
+
+    /// Mark this entry as reconstructed from the SSD tier (placeholder
+    /// `first_id`). The Exact fast path must exclude it.
+    fn ssd_hydrated(mut self) -> Self {
+        self.is_ssd_hydrated = true;
+        self
     }
 }
 
@@ -78,6 +88,7 @@ impl PromptCacheEntry for TestEntry {
             ids: self.ids.clone(),
             hashes: self.hashes.clone(),
             truncated_to: std::cell::Cell::new(self.truncated_to.get()),
+            is_ssd_hydrated: self.is_ssd_hydrated,
         })
     }
 
@@ -96,6 +107,10 @@ impl PromptCacheEntry for TestEntry {
 
     fn kv_quant(&self) -> Option<KvQuant> {
         None
+    }
+
+    fn is_ssd_hydrated(&self) -> bool {
+        self.is_ssd_hydrated
     }
 
     fn lin_caches(&self) -> &[LinearAttnCache] {
@@ -408,6 +423,76 @@ fn hit_miss_counters_three_requests() {
     assert_eq!(
         stats.bytes, expected_bytes,
         "bytes should match kv_bytes() of the single slot"
+    );
+}
+
+/// `is_ssd_hydrated()` defaults to `false` for a normal RAM-cached entry and
+/// flips to `true` once an entry is marked hydrated.
+#[test]
+fn is_ssd_hydrated_defaults_false() {
+    let ram = TestEntry::new(make_ids(BLOCK_TOKENS));
+    assert!(
+        !ram.is_ssd_hydrated(),
+        "a normal RAM-cached entry must report is_ssd_hydrated() == false"
+    );
+    let hydrated = TestEntry::new(make_ids(BLOCK_TOKENS)).ssd_hydrated();
+    assert!(
+        hydrated.is_ssd_hydrated(),
+        "an SSD-hydrated entry must report is_ssd_hydrated() == true"
+    );
+}
+
+/// Pins the exact-hit selection predicate the per-arch generate loops evaluate:
+/// an Exact serve requires `!entry.is_ssd_hydrated() && entry.prompt_token_ids()
+/// == prompt`. A normal RAM entry whose ids equal the prompt is served (replay
+/// the stored real first token); an SSD-hydrated entry with the SAME block-
+/// aligned ids must NOT be served as Exact — its `first_id` is the placeholder 0
+/// and replaying it poisons generation. Excluding it forces a fall-through to a
+/// full re-prefill that recomputes the real first token.
+///
+/// This is the codec-agnostic core of the SSD exact-hit sentinel fix; it runs in
+/// the default gate (no model) by checking the predicate against `find_best_prefix`
+/// hits for both a RAM-cached and a hydrated full-prompt entry.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "find_best_prefix returns Some by construction (a block-aligned full-prompt entry was just pushed); the returned slot index is a valid `slots` index"
+)]
+fn ssd_hydrated_entry_excluded_from_exact_serve() {
+    // Block-aligned full prompt (no tail) — the SSD exact-hit reproduction shape
+    // where the restored prefix equals the whole prompt.
+    let prompt: Vec<u32> = make_ids(2 * BLOCK_TOKENS);
+
+    // The decision the generate loop makes on a matched slot.
+    let served_as_exact = |cache: &mut PromptCache<TestEntry>, prompt: &[u32]| -> bool {
+        let Some((slot_idx, _)) = cache.find_best_prefix(prompt, FNV_OFFSET) else {
+            return false;
+        };
+        let entry = &cache.slots[slot_idx].entry;
+        !entry.is_ssd_hydrated() && entry.prompt_token_ids() == prompt
+    };
+
+    // RAM-cached entry with the same ids → SERVED as Exact (real first token).
+    let mut ram_cache: PromptCache<TestEntry> = PromptCache::new(4);
+    ram_cache.push(TestEntry::new(prompt.clone()));
+    assert!(
+        served_as_exact(&mut ram_cache, &prompt),
+        "a normal RAM-cached full-prompt entry must be served as Exact"
+    );
+
+    // SSD-hydrated entry with the same ids → NOT served as Exact (falls through
+    // to re-prefill so the placeholder first_id is never replayed).
+    let mut ssd_cache: PromptCache<TestEntry> = PromptCache::new(4);
+    ssd_cache.push(TestEntry::new(prompt.clone()).ssd_hydrated());
+    // Sanity: the block-hash match still fires (only the exact-serve gate differs).
+    assert!(
+        ssd_cache.find_best_prefix(&prompt, FNV_OFFSET).is_some(),
+        "a hydrated full-prompt entry must still produce a block-hash match"
+    );
+    assert!(
+        !served_as_exact(&mut ssd_cache, &prompt),
+        "an SSD-hydrated full-prompt entry must NOT be served as Exact — \
+         replaying its placeholder first_id poisons generation"
     );
 }
 
@@ -1269,6 +1354,7 @@ impl SsdHydrate<TestEntry> for MockHydrateSalted {
             ids: self.ids.clone(),
             hashes,
             truncated_to: std::cell::Cell::new(None),
+            is_ssd_hydrated: true,
         }))
     }
 }
@@ -1288,6 +1374,7 @@ impl SsdHydrate<TestEntry> for MockHydrateUnsalted {
             ids: self.ids.clone(),
             hashes,
             truncated_to: std::cell::Cell::new(None),
+            is_ssd_hydrated: true,
         }))
     }
 }

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -131,6 +131,16 @@ pub(crate) struct Qwen3Entry {
     /// Runtime `KvQuant` discriminant in effect when this snapshot was
     /// written (Plan §D8 / Task 11.5). See `Gemma4Entry::kv_quant`.
     pub(crate) kv_quant: Option<KvQuant>,
+    /// True when this entry was reconstructed from the SSD tier and therefore
+    /// stores only the block-aligned prefix KV — `first_id` / `first_piece` are
+    /// placeholders, not a real decode token. The generate loop excludes such
+    /// an entry from the Exact fast path so it falls through to a full
+    /// re-prefill that recomputes the real first token.
+    ///
+    /// MUST be set only in `SsdHydrate::hydrate`; never by the RAM-cache push
+    /// path. Do NOT use the `first_id == 0` heuristic as a substitute —
+    /// `<bos>` token id is 0 for some models.
+    pub(crate) is_ssd_hydrated: bool,
 }
 
 impl PromptCacheEntry for Qwen3Entry {
@@ -152,6 +162,7 @@ impl PromptCacheEntry for Qwen3Entry {
             first_piece: self.first_piece.clone(),
             first_logprobs: self.first_logprobs.clone(),
             kv_quant: self.kv_quant,
+            is_ssd_hydrated: self.is_ssd_hydrated,
         })
     }
 
@@ -165,6 +176,10 @@ impl PromptCacheEntry for Qwen3Entry {
 
     fn kv_quant(&self) -> Option<KvQuant> {
         self.kv_quant
+    }
+
+    fn is_ssd_hydrated(&self) -> bool {
+        self.is_ssd_hydrated
     }
 
     // Pure-attention dense arch: no GDN linear state.
@@ -206,7 +221,9 @@ fn qwen3_active_layout_key() -> u64 {
 /// GDN linear state — `lin_caches` from the block is discarded). The matched
 /// block-aligned prefix token IDs become the entry's `prompt_token_ids`; block
 /// hashes are recomputed and the runtime `kv_quant` recorded. `first_id` /
-/// `first_piece` are sentinels (the SSD block stores no first decode token).
+/// `first_piece` are sentinels (the SSD block stores no first decode token), so
+/// the entry is flagged `is_ssd_hydrated = true`; the generate loop excludes it
+/// from the Exact fast path and recomputes the real first token via re-prefill.
 impl SsdHydrate<Qwen3Entry> for SsdHydrator {
     fn hydrate(&self, prompt_ids: &[u32]) -> Result<Option<Qwen3Entry>> {
         let Some((block, block_hashes)) = self.lookup_seeded(prompt_ids)? else {
@@ -226,6 +243,9 @@ impl SsdHydrate<Qwen3Entry> for SsdHydrator {
             // SSD block stores no first decode token, so no logprob to replay.
             first_logprobs: None,
             kv_quant: Some(self.kv_quant()),
+            // Block-aligned prefix only; the placeholder first_id must not be
+            // replayed — the generate loop re-prefills to recompute it.
+            is_ssd_hydrated: true,
         }))
     }
 }
@@ -1896,8 +1916,20 @@ pub fn generate_greedy<'a>(
             None => None,
         };
         match safe_match {
+            // Exact match: full token-id equality AND a real first decode token.
+            //
+            // A SSD-hydrated entry whose block-aligned prefix length happens to
+            // equal `prompt_ids.len()` (prompt is an exact multiple of
+            // BLOCK_TOKENS → no tail → restored prefix == full prompt) must NOT
+            // be served here: its `first_id` is the placeholder 0 set in
+            // `SsdHydrate::hydrate`, not a real decode token. Replaying it emits
+            // a sentinel first token and seeds decode with garbage. The
+            // `!is_ssd_hydrated` guard drops it through to `Miss` → a full
+            // re-prefill re-derives the real first token. Correctness over the
+            // micro-opt (mirrors the qwen3_5_moe Exact arm guard).
             Some((slot_idx, _block_count))
-                if cache.slots[slot_idx].entry.prompt_token_ids() == prompt_ids =>
+                if !cache.slots[slot_idx].entry.is_ssd_hydrated()
+                    && cache.slots[slot_idx].entry.prompt_token_ids() == prompt_ids =>
             {
                 let slot = &cache.slots[slot_idx].entry;
                 match slot.deep_clone() {
@@ -2182,6 +2214,7 @@ pub fn generate_greedy<'a>(
                             .unwrap_or_else(|| format!("<unk:{last_id}>")),
                         first_logprobs,
                         kv_quant: Some(kv_quant),
+                        is_ssd_hydrated: false,
                     };
                     QWEN3_PROMPT_CACHE.with_inner_mut(|guard| {
                         if let Some(cache) = guard.as_mut() {

--- a/crates/rmlx-models/src/qwen3_tests.rs
+++ b/crates/rmlx-models/src/qwen3_tests.rs
@@ -221,6 +221,7 @@ fn qwen3_spill_sink_skips_entry_with_no_full_block() {
         first_piece: String::new(),
         first_logprobs: None,
         kv_quant: Some(KvQuant::K8V8),
+        is_ssd_hydrated: false,
     });
 
     // Entry B: also short, triggers slot eviction of A.
@@ -233,6 +234,7 @@ fn qwen3_spill_sink_skips_entry_with_no_full_block() {
         first_piece: String::new(),
         first_logprobs: None,
         kv_quant: Some(KvQuant::K8V8),
+        is_ssd_hydrated: false,
     });
 
     // A was evicted but its block_hashes was empty → sink captured nothing.
@@ -283,6 +285,8 @@ fn qwen3_ssd_hydrate_promotes_entry_into_ram() {
                 first_piece: String::new(),
                 first_logprobs: None,
                 kv_quant: Some(KvQuant::K8V8),
+                // Mirrors SsdHydrate::hydrate — hydrated entries are flagged.
+                is_ssd_hydrated: true,
             }))
         }
     }
@@ -354,4 +358,256 @@ fn qwen3_kv_bytes_store_read_roundtrip() {
 #[test]
 fn qwen3_arch_policy_is_exact_only() {
     assert_eq!(QWEN3_PROMPT_CACHE.policy(), ReusePolicy::ExactOnly);
+}
+
+/// Regression: an SSD-hydrated full-prompt entry (block-aligned, no tail) must
+/// NOT be served via the Exact fast path. Its `first_id` / `first_piece` are
+/// placeholders (id 0) — replaying them emits a sentinel first token and seeds
+/// decode with garbage. The `!is_ssd_hydrated` Exact-arm guard forces a
+/// fall-through to a full re-prefill that re-derives the real first token.
+///
+/// Test structure (mirrors the qwen3_5_moe `hydrated_exact_block_no_tail`
+/// regression):
+///
+/// 1. COLD: `generate_greedy` from an empty cache with a block-aligned prompt
+///    (exact multiple of BLOCK_TOKENS, no tail) → record N_DECODE token ids.
+/// 2. WARM: inject a real KV snapshot of the SAME full prompt, marked
+///    `is_ssd_hydrated=true` with `first_id=0, first_piece=""` (exactly what
+///    `SsdHydrate::hydrate` produces). Before the fix this is served as Exact →
+///    `warm[0] == 0`. After the fix it falls to Miss → `warm == cold`.
+///
+/// Run:
+/// ```sh
+/// RMLX_TEST_MODEL_BONSAI=/path/to/Ternary-Bonsai-8B-mlx-2bit \
+/// cargo test -p rmlx-models qwen3_hydrated_exact_no_tail_not_placeholder \
+///     -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free; remaining unwrap is on values constructed in this fn"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: indices bounded by slice length validated before call"
+)]
+fn qwen3_hydrated_exact_no_tail_not_placeholder() {
+    let Some(model_dir_buf) =
+        std::env::var_os("RMLX_TEST_MODEL_BONSAI").map(std::path::PathBuf::from)
+    else {
+        println!("SKIP: RMLX_TEST_MODEL_BONSAI not set");
+        return;
+    };
+    let model_dir = model_dir_buf.as_path();
+    if !model_dir.exists() {
+        println!("SKIP: model dir not found at {}", model_dir.display());
+        return;
+    }
+
+    let arch_str = {
+        let cfg_path = model_dir.join("config.json");
+        let data = std::fs::read(&cfg_path).expect("read config.json");
+        let v: serde_json::Value = serde_json::from_slice(&data).expect("parse config.json");
+        v.get("architectures")
+            .and_then(|a| a.get(0))
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_owned()
+    };
+    if arch_str != "Qwen3ForCausalLM" {
+        println!("SKIP: arch \"{arch_str}\" is not Qwen3ForCausalLM");
+        return;
+    }
+
+    println!("Loading model from {}", model_dir.display());
+    let model = load_from_path(model_dir, None).expect("load model");
+    let n_layers = model.cfg.num_hidden_layers;
+    let device = Device::Gpu;
+
+    // Unquantized KV: COLD and WARM must produce token-identical output (the
+    // merged none-payload spill fix restores KV exactly, so only the sentinel
+    // would differ pre-fix).
+    let kv_quant = KvQuant::None;
+    let max_seq = 4096i32;
+
+    // Prompt: exactly BLOCK_TOKENS = 256 tokens — NO tail (the SSD exact-hit
+    // shape: the spilled block equals the full prompt).
+    let prompt_len = BLOCK_TOKENS; // 256
+    assert_eq!(
+        prompt_len % BLOCK_TOKENS,
+        0,
+        "fixture must be block-aligned (no tail)"
+    );
+    let prompt_ids: Vec<u32> = (1u32..=prompt_len as u32)
+        .map(|i| (i % 9999).max(1))
+        .collect();
+
+    let sampler_cfg = crate::sampler::SamplerConfig {
+        temperature: 0.0,
+        top_p: 1.0,
+        top_k: 0,
+        min_p: 0.0,
+        seed: Some(0),
+        top_logprobs_k: 0,
+    };
+    let penalty_cfg = crate::sampler::PenaltyConfig::default();
+    let n_decode = 4usize;
+    let tokenizer =
+        tokenizers::Tokenizer::from_file(model_dir.join("tokenizer.json")).expect("load tokenizer");
+
+    // ── Step 1: COLD full prefill ─────────────────────────────────────────────
+    ensure_qwen3_prompt_cache(4);
+    QWEN3_PROMPT_CACHE.with_inner_mut(|guard| {
+        if let Some(cache) = guard.as_mut() {
+            cache.clear();
+        }
+    });
+
+    let cold_tokens: Vec<u32> = {
+        let mut rng = crate::sampler::Pcg32::new(sampler_cfg.seed_or_default());
+        let mut token_history: Vec<u32> = Vec::new();
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
+        let steps = generate_greedy(
+            &model,
+            &tokenizer,
+            &prompt_ids,
+            n_decode,
+            device,
+            kv_quant,
+            Some(max_seq),
+            4,
+            &[],
+            &mut step_fn,
+            None,
+            &sampler_cfg,
+            &mut rng,
+            &penalty_cfg,
+            &mut token_history,
+        )
+        .expect("cold generate_greedy");
+        steps.into_iter().map(|s| s.token_id).collect()
+    };
+    println!("COLD tokens: {cold_tokens:?}");
+    assert_eq!(cold_tokens.len(), n_decode);
+    assert_ne!(
+        cold_tokens[0], 0,
+        "cold first token is 0 — model anomaly; the regression check would be vacuous"
+    );
+
+    // ── Step 2: Build a real KV snapshot for the full block-aligned prompt ──
+    let full_kv_caches = {
+        use crate::kv_cache::{kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N};
+        let mut kv_caches: Vec<KvCache> = (0..n_layers)
+            .map(|i| {
+                let q = kv_quant_for_layer(
+                    i,
+                    n_layers,
+                    kv_quant,
+                    LAYER_ADAPTIVE_TAIL_N,
+                    LAYER_ADAPTIVE_HEAD_N,
+                );
+                KvCache::with_quant_max_seq(q, max_seq).with_layer_idx(i)
+            })
+            .collect();
+        for c in &mut kv_caches {
+            c.enter_prefill();
+        }
+        let prefill_chunk = crate::prefill_chunk::prefill_chunk_for("qwen3");
+        let n_chunks = prompt_len.div_ceil(prefill_chunk);
+        for (chunk_idx, chunk) in prompt_ids.chunks(prefill_chunk).enumerate() {
+            let is_last = chunk_idx + 1 == n_chunks;
+            let logits = model
+                .forward_seq_with_cache(chunk, Some(&mut kv_caches), device)
+                .expect("prefill chunk");
+            if is_last {
+                logits.eval().expect("eval last-chunk logits");
+            } else {
+                for c in &kv_caches {
+                    c.eval_prefill_state().expect("eval_prefill_state");
+                }
+            }
+        }
+        for c in &mut kv_caches {
+            c.exit_prefill(device).expect("exit_prefill");
+        }
+        for c in &kv_caches {
+            c.eval_for_spill().expect("eval_for_spill kv");
+        }
+        kv_caches
+    };
+
+    // ── Step 3: WARM — inject SSD-hydrated FULL-PROMPT snapshot ──────────────
+    // first_id=0, first_piece="" — the placeholder a real SsdHydrate::hydrate
+    // sets. Before the fix this entry is served as Exact → warm[0] == 0.
+    QWEN3_PROMPT_CACHE.with_inner_mut(|guard| {
+        if let Some(cache) = guard.as_mut() {
+            cache.clear();
+            let block_hashes =
+                chained_block_hashes_seeded(&prompt_ids, FNV_OFFSET ^ kv_quant.cache_key_salt());
+            let kv_snap: Result<Vec<_>> =
+                full_kv_caches.iter().map(KvCache::try_deep_clone).collect();
+            let kv_snap = kv_snap.expect("kv clone");
+            cache.push(Qwen3Entry {
+                prompt_token_ids: prompt_ids.clone(),
+                block_hashes,
+                kv_caches: kv_snap,
+                first_id: 0,
+                first_piece: String::new(),
+                first_logprobs: None,
+                kv_quant: Some(kv_quant),
+                // KEY: full-length entry marked hydrated (no tail). Before the
+                // fix the Exact arm fires → emits first_id=0. After the fix the
+                // Exact arm skips → Miss → re-prefill.
+                is_ssd_hydrated: true,
+            });
+        }
+    });
+
+    let warm_tokens: Vec<u32> = {
+        let mut rng = crate::sampler::Pcg32::new(sampler_cfg.seed_or_default());
+        let mut token_history: Vec<u32> = Vec::new();
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
+        let steps = generate_greedy(
+            &model,
+            &tokenizer,
+            &prompt_ids,
+            n_decode,
+            device,
+            kv_quant,
+            Some(max_seq),
+            4,
+            &[],
+            &mut step_fn,
+            None,
+            &sampler_cfg,
+            &mut rng,
+            &penalty_cfg,
+            &mut token_history,
+        )
+        .expect("warm generate_greedy");
+        steps.into_iter().map(|s| s.token_id).collect()
+    };
+    println!("WARM tokens: {warm_tokens:?}");
+
+    assert_ne!(
+        warm_tokens.first().copied(),
+        Some(0u32),
+        "REGRESSION: warm first token is placeholder 0. \
+         The Exact arm must be guarded by !is_ssd_hydrated."
+    );
+    assert_eq!(
+        warm_tokens, cold_tokens,
+        "regression: WARM must equal COLD after fix.\n\
+         COLD: {cold_tokens:?}\n\
+         WARM: {warm_tokens:?}"
+    );
+    println!(
+        "PASS: SSD exact-hit sentinel guard works — warm[0]={} (not 0), warm==cold",
+        warm_tokens[0]
+    );
 }


### PR DESCRIPTION
## Summary

Fixes the SSD prompt-cache exact-hit sentinel bug. An SSD-hydrated entry restores only the prefix KV — the first decode token was never serialized — so its `first_id` is a placeholder (token id 0, which is `"!"` in e.g. the Bonsai tokenizer). The exact-hit fast path replayed that placeholder as the first emitted token and decode seed, poisoning generation on every SSD exact-hit (codec-agnostic; qwen3, gemma4, qwen3.5-moe).

## Fix

- `PromptCacheEntry::is_ssd_hydrated()` trait method (default `false`).
- `is_ssd_hydrated` field on `Qwen3Entry` + `Gemma4Entry`: set `true` only in `SsdHydrate::hydrate`, `false` on the miss-path push, propagated through `deep_clone`.
- The exact-serve arm is guarded with `!entry.is_ssd_hydrated()`, so a hydrated full-prompt match falls through to a full re-prefill that recomputes the real first token. This mirrors the qwen3.5-moe pattern (which already excludes hydrated entries from the exact path).

No sampled token is persisted in the spill (that would be temperature/seed-dependent); the first token is always recomputed.

## Proof

Bonsai (Qwen3 dense, pure full-attention), `--kv-quant none` (KV restores correctly, so the sentinel is isolated), SSD tier on, exact-256-token prompt, temp 0:
- Baseline (SSD off): coherent, first token `"It"`.
- Post-fix SSD-hydrate exact-hit: **byte-identical** to baseline (was a `"!"` sentinel + degenerate decode pre-fix). Hydrate fires in logs, then routes to re-prefill.

Tests: `ssd_hydrated_entry_excluded_from_exact_serve` + `is_ssd_hydrated_defaults_false` (default gate) pin the predicate; model-gated `qwen3_hydrated_exact_no_tail_not_placeholder` pins cold==warm with a non-placeholder first token.

## Notes

- By design, an SSD exact-hit now does a full re-prefill (no KV reuse) — consistent with qwen3.5-moe. Reusing the restored prefix KV for a strict-prefix (tail re-prefill) is tracked separately (#80).
- gemma4's consume path gets the same guard for correctness, but a live gemma4 SSD proof is deferred to #82 (its SWA-ring hydrate is a separate bug).
- Two LOW follow-ups noted in review (a decline-path trace event; evicting the declined hydrated slot so identical prompts recover the fast path) are deferred to the SSD-consume-path work.

Closes #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
