### PR TITLE
feat(prompt-cache): model-agnostic consume engine + retrofit caches onto 5 arches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,6 +2053,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokenizers",
  "tracing",
+ "tracing-subscriber",
  "twox-hash",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokenizers",
  "tracing",
- "tracing-subscriber",
  "twox-hash",
 ]
 

--- a/crates/rmlx-models/Cargo.toml
+++ b/crates/rmlx-models/Cargo.toml
@@ -35,9 +35,6 @@ rustfft   = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-# Already pinned at the workspace root; used only by prompt-cache degrade-trace
-# tests to capture `debug!{branch=...}` events without a hand-rolled subscriber.
-tracing-subscriber = { workspace = true }
 # Criterion micro-benchmarks for prefix-index strategies. Pulled
 # from the workspace pin so rmlx-quant and rmlx-models stay aligned. Not
 # wired into `make ci` — run on demand via

--- a/crates/rmlx-models/Cargo.toml
+++ b/crates/rmlx-models/Cargo.toml
@@ -35,6 +35,9 @@ rustfft   = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# Already pinned at the workspace root; used only by prompt-cache degrade-trace
+# tests to capture `debug!{branch=...}` events without a hand-rolled subscriber.
+tracing-subscriber = { workspace = true }
 # Criterion micro-benchmarks for prefix-index strategies. Pulled
 # from the workspace pin so rmlx-quant and rmlx-models stay aligned. Not
 # wired into `make ci` — run on demand via

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -1042,6 +1042,7 @@ impl Architecture {
                 device,
                 kv_quant,
                 max_ctx_override,
+                prompt_cache_slots,
                 eos_ids,
                 step_fn,
                 constraint,
@@ -1209,7 +1210,7 @@ impl Architecture {
     ///
     /// Reads the arch-specific global static that `generate_greedy` writes after
     /// each generation call.  Returns `None` for architectures that do not yet
-    /// maintain a shared PromptCache (BitNet, Laguna, Qwen3VlMoe).
+    /// maintain a shared PromptCache (Laguna, Qwen3VlMoe).
     #[allow(
         clippy::wildcard_enum_match_arm,
         reason = "archs without a shared PromptCache fall through to None"
@@ -1222,6 +1223,7 @@ impl Architecture {
             Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::qwen3_5_moe_cache_stats(),
             Architecture::Qwen3(_) => crate::qwen3::read_cache_stats(),
             Architecture::Qwen2(_) => crate::qwen2::qwen2_cache_stats(),
+            Architecture::BitNet(_) => crate::bitnet::bitnet_cache_stats(),
             _ => None,
         }
     }
@@ -1231,7 +1233,7 @@ impl Architecture {
     ///
     /// Reads the arch-specific prompt-cache static that `generate_greedy` writes
     /// via `store_kv_cache_bytes` at the end of every generate call.  Returns 0
-    /// for architectures that do not yet maintain that static (BitNet, Laguna,
+    /// for architectures that do not yet maintain that static (Laguna,
     /// Qwen3VlMoe).
     pub fn kv_cache_bytes(&self) -> u64 {
         match self {
@@ -1244,7 +1246,8 @@ impl Architecture {
             Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::qwen3_5_moe_kv_cache_bytes(),
             Architecture::Qwen3(_) => crate::qwen3::read_kv_cache_bytes(),
             Architecture::Qwen2(_) => crate::qwen2::qwen2_kv_cache_bytes(),
-            Architecture::Laguna(_) | Architecture::Qwen3VlMoe(_) | Architecture::BitNet(_) => 0,
+            Architecture::BitNet(_) => crate::bitnet::bitnet_kv_cache_bytes(),
+            Architecture::Laguna(_) | Architecture::Qwen3VlMoe(_) => 0,
         }
     }
 

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -1215,11 +1215,7 @@ impl Architecture {
     ///
     /// Reads the arch-specific global static that `generate_greedy` writes after
     /// each generation call.  Returns `None` for architectures that do not yet
-    /// maintain a shared PromptCache (Laguna, Qwen3VlMoe).
-    #[allow(
-        clippy::wildcard_enum_match_arm,
-        reason = "archs without a shared PromptCache fall through to None"
-    )]
+    /// maintain a shared PromptCache (Laguna).
     pub fn cache_stats(&self) -> Option<crate::CacheStats> {
         match self {
             Architecture::Gemma4(_) => crate::gemma4::gemma4_cache_stats(),
@@ -1228,7 +1224,8 @@ impl Architecture {
             Architecture::Qwen3(_) => crate::qwen3::read_cache_stats(),
             Architecture::Qwen2(_) => crate::qwen2::qwen2_cache_stats(),
             Architecture::BitNet(_) => crate::bitnet::bitnet_cache_stats(),
-            _ => None,
+            Architecture::Qwen3VlMoe(_) => crate::qwen3_vl_moe::qwen3_vl_moe_cache_stats(),
+            Architecture::Laguna(_) => None,
         }
     }
 
@@ -1237,8 +1234,7 @@ impl Architecture {
     ///
     /// Reads the arch-specific prompt-cache static that `generate_greedy` writes
     /// via `store_kv_cache_bytes` at the end of every generate call.  Returns 0
-    /// for architectures that do not yet maintain that static (Laguna,
-    /// Qwen3VlMoe).
+    /// for architectures that do not yet maintain that static (Laguna).
     pub fn kv_cache_bytes(&self) -> u64 {
         match self {
             Architecture::Gemma4(_) => crate::gemma4::gemma4_kv_cache_bytes(),
@@ -1247,7 +1243,8 @@ impl Architecture {
             Architecture::Qwen3(_) => crate::qwen3::read_kv_cache_bytes(),
             Architecture::Qwen2(_) => crate::qwen2::qwen2_kv_cache_bytes(),
             Architecture::BitNet(_) => crate::bitnet::bitnet_kv_cache_bytes(),
-            Architecture::Laguna(_) | Architecture::Qwen3VlMoe(_) => 0,
+            Architecture::Qwen3VlMoe(_) => crate::qwen3_vl_moe::qwen3_vl_moe_kv_cache_bytes(),
+            Architecture::Laguna(_) => 0,
         }
     }
 

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -993,6 +993,7 @@ impl Architecture {
                 device,
                 kv_quant,
                 max_ctx_override,
+                prompt_cache_slots,
                 eos_ids,
                 step_fn,
                 constraint,
@@ -1214,8 +1215,7 @@ impl Architecture {
     /// Prompt-cache stats for the arch's shared PromptCache, when it has one.
     ///
     /// Reads the arch-specific global static that `generate_greedy` writes after
-    /// each generation call.  Returns `None` for architectures that do not yet
-    /// maintain a shared PromptCache (Laguna).
+    /// each generation call.
     pub fn cache_stats(&self) -> Option<crate::CacheStats> {
         match self {
             Architecture::Gemma4(_) => crate::gemma4::gemma4_cache_stats(),
@@ -1225,7 +1225,7 @@ impl Architecture {
             Architecture::Qwen2(_) => crate::qwen2::qwen2_cache_stats(),
             Architecture::BitNet(_) => crate::bitnet::bitnet_cache_stats(),
             Architecture::Qwen3VlMoe(_) => crate::qwen3_vl_moe::qwen3_vl_moe_cache_stats(),
-            Architecture::Laguna(_) => None,
+            Architecture::Laguna(_) => crate::laguna::laguna_cache_stats(),
         }
     }
 
@@ -1233,8 +1233,7 @@ impl Architecture {
     /// call on this architecture.
     ///
     /// Reads the arch-specific prompt-cache static that `generate_greedy` writes
-    /// via `store_kv_cache_bytes` at the end of every generate call.  Returns 0
-    /// for architectures that do not yet maintain that static (Laguna).
+    /// via `store_kv_cache_bytes` at the end of every generate call.
     pub fn kv_cache_bytes(&self) -> u64 {
         match self {
             Architecture::Gemma4(_) => crate::gemma4::gemma4_kv_cache_bytes(),
@@ -1244,7 +1243,7 @@ impl Architecture {
             Architecture::Qwen2(_) => crate::qwen2::qwen2_kv_cache_bytes(),
             Architecture::BitNet(_) => crate::bitnet::bitnet_kv_cache_bytes(),
             Architecture::Qwen3VlMoe(_) => crate::qwen3_vl_moe::qwen3_vl_moe_kv_cache_bytes(),
-            Architecture::Laguna(_) => 0,
+            Architecture::Laguna(_) => crate::laguna::laguna_kv_cache_bytes(),
         }
     }
 

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -940,6 +940,7 @@ impl Architecture {
                 device,
                 kv_quant,
                 max_ctx_override,
+                prompt_cache_slots,
                 eos_ids,
                 step_fn,
                 constraint,
@@ -1131,10 +1132,13 @@ impl Architecture {
                     KvCacheBuilder::for_arch_default("Gemma3ForConditionalGeneration")
                 });
                 // Gemma3 has no per-layer-input gating, so `masked_ids` is
-                // unused (the scatter-merged embeds carry everything). Gemma3's
-                // generate_greedy also takes no prompt_cache_slots (image
-                // prompts are one-shot -- the cache is bypassed internally).
-                let _ = (masked_ids, prompt_cache_slots);
+                // unused (the scatter-merged embeds carry everything). The
+                // prompt cache is bypassed internally for an image prompt
+                // (`has_image` → consume returns Miss without touching the
+                // cache, and the snapshot store-back is `!has_image`-gated), but
+                // `prompt_cache_slots` is still threaded so the cache shell is
+                // sized consistently with the text path.
+                let _ = masked_ids;
                 crate::gemma3::generate_greedy(
                     m,
                     tokenizer,
@@ -1143,6 +1147,7 @@ impl Architecture {
                     device,
                     kv_quant,
                     max_ctx_override,
+                    prompt_cache_slots,
                     eos_ids,
                     step_fn,
                     constraint,
@@ -1217,9 +1222,8 @@ impl Architecture {
     )]
     pub fn cache_stats(&self) -> Option<crate::CacheStats> {
         match self {
-            Architecture::Gemma4(_) | Architecture::Gemma3(_) => {
-                crate::gemma4::gemma4_cache_stats()
-            }
+            Architecture::Gemma4(_) => crate::gemma4::gemma4_cache_stats(),
+            Architecture::Gemma3(_) => crate::gemma3::gemma3_cache_stats(),
             Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::qwen3_5_moe_cache_stats(),
             Architecture::Qwen3(_) => crate::qwen3::read_cache_stats(),
             Architecture::Qwen2(_) => crate::qwen2::qwen2_cache_stats(),
@@ -1238,11 +1242,7 @@ impl Architecture {
     pub fn kv_cache_bytes(&self) -> u64 {
         match self {
             Architecture::Gemma4(_) => crate::gemma4::gemma4_kv_cache_bytes(),
-            // NOTE: Gemma3 has its own generate path (`crate::gemma3::generate_greedy`)
-            // that does NOT call `store_kv_cache_bytes`, so `gemma4_kv_cache_bytes()`
-            // always returns 0 (or the last Gemma4 value if both were loaded in the
-            // same process). Gemma3 KV byte reporting is not yet wired.
-            Architecture::Gemma3(_) => 0,
+            Architecture::Gemma3(_) => crate::gemma3::gemma3_kv_cache_bytes(),
             Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::qwen3_5_moe_kv_cache_bytes(),
             Architecture::Qwen3(_) => crate::qwen3::read_kv_cache_bytes(),
             Architecture::Qwen2(_) => crate::qwen2::qwen2_kv_cache_bytes(),

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -958,6 +958,7 @@ impl Architecture {
                 device,
                 kv_quant,
                 max_ctx_override,
+                prompt_cache_slots,
                 eos_ids,
                 step_fn,
                 constraint,
@@ -1208,7 +1209,7 @@ impl Architecture {
     ///
     /// Reads the arch-specific global static that `generate_greedy` writes after
     /// each generation call.  Returns `None` for architectures that do not yet
-    /// maintain a shared PromptCache (Qwen2, BitNet, Laguna, Qwen3VlMoe).
+    /// maintain a shared PromptCache (BitNet, Laguna, Qwen3VlMoe).
     #[allow(
         clippy::wildcard_enum_match_arm,
         reason = "archs without a shared PromptCache fall through to None"
@@ -1220,6 +1221,7 @@ impl Architecture {
             }
             Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::qwen3_5_moe_cache_stats(),
             Architecture::Qwen3(_) => crate::qwen3::read_cache_stats(),
+            Architecture::Qwen2(_) => crate::qwen2::qwen2_cache_stats(),
             _ => None,
         }
     }
@@ -1229,8 +1231,8 @@ impl Architecture {
     ///
     /// Reads the arch-specific prompt-cache static that `generate_greedy` writes
     /// via `store_kv_cache_bytes` at the end of every generate call.  Returns 0
-    /// for architectures that do not yet maintain that static (Qwen2, BitNet,
-    /// Laguna, Qwen3VlMoe).
+    /// for architectures that do not yet maintain that static (BitNet, Laguna,
+    /// Qwen3VlMoe).
     pub fn kv_cache_bytes(&self) -> u64 {
         match self {
             Architecture::Gemma4(_) => crate::gemma4::gemma4_kv_cache_bytes(),
@@ -1241,10 +1243,8 @@ impl Architecture {
             Architecture::Gemma3(_) => 0,
             Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::qwen3_5_moe_kv_cache_bytes(),
             Architecture::Qwen3(_) => crate::qwen3::read_kv_cache_bytes(),
-            Architecture::Qwen2(_)
-            | Architecture::Laguna(_)
-            | Architecture::Qwen3VlMoe(_)
-            | Architecture::BitNet(_) => 0,
+            Architecture::Qwen2(_) => crate::qwen2::qwen2_kv_cache_bytes(),
+            Architecture::Laguna(_) | Architecture::Qwen3VlMoe(_) | Architecture::BitNet(_) => 0,
         }
     }
 

--- a/crates/rmlx-models/src/bitnet/generate.rs
+++ b/crates/rmlx-models/src/bitnet/generate.rs
@@ -4,6 +4,7 @@
     clippy::cognitive_complexity,
     clippy::collapsible_else_if,
     clippy::items_after_statements,
+    clippy::redundant_closure_for_method_calls,
     clippy::too_many_lines,
     reason = "greedy decode loop: large branchy state machine over sampler/penalty/mask combos; splitting hides the per-step decision tree"
 )]
@@ -17,10 +18,14 @@ use tracing::{info, warn};
 
 use crate::constraint::ConstraintEngine;
 use crate::kv_cache::{kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N};
+use crate::prompt_cache::{chained_block_hashes_seeded, Consumed, ReusePolicy, FNV_OFFSET};
 use crate::sampler::apply_mask_argmax;
 use rmlx_kv_quant::{KvCache, KV_MAX_SEQ_DEFAULT};
 
 use super::model::BitNetText;
+use super::prompt_cache::{
+    active_layout_key, ensure_prompt_cache, store_kv_cache_bytes, BitNetEntry, PROMPT_CACHE,
+};
 
 // ---------------------------------------------------------------------------
 // Greedy generation
@@ -29,6 +34,12 @@ use super::model::BitNetText;
 /// Greedy autoregressive generation for BitNetForCausalLM.
 ///
 /// Returns `Vec<ProbeStep>` — same shape as `gemma4::generate_greedy`.
+///
+/// `prompt_cache_slots` — number of post-prefill KV snapshots kept across
+/// requests. Pass 1 for single-slot; pass N for multi-slot prefix matching.
+/// Recommended: 4. Only the Exact hit path is active (identical-prompt repeat
+/// skips re-prefill entirely, same `ReusePolicy::ExactOnly` contract as Qwen2
+/// and Qwen3 dense).
 #[allow(clippy::too_many_arguments)]
 #[allow(
     clippy::indexing_slicing,
@@ -36,7 +47,7 @@ use super::model::BitNetText;
 )]
 #[allow(
     clippy::unwrap_used,
-    reason = "steps.last().unwrap() at L231/L360: immediately preceded by steps.push(...), so Vec is non-empty"
+    reason = "steps.last().unwrap() immediately preceded by steps.push(...), so Vec is non-empty"
 )]
 pub fn generate_greedy(
     model: &BitNetText,
@@ -46,6 +57,7 @@ pub fn generate_greedy(
     device: Device,
     kv_quant: rmlx_kv_quant::KvQuant,
     max_ctx_override: Option<i32>,
+    prompt_cache_slots: usize,
     eos_ids: &[u32],
     step_fn: &mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
     mut constraint: Option<&mut dyn ConstraintEngine>,
@@ -70,6 +82,96 @@ pub fn generate_greedy(
     let vocab = model.cfg.vocab_size as i32;
     let mut steps = Vec::with_capacity(n_tokens);
 
+    ensure_prompt_cache(prompt_cache_slots);
+
+    // Decode profile timers.
+    let mut forward_total_ns: u128 = 0;
+    let mut decode_steps_count: u32 = 0;
+
+    // ------------------------------------------------------------------
+    // Prompt cache lookup via the shared consume() engine. BitNet is a dense
+    // pure-attention arch with no recurrent state and uses
+    // ReusePolicy::ExactOnly (it overrides none of the reuse hooks), so the only
+    // reachable outcomes are Exact (identical-prompt repeat skips re-prefill)
+    // and Miss (full re-prefill). The engine owns the find → SSD-hydrate retry
+    // → quant-mismatch guard → SSD-hydrated exclusion → Exact decision and
+    // traces every degrade branch. The ExactOnly policy tripwire lives here at
+    // the call site — not in the generic engine — because the engine is
+    // policy-agnostic and shared across architectures that may use different
+    // policies.
+    // ------------------------------------------------------------------
+    assert_eq!(
+        PROMPT_CACHE.policy(),
+        ReusePolicy::ExactOnly,
+        "BitNet prompt cache must be ExactOnly — pure-attention with no recurrent \
+         state and an Exact-hit-dominated workload; partial-prefix reuse is not wired",
+    );
+    // BitNet is text-only (no vision tower), so there is never an image prompt;
+    // the engine's has_image bypass is belt-and-suspenders.
+    let consumed = PROMPT_CACHE.consume(prompt_ids, kv_quant, false);
+
+    // Path A: exact cache hit — skip re-prefill, replay the stored first token,
+    // then run the shared decode loop on the cloned caches.
+    if let Consumed::Exact(cloned) = consumed {
+        let BitNetEntry {
+            kv_caches: mut caches,
+            first_id: last_id,
+            first_piece: piece,
+            ..
+        } = cloned;
+        tracing::debug!(
+            prompt_len = prompt_ids.len(),
+            token_id = last_id,
+            "bitnet generate_greedy: prompt cache EXACT HIT"
+        );
+        steps.push(ProbeStep {
+            token_id: last_id,
+            piece: piece.into_boxed_str(),
+            max_abs_logit: 0.0,
+            nan_count: 0,
+            logprobs: None,
+        });
+        step_fn(steps.last().unwrap());
+        token_history.push(last_id);
+
+        if eos_ids.contains(&last_id) {
+            return Ok(steps);
+        }
+
+        decode_loop(
+            model,
+            tokenizer,
+            &mut caches,
+            last_id,
+            n_tokens,
+            vocab,
+            device,
+            eos_ids,
+            &mut steps,
+            step_fn,
+            &mut constraint,
+            sampler_cfg,
+            rng,
+            penalty_cfg,
+            token_history,
+            &mut forward_total_ns,
+            &mut decode_steps_count,
+        )?;
+
+        {
+            let kv_bytes: u64 = caches.iter().map(|c| c.resident_bytes()).sum();
+            store_kv_cache_bytes(kv_bytes);
+        }
+        info!(
+            arch = "BitNetForCausalLM",
+            total_tokens = steps.len(),
+            decode_steps = decode_steps_count,
+            "generate_greedy: complete (exact hit)"
+        );
+        return Ok(steps);
+    }
+
+    // Path B (Miss): full re-prefill from scratch.
     let prefill_t0 = Instant::now();
     let max_seq = max_ctx_override.unwrap_or(KV_MAX_SEQ_DEFAULT);
 
@@ -225,25 +327,147 @@ pub fn generate_greedy(
 
     steps.push(ProbeStep {
         token_id: last_id,
-        piece: piece.into_boxed_str(),
+        piece: piece.clone().into_boxed_str(),
         max_abs_logit,
         nan_count,
         logprobs: None,
     });
     step_fn(steps.last().unwrap());
 
-    // TODO: wire a base-model degeneracy allowlist or
-    // repetition-score guard. Current snapshot is base-model; instruct
-    // fine-tunes regressing to base-model behaviour would currently pass smoke
-    // silently.
     if nan_count > 0 {
         return Ok(steps);
     }
+
+    // Push this prefill snapshot to the prompt cache (Miss → store). Clone the
+    // post-prefill KV caches (refcount bump, no data copy) before the decode
+    // loop starts writing new decode-step K/V into them. Materialize the GPU
+    // arrays on the current inference thread first so a later eviction on a
+    // different tokio/Metal thread can re-eval them as a no-op.
+    {
+        let kv_bytes: u64 = caches.iter().map(|c| c.resident_bytes()).sum();
+        store_kv_cache_bytes(kv_bytes);
+        let cloned_caches: Result<Vec<KvCache>> =
+            caches.iter().map(|c| c.try_deep_clone()).collect();
+        if let Ok(kv_snapshot) = cloned_caches {
+            match kv_snapshot.iter().try_for_each(|c| c.eval_for_spill()) {
+                Ok(()) => {
+                    // Salt the chained block-hash walk with the active layout_key
+                    // + KV codec so a slot stored under a different codec / layout
+                    // never cross-serves. Identical to the consume() seed.
+                    let lk = active_layout_key();
+                    let block_hashes = chained_block_hashes_seeded(
+                        prompt_ids,
+                        FNV_OFFSET ^ lk ^ kv_quant.cache_key_salt(),
+                    );
+                    let entry = BitNetEntry {
+                        prompt_token_ids: prompt_ids.to_vec(),
+                        block_hashes,
+                        kv_caches: kv_snapshot,
+                        first_id: last_id,
+                        // Last use of `piece` — move it (the prefill ProbeStep
+                        // above already consumed its own clone via into_boxed_str).
+                        first_piece: piece,
+                        kv_quant: Some(kv_quant),
+                        is_ssd_hydrated: false,
+                    };
+                    PROMPT_CACHE.with_inner_mut(|guard| {
+                        if let Some(cache) = guard.as_mut() {
+                            cache.push(entry);
+                            let stats = cache.stats();
+                            tracing::debug!(
+                                prompt_len = prompt_ids.len(),
+                                cache_hits = stats.hits,
+                                cache_misses = stats.misses,
+                                cache_bytes = stats.bytes,
+                                "bitnet generate_greedy: pushed snapshot to prompt cache (miss path)"
+                            );
+                        }
+                    });
+                }
+                Err(e) => tracing::warn!(error = %e,
+                    "bitnet generate_greedy: pre-eval of KV caches failed, skipping prompt cache store"),
+            }
+        }
+    }
+
+    // EOS-stop. If prefill emitted an EOS already, no decode steps.
     if eos_ids.contains(&last_id) {
         return Ok(steps);
     }
 
-    // Decode loop — simple sequential (non-pipelined) for clarity.
+    decode_loop(
+        model,
+        tokenizer,
+        &mut caches,
+        last_id,
+        n_tokens,
+        vocab,
+        device,
+        eos_ids,
+        &mut steps,
+        step_fn,
+        &mut constraint,
+        sampler_cfg,
+        rng,
+        penalty_cfg,
+        token_history,
+        &mut forward_total_ns,
+        &mut decode_steps_count,
+    )?;
+
+    info!(
+        arch = "BitNetForCausalLM",
+        total_tokens = steps.len(),
+        decode_steps = decode_steps_count,
+        avg_decode_ns = if decode_steps_count > 0 {
+            forward_total_ns / u128::from(decode_steps_count)
+        } else {
+            0
+        },
+        "generate_greedy: complete"
+    );
+
+    Ok(steps)
+}
+
+/// Shared sequential decode loop for both the Exact-hit and Miss paths.
+///
+/// `last_id` is the already-emitted step-0 token (prefill argmax or replayed
+/// cache first token); `steps` already holds its `ProbeStep`. This drives steps
+/// `1..n_tokens`.
+///
+/// The per-step decode math is byte-identical to the original inline loop; only
+/// the wrapping (function boundary + accumulated counters) differs.
+#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: argmax byte slices are sized 4 by the I32 dtype; loop indices bounded by slice length"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "steps.last().unwrap() immediately preceded by steps.push(...), so Vec is non-empty"
+)]
+fn decode_loop(
+    model: &BitNetText,
+    tokenizer: &tokenizers::Tokenizer,
+    caches: &mut [KvCache],
+    last_id: u32,
+    n_tokens: usize,
+    vocab: i32,
+    device: Device,
+    eos_ids: &[u32],
+    steps: &mut Vec<crate::decode_loop::ProbeStep>,
+    step_fn: &mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
+    constraint: &mut Option<&mut dyn ConstraintEngine>,
+    sampler_cfg: &crate::sampler::SamplerConfig,
+    rng: &mut crate::sampler::Pcg32,
+    penalty_cfg: &crate::sampler::PenaltyConfig,
+    token_history: &mut Vec<u32>,
+    forward_total_ns: &mut u128,
+    decode_steps_count: &mut u32,
+) -> Result<()> {
+    use crate::decode_loop::ProbeStep;
+
     let mut y: Array = {
         let id_i32 = last_id as i32;
         let bytes = id_i32.to_le_bytes();
@@ -251,12 +475,9 @@ pub fn generate_greedy(
     };
     y.eval()?;
 
-    let mut decode_steps: u32 = 0;
-    let mut forward_total_ns: u128 = 0;
-
     for step_idx in 1..n_tokens {
         let fwd_t0 = Instant::now();
-        let decode_logits = match model.forward_arr(&y, 1, Some(&mut caches), device) {
+        let decode_logits = match model.forward_arr(&y, 1, Some(&mut *caches), device) {
             Ok(l) => l,
             Err(e) => {
                 warn!(
@@ -267,7 +488,7 @@ pub fn generate_greedy(
                 break;
             }
         };
-        forward_total_ns += fwd_t0.elapsed().as_nanos();
+        *forward_total_ns += fwd_t0.elapsed().as_nanos();
 
         let logits_flat = decode_logits.reshape(&[1, vocab], device)?;
 
@@ -330,7 +551,7 @@ pub fn generate_greedy(
         };
 
         next_y.eval()?;
-        decode_steps += 1;
+        *decode_steps_count += 1;
 
         let top_bytes = next_y.to_bytes()?;
         let next_id =
@@ -368,19 +589,5 @@ pub fn generate_greedy(
         }
     }
 
-    let avg_decode_ns = if decode_steps > 0 {
-        forward_total_ns / u128::from(decode_steps)
-    } else {
-        0
-    };
-
-    info!(
-        arch = "BitNetForCausalLM",
-        total_tokens = steps.len(),
-        decode_steps,
-        avg_decode_ns,
-        "generate_greedy: complete"
-    );
-
-    Ok(steps)
+    Ok(())
 }

--- a/crates/rmlx-models/src/bitnet/generate.rs
+++ b/crates/rmlx-models/src/bitnet/generate.rs
@@ -166,6 +166,11 @@ pub fn generate_greedy(
             arch = "BitNetForCausalLM",
             total_tokens = steps.len(),
             decode_steps = decode_steps_count,
+            avg_decode_ns = if decode_steps_count > 0 {
+                forward_total_ns / u128::from(decode_steps_count)
+            } else {
+                0
+            },
             "generate_greedy: complete (exact hit)"
         );
         return Ok(steps);

--- a/crates/rmlx-models/src/bitnet/mod.rs
+++ b/crates/rmlx-models/src/bitnet/mod.rs
@@ -35,11 +35,14 @@ mod config;
 mod generate;
 mod loader;
 mod model;
+pub(crate) mod prompt_cache;
 
 pub use config::BitNetConfig;
 pub use generate::generate_greedy;
 pub use loader::load_from_path;
 pub use model::BitNetText;
+pub use prompt_cache::read_cache_stats as bitnet_cache_stats;
+pub use prompt_cache::read_kv_cache_bytes as bitnet_kv_cache_bytes;
 
 #[cfg(test)]
 #[path = "tests.rs"]

--- a/crates/rmlx-models/src/bitnet/prompt_cache.rs
+++ b/crates/rmlx-models/src/bitnet/prompt_cache.rs
@@ -1,0 +1,207 @@
+//! BitNet prompt-cache entry + global.
+//!
+//! The heavy lifting (static cache, SSD attach/install, ensure, stats readback,
+//! last-bytes counter, and the find → SSD-hydrate retry → quant-guard → Exact →
+//! Miss consume decision) is unified in
+//! [`crate::prompt_cache::ArchPromptCache`]. This file keeps only the genuinely
+//! BitNet-specific bits:
+//!
+//! - `BitNetEntry`: `Vec<KvCache>` only (pure-attention dense arch, no
+//!   GatedDeltaNet / linear-attention recurrent state — same shape as the
+//!   Qwen2 entry; ternary-weight quantization is a weight-side detail that
+//!   does not change KV-cache geometry).
+//! - `impl PromptCacheEntry for BitNetEntry`: deep_clone + KV accessors. All
+//!   three reuse hooks (`is_hydrate_complete`, `is_reusable_prefix_of`,
+//!   `prepare_reuse`) take the trait defaults, which give correct
+//!   [`ReusePolicy::ExactOnly`] behaviour: a non-hydrated partial match is never
+//!   reusable, and the only reuse the engine permits (a hydrated strict-prefix)
+//!   is declined here (`is_reusable_prefix_of` → `None`), so the only reachable
+//!   consume outcomes are `Exact` and `Miss`.
+//! - `impl SsdHydrate<BitNetEntry> for SsdHydrator`: pure-attention hydrate (the
+//!   reconstructed block carries `kv_caches` only; `lin_caches` is discarded).
+//!   The SSD spill path is the blanket `SpillSink<E> for SsdSpiller` in
+//!   `crate::prompt_cache`, which spills `kv_caches()` only for a pure-attention
+//!   entry (`lin_caches()` is `&[]`).
+//!
+//! ## Reuse policy — Exact-only
+//!
+//! BitNet uses [`ReusePolicy::ExactOnly`]. It is pure-attention with no
+//! recurrent state; the dominant workload is the Exact-hit warm-TTFT (identical
+//! prompt repeat skips re-prefill entirely), and keeping the single Exact / Miss
+//! arm set is simpler and matches the Qwen2/Qwen3 dense policy.
+
+#![allow(clippy::redundant_closure_for_method_calls)]
+use rmlx_core::error::Result;
+
+use crate::prompt_cache::{ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate};
+use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
+use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
+
+// ---------------------------------------------------------------------------
+// Entry type
+// ---------------------------------------------------------------------------
+
+/// Post-prefill snapshot for one BitNet request.
+///
+/// Pure-attention dense arch: only `kv_caches` needs snapshotting (no GDN
+/// recurrent state). Ternary-weight quantization is weight-side only and does
+/// not change the KV-cache geometry; the entry shape is identical to Qwen2.
+pub(crate) struct BitNetEntry {
+    /// Full prompt token IDs used to fill this slot.
+    pub(crate) prompt_token_ids: Vec<u32>,
+    /// Chained 256-token block digests of `prompt_token_ids` (trailing partial
+    /// block excluded). Computed at construction.
+    pub(crate) block_hashes: Vec<u64>,
+    /// Post-prefill KV caches (one per decoder layer).
+    pub(crate) kv_caches: Vec<KvCache>,
+    /// Argmax token from the first decode step after prefill.
+    pub(crate) first_id: u32,
+    /// Decoded piece for `first_id`.
+    pub(crate) first_piece: String,
+    /// Runtime `KvQuant` discriminant in effect when this snapshot was written.
+    /// Read by the engine's quant-mismatch guard and by the blanket spill path.
+    pub(crate) kv_quant: Option<KvQuant>,
+    /// True when this entry was reconstructed from the SSD tier and therefore
+    /// stores only the block-aligned prefix KV — `first_id` / `first_piece` are
+    /// placeholders, not a real decode token. The consume engine excludes such
+    /// an entry from the Exact fast path so it falls through to a full
+    /// re-prefill that recomputes the real first token.
+    ///
+    /// MUST be set only in `SsdHydrate::hydrate`; never by the RAM-cache push
+    /// path. Do NOT use the `first_id == 0` heuristic as a substitute —
+    /// `<bos>` token id is 0 for some models.
+    pub(crate) is_ssd_hydrated: bool,
+}
+
+impl PromptCacheEntry for BitNetEntry {
+    fn prompt_token_ids(&self) -> &[u32] {
+        &self.prompt_token_ids
+    }
+
+    fn block_hashes(&self) -> &[u64] {
+        &self.block_hashes
+    }
+
+    fn deep_clone(&self) -> Result<Self> {
+        let kv_caches: Result<Vec<_>> = self.kv_caches.iter().map(|c| c.try_deep_clone()).collect();
+        Ok(Self {
+            prompt_token_ids: self.prompt_token_ids.clone(),
+            block_hashes: self.block_hashes.clone(),
+            kv_caches: kv_caches?,
+            first_id: self.first_id,
+            first_piece: self.first_piece.clone(),
+            kv_quant: self.kv_quant,
+            is_ssd_hydrated: self.is_ssd_hydrated,
+        })
+    }
+
+    fn kv_caches(&self) -> &[KvCache] {
+        &self.kv_caches
+    }
+
+    fn kv_caches_mut(&mut self) -> &mut [KvCache] {
+        &mut self.kv_caches
+    }
+
+    fn kv_quant(&self) -> Option<KvQuant> {
+        self.kv_quant
+    }
+
+    fn is_ssd_hydrated(&self) -> bool {
+        self.is_ssd_hydrated
+    }
+
+    // Pure-attention dense arch: no GDN linear state.
+    fn lin_caches(&self) -> &[LinearAttnCache] {
+        &[]
+    }
+    // is_hydrate_complete / is_reusable_prefix_of / prepare_reuse: trait
+    // defaults. The defaults give correct ExactOnly behaviour (complete by
+    // construction, no partial reuse, deep_clone on the unreachable reuse path).
+    // truncate_kv_to / truncate_kv_to_block / kv_bytes: trait defaults.
+}
+
+// ---------------------------------------------------------------------------
+// SSD-spill sink — the blanket `impl SpillSink<E> for SsdSpiller` in
+// `crate::prompt_cache` covers BitNet (pure-attention: `lin_caches()` is `&[]`,
+// so the spill job carries `kv_caches` only).
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// SSD-hydrate source
+// ---------------------------------------------------------------------------
+
+/// Hydrate a `BitNetEntry` from the SSD tier on a RAM-cache miss.
+///
+/// Pure-attention arch: the reconstructed block carries `kv_caches` only (the
+/// `lin_caches` from the block are discarded). The matched block-aligned prefix
+/// token IDs become the entry's `prompt_token_ids`; block hashes are recomputed
+/// and the runtime `kv_quant` recorded. `first_id` / `first_piece` are sentinels
+/// (the SSD block stores no first decode token), so the entry is flagged
+/// `is_ssd_hydrated = true`; the consume engine excludes it from the Exact fast
+/// path and the generate loop recomputes the real first token via re-prefill.
+impl SsdHydrate<BitNetEntry> for SsdHydrator {
+    fn hydrate(&self, prompt_ids: &[u32]) -> Result<Option<BitNetEntry>> {
+        let Some((block, block_hashes)) = self.lookup_seeded(prompt_ids)? else {
+            return Ok(None);
+        };
+        let HydratedBlock {
+            prompt_ids,
+            kv_caches,
+            lin_caches: _, // pure-attention arch has no GDN state
+        } = block;
+        Ok(Some(BitNetEntry {
+            prompt_token_ids: prompt_ids,
+            block_hashes,
+            kv_caches,
+            first_id: 0,
+            first_piece: String::new(),
+            kv_quant: Some(self.kv_quant()),
+            // Block-aligned prefix only; the placeholder first_id must not be
+            // replayed — the generate loop re-prefills to recompute it.
+            is_ssd_hydrated: true,
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global cache instance — unified ArchPromptCache shell.
+// ---------------------------------------------------------------------------
+
+/// Per-arch shell with `ReusePolicy::ExactOnly`. BitNet is pure-attention with
+/// no recurrent state; the dominant workload is the Exact-hit warm-TTFT, so the
+/// single Exact / Miss arm set (no partial reuse) is the policy — matching Qwen2
+/// and Qwen3 dense.
+pub(crate) static PROMPT_CACHE: ArchPromptCache<BitNetEntry> =
+    ArchPromptCache::new("BitNetForCausalLM", ReusePolicy::ExactOnly);
+
+/// Active SSD-tier `layout_key` for the bitnet cache, or `0` when the tier is
+/// OFF. `FNV_OFFSET ^ 0 == FNV_OFFSET` ⇒ legacy un-salted digests when no SSD
+/// tier is attached, preserving byte-identical RAM-only behaviour.
+pub(crate) fn active_layout_key() -> u64 {
+    PROMPT_CACHE.active_layout_key()
+}
+
+/// Ensure the global prompt cache is initialised with at least `capacity` slots.
+pub(crate) fn ensure_prompt_cache(capacity: usize) {
+    PROMPT_CACHE.ensure(capacity);
+}
+
+/// Read the current hit/miss/bytes stats for the BitNet prompt cache.
+pub fn read_cache_stats() -> Option<CacheStats> {
+    PROMPT_CACHE.read_cache_stats()
+}
+
+/// Read the KV-cache bytes from the last completed BitNet request.
+pub fn read_kv_cache_bytes() -> u64 {
+    PROMPT_CACHE.read_kv_cache_bytes()
+}
+
+/// Record the KV-cache byte total for the just-completed request.
+pub(crate) fn store_kv_cache_bytes(n: u64) {
+    PROMPT_CACHE.store_kv_cache_bytes(n);
+}
+
+#[cfg(test)]
+#[path = "prompt_cache_tests.rs"]
+mod tests;

--- a/crates/rmlx-models/src/bitnet/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/bitnet/prompt_cache_tests.rs
@@ -1,0 +1,119 @@
+//! In-process unit tests for the BitNet prompt cache.
+//!
+//! These exercise the parts that do not need a loaded model or a Metal GPU
+//! stream: the arch policy, the `BitNetEntry` deep_clone round-trip over empty
+//! (never-prefilled) KV caches, and the SSD-hydrated entry field invariants
+//! (placeholder `first_id` + `is_ssd_hydrated` flag) the real-model SSD smoke
+//! relies on. Decoded-token reuse is proven by the real-model smoke, not here.
+
+use super::*;
+use rmlx_kv_quant::{KvCache, KvQuant};
+
+/// Build a `BitNetEntry` with `n_layers` empty (never-prefilled) KV caches.
+///
+/// An empty cache holds no live GPU arrays, so `try_deep_clone` is a no-op
+/// refcount walk that runs without a Metal stream — safe in a plain unit test.
+fn mock_ram_entry(n_layers: usize, prompt: &[u32], first_id: u32) -> BitNetEntry {
+    BitNetEntry {
+        prompt_token_ids: prompt.to_vec(),
+        block_hashes: vec![0xABCD_u64; n_layers],
+        kv_caches: (0..n_layers)
+            .map(|_| KvCache::with_quant(KvQuant::None))
+            .collect(),
+        first_id,
+        first_piece: "hello".to_string(),
+        kv_quant: Some(KvQuant::None),
+        is_ssd_hydrated: false,
+    }
+}
+
+/// BitNet's policy is hard-gated `ExactOnly`: the shared consume engine must
+/// only ever yield `Exact` or `Miss` for this arch (no partial-prefix reuse).
+#[test]
+fn arch_policy_is_exact_only() {
+    assert_eq!(PROMPT_CACHE.policy(), ReusePolicy::ExactOnly);
+}
+
+/// `deep_clone` copies every metadata field and produces an independent entry
+/// with the same KV-cache cardinality. (Empty caches carry no GPU data, so the
+/// clone is a refcount walk; this pins the field-copy contract.)
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: deep_clone over empty KV caches cannot fail — .expect documents the invariant"
+)]
+fn entry_deep_clone_preserves_fields() {
+    let prompt = [1_u32, 2, 3, 4];
+    let entry = mock_ram_entry(3, &prompt, 42);
+    let cloned = entry
+        .deep_clone()
+        .expect("deep_clone of empty-cache entry must succeed");
+
+    assert_eq!(cloned.prompt_token_ids, entry.prompt_token_ids);
+    assert_eq!(cloned.block_hashes, entry.block_hashes);
+    assert_eq!(cloned.kv_caches.len(), entry.kv_caches.len());
+    assert_eq!(cloned.first_id, 42);
+    assert_eq!(cloned.first_piece, "hello");
+    assert_eq!(cloned.kv_quant, Some(KvQuant::None));
+    assert!(!cloned.is_ssd_hydrated);
+}
+
+/// The `PromptCacheEntry` accessors expose the entry's fields verbatim. A
+/// pure-attention BitNet entry has no GDN recurrent state, so `lin_caches()` is
+/// empty — this is what makes the blanket `SpillSink` carry KV only.
+#[test]
+fn entry_accessors_match_fields() {
+    let prompt = [7_u32, 8, 9];
+    let entry = mock_ram_entry(2, &prompt, 5);
+
+    assert_eq!(entry.prompt_token_ids(), &prompt);
+    assert_eq!(entry.block_hashes(), &[0xABCD_u64, 0xABCD_u64]);
+    assert_eq!(entry.kv_caches().len(), 2);
+    assert_eq!(entry.kv_quant(), Some(KvQuant::None));
+    assert!(!entry.is_ssd_hydrated());
+    assert!(
+        entry.lin_caches().is_empty(),
+        "pure-attention arch has no GDN lin state"
+    );
+}
+
+/// A non-hydrated partial match is never reusable under ExactOnly: the default
+/// `is_reusable_prefix_of` hook returns `None` regardless of `matched_blocks`,
+/// so the consume engine can only reach `Exact` or `Miss`.
+#[test]
+fn non_hydrated_partial_is_not_reusable() {
+    let entry = mock_ram_entry(1, &[1, 2, 3], 0);
+    // A longer incoming prompt that the cached one is a prefix of: still None
+    // because the entry is not SSD-hydrated and the default hook declines.
+    assert!(entry
+        .is_reusable_prefix_of(&[1, 2, 3, 4, 5], false, 1)
+        .is_none());
+}
+
+/// An SSD-hydrated entry carries placeholder first-token fields (`first_id == 0`,
+/// empty `first_piece`) and the `is_ssd_hydrated` flag set, mirroring exactly
+/// what `SsdHydrate::hydrate` constructs. The consume engine excludes such an
+/// entry from the Exact fast path so the generate loop recomputes the real
+/// first token via re-prefill. Even as a strict prefix of a longer prompt it is
+/// declined here (the default hook returns `None`), so BitNet stays Exact-only.
+#[test]
+fn ssd_hydrated_entry_field_invariants() {
+    let hydrated = BitNetEntry {
+        prompt_token_ids: vec![10, 11, 12],
+        block_hashes: vec![0xFEED_u64],
+        kv_caches: vec![KvCache::with_quant(KvQuant::None)],
+        first_id: 0,
+        first_piece: String::new(),
+        kv_quant: Some(KvQuant::None),
+        is_ssd_hydrated: true,
+    };
+
+    assert_eq!(hydrated.first_id, 0, "SSD block stores no real first token");
+    assert!(hydrated.first_piece.is_empty());
+    assert!(hydrated.is_ssd_hydrated());
+    // ExactOnly BitNet declines even a hydrated strict-prefix reuse (default
+    // hook → None), unlike the moe HydratedTail seam.
+    assert!(hydrated
+        .is_reusable_prefix_of(&[10, 11, 12, 13], true, 0)
+        .is_none());
+}

--- a/crates/rmlx-models/src/gemma3/generate.rs
+++ b/crates/rmlx-models/src/gemma3/generate.rs
@@ -29,10 +29,14 @@ use crate::decode_loop::{
     capture_logprobs, choose_token, chunked_prefill, pipelined_decode, DecodeCtx,
 };
 use crate::kv_cache::{kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N};
+use crate::prompt_cache::{chained_block_hashes_seeded, Consumed, ReusePolicy, FNV_OFFSET};
 use rmlx_kv_quant::{KvCache, KV_MAX_SEQ_DEFAULT};
 
 use super::loader::load_from_path;
 use super::model::Gemma3Text;
+use super::prompt_cache::{
+    active_layout_key, ensure_prompt_cache, store_kv_cache_bytes, Gemma3Entry, PROMPT_CACHE,
+};
 
 // ---------------------------------------------------------------------------
 // probe_forward -- CLI entry point
@@ -114,6 +118,11 @@ pub fn generate_greedy<'a>(
     device: Device,
     kv_quant: rmlx_kv_quant::KvQuant,
     max_ctx_override: Option<i32>,
+    // number of post-prefill KV snapshots kept across requests. Pass 1 for
+    // single-slot; pass N for multi-slot exact-match. Recommended: 4. Only the
+    // Exact-hit path is active for gemma3 (ReusePolicy::ExactOnly); an
+    // identical-prompt repeat skips re-prefill entirely.
+    prompt_cache_slots: usize,
     eos_ids: &'a [u32],
     // The shared `DecodeCtx` bundles every per-request borrow under one
     // lifetime, so these references share `'a` (a `&mut dyn` trait-object
@@ -141,6 +150,8 @@ pub fn generate_greedy<'a>(
         arch = "Gemma3ForConditionalGeneration",
         ?kv_quant,
         ?max_ctx_override,
+        prompt_cache_slots,
+        has_image = image_prefill.is_some(),
         "generate_greedy: selected KV cache quant"
     );
 
@@ -148,8 +159,63 @@ pub fn generate_greedy<'a>(
         return Ok(vec![]);
     }
 
+    // capture before `image_prefill` is moved into the prefill branch.
+    // Image prompts must not be served from or saved to the token-id-keyed
+    // prompt cache (the K/V depends on scattered vision features, not just the
+    // token ids).
+    let has_image = image_prefill.is_some();
+
     let vocab = model.cfg.vocab_size as i32;
     let mut steps = Vec::with_capacity(n_tokens);
+
+    ensure_prompt_cache(prompt_cache_slots);
+
+    // ------------------------------------------------------------------
+    // Prompt cache lookup via the shared consume() engine. Gemma3 is a
+    // pure-attention arch (no recurrent state) with sliding-window-attention
+    // layers, and uses ReusePolicy::ExactOnly: it overrides none of the
+    // prefix-reuse hooks, so the only reachable consume outcomes are Exact
+    // (identical-prompt repeat skips re-prefill — a full in-memory deep_clone of
+    // every layer cache including the SWA ring, so it is safe) and Miss (full
+    // re-prefill). Gemma3's ring / SWA-mask differs from gemma4, so the
+    // gemma4-style partial / strict-prefix snapshot-restore path is NOT enabled
+    // here yet (promotion to Partial is a separate follow-up). The engine owns
+    // the find → SSD-hydrate retry → quant-mismatch guard → SSD-hydrated
+    // exclusion → Exact decision and traces every degrade branch. The ExactOnly
+    // tripwire lives here at the call site — not in the generic engine — because
+    // the engine is policy-agnostic and shared across architectures.
+    // ------------------------------------------------------------------
+    assert_eq!(
+        PROMPT_CACHE.policy(),
+        ReusePolicy::ExactOnly,
+        "Gemma3 prompt cache must be ExactOnly — SWA-first: gemma3's sliding-window ring \
+         and mask differ from gemma4, so only a full-token-equality Exact hit (RAM deep_clone, \
+         SWA ring included) is reused; partial / strict-prefix reuse is a separate follow-up",
+    );
+
+    // image prompts bypass the prompt cache: pass `has_image` so the engine
+    // returns Miss without touching the cache (mirrored by the `!has_image`
+    // store gate below).
+    if !has_image {
+        if let Consumed::Exact(cloned) = PROMPT_CACHE.consume(prompt_ids, kv_quant, false) {
+            return exact_hit_decode(
+                model,
+                tokenizer,
+                cloned,
+                prompt_ids,
+                n_tokens,
+                vocab,
+                device,
+                eos_ids,
+                step_fn,
+                constraint,
+                sampler_cfg,
+                rng,
+                penalty_cfg,
+                token_history,
+            );
+        }
+    }
 
     // Prefill timer; decode timers come from `pipelined_decode`'s `DecodeStats`.
     let prefill_t0 = Instant::now();
@@ -296,6 +362,56 @@ pub fn generate_greedy<'a>(
         "gemma3 generate_greedy prefill"
     );
 
+    // Push this prefill snapshot to the prompt cache (Miss → store), gated
+    // `!has_image`: an image prompt's K/V is not reconstructible from the
+    // token-id cache key, so it must neither be served from nor stored into the
+    // cache. Clone the post-prefill KV caches (refcount bump, no data copy)
+    // before the decode loop starts writing new decode-step K/V into them.
+    // Materialize the GPU arrays on the current inference thread first so a
+    // later eviction on a different tokio/Metal thread can re-eval them as a
+    // no-op (see gemma4/generate/mod.rs).
+    if !has_image {
+        let kv_snap: Result<Vec<KvCache>> = caches.iter().map(KvCache::try_deep_clone).collect();
+        if let Ok(kvs) = kv_snap {
+            match kvs.iter().try_for_each(KvCache::eval_for_spill) {
+                Ok(()) => {
+                    // Salt the chained block-hash walk with the active layout_key
+                    // + KV codec so a slot stored under a different codec / layout
+                    // never cross-serves. Identical to the consume() seed.
+                    let lk = active_layout_key();
+                    let block_hashes = chained_block_hashes_seeded(
+                        prompt_ids,
+                        FNV_OFFSET ^ lk ^ kv_quant.cache_key_salt(),
+                    );
+                    let entry = Gemma3Entry {
+                        prompt_token_ids: prompt_ids.to_vec(),
+                        block_hashes,
+                        kv_caches: kvs,
+                        first_id: last_id,
+                        first_piece: piece.clone(),
+                        kv_quant: Some(kv_quant),
+                        is_ssd_hydrated: false,
+                    };
+                    PROMPT_CACHE.with_inner_mut(|guard| {
+                        if let Some(cache) = guard.as_mut() {
+                            cache.push(entry);
+                            let stats = cache.stats();
+                            tracing::debug!(
+                                prompt_len = prompt_ids.len(),
+                                cache_hits = stats.hits,
+                                cache_misses = stats.misses,
+                                cache_bytes = stats.bytes,
+                                "gemma3 generate_greedy: pushed snapshot to prompt cache (miss path)"
+                            );
+                        }
+                    });
+                }
+                Err(e) => tracing::warn!(error = %e,
+                    "gemma3 generate_greedy: pre-eval of KV caches failed, skipping prompt cache store"),
+            }
+        }
+    }
+
     // prefill is non-pipelined (last_id already materialised), so the prefill
     // token's logprobs come straight from this step's logits.
     let prefill_logprobs = if lp_k > 0 {
@@ -343,8 +459,109 @@ pub fn generate_greedy<'a>(
         step_total_ms = step_ms,
         forward_per_step_ms = forward_ms / n,
         eval_per_step_ms = eval_ms / n,
+        cache_path = "miss",
         "decode_profile"
     );
+
+    // store KV-cache bytes for the /metrics/cache endpoint.
+    store_kv_cache_bytes(caches.iter().map(KvCache::resident_bytes).sum());
+
+    Ok(steps)
+}
+
+/// Exact prompt-cache hit: skip re-prefill, replay the stored first token, then
+/// run the shared pipelined decode loop on the cloned caches (SWA ring
+/// included). `cloned` is the deep-cloned `Gemma3Entry` the consume engine
+/// returned; its `kv_caches` are post-prefill state for `prompt_ids`.
+#[allow(clippy::too_many_arguments)]
+fn exact_hit_decode<'a>(
+    model: &Gemma3Text,
+    tokenizer: &'a tokenizers::Tokenizer,
+    cloned: Gemma3Entry,
+    prompt_ids: &[u32],
+    n_tokens: usize,
+    vocab: i32,
+    device: Device,
+    eos_ids: &'a [u32],
+    step_fn: &'a mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
+    mut constraint: Option<&'a mut dyn ConstraintEngine>,
+    sampler_cfg: &'a crate::sampler::SamplerConfig,
+    rng: &'a mut crate::sampler::Pcg32,
+    penalty_cfg: &'a crate::sampler::PenaltyConfig,
+    token_history: &'a mut Vec<u32>,
+) -> Result<Vec<crate::decode_loop::ProbeStep>> {
+    use crate::decode_loop::ProbeStep;
+
+    let Gemma3Entry {
+        kv_caches: mut caches,
+        first_id: last_id,
+        first_piece: piece,
+        ..
+    } = cloned;
+    let mut steps = Vec::with_capacity(n_tokens);
+
+    tracing::debug!(
+        prompt_len = prompt_ids.len(),
+        token_id = last_id,
+        "gemma3 generate_greedy: prompt cache EXACT HIT"
+    );
+
+    step_fn(steps.push_mut(ProbeStep {
+        token_id: last_id,
+        piece: piece.into_boxed_str(),
+        max_abs_logit: 0.0,
+        nan_count: 0,
+        logprobs: None,
+    }));
+    // exact-hit token into history.
+    token_history.push(last_id);
+
+    // EOS-stop. If the cached first token is an EOS, no decode steps.
+    if eos_ids.contains(&last_id) {
+        return Ok(steps);
+    }
+
+    let stats = {
+        let mut ctx = DecodeCtx {
+            tokenizer,
+            vocab,
+            n_tokens,
+            device,
+            eos_ids,
+            step_fn,
+            constraint: constraint.take(),
+            sampler_cfg,
+            rng,
+            penalty_cfg,
+            token_history,
+            arch: "Gemma3ForConditionalGeneration",
+            resolve_pieces: true,
+        };
+        pipelined_decode(&mut ctx, last_id, &mut steps, |y| {
+            model.forward_arr(y, 1, Some(&mut caches), device)
+        })?
+    };
+
+    let forward_ms = (stats.forward_total_ns as f64) / 1.0e6;
+    let eval_ms = (stats.eval_total_ns as f64) / 1.0e6;
+    let step_ms = (stats.step_total_ns as f64) / 1.0e6;
+    let n = f64::from(stats.decode_steps.max(1));
+    tracing::info!(
+        target: "decode_profile",
+        arch = "Gemma3ForConditionalGeneration",
+        n_steps = stats.decode_steps,
+        prefill_ms = 0.0_f64,
+        forward_total_ms = forward_ms,
+        eval_total_ms = eval_ms,
+        step_total_ms = step_ms,
+        forward_per_step_ms = forward_ms / n,
+        eval_per_step_ms = eval_ms / n,
+        cache_path = "exact",
+        "decode_profile"
+    );
+
+    // store KV-cache bytes for the /metrics/cache endpoint.
+    store_kv_cache_bytes(caches.iter().map(KvCache::resident_bytes).sum());
 
     Ok(steps)
 }

--- a/crates/rmlx-models/src/gemma3/mod.rs
+++ b/crates/rmlx-models/src/gemma3/mod.rs
@@ -42,6 +42,7 @@ mod generate;
 mod layers;
 pub mod loader;
 mod model;
+pub(crate) mod prompt_cache;
 #[cfg(test)]
 mod tests;
 mod vision;
@@ -50,6 +51,8 @@ pub use config::{Gemma3TextConfig, Gemma3VisionConfig, LayerType};
 pub use generate::{generate_greedy, probe_forward};
 pub use loader::load_from_path;
 pub use model::Gemma3Text;
+pub use prompt_cache::read_cache_stats as gemma3_cache_stats;
+pub use prompt_cache::read_kv_cache_bytes as gemma3_kv_cache_bytes;
 pub use vision::{
     build_inputs_embeds, load_vision_tower, Gemma3ImageProcessor, Gemma3PixelValues,
     MultiModalProjector, VisionModel, BOI_TOKEN_ID, EOI_TOKEN_ID, IMAGE_TOKEN_ID,

--- a/crates/rmlx-models/src/gemma3/prompt_cache.rs
+++ b/crates/rmlx-models/src/gemma3/prompt_cache.rs
@@ -1,0 +1,264 @@
+//! Gemma3 prompt-cache entry + global.
+//!
+//! The heavy lifting (static cache, SSD attach/install, ensure, stats readback,
+//! last-bytes counter, and the find → SSD-hydrate retry → quant-guard → Exact →
+//! Miss consume decision) is unified in
+//! [`crate::prompt_cache::ArchPromptCache`]. This file keeps only the genuinely
+//! Gemma3-specific bits:
+//!
+//! - `Gemma3Entry`: `Vec<KvCache>` only (pure-attention arch — no GDN state).
+//!   Same shape as `Gemma4Entry`: gemma3 also has sliding-window-attention (SWA)
+//!   layers backed by a `RotatingKvCache`, so the entry must carry the full
+//!   layer-cache vector (SWA ring included) for a RAM Exact `deep_clone` to be
+//!   safe.
+//! - `impl PromptCacheEntry for Gemma3Entry`: deep_clone + KV accessors, plus an
+//!   `is_hydrate_complete` SWA-completeness override. The two prefix-reuse hooks
+//!   (`is_reusable_prefix_of`, `prepare_reuse`) take the trait defaults, which
+//!   give correct [`ReusePolicy::ExactOnly`] behaviour: a non-hydrated partial
+//!   match is never reusable, and the only reuse the engine would permit (a
+//!   hydrated strict-prefix) is declined here (`is_reusable_prefix_of` → `None`),
+//!   so the only reachable consume outcomes are `Exact` and `Miss`.
+//! - `impl SsdHydrate<Gemma3Entry> for SsdHydrator`: pure-attention hydrate (the
+//!   reconstructed block carries `kv_caches` only; the SWA rotating-ring layers
+//!   come back payload-less). The SSD spill path is the blanket
+//!   `SpillSink<E> for SsdSpiller` in `crate::prompt_cache`.
+//!
+//! ## Reuse policy — Exact-only (SWA-first)
+//!
+//! Gemma3 uses [`ReusePolicy::ExactOnly`]. Gemma3's sliding-window ring and
+//! SWA-mask differ from gemma4, so the partial / strict-prefix snapshot-restore
+//! path that gemma4 runs under `ReusePolicy::Partial` is NOT enabled here yet —
+//! a Partial promotion (reusing a gemma4-style prefix predicate + completeness
+//! gate) is a separate follow-up that must first prove a strict-prefix restore
+//! on gemma3's ring. Under ExactOnly the only reuse is a RAM `Exact` hit on a
+//! non-hydrated entry: that is a full in-memory `deep_clone` of every layer
+//! cache (SWA ring included), so it is correct by construction.
+//!
+//! ## SWA-hydrate completeness
+//!
+//! An SSD-hydrated entry restores only the block-aligned prefix of the
+//! full-attention layers; the SWA rotating-ring layers are NOT serialised to the
+//! SSD tier and come back as a payload-less `KvStorage::None`. Such an entry is
+//! never reused under ExactOnly anyway (the Exact arm declines
+//! `is_ssd_hydrated`, and the default `is_reusable_prefix_of` returns `None`), so
+//! it always falls to a full re-prefill — safe by construction. The
+//! `is_hydrate_complete` override below encodes the SWA-completeness predicate
+//! regardless, both to document the truth and to future-proof a later Partial
+//! promotion (the engine excludes an incomplete hydrated entry from prefix
+//! reuse).
+
+#![allow(clippy::redundant_closure_for_method_calls)]
+use rmlx_core::error::Result;
+
+use crate::prompt_cache::{ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate};
+use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
+use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
+
+// ---------------------------------------------------------------------------
+// Entry type
+// ---------------------------------------------------------------------------
+
+/// Post-prefill snapshot for one Gemma3 request.
+///
+/// Pure-attention arch (no GDN recurrent state), but with SWA layers backed by
+/// a `RotatingKvCache`. Same shape as `Gemma4Entry`; the layer-cache vector
+/// carries the full per-layer KV (SWA ring included) so a RAM Exact `deep_clone`
+/// reuses the exact attention context.
+pub(crate) struct Gemma3Entry {
+    /// Full prompt token IDs used to fill this slot.
+    pub(crate) prompt_token_ids: Vec<u32>,
+    /// Chained 256-token block digests of `prompt_token_ids` (trailing partial
+    /// block excluded). Computed at construction.
+    pub(crate) block_hashes: Vec<u64>,
+    /// Post-prefill KV caches (one per decoder layer; SWA + full-attention).
+    pub(crate) kv_caches: Vec<KvCache>,
+    /// Argmax token from the first decode step after prefill.
+    pub(crate) first_id: u32,
+    /// Decoded piece for `first_id`.
+    pub(crate) first_piece: String,
+    /// Runtime `KvQuant` discriminant in effect when this snapshot was written.
+    /// Read by the engine's quant-mismatch guard and by the blanket spill path.
+    pub(crate) kv_quant: Option<KvQuant>,
+    /// True when this entry was reconstructed from the SSD tier and therefore
+    /// stores only the block-aligned prefix KV — `first_id` / `first_piece` are
+    /// placeholders, not a real decode token. The consume engine excludes such
+    /// an entry from the Exact fast path so it falls through to a full
+    /// re-prefill that recomputes the real first token.
+    ///
+    /// MUST be set only in `SsdHydrate::hydrate`; never by the RAM-cache push
+    /// path. Do NOT use the `first_id == 0` heuristic as a substitute —
+    /// `<bos>` token id is 0 for some models.
+    pub(crate) is_ssd_hydrated: bool,
+}
+
+impl Gemma3Entry {
+    /// True iff every layer this architecture attends to carries real K/V
+    /// payload — i.e. the snapshot has a complete attention context.
+    ///
+    /// Gemma3's sliding-window (SWA) layers run a bf16 `RotatingKvCache` ring
+    /// that is NOT serialised to the SSD tier; on hydrate they are reconstructed
+    /// as a payload-less `KvStorage::None` (the spill writer records them
+    /// geometry-only). A layer is payload-less when its storage is `None` AND it
+    /// carries no off-storage bf16 seed. This distinguishes a dropped SWA ring
+    /// (no seed → incomplete) from a `KvQuant::None` global layer whose bf16 K/V
+    /// was spilled and restored via `KvCache::with_decode_fp16_seed` (seed
+    /// present → complete). A fully RAM-resident snapshot always passes (no layer
+    /// is `None`-without-seed), so only hydrated SWA entries are degraded.
+    ///
+    /// Under ExactOnly such a hydrated entry is never reused anyway, but the
+    /// predicate documents the SWA truth and gates the engine's prefix-reuse
+    /// path for a future Partial promotion.
+    pub(crate) fn is_hydrate_complete(&self) -> bool {
+        self.kv_caches
+            .iter()
+            .all(|c| c.has_persistent_cache() || c.decode_fp16_kv().is_some())
+    }
+}
+
+impl PromptCacheEntry for Gemma3Entry {
+    fn prompt_token_ids(&self) -> &[u32] {
+        &self.prompt_token_ids
+    }
+
+    fn block_hashes(&self) -> &[u64] {
+        &self.block_hashes
+    }
+
+    fn deep_clone(&self) -> Result<Self> {
+        let kv_caches: Result<Vec<_>> = self.kv_caches.iter().map(|c| c.try_deep_clone()).collect();
+        Ok(Self {
+            prompt_token_ids: self.prompt_token_ids.clone(),
+            block_hashes: self.block_hashes.clone(),
+            kv_caches: kv_caches?,
+            first_id: self.first_id,
+            first_piece: self.first_piece.clone(),
+            kv_quant: self.kv_quant,
+            is_ssd_hydrated: self.is_ssd_hydrated,
+        })
+    }
+
+    fn kv_caches(&self) -> &[KvCache] {
+        &self.kv_caches
+    }
+
+    fn kv_caches_mut(&mut self) -> &mut [KvCache] {
+        &mut self.kv_caches
+    }
+
+    fn kv_quant(&self) -> Option<KvQuant> {
+        self.kv_quant
+    }
+
+    fn is_ssd_hydrated(&self) -> bool {
+        self.is_ssd_hydrated
+    }
+
+    // Pure-attention arch: no GDN linear state.
+    fn lin_caches(&self) -> &[LinearAttnCache] {
+        &[]
+    }
+
+    /// Delegates to the inherent [`Gemma3Entry::is_hydrate_complete`]: an
+    /// SSD-hydrated entry whose SWA rotating ring came back as a payload-less
+    /// `KvStorage::None` (the ring is not serialised to the SSD tier) is
+    /// incomplete, so the consume engine would exclude it from any prefix reuse.
+    /// (Under the current ExactOnly policy it is excluded from the Exact arm by
+    /// `!is_ssd_hydrated` regardless; this override documents the SWA truth and
+    /// future-proofs a Partial promotion.)
+    fn is_hydrate_complete(&self) -> bool {
+        Gemma3Entry::is_hydrate_complete(self)
+    }
+    // is_reusable_prefix_of / prepare_reuse: trait defaults. The defaults give
+    // correct ExactOnly behaviour (no partial reuse, deep_clone on the
+    // unreachable reuse path). Gemma3's SWA ring/mask differs from gemma4, so a
+    // gemma4-style block-truncate / B1 strict-prefix path is deliberately NOT
+    // enabled — promotion to Partial is a separate follow-up.
+    // truncate_kv_to / truncate_kv_to_block / kv_bytes: trait defaults.
+}
+
+// ---------------------------------------------------------------------------
+// SSD-spill sink — the blanket `impl SpillSink<E> for SsdSpiller` in
+// `crate::prompt_cache` covers Gemma3 (pure-attention: `lin_caches()` is `&[]`,
+// so the spill job carries `kv_caches` only).
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// SSD-hydrate source
+// ---------------------------------------------------------------------------
+
+/// Hydrate a `Gemma3Entry` from the SSD tier on a RAM-cache miss.
+///
+/// Pure-attention arch: the reconstructed block carries `kv_caches` only (the
+/// `lin_caches` from the block are discarded). The SWA rotating-ring layers come
+/// back payload-less (the ring is not serialised). The matched block-aligned
+/// prefix token IDs become the entry's `prompt_token_ids`; block hashes are
+/// recomputed and the runtime `kv_quant` recorded. `first_id` / `first_piece`
+/// are sentinels (the SSD block stores no first decode token), so the entry is
+/// flagged `is_ssd_hydrated = true`; the consume engine excludes it from the
+/// Exact fast path and the generate loop recomputes the real first token via
+/// re-prefill.
+impl SsdHydrate<Gemma3Entry> for SsdHydrator {
+    fn hydrate(&self, prompt_ids: &[u32]) -> Result<Option<Gemma3Entry>> {
+        let Some((block, block_hashes)) = self.lookup_seeded(prompt_ids)? else {
+            return Ok(None);
+        };
+        let HydratedBlock {
+            prompt_ids,
+            kv_caches,
+            lin_caches: _, // pure-attention arch has no GDN state
+        } = block;
+        Ok(Some(Gemma3Entry {
+            prompt_token_ids: prompt_ids,
+            block_hashes,
+            kv_caches,
+            first_id: 0,
+            first_piece: String::new(),
+            kv_quant: Some(self.kv_quant()),
+            // Block-aligned prefix only; the placeholder first_id must not be
+            // replayed — the generate loop re-prefills to recompute it.
+            is_ssd_hydrated: true,
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global cache instance — unified ArchPromptCache shell.
+// ---------------------------------------------------------------------------
+
+/// per-arch shell with `ReusePolicy::ExactOnly`. Gemma3 has SWA layers, but
+/// gemma3's ring / SWA-mask differs from gemma4, so the prefix-reuse path is not
+/// wired here — the only reuse is a RAM Exact hit (full `deep_clone`, SWA ring
+/// included). Promotion to `Partial` is a separate follow-up.
+pub(crate) static PROMPT_CACHE: ArchPromptCache<Gemma3Entry> =
+    ArchPromptCache::new("Gemma3ForConditionalGeneration", ReusePolicy::ExactOnly);
+
+/// active SSD-tier `layout_key` for the gemma3 cache, or `0` when the tier is
+/// OFF. `FNV_OFFSET ^ 0 == FNV_OFFSET` ⇒ legacy un-salted digests when no SSD
+/// tier is attached, preserving byte-identical RAM-only behaviour.
+pub(crate) fn active_layout_key() -> u64 {
+    PROMPT_CACHE.active_layout_key()
+}
+
+/// Ensure the global prompt cache is initialised with at least `capacity` slots.
+pub(crate) fn ensure_prompt_cache(capacity: usize) {
+    PROMPT_CACHE.ensure(capacity);
+}
+
+/// Read the current hit/miss/bytes stats for the Gemma3 prompt cache.
+pub fn read_cache_stats() -> Option<CacheStats> {
+    PROMPT_CACHE.read_cache_stats()
+}
+
+/// Read the KV-cache bytes from the last completed Gemma3 request.
+pub fn read_kv_cache_bytes() -> u64 {
+    PROMPT_CACHE.read_kv_cache_bytes()
+}
+
+/// Record the KV-cache byte total for the just-completed request.
+pub(crate) fn store_kv_cache_bytes(n: u64) {
+    PROMPT_CACHE.store_kv_cache_bytes(n);
+}
+
+#[cfg(test)]
+#[path = "prompt_cache_tests.rs"]
+mod tests;

--- a/crates/rmlx-models/src/gemma3/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/gemma3/prompt_cache_tests.rs
@@ -1,0 +1,173 @@
+//! In-process unit tests for the Gemma3 prompt cache.
+//!
+//! These exercise the parts that do not need a loaded model or a Metal GPU
+//! stream: the arch policy, the `Gemma3Entry` deep_clone round-trip over empty
+//! (never-prefilled) KV caches, the SSD-hydrated entry field invariants
+//! (placeholder `first_id` + `is_ssd_hydrated` flag) the real-model SSD smoke
+//! relies on, and the SWA `is_hydrate_complete` predicate (complete vs
+//! synthetically-incomplete). Decoded-token reuse is proven by the real-model
+//! smoke, not here.
+//!
+//! `is_hydrate_complete` is GPU-free: a `KvQuant::K8V8` cache constructs with a
+//! non-`None` storage (so `has_persistent_cache()` is `true`) and a
+//! `KvQuant::None` cache constructs with `KvStorage::None` and no `decode_fp16`
+//! seed (so it is payload-less) — neither path materialises any GPU array.
+
+use super::*;
+use rmlx_kv_quant::{KvCache, KvQuant};
+
+/// Build a `Gemma3Entry` with `n_layers` empty (never-prefilled) `K8V8` KV
+/// caches.
+///
+/// An empty cache holds no live GPU arrays, so `try_deep_clone` is a no-op
+/// refcount walk that runs without a Metal stream — safe in a plain unit test.
+/// `K8V8` storage is non-`None`, so every layer reports `has_persistent_cache()`
+/// → the entry is hydrate-complete.
+fn mock_ram_entry(n_layers: usize, prompt: &[u32], first_id: u32) -> Gemma3Entry {
+    Gemma3Entry {
+        prompt_token_ids: prompt.to_vec(),
+        block_hashes: vec![0xABCD_u64; n_layers],
+        kv_caches: (0..n_layers)
+            .map(|_| KvCache::with_quant(KvQuant::K8V8))
+            .collect(),
+        first_id,
+        first_piece: "hello".to_string(),
+        kv_quant: Some(KvQuant::K8V8),
+        is_ssd_hydrated: false,
+    }
+}
+
+/// Gemma3's policy is hard-gated `ExactOnly` (SWA-first): the shared consume
+/// engine must only ever yield `Exact` or `Miss` for this arch (no partial /
+/// strict-prefix reuse — gemma3's ring/mask differs from gemma4).
+#[test]
+fn arch_policy_is_exact_only() {
+    assert_eq!(PROMPT_CACHE.policy(), ReusePolicy::ExactOnly);
+}
+
+/// `deep_clone` copies every metadata field and produces an independent entry
+/// with the same KV-cache cardinality (SWA ring included). Empty caches carry
+/// no GPU data, so the clone is a refcount walk; this pins the field-copy
+/// contract that the RAM Exact-hit reuse relies on.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: deep_clone over empty KV caches cannot fail — .expect documents the invariant"
+)]
+fn entry_deep_clone_preserves_fields() {
+    let prompt = [1_u32, 2, 3, 4];
+    let entry = mock_ram_entry(3, &prompt, 42);
+    let cloned = entry
+        .deep_clone()
+        .expect("deep_clone of empty-cache entry must succeed");
+
+    assert_eq!(cloned.prompt_token_ids, entry.prompt_token_ids);
+    assert_eq!(cloned.block_hashes, entry.block_hashes);
+    assert_eq!(cloned.kv_caches.len(), entry.kv_caches.len());
+    assert_eq!(cloned.first_id, 42);
+    assert_eq!(cloned.first_piece, "hello");
+    assert_eq!(cloned.kv_quant, Some(KvQuant::K8V8));
+    assert!(!cloned.is_ssd_hydrated);
+}
+
+/// The `PromptCacheEntry` accessors expose the entry's fields verbatim. A
+/// pure-attention Gemma3 entry has no GDN recurrent state, so `lin_caches()` is
+/// empty — this is what makes the blanket `SpillSink` carry KV only.
+#[test]
+fn entry_accessors_match_fields() {
+    let prompt = [7_u32, 8, 9];
+    let entry = mock_ram_entry(2, &prompt, 5);
+
+    assert_eq!(entry.prompt_token_ids(), &prompt);
+    assert_eq!(entry.block_hashes(), &[0xABCD_u64, 0xABCD_u64]);
+    assert_eq!(entry.kv_caches().len(), 2);
+    assert_eq!(entry.kv_quant(), Some(KvQuant::K8V8));
+    assert!(!entry.is_ssd_hydrated());
+    assert!(
+        entry.lin_caches().is_empty(),
+        "pure-attention arch has no GDN lin state"
+    );
+}
+
+/// A non-hydrated partial match is never reusable under ExactOnly: the default
+/// `is_reusable_prefix_of` hook returns `None` regardless of `matched_blocks`,
+/// so the consume engine can only reach `Exact` or `Miss`. Gemma3 keeps the
+/// default (no gemma4-style block-truncate / B1 strict-prefix).
+#[test]
+fn non_hydrated_partial_is_not_reusable() {
+    let entry = mock_ram_entry(1, &[1, 2, 3], 0);
+    // A longer incoming prompt that the cached one is a prefix of: still None
+    // because the entry is not SSD-hydrated and the default hook declines.
+    assert!(entry
+        .is_reusable_prefix_of(&[1, 2, 3, 4, 5], false, 1)
+        .is_none());
+}
+
+/// An SSD-hydrated entry carries placeholder first-token fields (`first_id == 0`,
+/// empty `first_piece`) and the `is_ssd_hydrated` flag set, mirroring exactly
+/// what `SsdHydrate::hydrate` constructs. The consume engine excludes such an
+/// entry from the Exact fast path so the generate loop recomputes the real first
+/// token via re-prefill. Even as a strict prefix of a longer prompt it is
+/// declined here (the default hook returns `None`), so Gemma3 stays Exact-only.
+#[test]
+fn ssd_hydrated_entry_field_invariants() {
+    let hydrated = Gemma3Entry {
+        prompt_token_ids: vec![10, 11, 12],
+        block_hashes: vec![0xFEED_u64],
+        kv_caches: vec![KvCache::with_quant(KvQuant::K8V8)],
+        first_id: 0,
+        first_piece: String::new(),
+        kv_quant: Some(KvQuant::K8V8),
+        is_ssd_hydrated: true,
+    };
+
+    assert_eq!(hydrated.first_id, 0, "SSD block stores no real first token");
+    assert!(hydrated.first_piece.is_empty());
+    assert!(hydrated.is_ssd_hydrated());
+    // ExactOnly Gemma3 declines even a hydrated strict-prefix reuse (default
+    // hook → None), unlike the moe HydratedTail seam.
+    assert!(hydrated
+        .is_reusable_prefix_of(&[10, 11, 12, 13], true, 0)
+        .is_none());
+}
+
+/// A fully RAM-resident snapshot (every layer cache `K8V8`, so non-`None`
+/// storage) is hydrate-complete: every attended layer carries payload.
+#[test]
+fn is_hydrate_complete_true_for_complete_entry() {
+    let entry = mock_ram_entry(4, &[1, 2, 3, 4], 7);
+    assert!(
+        entry.is_hydrate_complete(),
+        "all-K8V8 caches have persistent storage → complete"
+    );
+}
+
+/// An entry with a payload-less SWA layer — a `KvQuant::None` cache that carries
+/// neither a persistent storage buffer (`KvStorage::None`) nor an off-storage
+/// bf16 decode seed — is hydrate-incomplete, exactly the shape an SSD-hydrated
+/// gemma3 entry has after its rotating ring was dropped. The engine would
+/// exclude such an entry from prefix reuse (and the Exact arm already excludes
+/// it via `!is_ssd_hydrated`).
+#[test]
+fn is_hydrate_complete_false_for_payloadless_swa_layer() {
+    // Three persistent (full-attention) layers + one payload-less SWA layer.
+    let mut kv_caches: Vec<KvCache> = (0..3).map(|_| KvCache::with_quant(KvQuant::K8V8)).collect();
+    // `KvQuant::None` constructs `KvStorage::None`; with no `with_decode_fp16_seed`
+    // it has no persistent cache and no decode seed → payload-less.
+    kv_caches.push(KvCache::with_quant(KvQuant::None));
+
+    let entry = Gemma3Entry {
+        prompt_token_ids: vec![1, 2, 3, 4],
+        block_hashes: vec![0xABCD_u64],
+        kv_caches,
+        first_id: 0,
+        first_piece: String::new(),
+        kv_quant: Some(KvQuant::None),
+        is_ssd_hydrated: true,
+    };
+
+    assert!(
+        !entry.is_hydrate_complete(),
+        "a None-storage SWA layer with no bf16 seed makes the entry incomplete"
+    );
+}

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -47,7 +47,7 @@ use crate::kv_cache::{
     kv_max_seq_and_ceiling, kv_quant_for_layer, warn_if_kv_codec_net_negative, KvLayerShape,
     LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N,
 };
-use crate::prompt_cache::PromptCacheEntry as _;
+use crate::prompt_cache::{Consumed, ReuseKind, ReusePolicy, BLOCK_TOKENS};
 use rmlx_kv_quant::{KvCache, KvQuant};
 
 use super::model::Gemma4Text;
@@ -138,17 +138,29 @@ pub fn generate_greedy<'a>(
     ensure_prompt_cache(prompt_cache_slots);
 
     // ------------------------------------------------------------------
-    // Prompt cache lookup
+    // Prompt cache lookup via the shared consume() engine.
     // ------------------------------------------------------------------
-    // C1: three outcomes. `Exact` = cached prompt token-for-token equal to
-    // this prompt (full reuse, no truncate, no re-prefill). `Prefix` = cached
-    // prompt shares >= 1 full 256-token block then diverges AND every layer
-    // cache is losslessly trimmable (mlx-lm `can_trim_prompt_cache`) — the KV
-    // is block-truncated and only the tail `[prefix_len..prompt_len)` is
-    // re-prefilled, at correct absolute positions. `Miss` = no usable prefix
-    // OR an SWA layer wrapped (ring buffer not trimmable, see
-    // `Gemma4Entry::can_truncate_to_block`) so a partial reuse cannot be made
-    // cold-equal — fall back to a full re-prefill.
+    // gemma4 is pure-attention (no GDN recurrent state) and uses
+    // `ReusePolicy::Partial`, so all three outcomes are reachable:
+    //   - `Exact`  = cached prompt token-for-token equal to this prompt (full
+    //                reuse, no truncate, no re-prefill).
+    //   - `Reuse{StrictPrefix}` = B1 SWA snapshot/restore: the cached prompt is
+    //                a token-for-token prefix the request extends; restore the
+    //                snapshot as-is (NO truncation, so a wrapped SWA ring is not
+    //                desynced) and forward only the tail.
+    //   - `Reuse{BlockTruncate}` = block-aligned partial hit: the KV is trimmed
+    //                to `effective_blocks * BLOCK_TOKENS` and only the tail is
+    //                re-prefilled. Gated per-slot by `can_truncate_to_block`
+    //                (an SWA ring that has wrapped is not trimmable → Miss).
+    //   - `Miss`   = no usable prefix, an incomplete SSD-hydrate (payload-less
+    //                SWA layer), or a quant mismatch — full re-prefill.
+    // The engine owns find → SSD-hydrate retry → quant-mismatch guard →
+    // SSD-hydrated Exact exclusion → reuse-gate, and traces every degrade
+    // branch; the per-arch policy tripwire lives here at the call site.
+    //
+    // The local `CacheLookup` enum is the bridge from the engine outcome to the
+    // existing decode paths below (Path A exact-hit, Path B prefix tail, Path C
+    // miss) — those paths are kept verbatim.
     enum CacheLookup {
         Exact {
             kv_caches: Vec<KvCache>,
@@ -162,238 +174,73 @@ pub fn generate_greedy<'a>(
         Miss,
     }
 
-    // image prompts bypass the prompt cache. The cached K/V is keyed by
-    // token ids only; an image prompt's K/V depends on the scattered vision
-    // features, so it must never be reused for (or saved under) a token-id key.
-    // Issue #26: codec-partitioned prompt-cache key. The query digest stream is
-    // salted by `FNV_OFFSET ^ layout_key ^ codec_salt(kv_quant)` — identical to
-    // the push seed below — so a slot stored under a different KV codec never
-    // matches this request (no cross-codec serve), and codecs coexist as
-    // distinct slots rather than thrash-evicting one another. On a RAM-only run
-    // (layout_key=0) the push and query seeds are equal (`FNV_OFFSET ^
-    // codec_salt`), so same-codec hits still land; digests differ from the
-    // pre-#26 stream by the constant codec salt, harmless because the cache is
-    // rebuilt per process.
-    let cache_seed = crate::prompt_cache::FNV_OFFSET
-        ^ crate::gemma4::prompt_cache::active_layout_key()
-        ^ kv_quant.cache_key_salt();
-    let lookup: CacheLookup = if image_prefill.is_some() {
-        CacheLookup::Miss
-    } else {
-        PROMPT_CACHE.with_inner_mut(|guard| {
-            let cache = guard.as_mut().unwrap();
-            let mut raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
-            // on a RAM miss, try to serve the longest cached block-aligned
-            // prefix from the SSD tier (no-op when no SSD source is attached —
-            // tier OFF). A hydrate hit promotes the block into RAM; re-run
-            // find_best_prefix so the promoted slot is matched (and quant-checked)
-            // by the normal path below.
-            if raw_match.is_none() && cache.hydrate_from_ssd(prompt_ids).is_some() {
-                raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
+    // hard runtime gate: gemma4 must use ReusePolicy::Partial so the engine's
+    // reuse arm is reachable for the B1 strict-prefix + block-truncate paths.
+    // A real (not debug_) assert so the tripwire fires under release-perf.
+    assert_eq!(
+        PROMPT_CACHE.policy(),
+        ReusePolicy::Partial,
+        "gemma4 prompt cache must be Partial — pure-attention KV is block-truncatable and the \
+         SWA snapshot/restore prefix reuse depends on the engine's reuse arm being reachable",
+    );
+
+    // image prompts bypass the prompt cache (`has_image` → engine returns Miss
+    // without touching the cache; mirrored by the `!has_image` store gate
+    // below). The token-id-keyed K/V is unsafe for image spans (the K/V depends
+    // on scattered vision features, not just the token ids).
+    let lookup: CacheLookup = match PROMPT_CACHE.consume(prompt_ids, kv_quant, has_image) {
+        Consumed::Exact(cloned) => {
+            tracing::debug!(
+                prompt_len = prompt_ids.len(),
+                token_id = cloned.first_id,
+                "gemma4 generate_greedy: prompt cache EXACT HIT"
+            );
+            CacheLookup::Exact {
+                kv_caches: cloned.kv_caches,
+                last_id: cloned.first_id,
+                piece: cloned.first_piece,
             }
-            // Plan §D8 / Task 11.5: the snapshot is only safe to reuse when the
-            // stored `KvQuant` discriminant matches the runtime quant for this
-            // request. A mismatch (or a legacy `None`) means the cached
-            // K/V layout / dtype / packing is incompatible with the model wired
-            // up for this request — evict the slot, log a warn, and fall through
-            // to a Miss (full re-prefill is always safe).
-            let safe_match = match raw_match {
-                Some((slot_idx, block_count)) => {
-                    let stored = cache.slots[slot_idx].entry.kv_quant;
-                    if stored == Some(kv_quant) {
-                        Some((slot_idx, block_count))
-                    } else {
-                        tracing::warn!(
-                            stored = ?stored,
-                            runtime = ?kv_quant,
-                            prompt_len = prompt_ids.len(),
-                            "prompt cache KV quant mismatch — evicting entry, \
-                             degrading to re-prefill"
-                        );
-                        cache.evict_slot(slot_idx);
-                        None
-                    }
-                }
-                None => None,
-            };
-            match safe_match {
-                // Exact match: the cached entry's FULL token id list equals the
-                // incoming prompt. Verified at token granularity, NOT by
-                // `block_count * BLOCK_TOKENS == len` — the block-floored test is
-                // essentially never true (only when len % 256 == 0) and was
-                // misrouting identical-prompt repeats into the block-truncate +
-                // tail-reprefill Prefix path, which produced wrong output here too
-                // (22 -> 0 tokens for an identical re-request). Full-equality
-                // reuse sidesteps truncation entirely (pre-C1 behaviour).
-                //
-                // A SSD-hydrated entry whose block-aligned prefix length equals
-                // `prompt_ids.len()` (prompt is an exact multiple of
-                // BLOCK_TOKENS → no tail) must NOT be served here: its
-                // `first_id` is the placeholder 0 set in `SsdHydrate::hydrate`,
-                // not a real decode token. The `!is_ssd_hydrated` guard drops it
-                // through to the block-partial / Miss arms, which re-prefill and
-                // recompute the real first token. Correctness over the micro-opt
-                // (mirrors the qwen3 / qwen3_5_moe Exact arm guards).
-                Some((slot_idx, _block_count))
-                    if !cache.slots[slot_idx].entry.is_ssd_hydrated()
-                        && cache.slots[slot_idx].entry.prompt_token_ids() == prompt_ids =>
-                {
-                    let slot = &cache.slots[slot_idx].entry;
-                    match slot.deep_clone() {
-                        Ok(cloned) => {
-                            tracing::debug!(
-                                prompt_len = prompt_ids.len(),
-                                token_id = cloned.first_id,
-                                "gemma4 generate_greedy: prompt cache EXACT HIT"
-                            );
-                            CacheLookup::Exact {
-                                kv_caches: cloned.kv_caches,
-                                last_id: cloned.first_id,
-                                piece: cloned.first_piece,
-                            }
-                        }
-                        Err(_) => CacheLookup::Miss,
-                    }
-                }
-                // B1: strict-prefix multi-turn extension. The cached entry's FULL
-                // token sequence is a token-for-token prefix of this prompt and
-                // the new prompt extends it by >= 1 token. The post-prefill
-                // snapshot is EXACTLY the state the new prompt needs at absolute
-                // position `cached_len` for every layer type — including SWA
-                // layers whose RotatingKvCache has WRAPPED. The deep-cloned ring
-                // already holds the last `sliding_window` K/V of the cached
-                // prefix (mlx-lm `state`/`meta_state` reuse contract), which is
-                // precisely and sufficiently what the tail attends to under SWA.
-                // We restore the snapshot as-is (NO truncation — `prefix_len ==
-                // cached_len`, both full-attn `KVCache.offset` and SWA
-                // `RotatingKVCache.offset` are `cached_len` post-prefill) and
-                // forward only `prompt_ids[cached_len..]` at positions
-                // `[cached_len, new_len)`. Because nothing is trimmed, the wrapped
-                // SWA `22 -> 0` desync cannot arise. This supersedes the
-                // block-aligned + `can_truncate_to_block` path for the multi-turn
-                // case (which forced a full re-prefill Miss on every wrapped-SWA
-                // turn — bug B1: prefill_ms grew with conversation length).
-                // Hydrate-completeness guard: a SSD-hydrated entry whose SWA
-                // layers came back as payload-less `KvStorage::None` (the
-                // rotating ring is not serialised to the SSD tier — see
-                // `Gemma4Entry::is_hydrate_complete`) MUST NOT be reused via a
-                // prefix arm. Reusing it would re-prefill only the tail on top
-                // of an empty SWA prefix and corrupt the output. Such an entry
-                // falls through to a full re-prefill (Miss). The guard is a
-                // no-op for RAM-resident snapshots (every layer holds payload).
-                Some((slot_idx, _block_count))
-                    if cache.slots[slot_idx].entry.is_strict_prefix_of(prompt_ids)
-                        && cache.slots[slot_idx].entry.is_hydrate_complete() =>
-                {
-                    let slot = &cache.slots[slot_idx].entry;
-                    let prefix_len = slot.prompt_token_ids().len();
-                    match slot.deep_clone() {
-                        Ok(cloned) => {
-                            tracing::debug!(
-                                prompt_len = prompt_ids.len(),
-                                prefix_len,
-                                tail_len = prompt_ids.len() - prefix_len,
-                                "gemma4 generate_greedy: prompt cache PREFIX-EXACT HIT \
-                             (B1 SWA snapshot/restore — restore + tail-only re-prefill)"
-                            );
-                            CacheLookup::Prefix {
-                                kv_caches: cloned.kv_caches,
-                                prefix_len,
-                            }
-                        }
-                        Err(_) => CacheLookup::Miss,
-                    }
-                }
-                // Genuine partial block-prefix hit: cached prompt shares the
-                // first `block_count` full 256-token blocks then diverges.
-                // gemma4 is pure-KV (no recurrent state), so block-truncating
-                // the KV to `block_count*256` and re-prefilling the tail at
-                // absolute positions `[prefix_len..prompt_len)` is cold-equal —
-                // BUT only when every layer cache is losslessly trimmable
-                // (mlx-lm `can_trim_prompt_cache`: `all(c.is_trimmable())`).
-                // gemma4 SWA layers use a RotatingKvCache; once the cached
-                // prompt exceeds `sliding_window` that ring buffer wraps and
-                // `truncate_kv_to_block` would silently no-op on the SWA layers
-                // while truncating the full-attention layers — desyncing the
-                // caches and corrupting the tail (the original broken path:
-                // longctx 22 -> 0 tokens). When `can_truncate_to_block` is
-                // false we fall back to a full re-prefill (Miss); correctness
-                // over speed for the wrapped-SWA case.
-                // Block-truncate partial-prefix reuse — same hydrate-
-                // completeness guard as the B1 arm above. A SSD-hydrated entry
-                // with a payload-less SWA `None` layer cannot be block-truncated
-                // and tail-re-prefilled correctly (the empty SWA prefix would
-                // give wrong attention), so it is excluded here and falls
-                // through to a full re-prefill (Miss).
-                Some((slot_idx, block_count))
-                    if block_count >= 1 && cache.slots[slot_idx].entry.is_hydrate_complete() =>
-                {
-                    // The tail `[prefix_len..prompt_len)` must be non-empty: the
-                    // re-prefilled tail's final position is where we read the
-                    // next-token logits from. If the matched blocks cover the
-                    // whole (block-aligned) prompt, drop the last matched block
-                    // back into the re-prefill tail (oMLX `prefix_cache.py`
-                    // 421-437 keeps a re-prefill remainder past the last block
-                    // boundary). If that leaves zero blocks, it is a Miss.
-                    let prompt_blocks = prompt_ids.len() / crate::prompt_cache::BLOCK_TOKENS;
-                    let effective_blocks =
-                        if block_count * crate::prompt_cache::BLOCK_TOKENS >= prompt_ids.len() {
-                            block_count.min(prompt_blocks).saturating_sub(1)
-                        } else {
-                            block_count
-                        };
-                    let slot = &cache.slots[slot_idx].entry;
-                    if effective_blocks >= 1 && slot.can_truncate_to_block(effective_blocks) {
-                        match slot.deep_clone() {
-                            Ok(mut cloned) => {
-                                cloned.truncate_kv_to_block(effective_blocks);
-                                let prefix_len =
-                                    effective_blocks * crate::prompt_cache::BLOCK_TOKENS;
-                                tracing::debug!(
-                                    prompt_len = prompt_ids.len(),
-                                    block_count,
-                                    effective_blocks,
-                                    prefix_len,
-                                    "gemma4 generate_greedy: prompt cache PREFIX HIT \
-                                 (block-truncate + tail re-prefill)"
-                                );
-                                CacheLookup::Prefix {
-                                    kv_caches: cloned.kv_caches,
-                                    prefix_len,
-                                }
-                            }
-                            Err(_) => CacheLookup::Miss,
-                        }
-                    } else {
-                        tracing::debug!(
-                            prompt_len = prompt_ids.len(),
-                            block_count,
-                            effective_blocks,
-                            "gemma4 generate_greedy: partial prefix hit not usable \
-                         (no tail blocks left, or an SWA layer wrapped / not \
-                         trimmable) — falling back to Miss"
-                        );
-                        CacheLookup::Miss
-                    }
-                }
-                // Incomplete SSD-hydrated entry: the prefix arms above were
-                // skipped by the `is_hydrate_complete` guard because at least
-                // one attended layer (a gemma4 SWA ring) came back payload-less
-                // after hydrate. Degrade to a full re-prefill (Miss) and record
-                // the decision so the empty-SWA reuse path is traceable.
-                Some((slot_idx, _)) if !cache.slots[slot_idx].entry.is_hydrate_complete() => {
-                    tracing::debug!(
-                        prompt_len = prompt_ids.len(),
-                        "gemma4 generate_greedy: SSD-hydrated entry has a payload-less \
-                         SWA layer (rotating ring not spilled) — degrading prefix reuse \
-                         to full re-prefill (Miss)"
-                    );
-                    CacheLookup::Miss
-                }
-                Some(_) => CacheLookup::Miss,
-                None => CacheLookup::Miss,
+        }
+        // B1 SWA snapshot/restore: restore the cloned snapshot verbatim at
+        // absolute position `prefix_len == cached_len` and tail-forward only
+        // `prompt_ids[prefix_len..]`. No truncation → no wrapped-SWA desync.
+        Consumed::Reuse {
+            entry: cloned,
+            kind: ReuseKind::StrictPrefix { prefix_len },
+        } => {
+            tracing::debug!(
+                prompt_len = prompt_ids.len(),
+                prefix_len,
+                tail_len = prompt_ids.len() - prefix_len,
+                "gemma4 generate_greedy: prompt cache PREFIX-EXACT HIT \
+                 (B1 SWA snapshot/restore — restore + tail-only re-prefill)"
+            );
+            CacheLookup::Prefix {
+                kv_caches: cloned.kv_caches,
+                prefix_len,
             }
-        })
+        }
+        // Block-aligned partial hit: `prepare_reuse` already trimmed the cloned
+        // KV to the block boundary; the tail re-prefills from
+        // `prefix_len = effective_blocks * BLOCK_TOKENS`.
+        Consumed::Reuse {
+            entry: cloned,
+            kind: ReuseKind::BlockTruncate { effective_blocks },
+        } => {
+            let prefix_len = effective_blocks * BLOCK_TOKENS;
+            tracing::debug!(
+                prompt_len = prompt_ids.len(),
+                effective_blocks,
+                prefix_len,
+                "gemma4 generate_greedy: prompt cache PREFIX HIT \
+                 (block-truncate + tail re-prefill)"
+            );
+            CacheLookup::Prefix {
+                kv_caches: cloned.kv_caches,
+                prefix_len,
+            }
+        }
+        Consumed::Miss => CacheLookup::Miss,
     };
 
     // Derive the initial ring size and the virtual ceiling (issue #25):

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -157,22 +157,9 @@ pub fn generate_greedy<'a>(
     // The engine owns find → SSD-hydrate retry → quant-mismatch guard →
     // SSD-hydrated Exact exclusion → reuse-gate, and traces every degrade
     // branch; the per-arch policy tripwire lives here at the call site.
-    //
-    // The local `CacheLookup` enum is the bridge from the engine outcome to the
-    // existing decode paths below (Path A exact-hit, Path B prefix tail, Path C
-    // miss) — those paths are kept verbatim.
-    enum CacheLookup {
-        Exact {
-            kv_caches: Vec<KvCache>,
-            last_id: u32,
-            piece: String,
-        },
-        Prefix {
-            kv_caches: Vec<KvCache>,
-            prefix_len: usize,
-        },
-        Miss,
-    }
+    // The `Consumed` outcome is matched directly into the existing decode
+    // dispatch below (Path A exact-hit early-return, Path B prefix tail, Path C
+    // miss) — those decode bodies are kept verbatim.
 
     // hard runtime gate: gemma4 must use ReusePolicy::Partial so the engine's
     // reuse arm is reachable for the B1 strict-prefix + block-truncate paths.
@@ -188,18 +175,19 @@ pub fn generate_greedy<'a>(
     // without touching the cache; mirrored by the `!has_image` store gate
     // below). The token-id-keyed K/V is unsafe for image spans (the K/V depends
     // on scattered vision features, not just the token ids).
-    let lookup: CacheLookup = match PROMPT_CACHE.consume(prompt_ids, kv_quant, has_image) {
+    // `exact_hit` carries the Path-A early-return locals; `prefix_hit` carries
+    // the Path-B tail-re-prefill locals. `Consumed::Miss` leaves both `None` and
+    // falls through to Path C (full re-prefill).
+    let mut exact_hit: Option<(Vec<KvCache>, u32, String)> = None;
+    let mut prefix_hit: Option<(Vec<KvCache>, usize)> = None;
+    match PROMPT_CACHE.consume(prompt_ids, kv_quant, has_image) {
         Consumed::Exact(cloned) => {
             tracing::debug!(
                 prompt_len = prompt_ids.len(),
                 token_id = cloned.first_id,
                 "gemma4 generate_greedy: prompt cache EXACT HIT"
             );
-            CacheLookup::Exact {
-                kv_caches: cloned.kv_caches,
-                last_id: cloned.first_id,
-                piece: cloned.first_piece,
-            }
+            exact_hit = Some((cloned.kv_caches, cloned.first_id, cloned.first_piece));
         }
         // B1 SWA snapshot/restore: restore the cloned snapshot verbatim at
         // absolute position `prefix_len == cached_len` and tail-forward only
@@ -215,10 +203,7 @@ pub fn generate_greedy<'a>(
                 "gemma4 generate_greedy: prompt cache PREFIX-EXACT HIT \
                  (B1 SWA snapshot/restore — restore + tail-only re-prefill)"
             );
-            CacheLookup::Prefix {
-                kv_caches: cloned.kv_caches,
-                prefix_len,
-            }
+            prefix_hit = Some((cloned.kv_caches, prefix_len));
         }
         // Block-aligned partial hit: `prepare_reuse` already trimmed the cloned
         // KV to the block boundary; the tail re-prefills from
@@ -235,13 +220,10 @@ pub fn generate_greedy<'a>(
                 "gemma4 generate_greedy: prompt cache PREFIX HIT \
                  (block-truncate + tail re-prefill)"
             );
-            CacheLookup::Prefix {
-                kv_caches: cloned.kv_caches,
-                prefix_len,
-            }
+            prefix_hit = Some((cloned.kv_caches, prefix_len));
         }
-        Consumed::Miss => CacheLookup::Miss,
-    };
+        Consumed::Miss => {}
+    }
 
     // Derive the initial ring size and the virtual ceiling (issue #25):
     // `--max-ctx` is a ceiling the ring grows lazily up to, not an eager
@@ -256,12 +238,7 @@ pub fn generate_greedy<'a>(
     // site. GDN linear state does not exist for gemma4 (pure KV), so the
     // closure threads only `kv_caches`.
     // ------------------------------------------------------------------
-    if let CacheLookup::Exact {
-        mut kv_caches,
-        last_id,
-        piece,
-    } = lookup
-    {
+    if let Some((mut kv_caches, last_id, piece)) = exact_hit {
         step_fn(steps.push_mut(ProbeStep {
             token_id: last_id,
             piece: piece.into_boxed_str(),
@@ -386,11 +363,7 @@ pub fn generate_greedy<'a>(
     // truncated clone is already post-prefill quantized, so the tail must
     // append via decode-mode `update`, exactly like the Exact-hit decode.
     let (mut caches, prefill_ids, is_prefix): (Vec<KvCache>, &[u32], bool) =
-        if let CacheLookup::Prefix {
-            kv_caches,
-            prefix_len,
-        } = lookup
-        {
+        if let Some((kv_caches, prefix_len)) = prefix_hit {
             tracing::debug!(
                 prompt_len = prompt_ids.len(),
                 prefix_len,
@@ -399,7 +372,7 @@ pub fn generate_greedy<'a>(
             );
             (kv_caches, &prompt_ids[prefix_len..], true)
         } else {
-            // CacheLookup::Exact is handled by Path A above and returns early;
+            // The exact hit is handled by Path A above and returns early;
             // Miss falls through to a full fresh-cache prefill.
             // Allocate one KvCache per decoder layer using the selected
             // quant mode.

--- a/crates/rmlx-models/src/gemma4/prompt_cache.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache.rs
@@ -12,7 +12,7 @@
 //!   `crate::prompt_cache` (pure-attention: `lin_caches()` is `&[]`).
 //! - `impl SsdHydrate<Gemma4Entry> for SsdHydrator`: pure-attention hydrate.
 //! - SWA helpers `can_truncate_to_block` / `is_strict_prefix_of` consumed by
-//!   `gemma4/generate.rs`'s `CacheLookup` match (/ B1 snapshot/restore).
+//!   `gemma4/generate.rs`'s `consume()` dispatch (/ B1 snapshot/restore).
 //!
 //! The per-arch shell (`PROMPT_CACHE` static, ensure/stats wrappers) is
 //! pure delegation to `ArchPromptCache`; SSD attach is invoked directly on the
@@ -226,10 +226,17 @@ impl PromptCacheEntry for Gemma4Entry {
         }
         // Block-truncate path. The tail `[prefix_len..prompt_len)` must be
         // non-empty (its final position is where the next-token logits are
-        // read), so when the matched blocks already cover the whole
-        // block-aligned prompt, drop the last matched block back into the tail.
+        // read). When the matched blocks already cover the whole block-aligned
+        // prompt, drop the last matched block back into the re-prefill tail; a
+        // genuine partial divergence (`matched * BLOCK < len`) reuses ALL
+        // matched blocks since the tail past the last block boundary is already
+        // non-empty.
         let prompt_blocks = prompt_ids.len() / BLOCK_TOKENS;
-        let effective_blocks = matched_blocks.min(prompt_blocks).saturating_sub(1);
+        let effective_blocks = if matched_blocks * BLOCK_TOKENS >= prompt_ids.len() {
+            matched_blocks.min(prompt_blocks).saturating_sub(1)
+        } else {
+            matched_blocks
+        };
         if effective_blocks >= 1 && self.can_truncate_to_block(effective_blocks) {
             Some(ReuseKind::BlockTruncate { effective_blocks })
         } else {
@@ -239,8 +246,8 @@ impl PromptCacheEntry for Gemma4Entry {
 
     /// `StrictPrefix` reuses the whole cached prefix verbatim → plain
     /// `deep_clone` (trait default semantics). `BlockTruncate` deep-clones then
-    /// trims the KV to the block boundary, asserting the
-    /// `prefix_len == effective_blocks * BLOCK_TOKENS` invariant the
+    /// trims the KV to the block boundary, asserting the post-trim
+    /// `offset == effective_blocks * BLOCK_TOKENS` invariant the
     /// generate-loop tail-forward relies on.
     fn prepare_reuse(&self, kind: ReuseKind) -> Result<Self> {
         match kind {
@@ -251,15 +258,26 @@ impl PromptCacheEntry for Gemma4Entry {
                 // position the tail re-prefills from. The block-truncate path is
                 // only constructed when `can_truncate_to_block(effective_blocks)`
                 // held (every layer cache losslessly trimmable — no wrapped-SWA
-                // ring), which is exactly the precondition that makes the
-                // post-trim offset land on that block boundary.
-                debug_assert!(
-                    self.can_truncate_to_block(effective_blocks),
-                    "block-truncate reuse must keep prefix_len == effective_blocks * BLOCK_TOKENS \
-                     (every layer cache losslessly trimmable)"
-                );
+                // ring), so re-asserting the precondition here is redundant.
+                // Assert the spec POSTcondition instead: after the trim, every
+                // KV cache that holds data lands exactly on the block boundary
+                // `effective_blocks * BLOCK_TOKENS`. Never-filled layers
+                // (`offset() == 0`) are skipped by `truncate_kv_to`, so they are
+                // excluded from the check.
                 let mut cloned = self.deep_clone()?;
                 cloned.truncate_kv_to_block(effective_blocks);
+                debug_assert!(
+                    {
+                        let expected = (effective_blocks * BLOCK_TOKENS) as i32;
+                        cloned
+                            .kv_caches
+                            .iter()
+                            .filter(|c| c.offset() > 0)
+                            .all(|c| c.offset() == expected)
+                    },
+                    "block-truncate postcondition: every filled KV cache offset \
+                     must equal effective_blocks * BLOCK_TOKENS after the trim"
+                );
                 Ok(cloned)
             }
         }

--- a/crates/rmlx-models/src/gemma4/prompt_cache.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache.rs
@@ -30,7 +30,7 @@
 use rmlx_core::error::Result;
 
 use crate::prompt_cache::{
-    ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate, BLOCK_TOKENS,
+    ArchPromptCache, CacheStats, PromptCacheEntry, ReuseKind, ReusePolicy, SsdHydrate, BLOCK_TOKENS,
 };
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
@@ -185,6 +185,85 @@ impl PromptCacheEntry for Gemma4Entry {
     // truncate_kv_to / truncate_kv_to_block / kv_bytes: trait defaults.
     // SWA correctness is gated upstream by `can_truncate_to_block` /
     // `is_strict_prefix_of`; the trim itself is the byte-identical default.
+
+    /// Delegates to the inherent [`Gemma4Entry::is_hydrate_complete`]: an
+    /// SSD-hydrated entry whose SWA rotating ring came back as a payload-less
+    /// `KvStorage::None` (the ring is not serialised to the SSD tier) is
+    /// incomplete, so the consume engine excludes it from prefix reuse and
+    /// degrades it to a full re-prefill.
+    fn is_hydrate_complete(&self) -> bool {
+        Gemma4Entry::is_hydrate_complete(self)
+    }
+
+    /// B1 (strict-prefix SWA snapshot/restore) is checked FIRST; only when it
+    /// declines does the block-truncate path run. This precedence preserves the
+    /// live arm order: the strict-prefix snapshot supersedes block-truncate for
+    /// the wrapped-SWA multi-turn case (where truncation would desync the SWA
+    /// ring).
+    ///
+    /// - Strict prefix: the cached prompt is a token-for-token prefix that the
+    ///   request extends by `>= 1` token (`is_strict_prefix_of`, with the
+    ///   `cached_len >= BLOCK_TOKENS` worthwhile floor). Reuse the snapshot
+    ///   verbatim at `prefix_len == cached_len` (no truncation → no SWA-wrap
+    ///   desync). Works whether the entry is RAM-resident or SSD-hydrated.
+    /// - Block truncate: otherwise, derive `effective_blocks` by dropping the
+    ///   trailing block when the matched blocks would cover the whole
+    ///   block-aligned prompt (the re-prefilled tail must be non-empty). When
+    ///   `effective_blocks >= 1` and every layer cache is losslessly trimmable
+    ///   (`can_truncate_to_block` — false once an SWA ring has wrapped), reuse
+    ///   the first `effective_blocks` blocks; otherwise decline.
+    fn is_reusable_prefix_of(
+        &self,
+        prompt_ids: &[u32],
+        _is_ssd_hydrated: bool,
+        matched_blocks: usize,
+    ) -> Option<ReuseKind> {
+        // B1 precedence — strict prefix supersedes block-truncate.
+        if self.is_strict_prefix_of(prompt_ids) {
+            return Some(ReuseKind::StrictPrefix {
+                prefix_len: self.prompt_token_ids.len(),
+            });
+        }
+        // Block-truncate path. The tail `[prefix_len..prompt_len)` must be
+        // non-empty (its final position is where the next-token logits are
+        // read), so when the matched blocks already cover the whole
+        // block-aligned prompt, drop the last matched block back into the tail.
+        let prompt_blocks = prompt_ids.len() / BLOCK_TOKENS;
+        let effective_blocks = matched_blocks.min(prompt_blocks).saturating_sub(1);
+        if effective_blocks >= 1 && self.can_truncate_to_block(effective_blocks) {
+            Some(ReuseKind::BlockTruncate { effective_blocks })
+        } else {
+            None
+        }
+    }
+
+    /// `StrictPrefix` reuses the whole cached prefix verbatim → plain
+    /// `deep_clone` (trait default semantics). `BlockTruncate` deep-clones then
+    /// trims the KV to the block boundary, asserting the
+    /// `prefix_len == effective_blocks * BLOCK_TOKENS` invariant the
+    /// generate-loop tail-forward relies on.
+    fn prepare_reuse(&self, kind: ReuseKind) -> Result<Self> {
+        match kind {
+            ReuseKind::StrictPrefix { .. } => self.deep_clone(),
+            ReuseKind::BlockTruncate { effective_blocks } => {
+                // The caller (generate-loop tail-forward) uses
+                // `prefix_len = effective_blocks * BLOCK_TOKENS` as the absolute
+                // position the tail re-prefills from. The block-truncate path is
+                // only constructed when `can_truncate_to_block(effective_blocks)`
+                // held (every layer cache losslessly trimmable — no wrapped-SWA
+                // ring), which is exactly the precondition that makes the
+                // post-trim offset land on that block boundary.
+                debug_assert!(
+                    self.can_truncate_to_block(effective_blocks),
+                    "block-truncate reuse must keep prefix_len == effective_blocks * BLOCK_TOKENS \
+                     (every layer cache losslessly trimmable)"
+                );
+                let mut cloned = self.deep_clone()?;
+                cloned.truncate_kv_to_block(effective_blocks);
+                Ok(cloned)
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
@@ -34,7 +34,7 @@ fn entry_with_quant(
 }
 
 /// A freshly built snapshot — every cache at offset 0 — is trimmable, so
-/// `can_truncate_to_block` permits the production `CacheLookup::Prefix`
+/// `can_truncate_to_block` permits the production block-truncate prefix
 /// path. This is the cold-equal regime (cached prompt within
 /// `sliding_window`, SWA ring not wrapped).
 #[test]
@@ -282,13 +282,21 @@ fn is_strict_prefix_of_swa_snapshot_hook() {
     );
 }
 
-/// `is_reusable_prefix_of` block-truncate arithmetic (no model). When the
-/// strict-prefix arm declines, the hook drops the trailing block so the
-/// re-prefilled tail is non-empty:
-///   - A 3-block-aligned prompt matching all 3 blocks → `effective_blocks == 2`
-///     (block_count - 1), since `block_count * 256 >= len`.
-///   - A single-block prompt matching its one block → `effective_blocks == 0`
-///     → `None` (no tail blocks left).
+/// `is_reusable_prefix_of` block-truncate arithmetic (no model). The hook is
+/// CONDITIONAL on whether the matched blocks cover the whole block-aligned
+/// prompt:
+///   - Block-aligned full match (`matched * 256 >= len`): drop the trailing
+///     block so the re-prefilled tail is non-empty.
+///       * A 3-block-aligned prompt matching all 3 blocks → `effective_blocks
+///         == 2` (matched_blocks - 1).
+///       * A single-block prompt matching its one block → `effective_blocks
+///         == 0` → `None` (no tail blocks left).
+///   - Genuine partial divergence (`matched * 256 < len`): reuse ALL matched
+///     blocks; the tail past the last block boundary is already non-empty.
+///       * A 512-token prompt diverging inside block 2 with `matched_blocks ==
+///         1` → `BlockTruncate { effective_blocks: 1 }` (NOT `None`). The
+///         pre-restoration unconditional `matched.min(prompt_blocks) - 1` would
+///         have dropped this to `effective_blocks == 0` → `None` (a lost hit).
 #[test]
 #[allow(
     clippy::indexing_slicing,
@@ -343,12 +351,44 @@ fn is_reusable_prefix_of_block_truncate_arithmetic() {
         e1.is_reusable_prefix_of(&single, false, 1).is_none(),
         "all-blocks-consumed (effective_blocks == 0) must decline → None → Miss"
     );
+
+    // Partial-divergence branch: a 512-token (2-block) request that shares only
+    // its first FULL block with the cached entry (`matched_blocks == 1`) and
+    // diverges inside block 2. `matched_blocks * 256 = 256 < 512`, so ALL
+    // matched blocks are reused → `effective_blocks == 1`. The cached entry is a
+    // distinct 512-token prompt (equal length, differing content) so the
+    // strict-prefix arm declines and the block-truncate arm runs. A fresh
+    // (offset 0) flat cache is trimmable, so `can_truncate_to_block(1)` holds.
+    let request: Vec<u32> = (0..(2 * BLOCK_TOKENS) as u32).collect();
+    let cached_ids: Vec<u32> = (1000..1000 + (2 * BLOCK_TOKENS) as u32).collect();
+    let kv2 = vec![KvCache::with_quant_max_seq_window(
+        KvQuant::K8V8,
+        8192,
+        None,
+    )];
+    let e2 = entry_with(kv2, cached_ids);
+    assert!(
+        !e2.is_strict_prefix_of(&request),
+        "differing same-length cached prompt must not take the strict-prefix arm"
+    );
+    match e2.is_reusable_prefix_of(&request, false, 1) {
+        Some(ReuseKind::BlockTruncate { effective_blocks }) => {
+            assert_eq!(
+                effective_blocks, 1,
+                "partial divergence (matched * 256 < len) must reuse ALL matched blocks"
+            );
+        }
+        other => panic!(
+            "partial divergence with 1 shared block must be BlockTruncate{{1}}, \
+             not a Miss; got {other:?}"
+        ),
+    }
 }
 
 /// Phase B consume-engine migration golden (gemma4, e2b — model-gated).
 ///
 /// Pins that routing gemma4 through the shared `consume()` engine is
-/// behavior-identical to the pre-migration inline `CacheLookup` across all
+/// behavior-identical to the pre-migration inline dispatch across all
 /// three reachable gemma4 paths. At temp 0, every reuse path must decode
 /// token-identically to a cold (Miss) baseline of the SAME prompt:
 ///   (a) SWA degrade-to-reprefill: a 336-token (non-block-aligned) prompt whose
@@ -360,9 +400,10 @@ fn is_reusable_prefix_of_block_truncate_arithmetic() {
 ///           extends to 768 tokens → `Reuse{StrictPrefix}` → restore + tail →
 ///           WARM == COLD(768);
 ///         - block-truncate arm: a 512-token cached prompt and a same-length
-///           request that diverges in the second block (1 shared block) →
-///           `Reuse{BlockTruncate}` → trim + tail → WARM == COLD(request).
-///   (c) #87 exact-hit: a block-aligned (256-token) SSD-hydrated entry whose
+///           request that diverges in the second block (1 shared full block,
+///           `matched * 256 < len`) → `Reuse{BlockTruncate{1}}` → trim + tail →
+///           WARM == COLD(request).
+///   (c) hydrated-exact-length exclusion: a block-aligned (256-token) SSD-hydrated entry whose
 ///       prefix length equals the full prompt (placeholder first_id 0) → the
 ///       `!is_ssd_hydrated` Exact exclusion drops it to Miss → recompute →
 ///       WARM == COLD, never the placeholder 0.
@@ -389,7 +430,7 @@ fn is_reusable_prefix_of_block_truncate_arithmetic() {
 )]
 #[allow(
     clippy::too_many_lines,
-    reason = "test-only: a single golden covering the three reachable gemma4 reuse paths (SWA-degrade / RAM strict-prefix + block-truncate / #87 exact-hit) reads clearest as one sequential fixture"
+    reason = "test-only: a single golden covering the three reachable gemma4 reuse paths (SWA-degrade / RAM strict-prefix + block-truncate / hydrated-exact-length exclusion) reads clearest as one sequential fixture"
 )]
 fn gemma4_consume_engine_migration_golden() {
     use crate::gemma4::{generate_greedy, load_from_path};
@@ -618,7 +659,7 @@ fn gemma4_consume_engine_migration_golden() {
         "(b) RAM block-truncate reuse must equal the cold baseline for the divergent prompt"
     );
 
-    // ── (c) #87 exact-hit: block-aligned hydrated entry == full prompt ──────
+    // ── (c) hydrated-exact-length exclusion: block-aligned hydrated entry == full prompt ──
     // A 256-token block-aligned prompt; the hydrated entry's prefix length
     // equals the full prompt (no tail, placeholder first_id 0). The Exact arm's
     // `!is_ssd_hydrated` guard drops it to Miss → recompute → WARM == COLD.
@@ -634,7 +675,7 @@ fn gemma4_consume_engine_migration_golden() {
     let full_kv = read_back_kv(&p256);
     push_hydrated(&p256, full_kv); // re-key as a hydrated full-length entry
     let warm_exact = run(&p256);
-    println!("(c) #87 exact-hit: cold={cold_256:?} warm={warm_exact:?}");
+    println!("(c) hydrated-exact-length exclusion: cold={cold_256:?} warm={warm_exact:?}");
     assert_ne!(
         warm_exact.first().copied(),
         Some(0u32),
@@ -642,11 +683,11 @@ fn gemma4_consume_engine_migration_golden() {
     );
     assert_eq!(
         warm_exact, cold_256,
-        "(c) #87 hydrated exact-length recompute must equal the cold baseline"
+        "(c) block-aligned hydrated exact-length recompute must equal the cold baseline"
     );
 
     println!(
         "PASS: gemma4 consume-engine migration golden — SWA-degrade / strict-prefix / \
-         block-truncate / #87 exact-hit all match their cold baselines"
+         block-truncate / hydrated-exact-length exclusion all match their cold baselines"
     );
 }

--- a/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
@@ -344,3 +344,309 @@ fn is_reusable_prefix_of_block_truncate_arithmetic() {
         "all-blocks-consumed (effective_blocks == 0) must decline → None → Miss"
     );
 }
+
+/// Phase B consume-engine migration golden (gemma4, e2b — model-gated).
+///
+/// Pins that routing gemma4 through the shared `consume()` engine is
+/// behavior-identical to the pre-migration inline `CacheLookup` across all
+/// three reachable gemma4 paths. At temp 0, every reuse path must decode
+/// token-identically to a cold (Miss) baseline of the SAME prompt:
+///   (a) SWA degrade-to-reprefill: a 336-token (non-block-aligned) prompt whose
+///       1 shared block is served from an SSD-hydrated entry with a payload-less
+///       SWA layer (`is_hydrate_complete == false`) → the engine degrades it to
+///       Miss → full re-prefill → WARM == COLD (the SWA-empty correctness fix).
+///   (b) RAM multi-turn prefix reuse, BOTH arms:
+///         - strict-prefix arm: a 512-token cached prompt that the request
+///           extends to 768 tokens → `Reuse{StrictPrefix}` → restore + tail →
+///           WARM == COLD(768);
+///         - block-truncate arm: a 512-token cached prompt and a same-length
+///           request that diverges in the second block (1 shared block) →
+///           `Reuse{BlockTruncate}` → trim + tail → WARM == COLD(request).
+///   (c) #87 exact-hit: a block-aligned (256-token) SSD-hydrated entry whose
+///       prefix length equals the full prompt (placeholder first_id 0) → the
+///       `!is_ssd_hydrated` Exact exclusion drops it to Miss → recompute →
+///       WARM == COLD, never the placeholder 0.
+///
+/// Run:
+/// ```sh
+/// RMLX_TEST_MODEL_GEMMA4_E2B=/path/to/mlx-community__gemma-4-e2b-it-mxfp8 \
+/// cargo test -p rmlx-models gemma4_consume_engine_migration_golden \
+///     -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: Mutex critical section is panic-free; remaining unwrap is on values constructed in this fn"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: indices bounded by slice length validated before call"
+)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "test-only: a single golden covering the three reachable gemma4 reuse paths (SWA-degrade / RAM strict-prefix + block-truncate / #87 exact-hit) reads clearest as one sequential fixture"
+)]
+fn gemma4_consume_engine_migration_golden() {
+    use crate::gemma4::{generate_greedy, load_from_path};
+    use rmlx_mlx::Device;
+
+    let Some(model_dir_buf) =
+        std::env::var_os("RMLX_TEST_MODEL_GEMMA4_E2B").map(std::path::PathBuf::from)
+    else {
+        println!("SKIP: RMLX_TEST_MODEL_GEMMA4_E2B not set");
+        return;
+    };
+    let model_dir = model_dir_buf.as_path();
+    if !model_dir.exists() {
+        println!("SKIP: model dir not found at {}", model_dir.display());
+        return;
+    }
+    let arch_str = {
+        let cfg_path = model_dir.join("config.json");
+        let data = std::fs::read(&cfg_path).expect("read config.json");
+        let v: serde_json::Value = serde_json::from_slice(&data).expect("parse config.json");
+        v.get("architectures")
+            .and_then(|a| a.get(0))
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_owned()
+    };
+    if arch_str != "Gemma4ForConditionalGeneration" {
+        println!("SKIP: arch \"{arch_str}\" is not Gemma4ForConditionalGeneration");
+        return;
+    }
+
+    let model = load_from_path(model_dir).expect("load model");
+    let device = Device::Gpu;
+    let kv_quant = KvQuant::None;
+    let max_seq = 4096i32;
+    let n_decode = 6usize;
+    let tokenizer =
+        tokenizers::Tokenizer::from_file(model_dir.join("tokenizer.json")).expect("load tokenizer");
+
+    // Deterministic synthetic token ids (kept in a safe mid-vocab band).
+    let make_ids = |len: usize, salt: u32| -> Vec<u32> {
+        (1u32..=len as u32)
+            .map(|i| ((i.wrapping_mul(7).wrapping_add(salt)) % 9999).max(1))
+            .collect()
+    };
+
+    let sampler = crate::sampler::SamplerConfig {
+        temperature: 0.0,
+        top_p: 1.0,
+        top_k: 0,
+        min_p: 0.0,
+        seed: Some(0),
+        top_logprobs_k: 0,
+    };
+    let penalty_cfg = crate::sampler::PenaltyConfig::default();
+
+    // Run generate_greedy at temp 0, return the decoded token_id sequence.
+    let run = |ids: &[u32]| -> Vec<u32> {
+        let mut rng = crate::sampler::Pcg32::new(sampler.seed_or_default());
+        let mut token_history: Vec<u32> = Vec::new();
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
+        generate_greedy(
+            &model,
+            &tokenizer,
+            ids,
+            n_decode,
+            device,
+            kv_quant,
+            Some(max_seq),
+            4,
+            &[],
+            &mut step_fn,
+            None,
+            &sampler,
+            &mut rng,
+            &penalty_cfg,
+            &mut token_history,
+            None,
+        )
+        .expect("generate_greedy")
+        .into_iter()
+        .map(|s| s.token_id)
+        .collect()
+    };
+
+    let clear_cache = || {
+        ensure_prompt_cache(4);
+        PROMPT_CACHE.with_inner_mut(|guard| {
+            if let Some(cache) = guard.as_mut() {
+                cache.clear();
+            }
+        });
+    };
+
+    // Read back the RAM snapshot store-back left by the most recent cold run of
+    // `ids`, deep-cloning its KV caches (the cache keeps ownership).
+    let read_back_kv = |ids: &[u32]| -> Vec<KvCache> {
+        let seed = FNV_OFFSET ^ active_layout_key() ^ kv_quant.cache_key_salt();
+        PROMPT_CACHE.with_inner_mut(|guard| {
+            let cache = guard.as_mut().expect("cache present");
+            let (slot_idx, _) = cache
+                .find_best_prefix(ids, seed)
+                .expect("cold store-back must be resident");
+            cache.slots[slot_idx]
+                .entry
+                .kv_caches
+                .iter()
+                .map(|c| c.try_deep_clone().expect("kv clone"))
+                .collect()
+        })
+    };
+
+    // Push an SSD-hydrated entry (placeholder first_id 0, is_ssd_hydrated=true)
+    // keyed on `key_ids`, carrying `kv_caches`, into a freshly cleared cache.
+    let push_hydrated = |key_ids: &[u32], kv_caches: Vec<KvCache>| {
+        clear_cache();
+        PROMPT_CACHE.with_inner_mut(|guard| {
+            let cache = guard.as_mut().expect("cache present");
+            let block_hashes = crate::prompt_cache::chained_block_hashes_seeded(
+                key_ids,
+                FNV_OFFSET ^ active_layout_key() ^ kv_quant.cache_key_salt(),
+            );
+            cache.push(Gemma4Entry {
+                prompt_token_ids: key_ids.to_vec(),
+                block_hashes,
+                kv_caches,
+                first_id: 0,
+                first_piece: String::new(),
+                kv_quant: Some(kv_quant),
+                is_ssd_hydrated: true,
+            });
+        });
+    };
+
+    // ── (a) SWA degrade-to-reprefill — 336-token (non-block-aligned) prompt ──
+    // COLD baseline of the full 336-token prompt.
+    let p336 = make_ids(336, 0);
+    clear_cache();
+    let cold_336 = run(&p336);
+    assert_eq!(cold_336.len(), n_decode);
+    assert_ne!(
+        cold_336[0], 0,
+        "cold first token is placeholder 0 — anomaly"
+    );
+
+    // Build a real snapshot of the first 256-token (1-block) prefix via a cold
+    // run, then read its KV back and rebuild the SWA layers as payload-less
+    // `KvStorage::None` — exactly what `block_io` reconstructs on hydrate (the
+    // rotating ring is not serialised to the SSD tier).
+    let prefix256: Vec<u32> = p336[..BLOCK_TOKENS].to_vec();
+    clear_cache();
+    let _ = run(&prefix256); // store-back leaves a RAM snapshot of the prefix
+    let mut hydrated_kv = read_back_kv(&prefix256);
+    for (i, c) in hydrated_kv.iter_mut().enumerate() {
+        if matches!(
+            model.cfg.layer_types[i],
+            crate::gemma4::LayerType::SlidingAttention
+        ) {
+            // Drop the SWA ring to a payload-less None with no bf16 seed — the
+            // incomplete-hydrate shape the engine must degrade.
+            *c = KvCache::from_storage(
+                KvStorage::None {
+                    max_seq: model.cfg.sliding_window as i32,
+                },
+                kv_quant,
+                BLOCK_TOKENS as i32,
+                i,
+            );
+            assert!(
+                !c.has_persistent_cache() && c.decode_fp16_kv().is_none(),
+                "rebuilt SWA layer must be payload-less None"
+            );
+        }
+    }
+    push_hydrated(&prefix256, hydrated_kv);
+    let warm_swa = run(&p336);
+    println!("(a) SWA degrade: cold={cold_336:?} warm={warm_swa:?}");
+    assert_ne!(
+        warm_swa.first().copied(),
+        Some(0u32),
+        "SWA-incomplete hydrate must degrade to re-prefill, never replay placeholder 0"
+    );
+    assert_eq!(
+        warm_swa, cold_336,
+        "(a) SWA degrade-to-reprefill must equal the cold baseline"
+    );
+
+    // ── (b) RAM multi-turn prefix reuse — BOTH arms ─────────────────────────
+    // Strict-prefix arm: cache a 512-token prompt, then extend to 768 tokens.
+    let p512 = make_ids(512, 0);
+    let p768: Vec<u32> = {
+        let mut v = p512.clone();
+        v.extend(make_ids(256, 5)); // 256-token tail with a distinct salt
+        v
+    };
+    clear_cache();
+    let cold_768 = run(&p768);
+    clear_cache();
+    let _ = run(&p512); // store-back caches the 512-token prompt (RAM)
+    let warm_strict = run(&p768); // strict-prefix extension → Reuse{StrictPrefix}
+    println!("(b) strict-prefix: cold={cold_768:?} warm={warm_strict:?}");
+    assert_eq!(
+        warm_strict, cold_768,
+        "(b) RAM strict-prefix reuse must equal the cold baseline for the extended prompt"
+    );
+
+    // Block-truncate arm: a same-length 512-token request that shares the first
+    // block then diverges in the second block. find_best_prefix matches 1 block;
+    // `is_strict_prefix_of` is false (divergent, equal length) so the
+    // block-truncate arm fires (effective_blocks = 1).
+    let p512_div: Vec<u32> = {
+        let mut v = p512.clone();
+        for t in v.iter_mut().skip(BLOCK_TOKENS) {
+            *t = ((*t).wrapping_add(101) % 9999).max(1);
+        }
+        v
+    };
+    clear_cache();
+    let cold_div = run(&p512_div);
+    clear_cache();
+    let _ = run(&p512); // cache the 512-token prompt sharing the first block
+    let warm_trunc = run(&p512_div); // 1 shared block, diverges → Reuse{BlockTruncate}
+    println!("(b) block-truncate: cold={cold_div:?} warm={warm_trunc:?}");
+    assert_eq!(
+        warm_trunc, cold_div,
+        "(b) RAM block-truncate reuse must equal the cold baseline for the divergent prompt"
+    );
+
+    // ── (c) #87 exact-hit: block-aligned hydrated entry == full prompt ──────
+    // A 256-token block-aligned prompt; the hydrated entry's prefix length
+    // equals the full prompt (no tail, placeholder first_id 0). The Exact arm's
+    // `!is_ssd_hydrated` guard drops it to Miss → recompute → WARM == COLD.
+    let p256 = make_ids(BLOCK_TOKENS, 13);
+    clear_cache();
+    let cold_256 = run(&p256);
+    assert_ne!(
+        cold_256[0], 0,
+        "cold 256 first token is placeholder 0 — anomaly"
+    );
+    clear_cache();
+    let _ = run(&p256); // build a real RAM snapshot of the full block-aligned prompt
+    let full_kv = read_back_kv(&p256);
+    push_hydrated(&p256, full_kv); // re-key as a hydrated full-length entry
+    let warm_exact = run(&p256);
+    println!("(c) #87 exact-hit: cold={cold_256:?} warm={warm_exact:?}");
+    assert_ne!(
+        warm_exact.first().copied(),
+        Some(0u32),
+        "(c) block-aligned hydrated exact-length must NOT replay placeholder 0"
+    );
+    assert_eq!(
+        warm_exact, cold_256,
+        "(c) #87 hydrated exact-length recompute must equal the cold baseline"
+    );
+
+    println!(
+        "PASS: gemma4 consume-engine migration golden — SWA-degrade / strict-prefix / \
+         block-truncate / #87 exact-hit all match their cold baselines"
+    );
+}

--- a/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::prompt_cache::{PromptCache, FNV_OFFSET};
+use crate::prompt_cache::{PromptCache, ReuseKind, FNV_OFFSET};
 use rmlx_kv_quant::storage::KvStorage;
 use rmlx_kv_quant::KvQuant;
 
@@ -279,5 +279,68 @@ fn is_strict_prefix_of_swa_snapshot_hook() {
     assert!(
         !e.is_strict_prefix_of(&diverged),
         "divergent prompt is not a strict prefix"
+    );
+}
+
+/// `is_reusable_prefix_of` block-truncate arithmetic (no model). When the
+/// strict-prefix arm declines, the hook drops the trailing block so the
+/// re-prefilled tail is non-empty:
+///   - A 3-block-aligned prompt matching all 3 blocks → `effective_blocks == 2`
+///     (block_count - 1), since `block_count * 256 >= len`.
+///   - A single-block prompt matching its one block → `effective_blocks == 0`
+///     → `None` (no tail blocks left).
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+fn is_reusable_prefix_of_block_truncate_arithmetic() {
+    // Block-aligned 3-block prompt. A fresh (offset 0) flat cache is trimmable,
+    // so `can_truncate_to_block` permits the block-truncate path. The cached
+    // entry and the request are the SAME block-aligned prompt, so
+    // `is_strict_prefix_of` is false (equal length, not a strict extension) and
+    // the block-truncate arm runs.
+    let block_count = 3usize;
+    let ids: Vec<u32> = (0..(block_count * BLOCK_TOKENS) as u32).collect();
+    let kv = vec![KvCache::with_quant_max_seq_window(
+        KvQuant::K8V8,
+        8192,
+        None,
+    )];
+    let e = entry_with(kv, ids.clone());
+    assert!(
+        !e.is_strict_prefix_of(&ids),
+        "equal-length prompt must not take the strict-prefix arm — exercise block-truncate"
+    );
+
+    // matched_blocks == block_count == prompt_blocks; effective_blocks drops the
+    // trailing block (block_count * 256 >= len) → block_count - 1.
+    match e.is_reusable_prefix_of(&ids, false, block_count) {
+        Some(ReuseKind::BlockTruncate { effective_blocks }) => {
+            assert_eq!(
+                effective_blocks,
+                block_count - 1,
+                "block-aligned full match must drop one trailing block"
+            );
+        }
+        other => panic!("expected BlockTruncate, got {other:?}"),
+    }
+
+    // Single-block prompt matching its one block: effective_blocks saturates to
+    // 0 → None (no tail blocks left → Miss).
+    let single: Vec<u32> = (0..BLOCK_TOKENS as u32).collect();
+    let kv1 = vec![KvCache::with_quant_max_seq_window(
+        KvQuant::K8V8,
+        8192,
+        None,
+    )];
+    let e1 = entry_with(kv1, single.clone());
+    assert!(
+        !e1.is_strict_prefix_of(&single),
+        "equal-length single-block prompt must not take the strict-prefix arm"
+    );
+    assert!(
+        e1.is_reusable_prefix_of(&single, false, 1).is_none(),
+        "all-blocks-consumed (effective_blocks == 0) must decline → None → Miss"
     );
 }

--- a/crates/rmlx-models/src/laguna/generate.rs
+++ b/crates/rmlx-models/src/laguna/generate.rs
@@ -10,6 +10,7 @@
 #![allow(
     clippy::cognitive_complexity,
     clippy::collapsible_else_if,
+    clippy::redundant_closure_for_method_calls,
     clippy::too_many_lines
 )]
 use std::time::Instant;
@@ -19,10 +20,14 @@ use rmlx_mlx::{argmax, Array, Device, Dtype};
 
 use crate::constraint::ConstraintEngine;
 use crate::kv_cache::{kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N};
+use crate::prompt_cache::{chained_block_hashes_seeded, Consumed, ReusePolicy, FNV_OFFSET};
 use crate::sampler::apply_mask_argmax;
 use rmlx_kv_quant::{KvCache, KV_MAX_SEQ_DEFAULT};
 
 use super::model::LagunaText;
+use super::prompt_cache::{
+    active_layout_key, ensure_prompt_cache, store_kv_cache_bytes, LagunaEntry, PROMPT_CACHE,
+};
 
 // ---------------------------------------------------------------------------
 // Smoke probe -- generate_greedy
@@ -83,6 +88,12 @@ fn max_abs_from_bytes(bytes: &[u8], dtype: Dtype) -> f32 {
 /// Greedy autoregressive generation using KV-cache prefill + decode.
 ///
 /// Returns `Vec<ProbeStep>` -- same shape as `gemma4::generate_greedy`.
+///
+/// `prompt_cache_slots` — number of post-prefill KV snapshots kept across
+/// requests. Pass 1 for single-slot; pass N for multi-slot prefix matching.
+/// Recommended: 4. Only the Exact hit path is active (identical-prompt repeat
+/// skips re-prefill entirely, same `ReusePolicy::ExactOnly` contract as Qwen2
+/// and BitNet).
 #[allow(clippy::too_many_arguments)]
 #[allow(
     clippy::indexing_slicing,
@@ -100,6 +111,7 @@ pub fn generate_greedy(
     device: Device,
     kv_quant: rmlx_kv_quant::KvQuant,
     max_ctx_override: Option<i32>,
+    prompt_cache_slots: usize,
     eos_ids: &[u32],
     step_fn: &mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
     // A6.2: optional sampler constraint. See gemma4::generate_greedy.
@@ -127,13 +139,106 @@ pub fn generate_greedy(
     let vocab = model.cfg.vocab_size as i32;
     let mut steps = Vec::with_capacity(n_tokens);
 
+    ensure_prompt_cache(prompt_cache_slots);
+
     // Decode profile timers. See gemma4::generate_greedy for rationale.
     let mut forward_total_ns: u128 = 0;
     let mut eval_total_ns: u128 = 0;
     let mut step_total_ns: u128 = 0;
     let mut decode_steps: u32 = 0;
-    let prefill_t0 = Instant::now();
 
+    // ------------------------------------------------------------------
+    // Prompt cache lookup via the shared consume() engine. Laguna is a
+    // pure-attention sparse-MoE arch with no recurrent state and uses
+    // ReusePolicy::ExactOnly (it overrides none of the reuse hooks), so the
+    // only reachable outcomes are Exact (identical-prompt repeat skips
+    // re-prefill) and Miss (full re-prefill). The engine owns the find →
+    // SSD-hydrate retry → quant-mismatch guard → SSD-hydrated exclusion →
+    // Exact decision and traces every degrade branch. The ExactOnly policy
+    // tripwire lives here at the call site — not in the generic engine —
+    // because the engine is policy-agnostic and shared across architectures
+    // that may use different policies.
+    // ------------------------------------------------------------------
+    assert_eq!(
+        PROMPT_CACHE.policy(),
+        ReusePolicy::ExactOnly,
+        "Laguna prompt cache must be ExactOnly — pure-attention with no recurrent \
+         state and an Exact-hit-dominated workload; partial-prefix reuse is not wired",
+    );
+    // Laguna is text-only (no vision tower), so there is never an image prompt;
+    // the engine's has_image bypass is belt-and-suspenders.
+    let consumed = PROMPT_CACHE.consume(prompt_ids, kv_quant, false);
+
+    // Path A: exact cache hit — skip re-prefill, replay the stored first token,
+    // then run the shared decode loop on the cloned caches.
+    if let Consumed::Exact(cloned) = consumed {
+        let LagunaEntry {
+            kv_caches: mut caches,
+            first_id: last_id,
+            first_piece: piece,
+            ..
+        } = cloned;
+        tracing::debug!(
+            prompt_len = prompt_ids.len(),
+            token_id = last_id,
+            "laguna generate_greedy: prompt cache EXACT HIT"
+        );
+        steps.push(ProbeStep {
+            token_id: last_id,
+            piece: piece.into_boxed_str(),
+            max_abs_logit: 0.0,
+            nan_count: 0,
+            logprobs: None,
+        });
+        step_fn(steps.last().unwrap());
+        token_history.push(last_id);
+
+        if eos_ids.contains(&last_id) {
+            return Ok(steps);
+        }
+
+        decode_loop(
+            model,
+            tokenizer,
+            &mut caches,
+            last_id,
+            n_tokens,
+            vocab,
+            device,
+            eos_ids,
+            &mut steps,
+            step_fn,
+            &mut constraint,
+            sampler_cfg,
+            rng,
+            penalty_cfg,
+            token_history,
+            &mut forward_total_ns,
+            &mut eval_total_ns,
+            &mut step_total_ns,
+            &mut decode_steps,
+        )?;
+
+        {
+            let kv_bytes: u64 = caches.iter().map(|c| c.resident_bytes()).sum();
+            store_kv_cache_bytes(kv_bytes);
+        }
+        tracing::info!(
+            arch = "LagunaForCausalLM",
+            total_tokens = steps.len(),
+            decode_steps,
+            avg_decode_ns = if decode_steps > 0 {
+                forward_total_ns / u128::from(decode_steps)
+            } else {
+                0
+            },
+            "generate_greedy: complete (exact hit)"
+        );
+        return Ok(steps);
+    }
+
+    // Path B (Miss): full re-prefill from scratch.
+    let prefill_t0 = Instant::now();
     let max_seq = max_ctx_override.unwrap_or(KV_MAX_SEQ_DEFAULT);
 
     // Allocate one KvCache per decoder layer using the selected quant mode.
@@ -270,7 +375,7 @@ pub fn generate_greedy(
     };
     top.eval()?;
     let top_bytes = top.to_bytes()?;
-    let mut last_id = i32::from_le_bytes(top_bytes[..4].try_into().unwrap()) as u32;
+    let last_id = i32::from_le_bytes(top_bytes[..4].try_into().unwrap()) as u32;
     // A6.2: advance constraint with emitted id.
     if let Some(c) = constraint.as_mut() {
         c.advance(last_id);
@@ -295,7 +400,7 @@ pub fn generate_greedy(
 
     steps.push(ProbeStep {
         token_id: last_id,
-        piece: piece.into_boxed_str(),
+        piece: piece.clone().into_boxed_str(),
         max_abs_logit,
         nan_count,
         logprobs: None,
@@ -306,27 +411,164 @@ pub fn generate_greedy(
         return Ok(steps);
     }
 
+    // Push this prefill snapshot to the prompt cache (Miss → store). Clone the
+    // post-prefill KV caches (refcount bump, no data copy) before the decode
+    // loop starts writing new decode-step K/V into them. Materialize the GPU
+    // arrays on the current inference thread first so a later eviction on a
+    // different tokio/Metal thread can re-eval them as a no-op.
+    {
+        let kv_bytes: u64 = caches.iter().map(|c| c.resident_bytes()).sum();
+        store_kv_cache_bytes(kv_bytes);
+        let cloned_caches: Result<Vec<KvCache>> =
+            caches.iter().map(|c| c.try_deep_clone()).collect();
+        if let Ok(kv_snapshot) = cloned_caches {
+            match kv_snapshot.iter().try_for_each(|c| c.eval_for_spill()) {
+                Ok(()) => {
+                    // Salt the chained block-hash walk with the active layout_key
+                    // + KV codec so a slot stored under a different codec / layout
+                    // never cross-serves. Identical to the consume() seed.
+                    let lk = active_layout_key();
+                    let block_hashes = chained_block_hashes_seeded(
+                        prompt_ids,
+                        FNV_OFFSET ^ lk ^ kv_quant.cache_key_salt(),
+                    );
+                    let entry = LagunaEntry {
+                        prompt_token_ids: prompt_ids.to_vec(),
+                        block_hashes,
+                        kv_caches: kv_snapshot,
+                        first_id: last_id,
+                        // Last use of `piece` — move it (the prefill ProbeStep
+                        // above already consumed its own clone via into_boxed_str).
+                        first_piece: piece,
+                        kv_quant: Some(kv_quant),
+                        is_ssd_hydrated: false,
+                    };
+                    PROMPT_CACHE.with_inner_mut(|guard| {
+                        if let Some(cache) = guard.as_mut() {
+                            cache.push(entry);
+                            let stats = cache.stats();
+                            tracing::debug!(
+                                prompt_len = prompt_ids.len(),
+                                cache_hits = stats.hits,
+                                cache_misses = stats.misses,
+                                cache_bytes = stats.bytes,
+                                "laguna generate_greedy: pushed snapshot to prompt cache (miss path)"
+                            );
+                        }
+                    });
+                }
+                Err(e) => tracing::warn!(error = %e,
+                    "laguna generate_greedy: pre-eval of KV caches failed, skipping prompt cache store"),
+            }
+        }
+    }
+
     // EOS-stop. If prefill emitted an EOS already, no decode steps.
     if eos_ids.contains(&last_id) {
         return Ok(steps);
     }
 
+    decode_loop(
+        model,
+        tokenizer,
+        &mut caches,
+        last_id,
+        n_tokens,
+        vocab,
+        device,
+        eos_ids,
+        &mut steps,
+        step_fn,
+        &mut constraint,
+        sampler_cfg,
+        rng,
+        penalty_cfg,
+        token_history,
+        &mut forward_total_ns,
+        &mut eval_total_ns,
+        &mut step_total_ns,
+        &mut decode_steps,
+    )?;
+
+    let prefill_ms = (prefill_total_ns as f64) / 1.0e6;
+    let forward_ms = (forward_total_ns as f64) / 1.0e6;
+    let eval_ms = (eval_total_ns as f64) / 1.0e6;
+    let step_ms = (step_total_ns as f64) / 1.0e6;
+    let n = f64::from(decode_steps.max(1));
+    tracing::info!(
+        target: "decode_profile",
+        arch = "LagunaForCausalLM",
+        n_steps = decode_steps,
+        prefill_ms,
+        forward_total_ms = forward_ms,
+        eval_total_ms = eval_ms,
+        step_total_ms = step_ms,
+        forward_per_step_ms = forward_ms / n,
+        eval_per_step_ms = eval_ms / n,
+        "decode_profile"
+    );
+
+    Ok(steps)
+}
+
+/// Shared sequential decode loop for both the Exact-hit and Miss paths.
+///
+/// `last_id` is the already-emitted step-0 token (prefill argmax or replayed
+/// cache first token); `steps` already holds its `ProbeStep`. This drives steps
+/// `1..n_tokens`.
+///
+/// The per-step decode math is byte-identical to the original inline loop; only
+/// the wrapping (function boundary + accumulated counters) differs.
+#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "steps.last().unwrap() immediately preceded by steps.push(...), so Vec is non-empty"
+)]
+fn decode_loop(
+    model: &LagunaText,
+    tokenizer: &tokenizers::Tokenizer,
+    caches: &mut [KvCache],
+    last_id: u32,
+    n_tokens: usize,
+    vocab: i32,
+    device: Device,
+    eos_ids: &[u32],
+    steps: &mut Vec<crate::decode_loop::ProbeStep>,
+    step_fn: &mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
+    constraint: &mut Option<&mut dyn ConstraintEngine>,
+    sampler_cfg: &crate::sampler::SamplerConfig,
+    rng: &mut crate::sampler::Pcg32,
+    penalty_cfg: &crate::sampler::PenaltyConfig,
+    token_history: &mut Vec<u32>,
+    forward_total_ns: &mut u128,
+    eval_total_ns: &mut u128,
+    step_total_ns: &mut u128,
+    decode_steps: &mut u32,
+) -> Result<()> {
+    use crate::decode_loop::ProbeStep;
+
+    // The starting token for step 1 is the last emitted (step 0) token.
+    let mut cur_id = last_id;
+
     // Decode: one token at a time.
     for step_idx in 1..n_tokens {
         let step_t0 = Instant::now();
         let fwd_t0 = Instant::now();
-        let decode_logits =
-            match model.forward_seq_with_cache(&[last_id], Some(&mut caches), device) {
-                Ok(l) => l,
-                Err(e) => {
-                    tracing::warn!(
-                        step = step_idx,
-                        error = %e,
-                        "laguna generate_greedy: decode step failed, stopping early"
-                    );
-                    break;
-                }
-            };
+        let decode_logits = match model.forward_seq_with_cache(&[cur_id], Some(caches), device) {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!(
+                    step = step_idx,
+                    error = %e,
+                    "laguna generate_greedy: decode step failed, stopping early"
+                );
+                break;
+            }
+        };
         let fwd_dt = fwd_t0.elapsed().as_nanos();
 
         let eval_t0 = Instant::now();
@@ -392,10 +634,10 @@ pub fn generate_greedy(
         // A7.3: accumulate emitted token into history.
         token_history.push(next_id);
         let eval_dt = eval_t0.elapsed().as_nanos();
-        forward_total_ns += fwd_dt;
-        eval_total_ns += eval_dt;
-        step_total_ns += step_t0.elapsed().as_nanos();
-        decode_steps += 1;
+        *forward_total_ns += fwd_dt;
+        *eval_total_ns += eval_dt;
+        *step_total_ns += step_t0.elapsed().as_nanos();
+        *decode_steps += 1;
 
         let piece = tokenizer
             .id_to_token(next_id)
@@ -433,26 +675,8 @@ pub fn generate_greedy(
             break;
         }
 
-        last_id = next_id;
+        cur_id = next_id;
     }
 
-    let prefill_ms = (prefill_total_ns as f64) / 1.0e6;
-    let forward_ms = (forward_total_ns as f64) / 1.0e6;
-    let eval_ms = (eval_total_ns as f64) / 1.0e6;
-    let step_ms = (step_total_ns as f64) / 1.0e6;
-    let n = f64::from(decode_steps.max(1));
-    tracing::info!(
-        target: "decode_profile",
-        arch = "LagunaForCausalLM",
-        n_steps = decode_steps,
-        prefill_ms,
-        forward_total_ms = forward_ms,
-        eval_total_ms = eval_ms,
-        step_total_ms = step_ms,
-        forward_per_step_ms = forward_ms / n,
-        eval_per_step_ms = eval_ms / n,
-        "decode_profile"
-    );
-
-    Ok(steps)
+    Ok(())
 }

--- a/crates/rmlx-models/src/laguna/mod.rs
+++ b/crates/rmlx-models/src/laguna/mod.rs
@@ -25,6 +25,7 @@ mod layers;
 pub mod loader;
 mod model;
 mod moe;
+pub(crate) mod prompt_cache;
 #[cfg(test)]
 mod tests;
 
@@ -32,3 +33,5 @@ pub use config::{LagunaConfig, LayerKind, MlpKind};
 pub use generate::generate_greedy;
 pub use loader::load_from_path;
 pub use model::LagunaText;
+pub use prompt_cache::read_cache_stats as laguna_cache_stats;
+pub use prompt_cache::read_kv_cache_bytes as laguna_kv_cache_bytes;

--- a/crates/rmlx-models/src/laguna/prompt_cache.rs
+++ b/crates/rmlx-models/src/laguna/prompt_cache.rs
@@ -1,0 +1,207 @@
+//! Laguna prompt-cache entry + global.
+//!
+//! The heavy lifting (static cache, SSD attach/install, ensure, stats readback,
+//! last-bytes counter, and the find → SSD-hydrate retry → quant-guard → Exact →
+//! Miss consume decision) is unified in
+//! [`crate::prompt_cache::ArchPromptCache`]. This file keeps only the genuinely
+//! Laguna-specific bits:
+//!
+//! - `LagunaEntry`: `Vec<KvCache>` only (pure-attention sparse-MoE arch; the MoE
+//!   routing is a forward-pass detail that does not change KV-cache geometry —
+//!   each decoder layer still maintains a standard K/V cache pair, and no GDN
+//!   recurrent / linear-attention state exists).
+//! - `impl PromptCacheEntry for LagunaEntry`: deep_clone + KV accessors. All
+//!   three reuse hooks (`is_hydrate_complete`, `is_reusable_prefix_of`,
+//!   `prepare_reuse`) take the trait defaults, which give correct
+//!   [`ReusePolicy::ExactOnly`] behaviour: a non-hydrated partial match is never
+//!   reusable, and the only reuse the engine permits (a hydrated strict-prefix)
+//!   is declined here (`is_reusable_prefix_of` → `None`), so the only reachable
+//!   consume outcomes are `Exact` and `Miss`.
+//! - `impl SsdHydrate<LagunaEntry> for SsdHydrator`: pure-attention hydrate (the
+//!   reconstructed block carries `kv_caches` only; `lin_caches` is discarded).
+//!   The SSD spill path is the blanket `SpillSink<E> for SsdSpiller` in
+//!   `crate::prompt_cache`, which spills `kv_caches()` only for a pure-attention
+//!   entry (`lin_caches()` is `&[]`).
+//!
+//! ## Reuse policy — Exact-only
+//!
+//! Laguna uses [`ReusePolicy::ExactOnly`]. It is pure-attention (no recurrent
+//! state); the dominant workload is the Exact-hit warm-TTFT (identical prompt
+//! repeat skips re-prefill entirely), and keeping the single Exact / Miss arm set
+//! is simpler and matches the Qwen2/BitNet/Qwen3 dense policy.
+
+#![allow(clippy::redundant_closure_for_method_calls)]
+use rmlx_core::error::Result;
+
+use crate::prompt_cache::{ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate};
+use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
+use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
+
+// ---------------------------------------------------------------------------
+// Entry type
+// ---------------------------------------------------------------------------
+
+/// Post-prefill snapshot for one Laguna request.
+///
+/// Pure-attention sparse-MoE arch: only `kv_caches` needs snapshotting (no GDN
+/// recurrent state). MoE routing is a weight-side detail that does not change
+/// the KV-cache geometry; the entry shape is identical to Qwen2 and BitNet.
+pub(crate) struct LagunaEntry {
+    /// Full prompt token IDs used to fill this slot.
+    pub(crate) prompt_token_ids: Vec<u32>,
+    /// Chained 256-token block digests of `prompt_token_ids` (trailing partial
+    /// block excluded). Computed at construction.
+    pub(crate) block_hashes: Vec<u64>,
+    /// Post-prefill KV caches (one per decoder layer).
+    pub(crate) kv_caches: Vec<KvCache>,
+    /// Argmax token from the first decode step after prefill.
+    pub(crate) first_id: u32,
+    /// Decoded piece for `first_id`.
+    pub(crate) first_piece: String,
+    /// Runtime `KvQuant` discriminant in effect when this snapshot was written.
+    /// Read by the engine's quant-mismatch guard and by the blanket spill path.
+    pub(crate) kv_quant: Option<KvQuant>,
+    /// True when this entry was reconstructed from the SSD tier and therefore
+    /// stores only the block-aligned prefix KV — `first_id` / `first_piece` are
+    /// placeholders, not a real decode token. The consume engine excludes such
+    /// an entry from the Exact fast path so it falls through to a full
+    /// re-prefill that recomputes the real first token.
+    ///
+    /// MUST be set only in `SsdHydrate::hydrate`; never by the RAM-cache push
+    /// path. Do NOT use the `first_id == 0` heuristic as a substitute —
+    /// `<bos>` token id is 0 for some models.
+    pub(crate) is_ssd_hydrated: bool,
+}
+
+impl PromptCacheEntry for LagunaEntry {
+    fn prompt_token_ids(&self) -> &[u32] {
+        &self.prompt_token_ids
+    }
+
+    fn block_hashes(&self) -> &[u64] {
+        &self.block_hashes
+    }
+
+    fn deep_clone(&self) -> Result<Self> {
+        let kv_caches: Result<Vec<_>> = self.kv_caches.iter().map(|c| c.try_deep_clone()).collect();
+        Ok(Self {
+            prompt_token_ids: self.prompt_token_ids.clone(),
+            block_hashes: self.block_hashes.clone(),
+            kv_caches: kv_caches?,
+            first_id: self.first_id,
+            first_piece: self.first_piece.clone(),
+            kv_quant: self.kv_quant,
+            is_ssd_hydrated: self.is_ssd_hydrated,
+        })
+    }
+
+    fn kv_caches(&self) -> &[KvCache] {
+        &self.kv_caches
+    }
+
+    fn kv_caches_mut(&mut self) -> &mut [KvCache] {
+        &mut self.kv_caches
+    }
+
+    fn kv_quant(&self) -> Option<KvQuant> {
+        self.kv_quant
+    }
+
+    fn is_ssd_hydrated(&self) -> bool {
+        self.is_ssd_hydrated
+    }
+
+    // Pure-attention sparse-MoE arch: no GDN linear state.
+    fn lin_caches(&self) -> &[LinearAttnCache] {
+        &[]
+    }
+    // is_hydrate_complete / is_reusable_prefix_of / prepare_reuse: trait
+    // defaults. The defaults give correct ExactOnly behaviour (complete by
+    // construction, no partial reuse, deep_clone on the unreachable reuse path).
+    // truncate_kv_to / truncate_kv_to_block / kv_bytes: trait defaults.
+}
+
+// ---------------------------------------------------------------------------
+// SSD-spill sink — the blanket `impl SpillSink<E> for SsdSpiller` in
+// `crate::prompt_cache` covers Laguna (pure-attention: `lin_caches()` is `&[]`,
+// so the spill job carries `kv_caches` only).
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// SSD-hydrate source
+// ---------------------------------------------------------------------------
+
+/// Hydrate a `LagunaEntry` from the SSD tier on a RAM-cache miss.
+///
+/// Pure-attention arch: the reconstructed block carries `kv_caches` only (the
+/// `lin_caches` from the block are discarded). The matched block-aligned prefix
+/// token IDs become the entry's `prompt_token_ids`; block hashes are recomputed
+/// and the runtime `kv_quant` recorded. `first_id` / `first_piece` are sentinels
+/// (the SSD block stores no first decode token), so the entry is flagged
+/// `is_ssd_hydrated = true`; the consume engine excludes it from the Exact fast
+/// path and the generate loop recomputes the real first token via re-prefill.
+impl SsdHydrate<LagunaEntry> for SsdHydrator {
+    fn hydrate(&self, prompt_ids: &[u32]) -> Result<Option<LagunaEntry>> {
+        let Some((block, block_hashes)) = self.lookup_seeded(prompt_ids)? else {
+            return Ok(None);
+        };
+        let HydratedBlock {
+            prompt_ids,
+            kv_caches,
+            lin_caches: _, // pure-attention arch has no GDN state
+        } = block;
+        Ok(Some(LagunaEntry {
+            prompt_token_ids: prompt_ids,
+            block_hashes,
+            kv_caches,
+            first_id: 0,
+            first_piece: String::new(),
+            kv_quant: Some(self.kv_quant()),
+            // Block-aligned prefix only; the placeholder first_id must not be
+            // replayed — the generate loop re-prefills to recompute it.
+            is_ssd_hydrated: true,
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global cache instance — unified ArchPromptCache shell.
+// ---------------------------------------------------------------------------
+
+/// Per-arch shell with `ReusePolicy::ExactOnly`. Laguna is pure-attention with
+/// no recurrent state; the dominant workload is the Exact-hit warm-TTFT, so the
+/// single Exact / Miss arm set (no partial reuse) is the policy — matching Qwen2
+/// and BitNet.
+pub(crate) static PROMPT_CACHE: ArchPromptCache<LagunaEntry> =
+    ArchPromptCache::new("LagunaForCausalLM", ReusePolicy::ExactOnly);
+
+/// Active SSD-tier `layout_key` for the Laguna cache, or `0` when the tier is
+/// OFF. `FNV_OFFSET ^ 0 == FNV_OFFSET` ⇒ legacy un-salted digests when no SSD
+/// tier is attached, preserving byte-identical RAM-only behaviour.
+pub(crate) fn active_layout_key() -> u64 {
+    PROMPT_CACHE.active_layout_key()
+}
+
+/// Ensure the global prompt cache is initialised with at least `capacity` slots.
+pub(crate) fn ensure_prompt_cache(capacity: usize) {
+    PROMPT_CACHE.ensure(capacity);
+}
+
+/// Read the current hit/miss/bytes stats for the Laguna prompt cache.
+pub fn read_cache_stats() -> Option<CacheStats> {
+    PROMPT_CACHE.read_cache_stats()
+}
+
+/// Read the KV-cache bytes from the last completed Laguna request.
+pub fn read_kv_cache_bytes() -> u64 {
+    PROMPT_CACHE.read_kv_cache_bytes()
+}
+
+/// Record the KV-cache byte total for the just-completed request.
+pub(crate) fn store_kv_cache_bytes(n: u64) {
+    PROMPT_CACHE.store_kv_cache_bytes(n);
+}
+
+#[cfg(test)]
+#[path = "prompt_cache_tests.rs"]
+mod tests;

--- a/crates/rmlx-models/src/laguna/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/laguna/prompt_cache_tests.rs
@@ -1,0 +1,119 @@
+//! In-process unit tests for the Laguna prompt cache.
+//!
+//! These exercise the parts that do not need a loaded model or a Metal GPU
+//! stream: the arch policy, the `LagunaEntry` deep_clone round-trip over empty
+//! (never-prefilled) KV caches, and the SSD-hydrated entry field invariants
+//! (placeholder `first_id` + `is_ssd_hydrated` flag) the real-model SSD smoke
+//! relies on. Decoded-token reuse is proven by the real-model smoke, not here.
+
+use super::*;
+use rmlx_kv_quant::{KvCache, KvQuant};
+
+/// Build a `LagunaEntry` with `n_layers` empty (never-prefilled) KV caches.
+///
+/// An empty cache holds no live GPU arrays, so `try_deep_clone` is a no-op
+/// refcount walk that runs without a Metal stream — safe in a plain unit test.
+fn mock_ram_entry(n_layers: usize, prompt: &[u32], first_id: u32) -> LagunaEntry {
+    LagunaEntry {
+        prompt_token_ids: prompt.to_vec(),
+        block_hashes: vec![0xABCD_u64; n_layers],
+        kv_caches: (0..n_layers)
+            .map(|_| KvCache::with_quant(KvQuant::None))
+            .collect(),
+        first_id,
+        first_piece: "hello".to_string(),
+        kv_quant: Some(KvQuant::None),
+        is_ssd_hydrated: false,
+    }
+}
+
+/// Laguna's policy is hard-gated `ExactOnly`: the shared consume engine must
+/// only ever yield `Exact` or `Miss` for this arch (no partial-prefix reuse).
+#[test]
+fn arch_policy_is_exact_only() {
+    assert_eq!(PROMPT_CACHE.policy(), ReusePolicy::ExactOnly);
+}
+
+/// `deep_clone` copies every metadata field and produces an independent entry
+/// with the same KV-cache cardinality. (Empty caches carry no GPU data, so the
+/// clone is a refcount walk; this pins the field-copy contract.)
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: deep_clone over empty KV caches cannot fail — .expect documents the invariant"
+)]
+fn entry_deep_clone_preserves_fields() {
+    let prompt = [1_u32, 2, 3, 4];
+    let entry = mock_ram_entry(3, &prompt, 42);
+    let cloned = entry
+        .deep_clone()
+        .expect("deep_clone of empty-cache entry must succeed");
+
+    assert_eq!(cloned.prompt_token_ids, entry.prompt_token_ids);
+    assert_eq!(cloned.block_hashes, entry.block_hashes);
+    assert_eq!(cloned.kv_caches.len(), entry.kv_caches.len());
+    assert_eq!(cloned.first_id, 42);
+    assert_eq!(cloned.first_piece, "hello");
+    assert_eq!(cloned.kv_quant, Some(KvQuant::None));
+    assert!(!cloned.is_ssd_hydrated);
+}
+
+/// The `PromptCacheEntry` accessors expose the entry's fields verbatim. A
+/// pure-attention Laguna entry has no GDN recurrent state, so `lin_caches()` is
+/// empty — this is what makes the blanket `SpillSink` carry KV only.
+#[test]
+fn entry_accessors_match_fields() {
+    let prompt = [7_u32, 8, 9];
+    let entry = mock_ram_entry(2, &prompt, 5);
+
+    assert_eq!(entry.prompt_token_ids(), &prompt);
+    assert_eq!(entry.block_hashes(), &[0xABCD_u64, 0xABCD_u64]);
+    assert_eq!(entry.kv_caches().len(), 2);
+    assert_eq!(entry.kv_quant(), Some(KvQuant::None));
+    assert!(!entry.is_ssd_hydrated());
+    assert!(
+        entry.lin_caches().is_empty(),
+        "pure-attention arch has no GDN lin state"
+    );
+}
+
+/// A non-hydrated partial match is never reusable under ExactOnly: the default
+/// `is_reusable_prefix_of` hook returns `None` regardless of `matched_blocks`,
+/// so the consume engine can only reach `Exact` or `Miss`.
+#[test]
+fn non_hydrated_partial_is_not_reusable() {
+    let entry = mock_ram_entry(1, &[1, 2, 3], 0);
+    // A longer incoming prompt that the cached one is a prefix of: still None
+    // because the entry is not SSD-hydrated and the default hook declines.
+    assert!(entry
+        .is_reusable_prefix_of(&[1, 2, 3, 4, 5], false, 1)
+        .is_none());
+}
+
+/// An SSD-hydrated entry carries placeholder first-token fields (`first_id == 0`,
+/// empty `first_piece`) and the `is_ssd_hydrated` flag set, mirroring exactly
+/// what `SsdHydrate::hydrate` constructs. The consume engine excludes such an
+/// entry from the Exact fast path so the generate loop recomputes the real
+/// first token via re-prefill. Even as a strict prefix of a longer prompt it is
+/// declined here (the default hook returns `None`), so Laguna stays Exact-only.
+#[test]
+fn ssd_hydrated_entry_field_invariants() {
+    let hydrated = LagunaEntry {
+        prompt_token_ids: vec![10, 11, 12],
+        block_hashes: vec![0xFEED_u64],
+        kv_caches: vec![KvCache::with_quant(KvQuant::None)],
+        first_id: 0,
+        first_piece: String::new(),
+        kv_quant: Some(KvQuant::None),
+        is_ssd_hydrated: true,
+    };
+
+    assert_eq!(hydrated.first_id, 0, "SSD block stores no real first token");
+    assert!(hydrated.first_piece.is_empty());
+    assert!(hydrated.is_ssd_hydrated());
+    // ExactOnly Laguna declines even a hydrated strict-prefix reuse (default
+    // hook → None), unlike the moe HydratedTail seam.
+    assert!(hydrated
+        .is_reusable_prefix_of(&[10, 11, 12, 13], true, 0)
+        .is_none());
+}

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -330,8 +330,6 @@ pub(crate) trait PromptCacheEntry: Sized {
     /// overrides this — its rotating-ring layers are not serialised to the SSD
     /// tier, so a hydrated entry can come back with a payload-less attended
     /// layer; the consume engine excludes such an entry from prefix reuse.
-    // Allowed until the `consume` engine that calls these hooks is wired in.
-    #[allow(dead_code)]
     fn is_hydrate_complete(&self) -> bool {
         true
     }
@@ -347,7 +345,6 @@ pub(crate) trait PromptCacheEntry: Sized {
     /// e.g. qwen3 dense and every ExactOnly retrofit).
     ///
     /// [`is_ssd_hydrated`]: PromptCacheEntry::is_ssd_hydrated
-    #[allow(dead_code)]
     fn is_reusable_prefix_of(
         &self,
         _prompt_ids: &[u32],
@@ -366,7 +363,6 @@ pub(crate) trait PromptCacheEntry: Sized {
     /// boundary.
     ///
     /// [`deep_clone`]: PromptCacheEntry::deep_clone
-    #[allow(dead_code)]
     fn prepare_reuse(&self, _kind: ReuseKind) -> Result<Self> {
         self.deep_clone()
     }
@@ -863,21 +859,28 @@ impl<E: PromptCacheEntry> PromptCache<E> {
 /// stored first token; `Reuse` restores the cloned prefix and the arch forwards
 /// the tail; `Miss` falls back to a full re-prefill. The cloned `E` carries
 /// whatever per-arch extras the entry holds (e.g. qwen3's `first_logprobs`).
-// Allowed until the `consume` engine and the migrated arches that produce and
-// match this are wired in (same change series).
-#[allow(dead_code)]
 pub(crate) enum Consumed<E> {
     /// Full-token-equality hit: the cloned entry's prompt equals the request
     /// prompt and it is not an SSD placeholder. Reuse the snapshot as-is.
     Exact(E),
     /// Prefix reuse: the cloned entry covers a leading prefix of the request
     /// prompt; the arch re-prefills the remaining tail on top of it.
+    ///
+    /// Only constructed for `Partial`-policy arches and the SSD-hydrated
+    /// strict-prefix case; the dense ExactOnly arch never produces it, so it
+    /// reads as dead until a prefix-reusing arch is routed through the engine.
+    #[allow(dead_code)]
     Reuse { entry: E, kind: ReuseKind },
     /// No usable entry — re-prefill from scratch.
     Miss,
 }
 
 /// How a `Consumed::Reuse` prefix relates to the request prompt.
+///
+/// Constructed only by prefix-reusing arches (a `StrictPrefix` for the
+/// SSD-hydrated strict-prefix / SWA-snapshot case, a `BlockTruncate` for the
+/// block-aligned gemma4 path). The dense ExactOnly arch never builds either, so
+/// the variants read as dead until such an arch is routed through the engine.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(dead_code)]
 pub(crate) enum ReuseKind {
@@ -1106,6 +1109,224 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .as_ref()
             .map_or(0, |p| p.layout_key)
+    }
+
+    /// Resolve the prompt-cache consume decision for one request.
+    ///
+    /// Read-only with respect to slot population — never `push`es. It owns the
+    /// logic that was duplicated byte-for-byte across the cached arches, AFTER
+    /// the caller's `n_tokens == 0` early return (consume is never called for an
+    /// empty prompt). The flow:
+    ///
+    /// 1. `has_image` → `Miss` immediately, WITHOUT consulting the cache (no
+    ///    find, no evict side-effect). The cached K/V is keyed by token ids
+    ///    only; an image prompt's K/V depends on scattered vision features, so
+    ///    it must never be served from or stored under a token-id key.
+    /// 2. Compute the codec-partitioned seed from `active_layout_key()` +
+    ///    `kv_quant.cache_key_salt()` so a slot stored under a different KV codec
+    ///    never cross-serves.
+    /// 3. `find_best_prefix` (capturing `block_count`) + the hydrate-from-SSD
+    ///    retry (no-op when the tier is OFF).
+    /// 4. Quant-mismatch guard: a stored `KvQuant` that differs from the runtime
+    ///    quant (or a legacy `None`) means the cached K/V layout is incompatible
+    ///    — evict the slot, `warn!`, degrade to `Miss`.
+    /// 5. Exact arm: `!is_ssd_hydrated() && prompt_token_ids() == prompt_ids` →
+    ///    `Exact(deep_clone())`. The clone preserves whatever per-arch extras the
+    ///    entry holds (e.g. qwen3's `first_logprobs`).
+    /// 6. Reuse gate ([`ReusePolicy`] + `is_hydrate_complete`): a hydrated
+    ///    strict-prefix is permitted under any policy; a non-hydrated partial
+    ///    match only under `Partial`. When permitted, the entry's
+    ///    `is_reusable_prefix_of` hook decides the [`ReuseKind`]; `prepare_reuse`
+    ///    clones (+ truncates) for reuse. Hook `None` or an incomplete hydrate
+    ///    degrades to `Miss`.
+    ///
+    /// Every degrade branch emits exactly one `debug!{branch, reason}` so the
+    /// decision is reconstructable from a single run's log — the cached arches
+    /// previously had silent degrade arms.
+    // `dead_code` until the first arch (qwen3 dense) routes through this; the
+    // unit tests exercise it crate-internally in the same change series.
+    #[allow(dead_code)]
+    pub(crate) fn consume(
+        &self,
+        prompt_ids: &[u32],
+        kv_quant: KvQuant,
+        has_image: bool,
+    ) -> Consumed<E> {
+        // (1) Image prompts bypass the cache entirely — no find, no evict.
+        if has_image {
+            tracing::debug!(
+                arch = self.arch_name,
+                branch = "has_image",
+                reason = "image prompt bypasses the token-id-keyed cache",
+                "prompt cache consume: Miss (image)"
+            );
+            return Consumed::Miss;
+        }
+
+        // hard runtime gate: this arch's policy must be the one the call site
+        // expects. The per-arch tripwire (previously an inline assert_eq! in
+        // each generate loop) lives here now, keyed on the policy field.
+        debug_assert!(
+            matches!(self.policy, ReusePolicy::Partial | ReusePolicy::ExactOnly),
+            "ArchPromptCache policy must be a known ReusePolicy variant",
+        );
+
+        // (2) Codec-partitioned seed: identical to the per-arch push seed, so a
+        // slot stored under a different KV codec / layout never matches.
+        let seed = FNV_OFFSET ^ self.active_layout_key() ^ kv_quant.cache_key_salt();
+        let policy = self.policy;
+        let arch = self.arch_name;
+
+        self.with_inner_mut(|guard| match guard.as_mut() {
+            Some(cache) => Self::decide_locked(arch, policy, cache, prompt_ids, kv_quant, seed),
+            None => Consumed::Miss,
+        })
+    }
+
+    /// The find → hydrate-retry → quant-guard → Exact → reuse-gate decision,
+    /// run while holding the cache lock. Split out of [`consume`] so the single
+    /// cohesive decision keeps one home (the `cognitive_complexity` allow scopes
+    /// to it, not the lock-management wrapper).
+    ///
+    /// [`consume`]: ArchPromptCache::consume
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "slot_idx is returned by find_best_prefix as a valid index into `cache.slots` and is not mutated before use"
+    )]
+    #[allow(
+        clippy::cognitive_complexity,
+        reason = "one cohesive consume decision (find/guard/exact/reuse arms) — splitting the arms across helpers would scatter a single decision and hurt readability"
+    )]
+    fn decide_locked(
+        arch: &'static str,
+        policy: ReusePolicy,
+        cache: &mut PromptCache<E>,
+        prompt_ids: &[u32],
+        kv_quant: KvQuant,
+        seed: u64,
+    ) -> Consumed<E> {
+        // (3) RAM find, then SSD-hydrate retry. A hydrate hit promotes the
+        // block into RAM; re-run find_best_prefix so the promoted slot is
+        // matched + quant-checked by the path below.
+        let mut raw_match = cache.find_best_prefix(prompt_ids, seed);
+        if raw_match.is_none() && cache.hydrate_from_ssd(prompt_ids).is_some() {
+            raw_match = cache.find_best_prefix(prompt_ids, seed);
+        }
+
+        // (4) Quant-mismatch guard (Plan §D8). The snapshot is only safe to
+        // reuse when the stored KvQuant equals the runtime quant.
+        let (slot_idx, block_count) = match raw_match {
+            Some((slot_idx, block_count)) => {
+                let stored = cache.slots[slot_idx].entry.kv_quant();
+                if stored == Some(kv_quant) {
+                    (slot_idx, block_count)
+                } else {
+                    tracing::debug!(
+                        arch,
+                        branch = "quant_mismatch",
+                        reason = "stored KV quant differs from runtime — evict + re-prefill",
+                        stored = ?stored,
+                        runtime = ?kv_quant,
+                        prompt_len = prompt_ids.len(),
+                    );
+                    tracing::warn!(
+                        stored = ?stored,
+                        runtime = ?kv_quant,
+                        prompt_len = prompt_ids.len(),
+                        "prompt cache KV quant mismatch — evicting entry, \
+                         degrading to re-prefill"
+                    );
+                    cache.evict_slot(slot_idx);
+                    return Consumed::Miss;
+                }
+            }
+            None => return Consumed::Miss,
+        };
+
+        let entry = &cache.slots[slot_idx].entry;
+        let is_ssd_hydrated = entry.is_ssd_hydrated();
+
+        // (5) Exact arm: full token-id equality AND a real (non-placeholder)
+        // first decode token. An SSD-hydrated entry is excluded — its
+        // first_id is the placeholder 0, replaying it poisons generation.
+        if !is_ssd_hydrated && entry.prompt_token_ids() == prompt_ids {
+            return match entry.deep_clone() {
+                Ok(cloned) => Consumed::Exact(cloned),
+                Err(e) => {
+                    tracing::debug!(
+                        arch,
+                        branch = "deep_clone_err",
+                        reason = "Exact deep_clone failed — re-prefill (source slot untouched)",
+                        error = %e,
+                        prompt_len = prompt_ids.len(),
+                    );
+                    Consumed::Miss
+                }
+            };
+        }
+
+        // (6) Reuse gate. A hydrated strict-prefix is permitted under any
+        // policy (moe HydratedTail); a non-hydrated partial match only under
+        // `Partial` (gemma4). Either way the hydrated entry must be COMPLETE
+        // (gemma4 SWA: a payload-less attended layer is not reusable).
+        let reuse_eligible = if is_ssd_hydrated {
+            if entry.is_hydrate_complete() {
+                true
+            } else {
+                tracing::debug!(
+                    arch,
+                    branch = "incomplete_hydrate",
+                    reason = "hydrated entry has a payload-less attended layer — re-prefill",
+                    prompt_len = prompt_ids.len(),
+                );
+                return Consumed::Miss;
+            }
+        } else {
+            policy == ReusePolicy::Partial
+        };
+
+        if reuse_eligible {
+            if let Some(kind) =
+                entry.is_reusable_prefix_of(prompt_ids, is_ssd_hydrated, block_count)
+            {
+                return match entry.prepare_reuse(kind) {
+                    Ok(prepared) => Consumed::Reuse {
+                        entry: prepared,
+                        kind,
+                    },
+                    Err(e) => {
+                        tracing::debug!(
+                            arch,
+                            branch = "deep_clone_err",
+                            reason = "prepare_reuse failed — re-prefill (source slot untouched)",
+                            error = %e,
+                            prompt_len = prompt_ids.len(),
+                        );
+                        Consumed::Miss
+                    }
+                };
+            }
+            tracing::debug!(
+                arch,
+                branch = "non_reusable",
+                reason = "matched slot is not a reusable prefix for this prompt — re-prefill",
+                prompt_len = prompt_ids.len(),
+                block_count,
+            );
+            return Consumed::Miss;
+        }
+
+        // A matched non-hydrated partial under a non-Partial policy, or a
+        // hydrated entry that declined the strict-prefix hook (e.g. the
+        // block-aligned equal-length case) — re-prefill.
+        tracing::debug!(
+            arch,
+            branch = "hydrated_declined_to_exact",
+            reason = "matched slot is not Exact-eligible and reuse is not permitted — re-prefill",
+            is_ssd_hydrated,
+            prompt_len = prompt_ids.len(),
+        );
+        Consumed::Miss
     }
 
     /// Read the current hit/miss/bytes stats, or `None` if the cache has not

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -1160,14 +1160,6 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
             return Consumed::Miss;
         }
 
-        // hard runtime gate: this arch's policy must be the one the call site
-        // expects. The per-arch tripwire (previously an inline assert_eq! in
-        // each generate loop) lives here now, keyed on the policy field.
-        debug_assert!(
-            matches!(self.policy, ReusePolicy::Partial | ReusePolicy::ExactOnly),
-            "ArchPromptCache policy must be a known ReusePolicy variant",
-        );
-
         // (2) Codec-partitioned seed: identical to the per-arch push seed, so a
         // slot stored under a different KV codec / layout never matches.
         let seed = FNV_OFFSET ^ self.active_layout_key() ^ kv_quant.cache_key_salt();
@@ -1210,7 +1202,7 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
             raw_match = cache.find_best_prefix(prompt_ids, seed);
         }
 
-        // (4) Quant-mismatch guard (Plan §D8). The snapshot is only safe to
+        // (4) Quant-mismatch guard. The snapshot is only safe to
         // reuse when the stored KvQuant equals the runtime quant.
         let (slot_idx, block_count) = match raw_match {
             Some((slot_idx, block_count)) => {

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -321,6 +321,55 @@ pub(crate) trait PromptCacheEntry: Sized {
                 .map(LinearAttnCache::approx_bytes)
                 .sum::<u64>()
     }
+
+    /// True unless a hydrated entry is missing K/V payload for a layer this
+    /// architecture attends to.
+    ///
+    /// Default `true`: a fully RAM-resident snapshot (or a pure-attention arch
+    /// whose SSD blocks restore every layer) is always complete. gemma4 SWA
+    /// overrides this — its rotating-ring layers are not serialised to the SSD
+    /// tier, so a hydrated entry can come back with a payload-less attended
+    /// layer; the consume engine excludes such an entry from prefix reuse.
+    // Allowed until the `consume` engine that calls these hooks is wired in.
+    #[allow(dead_code)]
+    fn is_hydrate_complete(&self) -> bool {
+        true
+    }
+
+    /// The reusable-prefix policy seam: decide whether (and how) the entry's
+    /// cached prefix may be reused for `prompt_ids`.
+    ///
+    /// `matched_blocks` is `find_best_prefix`'s block_count for this entry.
+    /// `is_ssd_hydrated` mirrors [`is_ssd_hydrated`]. Each arch keeps its own
+    /// predicate (they differ deliberately); the engine does not impose one.
+    ///
+    /// Default `None`: no partial reuse (full-token-equality Exact-only archs,
+    /// e.g. qwen3 dense and every ExactOnly retrofit).
+    ///
+    /// [`is_ssd_hydrated`]: PromptCacheEntry::is_ssd_hydrated
+    #[allow(dead_code)]
+    fn is_reusable_prefix_of(
+        &self,
+        _prompt_ids: &[u32],
+        _is_ssd_hydrated: bool,
+        _matched_blocks: usize,
+    ) -> Option<ReuseKind> {
+        None
+    }
+
+    /// Clone the entry for reuse, applying any truncation the `kind` requires.
+    ///
+    /// Atomic: on `Err` the engine yields `Miss` and the source slot is left
+    /// untouched. Default body is a plain [`deep_clone`] (correct for
+    /// `StrictPrefix`, where the whole cached prefix is reused verbatim). gemma4
+    /// overrides `BlockTruncate` to deep-clone then trim the KV to the block
+    /// boundary.
+    ///
+    /// [`deep_clone`]: PromptCacheEntry::deep_clone
+    #[allow(dead_code)]
+    fn prepare_reuse(&self, _kind: ReuseKind) -> Result<Self> {
+        self.deep_clone()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -1143,9 +1143,6 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
     /// Every degrade branch emits exactly one `debug!{branch, reason}` so the
     /// decision is reconstructable from a single run's log — the cached arches
     /// previously had silent degrade arms.
-    // `dead_code` until the first arch (qwen3 dense) routes through this; the
-    // unit tests exercise it crate-internally in the same change series.
-    #[allow(dead_code)]
     pub(crate) fn consume(
         &self,
         prompt_ids: &[u32],

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -804,6 +804,46 @@ impl<E: PromptCacheEntry> PromptCache<E> {
 }
 
 // ---------------------------------------------------------------------------
+// Consumed / ReuseKind — outcome of the shared consume engine
+// ---------------------------------------------------------------------------
+
+/// Outcome of a prompt-cache consume decision.
+///
+/// Read-only — the engine that produces this never `push`es. The arch maps each
+/// variant onto its own decode path: `Exact` skips prefill and replays the
+/// stored first token; `Reuse` restores the cloned prefix and the arch forwards
+/// the tail; `Miss` falls back to a full re-prefill. The cloned `E` carries
+/// whatever per-arch extras the entry holds (e.g. qwen3's `first_logprobs`).
+// Allowed until the `consume` engine and the migrated arches that produce and
+// match this are wired in (same change series).
+#[allow(dead_code)]
+pub(crate) enum Consumed<E> {
+    /// Full-token-equality hit: the cloned entry's prompt equals the request
+    /// prompt and it is not an SSD placeholder. Reuse the snapshot as-is.
+    Exact(E),
+    /// Prefix reuse: the cloned entry covers a leading prefix of the request
+    /// prompt; the arch re-prefills the remaining tail on top of it.
+    Reuse { entry: E, kind: ReuseKind },
+    /// No usable entry — re-prefill from scratch.
+    Miss,
+}
+
+/// How a `Consumed::Reuse` prefix relates to the request prompt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum ReuseKind {
+    /// Reuse the entry's full cached prefix verbatim. `prefix_len` is the
+    /// cached token length (NOT necessarily block-aligned). The arch forwards
+    /// `prompt_ids[prefix_len..]`. gemma4 B1 (SWA snapshot/restore), qwen3.5-moe
+    /// HydratedTail.
+    StrictPrefix { prefix_len: usize },
+    /// Block-aligned truncate then tail re-prefill (gemma4 only). The reuse
+    /// prefix is `effective_blocks * BLOCK_TOKENS` tokens; `prepare_reuse`
+    /// truncates the cloned KV to that boundary and asserts the invariant.
+    BlockTruncate { effective_blocks: usize },
+}
+
+// ---------------------------------------------------------------------------
 // ReusePolicy — per-arch hard runtime gate
 // ---------------------------------------------------------------------------
 

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -1899,6 +1899,13 @@ impl tracing::Subscriber for TeeBranchSubscriber {
 /// `register_callsite` is `always`, the consume callsites dispatch to it on
 /// every thread regardless of which test fired them first — only the armed
 /// thread records, so the capture is deterministic across the shared binary.
+///
+/// test-ordering note: `set_global_default` is called exactly once (via
+/// `Once`) and is never uninstalled. No other test in this binary may rely on
+/// the global tracing dispatcher's span-filter or subscriber-specific
+/// semantics — the permanent install here will shadow any later attempt to set
+/// a different global default. Tests that need custom tracing must use a
+/// per-thread or scoped subscriber rather than the global dispatcher.
 fn capture_branches(f: impl FnOnce()) -> Vec<String> {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -198,8 +198,9 @@ impl PromptCacheEntry for TestEntry {
         match self.reuse_kind? {
             // moe HydratedTail / gemma4 B1: a STRICT token-level prefix only
             // (stored.len() < prompt.len() && starts_with). The strict-less is
-            // the load-bearing #87 guard — an equal-length hydrated entry
-            // returns `None` and falls to Miss even with a canned reuse_kind.
+            // the load-bearing guard for the hydrated-equal-length case — such
+            // an entry returns `None` and falls to Miss even with a canned
+            // reuse_kind, so its placeholder first_id is never replayed.
             kind @ ReuseKind::StrictPrefix { .. } => {
                 if self.ids.len() < prompt_ids.len() && prompt_ids.starts_with(&self.ids) {
                     Some(kind)
@@ -1626,8 +1627,8 @@ fn consume_exact_ram_entry() {
     assert_eq!(tag(&out), ConsumedTag::Exact);
 }
 
-/// #87 path: a hydrated entry whose ids exactly equal the request (block-aligned,
-/// no tail) must be `Miss` — the Exact arm excludes hydrated entries (placeholder
+/// Hydrated entry whose ids exactly equal the request (block-aligned, no tail)
+/// must be `Miss` — the Exact arm excludes hydrated entries (placeholder
 /// first_id) and the reuse hook's strict-less guard excludes equal-length.
 #[test]
 fn consume_hydrated_equal_length_is_miss() {
@@ -1828,73 +1829,99 @@ fn consume_quant_mismatch_evicts_and_misses() {
 //
 // Every consume degrade branch must emit exactly one `debug!{branch=...}` so a
 // silent-drop regression (the qwen3/moe arms were silent before unification)
-// fails this test rather than passing every other one. A `tracing-subscriber`
-// fmt layer writes events to a shared buffer; we parse the `branch="..."` field.
+// fails this test rather than passing every other one.
+//
+// Capturing tracing events reliably from a test that shares one binary with
+// many other tracing-emitting tests is subtle: the per-callsite Interest cache
+// is GLOBAL and is populated by whatever dispatcher was current the FIRST time a
+// callsite fired. A thread-local `with_default` subscriber cannot retroactively
+// un-disable a callsite that a sibling test already cached as `never` under the
+// no-op default. The fix is a process-global "tee" subscriber installed once:
+// its `register_callsite` returns `always` (so callsites are never cached
+// disabled) and its `event` forwards the `branch` field to a THREAD-LOCAL sink
+// that is only armed inside `capture_branches`. Outside a capture it is inert.
 
-/// A `MakeWriter` that appends all formatted log output to a shared buffer.
-#[derive(Clone)]
-struct BufWriter {
-    buf: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+thread_local! {
+    static BRANCH_SINK: std::cell::RefCell<Option<Vec<String>>> =
+        const { std::cell::RefCell::new(None) };
 }
 
-impl std::io::Write for BufWriter {
-    #[allow(
-        clippy::unwrap_used,
-        reason = "test-only: the capture Mutex is never poisoned"
-    )]
-    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
-        self.buf.lock().unwrap().extend_from_slice(data);
-        Ok(data.len())
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
+struct BranchVisitor<'a> {
+    out: &'a mut Vec<String>,
 }
 
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufWriter {
-    type Writer = BufWriter;
-    fn make_writer(&'a self) -> Self::Writer {
-        self.clone()
-    }
-}
-
-/// Run `f` with a DEBUG-level fmt subscriber capturing to a buffer; return the
-/// list of `branch` field values across all captured events, in order.
-#[allow(
-    clippy::unwrap_used,
-    reason = "test-only: the capture Mutex is never poisoned; the captured UTF-8 is valid fmt output"
-)]
-#[allow(
-    clippy::clone_on_ref_ptr,
-    reason = "intentional Arc::clone — explicit form aids grep for shared-ownership transfer sites"
-)]
-fn capture_branches(f: impl FnOnce()) -> Vec<String> {
-    let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
-    let writer = BufWriter { buf: buf.clone() };
-    let subscriber = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .with_writer(writer)
-        .with_ansi(false)
-        .finish();
-    tracing::subscriber::with_default(subscriber, f);
-
-    let text = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
-    // Parse `branch="value"` (fmt renders string fields quoted).
-    let mut branches = Vec::new();
-    for line in text.lines() {
-        if let Some(start) = line.find("branch=\"") {
-            let rest = &line[start + "branch=\"".len()..];
-            if let Some(end) = rest.find('"') {
-                branches.push(rest[..end].to_owned());
-            }
+impl tracing::field::Visit for BranchVisitor<'_> {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "branch" {
+            self.out.push(value.to_owned());
         }
     }
-    branches
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+}
+
+/// Process-global tee subscriber. Always-interest so no callsite is cached as
+/// disabled; forwards `branch` fields to the thread-local sink when armed.
+struct TeeBranchSubscriber;
+
+impl tracing::Subscriber for TeeBranchSubscriber {
+    fn register_callsite(
+        &self,
+        _meta: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        tracing::subscriber::Interest::always()
+    }
+    fn enabled(&self, _md: &tracing::Metadata<'_>) -> bool {
+        true
+    }
+    fn max_level_hint(&self) -> Option<tracing::level_filters::LevelFilter> {
+        Some(tracing::level_filters::LevelFilter::TRACE)
+    }
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+    fn event(&self, event: &tracing::Event<'_>) {
+        BRANCH_SINK.with(|sink| {
+            if let Some(out) = sink.borrow_mut().as_mut() {
+                let mut v = BranchVisitor { out };
+                event.record(&mut v);
+            }
+        });
+    }
+    fn enter(&self, _span: &tracing::span::Id) {}
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
+/// Run `f` with the thread-local branch sink armed; return captured branches.
+///
+/// Installs the process-global tee subscriber on first use. Because the tee's
+/// `register_callsite` is `always`, the consume callsites dispatch to it on
+/// every thread regardless of which test fired them first — only the armed
+/// thread records, so the capture is deterministic across the shared binary.
+fn capture_branches(f: impl FnOnce()) -> Vec<String> {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        // Ignore an error: another test having set a global default would only
+        // mean our tee is not installed; the assertions below would then catch
+        // a silent-drop, which is the desired failure mode.
+        let _ = tracing::subscriber::set_global_default(TeeBranchSubscriber);
+    });
+    BRANCH_SINK.with(|sink| *sink.borrow_mut() = Some(Vec::new()));
+    f();
+    BRANCH_SINK.with(|sink| sink.borrow_mut().take().unwrap_or_default())
 }
 
 /// Each degrade path emits exactly one `debug!{branch=...}` with the expected
-/// branch name. The set covers: has_image, quant_mismatch, incomplete_hydrate,
-/// non_reusable, hydrated_declined_to_exact.
+/// branch name. All six scenarios run inside ONE capture scope (one subscriber
+/// install + interest rebuild) so the collected `branch` sequence is
+/// deterministic — the per-call capture variant raced the global tracing
+/// interest cache against other tests sharing the binary.
+///
+/// Covers: has_image, quant_mismatch, incomplete_hydrate, non_reusable (fresh
+/// partial under Partial), hydrated_declined_to_exact (fresh partial under
+/// ExactOnly), and the hydrated equal-length case (declines via non_reusable).
+/// Exactly one `branch` per consume call.
 #[test]
 #[allow(
     clippy::unwrap_used,
@@ -1907,115 +1934,103 @@ fn capture_branches(f: impl FnOnce()) -> Vec<String> {
 fn consume_degrade_branches_each_emit_one_debug() {
     let prompt = make_ids(2 * BLOCK_TOKENS);
 
-    // has_image → branch "has_image", no cache touch.
-    let b = capture_branches(|| {
-        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::ExactOnly);
-        arch.with_inner_mut(|g| *g = Some(PromptCache::new(4)));
-        let _ = arch.consume(&prompt, TEST_QUANT, true);
-    });
-    assert_eq!(b, vec!["has_image".to_owned()], "has_image: one debug");
-
-    // quant_mismatch → branch "quant_mismatch".
-    let b = capture_branches(|| {
-        let runtime_seed = FNV_OFFSET ^ TEST_QUANT.cache_key_salt();
-        let mut entry = TestEntry::new_seeded(prompt.clone(), runtime_seed);
-        entry.kv_quant = Some(KvQuant::K8V4);
-        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::ExactOnly);
-        arch.with_inner_mut(|g| {
-            *g = Some(PromptCache::new(4));
-            g.as_mut().unwrap().push(entry);
-        });
-        let _ = arch.consume(&prompt, TEST_QUANT, false);
-    });
-    assert_eq!(
-        b,
-        vec!["quant_mismatch".to_owned()],
-        "quant_mismatch: one debug"
-    );
-
-    // incomplete_hydrate (Partial, hydrated, incomplete) → branch "incomplete_hydrate".
-    let b = capture_branches(|| {
-        let mut req = prompt.clone();
-        req.extend(11_000..11_000 + BLOCK_TOKENS as u32);
-        let entry = TestEntry::for_quant(prompt.clone(), TEST_QUANT)
-            .with_ssd_hydrated(true)
-            .with_hydrate_complete(false)
-            .with_reuse_kind(ReuseKind::StrictPrefix {
-                prefix_len: prompt.len(),
+    let branches = capture_branches(|| {
+        // 1. has_image → "has_image" (no cache touch).
+        {
+            let arch: ArchPromptCache<TestEntry> =
+                ArchPromptCache::new("test", ReusePolicy::ExactOnly);
+            arch.with_inner_mut(|g| *g = Some(PromptCache::new(4)));
+            let _ = arch.consume(&prompt, TEST_QUANT, true);
+        }
+        // 2. quant_mismatch → "quant_mismatch".
+        {
+            let runtime_seed = FNV_OFFSET ^ TEST_QUANT.cache_key_salt();
+            let mut entry = TestEntry::new_seeded(prompt.clone(), runtime_seed);
+            entry.kv_quant = Some(KvQuant::K8V4);
+            let arch: ArchPromptCache<TestEntry> =
+                ArchPromptCache::new("test", ReusePolicy::ExactOnly);
+            arch.with_inner_mut(|g| {
+                *g = Some(PromptCache::new(4));
+                g.as_mut().unwrap().push(entry);
             });
-        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::Partial);
-        arch.with_inner_mut(|g| {
-            *g = Some(PromptCache::new(4));
-            g.as_mut().unwrap().push(entry);
-        });
-        let _ = arch.consume(&req, TEST_QUANT, false);
-    });
-    assert_eq!(
-        b,
-        vec!["incomplete_hydrate".to_owned()],
-        "incomplete_hydrate: one debug"
-    );
-
-    // non_reusable (Partial, fresh partial, hook returns None) → branch "non_reusable".
-    let b = capture_branches(|| {
-        let cached = make_ids(4 * BLOCK_TOKENS);
-        let mut req = cached[..3 * BLOCK_TOKENS].to_vec();
-        req.extend(60_000..60_000 + BLOCK_TOKENS as u32);
-        // No reuse_kind set → hook returns None → non_reusable degrade.
-        let entry = TestEntry::for_quant(cached, TEST_QUANT);
-        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::Partial);
-        arch.with_inner_mut(|g| {
-            *g = Some(PromptCache::new(4));
-            g.as_mut().unwrap().push(entry);
-        });
-        let _ = arch.consume(&req, TEST_QUANT, false);
-    });
-    assert_eq!(
-        b,
-        vec!["non_reusable".to_owned()],
-        "non_reusable: one debug"
-    );
-
-    // hydrated_declined_to_exact (ExactOnly, fresh non-hydrated partial match
-    // that is neither token-equal nor reuse-permitted) → branch
-    // "hydrated_declined_to_exact".
-    let b = capture_branches(|| {
-        let cached = make_ids(4 * BLOCK_TOKENS);
-        let mut req = cached[..3 * BLOCK_TOKENS].to_vec();
-        req.extend(61_000..61_000 + BLOCK_TOKENS as u32);
-        let entry = TestEntry::for_quant(cached, TEST_QUANT);
-        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::ExactOnly);
-        arch.with_inner_mut(|g| {
-            *g = Some(PromptCache::new(4));
-            g.as_mut().unwrap().push(entry);
-        });
-        let _ = arch.consume(&req, TEST_QUANT, false);
-    });
-    assert_eq!(
-        b,
-        vec!["hydrated_declined_to_exact".to_owned()],
-        "hydrated_declined_to_exact: one debug"
-    );
-
-    // #87 hydrated equal-length: reuse-eligible (complete) but the hook declines
-    // (strict-less guard) → branch "non_reusable" (one debug). This is the
-    // equal-length-hydrated Miss path.
-    let b = capture_branches(|| {
-        let entry = TestEntry::for_quant(prompt.clone(), TEST_QUANT)
-            .with_ssd_hydrated(true)
-            .with_reuse_kind(ReuseKind::StrictPrefix {
-                prefix_len: prompt.len(),
+            let _ = arch.consume(&prompt, TEST_QUANT, false);
+        }
+        // 3. incomplete_hydrate (Partial, hydrated, incomplete) → "incomplete_hydrate".
+        {
+            let mut req = prompt.clone();
+            req.extend(11_000..11_000 + BLOCK_TOKENS as u32);
+            let entry = TestEntry::for_quant(prompt.clone(), TEST_QUANT)
+                .with_ssd_hydrated(true)
+                .with_hydrate_complete(false)
+                .with_reuse_kind(ReuseKind::StrictPrefix {
+                    prefix_len: prompt.len(),
+                });
+            let arch: ArchPromptCache<TestEntry> =
+                ArchPromptCache::new("test", ReusePolicy::Partial);
+            arch.with_inner_mut(|g| {
+                *g = Some(PromptCache::new(4));
+                g.as_mut().unwrap().push(entry);
             });
-        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::ExactOnly);
-        arch.with_inner_mut(|g| {
-            *g = Some(PromptCache::new(4));
-            g.as_mut().unwrap().push(entry);
-        });
-        let _ = arch.consume(&prompt, TEST_QUANT, false);
+            let _ = arch.consume(&req, TEST_QUANT, false);
+        }
+        // 4. non_reusable (Partial, fresh partial, hook returns None) → "non_reusable".
+        {
+            let cached = make_ids(4 * BLOCK_TOKENS);
+            let mut req = cached[..3 * BLOCK_TOKENS].to_vec();
+            req.extend(60_000..60_000 + BLOCK_TOKENS as u32);
+            let entry = TestEntry::for_quant(cached, TEST_QUANT);
+            let arch: ArchPromptCache<TestEntry> =
+                ArchPromptCache::new("test", ReusePolicy::Partial);
+            arch.with_inner_mut(|g| {
+                *g = Some(PromptCache::new(4));
+                g.as_mut().unwrap().push(entry);
+            });
+            let _ = arch.consume(&req, TEST_QUANT, false);
+        }
+        // 5. hydrated_declined_to_exact (ExactOnly, fresh partial, not token-equal,
+        //    reuse not permitted) → "hydrated_declined_to_exact".
+        {
+            let cached = make_ids(4 * BLOCK_TOKENS);
+            let mut req = cached[..3 * BLOCK_TOKENS].to_vec();
+            req.extend(61_000..61_000 + BLOCK_TOKENS as u32);
+            let entry = TestEntry::for_quant(cached, TEST_QUANT);
+            let arch: ArchPromptCache<TestEntry> =
+                ArchPromptCache::new("test", ReusePolicy::ExactOnly);
+            arch.with_inner_mut(|g| {
+                *g = Some(PromptCache::new(4));
+                g.as_mut().unwrap().push(entry);
+            });
+            let _ = arch.consume(&req, TEST_QUANT, false);
+        }
+        // 6. hydrated equal-length: reuse-eligible (complete) but the hook
+        //    declines (strict-less) → "non_reusable".
+        {
+            let entry = TestEntry::for_quant(prompt.clone(), TEST_QUANT)
+                .with_ssd_hydrated(true)
+                .with_reuse_kind(ReuseKind::StrictPrefix {
+                    prefix_len: prompt.len(),
+                });
+            let arch: ArchPromptCache<TestEntry> =
+                ArchPromptCache::new("test", ReusePolicy::ExactOnly);
+            arch.with_inner_mut(|g| {
+                *g = Some(PromptCache::new(4));
+                g.as_mut().unwrap().push(entry);
+            });
+            let _ = arch.consume(&prompt, TEST_QUANT, false);
+        }
     });
+
+    // Exactly one branch per consume call, in order.
     assert_eq!(
-        b,
-        vec!["non_reusable".to_owned()],
-        "#87 hydrated equal-length declines via non_reusable: one debug"
+        branches,
+        vec![
+            "has_image".to_owned(),
+            "quant_mismatch".to_owned(),
+            "incomplete_hydrate".to_owned(),
+            "non_reusable".to_owned(),
+            "hydrated_declined_to_exact".to_owned(),
+            "non_reusable".to_owned(),
+        ],
+        "each consume degrade branch must emit exactly one debug!{{branch=...}}"
     );
 }

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -34,11 +34,20 @@ fn chained_seeded_with_non_default_seed_diverges() {
 
 /// Minimal entry for testing: token ID list + chained block hashes,
 /// no KV tensors. `truncated_to` records the last block-truncation call.
+///
+/// The consume-engine tests drive the three trait hooks through configurable
+/// fields: `kv_quant` (so the engine's quant-guard can match a runtime quant),
+/// `hydrate_complete` (gemma4-style incomplete-hydrate degrade), and
+/// `reuse_kind` (the canned `is_reusable_prefix_of` result the engine consults
+/// once its policy gate permits).
 struct TestEntry {
     ids: Vec<u32>,
     hashes: Vec<u64>,
     truncated_to: std::cell::Cell<Option<usize>>,
     is_ssd_hydrated: bool,
+    kv_quant: Option<KvQuant>,
+    hydrate_complete: bool,
+    reuse_kind: Option<ReuseKind>,
 }
 
 impl TestEntry {
@@ -49,6 +58,9 @@ impl TestEntry {
             hashes,
             truncated_to: std::cell::Cell::new(None),
             is_ssd_hydrated: false,
+            kv_quant: None,
+            hydrate_complete: true,
+            reuse_kind: None,
         }
     }
 
@@ -63,6 +75,9 @@ impl TestEntry {
             hashes,
             truncated_to: std::cell::Cell::new(None),
             is_ssd_hydrated: false,
+            kv_quant: None,
+            hydrate_complete: true,
+            reuse_kind: None,
         }
     }
 
@@ -70,6 +85,41 @@ impl TestEntry {
     /// `first_id`). The Exact fast path must exclude it.
     fn ssd_hydrated(mut self) -> Self {
         self.is_ssd_hydrated = true;
+        self
+    }
+
+    /// Build an entry whose block hashes are salted to match the engine's
+    /// consume seed for `kv_quant` on a RAM-only run (`layout_key == 0`), and
+    /// tag the entry with that same `kv_quant` so the quant-guard accepts it.
+    fn for_quant(ids: Vec<u32>, kv_quant: KvQuant) -> Self {
+        let seed = FNV_OFFSET ^ kv_quant.cache_key_salt();
+        let hashes = chained_block_hashes_seeded(&ids, seed);
+        TestEntry {
+            ids,
+            hashes,
+            truncated_to: std::cell::Cell::new(None),
+            is_ssd_hydrated: false,
+            kv_quant: Some(kv_quant),
+            hydrate_complete: true,
+            reuse_kind: None,
+        }
+    }
+
+    fn with_ssd_hydrated(mut self, v: bool) -> Self {
+        self.is_ssd_hydrated = v;
+        self
+    }
+
+    fn with_hydrate_complete(mut self, v: bool) -> Self {
+        self.hydrate_complete = v;
+        self
+    }
+
+    /// Set the canned `is_reusable_prefix_of` result. The engine only consults
+    /// this once its policy gate permits (hydrated strict-prefix under any
+    /// policy; non-hydrated partial under `Partial`).
+    fn with_reuse_kind(mut self, kind: ReuseKind) -> Self {
+        self.reuse_kind = Some(kind);
         self
     }
 }
@@ -89,6 +139,9 @@ impl PromptCacheEntry for TestEntry {
             hashes: self.hashes.clone(),
             truncated_to: std::cell::Cell::new(self.truncated_to.get()),
             is_ssd_hydrated: self.is_ssd_hydrated,
+            kv_quant: self.kv_quant,
+            hydrate_complete: self.hydrate_complete,
+            reuse_kind: self.reuse_kind,
         })
     }
 
@@ -106,7 +159,7 @@ impl PromptCacheEntry for TestEntry {
     }
 
     fn kv_quant(&self) -> Option<KvQuant> {
-        None
+        self.kv_quant
     }
 
     fn is_ssd_hydrated(&self) -> bool {
@@ -128,6 +181,52 @@ impl PromptCacheEntry for TestEntry {
     fn kv_bytes(&self) -> u64 {
         // Fake: 8 bytes per token id so we can assert non-zero bytes.
         self.ids.len() as u64 * 8
+    }
+
+    fn is_hydrate_complete(&self) -> bool {
+        self.hydrate_complete
+    }
+
+    fn is_reusable_prefix_of(
+        &self,
+        prompt_ids: &[u32],
+        _is_ssd_hydrated: bool,
+        matched_blocks: usize,
+    ) -> Option<ReuseKind> {
+        // Mirror the real arch hooks' predicates so the matrix tests are honest;
+        // the policy gate that decides WHEN to call this lives in the engine.
+        match self.reuse_kind? {
+            // moe HydratedTail / gemma4 B1: a STRICT token-level prefix only
+            // (stored.len() < prompt.len() && starts_with). The strict-less is
+            // the load-bearing #87 guard — an equal-length hydrated entry
+            // returns `None` and falls to Miss even with a canned reuse_kind.
+            kind @ ReuseKind::StrictPrefix { .. } => {
+                if self.ids.len() < prompt_ids.len() && prompt_ids.starts_with(&self.ids) {
+                    Some(kind)
+                } else {
+                    None
+                }
+            }
+            // gemma4 block-truncate: a divergent partial that shares >= 1 leading
+            // block (the engine passes find_best_prefix's block_count).
+            kind @ ReuseKind::BlockTruncate { .. } => {
+                if matched_blocks >= 1 {
+                    Some(kind)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn prepare_reuse(&self, kind: ReuseKind) -> Result<Self> {
+        let cloned = self.deep_clone()?;
+        if let ReuseKind::BlockTruncate { effective_blocks } = kind {
+            cloned
+                .truncated_to
+                .set(Some(effective_blocks * BLOCK_TOKENS));
+        }
+        Ok(cloned)
     }
 }
 
@@ -1355,6 +1454,9 @@ impl SsdHydrate<TestEntry> for MockHydrateSalted {
             hashes,
             truncated_to: std::cell::Cell::new(None),
             is_ssd_hydrated: true,
+            kv_quant: None,
+            hydrate_complete: true,
+            reuse_kind: None,
         }))
     }
 }
@@ -1375,6 +1477,9 @@ impl SsdHydrate<TestEntry> for MockHydrateUnsalted {
             hashes,
             truncated_to: std::cell::Cell::new(None),
             is_ssd_hydrated: true,
+            kv_quant: None,
+            hydrate_complete: true,
+            reuse_kind: None,
         }))
     }
 }
@@ -1456,5 +1561,461 @@ fn ssd_hydrate_seed_symmetry_with_nonzero_layout_key() {
     assert!(
         cross_codec.is_none(),
         "codec-A hydrated entry must not cross-serve a codec-B query"
+    );
+}
+
+// ── consume() engine — golden discriminant, policy×entry matrix, edges ───────
+//
+// These exercise the shared `ArchPromptCache::consume` decision over the
+// `TestEntry` mock. The cache is installed via `with_inner_mut` (TestEntry
+// lacks the SsdSpiller/SsdHydrator bounds `ensure` needs). On a RAM-only run
+// `active_layout_key() == 0`, so the engine's seed is `FNV_OFFSET ^
+// kv_quant.cache_key_salt()` — `TestEntry::for_quant` salts its block hashes to
+// match, and tags the entry with that same quant so the quant-guard accepts it.
+
+/// The runtime KV quant used for every consume test (entries are salted +
+/// tagged to match via `TestEntry::for_quant`).
+const TEST_QUANT: KvQuant = KvQuant::K8V8;
+
+/// Compact discriminant of a `Consumed` for golden-pair assertions.
+#[derive(Debug, PartialEq, Eq)]
+enum ConsumedTag {
+    Exact,
+    Reuse(ReuseKind),
+    Miss,
+}
+
+fn tag<E>(c: &Consumed<E>) -> ConsumedTag {
+    match c {
+        Consumed::Exact(_) => ConsumedTag::Exact,
+        Consumed::Reuse { kind, .. } => ConsumedTag::Reuse(*kind),
+        Consumed::Miss => ConsumedTag::Miss,
+    }
+}
+
+/// Install a single pushed entry into a fresh `ArchPromptCache` and run consume.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: the cache is installed inside the same closure just above each use"
+)]
+fn consume_one(
+    policy: ReusePolicy,
+    pushed: TestEntry,
+    prompt_ids: &[u32],
+    has_image: bool,
+) -> (ArchPromptCache<TestEntry>, Consumed<TestEntry>) {
+    let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", policy);
+    arch.with_inner_mut(|g| {
+        *g = Some(PromptCache::new(4));
+        g.as_mut().unwrap().push(pushed);
+    });
+    let out = arch.consume(prompt_ids, TEST_QUANT, has_image);
+    (arch, out)
+}
+
+/// RAM exact hit: stored ids == request ids, not hydrated → `Exact`.
+#[test]
+fn consume_exact_ram_entry() {
+    let prompt = make_ids(2 * BLOCK_TOKENS);
+    let (_arch, out) = consume_one(
+        ReusePolicy::ExactOnly,
+        TestEntry::for_quant(prompt.clone(), TEST_QUANT),
+        &prompt,
+        false,
+    );
+    assert_eq!(tag(&out), ConsumedTag::Exact);
+}
+
+/// #87 path: a hydrated entry whose ids exactly equal the request (block-aligned,
+/// no tail) must be `Miss` — the Exact arm excludes hydrated entries (placeholder
+/// first_id) and the reuse hook's strict-less guard excludes equal-length.
+#[test]
+fn consume_hydrated_equal_length_is_miss() {
+    let prompt = make_ids(2 * BLOCK_TOKENS);
+    // Moe-style hook would only return StrictPrefix when stored.len() <
+    // prompt.len(); equal-length yields None here regardless. Configure a
+    // StrictPrefix reuse_kind to prove even a permissive hook can't rescue the
+    // equal-length hydrated entry (the engine never reaches reuse for it).
+    let entry = TestEntry::for_quant(prompt.clone(), TEST_QUANT)
+        .with_ssd_hydrated(true)
+        .with_reuse_kind(ReuseKind::StrictPrefix {
+            prefix_len: prompt.len(),
+        });
+    let (_arch, out) = consume_one(ReusePolicy::ExactOnly, entry, &prompt, false);
+    assert_eq!(tag(&out), ConsumedTag::Miss);
+}
+
+/// ExactOnly forbids a fresh (non-hydrated) partial match → `Miss`, even if the
+/// hook would otherwise offer a StrictPrefix (the gate never calls it).
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "test-only: slice bound is a literal block multiple <= the just-built prompt length"
+)]
+fn consume_exactonly_fresh_partial_is_miss() {
+    let cached = make_ids(4 * BLOCK_TOKENS);
+    // Request shares the first 3 blocks then diverges.
+    let mut req = cached[..3 * BLOCK_TOKENS].to_vec();
+    req.extend(50_000..50_000 + BLOCK_TOKENS as u32);
+    let entry = TestEntry::for_quant(cached, TEST_QUANT).with_reuse_kind(ReuseKind::StrictPrefix {
+        prefix_len: 3 * BLOCK_TOKENS,
+    });
+    let (_arch, out) = consume_one(ReusePolicy::ExactOnly, entry, &req, false);
+    assert_eq!(tag(&out), ConsumedTag::Miss);
+}
+
+/// ExactOnly STILL permits a hydrated strict-prefix (the moe HydratedTail) →
+/// `Reuse{StrictPrefix}`.
+#[test]
+fn consume_exactonly_hydrated_strict_prefix_is_reuse() {
+    let stored = make_ids(2 * BLOCK_TOKENS);
+    let mut req = stored.clone();
+    req.extend(70_000..70_000 + BLOCK_TOKENS as u32);
+    let entry = TestEntry::for_quant(stored.clone(), TEST_QUANT)
+        .with_ssd_hydrated(true)
+        .with_reuse_kind(ReuseKind::StrictPrefix {
+            prefix_len: stored.len(),
+        });
+    let (_arch, out) = consume_one(ReusePolicy::ExactOnly, entry, &req, false);
+    assert_eq!(
+        tag(&out),
+        ConsumedTag::Reuse(ReuseKind::StrictPrefix {
+            prefix_len: 2 * BLOCK_TOKENS,
+        })
+    );
+    // The Reuse carries the cloned entry (its prefix tokens), which the arch
+    // forwards a tail on top of. Assert the clone preserved the stored prefix.
+    if let Consumed::Reuse { entry, .. } = out {
+        assert_eq!(
+            entry.prompt_token_ids(),
+            stored.as_slice(),
+            "the reused clone must carry the stored prefix tokens"
+        );
+    } else {
+        panic!("asserted Reuse above");
+    }
+}
+
+/// Partial policy permits a fresh (non-hydrated) prefix reuse via the hook.
+/// Here the hook returns BlockTruncate → `Reuse{BlockTruncate}`.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "test-only: slice bound is a literal block multiple <= the just-built prompt length"
+)]
+fn consume_partial_fresh_prefix_is_reuse() {
+    let cached = make_ids(4 * BLOCK_TOKENS);
+    let mut req = cached[..3 * BLOCK_TOKENS].to_vec();
+    req.extend(80_000..80_000 + BLOCK_TOKENS as u32);
+    let entry =
+        TestEntry::for_quant(cached, TEST_QUANT).with_reuse_kind(ReuseKind::BlockTruncate {
+            effective_blocks: 3,
+        });
+    let (_arch, out) = consume_one(ReusePolicy::Partial, entry, &req, false);
+    assert_eq!(
+        tag(&out),
+        ConsumedTag::Reuse(ReuseKind::BlockTruncate {
+            effective_blocks: 3
+        })
+    );
+}
+
+/// Partial policy with an incomplete hydrated entry (gemma4 SWA payload-less
+/// layer) → `Miss` via `is_hydrate_complete == false`, even though the hook
+/// would offer a StrictPrefix.
+#[test]
+fn consume_incomplete_hydrate_partial_is_miss() {
+    let stored = make_ids(2 * BLOCK_TOKENS);
+    let mut req = stored.clone();
+    req.extend(90_000..90_000 + BLOCK_TOKENS as u32);
+    let entry = TestEntry::for_quant(stored.clone(), TEST_QUANT)
+        .with_ssd_hydrated(true)
+        .with_hydrate_complete(false)
+        .with_reuse_kind(ReuseKind::StrictPrefix {
+            prefix_len: stored.len(),
+        });
+    let (_arch, out) = consume_one(ReusePolicy::Partial, entry, &req, false);
+    assert_eq!(tag(&out), ConsumedTag::Miss);
+}
+
+/// `has_image == true` → `Miss` WITHOUT touching the cache: a pre-existing exact
+/// entry must survive (not evicted), so a later text request still hits it.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: cache installed in the same closure just above"
+)]
+fn consume_has_image_is_miss_no_cache_touch() {
+    let prompt = make_ids(2 * BLOCK_TOKENS);
+    let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::ExactOnly);
+    arch.with_inner_mut(|g| {
+        *g = Some(PromptCache::new(4));
+        g.as_mut()
+            .unwrap()
+            .push(TestEntry::for_quant(prompt.clone(), TEST_QUANT));
+    });
+
+    // Image request: Miss, and the cache is not consulted/evicted.
+    let img = arch.consume(&prompt, TEST_QUANT, true);
+    assert_eq!(tag(&img), ConsumedTag::Miss);
+    let slots = arch.with_inner_mut(|g| g.as_ref().unwrap().slots.len());
+    assert_eq!(slots, 1, "image request must not evict the existing entry");
+
+    // The surviving entry is still served as Exact to a text request.
+    let txt = arch.consume(&prompt, TEST_QUANT, false);
+    assert_eq!(tag(&txt), ConsumedTag::Exact);
+}
+
+/// Sub-one-block prompt → always `Miss` (find_best_prefix needs ≥1 full block).
+#[test]
+fn consume_short_prompt_under_one_block_is_miss() {
+    let short = make_ids(BLOCK_TOKENS - 1);
+    let (_arch, out) = consume_one(
+        ReusePolicy::ExactOnly,
+        TestEntry::for_quant(short.clone(), TEST_QUANT),
+        &short,
+        false,
+    );
+    assert_eq!(tag(&out), ConsumedTag::Miss);
+}
+
+/// Guard contract: consume is never called for an empty prompt (the arch
+/// early-returns on `n_tokens == 0` before `ensure_prompt_cache`). We still pin
+/// that an empty prompt yields `Miss` if it ever reaches the engine, so the
+/// guard is the only place that decides "no generation."
+#[test]
+fn consume_empty_after_guard() {
+    let empty: Vec<u32> = Vec::new();
+    let (_arch, out) = consume_one(
+        ReusePolicy::ExactOnly,
+        TestEntry::for_quant(make_ids(2 * BLOCK_TOKENS), TEST_QUANT),
+        &empty,
+        false,
+    );
+    assert_eq!(tag(&out), ConsumedTag::Miss);
+}
+
+/// Quant-mismatch degrade: the stored entry's quant differs from the runtime
+/// quant → evict + `Miss`. The entry is salted for `K8V4` but queried at the
+/// `TEST_QUANT` (`K8V8`) seed, so it would already miss the block-hash match;
+/// to isolate the quant-guard we salt with the RUNTIME seed but tag a different
+/// stored quant so the match fires and the guard rejects it.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: cache installed in the same closure just above"
+)]
+fn consume_quant_mismatch_evicts_and_misses() {
+    let prompt = make_ids(2 * BLOCK_TOKENS);
+    // Salt with the runtime seed so find_best_prefix matches, but tag a DIFFERENT
+    // stored quant so the quant-guard rejects it.
+    let runtime_seed = FNV_OFFSET ^ TEST_QUANT.cache_key_salt();
+    let mut entry = TestEntry::new_seeded(prompt.clone(), runtime_seed);
+    entry.kv_quant = Some(KvQuant::K8V4); // != TEST_QUANT (K8V8)
+
+    let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::ExactOnly);
+    arch.with_inner_mut(|g| {
+        *g = Some(PromptCache::new(4));
+        g.as_mut().unwrap().push(entry);
+    });
+    let out = arch.consume(&prompt, TEST_QUANT, false);
+    assert_eq!(tag(&out), ConsumedTag::Miss);
+    let slots = arch.with_inner_mut(|g| g.as_ref().unwrap().slots.len());
+    assert_eq!(slots, 0, "quant-mismatch must evict the unusable slot");
+}
+
+// ── degrade-trace coverage ───────────────────────────────────────────────────
+//
+// Every consume degrade branch must emit exactly one `debug!{branch=...}` so a
+// silent-drop regression (the qwen3/moe arms were silent before unification)
+// fails this test rather than passing every other one. A `tracing-subscriber`
+// fmt layer writes events to a shared buffer; we parse the `branch="..."` field.
+
+/// A `MakeWriter` that appends all formatted log output to a shared buffer.
+#[derive(Clone)]
+struct BufWriter {
+    buf: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+}
+
+impl std::io::Write for BufWriter {
+    #[allow(
+        clippy::unwrap_used,
+        reason = "test-only: the capture Mutex is never poisoned"
+    )]
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        self.buf.lock().unwrap().extend_from_slice(data);
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufWriter {
+    type Writer = BufWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Run `f` with a DEBUG-level fmt subscriber capturing to a buffer; return the
+/// list of `branch` field values across all captured events, in order.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: the capture Mutex is never poisoned; the captured UTF-8 is valid fmt output"
+)]
+#[allow(
+    clippy::clone_on_ref_ptr,
+    reason = "intentional Arc::clone — explicit form aids grep for shared-ownership transfer sites"
+)]
+fn capture_branches(f: impl FnOnce()) -> Vec<String> {
+    let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+    let writer = BufWriter { buf: buf.clone() };
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_writer(writer)
+        .with_ansi(false)
+        .finish();
+    tracing::subscriber::with_default(subscriber, f);
+
+    let text = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    // Parse `branch="value"` (fmt renders string fields quoted).
+    let mut branches = Vec::new();
+    for line in text.lines() {
+        if let Some(start) = line.find("branch=\"") {
+            let rest = &line[start + "branch=\"".len()..];
+            if let Some(end) = rest.find('"') {
+                branches.push(rest[..end].to_owned());
+            }
+        }
+    }
+    branches
+}
+
+/// Each degrade path emits exactly one `debug!{branch=...}` with the expected
+/// branch name. The set covers: has_image, quant_mismatch, incomplete_hydrate,
+/// non_reusable, hydrated_declined_to_exact.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: caches installed in the same closures just above each consume"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "test-only: slice bound is a literal block multiple <= the just-built prompt length"
+)]
+fn consume_degrade_branches_each_emit_one_debug() {
+    let prompt = make_ids(2 * BLOCK_TOKENS);
+
+    // has_image → branch "has_image", no cache touch.
+    let b = capture_branches(|| {
+        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::ExactOnly);
+        arch.with_inner_mut(|g| *g = Some(PromptCache::new(4)));
+        let _ = arch.consume(&prompt, TEST_QUANT, true);
+    });
+    assert_eq!(b, vec!["has_image".to_owned()], "has_image: one debug");
+
+    // quant_mismatch → branch "quant_mismatch".
+    let b = capture_branches(|| {
+        let runtime_seed = FNV_OFFSET ^ TEST_QUANT.cache_key_salt();
+        let mut entry = TestEntry::new_seeded(prompt.clone(), runtime_seed);
+        entry.kv_quant = Some(KvQuant::K8V4);
+        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::ExactOnly);
+        arch.with_inner_mut(|g| {
+            *g = Some(PromptCache::new(4));
+            g.as_mut().unwrap().push(entry);
+        });
+        let _ = arch.consume(&prompt, TEST_QUANT, false);
+    });
+    assert_eq!(
+        b,
+        vec!["quant_mismatch".to_owned()],
+        "quant_mismatch: one debug"
+    );
+
+    // incomplete_hydrate (Partial, hydrated, incomplete) → branch "incomplete_hydrate".
+    let b = capture_branches(|| {
+        let mut req = prompt.clone();
+        req.extend(11_000..11_000 + BLOCK_TOKENS as u32);
+        let entry = TestEntry::for_quant(prompt.clone(), TEST_QUANT)
+            .with_ssd_hydrated(true)
+            .with_hydrate_complete(false)
+            .with_reuse_kind(ReuseKind::StrictPrefix {
+                prefix_len: prompt.len(),
+            });
+        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::Partial);
+        arch.with_inner_mut(|g| {
+            *g = Some(PromptCache::new(4));
+            g.as_mut().unwrap().push(entry);
+        });
+        let _ = arch.consume(&req, TEST_QUANT, false);
+    });
+    assert_eq!(
+        b,
+        vec!["incomplete_hydrate".to_owned()],
+        "incomplete_hydrate: one debug"
+    );
+
+    // non_reusable (Partial, fresh partial, hook returns None) → branch "non_reusable".
+    let b = capture_branches(|| {
+        let cached = make_ids(4 * BLOCK_TOKENS);
+        let mut req = cached[..3 * BLOCK_TOKENS].to_vec();
+        req.extend(60_000..60_000 + BLOCK_TOKENS as u32);
+        // No reuse_kind set → hook returns None → non_reusable degrade.
+        let entry = TestEntry::for_quant(cached, TEST_QUANT);
+        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::Partial);
+        arch.with_inner_mut(|g| {
+            *g = Some(PromptCache::new(4));
+            g.as_mut().unwrap().push(entry);
+        });
+        let _ = arch.consume(&req, TEST_QUANT, false);
+    });
+    assert_eq!(
+        b,
+        vec!["non_reusable".to_owned()],
+        "non_reusable: one debug"
+    );
+
+    // hydrated_declined_to_exact (ExactOnly, fresh non-hydrated partial match
+    // that is neither token-equal nor reuse-permitted) → branch
+    // "hydrated_declined_to_exact".
+    let b = capture_branches(|| {
+        let cached = make_ids(4 * BLOCK_TOKENS);
+        let mut req = cached[..3 * BLOCK_TOKENS].to_vec();
+        req.extend(61_000..61_000 + BLOCK_TOKENS as u32);
+        let entry = TestEntry::for_quant(cached, TEST_QUANT);
+        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::ExactOnly);
+        arch.with_inner_mut(|g| {
+            *g = Some(PromptCache::new(4));
+            g.as_mut().unwrap().push(entry);
+        });
+        let _ = arch.consume(&req, TEST_QUANT, false);
+    });
+    assert_eq!(
+        b,
+        vec!["hydrated_declined_to_exact".to_owned()],
+        "hydrated_declined_to_exact: one debug"
+    );
+
+    // #87 hydrated equal-length: reuse-eligible (complete) but the hook declines
+    // (strict-less guard) → branch "non_reusable" (one debug). This is the
+    // equal-length-hydrated Miss path.
+    let b = capture_branches(|| {
+        let entry = TestEntry::for_quant(prompt.clone(), TEST_QUANT)
+            .with_ssd_hydrated(true)
+            .with_reuse_kind(ReuseKind::StrictPrefix {
+                prefix_len: prompt.len(),
+            });
+        let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test", ReusePolicy::ExactOnly);
+        arch.with_inner_mut(|g| {
+            *g = Some(PromptCache::new(4));
+            g.as_mut().unwrap().push(entry);
+        });
+        let _ = arch.consume(&prompt, TEST_QUANT, false);
+    });
+    assert_eq!(
+        b,
+        vec!["non_reusable".to_owned()],
+        "#87 hydrated equal-length declines via non_reusable: one debug"
     );
 }

--- a/crates/rmlx-models/src/qwen2/generate.rs
+++ b/crates/rmlx-models/src/qwen2/generate.rs
@@ -19,10 +19,14 @@ use rmlx_mlx::{argmax, Array, Device, Dtype};
 
 use crate::constraint::ConstraintEngine;
 use crate::kv_cache::{kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N};
+use crate::prompt_cache::{chained_block_hashes_seeded, Consumed, ReusePolicy, FNV_OFFSET};
 use crate::sampler::apply_mask_argmax;
 use rmlx_kv_quant::{KvCache, KV_MAX_SEQ_DEFAULT};
 
 use super::model::Qwen2Text;
+use super::prompt_cache::{
+    active_layout_key, ensure_prompt_cache, store_kv_cache_bytes, Qwen2Entry, PROMPT_CACHE,
+};
 
 // ---------------------------------------------------------------------------
 // Smoke probe — generate_greedy
@@ -83,6 +87,12 @@ fn max_abs_from_bytes(bytes: &[u8], dtype: Dtype) -> f32 {
 /// Greedy autoregressive generation using KV-cache prefill + decode.
 ///
 /// Returns `Vec<ProbeStep>` — same shape as `gemma4::generate_greedy`.
+///
+/// `prompt_cache_slots` — number of post-prefill KV snapshots kept across
+/// requests. Pass 1 for single-slot; pass N for multi-slot prefix matching.
+/// Recommended: 4. Only the Exact hit path is active (identical-prompt repeat
+/// skips re-prefill entirely, same `ReusePolicy::ExactOnly` contract as Qwen3
+/// dense).
 #[allow(clippy::too_many_arguments)]
 #[allow(
     clippy::indexing_slicing,
@@ -100,6 +110,7 @@ pub fn generate_greedy(
     device: Device,
     kv_quant: rmlx_kv_quant::KvQuant,
     max_ctx_override: Option<i32>,
+    prompt_cache_slots: usize,
     eos_ids: &[u32],
     step_fn: &mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
     // A6.2: optional sampler constraint. See gemma4::generate_greedy.
@@ -127,11 +138,100 @@ pub fn generate_greedy(
     let vocab = model.cfg.vocab_size as i32;
     let mut steps = Vec::with_capacity(n_tokens);
 
+    ensure_prompt_cache(prompt_cache_slots);
+
     // Decode profile timers. See gemma4::generate_greedy for rationale.
     let mut forward_total_ns: u128 = 0;
     let mut eval_total_ns: u128 = 0;
     let mut step_total_ns: u128 = 0;
     let mut decode_steps: u32 = 0;
+
+    // ------------------------------------------------------------------
+    // Prompt cache lookup via the shared consume() engine. Qwen2 is a dense
+    // pure-attention arch with no recurrent state and uses
+    // ReusePolicy::ExactOnly (it overrides none of the reuse hooks), so the only
+    // reachable outcomes are Exact (identical-prompt repeat skips re-prefill) and
+    // Miss (full re-prefill). The engine owns the find → SSD-hydrate retry →
+    // quant-mismatch guard → SSD-hydrated exclusion → Exact decision and traces
+    // every degrade branch. The ExactOnly policy tripwire lives here at the call
+    // site — not in the generic engine — because the engine is policy-agnostic
+    // and shared across architectures that may use different policies.
+    // ------------------------------------------------------------------
+    assert_eq!(
+        PROMPT_CACHE.policy(),
+        ReusePolicy::ExactOnly,
+        "Qwen2 prompt cache must be ExactOnly — pure-attention with no recurrent \
+         state and an Exact-hit-dominated workload; partial-prefix reuse is not wired",
+    );
+    // Qwen2 is text-only (no vision tower), so there is never an image prompt;
+    // the engine's has_image bypass is belt-and-suspenders.
+    let consumed = PROMPT_CACHE.consume(prompt_ids, kv_quant, false);
+
+    // Path A: exact cache hit — skip re-prefill, replay the stored first token,
+    // then run the shared decode loop on the cloned caches.
+    if let Consumed::Exact(cloned) = consumed {
+        let Qwen2Entry {
+            kv_caches: mut caches,
+            first_id: last_id,
+            first_piece: piece,
+            ..
+        } = cloned;
+        tracing::debug!(
+            prompt_len = prompt_ids.len(),
+            token_id = last_id,
+            "qwen2 generate_greedy: prompt cache EXACT HIT"
+        );
+        steps.push(ProbeStep {
+            token_id: last_id,
+            piece: piece.into_boxed_str(),
+            max_abs_logit: 0.0,
+            nan_count: 0,
+            logprobs: None,
+        });
+        step_fn(steps.last().unwrap());
+        token_history.push(last_id);
+
+        if eos_ids.contains(&last_id) {
+            return Ok(steps);
+        }
+
+        decode_loop(
+            model,
+            tokenizer,
+            &mut caches,
+            last_id,
+            n_tokens,
+            vocab,
+            device,
+            eos_ids,
+            &mut steps,
+            step_fn,
+            &mut constraint,
+            sampler_cfg,
+            rng,
+            penalty_cfg,
+            token_history,
+            &mut forward_total_ns,
+            &mut eval_total_ns,
+            &mut step_total_ns,
+            &mut decode_steps,
+        )?;
+
+        {
+            let kv_bytes: u64 = caches.iter().map(|c| c.resident_bytes()).sum();
+            store_kv_cache_bytes(kv_bytes);
+        }
+        log_decode_profile(
+            0.0,
+            forward_total_ns,
+            eval_total_ns,
+            step_total_ns,
+            decode_steps,
+        );
+        return Ok(steps);
+    }
+
+    // Path B (Miss): full re-prefill from scratch.
     let prefill_t0 = Instant::now();
 
     let max_seq = max_ctx_override.unwrap_or(KV_MAX_SEQ_DEFAULT);
@@ -291,7 +391,7 @@ pub fn generate_greedy(
 
     steps.push(ProbeStep {
         token_id: last_id,
-        piece: piece.into_boxed_str(),
+        piece: piece.clone().into_boxed_str(),
         max_abs_logit,
         nan_count,
         logprobs: None,
@@ -302,18 +402,140 @@ pub fn generate_greedy(
         return Ok(steps);
     }
 
+    // Push this prefill snapshot to the prompt cache (Miss → store). Clone the
+    // post-prefill KV caches (refcount bump, no data copy) before the decode
+    // loop starts writing new decode-step K/V into them. Materialize the GPU
+    // arrays on the current inference thread first so a later eviction on a
+    // different tokio/Metal thread can re-eval them as a no-op (see qwen3.rs).
+    {
+        let kv_bytes: u64 = caches.iter().map(|c| c.resident_bytes()).sum();
+        store_kv_cache_bytes(kv_bytes);
+        let cloned_caches: Result<Vec<KvCache>> =
+            caches.iter().map(|c| c.try_deep_clone()).collect();
+        if let Ok(kv_snapshot) = cloned_caches {
+            match kv_snapshot.iter().try_for_each(|c| c.eval_for_spill()) {
+                Ok(()) => {
+                    // Salt the chained block-hash walk with the active layout_key
+                    // + KV codec so a slot stored under a different codec / layout
+                    // never cross-serves. Identical to the consume() seed.
+                    let lk = active_layout_key();
+                    let block_hashes = chained_block_hashes_seeded(
+                        prompt_ids,
+                        FNV_OFFSET ^ lk ^ kv_quant.cache_key_salt(),
+                    );
+                    let entry = Qwen2Entry {
+                        prompt_token_ids: prompt_ids.to_vec(),
+                        block_hashes,
+                        kv_caches: kv_snapshot,
+                        first_id: last_id,
+                        // Last use of `piece` — move it (the prefill ProbeStep
+                        // above already consumed its own clone via into_boxed_str).
+                        first_piece: piece,
+                        kv_quant: Some(kv_quant),
+                        is_ssd_hydrated: false,
+                    };
+                    PROMPT_CACHE.with_inner_mut(|guard| {
+                        if let Some(cache) = guard.as_mut() {
+                            cache.push(entry);
+                            let stats = cache.stats();
+                            tracing::debug!(
+                                prompt_len = prompt_ids.len(),
+                                cache_hits = stats.hits,
+                                cache_misses = stats.misses,
+                                cache_bytes = stats.bytes,
+                                "qwen2 generate_greedy: pushed snapshot to prompt cache (miss path)"
+                            );
+                        }
+                    });
+                }
+                Err(e) => tracing::warn!(error = %e,
+                    "qwen2 generate_greedy: pre-eval of KV caches failed, skipping prompt cache store"),
+            }
+        }
+    }
+
     // EOS-stop. If prefill emitted an EOS already, no decode steps.
     if eos_ids.contains(&last_id) {
         return Ok(steps);
     }
 
-    // Decode: async_eval + single-slot pending pipeline (mirrors qwen3.rs).
-    // Each iteration dispatches step i+1's forward while step i's argmax
-    // materialises in the background. GPU sync only happens on the *previous*
-    // step's `pending` via `to_bytes()`. The `last_id` u32 is only used to
-    // build the initial Array for the very first decode step.
-    //
-    // EOS-stop after pending drain (see gemma4::generate_greedy).
+    decode_loop(
+        model,
+        tokenizer,
+        &mut caches,
+        last_id,
+        n_tokens,
+        vocab,
+        device,
+        eos_ids,
+        &mut steps,
+        step_fn,
+        &mut constraint,
+        sampler_cfg,
+        rng,
+        penalty_cfg,
+        token_history,
+        &mut forward_total_ns,
+        &mut eval_total_ns,
+        &mut step_total_ns,
+        &mut decode_steps,
+    )?;
+
+    log_decode_profile(
+        (prefill_total_ns as f64) / 1.0e6,
+        forward_total_ns,
+        eval_total_ns,
+        step_total_ns,
+        decode_steps,
+    );
+
+    Ok(steps)
+}
+
+/// Shared pipelined decode loop for both the Exact-hit and Miss paths.
+///
+/// `last_id` is the already-emitted step-0 token (prefill argmax or replayed
+/// cache first token); `steps` already holds its `ProbeStep`. This drives steps
+/// `1..n_tokens` with the single-slot async_eval pipeline and the final drain,
+/// accumulating decode timers into the caller's counters.
+///
+/// async_eval + single-slot pending pipeline (mirrors qwen3.rs). Each iteration
+/// dispatches step i+1's forward while step i's argmax materialises in the
+/// background; GPU sync only happens on the *previous* step's `pending` via
+/// `to_bytes()`. The `last_id` u32 is only used to build the initial Array for
+/// the very first decode step.
+#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: argmax byte slices are sized 4 by the I32 dtype; loop indices bounded by slice length"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Option/Result unwrap is on values established by construction earlier in this fn (pending pipeline / try_into on a 4-byte slice)"
+)]
+fn decode_loop(
+    model: &Qwen2Text,
+    tokenizer: &tokenizers::Tokenizer,
+    caches: &mut [KvCache],
+    last_id: u32,
+    n_tokens: usize,
+    vocab: i32,
+    device: Device,
+    eos_ids: &[u32],
+    steps: &mut Vec<crate::decode_loop::ProbeStep>,
+    step_fn: &mut dyn FnMut(&crate::decode_loop::ProbeStep) -> Option<u32>,
+    constraint: &mut Option<&mut dyn ConstraintEngine>,
+    sampler_cfg: &crate::sampler::SamplerConfig,
+    rng: &mut crate::sampler::Pcg32,
+    penalty_cfg: &crate::sampler::PenaltyConfig,
+    token_history: &mut Vec<u32>,
+    forward_total_ns: &mut u128,
+    eval_total_ns: &mut u128,
+    step_total_ns: &mut u128,
+    decode_steps: &mut u32,
+) -> Result<()> {
+    use crate::decode_loop::ProbeStep;
+
     let mut y: Array = {
         let id_i32 = last_id as i32;
         let bytes = id_i32.to_le_bytes();
@@ -326,7 +548,7 @@ pub fn generate_greedy(
     for step_idx in 1..n_tokens {
         let step_t0 = Instant::now();
         let fwd_t0 = Instant::now();
-        let decode_logits = match model.forward_arr(&y, 1, Some(&mut caches), device) {
+        let decode_logits = match model.forward_arr(&y, 1, Some(&mut *caches), device) {
             Ok(l) => l,
             Err(e) => {
                 tracing::warn!(
@@ -345,7 +567,7 @@ pub fn generate_greedy(
         // argmax dtype + pipelining are bit-identical to the no-constraint
         // path. `advance()` is still called from the post-drain branch so
         // warm-up engagement detection works.
-        let mask_active = constraint.as_ref().is_some_and(|c| c.wants_mask());
+        let mask_active = constraint.as_deref().is_some_and(|c| c.wants_mask());
         // A7.2: temp>0 reads logits to host each step (no async pipelining
         // benefit), so it shares the masked branch's pre-drain. temp<=0
         // keeps the exact `mask_active`-gated pipelined path byte-for-byte.
@@ -364,7 +586,7 @@ pub fn generate_greedy(
             if let Some(p) = pending.take() {
                 let top_bytes = p.to_bytes()?;
                 let next_id = i32::from_le_bytes(top_bytes[..4].try_into().unwrap()) as u32;
-                if let Some(c) = constraint.as_mut() {
+                if let Some(c) = constraint.as_deref_mut() {
                     c.advance(next_id);
                 }
                 // A7.3: accumulate emitted token into history.
@@ -406,7 +628,7 @@ pub fn generate_greedy(
         let recent = &token_history[win_start..];
         let next_y = if sampling_active {
             let mask_opt: Option<&[bool]> = if mask_active {
-                Some(constraint.as_mut().unwrap().step_mask(vocab as usize))
+                Some(constraint.as_deref_mut().unwrap().step_mask(vocab as usize))
             } else {
                 None
             };
@@ -422,7 +644,7 @@ pub fn generate_greedy(
         } else {
             if penalties_active {
                 let mask_opt: Option<&[bool]> = if mask_active {
-                    Some(constraint.as_mut().unwrap().step_mask(vocab as usize))
+                    Some(constraint.as_deref_mut().unwrap().step_mask(vocab as usize))
                 } else {
                     None
                 };
@@ -434,7 +656,7 @@ pub fn generate_greedy(
                     device,
                 )?
             } else if mask_active {
-                let c = constraint.as_mut().unwrap();
+                let c = constraint.as_deref_mut().unwrap();
                 let m = c.step_mask(vocab as usize);
                 apply_mask_argmax(&logits_flat, m, device)?
             } else {
@@ -452,7 +674,7 @@ pub fn generate_greedy(
             if let Some(p) = pending.take() {
                 let top_bytes = p.to_bytes()?;
                 let next_id = i32::from_le_bytes(top_bytes[..4].try_into().unwrap()) as u32;
-                if let Some(c) = constraint.as_mut() {
+                if let Some(c) = constraint.as_deref_mut() {
                     c.advance(next_id);
                 }
                 // A7.3: accumulate pipelined token into history.
@@ -479,10 +701,10 @@ pub fn generate_greedy(
         }
         let eval_dt = eval_t0.elapsed().as_nanos();
 
-        forward_total_ns += fwd_dt_total;
-        eval_total_ns += eval_dt;
-        step_total_ns += step_t0.elapsed().as_nanos();
-        decode_steps += 1;
+        *forward_total_ns += fwd_dt_total;
+        *eval_total_ns += eval_dt;
+        *step_total_ns += step_t0.elapsed().as_nanos();
+        *decode_steps += 1;
 
         if emitted_eos {
             early_stop = true;
@@ -507,7 +729,7 @@ pub fn generate_greedy(
             let drain_t0 = Instant::now();
             p.eval()?;
             let top_bytes = p.to_bytes()?;
-            eval_total_ns += drain_t0.elapsed().as_nanos();
+            *eval_total_ns += drain_t0.elapsed().as_nanos();
             let next_id = i32::from_le_bytes(top_bytes[..4].try_into().unwrap()) as u32;
             if let Some(c) = constraint.as_mut() {
                 c.advance(next_id);
@@ -528,7 +750,19 @@ pub fn generate_greedy(
         }
     }
 
-    let prefill_ms = (prefill_total_ns as f64) / 1.0e6;
+    Ok(())
+}
+
+/// Emit the `decode_profile` info event for one generate call.
+///
+/// `prefill_ms` is `0.0` on the Exact-hit path (no prefill ran).
+fn log_decode_profile(
+    prefill_ms: f64,
+    forward_total_ns: u128,
+    eval_total_ns: u128,
+    step_total_ns: u128,
+    decode_steps: u32,
+) {
     let forward_ms = (forward_total_ns as f64) / 1.0e6;
     let eval_ms = (eval_total_ns as f64) / 1.0e6;
     let step_ms = (step_total_ns as f64) / 1.0e6;
@@ -545,6 +779,4 @@ pub fn generate_greedy(
         eval_per_step_ms = eval_ms / n,
         "decode_profile"
     );
-
-    Ok(steps)
 }

--- a/crates/rmlx-models/src/qwen2/mod.rs
+++ b/crates/rmlx-models/src/qwen2/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod config;
 pub(crate) mod generate;
 pub(crate) mod loader;
 pub(crate) mod model;
+pub(crate) mod prompt_cache;
 
 #[cfg(test)]
 mod tests;
@@ -29,3 +30,5 @@ pub use config::Qwen2Config;
 pub use generate::generate_greedy;
 pub use loader::load_from_path;
 pub use model::Qwen2Text;
+pub use prompt_cache::read_cache_stats as qwen2_cache_stats;
+pub use prompt_cache::read_kv_cache_bytes as qwen2_kv_cache_bytes;

--- a/crates/rmlx-models/src/qwen2/prompt_cache.rs
+++ b/crates/rmlx-models/src/qwen2/prompt_cache.rs
@@ -1,0 +1,207 @@
+//! Qwen2 prompt-cache entry + global.
+//!
+//! The heavy lifting (static cache, SSD attach/install, ensure, stats readback,
+//! last-bytes counter, and the find → SSD-hydrate retry → quant-guard → Exact →
+//! Miss consume decision) is unified in
+//! [`crate::prompt_cache::ArchPromptCache`]. This file keeps only the genuinely
+//! Qwen2-specific bits:
+//!
+//! - `Qwen2Entry`: `Vec<KvCache>` only (pure-attention dense arch, no
+//!   GatedDeltaNet / linear-attention recurrent state — the entry is the same
+//!   shape as Qwen3 dense minus the qwen3-only `first_logprobs`).
+//! - `impl PromptCacheEntry for Qwen2Entry`: deep_clone + KV accessors. All
+//!   three reuse hooks (`is_hydrate_complete`, `is_reusable_prefix_of`,
+//!   `prepare_reuse`) take the trait defaults, which give correct
+//!   [`ReusePolicy::ExactOnly`] behaviour: a non-hydrated partial match is never
+//!   reusable, and the only reuse the engine permits (a hydrated strict-prefix)
+//!   is declined here (`is_reusable_prefix_of` → `None`), so the only reachable
+//!   consume outcomes are `Exact` and `Miss`.
+//! - `impl SsdHydrate<Qwen2Entry> for SsdHydrator`: pure-attention hydrate (the
+//!   reconstructed block carries `kv_caches` only; `lin_caches` is discarded).
+//!   The SSD spill path is the blanket `SpillSink<E> for SsdSpiller` in
+//!   `crate::prompt_cache`, which spills `kv_caches()` only for a pure-attention
+//!   entry (`lin_caches()` is `&[]`).
+//!
+//! ## Reuse policy — Exact-only
+//!
+//! Qwen2 uses [`ReusePolicy::ExactOnly`]. Like Qwen3 dense it is pure-attention
+//! with losslessly trimmable KV, so a partial-prefix path would be technically
+//! safe; but the dominant workload is the Exact-hit warm-TTFT (identical-prompt
+//! repeat skips re-prefill entirely), and keeping the single Exact / Miss arm
+//! set is simpler and matches the Qwen3 dense policy.
+
+#![allow(clippy::redundant_closure_for_method_calls)]
+use rmlx_core::error::Result;
+
+use crate::prompt_cache::{ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate};
+use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
+use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
+
+// ---------------------------------------------------------------------------
+// Entry type
+// ---------------------------------------------------------------------------
+
+/// Post-prefill snapshot for one Qwen2 request.
+///
+/// Pure-attention dense arch: only `kv_caches` needs snapshotting (no GDN
+/// recurrent state). Same shape as `Qwen3Entry` minus the qwen3-only
+/// `first_logprobs`.
+pub(crate) struct Qwen2Entry {
+    /// Full prompt token IDs used to fill this slot.
+    pub(crate) prompt_token_ids: Vec<u32>,
+    /// Chained 256-token block digests of `prompt_token_ids` (trailing partial
+    /// block excluded). Computed at construction.
+    pub(crate) block_hashes: Vec<u64>,
+    /// Post-prefill KV caches (one per decoder layer).
+    pub(crate) kv_caches: Vec<KvCache>,
+    /// Argmax token from the first decode step after prefill.
+    pub(crate) first_id: u32,
+    /// Decoded piece for `first_id`.
+    pub(crate) first_piece: String,
+    /// Runtime `KvQuant` discriminant in effect when this snapshot was written.
+    /// Read by the engine's quant-mismatch guard and by the blanket spill path.
+    pub(crate) kv_quant: Option<KvQuant>,
+    /// True when this entry was reconstructed from the SSD tier and therefore
+    /// stores only the block-aligned prefix KV — `first_id` / `first_piece` are
+    /// placeholders, not a real decode token. The consume engine excludes such
+    /// an entry from the Exact fast path so it falls through to a full
+    /// re-prefill that recomputes the real first token.
+    ///
+    /// MUST be set only in `SsdHydrate::hydrate`; never by the RAM-cache push
+    /// path. Do NOT use the `first_id == 0` heuristic as a substitute —
+    /// `<bos>` token id is 0 for some models.
+    pub(crate) is_ssd_hydrated: bool,
+}
+
+impl PromptCacheEntry for Qwen2Entry {
+    fn prompt_token_ids(&self) -> &[u32] {
+        &self.prompt_token_ids
+    }
+
+    fn block_hashes(&self) -> &[u64] {
+        &self.block_hashes
+    }
+
+    fn deep_clone(&self) -> Result<Self> {
+        let kv_caches: Result<Vec<_>> = self.kv_caches.iter().map(|c| c.try_deep_clone()).collect();
+        Ok(Self {
+            prompt_token_ids: self.prompt_token_ids.clone(),
+            block_hashes: self.block_hashes.clone(),
+            kv_caches: kv_caches?,
+            first_id: self.first_id,
+            first_piece: self.first_piece.clone(),
+            kv_quant: self.kv_quant,
+            is_ssd_hydrated: self.is_ssd_hydrated,
+        })
+    }
+
+    fn kv_caches(&self) -> &[KvCache] {
+        &self.kv_caches
+    }
+
+    fn kv_caches_mut(&mut self) -> &mut [KvCache] {
+        &mut self.kv_caches
+    }
+
+    fn kv_quant(&self) -> Option<KvQuant> {
+        self.kv_quant
+    }
+
+    fn is_ssd_hydrated(&self) -> bool {
+        self.is_ssd_hydrated
+    }
+
+    // Pure-attention dense arch: no GDN linear state.
+    fn lin_caches(&self) -> &[LinearAttnCache] {
+        &[]
+    }
+    // is_hydrate_complete / is_reusable_prefix_of / prepare_reuse: trait
+    // defaults. The defaults give correct ExactOnly behaviour (complete by
+    // construction, no partial reuse, deep_clone on the unreachable reuse path).
+    // truncate_kv_to / truncate_kv_to_block / kv_bytes: trait defaults.
+}
+
+// ---------------------------------------------------------------------------
+// SSD-spill sink — the blanket `impl SpillSink<E> for SsdSpiller` in
+// `crate::prompt_cache` covers Qwen2 (pure-attention: `lin_caches()` is `&[]`,
+// so the spill job carries `kv_caches` only).
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// SSD-hydrate source
+// ---------------------------------------------------------------------------
+
+/// Hydrate a `Qwen2Entry` from the SSD tier on a RAM-cache miss.
+///
+/// Pure-attention arch: the reconstructed block carries `kv_caches` only (the
+/// `lin_caches` from the block are discarded). The matched block-aligned prefix
+/// token IDs become the entry's `prompt_token_ids`; block hashes are recomputed
+/// and the runtime `kv_quant` recorded. `first_id` / `first_piece` are sentinels
+/// (the SSD block stores no first decode token), so the entry is flagged
+/// `is_ssd_hydrated = true`; the consume engine excludes it from the Exact fast
+/// path and the generate loop recomputes the real first token via re-prefill.
+impl SsdHydrate<Qwen2Entry> for SsdHydrator {
+    fn hydrate(&self, prompt_ids: &[u32]) -> Result<Option<Qwen2Entry>> {
+        let Some((block, block_hashes)) = self.lookup_seeded(prompt_ids)? else {
+            return Ok(None);
+        };
+        let HydratedBlock {
+            prompt_ids,
+            kv_caches,
+            lin_caches: _, // pure-attention arch has no GDN state
+        } = block;
+        Ok(Some(Qwen2Entry {
+            prompt_token_ids: prompt_ids,
+            block_hashes,
+            kv_caches,
+            first_id: 0,
+            first_piece: String::new(),
+            kv_quant: Some(self.kv_quant()),
+            // Block-aligned prefix only; the placeholder first_id must not be
+            // replayed — the generate loop re-prefills to recompute it.
+            is_ssd_hydrated: true,
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global cache instance — unified ArchPromptCache shell.
+// ---------------------------------------------------------------------------
+
+/// per-arch shell with `ReusePolicy::ExactOnly`. Qwen2 is pure-attention with
+/// no recurrent state; the dominant workload is the Exact-hit warm-TTFT, so the
+/// single Exact / Miss arm set (no partial reuse) is the policy — matching Qwen3
+/// dense.
+pub(crate) static PROMPT_CACHE: ArchPromptCache<Qwen2Entry> =
+    ArchPromptCache::new("Qwen2ForCausalLM", ReusePolicy::ExactOnly);
+
+/// active SSD-tier `layout_key` for the qwen2 cache, or `0` when the tier is
+/// OFF. `FNV_OFFSET ^ 0 == FNV_OFFSET` ⇒ legacy un-salted digests when no SSD
+/// tier is attached, preserving byte-identical RAM-only behaviour.
+pub(crate) fn active_layout_key() -> u64 {
+    PROMPT_CACHE.active_layout_key()
+}
+
+/// Ensure the global prompt cache is initialised with at least `capacity` slots.
+pub(crate) fn ensure_prompt_cache(capacity: usize) {
+    PROMPT_CACHE.ensure(capacity);
+}
+
+/// Read the current hit/miss/bytes stats for the Qwen2 prompt cache.
+pub fn read_cache_stats() -> Option<CacheStats> {
+    PROMPT_CACHE.read_cache_stats()
+}
+
+/// Read the KV-cache bytes from the last completed Qwen2 request.
+pub fn read_kv_cache_bytes() -> u64 {
+    PROMPT_CACHE.read_kv_cache_bytes()
+}
+
+/// Record the KV-cache byte total for the just-completed request.
+pub(crate) fn store_kv_cache_bytes(n: u64) {
+    PROMPT_CACHE.store_kv_cache_bytes(n);
+}
+
+#[cfg(test)]
+#[path = "prompt_cache_tests.rs"]
+mod tests;

--- a/crates/rmlx-models/src/qwen2/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/qwen2/prompt_cache_tests.rs
@@ -1,0 +1,119 @@
+//! In-process unit tests for the Qwen2 prompt cache.
+//!
+//! These exercise the parts that do not need a loaded model or a Metal GPU
+//! stream: the arch policy, the `Qwen2Entry` deep_clone round-trip over empty
+//! (never-prefilled) KV caches, and the SSD-hydrated entry field invariants
+//! (placeholder `first_id` + `is_ssd_hydrated` flag) the real-model SSD smoke
+//! relies on. Decoded-token reuse is proven by the real-model smoke, not here.
+
+use super::*;
+use rmlx_kv_quant::{KvCache, KvQuant};
+
+/// Build a `Qwen2Entry` with `n_layers` empty (never-prefilled) KV caches.
+///
+/// An empty cache holds no live GPU arrays, so `try_deep_clone` is a no-op
+/// refcount walk that runs without a Metal stream — safe in a plain unit test.
+fn mock_ram_entry(n_layers: usize, prompt: &[u32], first_id: u32) -> Qwen2Entry {
+    Qwen2Entry {
+        prompt_token_ids: prompt.to_vec(),
+        block_hashes: vec![0xABCD_u64; n_layers],
+        kv_caches: (0..n_layers)
+            .map(|_| KvCache::with_quant(KvQuant::None))
+            .collect(),
+        first_id,
+        first_piece: "hello".to_string(),
+        kv_quant: Some(KvQuant::None),
+        is_ssd_hydrated: false,
+    }
+}
+
+/// Qwen2's policy is hard-gated `ExactOnly`: the shared consume engine must
+/// only ever yield `Exact` or `Miss` for this arch (no partial-prefix reuse).
+#[test]
+fn arch_policy_is_exact_only() {
+    assert_eq!(PROMPT_CACHE.policy(), ReusePolicy::ExactOnly);
+}
+
+/// `deep_clone` copies every metadata field and produces an independent entry
+/// with the same KV-cache cardinality. (Empty caches carry no GPU data, so the
+/// clone is a refcount walk; this pins the field-copy contract.)
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: deep_clone over empty KV caches cannot fail — .expect documents the invariant"
+)]
+fn entry_deep_clone_preserves_fields() {
+    let prompt = [1_u32, 2, 3, 4];
+    let entry = mock_ram_entry(3, &prompt, 42);
+    let cloned = entry
+        .deep_clone()
+        .expect("deep_clone of empty-cache entry must succeed");
+
+    assert_eq!(cloned.prompt_token_ids, entry.prompt_token_ids);
+    assert_eq!(cloned.block_hashes, entry.block_hashes);
+    assert_eq!(cloned.kv_caches.len(), entry.kv_caches.len());
+    assert_eq!(cloned.first_id, 42);
+    assert_eq!(cloned.first_piece, "hello");
+    assert_eq!(cloned.kv_quant, Some(KvQuant::None));
+    assert!(!cloned.is_ssd_hydrated);
+}
+
+/// The `PromptCacheEntry` accessors expose the entry's fields verbatim. A
+/// pure-attention Qwen2 entry has no GDN recurrent state, so `lin_caches()` is
+/// empty — this is what makes the blanket `SpillSink` carry KV only.
+#[test]
+fn entry_accessors_match_fields() {
+    let prompt = [7_u32, 8, 9];
+    let entry = mock_ram_entry(2, &prompt, 5);
+
+    assert_eq!(entry.prompt_token_ids(), &prompt);
+    assert_eq!(entry.block_hashes(), &[0xABCD_u64, 0xABCD_u64]);
+    assert_eq!(entry.kv_caches().len(), 2);
+    assert_eq!(entry.kv_quant(), Some(KvQuant::None));
+    assert!(!entry.is_ssd_hydrated());
+    assert!(
+        entry.lin_caches().is_empty(),
+        "pure-attention arch has no GDN lin state"
+    );
+}
+
+/// A non-hydrated partial match is never reusable under ExactOnly: the default
+/// `is_reusable_prefix_of` hook returns `None` regardless of `matched_blocks`,
+/// so the consume engine can only reach `Exact` or `Miss`.
+#[test]
+fn non_hydrated_partial_is_not_reusable() {
+    let entry = mock_ram_entry(1, &[1, 2, 3], 0);
+    // A longer incoming prompt that the cached one is a prefix of: still None
+    // because the entry is not SSD-hydrated and the default hook declines.
+    assert!(entry
+        .is_reusable_prefix_of(&[1, 2, 3, 4, 5], false, 1)
+        .is_none());
+}
+
+/// An SSD-hydrated entry carries placeholder first-token fields (`first_id == 0`,
+/// empty `first_piece`) and the `is_ssd_hydrated` flag set, mirroring exactly
+/// what `SsdHydrate::hydrate` constructs. The consume engine excludes such an
+/// entry from the Exact fast path so the generate loop recomputes the real
+/// first token via re-prefill. Even as a strict prefix of a longer prompt it is
+/// declined here (the default hook returns `None`), so Qwen2 stays Exact-only.
+#[test]
+fn ssd_hydrated_entry_field_invariants() {
+    let hydrated = Qwen2Entry {
+        prompt_token_ids: vec![10, 11, 12],
+        block_hashes: vec![0xFEED_u64],
+        kv_caches: vec![KvCache::with_quant(KvQuant::None)],
+        first_id: 0,
+        first_piece: String::new(),
+        kv_quant: Some(KvQuant::None),
+        is_ssd_hydrated: true,
+    };
+
+    assert_eq!(hydrated.first_id, 0, "SSD block stores no real first token");
+    assert!(hydrated.first_piece.is_empty());
+    assert!(hydrated.is_ssd_hydrated());
+    // ExactOnly Qwen2 declines even a hydrated strict-prefix reuse (default
+    // hook → None), unlike the moe HydratedTail seam.
+    assert!(hydrated
+        .is_reusable_prefix_of(&[10, 11, 12, 13], true, 0)
+        .is_none());
+}

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -1860,8 +1860,16 @@ pub fn generate_greedy<'a>(
     // Exact (identical-prompt repeat skips re-prefill) and Miss (full
     // re-prefill). The engine owns the find → SSD-hydrate retry → quant-mismatch
     // guard → SSD-hydrated exclusion → Exact decision and traces every degrade
-    // branch; the policy tripwire moved into the engine, keyed on policy().
+    // branch. The ExactOnly policy tripwire lives here at the call site — not in
+    // the generic engine — because the engine is policy-agnostic and shared across
+    // architectures that may use different policies.
     // ------------------------------------------------------------------
+    assert_eq!(
+        QWEN3_PROMPT_CACHE.policy(),
+        ReusePolicy::ExactOnly,
+        "Qwen3 prompt cache must be ExactOnly — pure-attention with no GDN recurrent state \
+         cannot safely reuse a partial prefix whose residual state is not stored",
+    );
     let consumed = QWEN3_PROMPT_CACHE.consume(prompt_ids, kv_quant, false);
 
     // Path A: exact cache hit — skip re-prefill, jump straight to decode.

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -74,8 +74,8 @@ use crate::kv_cache::{
 use crate::layers::{resolve_quant, QuantParams};
 use crate::load_util::Weights;
 use crate::prompt_cache::{
-    chained_block_hashes_seeded, ArchPromptCache, PromptCacheEntry, ReusePolicy, SsdHydrate,
-    FNV_OFFSET,
+    chained_block_hashes_seeded, ArchPromptCache, Consumed, PromptCacheEntry, ReusePolicy,
+    SsdHydrate, FNV_OFFSET,
 };
 use crate::sampler::TokenLogprobs;
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
@@ -1854,114 +1854,30 @@ pub fn generate_greedy<'a>(
     ensure_qwen3_prompt_cache(prompt_cache_slots);
 
     // ------------------------------------------------------------------
-    // Prompt cache lookup — Exact hit path only (Qwen3 pure-attention,
-    // no GDN recurrent state). Identical-prompt repeat skips re-prefill.
+    // Prompt cache lookup via the shared consume() engine. Qwen3 dense is
+    // pure-attention with no GDN recurrent state and uses ReusePolicy::ExactOnly
+    // (it overrides none of the reuse hooks), so the only reachable outcomes are
+    // Exact (identical-prompt repeat skips re-prefill) and Miss (full
+    // re-prefill). The engine owns the find → SSD-hydrate retry → quant-mismatch
+    // guard → SSD-hydrated exclusion → Exact decision and traces every degrade
+    // branch; the policy tripwire moved into the engine, keyed on policy().
     // ------------------------------------------------------------------
-    enum CacheLookup {
-        Exact {
-            kv_caches: Vec<KvCache>,
-            last_id: u32,
-            piece: String,
-            // Stored prefill-token logprobs (top-k @ OpenAI ceiling),
-            // replayed truncated to the current request's lp_k on the hit path.
-            first_logprobs: Option<TokenLogprobs>,
-        },
-        Miss,
-    }
-
-    // hard runtime gate: qwen3 dense must be ExactOnly. The match arm
-    // below already routes any non-Exact `Some(_)` to Miss, but this assert
-    // catches a misconfigured arch table before any cache lookup happens.
-    // Promoted from debug_assert_eq! so the tripwire fires in release-perf too.
-    assert_eq!(
-        QWEN3_PROMPT_CACHE.policy(),
-        ReusePolicy::ExactOnly,
-        "qwen3 ArchPromptCache must use ReusePolicy::ExactOnly",
-    );
-
-    // Issue #26: codec-partitioned prompt-cache key — see gemma4/generate/mod.rs
-    // for the full rationale. The query digest stream is salted by
-    // `FNV_OFFSET ^ layout_key ^ codec_salt(kv_quant)` (matches the push seed),
-    // so a slot stored under a different KV codec never cross-serves.
-    let cache_seed = FNV_OFFSET ^ qwen3_active_layout_key() ^ kv_quant.cache_key_salt();
-    let lookup: CacheLookup = QWEN3_PROMPT_CACHE.with_inner_mut(|guard| {
-        let cache = guard.as_mut().unwrap();
-        let mut raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
-        // on a RAM miss, try the SSD tier (no-op when no source attached
-        // — tier OFF). A hit promotes the block into RAM; re-run find_best_prefix
-        // so the promoted slot is matched + quant-checked by the path below.
-        if raw_match.is_none() && cache.hydrate_from_ssd(prompt_ids).is_some() {
-            raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
-        }
-        // Plan §D8 / Task 11.5: stored `KvQuant` must match runtime; on
-        // mismatch evict + warn + degrade to Miss. See `gemma4/generate.rs`
-        // for the full rationale.
-        let safe_match = match raw_match {
-            Some((slot_idx, block_count)) => {
-                let stored = cache.slots[slot_idx].entry.kv_quant;
-                if stored == Some(kv_quant) {
-                    Some((slot_idx, block_count))
-                } else {
-                    tracing::warn!(
-                        stored = ?stored,
-                        runtime = ?kv_quant,
-                        prompt_len = prompt_ids.len(),
-                        "prompt cache KV quant mismatch — evicting entry, \
-                         degrading to re-prefill"
-                    );
-                    cache.evict_slot(slot_idx);
-                    None
-                }
-            }
-            None => None,
-        };
-        match safe_match {
-            // Exact match: full token-id equality AND a real first decode token.
-            //
-            // A SSD-hydrated entry whose block-aligned prefix length happens to
-            // equal `prompt_ids.len()` (prompt is an exact multiple of
-            // BLOCK_TOKENS → no tail → restored prefix == full prompt) must NOT
-            // be served here: its `first_id` is the placeholder 0 set in
-            // `SsdHydrate::hydrate`, not a real decode token. Replaying it emits
-            // a sentinel first token and seeds decode with garbage. The
-            // `!is_ssd_hydrated` guard drops it through to `Miss` → a full
-            // re-prefill re-derives the real first token. Correctness over the
-            // micro-opt (mirrors the qwen3_5_moe Exact arm guard).
-            Some((slot_idx, _block_count))
-                if !cache.slots[slot_idx].entry.is_ssd_hydrated()
-                    && cache.slots[slot_idx].entry.prompt_token_ids() == prompt_ids =>
-            {
-                let slot = &cache.slots[slot_idx].entry;
-                match slot.deep_clone() {
-                    Ok(cloned) => {
-                        tracing::debug!(
-                            prompt_len = prompt_ids.len(),
-                            token_id = cloned.first_id,
-                            "qwen3 generate_greedy: prompt cache EXACT HIT"
-                        );
-                        CacheLookup::Exact {
-                            kv_caches: cloned.kv_caches,
-                            last_id: cloned.first_id,
-                            piece: cloned.first_piece,
-                            first_logprobs: cloned.first_logprobs,
-                        }
-                    }
-                    Err(_) => CacheLookup::Miss,
-                }
-            }
-            // Partial or no match — fall back to full re-prefill.
-            Some(_) | None => CacheLookup::Miss,
-        }
-    });
+    let consumed = QWEN3_PROMPT_CACHE.consume(prompt_ids, kv_quant, false);
 
     // Path A: exact cache hit — skip re-prefill, jump straight to decode.
-    if let CacheLookup::Exact {
-        mut kv_caches,
-        last_id,
-        piece,
-        first_logprobs,
-    } = lookup
-    {
+    if let Consumed::Exact(cloned) = consumed {
+        let Qwen3Entry {
+            mut kv_caches,
+            first_id: last_id,
+            first_piece: piece,
+            first_logprobs,
+            ..
+        } = cloned;
+        tracing::debug!(
+            prompt_len = prompt_ids.len(),
+            token_id = last_id,
+            "qwen3 generate_greedy: prompt cache EXACT HIT"
+        );
         // The cached first token was produced by a prior request's
         // prefill, but its raw-logit top-k logprobs were captured and stored
         // alongside `first_id` at store time. Replay the same true logprob the

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -34,7 +34,7 @@ use super::model::Qwen3_5MoeText;
 use super::prompt_cache::{
     ensure_prompt_cache, store_kv_cache_bytes, Qwen35MoeEntry, PROMPT_CACHE,
 };
-use crate::prompt_cache::PromptCacheEntry as _;
+use crate::prompt_cache::{Consumed, ReuseKind, ReusePolicy};
 
 /// Greedy autoregressive generation using KV-cache prefill + decode.
 ///
@@ -94,177 +94,88 @@ pub fn generate_greedy<'a>(
 
     ensure_prompt_cache(prompt_cache_slots);
 
-    // No `Prefix` variant for qwen3_5_moe: the block-truncate + tail-reprefill
-    // partial path is unsafe for the recurrent GDN `lin_caches` (see the
-    // `find_best_prefix` match below). Genuine partial hits fall back to Miss
-    // (full re-prefill). Only full-token-equality reuse (Exact) is optimized.
-    //
-    // `HydratedTail` is the exception: when a SSD-hydrated entry is a STRICT
-    // PREFIX of the incoming prompt (i.e. its token ids are a byte-identical
-    // leading subsequence of `prompt_ids`), the block-aligned KV + GDN
-    // lin_caches represent recurrent state at exactly t=prefix_len of THIS
-    // same prompt, so re-prefilling only `prompt_ids[prefix_len..]` on top
-    // is sequentially correct. This is safe because the strict-prefix check
-    // guarantees the tail is the continuation of the exact same prompt (not a
-    // divergent sequence), which is the unsafe case ExactOnly guards against.
-    enum CacheLookup {
-        Exact {
-            kv_caches: Vec<KvCache>,
-            lin_caches: Vec<LinearAttnCache>,
-            last_id: u32,
-            piece: String,
-        },
-        /// SSD-hydrated block-aligned prefix; caller must re-prefill the tail.
-        HydratedTail {
-            kv_caches: Vec<KvCache>,
-            lin_caches: Vec<LinearAttnCache>,
-            prefix_len: usize,
-        },
-        Miss,
-    }
+    // ------------------------------------------------------------------
+    // Prompt cache lookup via the shared consume() engine. Qwen3.5-MoE is a
+    // hybrid GDN arch and uses `ReusePolicy::ExactOnly`. The reachable outcomes:
+    //   - `Exact`  = cached prompt token-for-token equal to this prompt (full
+    //                reuse, no re-prefill).
+    //   - `Reuse{StrictPrefix}` = HydratedTail: an SSD-hydrated entry that is a
+    //                STRICT PREFIX of the incoming prompt. Its block-aligned KV +
+    //                GDN `lin_caches` are the recurrent state at t=prefix_len of
+    //                THIS same prompt, so re-prefilling only the tail on top is
+    //                sequentially correct (the engine's policy gate permits a
+    //                hydrated strict-prefix even under ExactOnly).
+    //   - `Miss`   = no usable entry — a non-hydrated partial match (forbidden by
+    //                ExactOnly for the GDN `lin_caches`), the block-aligned
+    //                equal-length hydrated case (placeholder first token — must
+    //                recompute), an incomplete hydrate, or a quant mismatch.
+    // `BlockTruncate` is never produced by moe (the GDN `lin_caches` cannot be
+    // reconstructed from a block-truncated KV), so that arm is unreachable here.
+    // The engine owns find → SSD-hydrate retry → quant-mismatch guard →
+    // SSD-hydrated Exact exclusion → reuse-gate, and traces every degrade branch.
+    // ------------------------------------------------------------------
 
-    // hard runtime gate: Qwen3.5-MoE must be on the ExactOnly policy.
-    // A wrong policy here would expose the unsafe partial-prefix path on GDN
+    // hard runtime gate: Qwen3.5-MoE must be on the ExactOnly policy. A wrong
+    // policy here would expose the unsafe partial-prefix path on the GDN
     // `lin_caches` (see Qwen35MoeEntry docs). Compile-time would also fail at
     // SsdHydrate impl resolution, but this catches a misconfigured arch table
-    // before any cache lookup happens.
-    // Promoted from debug_assert_eq! so the tripwire fires in release-perf too.
+    // before any cache lookup happens. A real (not debug_) assert so the
+    // tripwire fires under release-perf too.
     assert_eq!(
         PROMPT_CACHE.policy(),
-        crate::prompt_cache::ReusePolicy::ExactOnly,
+        ReusePolicy::ExactOnly,
         "qwen3_5_moe ArchPromptCache must use ReusePolicy::ExactOnly — \
          partial-prefix reuse is unsafe for GDN lin_caches",
     );
 
-    // Issue #26: codec-partitioned prompt-cache key — see gemma4/generate/mod.rs
-    // for the full rationale. Query digest stream salted by
-    // `FNV_OFFSET ^ layout_key ^ codec_salt(kv_quant)` (matches the push seed).
-    let cache_seed = crate::prompt_cache::FNV_OFFSET
-        ^ crate::qwen3_5_moe::prompt_cache::active_layout_key()
-        ^ kv_quant.cache_key_salt();
-    let lookup: CacheLookup = PROMPT_CACHE.with_inner_mut(|guard| {
-        let cache = guard.as_mut().unwrap();
-        let mut raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
-        // on a RAM miss, try the SSD tier (no-op when no source attached
-        // — tier OFF). A hit promotes the block into RAM; re-run find_best_prefix
-        // so the promoted slot is matched + quant-checked by the path below.
-        if raw_match.is_none() && cache.hydrate_from_ssd(prompt_ids).is_some() {
-            raw_match = cache.find_best_prefix(prompt_ids, cache_seed);
+    // image prompts never reach this arch (text path only), so `has_image` is
+    // always false here; the engine bypass is belt-and-suspenders.
+    let consumed = PROMPT_CACHE.consume(prompt_ids, kv_quant, false);
+
+    // `exact_hit` carries the Path-A locals; `hydrated_tail` carries the Path-B
+    // tail-re-prefill locals. `Consumed::Miss` leaves both `None` and falls
+    // through to Path C (full re-prefill).
+    let mut exact_hit: Option<(Vec<KvCache>, Vec<LinearAttnCache>, u32, String)> = None;
+    let mut hydrated_tail: Option<(Vec<KvCache>, Vec<LinearAttnCache>, usize)> = None;
+    match consumed {
+        Consumed::Exact(cloned) => {
+            exact_hit = Some((
+                cloned.kv_caches,
+                cloned.lin_caches,
+                cloned.first_id,
+                cloned.first_piece,
+            ));
         }
-        // Plan §D8 / Task 11.5: stored `KvQuant` must match runtime; on
-        // mismatch evict + warn + degrade to Miss. See `gemma4/generate.rs`
-        // for the full rationale.
-        let safe_match = match raw_match {
-            Some((slot_idx, block_count)) => {
-                let stored = cache.slots[slot_idx].entry.kv_quant;
-                if stored == Some(kv_quant) {
-                    Some((slot_idx, block_count))
-                } else {
-                    tracing::warn!(
-                        stored = ?stored,
-                        runtime = ?kv_quant,
-                        prompt_len = prompt_ids.len(),
-                        "prompt cache KV quant mismatch — evicting entry, \
-                         degrading to re-prefill"
-                    );
-                    cache.evict_slot(slot_idx);
-                    None
-                }
-            }
-            None => None,
-        };
-        match safe_match {
-            // Exact match: the cached entry's FULL token id list equals the
-            // incoming prompt. This is verified at token granularity, NOT by
-            // `block_count * BLOCK_TOKENS == len` — the block-floored test is
-            // essentially never true (only when len % 256 == 0) and was
-            // misrouting identical-prompt repeats into the Prefix path. For
-            // qwen3_5_moe that path is unsafe: the GDN `lin_caches` recurrent
-            // state cannot be reconstructed by truncating KV to a block
-            // boundary and re-prefilling a short tail (`truncate_kv_to_block`
-            // deliberately leaves `lin_caches` untouched), so it emitted
-            // corrupted output (258 -> 9 tokens for an identical re-request).
-            // True full-equality reuse sidesteps truncation entirely.
-            //
-            // BUG-1 guard: a SSD-hydrated entry whose block-aligned prefix
-            // length happens to equal `prompt_ids.len()` (prompt is an exact
-            // multiple of BLOCK_TOKENS → no tail → `prefix_len == len`) must
-            // NOT be served as Exact: `first_id` is the placeholder 0 set in
-            // `SsdHydrate::hydrate`, not a real decode token. Excluding it
-            // here causes the match to fall through to `Miss` → full re-prefill
-            // re-derives the real `first_id`. Correctness over the micro-opt.
-            Some((slot_idx, _block_count))
-                if !cache.slots[slot_idx].entry.is_ssd_hydrated
-                    && cache.slots[slot_idx].entry.prompt_token_ids() == prompt_ids =>
-            {
-                let slot = &cache.slots[slot_idx].entry;
-                match slot.deep_clone() {
-                    Ok(cloned) => CacheLookup::Exact {
-                        kv_caches: cloned.kv_caches,
-                        lin_caches: cloned.lin_caches,
-                        last_id: cloned.first_id,
-                        piece: cloned.first_piece,
-                    },
-                    Err(_) => CacheLookup::Miss,
-                }
-            }
-            // HydratedTail: SSD-hydrated block-aligned prefix that is a
-            // STRICT PREFIX of the incoming prompt. The hydrated KV + GDN
-            // lin_caches represent recurrent state at t=prefix_len of this
-            // exact prompt; re-prefilling only `prompt_ids[prefix_len..]`
-            // on top is sequentially correct (identical to pausing/resuming
-            // the original prefill at the block boundary).
-            //
-            // Guards (all must hold):
-            // 1. Entry was promoted from SSD (`is_ssd_hydrated == true`).
-            // 2. Stored ids are shorter than the incoming prompt (strict prefix,
-            //    not a full match — the Exact arm handles the equal-length case).
-            // 3. Stored ids are byte-identical to the matching leading subsequence
-            //    of `prompt_ids` (guarantees the tail is the same prompt's
-            //    continuation, not a divergent one).
-            //
-            // If deep_clone fails, fall through to Miss (full re-prefill).
-            Some((slot_idx, _block_count))
-                if {
-                    let e = &cache.slots[slot_idx].entry;
-                    let stored = e.prompt_token_ids();
-                    e.is_ssd_hydrated
-                        && stored.len() < prompt_ids.len()
-                        && prompt_ids.starts_with(stored)
-                } =>
-            {
-                let slot = &cache.slots[slot_idx].entry;
-                match slot.deep_clone() {
-                    Ok(cloned) => CacheLookup::HydratedTail {
-                        kv_caches: cloned.kv_caches,
-                        lin_caches: cloned.lin_caches,
-                        prefix_len: slot.prompt_token_ids().len(),
-                    },
-                    Err(_) => CacheLookup::Miss,
-                }
-            }
-            // Genuine partial block-prefix hit (shares leading blocks then
-            // diverges). The block-truncate + tail-reprefill Prefix path is
-            // NOT correct for qwen3_5_moe: `truncate_kv_to_block` truncates
-            // only `kv_caches`; the recurrent GDN `lin_caches` would still
-            // hold the full original-prompt state, which is wrong for the new
-            // (diverged) tail. Reconstructing recurrent linear-attn state for
-            // a block-truncated prefix is not straightforward, so fall back to
-            // a full re-prefill (Miss). Correctness over speed — the partial
-            // optimization is forfeited for this hybrid arch on purpose.
-            Some(_) => CacheLookup::Miss,
-            None => CacheLookup::Miss,
+        // HydratedTail: SSD-hydrated block-aligned prefix that is a strict
+        // prefix of the incoming prompt; tail re-prefills on top of the
+        // restored KV + GDN lin state (no truncation — recurrent state is
+        // resumed at the block boundary).
+        Consumed::Reuse {
+            entry: cloned,
+            kind: ReuseKind::StrictPrefix { prefix_len },
+        } => {
+            hydrated_tail = Some((cloned.kv_caches, cloned.lin_caches, prefix_len));
         }
-    });
+        // Unreachable for moe: the ExactOnly policy never permits a non-hydrated
+        // partial match, and the hydrated-prefix hook only ever yields
+        // `StrictPrefix` (block-truncating a GDN `lin_caches` is unsafe and
+        // structurally forbidden). Treat defensively as a Miss (full re-prefill)
+        // rather than panicking, since a Miss is always correctness-safe.
+        Consumed::Reuse {
+            kind: ReuseKind::BlockTruncate { .. },
+            ..
+        } => {
+            tracing::warn!(
+                prompt_len = prompt_ids.len(),
+                "qwen3_5moe generate_greedy: unexpected BlockTruncate reuse for a GDN arch — \
+                 degrading to full re-prefill"
+            );
+        }
+        Consumed::Miss => {}
+    }
 
     // Path A: exact match
-    if let CacheLookup::Exact {
-        mut kv_caches,
-        mut lin_caches,
-        last_id,
-        piece,
-    } = lookup
-    {
+    if let Some((mut kv_caches, mut lin_caches, last_id, piece)) = exact_hit {
         tracing::debug!(
             prompt_len = prompt_ids.len(),
             token_id = last_id,
@@ -344,12 +255,7 @@ pub fn generate_greedy<'a>(
     //
     // Chunking (same prefill_chunk as Path C): keeps GDN ts < 256 per chunk
     // to avoid Metal watchdog timeouts on long tails.
-    if let CacheLookup::HydratedTail {
-        mut kv_caches,
-        mut lin_caches,
-        prefix_len,
-    } = lookup
-    {
+    if let Some((mut kv_caches, mut lin_caches, prefix_len)) = hydrated_tail {
         let tail_len = prompt_ids.len() - prefix_len;
         tracing::info!(
             arch = "Qwen3_5MoeForConditionalGeneration",

--- a/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
@@ -31,7 +31,9 @@
 #![allow(clippy::redundant_closure_for_method_calls)]
 use rmlx_core::error::Result;
 
-use crate::prompt_cache::{ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate};
+use crate::prompt_cache::{
+    ArchPromptCache, CacheStats, PromptCacheEntry, ReuseKind, ReusePolicy, SsdHydrate,
+};
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
 
@@ -107,6 +109,10 @@ impl PromptCacheEntry for Qwen35MoeEntry {
         self.kv_quant
     }
 
+    fn is_ssd_hydrated(&self) -> bool {
+        self.is_ssd_hydrated
+    }
+
     // Hybrid GDN arch: real recurrent caches. The default `truncate_kv_to`
     // deliberately cannot reach these (recurrent state is re-run on the tail,
     // never sliced), and the default `kv_bytes` sums their `approx_bytes`.
@@ -114,6 +120,47 @@ impl PromptCacheEntry for Qwen35MoeEntry {
         &self.lin_caches
     }
     // truncate_kv_to / truncate_kv_to_block / kv_bytes: trait defaults.
+
+    /// HydratedTail seam: an SSD-hydrated entry whose stored block-aligned
+    /// prefix is a STRICT prefix of the incoming prompt may be reused — the
+    /// hydrated KV + GDN `lin_caches` are the recurrent state at exactly
+    /// `t = prefix_len` of THIS same prompt, so re-prefilling only
+    /// `prompt_ids[prefix_len..]` on top is sequentially correct (identical to
+    /// pausing/resuming the original prefill at the block boundary).
+    ///
+    /// All three guards must hold:
+    /// 1. The entry was promoted from the SSD tier (`is_ssd_hydrated`).
+    /// 2. Stored ids are STRICTLY shorter than the incoming prompt. The strict
+    ///    less-than is load-bearing: it excludes the block-aligned EQUAL-length
+    ///    hydrated entry (no tail), which must fall through to Miss so its
+    ///    placeholder first token is recomputed rather than replayed.
+    /// 3. Stored ids are byte-identical to the matching leading subsequence of
+    ///    `prompt_ids` (guarantees the tail is the same prompt's continuation,
+    ///    not a divergent one).
+    ///
+    /// A non-hydrated partial match never reaches this hook (the ExactOnly
+    /// policy gates it out in the engine). Unlike gemma4, there is no
+    /// `>= BLOCK_TOKENS` floor: a hydrated entry is block-aligned by
+    /// construction, so the strict less-than alone is the correct gate.
+    fn is_reusable_prefix_of(
+        &self,
+        prompt_ids: &[u32],
+        is_ssd_hydrated: bool,
+        _matched_blocks: usize,
+    ) -> Option<ReuseKind> {
+        let stored = self.prompt_token_ids();
+        if is_ssd_hydrated && stored.len() < prompt_ids.len() && prompt_ids.starts_with(stored) {
+            Some(ReuseKind::StrictPrefix {
+                prefix_len: stored.len(),
+            })
+        } else {
+            None
+        }
+    }
+    // is_hydrate_complete / prepare_reuse: trait defaults. The GDN `lin_caches`
+    // recurrent state is carried by `deep_clone` (the default `prepare_reuse`)
+    // and is NEVER block-truncated — moe only ever yields `StrictPrefix`, and
+    // the default `truncate_kv_to` structurally cannot reach `lin_caches`.
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
@@ -206,9 +206,11 @@ impl SsdHydrate<Qwen35MoeEntry> for SsdHydrator {
 
 /// per-arch shell with hard-gated `ReusePolicy::ExactOnly`. Partial /
 /// block-aligned reuse is unsafe for the hybrid GDN arch (the recurrent
-/// `lin_caches` cannot be reconstructed from a block-truncated KV) — the
-/// generate-loop's `CacheLookup` match enforces this at runtime by routing
-/// any `Some(_)` non-Exact match to `CacheLookup::Miss`.
+/// `lin_caches` cannot be reconstructed from a block-truncated KV) — the shared
+/// consume engine enforces this at runtime: under `ExactOnly` a non-hydrated
+/// partial match is forbidden, and the only permitted reuse is a hydrated
+/// strict-prefix (HydratedTail) via `is_reusable_prefix_of`; everything else
+/// degrades to a full re-prefill (Miss).
 pub(crate) static PROMPT_CACHE: ArchPromptCache<Qwen35MoeEntry> =
     ArchPromptCache::new("Qwen3_5MoeForConditionalGeneration", ReusePolicy::ExactOnly);
 

--- a/crates/rmlx-models/src/qwen3_5_moe/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/prompt_cache_tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 
-/// Qwen3.5-MoE's policy is hard-gated `ExactOnly` — the
-/// generate-loop's `CacheLookup` match must NEVER take the partial-prefix
-/// path because the GDN `lin_caches` cannot be block-truncated.
+/// Qwen3.5-MoE's policy is hard-gated `ExactOnly` — the shared consume
+/// engine must NEVER take the non-hydrated partial-prefix path because the GDN
+/// `lin_caches` cannot be block-truncated.
 #[test]
 fn arch_policy_is_exact_only() {
     assert_eq!(PROMPT_CACHE.policy(), ReusePolicy::ExactOnly);

--- a/crates/rmlx-models/src/qwen3_5_moe/tests.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/tests.rs
@@ -1710,8 +1710,9 @@ fn integration_qwen3_5_moe_35b() {
 /// 3. DIVERGENT: inject the same prefix snapshot but pass a prompt whose tail
 ///    diverges WITHIN the prefix range (not a strict prefix of the stored ids) →
 ///    `find_best_prefix` returns the slot but the strict-prefix gate rejects it →
-///    falls to `CacheLookup::Miss` (confirmed by checking the decode output
-///    differs from a crafted different-tail cold run, NOT from the warm run).
+///    the consume engine yields `Consumed::Miss` (confirmed by checking the
+///    decode output differs from a crafted different-tail cold run, NOT from the
+///    warm run).
 ///
 /// Run:
 /// ```sh

--- a/crates/rmlx-models/src/qwen3_5_moe/tests.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/tests.rs
@@ -2632,3 +2632,315 @@ fn hydrated_tail_k8v8_equivalence() {
          prefix_len={prefix_len} tail_len={tail_len} kv_quant=K8V8 n_decode={n_decode}"
     );
 }
+
+/// Phase C consume-engine migration golden (qwen3.5-moe, Qwen3.6 — model-gated).
+///
+/// Pins that routing qwen3.5-moe through the shared `consume()` engine is
+/// behavior-identical to the pre-migration inline dispatch across all three
+/// outcomes reachable for this hybrid GDN arch under `ReusePolicy::ExactOnly`.
+/// At temp 0, every reuse/degrade path must decode token-identically to a cold
+/// (Miss) baseline of the SAME prompt:
+///   (a) ExactOnly forbids a RAM (non-hydrated) PARTIAL match: a 512-token RAM
+///       snapshot whose first block is shared with a divergent 512-token request
+///       (1 shared full block, then diverges) → the ExactOnly policy gate
+///       degrades it to Miss → full re-prefill → WARM == COLD(divergent). The
+///       GDN `lin_caches` are never block-truncated.
+///   (b) hydrated strict-prefix HydratedTail resume: an SSD-hydrated 512-token
+///       block-aligned prefix that the request extends to 520 tokens →
+///       `Reuse{StrictPrefix}` → restore + tail-only re-prefill → WARM ==
+///       COLD(520).
+///   (c) hydrated block-aligned EQUAL-length exclusion (the strict-`<` guard): an
+///       SSD-hydrated 512-token entry whose prefix length equals the full
+///       512-token prompt (no tail, placeholder first_id 0) → both the Exact
+///       arm's `!is_ssd_hydrated` guard and the strict-less-than HydratedTail
+///       gate decline → Miss → recompute → WARM == COLD, never the placeholder 0.
+///
+/// Run:
+/// ```sh
+/// RMLX_TEST_MODEL_QWEN36=/path/to/mlx-community__Qwen3.6-35B-A3B-8bit \
+/// cargo test -p rmlx-models qwen3_5_moe_consume_engine_migration_golden \
+///     -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: Mutex critical section is panic-free; remaining unwrap is on values constructed in this fn"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: indices bounded by slice length validated before call"
+)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "test-only: a single golden covering the three reachable moe consume outcomes (RAM-partial degrade / hydrated strict-prefix HydratedTail / hydrated equal-length exclusion) reads clearest as one sequential fixture"
+)]
+fn qwen3_5_moe_consume_engine_migration_golden() {
+    let Some(model_dir_buf) = qwen36_model_dir() else {
+        println!("SKIP: RMLX_TEST_MODEL_QWEN36 not set");
+        return;
+    };
+    let model_dir = model_dir_buf.as_path();
+    if !model_dir.exists() {
+        println!("SKIP: model dir not found at {}", model_dir.display());
+        return;
+    }
+    let arch_str = {
+        let cfg_path = model_dir.join("config.json");
+        let data = std::fs::read(&cfg_path).expect("read config.json");
+        let v: serde_json::Value = serde_json::from_slice(&data).expect("parse config.json");
+        v.get("architectures")
+            .and_then(|a| a.get(0))
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_owned()
+    };
+    let expected_archs = [
+        "Qwen3_5MoeForCausalLM",
+        "Qwen3_5MoeForConditionalGeneration",
+    ];
+    if !expected_archs.contains(&arch_str.as_str()) {
+        println!("SKIP: arch \"{arch_str}\" is not a Qwen3.5-MoE arch");
+        return;
+    }
+
+    println!("Loading model from {}", model_dir.display());
+    let model = load_from_path(model_dir).expect("load model");
+    let n_layers = model.cfg.num_hidden_layers;
+    let device = Device::Gpu;
+
+    // Unquantized KV so the comparison is noise-free: warm == cold must hold
+    // token-for-token.
+    let kv_quant = rmlx_kv_quant::KvQuant::None;
+    let max_seq = 4096i32;
+    let n_decode = 6usize; // short — Qwen3.6 is a 35B model
+
+    let sampler_cfg = crate::sampler::SamplerConfig {
+        temperature: 0.0,
+        top_p: 1.0,
+        top_k: 0,
+        min_p: 0.0,
+        seed: Some(0),
+        top_logprobs_k: 0,
+    };
+    let penalty_cfg = crate::sampler::PenaltyConfig::default();
+
+    // Run generate_greedy at temp 0, return the decoded token_id sequence.
+    let run = |ids: &[u32]| -> Vec<u32> {
+        let mut rng = crate::sampler::Pcg32::new(sampler_cfg.seed_or_default());
+        let mut token_history: Vec<u32> = Vec::new();
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
+        generate_greedy(
+            &model,
+            &tokenizers::Tokenizer::from_file(model_dir.join("tokenizer.json"))
+                .expect("load tokenizer"),
+            ids,
+            n_decode,
+            device,
+            kv_quant,
+            Some(max_seq),
+            4,
+            &[],
+            &mut step_fn,
+            None,
+            &sampler_cfg,
+            &mut rng,
+            &penalty_cfg,
+            &mut token_history,
+        )
+        .expect("generate_greedy")
+        .into_iter()
+        .map(|s| s.token_id)
+        .collect()
+    };
+
+    let clear_cache = || {
+        prompt_cache::ensure_prompt_cache(4);
+        prompt_cache::PROMPT_CACHE.with_inner_mut(|guard| {
+            if let Some(cache) = guard.as_mut() {
+                cache.clear();
+            }
+        });
+    };
+
+    // Build a real (physically correct) KV/lin snapshot for `ids` via the same
+    // KV stack + enter/exit_prefill bracketing as generate_greedy's Miss path.
+    let make_snapshot = |ids: &[u32]| -> (
+        Vec<rmlx_kv_quant::KvCache>,
+        Vec<rmlx_kv_quant::LinearAttnCache>,
+    ) {
+        let mut kv_caches: Vec<rmlx_kv_quant::KvCache> = (0..n_layers)
+            .map(|i| {
+                use crate::kv_cache::{
+                    kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N,
+                };
+                let q = kv_quant_for_layer(
+                    i,
+                    n_layers,
+                    kv_quant,
+                    LAYER_ADAPTIVE_TAIL_N,
+                    LAYER_ADAPTIVE_HEAD_N,
+                );
+                rmlx_kv_quant::KvCache::with_quant_max_seq(q, max_seq).with_layer_idx(i)
+            })
+            .collect();
+        let mut lin_caches: Vec<rmlx_kv_quant::LinearAttnCache> = (0..n_layers)
+            .map(|_| rmlx_kv_quant::LinearAttnCache::new())
+            .collect();
+        for c in &mut kv_caches {
+            c.enter_prefill();
+        }
+        let prefill_chunk = crate::prefill_chunk::prefill_chunk_for("qwen3_5_moe");
+        let n_chunks = ids.len().div_ceil(prefill_chunk);
+        for (chunk_idx, chunk) in ids.chunks(prefill_chunk).enumerate() {
+            let is_last = chunk_idx + 1 == n_chunks;
+            let logits = model
+                .forward_seq_with_cache(chunk, Some(&mut kv_caches), Some(&mut lin_caches), device)
+                .expect("prefill chunk");
+            if is_last {
+                logits.eval().expect("eval last-chunk logits");
+            } else {
+                for c in &kv_caches {
+                    c.eval_prefill_state().expect("eval_prefill_state");
+                }
+            }
+        }
+        for c in &mut kv_caches {
+            c.exit_prefill(device).expect("exit_prefill");
+        }
+        for c in &kv_caches {
+            c.eval_for_spill().expect("eval_for_spill kv");
+        }
+        for c in &lin_caches {
+            c.eval_for_spill().expect("eval_for_spill lin");
+        }
+        (kv_caches, lin_caches)
+    };
+
+    // Push an entry keyed on `key_ids` carrying `(kv, lin)`, into a freshly
+    // cleared cache. `hydrated` sets is_ssd_hydrated + placeholder first token
+    // (id 0); a non-hydrated RAM entry carries a real first token.
+    let push_entry = |key_ids: &[u32],
+                      kv: Vec<rmlx_kv_quant::KvCache>,
+                      lin: Vec<rmlx_kv_quant::LinearAttnCache>,
+                      hydrated: bool,
+                      first_id: u32| {
+        clear_cache();
+        prompt_cache::PROMPT_CACHE.with_inner_mut(|guard| {
+            if let Some(cache) = guard.as_mut() {
+                let block_hashes = crate::prompt_cache::chained_block_hashes_seeded(
+                    key_ids,
+                    crate::prompt_cache::FNV_OFFSET
+                        ^ prompt_cache::active_layout_key()
+                        ^ kv_quant.cache_key_salt(),
+                );
+                cache.push(Qwen35MoeEntry {
+                    prompt_token_ids: key_ids.to_vec(),
+                    block_hashes,
+                    kv_caches: kv,
+                    lin_caches: lin,
+                    first_id,
+                    first_piece: String::new(),
+                    kv_quant: Some(kv_quant),
+                    is_ssd_hydrated: hydrated,
+                });
+            }
+        });
+    };
+
+    // Deterministic synthetic ids (1..=len, wrapping at 9999, never 0).
+    let make_ids = |len: usize, salt: u32| -> Vec<u32> {
+        (1u32..=len as u32)
+            .map(|i| ((i.wrapping_mul(7).wrapping_add(salt)) % 9999).max(1))
+            .collect()
+    };
+
+    // ── (a) ExactOnly forbids a RAM (non-hydrated) PARTIAL match → Miss ──────
+    // Cache a 512-token RAM snapshot; request a divergent 512-token prompt that
+    // shares only the first full block. find_best_prefix matches 1 block, but
+    // the ExactOnly policy gate forbids the non-hydrated partial → Miss → full
+    // re-prefill of the divergent prompt → WARM == COLD(divergent).
+    let p512 = make_ids(2 * BLOCK_TOKENS, 0);
+    let p512_div: Vec<u32> = {
+        let mut v = p512.clone();
+        for t in v.iter_mut().skip(BLOCK_TOKENS) {
+            *t = ((*t).wrapping_add(101) % 9999).max(1);
+        }
+        v
+    };
+    clear_cache();
+    let cold_div = run(&p512_div);
+    assert_eq!(cold_div.len(), n_decode);
+    assert_ne!(cold_div[0], 0, "cold divergent first token is 0 — anomaly");
+    let (kv512, lin512) = make_snapshot(&p512);
+    // A real RAM entry carries a real first token; use a sentinel non-zero id so
+    // a (forbidden) partial reuse would be detectable, but the test asserts the
+    // tokens equal the cold re-prefill regardless.
+    push_entry(&p512, kv512, lin512, false, 7u32);
+    let warm_partial = run(&p512_div);
+    println!("(a) RAM-partial degrade: cold={cold_div:?} warm={warm_partial:?}");
+    assert_eq!(
+        warm_partial, cold_div,
+        "(a) ExactOnly must forbid a non-hydrated partial match → Miss → full re-prefill \
+         equal to the cold baseline for the divergent prompt"
+    );
+
+    // ── (b) hydrated strict-prefix HydratedTail resume → warm == cold ────────
+    // SSD-hydrated 512-token block-aligned prefix; request extends it to 520
+    // tokens. The strict-`<` HydratedTail gate fires → restore + tail-only
+    // re-prefill → WARM == COLD(520).
+    let p520: Vec<u32> = {
+        let mut v = p512.clone();
+        v.extend(make_ids(8, 5)); // 8-token tail with a distinct salt
+        v
+    };
+    clear_cache();
+    let cold_520 = run(&p520);
+    let (kv_pref, lin_pref) = make_snapshot(&p512);
+    push_entry(&p512, kv_pref, lin_pref, true, 0u32);
+    let warm_tail = run(&p520);
+    println!("(b) HydratedTail: cold={cold_520:?} warm={warm_tail:?}");
+    assert_ne!(
+        warm_tail.first().copied(),
+        Some(0u32),
+        "(b) HydratedTail resume must decode a real first token, never the placeholder 0"
+    );
+    assert_eq!(
+        warm_tail, cold_520,
+        "(b) hydrated strict-prefix HydratedTail resume must equal the cold baseline for the \
+         extended 520-token prompt"
+    );
+
+    // ── (c) hydrated block-aligned EQUAL-length exclusion (strict-`<` guard) ──
+    // SSD-hydrated 512-token entry whose prefix length equals the full 512-token
+    // prompt (no tail, placeholder first_id 0). Neither the Exact arm
+    // (`!is_ssd_hydrated`) nor the strict-less-than HydratedTail gate accepts it
+    // → Miss → recompute → WARM == COLD, never the placeholder 0.
+    clear_cache();
+    let cold_512 = run(&p512);
+    assert_ne!(cold_512[0], 0, "cold 512 first token is 0 — anomaly");
+    let (kv_full, lin_full) = make_snapshot(&p512);
+    push_entry(&p512, kv_full, lin_full, true, 0u32);
+    let warm_equal = run(&p512);
+    println!("(c) hydrated equal-length exclusion: cold={cold_512:?} warm={warm_equal:?}");
+    assert_ne!(
+        warm_equal.first().copied(),
+        Some(0u32),
+        "(c) block-aligned hydrated equal-length must NOT replay placeholder 0 — \
+         the strict-< guard forces a re-prefill that recomputes the real first token"
+    );
+    assert_eq!(
+        warm_equal, cold_512,
+        "(c) block-aligned hydrated equal-length recompute must equal the cold baseline"
+    );
+
+    println!(
+        "PASS: qwen3_5_moe consume-engine migration golden — RAM-partial degrade / \
+         hydrated strict-prefix HydratedTail / hydrated equal-length exclusion all match \
+         their cold baselines"
+    );
+}

--- a/crates/rmlx-models/src/qwen3_tests.rs
+++ b/crates/rmlx-models/src/qwen3_tests.rs
@@ -611,3 +611,281 @@ fn qwen3_hydrated_exact_no_tail_not_placeholder() {
         warm_tokens[0]
     );
 }
+
+/// Phase A consume-engine migration golden (qwen3 dense, Bonsai).
+///
+/// Pins that routing qwen3 through the shared `consume()` engine is
+/// behavior-identical to the pre-migration inline `CacheLookup`. Captures the
+/// decoded `token_id` sequence at temp 0 for the four reachable cases and
+/// asserts each against the cold baseline:
+///   (i)   SSD exact-hit recompute: a hydrated FULL-prompt entry (no tail,
+///         placeholder first_id) must fall to Miss → WARM == COLD (engine drops
+///         it via the `!is_ssd_hydrated` Exact exclusion → re-prefill).
+///   (ii)  RAM exact-hit: a real RAM snapshot of the same prompt replays the
+///         stored first token → WARM == COLD.
+///   (iii) first_logprobs replay: a RAM exact-hit with `top_logprobs_k = 3`
+///         emits exactly one logprobs entry for the replayed first token,
+///         truncated to 3 alternatives — the Miss path's capture survives the
+///         Exact(E) clone.
+///   (iv)  Miss: a distinct prompt re-prefills → coherent, non-placeholder
+///         first token, distinct from the baseline.
+///
+/// Run:
+/// ```sh
+/// RMLX_TEST_MODEL_BONSAI=/path/to/Ternary-Bonsai-8B-mlx-2bit \
+/// cargo test -p rmlx-models qwen3_consume_engine_migration_golden \
+///     -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: Mutex critical section is panic-free; remaining unwrap is on values constructed in this fn"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: indices bounded by slice length validated before call"
+)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "test-only: a single golden covering the four reachable consume cases (cold/RAM/SSD/Miss) reads clearest as one sequential fixture"
+)]
+fn qwen3_consume_engine_migration_golden() {
+    let Some(model_dir_buf) =
+        std::env::var_os("RMLX_TEST_MODEL_BONSAI").map(std::path::PathBuf::from)
+    else {
+        println!("SKIP: RMLX_TEST_MODEL_BONSAI not set");
+        return;
+    };
+    let model_dir = model_dir_buf.as_path();
+    if !model_dir.exists() {
+        println!("SKIP: model dir not found at {}", model_dir.display());
+        return;
+    }
+    let arch_str = {
+        let cfg_path = model_dir.join("config.json");
+        let data = std::fs::read(&cfg_path).expect("read config.json");
+        let v: serde_json::Value = serde_json::from_slice(&data).expect("parse config.json");
+        v.get("architectures")
+            .and_then(|a| a.get(0))
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_owned()
+    };
+    if arch_str != "Qwen3ForCausalLM" {
+        println!("SKIP: arch \"{arch_str}\" is not Qwen3ForCausalLM");
+        return;
+    }
+
+    let model = load_from_path(model_dir, None).expect("load model");
+    let n_layers = model.cfg.num_hidden_layers;
+    let device = Device::Gpu;
+    let kv_quant = KvQuant::None;
+    let max_seq = 4096i32;
+    let n_decode = 6usize;
+    let tokenizer =
+        tokenizers::Tokenizer::from_file(model_dir.join("tokenizer.json")).expect("load tokenizer");
+
+    // Block-aligned prompt (no tail) — the SSD exact-hit shape (the spilled
+    // block equals the full prompt).
+    let prompt_len = BLOCK_TOKENS;
+    let prompt_ids: Vec<u32> = (1u32..=prompt_len as u32)
+        .map(|i| (i % 9999).max(1))
+        .collect();
+
+    // A distinct block-aligned prompt for the Miss case.
+    let other_ids: Vec<u32> = (1u32..=prompt_len as u32)
+        .map(|i| ((i * 7 + 3) % 9999).max(1))
+        .collect();
+
+    let base_sampler = crate::sampler::SamplerConfig {
+        temperature: 0.0,
+        top_p: 1.0,
+        top_k: 0,
+        min_p: 0.0,
+        seed: Some(0),
+        top_logprobs_k: 0,
+    };
+    let penalty_cfg = crate::sampler::PenaltyConfig::default();
+
+    // Helper: run generate_greedy at temp 0 and return the decoded steps.
+    let run = |ids: &[u32],
+               sampler: &crate::sampler::SamplerConfig|
+     -> Vec<crate::decode_loop::ProbeStep> {
+        let mut rng = crate::sampler::Pcg32::new(sampler.seed_or_default());
+        let mut token_history: Vec<u32> = Vec::new();
+        let mut step_fn = |_: &crate::decode_loop::ProbeStep| -> Option<u32> { None };
+        generate_greedy(
+            &model,
+            &tokenizer,
+            ids,
+            n_decode,
+            device,
+            kv_quant,
+            Some(max_seq),
+            4,
+            &[],
+            &mut step_fn,
+            None,
+            sampler,
+            &mut rng,
+            &penalty_cfg,
+            &mut token_history,
+        )
+        .expect("generate_greedy")
+    };
+
+    let clear_cache = || {
+        ensure_qwen3_prompt_cache(4);
+        QWEN3_PROMPT_CACHE.with_inner_mut(|guard| {
+            if let Some(cache) = guard.as_mut() {
+                cache.clear();
+            }
+        });
+    };
+
+    // ── (a) COLD baseline (Miss path: full prefill + store-back) ─────────────
+    clear_cache();
+    let cold: Vec<u32> = run(&prompt_ids, &base_sampler)
+        .into_iter()
+        .map(|s| s.token_id)
+        .collect();
+    println!("COLD tokens: {cold:?}");
+    assert_eq!(cold.len(), n_decode);
+    assert_ne!(
+        cold[0], 0,
+        "cold first token is the placeholder 0 — fixture anomaly"
+    );
+
+    // ── (ii) RAM exact-hit: the store-back from (a) is now resident. Re-running
+    // the same prompt must be an Exact hit → token-identical to COLD. ─────────
+    let warm_ram: Vec<u32> = run(&prompt_ids, &base_sampler)
+        .into_iter()
+        .map(|s| s.token_id)
+        .collect();
+    println!("WARM (RAM exact-hit) tokens: {warm_ram:?}");
+    assert_eq!(
+        warm_ram, cold,
+        "RAM exact-hit must be token-identical to the cold baseline"
+    );
+
+    // ── (iii) first_logprobs truncated replay: a RAM exact-hit with
+    // top_logprobs_k = 3 must emit exactly one logprobs entry for the replayed
+    // first token (captured at store time, truncated to 3). ──────────────────
+    let lp_sampler = crate::sampler::SamplerConfig {
+        top_logprobs_k: 3,
+        ..base_sampler
+    };
+    let lp_steps = run(&prompt_ids, &lp_sampler);
+    let first = &lp_steps[0];
+    let lp = first
+        .logprobs
+        .as_ref()
+        .expect("exact-hit first token must carry replayed logprobs when lp_k > 0");
+    assert_eq!(
+        lp.token_id, cold[0],
+        "replayed logprobs must describe the replayed first token"
+    );
+    assert!(
+        lp.top.len() <= 3,
+        "first_logprobs must be truncated to the request's top_logprobs_k (3), got {}",
+        lp.top.len()
+    );
+
+    // ── (i) SSD exact-hit recompute: inject a hydrated FULL-prompt
+    // snapshot (placeholder first_id=0, is_ssd_hydrated=true). The consume
+    // engine's `!is_ssd_hydrated` Exact exclusion + the reuse hook declining the
+    // equal-length case must drop it to Miss → WARM == COLD (never replay 0). ──
+    let full_kv_caches = {
+        use crate::kv_cache::{kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N};
+        let mut kv_caches: Vec<KvCache> = (0..n_layers)
+            .map(|i| {
+                let q = kv_quant_for_layer(
+                    i,
+                    n_layers,
+                    kv_quant,
+                    LAYER_ADAPTIVE_TAIL_N,
+                    LAYER_ADAPTIVE_HEAD_N,
+                );
+                KvCache::with_quant_max_seq(q, max_seq).with_layer_idx(i)
+            })
+            .collect();
+        for c in &mut kv_caches {
+            c.enter_prefill();
+        }
+        let prefill_chunk = crate::prefill_chunk::prefill_chunk_for("qwen3");
+        let n_chunks = prompt_len.div_ceil(prefill_chunk);
+        for (chunk_idx, chunk) in prompt_ids.chunks(prefill_chunk).enumerate() {
+            let is_last = chunk_idx + 1 == n_chunks;
+            let logits = model
+                .forward_seq_with_cache(chunk, Some(&mut kv_caches), device)
+                .expect("prefill chunk");
+            if is_last {
+                logits.eval().expect("eval last-chunk logits");
+            } else {
+                for c in &kv_caches {
+                    c.eval_prefill_state().expect("eval_prefill_state");
+                }
+            }
+        }
+        for c in &mut kv_caches {
+            c.exit_prefill(device).expect("exit_prefill");
+        }
+        for c in &kv_caches {
+            c.eval_for_spill().expect("eval_for_spill kv");
+        }
+        kv_caches
+    };
+
+    clear_cache();
+    QWEN3_PROMPT_CACHE.with_inner_mut(|guard| {
+        if let Some(cache) = guard.as_mut() {
+            let block_hashes =
+                chained_block_hashes_seeded(&prompt_ids, FNV_OFFSET ^ kv_quant.cache_key_salt());
+            let kv_snap: Result<Vec<_>> =
+                full_kv_caches.iter().map(KvCache::try_deep_clone).collect();
+            cache.push(Qwen3Entry {
+                prompt_token_ids: prompt_ids.clone(),
+                block_hashes,
+                kv_caches: kv_snap.expect("kv clone"),
+                first_id: 0,
+                first_piece: String::new(),
+                first_logprobs: None,
+                kv_quant: Some(kv_quant),
+                is_ssd_hydrated: true,
+            });
+        }
+    });
+    let warm_ssd: Vec<u32> = run(&prompt_ids, &base_sampler)
+        .into_iter()
+        .map(|s| s.token_id)
+        .collect();
+    println!("WARM (SSD exact-hit recompute) tokens: {warm_ssd:?}");
+    assert_ne!(
+        warm_ssd.first().copied(),
+        Some(0u32),
+        "SSD exact-hit must NOT replay the placeholder first_id 0"
+    );
+    assert_eq!(
+        warm_ssd, cold,
+        "SSD exact-hit recompute must equal the cold baseline"
+    );
+
+    // ── (iv) Miss: a distinct prompt re-prefills → coherent, distinct. ───────
+    clear_cache();
+    let miss: Vec<u32> = run(&other_ids, &base_sampler)
+        .into_iter()
+        .map(|s| s.token_id)
+        .collect();
+    println!("MISS (distinct prompt) tokens: {miss:?}");
+    assert_eq!(miss.len(), n_decode);
+    assert_ne!(miss[0], 0, "Miss first token must be a real decode token");
+
+    println!(
+        "PASS: consume-engine migration golden — RAM/SSD/logprobs/Miss all match the baseline"
+    );
+}

--- a/crates/rmlx-models/src/qwen3_vl_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_vl_moe/generate.rs
@@ -1,14 +1,25 @@
 // unsafe_code: mlx-rs Array zero-copy view — slice::from_raw_parts byte-reinterpret for Array::from_bytes
 #![allow(unsafe_code)]
+#![allow(clippy::redundant_closure_for_method_calls)]
 
 //! Greedy autoregressive generation for Qwen3-VL-MoE — text + image branches.
 //!
-//! Self-contained, deliberately simpler than the qwen3_5_moe generator: no
-//! prompt-cache reuse, no GatedDeltaNet, no MTP. The Qwen3-VL text decoder is a
-//! plain GQA stack with 3D interleaved M-RoPE, so a fresh per-layer
-//! [`KvCache`] + sequential prefill/decode is correct and fast enough for the
-//! single-image serve path. Sampling / penalty / constraint hooks mirror the
-//! other arch generators so the server's decode-loop call site is uniform.
+//! The Qwen3-VL text decoder is a plain GQA stack with 3D interleaved M-RoPE
+//! (the MoE lives in the FFN and never touches the KV cache), so a per-layer
+//! [`KvCache`] one-shot prefill + sequential decode is correct and fast enough
+//! for the single-image serve path. Sampling / penalty / constraint hooks mirror
+//! the other arch generators so the server's decode-loop call site is uniform.
+//!
+//! ## Prompt cache (text path only)
+//!
+//! The text [`generate_greedy`] routes through the shared
+//! [`crate::prompt_cache::ArchPromptCache::consume`] engine under
+//! [`crate::prompt_cache::ReusePolicy::ExactOnly`]: an identical-prompt repeat
+//! skips re-prefill (Exact), and every other request re-prefills and snapshots
+//! the post-prefill KV (Miss → store). Image turns route to [`generate_image`]
+//! (the text path never sees image ids), and both the consume bypass and the
+//! store-back are additionally `has_image`-gated as belt-and-suspenders — the
+//! token-id cache key is unsafe across image spans.
 //!
 //! The 3D position bookkeeping is the only Qwen3-VL-specific wrinkle:
 //! - text-only: positions are sequential in all three (t,h,w) dims;
@@ -21,12 +32,16 @@ use rmlx_mlx::{Array, Device, Dtype};
 
 use crate::constraint::ConstraintEngine;
 use crate::decode_loop::ProbeStep;
+use crate::prompt_cache::{chained_block_hashes_seeded, Consumed, ReusePolicy, FNV_OFFSET};
 use crate::sampler::{apply_mask_argmax, sample_token_array, Pcg32, PenaltyConfig, SamplerConfig};
 use rmlx_kv_quant::{KvCache, KvQuant};
 
 use super::image::{scatter_vision_features, visual_token_positions};
 use super::model::Qwen3VlMoeText;
 use super::mrope::{get_rope_index, RopeIndex3D};
+use super::prompt_cache::{
+    active_layout_key, ensure_prompt_cache, store_kv_cache_bytes, Qwen3VlMoeEntry, PROMPT_CACHE,
+};
 use super::vision::VisionOutput;
 
 /// Trailing-window size for repetition penalties (matches the other archs).
@@ -84,17 +99,23 @@ fn pick_token(
     Ok(i32::from_le_bytes(b[..4].try_into().unwrap()) as u32)
 }
 
+/// Decode one token id to its display piece (SentencePiece `▁` → space). Shared
+/// by `make_step` and the Miss-path snapshot store-back so a later Exact-hit
+/// replays a byte-identical piece without re-decoding.
+fn piece_for(token_id: u32, tokenizer: &tokenizers::Tokenizer) -> String {
+    tokenizer
+        .id_to_token(token_id)
+        .unwrap_or_default()
+        .replace('\u{2581}', " ")
+}
+
 /// Emit one decode step (token id + piece). Logit stats are left at defaults —
 /// the smoke classifier only needs ids + pieces, and the hot loop avoids the
 /// extra GPU→host transfer of the full logit row.
 fn make_step(token_id: u32, tokenizer: &tokenizers::Tokenizer) -> ProbeStep {
     ProbeStep {
         token_id,
-        piece: tokenizer
-            .id_to_token(token_id)
-            .unwrap_or_default()
-            .replace('\u{2581}', " ")
-            .into_boxed_str(),
+        piece: piece_for(token_id, tokenizer).into_boxed_str(),
         max_abs_logit: 0.0,
         nan_count: 0,
         logprobs: None,
@@ -102,6 +123,14 @@ fn make_step(token_id: u32, tokenizer: &tokenizers::Tokenizer) -> ProbeStep {
 }
 
 /// Greedy generation from plain text token ids.
+///
+/// `prompt_cache_slots` — number of post-prefill KV snapshots kept across
+/// requests. Pass 1 for single-slot; pass N for multi-slot prefix matching.
+/// Recommended: 4. Only the Exact-hit path is active under
+/// [`ReusePolicy::ExactOnly`] (identical-prompt repeat skips re-prefill
+/// entirely, same contract as Qwen2 / Qwen3 dense). `max_ctx_override` is unused
+/// here: the text decoder prefills the whole prompt in one shot and grows its KV
+/// ring lazily, so there is no pre-sized ceiling to clamp.
 #[allow(clippy::too_many_arguments)]
 pub fn generate_greedy(
     model: &Qwen3VlMoeText,
@@ -111,7 +140,7 @@ pub fn generate_greedy(
     device: Device,
     kv_quant: KvQuant,
     _max_ctx_override: Option<i32>,
-    _prompt_cache_slots: usize,
+    prompt_cache_slots: usize,
     eos_ids: &[u32],
     step_fn: &mut dyn FnMut(&ProbeStep) -> Option<u32>,
     mut constraint: Option<&mut dyn ConstraintEngine>,
@@ -132,12 +161,80 @@ pub fn generate_greedy(
     }
     let vocab = model.cfg.vocab_size;
     let n_layers = model.cfg.num_hidden_layers;
+    let mut steps = Vec::with_capacity(n_tokens);
+
+    ensure_prompt_cache(prompt_cache_slots);
+
+    // ------------------------------------------------------------------
+    // Prompt cache lookup via the shared consume() engine. The Qwen3-VL text
+    // decoder is plain GQA with no recurrent state and uses
+    // ReusePolicy::ExactOnly (it overrides none of the reuse hooks), so the only
+    // reachable outcomes are Exact (identical-prompt repeat skips re-prefill) and
+    // Miss (full re-prefill). The engine owns the find → SSD-hydrate retry →
+    // quant-mismatch guard → SSD-hydrated exclusion → Exact decision and traces
+    // every degrade branch. The ExactOnly policy tripwire lives here at the call
+    // site — not in the generic engine — because the engine is policy-agnostic
+    // and shared across architectures that may use different policies.
+    // ------------------------------------------------------------------
+    assert_eq!(
+        PROMPT_CACHE.policy(),
+        ReusePolicy::ExactOnly,
+        "Qwen3-VL-MoE prompt cache must be ExactOnly — pure-attention text decoder \
+         with no recurrent state and an Exact-hit-dominated workload; partial-prefix \
+         reuse is not wired",
+    );
+    // The text path never carries image ids (images route to generate_image), so
+    // has_image is always false here; the engine's bypass is belt-and-suspenders.
+    let has_image = false;
+    let consumed = PROMPT_CACHE.consume(prompt_ids, kv_quant, has_image);
+
+    // Path A: exact cache hit — skip re-prefill, replay the stored first token,
+    // then run the shared decode loop on the cloned caches.
+    if let Consumed::Exact(cloned) = consumed {
+        let Qwen3VlMoeEntry {
+            kv_caches: mut kv,
+            first_id: first,
+            first_piece,
+            ..
+        } = cloned;
+        tracing::debug!(
+            prompt_len = prompt_ids.len(),
+            token_id = first,
+            "qwen3_vl_moe generate_greedy: prompt cache EXACT HIT"
+        );
+        // The cached first_id is the same token the prefill argmax produced, and
+        // first_piece is its piece_for(...) string (stored at Miss-path push), so
+        // replaying it on the cloned caches yields the same decoded sequence as a
+        // cold run. Subsequent steps re-derive their piece via make_step.
+        decode_from(
+            model,
+            tokenizer,
+            &mut kv,
+            first,
+            Some(first_piece),
+            n_tokens,
+            vocab,
+            device,
+            eos_ids,
+            &mut steps,
+            step_fn,
+            &mut constraint,
+            sampler_cfg,
+            rng,
+            penalty_cfg,
+            token_history,
+        )?;
+        let kv_bytes: u64 = kv.iter().map(|c| c.resident_bytes()).sum();
+        store_kv_cache_bytes(kv_bytes);
+        return Ok(steps);
+    }
+
+    // Path B (Miss): one-shot prefill from scratch.
     let mut kv: Vec<KvCache> = (0..n_layers)
         .enumerate()
         .map(|(i, _)| KvCache::with_quant(kv_quant).with_layer_idx(i))
         .collect();
 
-    let mut steps = Vec::with_capacity(n_tokens);
     let logits = model.forward_seq_with_cache(prompt_ids, Some(&mut kv), device)?;
     let first = pick_token(
         &logits,
@@ -150,10 +247,125 @@ pub fn generate_greedy(
         device,
     )?;
 
+    // Push this prefill snapshot to the prompt cache (Miss → store), gated on
+    // !has_image so an image turn can never pollute the text cache. Clone the
+    // post-prefill KV caches (refcount bump, no data copy) before the decode loop
+    // starts writing new decode-step K/V into them. Materialize the GPU arrays on
+    // the current inference thread first so a later eviction on a different
+    // tokio/Metal thread can re-eval them as a no-op (see qwen3.rs).
+    if !has_image {
+        let kv_bytes: u64 = kv.iter().map(|c| c.resident_bytes()).sum();
+        store_kv_cache_bytes(kv_bytes);
+        let cloned_caches: Result<Vec<KvCache>> = kv.iter().map(|c| c.try_deep_clone()).collect();
+        if let Ok(kv_snapshot) = cloned_caches {
+            match kv_snapshot.iter().try_for_each(|c| c.eval_for_spill()) {
+                Ok(()) => {
+                    // Salt the chained block-hash walk with the active layout_key
+                    // + KV codec so a slot stored under a different codec / layout
+                    // never cross-serves. Identical to the consume() seed, so
+                    // find_best_prefix matches what is stored here.
+                    let lk = active_layout_key();
+                    let block_hashes = chained_block_hashes_seeded(
+                        prompt_ids,
+                        FNV_OFFSET ^ lk ^ kv_quant.cache_key_salt(),
+                    );
+                    let first_piece = piece_for(first, tokenizer);
+                    let entry = Qwen3VlMoeEntry {
+                        prompt_token_ids: prompt_ids.to_vec(),
+                        block_hashes,
+                        kv_caches: kv_snapshot,
+                        first_id: first,
+                        first_piece,
+                        kv_quant: Some(kv_quant),
+                        is_ssd_hydrated: false,
+                    };
+                    PROMPT_CACHE.with_inner_mut(|guard| {
+                        if let Some(cache) = guard.as_mut() {
+                            cache.push(entry);
+                            let stats = cache.stats();
+                            tracing::debug!(
+                                prompt_len = prompt_ids.len(),
+                                cache_hits = stats.hits,
+                                cache_misses = stats.misses,
+                                cache_bytes = stats.bytes,
+                                "qwen3_vl_moe generate_greedy: pushed snapshot to prompt cache (miss path)"
+                            );
+                        }
+                    });
+                }
+                Err(e) => tracing::warn!(error = %e,
+                    "qwen3_vl_moe generate_greedy: pre-eval of KV caches failed, skipping prompt cache store"),
+            }
+        }
+    }
+
+    decode_from(
+        model,
+        tokenizer,
+        &mut kv,
+        first,
+        None,
+        n_tokens,
+        vocab,
+        device,
+        eos_ids,
+        &mut steps,
+        step_fn,
+        &mut constraint,
+        sampler_cfg,
+        rng,
+        penalty_cfg,
+        token_history,
+    )?;
+    Ok(steps)
+}
+
+/// Shared sequential decode loop for both the Exact-hit and Miss text paths.
+///
+/// `first` is the step-0 token (prefill argmax or replayed cache first token);
+/// the loop emits it, then drives the remaining steps with the per-token
+/// `forward_seq_with_cache(&[feed], …)` continuation. `first_piece` is the
+/// stored display piece for `first` on the Exact path (set by `piece_for` at the
+/// Miss-path push, so it is byte-identical to what `make_step` produces); `None`
+/// re-derives it via `make_step`, matching the Miss path exactly.
+///
+/// The per-step decode math (token push, `step_fn` forced-feed, EOS break,
+/// constraint advance, `pick_token`) is byte-identical to the original inline
+/// loop; only the function boundary + the step-0 piece source differ (and that
+/// source produces the same string on both paths via `piece_for`).
+#[allow(clippy::too_many_arguments)]
+fn decode_from(
+    model: &Qwen3VlMoeText,
+    tokenizer: &tokenizers::Tokenizer,
+    kv: &mut [KvCache],
+    first: u32,
+    first_piece: Option<String>,
+    n_tokens: usize,
+    vocab: usize,
+    device: Device,
+    eos_ids: &[u32],
+    steps: &mut Vec<ProbeStep>,
+    step_fn: &mut dyn FnMut(&ProbeStep) -> Option<u32>,
+    constraint: &mut Option<&mut dyn ConstraintEngine>,
+    sampler_cfg: &SamplerConfig,
+    rng: &mut Pcg32,
+    penalty_cfg: &PenaltyConfig,
+    token_history: &mut Vec<u32>,
+) -> Result<()> {
     let mut next = first;
+    let mut first_piece = first_piece;
     for _ in 0..n_tokens {
         token_history.push(next);
-        let step = make_step(next, tokenizer);
+        let step = match first_piece.take() {
+            Some(piece) => ProbeStep {
+                token_id: next,
+                piece: piece.into_boxed_str(),
+                max_abs_logit: 0.0,
+                nan_count: 0,
+                logprobs: None,
+            },
+            None => make_step(next, tokenizer),
+        };
         let forced = step_fn(&step);
         steps.push(step);
         if eos_ids.contains(&next) {
@@ -163,19 +375,19 @@ pub fn generate_greedy(
             c.advance(next);
         }
         let feed = forced.unwrap_or(next);
-        let logits = model.forward_seq_with_cache(&[feed], Some(&mut kv), device)?;
+        let logits = model.forward_seq_with_cache(&[feed], Some(&mut *kv), device)?;
         next = pick_token(
             &logits,
             vocab,
             sampler_cfg,
             penalty_cfg,
-            &mut constraint,
+            constraint,
             token_history,
             rng,
             device,
         )?;
     }
-    Ok(steps)
+    Ok(())
 }
 
 /// Image-branch generation: ViT features already produced by the caller and

--- a/crates/rmlx-models/src/qwen3_vl_moe/mod.rs
+++ b/crates/rmlx-models/src/qwen3_vl_moe/mod.rs
@@ -52,6 +52,7 @@ pub mod loader;
 pub mod model;
 pub(super) mod moe;
 pub(crate) mod mrope;
+pub(crate) mod prompt_cache;
 pub mod vision;
 
 pub use config::{Qwen3VlMoeConfig, Qwen3VlMoeTextConfig, Qwen3VlMoeVisionConfig};
@@ -60,4 +61,6 @@ pub use image_preprocess::{preprocess, Qwen3VlImageConfig, Qwen3VlPixelValues};
 pub use loader::{load_config_qwen3_vl, load_from_path, load_text_from_path};
 pub use model::Qwen3VlMoe;
 pub use model::Qwen3VlMoeText;
+pub use prompt_cache::read_cache_stats as qwen3_vl_moe_cache_stats;
+pub use prompt_cache::read_kv_cache_bytes as qwen3_vl_moe_kv_cache_bytes;
 pub use vision::{load_vision_tower, Qwen3VlMoeVision, VisionOutput};

--- a/crates/rmlx-models/src/qwen3_vl_moe/prompt_cache.rs
+++ b/crates/rmlx-models/src/qwen3_vl_moe/prompt_cache.rs
@@ -1,0 +1,211 @@
+//! Qwen3-VL-MoE prompt-cache entry + global.
+//!
+//! The heavy lifting (static cache, SSD attach/install, ensure, stats readback,
+//! last-bytes counter, and the find → SSD-hydrate retry → quant-guard → Exact →
+//! Miss consume decision) is unified in
+//! [`crate::prompt_cache::ArchPromptCache`]. This file keeps only the genuinely
+//! Qwen3-VL-MoE-specific bits:
+//!
+//! - `Qwen3VlMoeEntry`: `Vec<KvCache>` only. The Qwen3-VL text decoder is a
+//!   plain GQA stack — the MoE is in the FFN and never touches the KV cache, so
+//!   the entry is the same pure-attention shape as Qwen2 / Qwen3 dense (no
+//!   GatedDeltaNet `lin_caches`, no qwen3-only `first_logprobs`).
+//! - `impl PromptCacheEntry for Qwen3VlMoeEntry`: deep_clone + KV accessors. All
+//!   three reuse hooks (`is_hydrate_complete`, `is_reusable_prefix_of`,
+//!   `prepare_reuse`) take the trait defaults, which give correct
+//!   [`ReusePolicy::ExactOnly`] behaviour: a non-hydrated partial match is never
+//!   reusable, and the only reuse the engine permits (a hydrated strict-prefix)
+//!   is declined here (`is_reusable_prefix_of` → `None`), so the only reachable
+//!   consume outcomes are `Exact` and `Miss`.
+//! - `impl SsdHydrate<Qwen3VlMoeEntry> for SsdHydrator`: pure-attention hydrate
+//!   (the reconstructed block carries `kv_caches` only; `lin_caches` is
+//!   discarded). The SSD spill path is the blanket `SpillSink<E> for SsdSpiller`
+//!   in `crate::prompt_cache`, which spills `kv_caches()` only for a
+//!   pure-attention entry (`lin_caches()` is `&[]`).
+//!
+//! ## Reuse policy — Exact-only
+//!
+//! Qwen3-VL-MoE uses [`ReusePolicy::ExactOnly`]. The text path is pure-attention
+//! with losslessly trimmable KV, so a partial-prefix path would be technically
+//! safe; but the dominant workload is the Exact-hit warm-TTFT (identical-prompt
+//! repeat skips re-prefill entirely), and keeping the single Exact / Miss arm
+//! set is simpler and matches the Qwen2 / Qwen3 dense policy. Image turns never
+//! reach the cache (a separate image generate path, plus the consume/store
+//! `has_image` gates) — the token-id key is unsafe across image spans.
+
+#![allow(clippy::redundant_closure_for_method_calls)]
+use rmlx_core::error::Result;
+
+use crate::prompt_cache::{ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate};
+use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
+use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
+
+// ---------------------------------------------------------------------------
+// Entry type
+// ---------------------------------------------------------------------------
+
+/// Post-prefill snapshot for one Qwen3-VL-MoE text request.
+///
+/// The text decoder is plain GQA (the MoE lives in the FFN and never touches the
+/// KV cache), so only `kv_caches` needs snapshotting (no recurrent state). Same
+/// shape as `Qwen2Entry`.
+pub(crate) struct Qwen3VlMoeEntry {
+    /// Full prompt token IDs used to fill this slot.
+    pub(crate) prompt_token_ids: Vec<u32>,
+    /// Chained 256-token block digests of `prompt_token_ids` (trailing partial
+    /// block excluded). Computed at construction.
+    pub(crate) block_hashes: Vec<u64>,
+    /// Post-prefill KV caches (one per decoder layer).
+    pub(crate) kv_caches: Vec<KvCache>,
+    /// Argmax token from the first decode step after prefill.
+    pub(crate) first_id: u32,
+    /// Decoded piece for `first_id`.
+    pub(crate) first_piece: String,
+    /// Runtime `KvQuant` discriminant in effect when this snapshot was written.
+    /// Read by the engine's quant-mismatch guard and by the blanket spill path.
+    pub(crate) kv_quant: Option<KvQuant>,
+    /// True when this entry was reconstructed from the SSD tier and therefore
+    /// stores only the block-aligned prefix KV — `first_id` / `first_piece` are
+    /// placeholders, not a real decode token. The consume engine excludes such
+    /// an entry from the Exact fast path so it falls through to a full
+    /// re-prefill that recomputes the real first token.
+    ///
+    /// MUST be set only in `SsdHydrate::hydrate`; never by the RAM-cache push
+    /// path. Do NOT use the `first_id == 0` heuristic as a substitute —
+    /// `<bos>` token id is 0 for some models.
+    pub(crate) is_ssd_hydrated: bool,
+}
+
+impl PromptCacheEntry for Qwen3VlMoeEntry {
+    fn prompt_token_ids(&self) -> &[u32] {
+        &self.prompt_token_ids
+    }
+
+    fn block_hashes(&self) -> &[u64] {
+        &self.block_hashes
+    }
+
+    fn deep_clone(&self) -> Result<Self> {
+        let kv_caches: Result<Vec<_>> = self.kv_caches.iter().map(|c| c.try_deep_clone()).collect();
+        Ok(Self {
+            prompt_token_ids: self.prompt_token_ids.clone(),
+            block_hashes: self.block_hashes.clone(),
+            kv_caches: kv_caches?,
+            first_id: self.first_id,
+            first_piece: self.first_piece.clone(),
+            kv_quant: self.kv_quant,
+            is_ssd_hydrated: self.is_ssd_hydrated,
+        })
+    }
+
+    fn kv_caches(&self) -> &[KvCache] {
+        &self.kv_caches
+    }
+
+    fn kv_caches_mut(&mut self) -> &mut [KvCache] {
+        &mut self.kv_caches
+    }
+
+    fn kv_quant(&self) -> Option<KvQuant> {
+        self.kv_quant
+    }
+
+    fn is_ssd_hydrated(&self) -> bool {
+        self.is_ssd_hydrated
+    }
+
+    // Plain-attention text decoder: no GDN linear state.
+    fn lin_caches(&self) -> &[LinearAttnCache] {
+        &[]
+    }
+    // is_hydrate_complete / is_reusable_prefix_of / prepare_reuse: trait
+    // defaults. The defaults give correct ExactOnly behaviour (complete by
+    // construction, no partial reuse, deep_clone on the unreachable reuse path).
+    // truncate_kv_to / truncate_kv_to_block / kv_bytes: trait defaults.
+}
+
+// ---------------------------------------------------------------------------
+// SSD-spill sink — the blanket `impl SpillSink<E> for SsdSpiller` in
+// `crate::prompt_cache` covers Qwen3-VL-MoE (pure-attention: `lin_caches()` is
+// `&[]`, so the spill job carries `kv_caches` only).
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// SSD-hydrate source
+// ---------------------------------------------------------------------------
+
+/// Hydrate a `Qwen3VlMoeEntry` from the SSD tier on a RAM-cache miss.
+///
+/// Plain-attention text decoder: the reconstructed block carries `kv_caches`
+/// only (the `lin_caches` from the block are discarded). The matched
+/// block-aligned prefix token IDs become the entry's `prompt_token_ids`; block
+/// hashes are recomputed and the runtime `kv_quant` recorded. `first_id` /
+/// `first_piece` are sentinels (the SSD block stores no first decode token), so
+/// the entry is flagged `is_ssd_hydrated = true`; the consume engine excludes it
+/// from the Exact fast path and the generate loop recomputes the real first
+/// token via re-prefill.
+impl SsdHydrate<Qwen3VlMoeEntry> for SsdHydrator {
+    fn hydrate(&self, prompt_ids: &[u32]) -> Result<Option<Qwen3VlMoeEntry>> {
+        let Some((block, block_hashes)) = self.lookup_seeded(prompt_ids)? else {
+            return Ok(None);
+        };
+        let HydratedBlock {
+            prompt_ids,
+            kv_caches,
+            lin_caches: _, // plain-attention text decoder has no GDN state
+        } = block;
+        Ok(Some(Qwen3VlMoeEntry {
+            prompt_token_ids: prompt_ids,
+            block_hashes,
+            kv_caches,
+            first_id: 0,
+            first_piece: String::new(),
+            kv_quant: Some(self.kv_quant()),
+            // Block-aligned prefix only; the placeholder first_id must not be
+            // replayed — the generate loop re-prefills to recompute it.
+            is_ssd_hydrated: true,
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global cache instance — unified ArchPromptCache shell.
+// ---------------------------------------------------------------------------
+
+/// per-arch shell with `ReusePolicy::ExactOnly`. The Qwen3-VL text decoder is
+/// pure-attention with no recurrent state; the dominant workload is the
+/// Exact-hit warm-TTFT, so the single Exact / Miss arm set (no partial reuse) is
+/// the policy — matching Qwen2 / Qwen3 dense.
+pub(crate) static PROMPT_CACHE: ArchPromptCache<Qwen3VlMoeEntry> =
+    ArchPromptCache::new("Qwen3VLMoeForConditionalGeneration", ReusePolicy::ExactOnly);
+
+/// active SSD-tier `layout_key` for the qwen3-vl-moe cache, or `0` when the tier
+/// is OFF. `FNV_OFFSET ^ 0 == FNV_OFFSET` ⇒ legacy un-salted digests when no SSD
+/// tier is attached, preserving byte-identical RAM-only behaviour.
+pub(crate) fn active_layout_key() -> u64 {
+    PROMPT_CACHE.active_layout_key()
+}
+
+/// Ensure the global prompt cache is initialised with at least `capacity` slots.
+pub(crate) fn ensure_prompt_cache(capacity: usize) {
+    PROMPT_CACHE.ensure(capacity);
+}
+
+/// Read the current hit/miss/bytes stats for the Qwen3-VL-MoE prompt cache.
+pub fn read_cache_stats() -> Option<CacheStats> {
+    PROMPT_CACHE.read_cache_stats()
+}
+
+/// Read the KV-cache bytes from the last completed Qwen3-VL-MoE request.
+pub fn read_kv_cache_bytes() -> u64 {
+    PROMPT_CACHE.read_kv_cache_bytes()
+}
+
+/// Record the KV-cache byte total for the just-completed request.
+pub(crate) fn store_kv_cache_bytes(n: u64) {
+    PROMPT_CACHE.store_kv_cache_bytes(n);
+}
+
+#[cfg(test)]
+#[path = "prompt_cache_tests.rs"]
+mod tests;

--- a/crates/rmlx-models/src/qwen3_vl_moe/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/qwen3_vl_moe/prompt_cache_tests.rs
@@ -1,0 +1,123 @@
+//! In-process unit tests for the Qwen3-VL-MoE prompt cache.
+//!
+//! These exercise the parts that do not need a loaded model or a Metal GPU
+//! stream: the arch policy, the `Qwen3VlMoeEntry` deep_clone round-trip over
+//! empty (never-prefilled) KV caches, the accessor contract, and the
+//! SSD-hydrated entry field invariants (placeholder `first_id` +
+//! `is_ssd_hydrated` flag) the real-model SSD smoke relies on. Decoded-token
+//! reuse is proven by the real-model smoke, not here.
+
+use super::*;
+use rmlx_kv_quant::{KvCache, KvQuant};
+
+/// Build a `Qwen3VlMoeEntry` with `n_layers` empty (never-prefilled) KV caches.
+///
+/// An empty cache holds no live GPU arrays, so `try_deep_clone` is a no-op
+/// refcount walk that runs without a Metal stream — safe in a plain unit test.
+fn mock_ram_entry(n_layers: usize, prompt: &[u32], first_id: u32) -> Qwen3VlMoeEntry {
+    Qwen3VlMoeEntry {
+        prompt_token_ids: prompt.to_vec(),
+        block_hashes: vec![0xABCD_u64; n_layers],
+        kv_caches: (0..n_layers)
+            .map(|_| KvCache::with_quant(KvQuant::None))
+            .collect(),
+        first_id,
+        first_piece: "hello".to_string(),
+        kv_quant: Some(KvQuant::None),
+        is_ssd_hydrated: false,
+    }
+}
+
+/// Qwen3-VL-MoE's policy is hard-gated `ExactOnly`: the shared consume engine
+/// must only ever yield `Exact` or `Miss` for this arch (no partial-prefix
+/// reuse — the text path never sees image ids, and the MoE is FFN-only).
+#[test]
+fn arch_policy_is_exact_only() {
+    assert_eq!(PROMPT_CACHE.policy(), ReusePolicy::ExactOnly);
+}
+
+/// `deep_clone` copies every metadata field and produces an independent entry
+/// with the same KV-cache cardinality. (Empty caches carry no GPU data, so the
+/// clone is a refcount walk; this pins the field-copy contract.)
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: deep_clone over empty KV caches cannot fail — .expect documents the invariant"
+)]
+fn entry_deep_clone_preserves_fields() {
+    let prompt = [1_u32, 2, 3, 4];
+    let entry = mock_ram_entry(3, &prompt, 42);
+    let cloned = entry
+        .deep_clone()
+        .expect("deep_clone of empty-cache entry must succeed");
+
+    assert_eq!(cloned.prompt_token_ids, entry.prompt_token_ids);
+    assert_eq!(cloned.block_hashes, entry.block_hashes);
+    assert_eq!(cloned.kv_caches.len(), entry.kv_caches.len());
+    assert_eq!(cloned.first_id, 42);
+    assert_eq!(cloned.first_piece, "hello");
+    assert_eq!(cloned.kv_quant, Some(KvQuant::None));
+    assert!(!cloned.is_ssd_hydrated);
+}
+
+/// The `PromptCacheEntry` accessors expose the entry's fields verbatim. A
+/// plain-attention Qwen3-VL-MoE entry has no GDN recurrent state, so
+/// `lin_caches()` is empty — this is what makes the blanket `SpillSink` carry KV
+/// only (the MoE is FFN-only and never produces a KV-side cache).
+#[test]
+fn entry_accessors_match_fields() {
+    let prompt = [7_u32, 8, 9];
+    let entry = mock_ram_entry(2, &prompt, 5);
+
+    assert_eq!(entry.prompt_token_ids(), &prompt);
+    assert_eq!(entry.block_hashes(), &[0xABCD_u64, 0xABCD_u64]);
+    assert_eq!(entry.kv_caches().len(), 2);
+    assert_eq!(entry.kv_quant(), Some(KvQuant::None));
+    assert!(!entry.is_ssd_hydrated());
+    assert!(
+        entry.lin_caches().is_empty(),
+        "plain-attention text decoder has no GDN lin state"
+    );
+}
+
+/// A non-hydrated partial match is never reusable under ExactOnly: the default
+/// `is_reusable_prefix_of` hook returns `None` regardless of `matched_blocks`,
+/// so the consume engine can only reach `Exact` or `Miss`.
+#[test]
+fn non_hydrated_partial_is_not_reusable() {
+    let entry = mock_ram_entry(1, &[1, 2, 3], 0);
+    // A longer incoming prompt that the cached one is a prefix of: still None
+    // because the entry is not SSD-hydrated and the default hook declines.
+    assert!(entry
+        .is_reusable_prefix_of(&[1, 2, 3, 4, 5], false, 1)
+        .is_none());
+}
+
+/// An SSD-hydrated entry carries placeholder first-token fields (`first_id == 0`,
+/// empty `first_piece`) and the `is_ssd_hydrated` flag set, mirroring exactly
+/// what `SsdHydrate::hydrate` constructs. The consume engine excludes such an
+/// entry from the Exact fast path so the generate loop recomputes the real first
+/// token via re-prefill. Even as a strict prefix of a longer prompt it is
+/// declined here (the default hook returns `None`), so Qwen3-VL-MoE stays
+/// Exact-only.
+#[test]
+fn ssd_hydrated_entry_field_invariants() {
+    let hydrated = Qwen3VlMoeEntry {
+        prompt_token_ids: vec![10, 11, 12],
+        block_hashes: vec![0xFEED_u64],
+        kv_caches: vec![KvCache::with_quant(KvQuant::None)],
+        first_id: 0,
+        first_piece: String::new(),
+        kv_quant: Some(KvQuant::None),
+        is_ssd_hydrated: true,
+    };
+
+    assert_eq!(hydrated.first_id, 0, "SSD block stores no real first token");
+    assert!(hydrated.first_piece.is_empty());
+    assert!(hydrated.is_ssd_hydrated());
+    // ExactOnly Qwen3-VL-MoE declines even a hydrated strict-prefix reuse
+    // (default hook → None), unlike the moe HydratedTail seam in qwen3_5_moe.
+    assert!(hydrated
+        .is_reusable_prefix_of(&[10, 11, 12, 13], true, 0)
+        .is_none());
+}

--- a/crates/rmlx-models/src/ssd_tier.rs
+++ b/crates/rmlx-models/src/ssd_tier.rs
@@ -90,6 +90,14 @@ pub fn attach_at_load(
                 info.device,
             );
         }
+        "Qwen3VLMoeForConditionalGeneration" => {
+            crate::qwen3_vl_moe::prompt_cache::PROMPT_CACHE.attach_ssd_tier(
+                &info.namespace,
+                info.kv_quant,
+                info.layout_key,
+                info.device,
+            );
+        }
         other => {
             tracing::info!(
                 arch = other,

--- a/crates/rmlx-models/src/ssd_tier.rs
+++ b/crates/rmlx-models/src/ssd_tier.rs
@@ -98,6 +98,14 @@ pub fn attach_at_load(
                 info.device,
             );
         }
+        "LagunaForCausalLM" => {
+            crate::laguna::prompt_cache::PROMPT_CACHE.attach_ssd_tier(
+                &info.namespace,
+                info.kv_quant,
+                info.layout_key,
+                info.device,
+            );
+        }
         other => {
             tracing::info!(
                 arch = other,

--- a/crates/rmlx-models/src/ssd_tier.rs
+++ b/crates/rmlx-models/src/ssd_tier.rs
@@ -66,6 +66,14 @@ pub fn attach_at_load(
                 info.device,
             );
         }
+        "Qwen2ForCausalLM" => {
+            crate::qwen2::prompt_cache::PROMPT_CACHE.attach_ssd_tier(
+                &info.namespace,
+                info.kv_quant,
+                info.layout_key,
+                info.device,
+            );
+        }
         other => {
             tracing::info!(
                 arch = other,

--- a/crates/rmlx-models/src/ssd_tier.rs
+++ b/crates/rmlx-models/src/ssd_tier.rs
@@ -50,6 +50,14 @@ pub fn attach_at_load(
                 info.device,
             );
         }
+        "Gemma3ForConditionalGeneration" => {
+            crate::gemma3::prompt_cache::PROMPT_CACHE.attach_ssd_tier(
+                &info.namespace,
+                info.kv_quant,
+                info.layout_key,
+                info.device,
+            );
+        }
         "Qwen3_5MoeForConditionalGeneration" => {
             crate::qwen3_5_moe::prompt_cache::PROMPT_CACHE.attach_ssd_tier(
                 &info.namespace,

--- a/crates/rmlx-models/src/ssd_tier.rs
+++ b/crates/rmlx-models/src/ssd_tier.rs
@@ -74,6 +74,14 @@ pub fn attach_at_load(
                 info.device,
             );
         }
+        "BitNetForCausalLM" => {
+            crate::bitnet::prompt_cache::PROMPT_CACHE.attach_ssd_tier(
+                &info.namespace,
+                info.kv_quant,
+                info.layout_key,
+                info.device,
+            );
+        }
         other => {
             tracing::info!(
                 arch = other,


### PR DESCRIPTION
## Summary

Lifts the per-architecture prompt-cache consume/hydrate decision into one
model-agnostic `consume()` engine on `ArchPromptCache<E>`, plus three defaulted
`PromptCacheEntry` hooks (`is_hydrate_complete`, `is_reusable_prefix_of`,
`prepare_reuse`). The engine owns the read-only find → hydrate-retry →
quant-guard → Exact → reuse → Miss decision once; per-arch policy rides on the
hooks. New architectures inherit correct behavior by default.

The 3 already-cached arches are migrated onto the engine **behavior-identically**;
caches are then **retrofitted** onto 5 previously-uncached arches (all `ExactOnly`).

Closes #84.

## What changed

- **Shared engine** (`rmlx-models/src/prompt_cache.rs`): `Consumed<E>` / `ReuseKind`,
  the `consume()` decision, the 3 defaulted hooks, per-branch degrade tracing.
- **Migrations (behavior-identical):** qwen3 dense (ExactOnly), gemma4 (Partial:
  strict-prefix + block-truncate + SWA hydrate-completeness), qwen3.5-moe
  (ExactOnly with the SSD-hydrated strict-prefix HydratedTail seam + GDN state
  preserved via deep-clone). The 3 migrated arches no longer carry a private
  `CacheLookup` enum.
- **Retrofits (ExactOnly):** qwen2, bitnet, gemma3 (SWA, text-only/`!has_image`-gated),
  qwen3-vl-moe (text path, image bypass), laguna. Each adds an Entry +
  `SsdHydrate` impl + static cache + dispatch + ssd-tier arm + prefill
  snapshot-store + a release-firing policy tripwire.

## Validation

Every phase is proven on a real model, not just unit tests:

- **Migrations:** golden decoded-token-sequence parity at temp 0 (RAM exact-hit,
  SSD spill→restart→hydrate byte-identity, hydrated-equal-length recompute) on
  Bonsai / gemma4-e2b / Qwen3.6.
- **Retrofits:** real-model smoke (cold → RAM exact-hit byte-identical → distinct
  Miss coherent) on a snapshot of each arch; gemma3 also proves image requests
  bypass the cache without polluting it.
- **Regression:** decode-TPS canary on the three tracked families shows no
  regression across all phases (consume is off the steady-state decode hot path).
- `make ci` green (fmt + clippy `-D warnings` + workspace tests + deny + audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)