### PR TITLE
fix(gemma4): degrade SSD-hydrated entry with empty SWA layer to full re-prefill

### DIFF
--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -273,8 +273,17 @@ pub fn generate_greedy<'a>(
                 // block-aligned + `can_truncate_to_block` path for the multi-turn
                 // case (which forced a full re-prefill Miss on every wrapped-SWA
                 // turn — bug B1: prefill_ms grew with conversation length).
+                // Hydrate-completeness guard: a SSD-hydrated entry whose SWA
+                // layers came back as payload-less `KvStorage::None` (the
+                // rotating ring is not serialised to the SSD tier — see
+                // `Gemma4Entry::is_hydrate_complete`) MUST NOT be reused via a
+                // prefix arm. Reusing it would re-prefill only the tail on top
+                // of an empty SWA prefix and corrupt the output. Such an entry
+                // falls through to a full re-prefill (Miss). The guard is a
+                // no-op for RAM-resident snapshots (every layer holds payload).
                 Some((slot_idx, _block_count))
-                    if cache.slots[slot_idx].entry.is_strict_prefix_of(prompt_ids) =>
+                    if cache.slots[slot_idx].entry.is_strict_prefix_of(prompt_ids)
+                        && cache.slots[slot_idx].entry.is_hydrate_complete() =>
                 {
                     let slot = &cache.slots[slot_idx].entry;
                     let prefix_len = slot.prompt_token_ids().len();
@@ -310,7 +319,15 @@ pub fn generate_greedy<'a>(
                 // longctx 22 -> 0 tokens). When `can_truncate_to_block` is
                 // false we fall back to a full re-prefill (Miss); correctness
                 // over speed for the wrapped-SWA case.
-                Some((slot_idx, block_count)) if block_count >= 1 => {
+                // Block-truncate partial-prefix reuse — same hydrate-
+                // completeness guard as the B1 arm above. A SSD-hydrated entry
+                // with a payload-less SWA `None` layer cannot be block-truncated
+                // and tail-re-prefilled correctly (the empty SWA prefix would
+                // give wrong attention), so it is excluded here and falls
+                // through to a full re-prefill (Miss).
+                Some((slot_idx, block_count))
+                    if block_count >= 1 && cache.slots[slot_idx].entry.is_hydrate_complete() =>
+                {
                     // The tail `[prefix_len..prompt_len)` must be non-empty: the
                     // re-prefilled tail's final position is where we read the
                     // next-token logits from. If the matched blocks cover the
@@ -358,6 +375,20 @@ pub fn generate_greedy<'a>(
                         );
                         CacheLookup::Miss
                     }
+                }
+                // Incomplete SSD-hydrated entry: the prefix arms above were
+                // skipped by the `is_hydrate_complete` guard because at least
+                // one attended layer (a gemma4 SWA ring) came back payload-less
+                // after hydrate. Degrade to a full re-prefill (Miss) and record
+                // the decision so the empty-SWA reuse path is traceable.
+                Some((slot_idx, _)) if !cache.slots[slot_idx].entry.is_hydrate_complete() => {
+                    tracing::debug!(
+                        prompt_len = prompt_ids.len(),
+                        "gemma4 generate_greedy: SSD-hydrated entry has a payload-less \
+                         SWA layer (rotating ring not spilled) — degrading prefix reuse \
+                         to full re-prefill (Miss)"
+                    );
+                    CacheLookup::Miss
                 }
                 Some(_) => CacheLookup::Miss,
                 None => CacheLookup::Miss,

--- a/crates/rmlx-models/src/gemma4/prompt_cache.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache.rs
@@ -111,6 +111,32 @@ impl Gemma4Entry {
             && cached_len < prompt_ids.len()
             && self.prompt_token_ids[..] == prompt_ids[..cached_len]
     }
+
+    /// True iff every layer this architecture attends to carries real K/V
+    /// payload — i.e. the snapshot is safe to reuse as a prefix (B1
+    /// strict-prefix snapshot/restore or block-truncate) without re-prefilling
+    /// the prefix.
+    ///
+    /// Gemma4's sliding-window (SWA) layers run a bf16 `RotatingKvCache` ring
+    /// that is NOT serialised to the SSD tier; on hydrate they are
+    /// reconstructed as a payload-less `KvStorage::None` (the spill writer
+    /// records them geometry-only, see `block_io::write_layer`). Reusing such a
+    /// hydrated entry via a prefix arm would re-prefill only the tail on top of
+    /// an empty SWA prefix, giving the SWA layers the wrong attention context
+    /// and corrupting the output. `KvCache::is_trimmable()` returns `true` for a
+    /// `None` layer, so it is the wrong predicate to detect this.
+    ///
+    /// A layer is payload-less when its storage is `None` AND it carries no
+    /// off-storage bf16 seed. This distinguishes a dropped SWA ring (no seed →
+    /// incomplete) from a `KvQuant::None` global layer whose bf16 K/V was
+    /// spilled and restored via `KvCache::with_decode_fp16_seed` (seed present →
+    /// complete). A fully RAM-resident snapshot always passes (no layer is
+    /// `None`-without-seed), so only hydrated SWA entries are degraded.
+    pub(crate) fn is_hydrate_complete(&self) -> bool {
+        self.kv_caches
+            .iter()
+            .all(|c| c.has_persistent_cache() || c.decode_fp16_kv().is_some())
+    }
 }
 
 impl PromptCacheEntry for Gemma4Entry {

--- a/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
@@ -187,8 +187,8 @@ fn hydrate_complete_for_resident_snapshot() {
 /// An SSD-hydrated entry whose SWA layer came back as a payload-less
 /// `KvStorage::None` (the rotating ring is not spilled) MUST be detected as
 /// hydrate-INCOMPLETE so the generate loop degrades the prefix reuse to a full
-/// re-prefill (Miss) — this is the issue-82 guard. The full-attention layer is
-/// reconstructed with real quantized payload; the SWA layer is empty `None`.
+/// re-prefill (Miss). The full-attention layer is reconstructed with real
+/// quantized payload; the SWA layer is empty `None`.
 #[test]
 fn hydrate_incomplete_when_swa_layer_empty() {
     // Full-attention layer: real K8V8 storage with a recorded offset (the
@@ -208,6 +208,8 @@ fn hydrate_incomplete_when_swa_layer_empty() {
     );
 
     let mut e = entry_with(vec![full, swa], (0..(2 * BLOCK_TOKENS) as u32).collect());
+    // Scene-setting: model a hydrated entry. `is_hydrate_complete` inspects the
+    // per-layer caches, not this flag, but a real degrade also requires it.
     e.is_ssd_hydrated = true;
     assert!(
         !e.is_hydrate_complete(),

--- a/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::prompt_cache::{PromptCache, FNV_OFFSET};
+use rmlx_kv_quant::storage::KvStorage;
 use rmlx_kv_quant::KvQuant;
 
 fn entry_with(kv_caches: Vec<KvCache>, ids: Vec<u32>) -> Gemma4Entry {
@@ -165,6 +166,54 @@ fn kv_quant_match_hits_no_eviction() {
 #[test]
 fn arch_policy_is_partial() {
     assert_eq!(PROMPT_CACHE.policy(), ReusePolicy::Partial);
+}
+
+/// A fully RAM-resident snapshot (every layer holds persistent K/V) is
+/// hydrate-complete — the guard never degrades a normal RAM-cache hit.
+#[test]
+fn hydrate_complete_for_resident_snapshot() {
+    let kv = vec![
+        KvCache::with_quant_max_seq_window(KvQuant::K8V8, 8192, None), // full-attn
+        KvCache::with_quant_max_seq_window(KvQuant::K8V8, 8192, Some(512)), // SWA
+        KvCache::with_quant_max_seq_window(KvQuant::K8V8, 8192, Some(512)), // SWA
+    ];
+    let e = entry_with(kv, (0..(2 * BLOCK_TOKENS) as u32).collect());
+    assert!(
+        e.is_hydrate_complete(),
+        "a RAM-resident snapshot must be hydrate-complete (no payload-less None layer)"
+    );
+}
+
+/// An SSD-hydrated entry whose SWA layer came back as a payload-less
+/// `KvStorage::None` (the rotating ring is not spilled) MUST be detected as
+/// hydrate-INCOMPLETE so the generate loop degrades the prefix reuse to a full
+/// re-prefill (Miss) — this is the issue-82 guard. The full-attention layer is
+/// reconstructed with real quantized payload; the SWA layer is empty `None`.
+#[test]
+fn hydrate_incomplete_when_swa_layer_empty() {
+    // Full-attention layer: real K8V8 storage with a recorded offset (the
+    // hydrate path reconstructs these with payload).
+    let full = KvCache::from_storage(KvStorage::new(KvQuant::K8V8, 8192), KvQuant::K8V8, 256, 0);
+    assert!(
+        full.has_persistent_cache(),
+        "K8V8 full-attn layer must report persistent cache"
+    );
+    // SWA layer: payload-less None (rotating ring dropped on spill), no bf16
+    // seed restored — exactly what `block_io` reconstructs for a gemma4 SWA
+    // layer on hydrate.
+    let swa = KvCache::from_storage(KvStorage::None { max_seq: 512 }, KvQuant::K8V8, 256, 1);
+    assert!(
+        !swa.has_persistent_cache() && swa.decode_fp16_kv().is_none(),
+        "dropped-SWA layer must be payload-less None with no bf16 seed"
+    );
+
+    let mut e = entry_with(vec![full, swa], (0..(2 * BLOCK_TOKENS) as u32).collect());
+    e.is_ssd_hydrated = true;
+    assert!(
+        !e.is_hydrate_complete(),
+        "a hydrated entry with an empty SWA None layer must be hydrate-INCOMPLETE \
+         (excluded from the prefix reuse arms → Miss)"
+    );
 }
 
 /// / B1: `is_strict_prefix_of` is the SWA snapshot/restore "hook"

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -447,6 +447,14 @@ unconditionally — the rotating buffer codec is bf16. Quantization flags
 apply to full-attention layers only. A one-shot `info!` log discloses this
 at startup when a quantized type is requested on a SWA model.
 
+The bf16 rotating ring is **not** serialised to the SSD KV tier (the ring
+layout is not expressed in the `.kvb` format), so SWA layers hydrate as empty
+`KvStorage::None`. A hydrated prompt-cache entry whose length is not
+block-aligned therefore cannot be reused as a prefix (the empty SWA prefix
+would corrupt attention) — the consume path detects the payload-less SWA layer
+and degrades the entry to a full re-prefill. See `docs/SSD_TIER.md` §"SWA layers
+are not spilled". Serialising the SWA ring is a future enhancement.
+
 ### 5.8 TurboQuant requires Flash Attention
 
 The `tq4` V-side path is only valid through the Flash Attention dispatch.

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -393,6 +393,30 @@ layer whose rotating ring was never serialised) falls back to the geometry-only
 This is the distinguishing signal: presence of `decode_fp16_{k,v}` means real KV
 exists and must travel; absence means there is nothing to persist.
 
+#### SWA layers are not spilled — hydrated entries degrade to re-prefill
+
+Gemma4's sliding-window-attention (SWA) layers run a bf16 `RotatingKvCache`
+ring that is **not** serialised to the SSD tier (the rotating ring layout is not
+expressed in the `.kvb` format). On hydrate those layers are reconstructed as
+payload-less `KvStorage::None` — empty, carrying neither quantized storage nor a
+restored bf16 seed.
+
+Reusing such a hydrated entry as a **prefix** (re-prefilling only the tail on top
+of the hydrated block) would leave every SWA layer's prefix empty, giving them
+the wrong attention context and corrupting the output for a non-block-aligned
+prompt. `KvCache::is_trimmable()` returns `true` for a `None` layer, so it is the
+wrong predicate to detect this.
+
+The consume path therefore evaluates a per-entry **hydrate-completeness** guard
+(`Gemma4Entry::is_hydrate_complete`) before the strict-prefix / block-truncate
+reuse arms: an entry is complete only if every attended layer holds payload
+(persistent storage, or a restored `decode_fp16_{k,v}` bf16 seed). A hydrated
+entry with an empty SWA `None` layer fails the check and is **degraded to a full
+re-prefill** (Miss), which recomputes the SWA prefix correctly. The guard is a
+no-op for RAM-resident snapshots (every layer holds payload), so non-SSD prefix
+reuse is unaffected. Serialising the SWA ring so hydrated entries could be reused
+as prefixes is a future enhancement.
+
 ---
 
 ## CLI Flags


### PR DESCRIPTION
## Summary

Fixes wrong output from a gemma4 SSD-hydrated, non-block-aligned prompt. Gemma4 SWA layers use a `RotatingKvCache` ring that is not serialized to the SSD tier, so hydrate rebuilds them as payload-less `KvStorage::None`. The strict-prefix (B1) and block-truncate Prefix consume arms reused that empty prefix and re-prefilled only the tail → wrong attention on every SWA layer → divergent output. The completeness gate `KvCache::is_trimmable()` returns `true` for a `None` layer, so the old guard passed for the wrong reason.

## Fix

- `Gemma4Entry::is_hydrate_complete()` = `kv_caches.iter().all(|c| c.has_persistent_cache() || c.decode_fp16_kv().is_some())`. This distinguishes a dropped SWA ring (`None`, no bf16 seed → incomplete) from a healthy quantized layer (real storage → complete) and from a `KvQuant::None` global layer spilled with a bf16 seed (the #88 path → complete). No-op for RAM-resident snapshots.
- The B1 strict-prefix and block-truncate Prefix arms are gated with `is_hydrate_complete()`. An incomplete hydrated entry hits an explicit degrade arm that logs a `tracing::debug!` and returns `Miss` → a full re-prefill (correct output).

## Proof

gemma-4-e2b, 336-token prompt (256 block + 80 tail), temp 0, SSD tier on:
- Baseline (SSD off): coherent.
- Pre-fix SSD restart-hydrate: diverges (B1 strict-prefix reuse on empty SWA).
- Post-fix SSD restart-hydrate: **byte-identical** to the baseline (content + per-token logprob tokens). Logs show the hydrate fires then the degrade arm fires (no `PREFIX HIT`).
- Control: RAM-only multi-turn strict-prefix still fires the prefix-reuse arm (guard is a no-op for resident entries).

Tests `hydrate_incomplete_when_swa_layer_empty` + `hydrate_complete_for_resident_snapshot` (default gate) pin both guard branches.

## Notes

- This degrades gemma4 SSD-hydrated prefixes to a full re-prefill (correct, no reuse). Serializing the SWA rotating ring so hydrated entries can be reused as prefixes is a future enhancement.
- Docs updated (`docs/SSD_TIER.md`, `docs/KV_CACHE.md`).

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
