### PR TITLE
fix(server): establish GPU default stream on all blocking-thread inference entries

### DIFF
--- a/crates/rmlx-mlx/src/lib_tests.rs
+++ b/crates/rmlx-mlx/src/lib_tests.rs
@@ -55,6 +55,45 @@ fn add_two_f32_arrays_gpu() {
     assert_eq!(out, vec![2.0f32, 4.0, 6.0, 8.0]);
 }
 
+/// Smoke test for the blocking-thread GPU stream guard.
+///
+/// The generate entry points call `ensure_gpu_default_stream()` once at the
+/// top of each tokio blocking-pool worker so MLX's per-thread CommandEncoder
+/// map has an entry for `Stream(gpu, 0)` before any `Array::eval()`. This test
+/// runs that exact sequence on a freshly-spawned OS thread (the analog of a
+/// blocking-pool worker that never called `mlx::core::new_stream`): establish
+/// the stream, then materialise a GPU array.
+///
+/// Note: this asserts the guard is safe + idempotent off a worker thread and
+/// that GPU eval succeeds there. It is NOT a strict negative regression — the
+/// "no Stream(gpu, 0)" eval failure is MLX-version- and timing-dependent
+/// (recent mlx-c may lazily register the encoder for the global default stream
+/// on first access), so a bare fresh-thread eval does not reliably fault. The
+/// real cross-path proof is a live serve exercising the speculative / image
+/// generate paths.
+#[test]
+#[ignore = "requires Metal GPU; run with `-- --ignored` in a GPU-capable environment"]
+fn gpu_default_stream_guard_idempotent_on_worker_thread() {
+    let handle = std::thread::spawn(|| {
+        // Establish the GPU default stream for THIS thread, exactly as the
+        // blocking-thread generate entry points do before any materialisation.
+        ensure_gpu_default_stream();
+        // Idempotent: a second call from the same thread is a no-op.
+        ensure_gpu_default_stream();
+
+        let input: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
+        let bytes = f32_as_bytes(&input);
+        let shape = [2i32, 2];
+        let a = Array::from_bytes(bytes, &shape, Dtype::F32).unwrap();
+        let b = Array::from_bytes(bytes, &shape, Dtype::F32).unwrap();
+        let c = add(&a, &b, Device::Gpu).unwrap();
+        c.eval().unwrap();
+        bytes_to_f32(&c.to_bytes().unwrap())
+    });
+    let out = handle.join().expect("worker thread panicked");
+    assert_eq!(out, vec![2.0f32, 4.0, 6.0, 8.0]);
+}
+
 #[test]
 fn from_bytes_wrong_size_is_err() {
     let result = Array::from_bytes(&[0u8; 3], &[2, 2], Dtype::F32);

--- a/crates/rmlx-mlx/src/lib_tests.rs
+++ b/crates/rmlx-mlx/src/lib_tests.rs
@@ -59,7 +59,7 @@ fn add_two_f32_arrays_gpu() {
 ///
 /// The generate entry points call `ensure_gpu_default_stream()` once at the
 /// top of each tokio blocking-pool worker so MLX's per-thread CommandEncoder
-/// map has an entry for `Stream(gpu, 0)` before any `Array::eval()`. This test
+/// map has a registered encoder before any `Array::eval()`. This test
 /// runs that exact sequence on a freshly-spawned OS thread (the analog of a
 /// blocking-pool worker that never called `mlx::core::new_stream`): establish
 /// the stream, then materialise a GPU array.

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -1094,6 +1094,17 @@ impl Architecture {
     ) -> Result<Vec<crate::decode_loop::ProbeStep>> {
         use crate::kv_cache::KvCacheBuilder;
         use rmlx_kv_quant::KvQuant;
+
+        // Ensure the GPU default stream is registered for the calling thread.
+        // tokio blocking-pool threads start with no GPU stream context; MLX's
+        // array materialisation then fails with "There is no Stream(gpu, 0) in
+        // current thread". Registering the process-global GPU stream once per
+        // thread entry point avoids this without changing any ML semantics.
+        // Mirrors the text `generate_greedy` entry.
+        if device == Device::Gpu {
+            rmlx_mlx::ensure_gpu_default_stream();
+        }
+
         match self {
             Architecture::Gemma4(m) => {
                 // `for_arch_default` deprecated; no ModelConfig at this call site → keep K8V8.

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -895,11 +895,10 @@ impl Architecture {
         let kv_quant: KvQuant =
             kv_quant_override.unwrap_or_else(|| KvCacheBuilder::for_arch_default(arch_name));
 
-        // Ensure the GPU default stream is registered for the calling thread.
-        // tokio blocking-pool threads start with no GPU stream context; MLX's
-        // array materialisation then fails with "There is no Stream(gpu, 0) in
-        // current thread". Registering the process-global GPU stream once per
-        // thread entry point avoids this without changing any ML semantics.
+        // Registering a thread-local GPU stream + CommandEncoder once per thread entry point.
+        // tokio blocking-pool threads start with no GPU stream context; MLX's array
+        // materialisation then fails with "There is no Stream(gpu, 0) in current thread".
+        // This is a no-op if already registered; zero ML-semantic effect.
         if device == Device::Gpu {
             rmlx_mlx::ensure_gpu_default_stream();
         }
@@ -1095,12 +1094,10 @@ impl Architecture {
         use crate::kv_cache::KvCacheBuilder;
         use rmlx_kv_quant::KvQuant;
 
-        // Ensure the GPU default stream is registered for the calling thread.
-        // tokio blocking-pool threads start with no GPU stream context; MLX's
-        // array materialisation then fails with "There is no Stream(gpu, 0) in
-        // current thread". Registering the process-global GPU stream once per
-        // thread entry point avoids this without changing any ML semantics.
-        // Mirrors the text `generate_greedy` entry.
+        // Registering a thread-local GPU stream + CommandEncoder once per thread entry point.
+        // tokio blocking-pool threads start with no GPU stream context; MLX's array
+        // materialisation then fails with "There is no Stream(gpu, 0) in current thread".
+        // Mirrors the text `generate_greedy` entry; zero ML-semantic effect.
         if device == Device::Gpu {
             rmlx_mlx::ensure_gpu_default_stream();
         }

--- a/crates/rmlx-server/src/audio.rs
+++ b/crates/rmlx-server/src/audio.rs
@@ -251,6 +251,14 @@ async fn handle_audio(state: AppState, mut multipart: Multipart, task: WhisperTa
 
         let device = Device::Gpu;
 
+        // Registering a thread-local GPU stream + CommandEncoder once per thread entry point.
+        // tokio blocking-pool threads start with no GPU stream context; MLX's array
+        // materialisation then fails with "There is no Stream(gpu, 0) in current thread".
+        // Mirrors the pattern used at the text and image generate entry points.
+        if device == Device::Gpu {
+            rmlx_mlx::ensure_gpu_default_stream();
+        }
+
         // Resolve model + tokenizer from cache, loading on first call.
         //
         // Read path (fast): no allocation, just Arc::clone while holding the

--- a/crates/rmlx-server/src/embeddings.rs
+++ b/crates/rmlx-server/src/embeddings.rs
@@ -598,6 +598,14 @@ fn compute_embeddings(
 
     let device = rmlx_mlx::Device::Gpu;
 
+    // Registering a thread-local GPU stream + CommandEncoder once per thread entry point.
+    // tokio blocking-pool threads start with no GPU stream context; MLX's array
+    // materialisation then fails with "There is no Stream(gpu, 0) in current thread".
+    // Mirrors the pattern used at the text and image generate entry points.
+    if device == rmlx_mlx::Device::Gpu {
+        rmlx_mlx::ensure_gpu_default_stream();
+    }
+
     // Build (single_vec | multi_vec) per item with a uniform serializer so
     // the response shape is identical for text and image.
     let mut data = Vec::new();

--- a/crates/rmlx-server/src/engine/image.rs
+++ b/crates/rmlx-server/src/engine/image.rs
@@ -237,13 +237,10 @@ pub(crate) fn run_qwen3vl_image(
     token_history: &mut Vec<u32>,
     mm_cache: Option<&rmlx_models::multimodal_cache::MultimodalCache>,
 ) -> rmlx_core::Result<Vec<rmlx_models::ProbeStep>> {
-    // Ensure the GPU default stream is registered for the calling thread.
-    // tokio blocking-pool threads start with no GPU stream context; MLX's
-    // array materialisation then fails with "There is no Stream(gpu, 0) in
-    // current thread". Registering the process-global GPU stream once per
-    // thread entry point avoids this without changing any ML semantics.
-    // Mirrors the text `generate_greedy` entry; the ViT pass and decode below
-    // both materialise arrays on this thread.
+    // Registering a thread-local GPU stream + CommandEncoder once per thread entry point.
+    // tokio blocking-pool threads start with no GPU stream context; MLX's array
+    // materialisation then fails with "There is no Stream(gpu, 0) in current thread".
+    // The ViT pass and decode below both materialise arrays on this thread; zero ML-semantic effect.
     if device == rmlx_mlx::Device::Gpu {
         rmlx_mlx::ensure_gpu_default_stream();
     }

--- a/crates/rmlx-server/src/engine/image.rs
+++ b/crates/rmlx-server/src/engine/image.rs
@@ -237,6 +237,17 @@ pub(crate) fn run_qwen3vl_image(
     token_history: &mut Vec<u32>,
     mm_cache: Option<&rmlx_models::multimodal_cache::MultimodalCache>,
 ) -> rmlx_core::Result<Vec<rmlx_models::ProbeStep>> {
+    // Ensure the GPU default stream is registered for the calling thread.
+    // tokio blocking-pool threads start with no GPU stream context; MLX's
+    // array materialisation then fails with "There is no Stream(gpu, 0) in
+    // current thread". Registering the process-global GPU stream once per
+    // thread entry point avoids this without changing any ML semantics.
+    // Mirrors the text `generate_greedy` entry; the ViT pass and decode below
+    // both materialise arrays on this thread.
+    if device == rmlx_mlx::Device::Gpu {
+        rmlx_mlx::ensure_gpu_default_stream();
+    }
+
     let (vision, processor) = match vb {
         VisionBundle::Qwen3VlMoe { vision, processor } => (vision, processor),
         _ => {

--- a/crates/rmlx-server/src/engine/speculative.rs
+++ b/crates/rmlx-server/src/engine/speculative.rs
@@ -712,6 +712,19 @@ impl Generator for SpeculativeGenerator {
             // (mirrors ArchGenerator). Released on closure exit.
             let _gpu_admission = gpu_admission;
 
+            // Ensure the GPU default stream is registered for the calling
+            // thread. tokio blocking-pool threads start with no GPU stream
+            // context; MLX's array materialisation then fails with "There is
+            // no Stream(gpu, 0) in current thread". The single-arch text path
+            // establishes this in `arch::generate_greedy`, but the speculative
+            // drafter round-loops dispatch into the verifier directly without
+            // going through that entry, so register it here once per thread
+            // entry — covers every drafter variant below with no ML-semantic
+            // effect.
+            if dispatcher.device() == rmlx_mlx::Device::Gpu {
+                rmlx_mlx::ensure_gpu_default_stream();
+            }
+
             tracing::debug!(model_id = %model_id_for_log, k, "spec generate: blocking thread started");
 
             // Full-prefix decode → byte-diff per token (mirrors

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -118,8 +118,10 @@ ML-semantic effect.
 **Contract:** every blocking-thread inference entry point must call it once
 before any GPU materialisation. Covered entries: the text generate dispatch
 (`arch::generate_greedy`), the image generate dispatch
-(`arch::generate_image` and the server's `run_qwen3vl_image`), and the
-speculative-decode blocking closure. New blocking-pool entry points that
+(`arch::generate_image` and the server's `run_qwen3vl_image`), the
+speculative-decode blocking closure, the audio-transcription blocking closure
+(`audio.rs` Whisper decode), and the embeddings compute closure
+(`embeddings.rs` `compute_embeddings`). New blocking-pool entry points that
 materialise GPU arrays must follow the same pattern.
 
 ### Null sentinel for optional arguments

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -99,6 +99,29 @@ which return a reference-counted handle to the already-running default
 stream. Freeing the handle decrements the ref-count; the stream and its
 thread are never torn down.
 
+### Per-thread GPU stream context — `ensure_gpu_default_stream`
+
+`with_stream` borrows the process-global default stream, but MLX's
+`eval` materialises arrays through a **thread-local** map of
+`{stream_index → CommandEncoder}`. The encoder entry for a given stream is
+created when `mlx::core::new_stream` runs on that thread. tokio
+blocking-pool worker threads never call `new_stream`, so an `Array::eval()`
+on such a thread can fail with `There is no Stream(gpu, 0) in current
+thread`.
+
+`rmlx_mlx::ensure_gpu_default_stream()` fixes this: it creates a GPU stream
+(registering a fresh `CommandEncoder` for the calling thread), sets it as the
+thread's default, and stores the handle in a thread-local for the thread's
+lifetime. It is idempotent and a no-op when the GPU is unavailable, with zero
+ML-semantic effect.
+
+**Contract:** every blocking-thread inference entry point must call it once
+before any GPU materialisation. Covered entries: the text generate dispatch
+(`arch::generate_greedy`), the image generate dispatch
+(`arch::generate_image` and the server's `run_qwen3vl_image`), and the
+speculative-decode blocking closure. New blocking-pool entry points that
+materialise GPU arrays must follow the same pattern.
+
 ### Null sentinel for optional arguments
 
 Several mlx-c functions accept optional `mlx_array` arguments. When the


### PR DESCRIPTION
## Summary

Fixes `Array::eval: There is no Stream(gpu, 0) in current thread` aborts on tokio `spawn_blocking` worker threads that materialize GPU arrays without first establishing the per-thread MLX stream/CommandEncoder.

Closes #99.

## Re-scope (the issue mislocated the bug)

The issue blamed the plain `--kv-quant none` text prefill (`exit_prefill` eval). Diagnosis against the code found that path is **already covered** by `ensure_gpu_default_stream()` in `Architecture::generate_greedy`. Corrections to the filed claims:

- **Not None-specific.** Every `exit_prefill` `.eval()` (None, quantized, and Paged) runs on the calling thread; any of them fail identically if the thread is stream-less.
- **The "Paged defers its seed eval" claim is false** — the Paged branch evals eagerly, same as None.
- **Genuinely uncovered** blocking-thread GPU-eval entries (no `ensure_gpu_default_stream` in their chain): the image dispatch (`Architecture::generate_image`), `run_qwen3vl_image` (defaults to `--kv-quant none`), the speculative-decode closure, and — same latent class — the audio-transcription and embeddings closures.

## Fix

Add the established idempotent, ML-neutral guard `if device == Device::Gpu { ensure_gpu_default_stream(); }` at the top of each uncovered blocking-thread entry, mirroring the already-covered text path. One guard at the speculative closure covers all five drafter dispatch arms. This closes the whole class — the `docs/FFI.md` contract ("every blocking-thread inference entry establishes the stream before any GPU materialization") is now actually met. Eval-deferral was rejected: it only moves the crash if the thread is genuinely stream-less, and the Paged "precedent" for deferral does not exist.

## Validation

Real-hardware serve smokes on the fixed branch — all coherent, all run logs contain **zero** `no Stream(gpu`:

- **Speculative:** Qwen3.6-35B verifier + MTP drafter — coherent output, round-loop engaged (accept-rate 0.83).
- **Image:** Qwen3-VL-30B (`run_qwen3vl_image`, `kv_quant=None` — the exact None eval path) — correct vision answer.
- **Audio:** Whisper-large-v3 transcription — correct.
- **Embeddings:** jina-v4 — valid 2048-dim vectors.
- **Plain `--kv-quant none`** text — coherent (regression guard; was never broken).

Honest caveat: the fault is timing/MLX-version-dependent and could not be turned into a deterministic fail-without/pass-with unit test (the guard is ML-neutral thread-context plumbing). It is **not** hypothetical — a pre-fix run log on the test machine contains the literal `Array::eval: There is no Stream(gpu, 0)` on a real `exit_prefill` path; the guarded branch shows it gone across every path. A `#[ignore]` GPU smoke/idempotency test is added and documented as such (not a strict negative regression).

## Docs

- `docs/FFI.md` — new "Per-thread GPU stream context" section: the thread-local stream/CommandEncoder mechanism, the failure mode, the contract, and the full list of covered entries.

## Followups (out of scope, flagged)

- The serve claim file is not auto-removed on SIGTERM (RAII drop fires on normal exit, not terminate) — unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)