### PR TITLE
docs(kv): remove stale env-var ghosts (RMLX_PAGED_KV, RMLX_GPU_RESIDENT_ISO) + env audit

### DIFF
--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -135,13 +135,12 @@ pub fn sparse_attn_enabled() -> bool {
 
 /// Returns `true` when the GPU-resident `QuantIsoV3` mirror is enabled.
 ///
-/// **Hardcoded OFF** (bench-driven decision; `RMLX_GPU_RESIDENT_ISO` env var
-/// removed in PASS 3 cleanup). Phase-1 bench showed deltas within noise on the
-/// `update_iso3` hot path because the FusedQkShadow already absorbs the dequant.
-/// See [docs/PERF_BASELINE.md] for bench rationale. The remaining 7 codecs
-/// (iso3 K, iso4 V/K, rotor3/4 V/K) are **deferred** until a bench arm shows a
-/// clear win on a FusedQkShadow-incompatible path (PPL eval, prompt-cache hits
-/// that skip prefill, or any seedless workload).
+/// **Hardcoded OFF** (bench-driven decision; no env-var opt-in). A/B bench
+/// showed deltas within noise on the `update_iso3` hot path because the
+/// warm-TTFT bf16 seed absorbs the dequant cost before the mirror is reached.
+/// See `docs/PERF_BASELINE.md` for bench numbers. The gate exists as a
+/// forward-compatibility hook for future seedless decode paths where
+/// `decode_fp16_k.is_none()` during steady-state decode.
 #[cfg(not(test))]
 pub fn gpu_resident_iso_enabled() -> bool {
     false

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -482,8 +482,8 @@ impl QuantIsoV3 {
         }
 
         // SAFETY: `gpu_resident_iso_enabled()` is hardcoded `false` in
-        // production (PASS 3); in test mode it uses OnceLock latching on first
-        // read. Either way the gate state cannot toggle between prev_seq capture
+        // production; in test mode it uses OnceLock latching on first read.
+        // Either way the gate state cannot toggle between prev_seq capture
         // (above) and this check, so prev_seq is safe to use unconditionally.
         // ── 4. GPU mirror write (gated). ───────────────────────────────────
         if !crate::gpu_resident_iso_enabled() {

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
@@ -163,8 +163,8 @@ fn quant_iso_v_truncate_to_keeps_first_n() {
 // All gated `#[ignore]` per Metal-context policy. Run explicitly via
 //   cargo test -p rmlx-kv-quant --lib -- --ignored quant_iso_v --test-threads=1
 //
-// The GPU mirror default is OFF (hardcoded; `RMLX_GPU_RESIDENT_ISO` removed in
-// PASS 3). The mirror tests need it ON, so each test calls
+// The GPU mirror default is OFF (hardcoded; no env-var opt-in). The mirror
+// tests need it ON, so each test calls
 // `force_gpu_resident_iso_on()` before any call into `append_gpu` —
 // `gpu_resident_iso_enabled()` latches the value on first read via OnceLock,
 // so the very first test to set it wins for the rest of the test-binary

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -571,7 +571,7 @@ the corresponding negative-skip test at that time.
 **Codecs routed through Paged**: `K8V4`, `K8V8`, `Planar`, `Planar3`.
 
 **Codecs NOT routed through Paged** (auto-fall-through to their contiguous
-storage variants regardless of `RMLX_PAGED_KV`):
+storage variants regardless of `--paged-kv`):
 
 - `K8VTurbo3`, `K8VTurbo2`, `TurboSym4`, `PlanarK`, `RotKTq4V` — each owns a
   CPU- or hybrid-path V codec that does not fit either `PagedVStorage`

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -896,7 +896,7 @@ helper when adding any future sub-8-bit-K codec.
 **Paged routing**: `PagedKStorage` is q8-only; adding a TurboQuant-K paged
 variant requires a separate page allocator and gather kernel.
 `KvStorage::new(KvQuant::TurboSym4, max_seq)` therefore returns the
-**non-paged** `TurboSym4` storage even when `RMLX_PAGED_KV=1`.
+**non-paged** `TurboSym4` storage even when `--paged-kv` is set.
 
 **Tail/head adaptive fallback** — `kv_quant_for_layer` falls back to `K8V8`
 (8-bit K) on the head / tail layers. `TurboSym4` is **not** added to the
@@ -941,7 +941,7 @@ are rejected at resolve-time by `validate_resolved` with the dedicated
 `ResolveError::QwenMoeTurboKRejected { variant: "tsym3" }`.
 
 **Paged routing**: `KvStorage::new(KvQuant::TurboSym3, max_seq)` returns
-non-paged `TurboSym3` storage even when `RMLX_PAGED_KV=1`.
+non-paged `TurboSym3` storage even when `--paged-kv` is set.
 
 **Tail/head adaptive fallback** — `kv_quant_for_layer` falls back to `K8V8`
 on head/tail layers. `TurboSym3` is not added to the tail/head candidate set.
@@ -992,7 +992,7 @@ sub-8-bit-K codec.
 
 **Paged routing**: there is no `PagedPlanarKStorage`.
 `KvStorage::new(KvQuant::PlanarK, max_seq)` returns the non-paged `PlanarK`
-storage even when `RMLX_PAGED_KV=1`.
+storage even when `--paged-kv` is set.
 
 **Tail/head adaptive fallback** — `kv_quant_for_layer` falls back to `K8V8`
 on the head / tail layers. `PlanarK` is **not** added to the tail/head
@@ -1052,7 +1052,7 @@ for standard affine + rotation codecs.
 
 ### `KvStorage::Paged` — vLLM-style block-table KV
 
-PagedAttention allocation (opt-in via `RMLX_PAGED_KV=1`; default OFF).
+PagedAttention allocation (opt-in via `--paged-kv` flag; default OFF).
 
 Instead of a single contiguous buffer grown in `KV_PAGE_SIZE=256` token
 increments (contiguous-growth path), `Paged` maintains:
@@ -1438,7 +1438,7 @@ a different measurement condition; rMLX LCG fixture measures mean ≈ 0.994
 | SSD tier integration | Done |
 | MSL kernel hook (`isoquant_msl.rs`) | Done |
 | **MSL encode dispatch + on-demand `Array::from_bytes` dequant** | **Done — `update_iso3` / `update_iso3_sym` / `update_iso_k_only_3` route encode and dequant through `iso_quantize_v3_gpu` + `iso_dequantize_v3_gpu` when `device == Device::Gpu`; `QuantIsoV3::dequant_gpu` / `QuantIsoK3::dequant_gpu` rebuild GPU Arrays directly from CPU blocks via `Array::from_bytes` (no intermediate `Vec<f32>`)** |
-| **GPU-resident `QuantIsoV3` mirror** | **Landed; default OFF behind `RMLX_GPU_RESIDENT_ISO=1` opt-in. `QuantIsoV3::append_gpu` retains the iso3 encode outputs in a per-struct pre-allocated buffer (codes / scales / per-group norms) via `slice_update`; `dequant_gpu` consumes the mirror directly when populated. CPU blocks are still populated for SSD spill (`.kvb` on-disk format unchanged). SSD hydrate leaves the mirror missing; the next `dequant_gpu` falls back to the `Array::from_bytes` path. See `docs/PERF_BASELINE.md` for the bench rationale.** |
+| **GPU-resident `QuantIsoV3` mirror** | **Landed; hardcoded OFF (bench decision — bench showed no measurable benefit on the warm-TTFT path where the bf16 seed absorbs the dequant). `QuantIsoV3::append_gpu` retains the mirror infrastructure for future seedless workloads but the gate `gpu_resident_iso_enabled()` returns `false` unconditionally in production. CPU blocks are still populated for SSD spill (`.kvb` on-disk format unchanged). See `docs/PERF_BASELINE.md` for the bench rationale.** |
 | `--kv-quant iso3` CLI flag | Done |
 
 The MSL kernel ships as a future-reference hook. The GPU dispatch is on:
@@ -2643,17 +2643,17 @@ Invariant tests:
   — seedless PlanarQuant-packed buffer through `sparse_attn_dispatch` increments the counter by exactly 2 and cosine ≥ 0.99 vs dense `planar_flash_decode_sdpa`.
 
 **GPU-resident iso/rotor V mirror — dormant by design:** the GPU-resident
-iso/rotor V mirror (`RMLX_GPU_RESIDENT_ISO`) is dormant on the normal decode
-path for the same structural reason: every iso and rotor update path
-short-circuits at `decode_fp16_k.is_some()` (warm-TTFT bf16 seed) before
-reaching the GPU-resident mirror branch. The 7-codec phase-2 extension (iso3
-K, iso4 V/K,
+iso/rotor V mirror is hardcoded OFF on the normal decode path for the same
+structural reason: every iso and rotor update path short-circuits at
+`decode_fp16_k.is_some()` (warm-TTFT bf16 seed) before reaching the
+GPU-resident mirror branch. The 7-codec phase-2 extension (iso3 K, iso4 V/K,
 rotor3/4 V/K) was evaluated and declined. A/B bench on Bonsai 8B
 (8k prompt, `--ctk q8_g128 --ctv iso_v_3`, 3 runs per arm) showed Δ decode-TPS
-= −0.73% and Δ TTFT = −0.46% (both inside ±2σ noise). The gate remains
-opt-in (`RMLX_GPU_RESIDENT_ISO=1`) for seedless workloads only. Re-open
-condition: a production path where `decode_fp16_k.is_none()` during steady-state
-decode. Full numbers: `docs/PERF_BASELINE.md`.
+= −0.73% and Δ TTFT = −0.46% (both inside ±2σ noise). The gate
+(`gpu_resident_iso_enabled()`) is hardcoded `false` in production; it is only
+controllable in tests. Re-open condition: a production path where
+`decode_fp16_k.is_none()` during steady-state decode. Full numbers:
+`docs/PERF_BASELINE.md`.
 
 ---
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -1923,7 +1923,7 @@ the 108 ms ON/OFF gap is comparable). This puts us in the
 - Decode TPS is **slightly worse** under GPU mirror ON (within ±1% reverse-
   noise envelope but consistent with TTFT pattern).
 
-→ **Gate is default-OFF**, opt-in via `RMLX_GPU_RESIDENT_ISO=1`.
+→ **Gate is hardcoded OFF** (`gpu_resident_iso_enabled()` returns `false` unconditionally in production; no env-var opt-in).
 
 The mirror architecture is landed and verified (5 ignored GPU tests pass;
 SSD round-trip preserves dequant output bit-identical). The gate-OFF path
@@ -1944,8 +1944,9 @@ the mirror is built but rarely read. The upload-cost saving the mirror buys
 ## GPU-resident mirror extension: dormant-by-design (2026-06-03)
 
 **Decision: won't extend.** The 7-codec GPU-resident mirror extension (iso3 K,
-iso4 V/K, rotor3/4 V/K) was evaluated and declined. The `RMLX_GPU_RESIDENT_ISO`
-gate is dormant on the normal decode path under the warm-TTFT bf16 seed contract
+iso4 V/K, rotor3/4 V/K) was evaluated and declined. The GPU-resident mirror
+gate (`gpu_resident_iso_enabled()`) is hardcoded `false` in production and
+dormant on the normal decode path under the warm-TTFT bf16 seed contract
 (`docs/KV_CACHE.md` §9.6, `decode_fp16_k`). Extending the mirror to the 7
 remaining codecs delivers no per-decode-step benefit because those codecs share
 the same early-return guard: every `update_iso3` / `update_iso4` /
@@ -1977,7 +1978,7 @@ interleaved. **Hardware:** M5 Max.
 
 | Arm | decode_tps runs | median | stdev | TTFT runs (ms) | median | stdev |
 |-----|----------------|--------|-------|---------------|--------|-------|
-| A — `RMLX_GPU_RESIDENT_ISO=1` (ON) | 61.755 / 60.570 / 61.302 | **61.302** | 0.598 | 6634 / 6639 / 6703 | **6639** | 38.5 |
+| A — GPU mirror ON (bench arm) | 61.755 / 60.570 / 61.302 | **61.302** | 0.598 | 6634 / 6639 / 6703 | **6639** | 38.5 |
 | B — unset (OFF, baseline) | 61.827 / 61.753 / 60.361 | **61.753** | 0.826 | 6636 / 6670 / 6758 | **6670** | 63.0 |
 | **Δ (A − B)** | | **−0.451 TPS** | | | **−31 ms** | |
 | **Δ %** | | **−0.73%** | | | **−0.46%** | |
@@ -1990,11 +1991,11 @@ condition for reversing this decision is not met.
 
 **Confirms null:** yes. The prior null result (TTFT delta 1.61%, decode TPS
 delta −1.30%, both inside noise) is reproduced with a fresh 3-run protocol.
-The `RMLX_GPU_RESIDENT_ISO` gate is a no-op on the normal decode path.
+The GPU-resident mirror gate is a no-op on the normal decode path.
 
 ### Dormant-by-design gate (permanent)
 
-The `RMLX_GPU_RESIDENT_ISO` opt-in gate remains in the codebase as a
+The `gpu_resident_iso_enabled()` gate is hardcoded `false` in production as a
 forward-compatibility knob for any **future** seedless workload — a decode path
 that leaves `decode_fp16_k`/`decode_fp16_v` absent (e.g. a PPL-eval harness that
 reads quantized KV instead of teacher-forced bf16, or a prompt-cache hydrate


### PR DESCRIPTION
## Summary

Removes two stale environment-variable "ghosts" that the docs presented as live knobs, and audits the remaining KV env-var surface against the project's "prefer CLI args" policy. Documentation + code-comment changes only — no runtime behavior change.

## Dead ghosts removed

- `RMLX_PAGED_KV` — was documented but read by no code; paged KV is selected by the `--paged-kv` CLI flag. All doc mentions now point at the flag.
- `RMLX_GPU_RESIDENT_ISO` — removed from code earlier (the gate `gpu_resident_iso_enabled()` returns `false` unconditionally), but still documented as a live opt-in. Docs + code comments now state the gate is hardcoded off with no env opt-in.

Both strings are now absent from all docs and code (only `CHANGELOG.md` retains them, correctly under "Removed"). Also dropped an internal task-number reference from a code comment.

## Live KV env-var audit (no migration needed)

All user-visible KV knobs already have CLI flags: `--fused-qk`, `--sparse-attn`, `--turbo-flash`, `--turbo-flash-lock`, `--planar-flash-decode`, `--rotor-qjl`. The env vars without flags are dev-thresholds (`RMLX_FUSED_QK_MIN`, `RMLX_TURBO_FLASH_MIN`) or justified escape-hatches documented in `docs/CLI.md` — `RMLX_ROT_K_FUSED` (ablation knob for an unvalidated kernel path, no production impact) and `RMLX_KV_MAX_SEQ_HARD_CAP` (last-resort safety cap independent of `--max-ctx`). None warrant forced migration.

## Verification

`cargo build --workspace`, `make lint`, `cargo test -p rmlx-cli` (190 passed), `cargo test -p rmlx-kv-quant` (295 passed) all green. The `gpu_resident_iso_enabled()` gate + its test infra are intentionally retained (still exercised by ignored GPU-mirror tests / forward-compat).

Closes #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
