### PR TITLE
fix(kv-quant): sequence-major layout for QuantV / TurboSym-K / paged handoff (part of #105)

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -4742,8 +4742,22 @@ impl KvCache {
         let page_tokens = paged_kv_page_tokens();
         let n_pages = ((max_seq + page_tokens - 1) / page_tokens) as usize;
 
+        // The page slabs store `words_per_token` (all heads) per token slot, so
+        // the physical layout is sequence-major: per token, all heads are
+        // contiguous. `new_k`/`new_v` arrive head-major (`[B, kv_h, S, D]`);
+        // quantizing them directly emits head-major codes that the per-token
+        // page write then mis-indexes (the `prev_seq * words_per_seq` class of
+        // the QuantK / QuantV layout fix). Reorder to sequence-major
+        // `[B, S, kv_h, D]` and materialize (`contiguous`) — the q8 / TurboQuant
+        // / PlanarQuant MSL kernels read their input by raw linear offset and
+        // ignore MLX strides. `gather` then yields a sequence-major prefix;
+        // dequant reshapes sequence-major and transposes back to the logical
+        // `[B, kv_h, S, D]`.
+        let new_k_sm = new_k.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
+        let new_v_sm = new_v.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
+
         // --- K (always q8_0) ---
-        let (codes_k, scales_k) = q8_quantize_gpu(new_k, device)?;
+        let (codes_k, scales_k) = q8_quantize_gpu(&new_k_sm, device)?;
         let KvStorage::Paged { k, .. } = &mut self.storage else {
             unreachable!()
         };
@@ -4756,18 +4770,24 @@ impl KvCache {
         let total_k = pk.total_tokens;
         let n_pages_k = pk.block_table.len();
         let (gathered_codes_k, gathered_scales_k) = pk.gather(device)?;
+        // `pk.shape` is the accumulated head-major `[B, kv_h, S, D]`; the page
+        // buffer is sequence-major, so dequant into `[B, S, kv_h, D]` then
+        // transpose heads↔seq back to the logical head-major shape.
+        let k_sm_shape = [k_shape[0], k_shape[2], k_shape[1], k_shape[3]];
         let k_full = q8_dequantize_gpu(
             &gathered_codes_k,
             &gathered_scales_k,
-            &k_shape,
+            &k_sm_shape,
             new_k.dtype(),
             device,
-        )?;
+        )?
+        .transpose(&[0, 2, 1, 3], device)?
+        .contiguous(device)?;
 
         // --- V (mode-dependent) ---
         let v_full = match paged_quant {
             KvQuant::K8V8 => {
-                let (codes_v, scales_v) = q8_quantize_gpu(new_v, device)?;
+                let (codes_v, scales_v) = q8_quantize_gpu(&new_v_sm, device)?;
                 let KvStorage::Paged { v_k8, .. } = &mut self.storage else {
                     unreachable!()
                 };
@@ -4782,17 +4802,20 @@ impl KvCache {
                 let pv = v_k8.as_mut().unwrap();
                 pv.append(&new_shape, codes_v, scales_v, device)?;
                 let v_shape = pv.shape.clone();
+                let v_sm_shape = [v_shape[0], v_shape[2], v_shape[1], v_shape[3]];
                 let (gathered_codes_v, gathered_scales_v) = pv.gather(device)?;
                 q8_dequantize_gpu(
                     &gathered_codes_v,
                     &gathered_scales_v,
-                    &v_shape,
+                    &v_sm_shape,
                     new_v.dtype(),
                     device,
                 )?
+                .transpose(&[0, 2, 1, 3], device)?
+                .contiguous(device)?
             }
             KvQuant::K8V4 => {
-                let (codes_v, scales_v) = turbo_quantize_v4_gpu(new_v, device)?;
+                let (codes_v, scales_v) = turbo_quantize_v4_gpu(&new_v_sm, device)?;
                 let KvStorage::Paged { v_k8, .. } = &mut self.storage else {
                     unreachable!()
                 };
@@ -4807,17 +4830,20 @@ impl KvCache {
                 let pv = v_k8.as_mut().unwrap();
                 pv.append(&new_shape, codes_v, scales_v, device)?;
                 let v_shape = pv.shape.clone();
+                let v_sm_shape = [v_shape[0], v_shape[2], v_shape[1], v_shape[3]];
                 let (gathered_codes_v, gathered_scales_v) = pv.gather(device)?;
                 turbo_dequantize_v4_gpu(
                     &gathered_codes_v,
                     &gathered_scales_v,
-                    &v_shape,
+                    &v_sm_shape,
                     new_v.dtype(),
                     device,
                 )?
+                .transpose(&[0, 2, 1, 3], device)?
+                .contiguous(device)?
             }
             KvQuant::Planar => {
-                let (codes_v, scales_v, rotations_v) = planar_quantize_v4_gpu(new_v, device)?;
+                let (codes_v, scales_v, rotations_v) = planar_quantize_v4_gpu(&new_v_sm, device)?;
                 let KvStorage::Paged { v_planar, .. } = &mut self.storage else {
                     unreachable!()
                 };
@@ -4831,15 +4857,18 @@ impl KvCache {
                 let pv = v_planar.as_mut().unwrap();
                 pv.append(&new_shape, codes_v, scales_v, rotations_v, device)?;
                 let v_shape = pv.shape.clone();
+                let v_sm_shape = [v_shape[0], v_shape[2], v_shape[1], v_shape[3]];
                 let (gathered_codes_v, gathered_scales_v, gathered_rotations_v) =
                     pv.gather(device)?;
                 let out = planar_dequantize_v4_gpu(
                     &gathered_codes_v,
                     &gathered_scales_v,
                     &gathered_rotations_v,
-                    &v_shape,
+                    &v_sm_shape,
                     device,
-                )?;
+                )?
+                .transpose(&[0, 2, 1, 3], device)?
+                .contiguous(device)?;
                 if out.dtype() == new_v.dtype() {
                     out
                 } else {

--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -46,6 +46,7 @@ mod quant_rotor_k4;
 mod quant_rotor_v3;
 mod quant_rotor_v4;
 mod quant_v;
+mod seq_layout;
 
 pub use kv_storage::{
     KvStorage, ISOV3_LAYOUT_TAG, ISOV4_LAYOUT_TAG, ISO_K_ONLY_3_LAYOUT_TAG,

--- a/crates/rmlx-kv-quant/src/storage/quant_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k.rs
@@ -64,47 +64,7 @@ pub struct QuantK {
     pub max_seq: i32,
 }
 
-/// Reorder a flat head-major `[B, kv_h, S, D]` buffer to sequence-major
-/// `[B, S, kv_h, D]`. Used by the CPU `append` path to mirror the GPU buffer's
-/// sequence-major layout.
-#[allow(
-    clippy::indexing_slicing,
-    reason = "src/out are sized b*kv_h*s*d; every (bi,h,si) base + d stays in bounds by construction"
-)]
-fn transpose_heads_seq(src: &[f32], b: usize, kv_h: usize, s: usize, d: usize) -> Vec<f32> {
-    let mut out = vec![0.0_f32; b * kv_h * s * d];
-    for bi in 0..b {
-        for h in 0..kv_h {
-            for si in 0..s {
-                let src_base = ((bi * kv_h + h) * s + si) * d;
-                let dst_base = ((bi * s + si) * kv_h + h) * d;
-                out[dst_base..dst_base + d].copy_from_slice(&src[src_base..src_base + d]);
-            }
-        }
-    }
-    out
-}
-
-/// Inverse of [`transpose_heads_seq`]: reorder a flat sequence-major
-/// `[B, S, kv_h, D]` buffer back to head-major `[B, kv_h, S, D]`. Used by the
-/// CPU `dequantize_choice` path so callers see the logical `[B, kv_h, S, D]`.
-#[allow(
-    clippy::indexing_slicing,
-    reason = "src/out are sized b*s*kv_h*d; every (bi,si,h) base + d stays in bounds by construction"
-)]
-fn transpose_seq_heads(src: &[f32], b: usize, s: usize, kv_h: usize, d: usize) -> Vec<f32> {
-    let mut out = vec![0.0_f32; b * s * kv_h * d];
-    for bi in 0..b {
-        for si in 0..s {
-            for h in 0..kv_h {
-                let src_base = ((bi * s + si) * kv_h + h) * d;
-                let dst_base = ((bi * kv_h + h) * s + si) * d;
-                out[dst_base..dst_base + d].copy_from_slice(&src[src_base..src_base + d]);
-            }
-        }
-    }
-    out
-}
+use super::seq_layout::{transpose_heads_seq, transpose_seq_heads};
 
 impl QuantK {
     /// Append a new K slice. Picks CPU or GPU path from `device`.

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo3.rs
@@ -1,18 +1,17 @@
 // K-side TurboQuant 3-bit storage, mirror of `QuantKTurbo4`.
 //
-// Decision A (CPU K-side handling): transpose-before-call for the CPU path.
-// The V-side codec `turbo_quantize_v` is axis-agnostic — it treats its input
-// as a flat buffer shaped [B, kv_h, S, D] and operates over the last axis.
-// For K we simply pass the K array as-is (axis labels are semantics; the
-// byte layout is identical). No transposition needed: the K array arriving
-// at `append` is already shaped [B, kv_h, S, D] just like V.
-//
-// Decision B (MSL kernel): extended in place via the existing
-// `k8vturbo3_append_msl.rs` GPU path (`turbo_quantize_v3_gpu` /
-// `turbo_dequantize_v3_gpu`). The 3-bit kernel is axis-agnostic (same as
-// the 4-bit kernel that is reused). No fork needed: the Turbo3 K side just
-// calls the same GPU functions as the V side (precedent: `QuantKTurbo4`
-// calls `turbo_quantize_v4_gpu` and `turbo_dequantize_v4_gpu`).
+// CPU + MSL codec reuse: the V-side codec `turbo_quantize_v` and the
+// `k8vturbo3_append_msl.rs` GPU kernels (`turbo_quantize_v3_gpu` /
+// `turbo_dequantize_v3_gpu`) are positional — they group a flat buffer over
+// the last axis and do not interpret the head/seq axes. The Turbo3 K side
+// reuses them directly (no kernel fork; precedent: `QuantKTurbo4` reuses the
+// 4-bit kernels). Because the codec is positional, the *physical buffer order*
+// is what determines correctness across appends: `append` stores every chunk
+// sequence-major (`[B, S, kv_h, D]`) — reordering the head-major input
+// heads↔seq before quantizing — and `dequantize_choice` reorders back to the
+// logical `[B, kv_h, S, D]`. A flat head-major store would transpose heads
+// across a multi-append GQA cache (the dequant reshapes head-major over the
+// full sequence), so the reorder is load-bearing, not cosmetic.
 #![allow(
     missing_docs,
     unreachable_pub,
@@ -316,7 +315,15 @@ impl QuantKTurbo3 {
             let words_per_seq = self.gpu_words_per_step;
             let scales_per_seq = self.gpu_scales_per_step;
 
-            let (new_codes, new_scales) = turbo_quantize_v3_gpu(k_arr, device)?;
+            // Reorder the chunk to sequence-major `[B, new_seq, kv_h, D]` before
+            // quantizing: the flat buffer accumulates chunks at
+            // `prev_seq * words_per_seq`, so a head-major store + head-major
+            // reshape on dequant transposes heads across appends when kv_h>1.
+            // `transpose` yields a strided view; the TurboQuant MSL kernel reads
+            // its input by raw linear offset (ignores MLX strides), so
+            // materialize the permutation with `contiguous` first.
+            let k_seq_major = k_arr.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
+            let (new_codes, new_scales) = turbo_quantize_v3_gpu(&k_seq_major, device)?;
 
             let codes_start = prev_seq * words_per_seq;
             let codes_stop = (prev_seq + new_seq) * words_per_seq;
@@ -347,7 +354,17 @@ impl QuantKTurbo3 {
         } else {
             // CPU path: scalar Rust quantization (axis-agnostic — same codec as
             // V-side turbo3; the codebook is N(0,1) Lloyd-Max regardless of axis).
-            let block = turbo_quantize_v(f32_data, self.bits, new_shape)?;
+            // Store the chunk sequence-major so the CPU blocks share one layout
+            // with the GPU buffer (spill/hydrate moves codes between them);
+            // `f32_data` is head-major, reorder to `[B, new_seq, kv_h, D]` and
+            // pass the matching shape.
+            let b = new_shape[0] as usize;
+            let kv_h = new_shape[1] as usize;
+            let new_seq = new_shape[2] as usize;
+            let d = new_shape[3] as usize;
+            let seq_major = super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, d);
+            let seq_shape = [new_shape[0], new_shape[2], new_shape[1], new_shape[3]];
+            let block = turbo_quantize_v(&seq_major, self.bits, &seq_shape)?;
             self.blocks.push(block);
         }
         Ok(())
@@ -373,18 +390,32 @@ impl QuantKTurbo3 {
                 let codes = codes_buf.slice(&[0], &[s * self.gpu_words_per_step], &[1], device)?;
                 let scales =
                     scales_buf.slice(&[0], &[s * self.gpu_scales_per_step], &[1], device)?;
-                let out = turbo_dequantize_v3_gpu(&codes, &scales, &self.shape, out_dtype, device)?;
+                // Flat buffer is sequence-major (see `append`): dequant into
+                // `[B, S, kv_h, D]`, then reorder heads↔seq back to the logical
+                // `[B, kv_h, S, D]`. `contiguous` after the output transpose so
+                // raw byte-readers (SSD spill) see the permuted bytes.
+                let seq_major_shape = [self.shape[0], self.shape[2], self.shape[1], self.shape[3]];
+                let out =
+                    turbo_dequantize_v3_gpu(&codes, &scales, &seq_major_shape, out_dtype, device)?;
+                let out = out.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
                 return Ok((Vec::new(), Some(out)));
             }
             return Ok((Vec::new(), None));
         }
-        // CPU path.
+        // CPU path. Blocks are sequence-major (see `append`); reorder the
+        // concatenated decode back to the logical `[B, kv_h, S, D]`.
         let total: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out = Vec::with_capacity(total);
         for block in &self.blocks {
             let slice = turbo_dequantize(block)?;
             out.extend_from_slice(&slice);
         }
+        out.resize(total, 0.0);
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let d = self.shape[3] as usize;
+        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, d);
         Ok((out, None))
     }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo3_tests.rs
@@ -214,6 +214,119 @@ fn quant_k_turbo3_from_cpu_blocks_max_seq_explicit() {
     assert_eq!(decoded.len(), data.len(), "decoded length must match input");
 }
 
+// ── Multi-append GQA layout round-trip ───────────────────────────────────────
+
+/// Distinct, small per-(head,token,dim) value so a head transposition (which
+/// swaps in a value differing by ≥ ~0.1) is obvious against q3 noise.
+fn rt_expected(h: i32, s: i32, d: i32) -> f32 {
+    (h * 100 + s * 5 + d % 7) as f32 * 0.001
+}
+
+/// Head-major flat `[1, kv_h, seq, d]` chunk — the layout `append` receives.
+fn rt_head_major_chunk(kv_h: i32, seq: i32, d: i32, base_s: i32) -> Vec<f32> {
+    let mut v = Vec::with_capacity((kv_h * seq * d) as usize);
+    for h in 0..kv_h {
+        for s in 0..seq {
+            for dd in 0..d {
+                v.push(rt_expected(h, base_s + s, dd));
+            }
+        }
+    }
+    v
+}
+
+fn rt_check(out: &[f32], kv_h: i32, s_total: i32, d: i32) -> f32 {
+    let mut m = 0.0_f32;
+    let mut i = 0usize;
+    for h in 0..kv_h {
+        for s in 0..s_total {
+            for dd in 0..d {
+                m = m.max((out[i] - rt_expected(h, s, dd)).abs());
+                i += 1;
+            }
+        }
+    }
+    m
+}
+
+#[allow(unsafe_code)]
+#[allow(
+    clippy::expect_used,
+    reason = "test: array construction from a fixed in-bounds buffer cannot fail"
+)]
+fn rt_f32_array(vals: &[f32], shape: &[i32]) -> Array {
+    // SAFETY: f32 is 4-byte LE; from_bytes copies immediately.
+    let bytes = unsafe { std::slice::from_raw_parts(vals.as_ptr().cast::<u8>(), vals.len() * 4) };
+    Array::from_bytes(bytes, shape, Dtype::F32).expect("rt_f32_array")
+}
+
+/// Two head-major appends, kv_h=3: the pre-fix head-major store + head-major
+/// reshape scrambled heads across the two blocks. The seq-major reorder fixes
+/// it; max-err must be q3 noise, not a head swap.
+#[test]
+fn quant_k_turbo3_two_append_multi_head_roundtrip() {
+    let (kv_h, d) = (3, 32);
+    let mut qk = QuantKTurbo3::new(vec![1, kv_h, 0, d], 512);
+    let c0 = rt_head_major_chunk(kv_h, 2, d, 0);
+    let c1 = rt_head_major_chunk(kv_h, 1, d, 2);
+    cpu_append(&mut qk, &c0, &[1, kv_h, 2, d]);
+    cpu_append(&mut qk, &c1, &[1, kv_h, 1, d]);
+    let out = qk.dequant().expect("dequant");
+    let m = rt_check(&out, kv_h, 3, d);
+    assert!(
+        m < 0.05,
+        "turbo3 kv_h=3 two-append max abs error {m} — expected q3 noise, not head scramble"
+    );
+}
+
+/// GPU two-append multi-head round-trip — the path the layout bug lived on.
+#[test]
+#[ignore = "GPU Metal context — run explicitly: -- --ignored --test-threads=1"]
+#[allow(
+    clippy::expect_used,
+    reason = "test: structural invariant established by construction; .expect() documents it"
+)]
+fn quant_k_turbo3_gpu_two_append_multi_head_roundtrip() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let (kv_h, d) = (2, 32);
+    let mut qk = QuantKTurbo3::new(vec![1, kv_h, 0, d], 512);
+    let c0 = rt_head_major_chunk(kv_h, 2, d, 0);
+    let c1 = rt_head_major_chunk(kv_h, 1, d, 2);
+    qk.append(
+        &[],
+        &[1, kv_h, 2, d],
+        &rt_f32_array(&c0, &[1, kv_h, 2, d]),
+        Device::Gpu,
+        512,
+    )
+    .expect("append0");
+    qk.append(
+        &[],
+        &[1, kv_h, 1, d],
+        &rt_f32_array(&c1, &[1, kv_h, 1, d]),
+        Device::Gpu,
+        512,
+    )
+    .expect("append1");
+    let (_, gpu) = qk
+        .dequantize_choice(Device::Gpu, Dtype::F32)
+        .expect("dequant");
+    let gpu = gpu.expect("gpu array");
+    gpu.eval().expect("eval");
+    let bytes = gpu.to_bytes().expect("to_bytes");
+    let out: Vec<f32> = bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().expect("chunk")))
+        .collect();
+    let m = rt_check(&out, kv_h, 3, d);
+    assert!(
+        m < 0.05,
+        "turbo3 GPU kv_h=2 two-append max abs error {m} — expected q3 noise, not head scramble"
+    );
+}
+
 // ── Parity: CPU == MSL (ignored, requires Metal) ─────────────────────────────
 
 /// Parity test: CPU path vs MSL kernel — both must decode to within 1e-5.

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo4.rs
@@ -16,9 +16,13 @@
 //!
 //! The CPU codec ([`crate::turboquant::turbo_quantize_v`] / `turbo_dequantize`)
 //! and MSL kernel ([`crate::turboquant_msl::turbo_quantize_v4_gpu`] /
-//! `turbo_dequantize_v4_gpu`) are axis-agnostic — they take a flat f32 buffer
-//! plus a 4-D shape and produce flat codes/scales. Re-using them for the K side
-//! is exact: no kernel fork (Step 0 decision documented in `docs/KV_QUANT.md`).
+//! `turbo_dequantize_v4_gpu`) are positional — they take a flat f32 buffer plus
+//! a 4-D shape, group over the last axis, and produce flat codes/scales without
+//! interpreting the head/seq axes. Re-using them for the K side is exact: no
+//! kernel fork (decision documented in `docs/KV_QUANT.md`). Because the codec is
+//! positional, `append` stores every chunk sequence-major (`[B, S, kv_h, D]`)
+//! and `dequantize_choice` reorders back to the logical `[B, kv_h, S, D]`; a
+//! flat head-major store would transpose heads across a multi-append GQA cache.
 //!
 //! # Layout
 //!
@@ -239,7 +243,15 @@ impl QuantKTurbo4 {
             let words_per_seq = self.gpu_words_per_step;
             let scales_per_seq = self.gpu_scales_per_step;
 
-            let (new_codes, new_scales) = turbo_quantize_v4_gpu(k_arr, device)?;
+            // Reorder the chunk to sequence-major `[B, new_seq, kv_h, D]` before
+            // quantizing: the flat buffer accumulates chunks at
+            // `prev_seq * words_per_seq`, so a head-major store + head-major
+            // reshape on dequant transposes heads across appends when kv_h>1.
+            // `transpose` yields a strided view; the TurboQuant MSL kernel reads
+            // its input by raw linear offset (ignores MLX strides), so
+            // materialize the permutation with `contiguous` first.
+            let k_seq_major = k_arr.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
+            let (new_codes, new_scales) = turbo_quantize_v4_gpu(&k_seq_major, device)?;
 
             let codes_start = prev_seq * words_per_seq;
             let codes_stop = (prev_seq + new_seq) * words_per_seq;
@@ -270,8 +282,17 @@ impl QuantKTurbo4 {
         } else {
             // CPU path: scalar Rust quantization (axis-agnostic — same codec as
             // V-side; the codebook is N(0,1) Lloyd-Max regardless of which axis
-            // the data came from).
-            let block = turbo_quantize_v(f32_data, self.bits, new_shape)?;
+            // the data came from). Store the chunk sequence-major so the CPU
+            // blocks share one layout with the GPU buffer (spill/hydrate moves
+            // codes between them); `f32_data` is head-major, reorder to
+            // `[B, new_seq, kv_h, D]` and pass the matching shape.
+            let b = new_shape[0] as usize;
+            let kv_h = new_shape[1] as usize;
+            let new_seq = new_shape[2] as usize;
+            let d = new_shape[3] as usize;
+            let seq_major = super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, d);
+            let seq_shape = [new_shape[0], new_shape[2], new_shape[1], new_shape[3]];
+            let block = turbo_quantize_v(&seq_major, self.bits, &seq_shape)?;
             self.blocks.push(block);
         }
         Ok(())
@@ -297,18 +318,32 @@ impl QuantKTurbo4 {
                 let codes = codes_buf.slice(&[0], &[s * self.gpu_words_per_step], &[1], device)?;
                 let scales =
                     scales_buf.slice(&[0], &[s * self.gpu_scales_per_step], &[1], device)?;
-                let out = turbo_dequantize_v4_gpu(&codes, &scales, &self.shape, out_dtype, device)?;
+                // Flat buffer is sequence-major (see `append`): dequant into
+                // `[B, S, kv_h, D]`, then reorder heads↔seq back to the logical
+                // `[B, kv_h, S, D]`. `contiguous` after the output transpose so
+                // raw byte-readers (SSD spill) see the permuted bytes.
+                let seq_major_shape = [self.shape[0], self.shape[2], self.shape[1], self.shape[3]];
+                let out =
+                    turbo_dequantize_v4_gpu(&codes, &scales, &seq_major_shape, out_dtype, device)?;
+                let out = out.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
                 return Ok((Vec::new(), Some(out)));
             }
             return Ok((Vec::new(), None));
         }
-        // CPU path.
+        // CPU path. Blocks are sequence-major (see `append`); reorder the
+        // concatenated decode back to the logical `[B, kv_h, S, D]`.
         let total: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out = Vec::with_capacity(total);
         for block in &self.blocks {
             let slice = turbo_dequantize(block)?;
             out.extend_from_slice(&slice);
         }
+        out.resize(total, 0.0);
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let d = self.shape[3] as usize;
+        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, d);
         Ok((out, None))
     }
 
@@ -348,3 +383,7 @@ impl QuantKTurbo4 {
         })
     }
 }
+
+#[cfg(test)]
+#[path = "quant_k_turbo4_tests.rs"]
+mod quant_k_turbo4_tests;

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo4_tests.rs
@@ -1,0 +1,145 @@
+//! Sequence-major layout round-trip tests for [`QuantKTurbo4`].
+//!
+//! The flat QuantKTurbo4 buffer accumulates one chunk per `append` at a
+//! sequence offset (`prev_seq * words_per_seq`) while the dequant reshapes the
+//! flat prefix as the logical head-major `[B, kv_h, S, D]`. The fix stores
+//! every chunk sequence-major (reorder heads↔seq before quantizing, reorder
+//! back on dequant). The round-trip tests below prove no head scramble on a
+//! multi-append GQA cache; the GPU one is `#[ignore]` (Metal context) — run
+//! with `--ignored --test-threads=1`.
+
+use rmlx_mlx::{Array, Device, Dtype};
+
+use super::QuantKTurbo4;
+use crate::test_utils::skip_if_no_gpu_env;
+
+fn new_turbo4(kv_h: i32, d: i32) -> QuantKTurbo4 {
+    QuantKTurbo4 {
+        blocks: Vec::new(),
+        gpu_codes_buf: None,
+        gpu_scales_buf: None,
+        gpu_words_per_step: 0,
+        gpu_scales_per_step: 0,
+        gpu_capacity: 0,
+        shape: vec![1, kv_h, 0, d],
+        bits: 4,
+        max_seq: 0,
+    }
+}
+
+/// Distinct, small per-(head,token,dim) value so a head transposition (swaps in
+/// a value differing by ≥ ~0.1) is obvious against q4 noise.
+fn expected(h: i32, s: i32, d: i32) -> f32 {
+    (h * 100 + s * 5 + d % 7) as f32 * 0.001
+}
+
+/// Head-major flat `[1, kv_h, seq, d]` chunk — the layout `append` receives.
+fn head_major_chunk(kv_h: i32, seq: i32, d: i32, base_s: i32) -> Vec<f32> {
+    let mut v = Vec::with_capacity((kv_h * seq * d) as usize);
+    for h in 0..kv_h {
+        for s in 0..seq {
+            for dd in 0..d {
+                v.push(expected(h, base_s + s, dd));
+            }
+        }
+    }
+    v
+}
+
+fn check(out: &[f32], kv_h: i32, s_total: i32, d: i32) -> f32 {
+    let mut m = 0.0_f32;
+    let mut i = 0usize;
+    for h in 0..kv_h {
+        for s in 0..s_total {
+            for dd in 0..d {
+                m = m.max((out[i] - expected(h, s, dd)).abs());
+                i += 1;
+            }
+        }
+    }
+    m
+}
+
+#[allow(unsafe_code)]
+#[allow(
+    clippy::expect_used,
+    reason = "test: array construction from a fixed in-bounds buffer cannot fail"
+)]
+fn f32_array(vals: &[f32], shape: &[i32]) -> Array {
+    // SAFETY: f32 is 4-byte LE; from_bytes copies immediately.
+    let bytes = unsafe { std::slice::from_raw_parts(vals.as_ptr().cast::<u8>(), vals.len() * 4) };
+    Array::from_bytes(bytes, shape, Dtype::F32).expect("f32_array")
+}
+
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: array/append construction from in-bounds fixed buffers cannot fail"
+)]
+fn cpu_two_append_multi_head_roundtrip() {
+    let (kv_h, d) = (3, 32);
+    let mut qk = new_turbo4(kv_h, d);
+    let c0 = head_major_chunk(kv_h, 2, d, 0);
+    let c1 = head_major_chunk(kv_h, 1, d, 2);
+    let dummy = Array::from_bytes(&0.0_f32.to_le_bytes(), &[1], Dtype::F32).expect("dummy");
+    qk.append(&c0, &[1, kv_h, 2, d], &dummy, Device::Cpu, 512)
+        .expect("append0");
+    qk.append(&c1, &[1, kv_h, 1, d], &dummy, Device::Cpu, 512)
+        .expect("append1");
+    let (out, arr) = qk
+        .dequantize_choice(Device::Cpu, Dtype::F32)
+        .expect("dequant");
+    assert!(arr.is_none(), "CPU dequant returns a flat vec");
+    let m = check(&out, kv_h, 3, d);
+    assert!(
+        m < 0.05,
+        "turbo4 kv_h=3 two-append max abs error {m} — expected q4 noise, not head scramble"
+    );
+}
+
+#[test]
+#[ignore = "GPU Metal context — run explicitly: -- --ignored --test-threads=1"]
+#[allow(
+    clippy::expect_used,
+    reason = "test: structural invariant established by construction; .expect() documents it"
+)]
+fn gpu_two_append_multi_head_roundtrip() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let (kv_h, d) = (2, 32);
+    let mut qk = new_turbo4(kv_h, d);
+    let c0 = head_major_chunk(kv_h, 2, d, 0);
+    let c1 = head_major_chunk(kv_h, 1, d, 2);
+    qk.append(
+        &[],
+        &[1, kv_h, 2, d],
+        &f32_array(&c0, &[1, kv_h, 2, d]),
+        Device::Gpu,
+        512,
+    )
+    .expect("append0");
+    qk.append(
+        &[],
+        &[1, kv_h, 1, d],
+        &f32_array(&c1, &[1, kv_h, 1, d]),
+        Device::Gpu,
+        512,
+    )
+    .expect("append1");
+    let (_, gpu) = qk
+        .dequantize_choice(Device::Gpu, Dtype::F32)
+        .expect("dequant");
+    let gpu = gpu.expect("gpu array");
+    gpu.eval().expect("eval");
+    let bytes = gpu.to_bytes().expect("to_bytes");
+    let out: Vec<f32> = bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().expect("chunk")))
+        .collect();
+    let m = check(&out, kv_h, 3, d);
+    assert!(
+        m < 0.05,
+        "turbo4 GPU kv_h=2 two-append max abs error {m} — expected q4 noise, not head scramble"
+    );
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_v.rs
@@ -459,12 +459,29 @@ impl QuantV {
                 "value_codebook ↔ value_codebook_gpu cache desync — \
                  caller mutated pub value_codebook after first GPU upload"
             );
+            // Reorder the chunk to sequence-major `[B, new_seq, kv_h, D]` before
+            // quantizing. The flat GPU buffer accumulates chunks back-to-back at
+            // `prev_seq * words_per_seq`, so the active prefix is sequence-major;
+            // `dequantize_choice` reads it back with the matching reshape +
+            // transpose. The incoming chunk is head-major
+            // (`[B, kv_h, new_seq, D]`); transposing heads↔seq makes the stored
+            // layout self-consistent across any number of appends and any
+            // `kv_h`. With a single chunk (`prev_seq == 0`) this is the identity
+            // for the dequant view, so the cold-prefill path stays logically
+            // correct (byte-identical when `D % GROUP_SIZE == 0`, which the
+            // init-block debug_assert enforces). `transpose` yields a strided
+            // view; the TurboQuant MSL kernel reads its input by raw linear
+            // offset (ignores MLX strides), so materialize the permutation into
+            // a row-major buffer with `contiguous` first.
+            let v_seq_major = v_arr.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
             let (new_codes, new_scales) = match (
                 self.value_codebook.is_some(),
                 self.value_codebook_gpu.as_ref(),
             ) {
-                (true, Some(cb_gpu)) => turbo_quantize_v4_codebook_buf_gpu(v_arr, cb_gpu, device)?,
-                (false, None) => turbo_quantize_v4_gpu(v_arr, device)?,
+                (true, Some(cb_gpu)) => {
+                    turbo_quantize_v4_codebook_buf_gpu(&v_seq_major, cb_gpu, device)?
+                }
+                (false, None) => turbo_quantize_v4_gpu(&v_seq_major, device)?,
                 (true, None) => {
                     return Err(rmlx_core::error::Error::Quant(
                         "value_codebook set but GPU upload missing — internal \
@@ -506,26 +523,42 @@ impl QuantV {
         } else {
             // CPU path: scalar Rust quantization.
             //
+            // CPU mirror of the GPU path: store the chunk sequence-major so the
+            // accumulated `self.blocks` share one layout with the GPU buffer
+            // (the spill/hydrate round-trip moves codes between the two, and the
+            // hydrated GPU init uploads CPU blocks at offset 0). `f32_data`
+            // arrives head-major (`[B, kv_h, new_seq, D]`); reorder it to
+            // `[B, new_seq, kv_h, D]` and pass the matching shape before
+            // quantizing. The codecs group positionally over the last axis `D`,
+            // so the seq-major shape is valid and `dequantize_choice` reorders
+            // back to the logical `[B, kv_h, S, D]`.
+            //
             // When `use_tcq` is set, dispatch to the Viterbi trellis encoder at
             // the matching bit-width. bits==3: 3-bit TCQ; bits==2: 2-bit TCQ.
             // Codebook override is supported for 3-bit only; 2-bit TCQ always
             // uses the built-in Lloyd-Max 2-bit codebook.
             // If no TCQ and a per-layer codebook override is set, use it;
             // otherwise fall back to the built-in Lloyd-Max codebook.
+            let b = new_shape[0] as usize;
+            let kv_h = new_shape[1] as usize;
+            let new_seq = new_shape[2] as usize;
+            let d = new_shape[3] as usize;
+            let seq_major = super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, d);
+            let seq_shape = [new_shape[0], new_shape[2], new_shape[1], new_shape[3]];
             let block = if self.use_tcq && self.bits == 3 {
                 match self.value_codebook.as_deref() {
-                    Some(cb) => tcq_quantize_v3_with_codebook(f32_data, new_shape, cb)?,
-                    None => tcq_quantize_v3(f32_data, new_shape)?,
+                    Some(cb) => tcq_quantize_v3_with_codebook(&seq_major, &seq_shape, cb)?,
+                    None => tcq_quantize_v3(&seq_major, &seq_shape)?,
                 }
             } else if self.use_tcq && self.bits == 2 {
                 // 2-bit TCQ. Codebook override not wired for 2-bit — TCQ reuses
                 // the standard Lloyd-Max 2-bit codebook.
-                tcq_quantize_v2(f32_data, new_shape)?
+                tcq_quantize_v2(&seq_major, &seq_shape)?
             } else {
                 turbo_quantize_v_with_codebook(
-                    f32_data,
+                    &seq_major,
                     self.bits,
-                    new_shape,
+                    &seq_shape,
                     self.value_codebook.as_deref(),
                 )?
             };
@@ -577,6 +610,16 @@ impl QuantV {
                     "value_codebook ↔ value_codebook_gpu cache desync — \
                      caller mutated pub value_codebook after first GPU upload"
                 );
+                // The flat buffer is sequence-major (see `append`): the active
+                // prefix lays out as `[B, S, kv_h, D]`. Dequant into that shape,
+                // then reorder heads↔seq back to the logical `[B, kv_h, S, D]`
+                // callers expect. For a single-chunk cache the transpose inverts
+                // the append-side reorder, so the round-trip is exact within
+                // quant noise. The dequant kernel reads its inputs by raw linear
+                // offset; the seq-major reshape on the OUTPUT then needs a final
+                // `contiguous` because raw byte-readers (SSD spill / hydrate)
+                // would otherwise see the un-permuted sequence-major bytes.
+                let seq_major_shape = [self.shape[0], self.shape[2], self.shape[1], self.shape[3]];
                 let out = match (
                     self.value_codebook.is_some(),
                     self.value_codebook_gpu.as_ref(),
@@ -585,13 +628,17 @@ impl QuantV {
                         &codes,
                         &scales,
                         cb_gpu,
-                        &self.shape,
+                        &seq_major_shape,
                         out_dtype,
                         device,
                     )?,
-                    (false, None) => {
-                        turbo_dequantize_v4_gpu(&codes, &scales, &self.shape, out_dtype, device)?
-                    }
+                    (false, None) => turbo_dequantize_v4_gpu(
+                        &codes,
+                        &scales,
+                        &seq_major_shape,
+                        out_dtype,
+                        device,
+                    )?,
                     (true, None) => {
                         return Err(rmlx_core::error::Error::Quant(
                             "value_codebook set but GPU upload missing — internal \
@@ -607,11 +654,14 @@ impl QuantV {
                         ));
                     }
                 };
+                let out = out.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
                 return Ok((Vec::new(), Some(out)));
             }
             return Ok((Vec::new(), None));
         }
-        // CPU path.
+        // CPU path. Blocks are stored sequence-major (see `append`): the
+        // concatenated decode lays out as `[B, S, kv_h, D]`. Reorder heads↔seq
+        // back to the logical `[B, kv_h, S, D]` the caller reshapes to.
         let total: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out = Vec::with_capacity(total);
         let cb_override = self.value_codebook.as_deref();
@@ -623,6 +673,15 @@ impl QuantV {
             };
             out.extend_from_slice(&slice);
         }
+        // The reorder requires the full `[B, S, kv_h, D]` buffer; pad/truncate
+        // to the declared element count first (blocks always sum to `shape[2]`
+        // in normal operation, so this is a defensive backstop).
+        out.resize(total, 0.0);
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let d = self.shape[3] as usize;
+        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, d);
         Ok((out, None))
     }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_v_tests.rs
@@ -1,6 +1,17 @@
-//! Tests for `QuantV` — focused on the codebook override surface.
+//! Tests for `QuantV` — codebook override surface + sequence-major layout
+//! round-trips.
+//!
+//! Like `QuantK`, the `QuantV` flat GPU buffer accumulates one chunk per
+//! `append` at a sequence offset (`prev_seq * words_per_seq`) while the dequant
+//! reshapes the flat prefix as the logical `[B, kv_h, S, D]`. The fix stores
+//! every chunk sequence-major (reorder heads↔seq before quantizing, reorder
+//! back on dequant). The round-trip tests below prove no head scramble on a
+//! multi-append GQA cache; the GPU ones are `#[ignore]` because they touch
+//! Metal — run with `--ignored --test-threads=1`.
 
 use super::QuantV;
+use crate::test_utils::skip_if_no_gpu_env;
+use rmlx_mlx::{zeros, Array, Device, Dtype};
 
 // ── value_codebook field ──────────────────────────────────────────────────────
 
@@ -83,4 +94,190 @@ fn try_deep_clone_propagates_value_codebook() {
         Some(cb.as_slice()),
         "try_deep_clone must propagate value_codebook"
     );
+}
+
+// ── Sequence-major layout round-trip ─────────────────────────────────────────
+
+/// Distinct, small per-(head,token,dim) value: q8/Lloyd-Max noise stays ≪ 0.01
+/// while a head transposition (swaps in a value differing by ≥ ~0.1) is obvious.
+fn expected(h: i32, s: i32, d: i32) -> f32 {
+    (h * 100 + s * 5 + d % 7) as f32 * 0.001
+}
+
+/// Head-major flat `[1, kv_h, seq, d]` chunk — the layout `append` receives.
+fn head_major_chunk(kv_h: i32, seq: i32, d: i32, base_s: i32) -> Vec<f32> {
+    let mut v = Vec::with_capacity((kv_h * seq * d) as usize);
+    for h in 0..kv_h {
+        for s in 0..seq {
+            for dd in 0..d {
+                v.push(expected(h, base_s + s, dd));
+            }
+        }
+    }
+    v
+}
+
+fn new_quant_v(kv_h: i32, d: i32, bits: u8) -> QuantV {
+    QuantV::new_affine_decode(vec![1, kv_h, 0, d], bits, 512)
+}
+
+fn check_roundtrip(out: &[f32], kv_h: i32, s_total: i32, d: i32) -> f32 {
+    let mut m = 0.0_f32;
+    let mut i = 0usize;
+    for h in 0..kv_h {
+        for s in 0..s_total {
+            for dd in 0..d {
+                m = m.max((out[i] - expected(h, s, dd)).abs());
+                i += 1;
+            }
+        }
+    }
+    m
+}
+
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: array/append construction from in-bounds fixed buffers cannot fail"
+)]
+fn cpu_two_append_multi_head_roundtrip_is_exact() {
+    // CPU path (bits=4): two head-major appends, kv_h=2. The pre-fix head-major
+    // store + head-major reshape scrambled heads across the two blocks.
+    let (kv_h, d) = (2, 64);
+    let mut qv = new_quant_v(kv_h, d, 4);
+    let c0 = head_major_chunk(kv_h, 2, d, 0);
+    let c1 = head_major_chunk(kv_h, 1, d, 2);
+    let dummy0 = zeros(&[1, kv_h, 2, d], Dtype::F32, Device::Cpu).expect("dummy0");
+    let dummy1 = zeros(&[1, kv_h, 1, d], Dtype::F32, Device::Cpu).expect("dummy1");
+    qv.append(&c0, &[1, kv_h, 2, d], &dummy0, Device::Cpu, 512)
+        .expect("append0");
+    qv.append(&c1, &[1, kv_h, 1, d], &dummy1, Device::Cpu, 512)
+        .expect("append1");
+    let (flat, arr) = qv
+        .dequantize_choice(Device::Cpu, Dtype::F32)
+        .expect("dequant");
+    assert!(arr.is_none(), "CPU dequant returns a flat vec");
+    let m = check_roundtrip(&flat, kv_h, 3, d);
+    assert!(
+        m < 0.05,
+        "CPU kv_h=2 two-append max abs error {m} — expected quant noise, not head scramble"
+    );
+}
+
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: array/append construction from in-bounds fixed buffers cannot fail"
+)]
+fn cpu_cross_head_group_roundtrip() {
+    // TurboQuant group size is 32; head_dim=32, kv_h=3, per-token decode steps.
+    // A single decode chunk is kv_h*d = 96 elems = 3 groups, one per head. Two
+    // appends land the second chunk at a sequence offset, exercising the
+    // multi-append reorder.
+    let (kv_h, d) = (3, 32);
+    let mut qv = new_quant_v(kv_h, d, 4);
+    let c0 = head_major_chunk(kv_h, 1, d, 0);
+    let c1 = head_major_chunk(kv_h, 1, d, 1);
+    let dummy = zeros(&[1, kv_h, 1, d], Dtype::F32, Device::Cpu).expect("dummy");
+    qv.append(&c0, &[1, kv_h, 1, d], &dummy, Device::Cpu, 512)
+        .expect("append0");
+    qv.append(&c1, &[1, kv_h, 1, d], &dummy, Device::Cpu, 512)
+        .expect("append1");
+    let (flat, _) = qv
+        .dequantize_choice(Device::Cpu, Dtype::F32)
+        .expect("dequant");
+    let m = check_roundtrip(&flat, kv_h, 2, d);
+    assert!(
+        m < 0.05,
+        "CPU kv_h=3 cross-group max abs error {m} — expected quant noise, not head scramble"
+    );
+}
+
+// ── GPU round-trip (real QuantV + Metal kernels) ─────────────────────────────
+
+#[allow(
+    clippy::expect_used,
+    reason = "test: structural invariant established by construction; .expect() documents it"
+)]
+fn make_v_array(kv_h: i32, seq: i32, d: i32, base_s: i32) -> Array {
+    let data = head_major_chunk(kv_h, seq, d, base_s);
+    // SAFETY: Apple-Silicon-only build; f32 is 4-byte LE. `data` is borrowed
+    // read-only and copied into MLX before the borrow ends.
+    let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), data.len() * 4) };
+    Array::from_bytes(bytes, &[1, kv_h, seq, d], Dtype::F32).expect("make_v_array")
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "test: structural invariant established by construction; .expect() documents it"
+)]
+fn append_gpu(qv: &mut QuantV, kv_h: i32, seq: i32, d: i32, base_s: i32) {
+    let arr = make_v_array(kv_h, seq, d, base_s);
+    arr.eval().expect("eval v");
+    qv.append(&[], &[1, kv_h, seq, d], &arr, Device::Gpu, 512)
+        .expect("append");
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "test: structural invariant established by construction; .expect() documents it"
+)]
+fn dequant_to_vec(qv: &QuantV) -> Vec<f32> {
+    let (_, out) = qv
+        .dequantize_choice(Device::Gpu, Dtype::F32)
+        .expect("dequantize_choice");
+    let out = out.expect("GPU dequant array");
+    out.eval().expect("eval");
+    let bytes = out.to_bytes().expect("to_bytes");
+    bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().expect("chunk")))
+        .collect()
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_v -- --ignored --test-threads=1"]
+fn gpu_two_append_multi_head_roundtrip() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let (kv_h, d) = (2, 64);
+    let mut qv = new_quant_v(kv_h, d, 4);
+    append_gpu(&mut qv, kv_h, 2, d, 0);
+    append_gpu(&mut qv, kv_h, 1, d, 2);
+    let out = dequant_to_vec(&qv);
+    let m = check_roundtrip(&out, kv_h, 3, d);
+    assert!(
+        m < 0.05,
+        "kv_h=2 two-append max abs error {m} — expected quant noise, not head scramble"
+    );
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_v -- --ignored --test-threads=1"]
+fn gpu_two_append_single_head_control() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let (kv_h, d) = (1, 64);
+    let mut qv = new_quant_v(kv_h, d, 4);
+    append_gpu(&mut qv, kv_h, 2, d, 0);
+    append_gpu(&mut qv, kv_h, 1, d, 2);
+    let out = dequant_to_vec(&qv);
+    let m = check_roundtrip(&out, kv_h, 3, d);
+    assert!(m < 0.05, "kv_h=1 control max abs error {m}");
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_v -- --ignored --test-threads=1"]
+fn gpu_single_shot_cold_prefill() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let (kv_h, d) = (4, 64);
+    let mut qv = new_quant_v(kv_h, d, 4);
+    append_gpu(&mut qv, kv_h, 8, d, 0);
+    let out = dequant_to_vec(&qv);
+    let m = check_roundtrip(&out, kv_h, 8, d);
+    assert!(m < 0.05, "single-shot cold prefill max abs error {m}");
 }

--- a/crates/rmlx-kv-quant/src/storage/seq_layout.rs
+++ b/crates/rmlx-kv-quant/src/storage/seq_layout.rs
@@ -1,0 +1,81 @@
+//! Shared head↔sequence reorder helpers for the quantized KV storage structs.
+//!
+//! Every flat-buffer quantized storage (`QuantK`, `QuantV`, `QuantKTurbo*`,
+//! `QuantPlanar*`) accumulates one chunk per `append` at a **sequence offset**
+//! (`prev_seq * words_per_seq`), so the active prefix is physically
+//! sequence-major: for each token, all heads are contiguous (`[B, S, kv_h, D]`
+//! ordering). The dequant view, however, reshapes the flat prefix to the
+//! logical head-major `[B, kv_h, S, D]`. Those two orderings only coincide when
+//! `B * kv_h == 1`. With `kv_h > 1` and more than one chunk, the second chunk's
+//! tokens land after *all* heads' prefixes while the head-major reshape maps one
+//! head's new-token slot onto another head's prefix — a head transposition that
+//! silently corrupts the cache.
+//!
+//! The fix makes every such buffer canonically sequence-major: `append`
+//! reorders the incoming head-major chunk heads↔seq before quantizing, and the
+//! dequant path reshapes the prefix as `[B, S, kv_h, D]` and reorders back to
+//! `[B, kv_h, S, D]`. For a single chunk (`prev_seq == 0`) the two reorders
+//! cancel, so the common cold-prefill path is logically unchanged.
+//!
+//! These are the CPU-side scalar mirrors of the GPU `transpose(&[0, 2, 1, 3])`;
+//! the GPU side additionally materializes the transposed view with
+//! `Array::contiguous` before any custom MSL kernel, because such kernels read
+//! their input by raw linear index and ignore MLX lazy-transpose strides.
+
+/// Reorder a flat head-major `[B, kv_h, S, D]` buffer to sequence-major
+/// `[B, S, kv_h, D]`. Used by the CPU `append` paths to mirror the GPU
+/// buffer's sequence-major layout.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "src/out are sized b*kv_h*s*d; every (bi,h,si) base + d stays in bounds by construction"
+)]
+pub(super) fn transpose_heads_seq(
+    src: &[f32],
+    b: usize,
+    kv_h: usize,
+    s: usize,
+    d: usize,
+) -> Vec<f32> {
+    let mut out = vec![0.0_f32; b * kv_h * s * d];
+    for bi in 0..b {
+        for h in 0..kv_h {
+            for si in 0..s {
+                let src_base = ((bi * kv_h + h) * s + si) * d;
+                let dst_base = ((bi * s + si) * kv_h + h) * d;
+                out[dst_base..dst_base + d].copy_from_slice(&src[src_base..src_base + d]);
+            }
+        }
+    }
+    out
+}
+
+/// Inverse of [`transpose_heads_seq`]: reorder a flat sequence-major
+/// `[B, S, kv_h, D]` buffer back to head-major `[B, kv_h, S, D]`. Used by the
+/// CPU dequant paths so callers see the logical `[B, kv_h, S, D]`.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "src/out are sized b*s*kv_h*d; every (bi,si,h) base + d stays in bounds by construction"
+)]
+pub(super) fn transpose_seq_heads(
+    src: &[f32],
+    b: usize,
+    s: usize,
+    kv_h: usize,
+    d: usize,
+) -> Vec<f32> {
+    let mut out = vec![0.0_f32; b * s * kv_h * d];
+    for bi in 0..b {
+        for si in 0..s {
+            for h in 0..kv_h {
+                let src_base = ((bi * s + si) * kv_h + h) * d;
+                let dst_base = ((bi * kv_h + h) * s + si) * d;
+                out[dst_base..dst_base + d].copy_from_slice(&src[src_base..src_base + d]);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "seq_layout_tests.rs"]
+mod seq_layout_tests;

--- a/crates/rmlx-kv-quant/src/storage/seq_layout_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/seq_layout_tests.rs
@@ -1,0 +1,138 @@
+//! Deterministic index-math tests for the head↔sequence reorder helpers.
+//!
+//! These model the flat-buffer ordering shared by every quantized KV storage
+//! struct: a chunk stored head-major (`[B, kv_h, new_seq, D]`) versus
+//! sequence-major (`[B, new_seq, kv_h, D]`), accumulated at a sequence offset
+//! across appends. They prove the pre-fix head-major store + head-major reshape
+//! corrupts a multi-append, multi-head cache, while the sequence-major reorder
+//! round-trips exactly for every append pattern.
+
+use super::{transpose_heads_seq, transpose_seq_heads};
+
+const B: usize = 1;
+
+/// Distinct value per (head, token, dim) so any transposition is detectable.
+fn val(h: usize, s: usize, d: usize) -> f32 {
+    (h * 100_000 + s * 100 + d) as f32
+}
+
+/// Build the flat buffer the way the GPU `append` path does, for a list of
+/// chunk lengths. `head_major_chunk = true` is the pre-fix ordering (chunk
+/// stored `[b][h][s][d]`); `false` is the fixed ordering (chunk reordered to
+/// `[b][s][h][d]` before quantizing).
+fn build_buffer(appends: &[usize], kv_h: usize, d: usize, head_major_chunk: bool) -> Vec<f32> {
+    let elems_per_seq = B * kv_h * d;
+    let total: usize = appends.iter().sum::<usize>() * elems_per_seq;
+    let mut buf = vec![f32::NAN; total];
+    let mut prev = 0usize;
+    for &new_seq in appends {
+        // Source chunk is always head-major (`[B, kv_h, new_seq, D]`) — that is
+        // the layout `append` receives. The fixed path reorders it to
+        // sequence-major via `transpose_heads_seq` before storing.
+        let mut chunk = vec![0.0_f32; elems_per_seq * new_seq];
+        let mut i = 0usize;
+        for _b in 0..B {
+            for h in 0..kv_h {
+                for sl in 0..new_seq {
+                    for dd in 0..d {
+                        chunk[i] = val(h, prev + sl, dd);
+                        i += 1;
+                    }
+                }
+            }
+        }
+        let stored = if head_major_chunk {
+            chunk
+        } else {
+            transpose_heads_seq(&chunk, B, kv_h, new_seq, d)
+        };
+        let start = prev * elems_per_seq;
+        buf[start..start + stored.len()].copy_from_slice(&stored);
+        prev += new_seq;
+    }
+    buf
+}
+
+/// Old (buggy) read: reshape the flat prefix directly to `[B, kv_h, S, D]`.
+fn read_head_major(buf: &[f32], kv_h: usize, s_total: usize, d: usize) -> f32 {
+    let mut m = 0.0_f32;
+    for h in 0..kv_h {
+        for s in 0..s_total {
+            for dd in 0..d {
+                let idx = ((h * s_total) + s) * d + dd;
+                m = m.max((buf[idx] - val(h, s, dd)).abs());
+            }
+        }
+    }
+    m
+}
+
+/// New (fixed) read: reshape the flat prefix to `[B, S, kv_h, D]`, then reorder
+/// heads↔seq back to `[B, kv_h, S, D]` via `transpose_seq_heads`.
+fn read_seq_major(buf: &[f32], kv_h: usize, s_total: usize, d: usize) -> f32 {
+    let logical = transpose_seq_heads(buf, B, s_total, kv_h, d);
+    let mut m = 0.0_f32;
+    for h in 0..kv_h {
+        for s in 0..s_total {
+            for dd in 0..d {
+                let idx = ((h * s_total) + s) * d + dd;
+                m = m.max((logical[idx] - val(h, s, dd)).abs());
+            }
+        }
+    }
+    m
+}
+
+#[test]
+fn head_major_store_corrupts_multi_append_multi_head() {
+    // Single chunk: head-major store + head-major read agree (cold-prefill ok).
+    let buf = build_buffer(&[3], 2, 4, true);
+    assert_eq!(
+        read_head_major(&buf, 2, 3, 4),
+        0.0,
+        "single-shot cold prefill exact"
+    );
+    // kv_h == 1 control: two appends still agree (no head axis to transpose).
+    let buf = build_buffer(&[2, 1], 1, 4, true);
+    assert_eq!(read_head_major(&buf, 1, 3, 4), 0.0, "kv_h=1 control exact");
+    // kv_h > 1 + two appends: head transposition corrupts the read.
+    let buf = build_buffer(&[2, 1], 2, 4, true);
+    let bug = read_head_major(&buf, 2, 3, 4);
+    assert!(
+        bug > 0.0,
+        "expected multi-head multi-append corruption, got {bug}"
+    );
+}
+
+#[test]
+fn seq_major_reorder_is_exact_for_all_append_patterns() {
+    for &(appends, kv_h, d) in &[
+        (&[3usize][..], 2usize, 4usize), // single-shot cold prefill
+        (&[2, 1][..], 1, 4),             // kv_h = 1 control
+        (&[2, 1][..], 2, 4),             // the bug case
+        (&[2, 2][..], 3, 4),             // multi-head, even split
+        (&[5, 3, 1][..], 4, 8),          // three appends, 4 heads
+        (&[1, 1, 1, 1][..], 8, 4),       // per-token decode, 8 heads
+    ] {
+        let s_total: usize = appends.iter().sum();
+        let buf = build_buffer(appends, kv_h, d, false);
+        let m = read_seq_major(&buf, kv_h, s_total, d);
+        assert_eq!(
+            m, 0.0,
+            "fixed path exact for appends={appends:?} kv_h={kv_h} d={d}, got {m}"
+        );
+    }
+}
+
+#[test]
+fn reorder_round_trips_identity() {
+    // transpose_seq_heads ∘ transpose_heads_seq == identity for any shape.
+    let (kv_h, s, d) = (3usize, 5usize, 4usize);
+    let mut src = vec![0.0_f32; B * kv_h * s * d];
+    for (i, v) in src.iter_mut().enumerate() {
+        *v = i as f32;
+    }
+    let seq = transpose_heads_seq(&src, B, kv_h, s, d);
+    let back = transpose_seq_heads(&seq, B, s, kv_h, d);
+    assert_eq!(src, back, "reorder round-trip must be identity");
+}

--- a/crates/rmlx-kv-quant/tests/paged_k_layout.rs
+++ b/crates/rmlx-kv-quant/tests/paged_k_layout.rs
@@ -59,7 +59,10 @@ fn head_major(kv_h: i32, seq: i32, d: i32, base_t: i32) -> Vec<f32> {
     v
 }
 
-/// Mirror of `update_paged`'s K handoff with the sequence-major fix.
+/// Mirror of `update_paged`'s K handoff with the sequence-major fix. This guards
+/// the handoff *pattern* (transpose+contiguous before quantize, transpose back on
+/// dequant), not the `update_paged` call site itself — keep in sync with
+/// `KvCache::update_paged` if that reorder changes.
 fn append_chunk(pk: &mut PagedKStorage, kv_h: i32, seq: i32, d: i32, base_t: i32) {
     let shape = [1, kv_h, seq, d];
     let k_hm = arr(&head_major(kv_h, seq, d, base_t), &shape);

--- a/crates/rmlx-kv-quant/tests/paged_k_layout.rs
+++ b/crates/rmlx-kv-quant/tests/paged_k_layout.rs
@@ -13,7 +13,14 @@
 //! reconstructs the true head-major K within q8 noise across a multi-page,
 //! multi-append, multi-head schedule. `#[ignore]` — Metal context; run with
 //! `--ignored --test-threads=1`.
-#![allow(clippy::all, clippy::pedantic, unsafe_code)]
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    unsafe_code,
+    missing_docs
+)]
 
 use rmlx_kv_quant::paged::PagedKStorage;
 use rmlx_kv_quant::q8_msl::{q8_dequantize_gpu, q8_quantize_gpu};

--- a/crates/rmlx-kv-quant/tests/paged_k_layout.rs
+++ b/crates/rmlx-kv-quant/tests/paged_k_layout.rs
@@ -1,0 +1,181 @@
+//! GPU layout round-trip for the Paged K storage handoff.
+//!
+//! `KvCache::update_paged` quantizes the head-major `new_k` (`[B, kv_h, S, D]`)
+//! and feeds the codes to `PagedKStorage::append`, which lays them out
+//! token-major in fixed-size page slabs (`words_per_token` per token slot).
+//! Quantizing head-major and indexing token-major scrambled per-head K on any
+//! chunk spanning more than one token-per-head (multi-page prefill or
+//! multi-append decode) when `kv_h > 1`. The fix reorders `new_k` to
+//! sequence-major before quantizing and transposes the dequant output back.
+//!
+//! This test reproduces the exact `update_paged` handoff (transpose → quantize
+//! → append → gather → dequant → transpose-back) and asserts the round-trip
+//! reconstructs the true head-major K within q8 noise across a multi-page,
+//! multi-append, multi-head schedule. `#[ignore]` — Metal context; run with
+//! `--ignored --test-threads=1`.
+#![allow(clippy::all, clippy::pedantic, unsafe_code)]
+
+use rmlx_kv_quant::paged::PagedKStorage;
+use rmlx_kv_quant::q8_msl::{q8_dequantize_gpu, q8_quantize_gpu};
+use rmlx_mlx::{Array, Device, Dtype};
+
+fn arr(vals: &[f32], shape: &[i32]) -> Array {
+    let bytes = unsafe { std::slice::from_raw_parts(vals.as_ptr().cast::<u8>(), vals.len() * 4) };
+    Array::from_bytes(bytes, shape, Dtype::F32).expect("arr")
+}
+
+fn to_vec(a: &Array) -> Vec<f32> {
+    a.eval().expect("eval");
+    a.to_bytes()
+        .expect("bytes")
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().expect("chunk")))
+        .collect()
+}
+
+/// Distinct, small per-(head,token,dim) value so a head transposition (≥ ~0.1)
+/// is unmistakable against q8 noise.
+fn expected(h: i32, t: i32, dd: i32) -> f32 {
+    (h * 100 + t * 5 + dd % 7) as f32 * 0.001
+}
+
+/// Head-major `[1, kv_h, seq, d]` chunk for tokens `[base_t, base_t+seq)`.
+fn head_major(kv_h: i32, seq: i32, d: i32, base_t: i32) -> Vec<f32> {
+    let mut v = Vec::with_capacity((kv_h * seq * d) as usize);
+    for h in 0..kv_h {
+        for t in 0..seq {
+            for dd in 0..d {
+                v.push(expected(h, base_t + t, dd));
+            }
+        }
+    }
+    v
+}
+
+/// Mirror of `update_paged`'s K handoff with the sequence-major fix.
+fn append_chunk(pk: &mut PagedKStorage, kv_h: i32, seq: i32, d: i32, base_t: i32) {
+    let shape = [1, kv_h, seq, d];
+    let k_hm = arr(&head_major(kv_h, seq, d, base_t), &shape);
+    let k_sm = k_hm
+        .transpose(&[0, 2, 1, 3], Device::Gpu)
+        .expect("transpose")
+        .contiguous(Device::Gpu)
+        .expect("contiguous");
+    let (codes, scales) = q8_quantize_gpu(&k_sm, Device::Gpu).expect("quantize");
+    pk.append(&shape, codes, scales, Device::Gpu)
+        .expect("append");
+}
+
+fn dequant_head_major(pk: &PagedKStorage, kv_h: i32, s_total: i32, d: i32) -> Vec<f32> {
+    let (codes, scales) = pk.gather(Device::Gpu).expect("gather");
+    let sm_shape = [1, s_total, kv_h, d];
+    let out = q8_dequantize_gpu(&codes, &scales, &sm_shape, Dtype::F32, Device::Gpu)
+        .expect("dequant")
+        .transpose(&[0, 2, 1, 3], Device::Gpu)
+        .expect("transpose")
+        .contiguous(Device::Gpu)
+        .expect("contiguous");
+    to_vec(&out)
+}
+
+fn max_err(out: &[f32], kv_h: i32, s_total: i32, d: i32) -> f32 {
+    let mut m = 0.0f32;
+    let mut i = 0usize;
+    for h in 0..kv_h {
+        for t in 0..s_total {
+            for dd in 0..d {
+                m = m.max((out[i] - expected(h, t, dd)).abs());
+                i += 1;
+            }
+        }
+    }
+    m
+}
+
+#[test]
+#[ignore = "GPU Metal context — run with --ignored --test-threads=1"]
+fn paged_k_multipage_multiappend_multi_head_roundtrip() {
+    if std::env::var("RMLX_SKIP_GPU").as_deref() == Ok("1") {
+        return;
+    }
+    // page_tokens=32 (default). A 70-token prefill spans 3 pages, then 5
+    // single-token decode appends. kv_h=8, head_dim=128 (Bonsai-ish).
+    let (kv_h, d) = (8i32, 128i32);
+    let page_tokens = 32i32;
+    let max_seq = 256i32;
+    let n_pages = ((max_seq + page_tokens - 1) / page_tokens) as usize;
+    let mut pk = PagedKStorage::new(max_seq, page_tokens, n_pages);
+
+    append_chunk(&mut pk, kv_h, 70, d, 0);
+    for t in 70..75 {
+        append_chunk(&mut pk, kv_h, 1, d, t);
+    }
+    let s_total = 75;
+    let out = dequant_head_major(&pk, kv_h, s_total, d);
+    let m = max_err(&out, kv_h, s_total, d);
+    assert!(
+        m < 0.05,
+        "paged K multipage/multiappend max abs error {m} — expected q8 noise, not head scramble"
+    );
+}
+
+/// Pre-fix reproduction: the head-major handoff (quantize head-major, append
+/// token-major, dequant head-major — no reorder) scrambles per-head K on a
+/// multi-page, multi-head chunk. Confirms the fix's reorder is load-bearing.
+#[test]
+#[ignore = "GPU Metal context — run with --ignored --test-threads=1"]
+fn paged_k_head_major_handoff_scrambles() {
+    if std::env::var("RMLX_SKIP_GPU").as_deref() == Ok("1") {
+        return;
+    }
+    let (kv_h, d) = (8i32, 128i32);
+    let page_tokens = 32i32;
+    let max_seq = 256i32;
+    let n_pages = ((max_seq + page_tokens - 1) / page_tokens) as usize;
+    let mut pk = PagedKStorage::new(max_seq, page_tokens, n_pages);
+
+    // Pre-fix handoff: quantize head-major directly (no transpose), append a
+    // prefill chunk then per-token decode steps, dequant head-major (no
+    // transpose-back). The second-and-later chunks land at a token offset where
+    // the head-major store and the head-major reshape disagree for kv_h > 1.
+    let append_hm = |pk: &mut PagedKStorage, seq: i32, base_t: i32| {
+        let shape = [1, kv_h, seq, d];
+        let k_hm = arr(&head_major(kv_h, seq, d, base_t), &shape);
+        let (codes, scales) = q8_quantize_gpu(&k_hm, Device::Gpu).expect("quantize");
+        pk.append(&shape, codes, scales, Device::Gpu)
+            .expect("append");
+    };
+    append_hm(&mut pk, 40, 0);
+    for t in 40..45 {
+        append_hm(&mut pk, 1, t);
+    }
+    let s_total = 45i32;
+    let full_shape = [1, kv_h, s_total, d];
+    let (g_codes, g_scales) = pk.gather(Device::Gpu).expect("gather");
+    let out = q8_dequantize_gpu(&g_codes, &g_scales, &full_shape, Dtype::F32, Device::Gpu)
+        .expect("dequant");
+    let out = to_vec(&out);
+    let m = max_err(&out, kv_h, s_total, d);
+    assert!(
+        m > 0.1,
+        "expected head-major handoff to scramble a multi-page GQA chunk, got max err {m}"
+    );
+}
+
+#[test]
+#[ignore = "GPU Metal context — run with --ignored --test-threads=1"]
+fn paged_k_single_head_control() {
+    if std::env::var("RMLX_SKIP_GPU").as_deref() == Ok("1") {
+        return;
+    }
+    let (kv_h, d) = (1i32, 128i32);
+    let page_tokens = 32i32;
+    let max_seq = 256i32;
+    let n_pages = ((max_seq + page_tokens - 1) / page_tokens) as usize;
+    let mut pk = PagedKStorage::new(max_seq, page_tokens, n_pages);
+    append_chunk(&mut pk, kv_h, 70, d, 0);
+    append_chunk(&mut pk, kv_h, 1, d, 70);
+    let out = dequant_head_major(&pk, kv_h, 71, d);
+    let m = max_err(&out, kv_h, 71, d);
+    assert!(m < 0.05, "paged K kv_h=1 control max abs error {m}");
+}

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -490,6 +490,48 @@ affected. The spill / hydrate / paged-grow paths copy the contiguous active
 prefix `[0 .. filled]` and are layout-agnostic, so the on-disk `.kvb` payload is
 unchanged.
 
+### 5.7.2 The same sequence-major rule covers `QuantV`, `QuantKTurbo3/4`, and the paged handoff
+
+The `prev_seq * words_per_seq` write vs head-major reshape is a buffer-shape
+property, not a K-vs-V one, so the sibling flat-buffer storage structs carry the
+**same** latent head-transposition and use the **same** sequence-major fix:
+
+- **`QuantV`** (TurboQuant V — K8V4 / Planar V side, bits=4 GPU + CPU
+  `Vec<TurboBlocks>`): `append` reorders the chunk heads↔seq before quantizing
+  on both backends; `dequantize_choice` reorders back. Byte-identical cold
+  prefill at `head_dim % 32 == 0` (TurboQuant group of 32). The CPU
+  `Vec<TurboBlocks>` path concatenates per-append blocks, so it carries the same
+  cross-block scramble and the same fix.
+- **`QuantKTurbo3` / `QuantKTurbo4`** (symmetric K side of `TurboSym3` /
+  `TurboSym4`): identical TurboQuant codec reuse; the "axis-agnostic" header
+  rationale was the root cause (a *positional* codec means physical buffer order
+  decides correctness across appends).
+- **Paged KV** (`update_paged` → `PagedKStorage` / `PagedVStorage` /
+  `PagedPlanarVStorage`): the page slabs are physically token-major
+  (`words_per_token` per token slot), so `update_paged` reorders the head-major
+  `new_k` / `new_v` to sequence-major **before** quantizing and transposes the
+  dequant output back. `--paged-kv` is default-off.
+
+In every case the GPU side adds `Array::contiguous` after the heads↔seq
+transpose because the custom quant / dequant MSL kernels read their buffers by
+raw linear index and ignore MLX lazy-transpose strides — a CPU-only test cannot
+catch that; the layout fixes are GPU round-trip verified.
+
+**Not yet covered (same class, deferred):** the PlanarQuant K/V structs
+(`QuantPlanarK` / `QuantPlanarV`) carry the same multi-append head scramble
+(reproduced on GPU: chunked decode vs one-shot diverges by ~4 abs at the Bonsai
+shape), but `QuantPlanarK` additionally exposes its packed codes buffer to the
+`planar_fused_qk` / `planar_flash_decode` MSL kernels via `gpu_packed_view`
+(the post-hydrate decode path, gated on `decode_fp16_k.is_none()`). Those
+kernels read the packed buffer with a head-major `(b, kv_h, kv_seq, head_dim)`
+indexing, so a sequence-major storage relayout would also have to relayout the
+fused-QK / flash kernels — a coordinated MSL-kernel change beyond the
+storage-local fix. The Iso / Rotor `Vec<Blocks>` codecs (`QuantIsoV3/V4`,
+`QuantIsoK3/K4`, `QuantRotorV3/V4`, `QuantRotorK3/K4`) share the CPU-blocks
+cross-block reshape and are affected on the same post-hydrate multi-append path;
+their rotation/quaternion sidebands need the reorder applied per codec with its
+own GPU proof.
+
 ### 5.8 TurboQuant requires Flash Attention
 
 The `tq4` V-side path is only valid through the Flash Attention dispatch.

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -469,6 +469,24 @@ The V side uses `QuantV { bits: 4 }`. Layout:
   `words_per_step = B * kv_h * D * 4 / GROUP_SIZE` (four u32 words per group
   of 32 at 4 bits = 128 bits = 4 u32). Paged growth as in K8V8.
 
+**Buffer layout (sequence-major).** Like `QuantK`, the `QuantV` buffer stores
+the filled prefix **sequence-major** (`[B, S, kv_h, D]`) on both backends:
+`append` reorders the head-major chunk heads↔seq before quantizing (GPU
+`transpose` + `contiguous` so the raw-linear-index TurboQuant MSL kernel sees
+the permuted bytes; CPU reorders `f32_data` and passes the seq-major shape to
+the positional `turbo_quantize_v` / TCQ codec), and `dequantize_choice`
+reshapes the prefix seq-major then transposes back to the logical
+`[B, kv_h, S, D]` (GPU output `contiguous` for raw byte-readers / SSD spill).
+Single-chunk cold prefill is the identity; byte-identical at `head_dim % 32 ==
+0` (every TurboQuant group of 32 stays inside one head). Without this reorder,
+a head-major store read with a `[B, kv_h, S, D]` reshape transposed heads
+whenever `kv_h > 1` and the cache was appended in more than one chunk (the
+post-SSD-hydrate decode-append path) — silent V corruption. The same
+sequence-major ordering applies to the K-side `QuantKTurbo3` / `QuantKTurbo4`
+structs (`TurboSym3` / `TurboSym4`) and to the paged K/V handoff in
+`update_paged` (which reorders `new_k`/`new_v` to seq-major before quantizing,
+since the page slabs are physically token-major).
+
 `update_and_sdpa` path (without TurboFlash):
 1. Append K via `QuantK::append`.
 2. Append V via `QuantV::append` (calls `turbo_quantize_v4_gpu` on GPU).


### PR DESCRIPTION
## Summary

Extends the #80 multi-append-after-SSD-hydrate layout fix to the sibling storage structs that share the same bug class. **Part 1 of #105** (does not close it — see Remaining).

Bug class (#80): a flat KV codec buffer written sequence-major but dequant-reshaped head-major scrambles per-head K/V on a multi-append after SSD hydrate with `kv_heads > 1`; and a custom MSL quant kernel reads its input by raw linear index, ignoring MLX lazy-transpose strides, so a transposed view must be `Array::contiguous`-materialized before the kernel (a CPU-only test cannot catch this).

Fixed here:
- **`QuantV`** (K8V4 / Planar V side)
- **`QuantKTurbo3` / `QuantKTurbo4`** (TurboSym K)
- **paged KV handoff** (`update_paged` quantize→page-write)

The shared heads↔seq reorder is extracted to `storage/seq_layout.rs`, and the merged #80 `quant_k.rs` is refactored onto it (behavior-identical).

## Validation

- **Real Metal GPU round-trips** (CPU can't catch the kernel-stride footgun): QuantV / turbo3 / turbo4 / paged multi-append `kv_heads>1` all at quant noise (<0.05); the head-major-handoff **scramble negative control fires** (>0.1), proving the reorder is load-bearing; `kv_heads=1` controls clean.
- **Deterministic CPU tests:** fail-before/pass-after per struct, incl. a cross-head-group case (a codec group spanning two heads).
- **End-to-end serve** (Bonsai, `Qwen3ForCausalLM`, kv_heads=8 — its HydratedTail policy actually decodes off hydrated K): K8V4 + SSD spill→hydrate→decode reconstructs a 2560-tok prefix from disk and decodes correctly (`nan_count=0`); paged-KV multi-page prefill + decode coherent.
- **No perf regression** (canary): within band; the fixed dequant path is post-hydrate-only, off the steady-state decode hot path.
- `make lint` clean, `cargo fmt --all` clean.

## Remaining (#105 stays open — same bug class, deferred for a coordinated fix)

- **`QuantPlanarK` / `QuantPlanarV`** — couple to the `planar_fused_qk` / `planar_flash_decode` MSL kernels on the post-hydrate decode path (`gpu_packed_view`), which index head-major. A seq-major relayout needs those kernels made seq-major-aware; tracked under #105.
- **Iso / Rotor `Vec<Blocks>` codecs (8 structs)** — same CPU cross-block layout class, need per-codec sideband handling + GPU proof; tracked under #105.

Documented in `docs/KV_CACHE.md` §5.7.2.

Part of #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)