### PR TITLE
fix(mlx): Array::to_bytes evaluates before reading the data pointer

### DIFF
--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -635,12 +635,19 @@ impl Array {
         unsafe { check_status(status, "Array::async_eval") }
     }
 
-    /// Copy evaluated array contents into a fresh `Vec<u8>`.
+    /// Copy array contents into a fresh `Vec<u8>`.
     ///
-    /// The array must have been evaluated first — returns an error if the
-    /// data pointer is null (unevaluated or empty array).
+    /// Forces evaluation first so the read is always of materialized data.
+    /// MLX is lazy and `async_eval` only *schedules* compute; the data pointer
+    /// returned by `mlx_array_data_uint8` is not guaranteed to hold the result
+    /// until the graph has actually run. Calling `eval()` here blocks until it
+    /// has — idempotent and near-free on an already-evaluated array. Without
+    /// it, reading the pointer can race the asynchronous evaluation and return
+    /// stale/recycled buffer bytes (another array's data) rather than this
+    /// array's value.
     pub fn to_bytes(&self) -> Result<Vec<u8>> {
         install_error_handler();
+        self.eval()?;
         let nbytes = unsafe { sys::mlx_array_nbytes(self.inner) };
         if nbytes == 0 {
             return Ok(Vec::new());

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -208,10 +208,14 @@ methods trigger execution:
 
 ### Data readback
 
-`Array::to_bytes()` calls `mlx_array_data_uint8` to obtain a raw pointer to
-the materialized buffer, then copies into a `Vec<u8>`. The pointer is valid
-only for the lifetime of the `Array` object and only after the graph has been
-materialized; the method returns `Err` if the pointer is null.
+`Array::to_bytes()` forces evaluation (`eval()`) before reading, then calls
+`mlx_array_data_uint8` to obtain a raw pointer to the materialized buffer and
+copies into a `Vec<u8>`. Because it materializes internally, callers do not
+need a preceding `eval()` / `async_eval()` for correctness — an upstream
+`async_eval()` stays a pipelining hint, not a correctness prerequisite (the
+data pointer is not guaranteed valid until evaluation has actually run). The
+pointer is valid only for the lifetime of the `Array` object; the method
+returns `Err` if the pointer is null.
 
 ```rust
 // SAFETY: ptr is non-null and points to `nbytes` contiguous bytes owned


### PR DESCRIPTION
## Summary

Fixes a latent read-before-eval defect in `Array::to_bytes()` that surfaced as a flaky test (`pipelined_decode_stops_on_eos`) under full-suite parallelism.

MLX is lazy: `async_eval()` only *schedules* compute on a background stream worker. `to_bytes()` read the data pointer (`mlx_array_data_uint8`) without forcing evaluation, so under load the read raced the async worker and returned stale/recycled buffer bytes — another array's f32 data reinterpreted as u32 token ids. The pipelined decode drain relied on `to_bytes()` being the materialization point, but it never actually blocked.

Fix: call `self.eval()?` at the top of `to_bytes()`. `eval()` joins an in-flight `async_eval` and is idempotent/near-free on an already-evaluated array — making the documented contract real for every caller, not just this test. `to_bytes` is the only `mlx_array_data_*` reader in the crate, so the fix is crate-complete.

Closes #100.

## Root cause

- `crates/rmlx-mlx/src/lib.rs` — `to_bytes()` read the pointer before the graph was guaranteed materialized.

The issue's original hypothesis (a `mlx_guard()` / concurrency-lock scope problem) was falsified during investigation: single-threaded runs still flaked, and a `synchronize()` probe had no effect. The defect is the deferred read, not concurrency.

## Validation

- **Suite stability:** baseline 7/40 full-suite parallel runs failed (~17.5%); after the fix **50/50 consecutive runs pass**, 0 failures. Isolated test still passes.
- **No decode regression** (perf canary, decode-only TPS vs recorded anchors): Bonsai +2.4%, Gemma4-e4b +1.9%, Qwen3.6-MoE −1.08% (median 95.56, within ±5%; one MoE thermal outlier). `to_bytes` is on the decode drain path, so the added `eval()` was the regression risk — confirmed clean across all three families.
- **Coherence:** all three families generate coherent output.
- `make lint` clean, `cargo fmt --all` clean.

## Docs

- `docs/FFI.md` "Data readback" — corrected to state `to_bytes()` self-materializes; an upstream `async_eval()` is a pipelining hint, not a correctness prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)