### PR TITLE
fix(kv-quant): sequence-major layout for Iso/Rotor rotation-KV codecs (part of #105)

### DIFF
--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -82,12 +82,22 @@ impl QuantIsoK3 {
                 "QuantIsoK3::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
+        let b = new_shape[0] as usize;
+        let kv_h = new_shape[1] as usize;
+        let new_seq = new_shape[2] as usize;
         let head_dim = new_shape[3] as usize;
-        let n_tokens_total =
-            (new_shape[0] as usize) * (new_shape[1] as usize) * (new_shape[2] as usize);
+        let n_tokens_total = b * kv_h * new_seq;
+
+        // Store each chunk sequence-major (`[B, new_seq, kv_h, D]`) so the
+        // per-append blocks share one layout; a head-major store transposes
+        // heads across multi-append GQA caches (kv_h>1) when `dequant`
+        // reshapes head-major over the full sequence. See
+        // [`super::QuantIsoV3::append`].
+        let seq_major =
+            super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
 
         let (codes, scales, quaternions, norms) =
-            iso_encode_fast(f32_data, head_dim, ISO_K3_GROUP_SIZE, ISO_K3_BITS).map_err(
+            iso_encode_fast(&seq_major, head_dim, ISO_K3_GROUP_SIZE, ISO_K3_BITS).map_err(
                 |e: IsoQuantError| rmlx_core::error::Error::Mlx(format!("iso_k3 encode: {e}")),
             )?;
 
@@ -216,6 +226,12 @@ impl QuantIsoK3 {
         } else if out.len() > total_elems {
             out.truncate(total_elems);
         }
+        // Blocks are sequence-major (see `append`); reorder back to the logical
+        // head-major `[B, kv_h, S, D]`.
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
         Ok(out)
     }
 
@@ -314,7 +330,11 @@ impl QuantIsoK3 {
             device,
         )?;
 
-        flat.reshape(&self.shape, device)
+        // CPU blocks are sequence-major (see `append`): reshape to
+        // `[B, S, kv_h, D]`, then reorder heads↔seq back to `[B, kv_h, S, D]`.
+        let seq_major_shape = [self.shape[0], self.shape[2], self.shape[1], self.shape[3]];
+        let out = flat.reshape(&seq_major_shape, device)?;
+        out.transpose(&[0, 2, 1, 3], device)?.contiguous(device)
     }
 }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
@@ -70,12 +70,20 @@ impl QuantIsoK4 {
                 "QuantIsoK4::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
+        let b = new_shape[0] as usize;
+        let kv_h = new_shape[1] as usize;
+        let new_seq = new_shape[2] as usize;
         let head_dim = new_shape[3] as usize;
-        let n_tokens_total =
-            (new_shape[0] as usize) * (new_shape[1] as usize) * (new_shape[2] as usize);
+        let n_tokens_total = b * kv_h * new_seq;
+
+        // Store each chunk sequence-major so the per-append blocks share one
+        // layout; a head-major store transposes heads across multi-append GQA
+        // caches (kv_h>1). See [`super::QuantIsoV3::append`].
+        let seq_major =
+            super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
 
         let (codes, scales, quaternions, norms) =
-            iso_encode_fast(f32_data, head_dim, ISO_K4_GROUP_SIZE, ISO_K4_BITS).map_err(
+            iso_encode_fast(&seq_major, head_dim, ISO_K4_GROUP_SIZE, ISO_K4_BITS).map_err(
                 |e: IsoQuantError| rmlx_core::error::Error::Mlx(format!("iso_k4 encode: {e}")),
             )?;
 
@@ -203,6 +211,12 @@ impl QuantIsoK4 {
         } else if out.len() > total_elems {
             out.truncate(total_elems);
         }
+        // Blocks are sequence-major (see `append`); reorder back to head-major
+        // `[B, kv_h, S, D]`.
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4_tests.rs
@@ -101,3 +101,61 @@ fn quant_iso_k4_cosine_empirical_floor_head_dim_128() {
         stats.min
     );
 }
+
+/// Multi-append with `kv_h > 1` must match a single-shot append of the
+/// concatenated head-major buffer (head↔seq layout invariant). Per-(head,
+/// token, dim) distinct values surface any head transposition as a large error.
+#[test]
+fn quant_iso_k4_multi_append_matches_single_shot_gqa() {
+    let kv_h = 3_usize;
+    let head_dim = 8_usize;
+    let chunk_a = 2_usize;
+    let chunk_b = 3_usize;
+    let s_total = chunk_a + chunk_b;
+    let val = |h: usize, s: usize, d: usize| {
+        (h as f32) * 100.0 + (s as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+    let build = |s_lo: usize, s_hi: usize| -> Vec<f32> {
+        let s = s_hi - s_lo;
+        let mut out = vec![0.0_f32; kv_h * s * head_dim];
+        for h in 0..kv_h {
+            for si in 0..s {
+                for d in 0..head_dim {
+                    out[(h * s + si) * head_dim + d] = val(h, s_lo + si, d);
+                }
+            }
+        }
+        out
+    };
+    let mut qref = QuantIsoK4::new(vec![1, kv_h as i32, 0, head_dim as i32], 64);
+    qref.append(
+        &build(0, s_total),
+        &[1, kv_h as i32, s_total as i32, head_dim as i32],
+    )
+    .expect("single-shot append");
+    let reference = qref.dequant().expect("single-shot dequant");
+
+    let mut qv = QuantIsoK4::new(vec![1, kv_h as i32, 0, head_dim as i32], 64);
+    qv.append(
+        &build(0, chunk_a),
+        &[1, kv_h as i32, chunk_a as i32, head_dim as i32],
+    )
+    .expect("append A");
+    qv.append(
+        &build(chunk_a, s_total),
+        &[1, kv_h as i32, chunk_b as i32, head_dim as i32],
+    )
+    .expect("append B");
+    let multi = qv.dequant().expect("multi dequant");
+
+    assert_eq!(multi.len(), reference.len());
+    let max_abs = multi
+        .iter()
+        .zip(reference.iter())
+        .fold(0.0_f32, |m, (a, b)| m.max((a - b).abs()));
+    assert!(
+        max_abs < 1.0,
+        "iso_k4 multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — head↔seq scramble"
+    );
+    let _ = (ISO_K4_BITS, ISO_K4_GROUP_SIZE);
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
@@ -7,7 +7,8 @@
 
 use crate::isoquant::{iso_decode_fast, iso_encode_fast};
 use crate::storage::quant_iso_k::{QuantIsoK3, ISO_K3_BITS, ISO_K3_GROUP_SIZE};
-use crate::test_utils::{cosine_similarity_per_row, lcg_data, TEST_SEED};
+use crate::test_utils::{cosine_similarity_per_row, lcg_data, skip_if_no_gpu_env, TEST_SEED};
+use rmlx_mlx::Device;
 
 #[test]
 fn quant_iso_k3_new_shapes_correct() {
@@ -166,4 +167,83 @@ fn quant_iso_k3_multi_append_matches_single_shot_gqa() {
         "iso_k3 multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — head↔seq scramble"
     );
     let _ = (ISO_K3_BITS, ISO_K3_GROUP_SIZE);
+}
+
+/// GPU multi-append with `kv_h > 1` must match a single-shot CPU-append +
+/// `dequant_gpu` of the concatenated head-major buffer. `dequant_gpu` uploads
+/// CPU blocks via `Array::from_bytes` and drives the iso3 MSL kernel; the
+/// subsequent reshape+transpose reorders sequence-major blocks back to
+/// head-major `[B, kv_h, S, D]`. A head transposition produces errors ~100;
+/// quant noise on this fixture is well under 1.0.
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test -p rmlx-kv-quant --release iso_k3_gpu_multi_append -- --ignored --test-threads=1"]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test: panic on failure is the desired test failure mode"
+)]
+fn iso_k3_gpu_multi_append_matches_single_shot_gqa() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let kv_h = 3_i32;
+    let head_dim = 8_i32; // must be multiple of ISO_K3_GROUP_SIZE (4)
+    let chunk_a = 2_i32;
+    let chunk_b = 3_i32;
+    let s_total = chunk_a + chunk_b;
+
+    let val = |h: i32, s: i32, d: i32| -> f32 {
+        (h as f32) * 100.0 + (s as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+    let build = |s_lo: i32, s_hi: i32| -> Vec<f32> {
+        let s = s_hi - s_lo;
+        let mut out = vec![0.0_f32; (kv_h * s * head_dim) as usize];
+        for h in 0..kv_h {
+            for si in 0..s {
+                for d in 0..head_dim {
+                    let idx = ((h * s + si) * head_dim + d) as usize;
+                    out[idx] = val(h, s_lo + si, d);
+                }
+            }
+        }
+        out
+    };
+
+    // Reference: single CPU append, then dequant_gpu.
+    let mut qref = QuantIsoK3::new(vec![1, kv_h, 0, head_dim], 64);
+    qref.append(&build(0, s_total), &[1, kv_h, s_total, head_dim])
+        .unwrap();
+    let ref_arr = qref.dequant_gpu(Device::Gpu).unwrap();
+    ref_arr.eval().unwrap();
+    let reference: Vec<f32> = ref_arr
+        .to_bytes()
+        .unwrap()
+        .chunks_exact(4)
+        .map(|x| f32::from_le_bytes(x.try_into().unwrap()))
+        .collect();
+
+    // Two CPU appends, then dequant_gpu.
+    let mut qv = QuantIsoK3::new(vec![1, kv_h, 0, head_dim], 64);
+    qv.append(&build(0, chunk_a), &[1, kv_h, chunk_a, head_dim])
+        .unwrap();
+    qv.append(&build(chunk_a, s_total), &[1, kv_h, chunk_b, head_dim])
+        .unwrap();
+    let multi_arr = qv.dequant_gpu(Device::Gpu).unwrap();
+    multi_arr.eval().unwrap();
+    let multi: Vec<f32> = multi_arr
+        .to_bytes()
+        .unwrap()
+        .chunks_exact(4)
+        .map(|x| f32::from_le_bytes(x.try_into().unwrap()))
+        .collect();
+
+    assert_eq!(multi.len(), reference.len(), "length parity");
+    let max_abs = multi
+        .iter()
+        .zip(reference.iter())
+        .fold(0.0_f32, |m, (a, b)| m.max((a - b).abs()));
+    assert!(
+        max_abs < 1.0,
+        "GPU multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — \
+         head↔seq layout scramble"
+    );
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
@@ -109,3 +109,61 @@ fn quant_iso_k3_cosine_empirical_floor_head_dim_128() {
         stats.min
     );
 }
+
+/// Multi-append with `kv_h > 1` must match a single-shot append of the
+/// concatenated head-major buffer (head↔seq layout invariant). Per-(head,
+/// token, dim) distinct values surface any head transposition as a large error.
+#[test]
+fn quant_iso_k3_multi_append_matches_single_shot_gqa() {
+    let kv_h = 3_usize;
+    let head_dim = 8_usize;
+    let chunk_a = 2_usize;
+    let chunk_b = 3_usize;
+    let s_total = chunk_a + chunk_b;
+    let val = |h: usize, s: usize, d: usize| {
+        (h as f32) * 100.0 + (s as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+    let build = |s_lo: usize, s_hi: usize| -> Vec<f32> {
+        let s = s_hi - s_lo;
+        let mut out = vec![0.0_f32; kv_h * s * head_dim];
+        for h in 0..kv_h {
+            for si in 0..s {
+                for d in 0..head_dim {
+                    out[(h * s + si) * head_dim + d] = val(h, s_lo + si, d);
+                }
+            }
+        }
+        out
+    };
+    let mut qref = QuantIsoK3::new(vec![1, kv_h as i32, 0, head_dim as i32], 64);
+    qref.append(
+        &build(0, s_total),
+        &[1, kv_h as i32, s_total as i32, head_dim as i32],
+    )
+    .expect("single-shot append");
+    let reference = qref.dequant().expect("single-shot dequant");
+
+    let mut qv = QuantIsoK3::new(vec![1, kv_h as i32, 0, head_dim as i32], 64);
+    qv.append(
+        &build(0, chunk_a),
+        &[1, kv_h as i32, chunk_a as i32, head_dim as i32],
+    )
+    .expect("append A");
+    qv.append(
+        &build(chunk_a, s_total),
+        &[1, kv_h as i32, chunk_b as i32, head_dim as i32],
+    )
+    .expect("append B");
+    let multi = qv.dequant().expect("multi dequant");
+
+    assert_eq!(multi.len(), reference.len());
+    let max_abs = multi
+        .iter()
+        .zip(reference.iter())
+        .fold(0.0_f32, |m, (a, b)| m.max((a - b).abs()));
+    assert!(
+        max_abs < 1.0,
+        "iso_k3 multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — head↔seq scramble"
+    );
+    let _ = (ISO_K3_BITS, ISO_K3_GROUP_SIZE);
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -170,12 +170,24 @@ impl QuantIsoV3 {
                 "QuantIsoV3::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
+        let b = new_shape[0] as usize;
+        let kv_h = new_shape[1] as usize;
+        let new_seq = new_shape[2] as usize;
         let head_dim = new_shape[3] as usize;
-        let n_tokens_total =
-            (new_shape[0] as usize) * (new_shape[1] as usize) * (new_shape[2] as usize);
+        let n_tokens_total = b * kv_h * new_seq;
+
+        // The codec is per-token-row positional (one row of length `head_dim`
+        // per token). Blocks accumulate one chunk per append; `dequant`
+        // concatenates them and the caller reshapes head-major `[B, kv_h, S, D]`.
+        // A head-major store transposes heads across a multi-append GQA cache
+        // (kv_h>1), so store each chunk sequence-major (`[B, new_seq, kv_h, D]`)
+        // — reorder the head-major input heads↔seq before quantizing and
+        // `dequant` reorders back to the logical `[B, kv_h, S, D]`.
+        let seq_major =
+            super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
 
         let (codes, scales, quaternions, norms) =
-            iso_encode_fast(f32_data, head_dim, ISO3_GROUP_SIZE, ISO3_BITS).map_err(
+            iso_encode_fast(&seq_major, head_dim, ISO3_GROUP_SIZE, ISO3_BITS).map_err(
                 |e: IsoQuantError| rmlx_core::error::Error::Mlx(format!("iso3 encode: {e}")),
             )?;
 
@@ -386,6 +398,12 @@ impl QuantIsoV3 {
         } else if out.len() > total_elems {
             out.truncate(total_elems);
         }
+        // Blocks are sequence-major (see `append`); reorder the concatenated
+        // decode back to the logical head-major `[B, kv_h, S, D]`.
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
         Ok(out)
     }
 
@@ -442,11 +460,19 @@ impl QuantIsoV3 {
             })?;
 
         // ── 1. Dispatch the MSL encode kernel. ─────────────────────────────
+        // The codec is per-token-row positional; the GPU mirror accumulates
+        // each chunk's encode at `prev_seq * words_per_step`, so a head-major
+        // store + head-major reshape on `dequant_gpu` transposes heads across
+        // multi-append GQA caches (kv_h>1). Reorder the chunk to sequence-major
+        // `[B, new_seq, kv_h, D]` before quantizing — `transpose` yields a
+        // strided view, and the iso3 MSL kernel reads its input by raw linear
+        // offset (ignores MLX strides), so materialize with `contiguous` first.
         // `quats_gpu` is a constant FIXED_QUAT-filled placeholder that the
         // dequant kernel never reads (see `iso_dequantize_v3_gpu`); we forward
         // it to `iso3_gpu_outputs_to_cpu` for ABI parity and then drop it.
+        let v_seq_major = v_arr.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
         let (codes_gpu, scales_gpu, quats_gpu, norms_gpu) =
-            crate::isoquant_msl::iso_quantize_v3_gpu(v_arr, head_dim, device)?;
+            crate::isoquant_msl::iso_quantize_v3_gpu(&v_seq_major, head_dim, device)?;
 
         // ── 2. Read back into CPU blocks (SSD spill compatibility). ────────
         // Reuse the shared helper so this path stays bit-identical with the
@@ -857,7 +883,13 @@ impl QuantIsoV3 {
                 Dtype::F32,
                 device,
             )?;
-            return flat.reshape(&self.shape, device);
+            // Mirror/blocks are sequence-major (see `append_gpu`): reshape the
+            // flat decode to `[B, S, kv_h, D]`, then reorder heads↔seq back to
+            // the logical `[B, kv_h, S, D]`. `contiguous` after the transpose so
+            // raw byte-readers (SSD spill) see the permuted bytes.
+            let seq_major_shape = [self.shape[0], self.shape[2], self.shape[1], self.shape[3]];
+            let out = flat.reshape(&seq_major_shape, device)?;
+            return out.transpose(&[0, 2, 1, 3], device)?.contiguous(device);
         }
 
         // Concatenate all block buffers. CPU codes/scales/quats are already in
@@ -947,7 +979,11 @@ impl QuantIsoV3 {
             device,
         )?;
 
-        flat.reshape(&self.shape, device)
+        // CPU blocks are sequence-major (see `append` / `append_gpu`): reshape
+        // to `[B, S, kv_h, D]`, then reorder heads↔seq back to `[B, kv_h, S, D]`.
+        let seq_major_shape = [self.shape[0], self.shape[2], self.shape[1], self.shape[3]];
+        let out = flat.reshape(&seq_major_shape, device)?;
+        out.transpose(&[0, 2, 1, 3], device)?.contiguous(device)
     }
 }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
@@ -85,12 +85,20 @@ impl QuantIsoV4 {
                 "QuantIsoV4::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
+        let b = new_shape[0] as usize;
+        let kv_h = new_shape[1] as usize;
+        let new_seq = new_shape[2] as usize;
         let head_dim = new_shape[3] as usize;
-        let n_tokens_total =
-            (new_shape[0] as usize) * (new_shape[1] as usize) * (new_shape[2] as usize);
+        let n_tokens_total = b * kv_h * new_seq;
+
+        // Store each chunk sequence-major so the per-append blocks share one
+        // layout; a head-major store transposes heads across multi-append GQA
+        // caches (kv_h>1). See [`super::QuantIsoV3::append`].
+        let seq_major =
+            super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
 
         let (codes, scales, quaternions, norms) =
-            iso_encode_fast(f32_data, head_dim, ISO4_GROUP_SIZE, ISO4_BITS).map_err(
+            iso_encode_fast(&seq_major, head_dim, ISO4_GROUP_SIZE, ISO4_BITS).map_err(
                 |e: IsoQuantError| rmlx_core::error::Error::Mlx(format!("iso4 encode: {e}")),
             )?;
 
@@ -218,6 +226,12 @@ impl QuantIsoV4 {
         } else if out.len() > total_elems {
             out.truncate(total_elems);
         }
+        // Blocks are sequence-major (see `append`); reorder back to head-major
+        // `[B, kv_h, S, D]`.
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v4_tests.rs
@@ -137,3 +137,61 @@ fn quant_iso_v4_truncate_to_keeps_first_n() {
         stats.min
     );
 }
+
+/// Multi-append with `kv_h > 1` must match a single-shot append of the
+/// concatenated head-major buffer (head↔seq layout invariant). Per-(head,
+/// token, dim) distinct values surface any head transposition as a large error.
+#[test]
+fn quant_iso_v4_multi_append_matches_single_shot_gqa() {
+    let kv_h = 3_usize;
+    let head_dim = 8_usize;
+    let chunk_a = 2_usize;
+    let chunk_b = 3_usize;
+    let s_total = chunk_a + chunk_b;
+    let val = |h: usize, s: usize, d: usize| {
+        (h as f32) * 100.0 + (s as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+    let build = |s_lo: usize, s_hi: usize| -> Vec<f32> {
+        let s = s_hi - s_lo;
+        let mut out = vec![0.0_f32; kv_h * s * head_dim];
+        for h in 0..kv_h {
+            for si in 0..s {
+                for d in 0..head_dim {
+                    out[(h * s + si) * head_dim + d] = val(h, s_lo + si, d);
+                }
+            }
+        }
+        out
+    };
+    let mut qref = QuantIsoV4::new(vec![1, kv_h as i32, 0, head_dim as i32], 64);
+    qref.append(
+        &build(0, s_total),
+        &[1, kv_h as i32, s_total as i32, head_dim as i32],
+    )
+    .expect("single-shot append");
+    let reference = qref.dequant().expect("single-shot dequant");
+
+    let mut qv = QuantIsoV4::new(vec![1, kv_h as i32, 0, head_dim as i32], 64);
+    qv.append(
+        &build(0, chunk_a),
+        &[1, kv_h as i32, chunk_a as i32, head_dim as i32],
+    )
+    .expect("append A");
+    qv.append(
+        &build(chunk_a, s_total),
+        &[1, kv_h as i32, chunk_b as i32, head_dim as i32],
+    )
+    .expect("append B");
+    let multi = qv.dequant().expect("multi dequant");
+
+    assert_eq!(multi.len(), reference.len());
+    let max_abs = multi
+        .iter()
+        .zip(reference.iter())
+        .fold(0.0_f32, |m, (a, b)| m.max((a - b).abs()));
+    assert!(
+        max_abs < 1.0,
+        "iso_v4 multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — head↔seq scramble"
+    );
+    let _ = (ISO4_BITS, ISO4_GROUP_SIZE);
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
@@ -81,6 +81,90 @@ fn quant_iso_v_roundtrip_dequant() {
     );
 }
 
+/// Multi-append with `kv_h > 1` must produce the same dequant output as a
+/// single-shot append of the concatenated head-major buffer. This is the
+/// head↔sequence layout invariant: the CPU blocks accumulate one chunk per
+/// append, and a head-major-per-block layout transposes heads across appends
+/// when the dequant reshapes head-major over the full sequence.
+///
+/// Fixture: per-(head, token) distinct values so any head transposition shows
+/// up as a large error (>> quant noise).
+#[test]
+fn quant_iso_v_multi_append_matches_single_shot_gqa() {
+    let b = 1_usize;
+    let kv_h = 3_usize;
+    let head_dim = 8_usize;
+    let chunk_a = 2_usize;
+    let chunk_b = 3_usize;
+    let s_total = chunk_a + chunk_b;
+
+    // Distinct, recognisable per-(head, token, dim) values. Encode the full
+    // head-major `[B, kv_h, S, D]` buffer once as the reference.
+    let val = |h: usize, s: usize, d: usize| -> f32 {
+        (h as f32) * 100.0 + (s as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+    let mut full = vec![0.0_f32; b * kv_h * s_total * head_dim];
+    for h in 0..kv_h {
+        for s in 0..s_total {
+            for d in 0..head_dim {
+                full[(h * s_total + s) * head_dim + d] = val(h, s, d);
+            }
+        }
+    }
+
+    // Reference: one append of the whole sequence.
+    let mut qref = QuantIsoV3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 64);
+    qref.append(
+        &full,
+        &[b as i32, kv_h as i32, s_total as i32, head_dim as i32],
+    )
+    .expect("single-shot append");
+    let reference = qref.dequant().expect("single-shot dequant");
+
+    // Two appends: chunk A then chunk B, each a head-major `[B, kv_h, s, D]`.
+    let extract = |s_lo: usize, s_hi: usize| -> Vec<f32> {
+        let s = s_hi - s_lo;
+        let mut out = vec![0.0_f32; b * kv_h * s * head_dim];
+        for h in 0..kv_h {
+            for si in 0..s {
+                for d in 0..head_dim {
+                    out[(h * s + si) * head_dim + d] = val(h, s_lo + si, d);
+                }
+            }
+        }
+        out
+    };
+    let mut qv = QuantIsoV3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 64);
+    qv.append(
+        &extract(0, chunk_a),
+        &[b as i32, kv_h as i32, chunk_a as i32, head_dim as i32],
+    )
+    .expect("append chunk A");
+    qv.append(
+        &extract(chunk_a, s_total),
+        &[b as i32, kv_h as i32, chunk_b as i32, head_dim as i32],
+    )
+    .expect("append chunk B");
+    let multi = qv.dequant().expect("multi-append dequant");
+
+    assert_eq!(multi.len(), reference.len(), "length parity");
+    let mut max_abs = 0.0_f32;
+    for (a, b) in multi.iter().zip(reference.iter()) {
+        let d = (a - b).abs();
+        if d > max_abs {
+            max_abs = d;
+        }
+    }
+    // A head transposition produces errors on the order of the value spread
+    // (~100s). Quant noise on this fixture is well under 1.0. Use 1.0 as the
+    // discriminating threshold.
+    assert!(
+        max_abs < 1.0,
+        "multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — \
+         head↔seq layout scramble"
+    );
+}
+
 /// After `append` then `reset`, the storage reports seq = 0 and dequant returns
 /// the zero-element prefix only.
 #[test]
@@ -380,6 +464,133 @@ fn iso_v3_reset_clears_gpu_mirror() {
     assert_eq!(qv.gpu_offset, 0, "reset must zero gpu_offset");
     assert_eq!(qv.gpu_capacity, 0, "reset must zero gpu_capacity");
     assert!(qv.blocks.is_empty(), "reset must clear CPU blocks");
+}
+
+/// GPU multi-append with `kv_h > 1` must match a single-shot GPU append of the
+/// concatenated head-major buffer. Exercises the GPU-mirror layout invariant:
+/// `append_gpu` reorders each chunk seq-major before the encode kernel, and
+/// `dequant_gpu` reorders back — a head-major store + head-major reshape would
+/// transpose heads across the two chunks. CPU tests cannot catch the MSL
+/// raw-linear-index stride footgun, so this runs on the real GPU.
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test -p rmlx-kv-quant -- --ignored quant_iso_v --test-threads=1"]
+fn iso_v3_gpu_multi_append_matches_single_shot_gqa() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    force_gpu_resident_iso_on();
+    let b = 1_i32;
+    let kv_h = 3_i32;
+    let head_dim = 8_i32;
+    let chunk_a = 2_i32;
+    let chunk_b = 3_i32;
+    let s_total = chunk_a + chunk_b;
+
+    let val = |h: i32, s: i32, d: i32| -> f32 {
+        (h as f32) * 100.0 + (s as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+    let build = |s_lo: i32, s_hi: i32| -> Vec<f32> {
+        let s = s_hi - s_lo;
+        let mut out = vec![0.0_f32; (b * kv_h * s * head_dim) as usize];
+        for h in 0..kv_h {
+            for si in 0..s {
+                for d in 0..head_dim {
+                    let idx = (((h * s) + si) * head_dim + d) as usize;
+                    out[idx] = val(h, s_lo + si, d);
+                }
+            }
+        }
+        out
+    };
+
+    // Reference: one GPU append of the full sequence.
+    let full = build(0, s_total);
+    let full_arr = make_f32_array_4d(&full, &[b, kv_h, s_total, head_dim]);
+    let mut qref = QuantIsoV3::new(vec![b, kv_h, 0, head_dim], 64);
+    qref.append_gpu(&full_arr, &[b, kv_h, s_total, head_dim], Device::Gpu)
+        .expect("single-shot append_gpu");
+    let ref_arr = qref
+        .dequant_gpu(Device::Gpu)
+        .expect("single-shot dequant_gpu");
+    ref_arr.eval().expect("eval");
+    let reference: Vec<f32> = ref_arr
+        .to_bytes()
+        .expect("to_bytes")
+        .chunks_exact(4)
+        .map(|x| f32::from_le_bytes(x.try_into().expect("chunk len 4")))
+        .collect();
+
+    // Two GPU appends.
+    let arr_a = make_f32_array_4d(&build(0, chunk_a), &[b, kv_h, chunk_a, head_dim]);
+    let arr_b = make_f32_array_4d(&build(chunk_a, s_total), &[b, kv_h, chunk_b, head_dim]);
+    let mut qv = QuantIsoV3::new(vec![b, kv_h, 0, head_dim], 64);
+    qv.append_gpu(&arr_a, &[b, kv_h, chunk_a, head_dim], Device::Gpu)
+        .expect("append_gpu A");
+    qv.append_gpu(&arr_b, &[b, kv_h, chunk_b, head_dim], Device::Gpu)
+        .expect("append_gpu B");
+    let multi_arr = qv.dequant_gpu(Device::Gpu).expect("multi dequant_gpu");
+    multi_arr.eval().expect("eval");
+    let multi: Vec<f32> = multi_arr
+        .to_bytes()
+        .expect("to_bytes")
+        .chunks_exact(4)
+        .map(|x| f32::from_le_bytes(x.try_into().expect("chunk len 4")))
+        .collect();
+
+    assert_eq!(multi.len(), reference.len(), "length parity");
+    let mut max_abs = 0.0_f32;
+    for (a, b) in multi.iter().zip(reference.iter()) {
+        let d = (a - b).abs();
+        if d > max_abs {
+            max_abs = d;
+        }
+    }
+    // A head transposition produces errors ~100s; quant noise on this fixture
+    // is well under 1.0.
+    assert!(
+        max_abs < 1.0,
+        "GPU multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — \
+         head↔seq layout scramble"
+    );
+
+    // kv_h=1 control: layout reorder is a no-op, multi-append still matches.
+    let head_dim1 = 8_i32;
+    let c1 = build_single_head(b, head_dim1, 0, chunk_a, &val);
+    let c2 = build_single_head(b, head_dim1, chunk_a, s_total, &val);
+    let arr_c1 = make_f32_array_4d(&c1, &[b, 1, chunk_a, head_dim1]);
+    let arr_c2 = make_f32_array_4d(&c2, &[b, 1, chunk_b, head_dim1]);
+    let mut qctrl = QuantIsoV3::new(vec![b, 1, 0, head_dim1], 64);
+    qctrl
+        .append_gpu(&arr_c1, &[b, 1, chunk_a, head_dim1], Device::Gpu)
+        .expect("ctrl append A");
+    qctrl
+        .append_gpu(&arr_c2, &[b, 1, chunk_b, head_dim1], Device::Gpu)
+        .expect("ctrl append B");
+    let ctrl_arr = qctrl.dequant_gpu(Device::Gpu).expect("ctrl dequant");
+    ctrl_arr.eval().expect("eval");
+    assert_eq!(
+        ctrl_arr.shape(),
+        vec![b, 1, s_total, head_dim1],
+        "kv_h=1 control shape"
+    );
+}
+
+/// Helper for the kv_h=1 control case: build a `[B, 1, s, D]` head-major chunk.
+fn build_single_head(
+    b: i32,
+    head_dim: i32,
+    s_lo: i32,
+    s_hi: i32,
+    val: &dyn Fn(i32, i32, i32) -> f32,
+) -> Vec<f32> {
+    let s = s_hi - s_lo;
+    let mut out = vec![0.0_f32; (b * s * head_dim) as usize];
+    for si in 0..s {
+        for d in 0..head_dim {
+            out[(si * head_dim + d) as usize] = val(0, s_lo + si, d);
+        }
+    }
+    out
 }
 
 /// SSD spill→hydrate round-trip preserves the CPU blocks layout.

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
@@ -176,9 +176,11 @@ impl QuantRotorK3 {
                 "QuantRotorK3::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
+        let b = new_shape[0] as usize;
+        let kv_h = new_shape[1] as usize;
+        let new_seq = new_shape[2] as usize;
         let head_dim = new_shape[3] as usize;
-        let n_tokens_total =
-            (new_shape[0] as usize) * (new_shape[1] as usize) * (new_shape[2] as usize);
+        let n_tokens_total = b * kv_h * new_seq;
 
         if self.rotors.is_empty() {
             let n_groups = n_groups_for(head_dim);
@@ -188,8 +190,18 @@ impl QuantRotorK3 {
             }
         }
 
+        // Store each chunk sequence-major (`[B, new_seq, kv_h, D]`) so the
+        // per-append blocks share one layout; a head-major store transposes
+        // heads across multi-append GQA caches (kv_h>1). The static rotor table
+        // and QJL projection are group/projection-keyed (not token), so the
+        // reorder leaves them correct; the per-token QJL sideband (qjl_codes /
+        // qjl_norms) reorders with the token rows. See
+        // [`super::QuantIsoV3::append`].
+        let seq_major =
+            super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
+
         let (codes, scales, norms, qjl_codes, qjl_norms) = rotor3_k_encode(
-            f32_data,
+            &seq_major,
             &self.rotors,
             head_dim,
             self.qjl_s_matrix.as_deref(),
@@ -346,6 +358,12 @@ impl QuantRotorK3 {
         } else if out.len() > total_elems {
             out.truncate(total_elems);
         }
+        // Blocks are sequence-major (see `append`); reorder back to head-major
+        // `[B, kv_h, S, D]`.
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
@@ -1,8 +1,8 @@
 //! Unit tests for [`QuantRotorK3`].
-#![allow(unsafe_code)]
 //!
 //! Mirror of `quant_iso_k_tests.rs` adapted to the rotor3 K codec. The
 //! `_with_qjl` / `_no_qjl` variants exercise both QJL branches.
+#![allow(unsafe_code)]
 
 use crate::clifford::make_rotor_table;
 use crate::rotorquant::{n_groups_for, rotor3_decode, rotor3_encode};

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
@@ -136,3 +136,71 @@ fn quant_rotor_k3_cosine_empirical_floor_head_dim_128_no_qjl() {
     );
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
 }
+
+/// Multi-append with `kv_h > 1` must match a single-shot append of the
+/// concatenated head-major buffer (head↔seq layout invariant), with the QJL
+/// sideband ON. The static rotor table and QJL projection are
+/// group/projection-keyed (not token); the per-token QJL sideband (qjl_codes /
+/// qjl_norms) reorders with the token rows. Per-(head, token, dim) distinct
+/// values surface any head transposition as a large error.
+#[test]
+fn quant_rotor_k3_multi_append_matches_single_shot_gqa_with_qjl() {
+    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
+        .lock()
+        .expect("env lock poisoned");
+    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    unsafe { std::env::set_var("RMLX_ROTOR_QJL", "1") };
+
+    let kv_h = 3_usize;
+    let head_dim = 128_usize;
+    let chunk_a = 2_usize;
+    let chunk_b = 3_usize;
+    let s_total = chunk_a + chunk_b;
+    let val = |h: usize, s: usize, d: usize| {
+        (h as f32) * 100.0 + (s as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+    let build = |s_lo: usize, s_hi: usize| -> Vec<f32> {
+        let s = s_hi - s_lo;
+        let mut out = vec![0.0_f32; kv_h * s * head_dim];
+        for h in 0..kv_h {
+            for si in 0..s {
+                for d in 0..head_dim {
+                    out[(h * s + si) * head_dim + d] = val(h, s_lo + si, d);
+                }
+            }
+        }
+        out
+    };
+    let mut qref = QuantRotorK3::new(vec![1, kv_h as i32, 0, head_dim as i32], 64, 7);
+    qref.append(
+        &build(0, s_total),
+        &[1, kv_h as i32, s_total as i32, head_dim as i32],
+    )
+    .unwrap();
+    assert!(qref.use_qjl(), "QJL must be ON for this test");
+    let reference = qref.dequant().unwrap();
+
+    let mut qv = QuantRotorK3::new(vec![1, kv_h as i32, 0, head_dim as i32], 64, 7);
+    qv.append(
+        &build(0, chunk_a),
+        &[1, kv_h as i32, chunk_a as i32, head_dim as i32],
+    )
+    .unwrap();
+    qv.append(
+        &build(chunk_a, s_total),
+        &[1, kv_h as i32, chunk_b as i32, head_dim as i32],
+    )
+    .unwrap();
+    let multi = qv.dequant().unwrap();
+
+    assert_eq!(multi.len(), reference.len());
+    let max_abs = multi
+        .iter()
+        .zip(reference.iter())
+        .fold(0.0_f32, |m, (a, b)| m.max((a - b).abs()));
+    assert!(
+        max_abs < 1.0,
+        "rotor3_k (QJL on) multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — head↔seq scramble"
+    );
+    unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
@@ -120,9 +120,11 @@ impl QuantRotorK4 {
                 "QuantRotorK4::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
+        let b = new_shape[0] as usize;
+        let kv_h = new_shape[1] as usize;
+        let new_seq = new_shape[2] as usize;
         let head_dim = new_shape[3] as usize;
-        let n_tokens_total =
-            (new_shape[0] as usize) * (new_shape[1] as usize) * (new_shape[2] as usize);
+        let n_tokens_total = b * kv_h * new_seq;
 
         if self.rotors.is_empty() {
             let n_groups = n_groups_for(head_dim);
@@ -132,8 +134,15 @@ impl QuantRotorK4 {
             }
         }
 
+        // Store each chunk sequence-major so the per-append blocks share one
+        // layout; static rotor/QJL projection are group/projection-keyed and
+        // the per-token QJL sideband reorders with the token rows. See
+        // [`super::QuantIsoV3::append`].
+        let seq_major =
+            super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
+
         let (codes, scales, norms, qjl_codes, qjl_norms) = rotor4_k_encode(
-            f32_data,
+            &seq_major,
             &self.rotors,
             head_dim,
             self.qjl_s_matrix.as_deref(),
@@ -285,6 +294,12 @@ impl QuantRotorK4 {
         } else if out.len() > total_elems {
             out.truncate(total_elems);
         }
+        // Blocks are sequence-major (see `append`); reorder back to head-major
+        // `[B, kv_h, S, D]`.
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for [`QuantRotorK4`]. Mirror of `quant_rotor_k3_tests.rs`
-#![allow(unsafe_code)]
 //! with `bits=4`.
+#![allow(unsafe_code)]
 
 use crate::clifford::make_rotor_table;
 use crate::rotorquant::{n_groups_for, rotor4_decode, rotor4_encode};

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
@@ -99,3 +99,70 @@ fn quant_rotor_k4_cosine_empirical_floor_head_dim_128_no_qjl() {
     );
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
 }
+
+/// Multi-append with `kv_h > 1` must match a single-shot append of the
+/// concatenated head-major buffer (head↔seq layout invariant), QJL ON. Static
+/// rotor/QJL projection are group/projection-keyed; per-token QJL sideband
+/// reorders with the token rows. Distinct per-(head, token, dim) values surface
+/// any head transposition as a large error.
+#[test]
+fn quant_rotor_k4_multi_append_matches_single_shot_gqa_with_qjl() {
+    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
+        .lock()
+        .expect("env lock poisoned");
+    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    unsafe { std::env::set_var("RMLX_ROTOR_QJL", "1") };
+
+    let kv_h = 3_usize;
+    let head_dim = 128_usize;
+    let chunk_a = 2_usize;
+    let chunk_b = 3_usize;
+    let s_total = chunk_a + chunk_b;
+    let val = |h: usize, s: usize, d: usize| {
+        (h as f32) * 100.0 + (s as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+    let build = |s_lo: usize, s_hi: usize| -> Vec<f32> {
+        let s = s_hi - s_lo;
+        let mut out = vec![0.0_f32; kv_h * s * head_dim];
+        for h in 0..kv_h {
+            for si in 0..s {
+                for d in 0..head_dim {
+                    out[(h * s + si) * head_dim + d] = val(h, s_lo + si, d);
+                }
+            }
+        }
+        out
+    };
+    let mut qref = QuantRotorK4::new(vec![1, kv_h as i32, 0, head_dim as i32], 64, 7);
+    qref.append(
+        &build(0, s_total),
+        &[1, kv_h as i32, s_total as i32, head_dim as i32],
+    )
+    .unwrap();
+    assert!(qref.use_qjl(), "QJL must be ON for this test");
+    let reference = qref.dequant().unwrap();
+
+    let mut qv = QuantRotorK4::new(vec![1, kv_h as i32, 0, head_dim as i32], 64, 7);
+    qv.append(
+        &build(0, chunk_a),
+        &[1, kv_h as i32, chunk_a as i32, head_dim as i32],
+    )
+    .unwrap();
+    qv.append(
+        &build(chunk_a, s_total),
+        &[1, kv_h as i32, chunk_b as i32, head_dim as i32],
+    )
+    .unwrap();
+    let multi = qv.dequant().unwrap();
+
+    assert_eq!(multi.len(), reference.len());
+    let max_abs = multi
+        .iter()
+        .zip(reference.iter())
+        .fold(0.0_f32, |m, (a, b)| m.max((a - b).abs()));
+    assert!(
+        max_abs < 1.0,
+        "rotor4_k (QJL on) multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — head↔seq scramble"
+    );
+    unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
@@ -170,17 +170,28 @@ impl QuantRotorV3 {
                 "QuantRotorV3::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
+        let b = new_shape[0] as usize;
+        let kv_h = new_shape[1] as usize;
+        let new_seq = new_shape[2] as usize;
         let head_dim = new_shape[3] as usize;
-        let n_tokens_total =
-            (new_shape[0] as usize) * (new_shape[1] as usize) * (new_shape[2] as usize);
+        let n_tokens_total = b * kv_h * new_seq;
 
         if self.rotors.is_empty() {
             let n_groups = n_groups_for(head_dim);
             self.rotors = make_rotor_table(self.layer_idx, self.head_idx, n_groups);
         }
 
+        // Store each chunk sequence-major (`[B, new_seq, kv_h, D]`) so the
+        // per-append blocks share one layout; a head-major store transposes
+        // heads across multi-append GQA caches (kv_h>1) when `dequant` reshapes
+        // head-major over the full sequence. The static rotor table is indexed
+        // by group position within `head_dim` (not by token), so the reorder
+        // leaves it correctly associated. See [`super::QuantIsoV3::append`].
+        let seq_major =
+            super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
+
         let (codes, scales, norms) =
-            rotor3_encode(f32_data, &self.rotors, head_dim).map_err(|e: RotorQuantError| {
+            rotor3_encode(&seq_major, &self.rotors, head_dim).map_err(|e: RotorQuantError| {
                 rmlx_core::error::Error::Mlx(format!("rotor3 encode: {e}"))
             })?;
 
@@ -305,6 +316,12 @@ impl QuantRotorV3 {
         } else if out.len() > total_elems {
             out.truncate(total_elems);
         }
+        // Blocks are sequence-major (see `append`); reorder back to head-major
+        // `[B, kv_h, S, D]`.
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3_tests.rs
@@ -116,3 +116,64 @@ fn quant_rotor_v3_deep_clone() {
     assert_eq!(cloned.blocks[0].codes, qv.blocks[0].codes);
     assert_eq!(cloned.layer_idx, qv.layer_idx);
 }
+
+/// Multi-append with `kv_h > 1` must match a single-shot append of the
+/// concatenated head-major buffer (head↔seq layout invariant). The static
+/// rotor table is group-position-keyed (not token), so the seq-major reorder
+/// leaves it correctly associated. Per-(head, token, dim) distinct values
+/// surface any head transposition as a large error.
+#[test]
+fn quant_rotor_v3_multi_append_matches_single_shot_gqa() {
+    let kv_h = 3_usize;
+    let head_dim = 96_usize;
+    let chunk_a = 2_usize;
+    let chunk_b = 3_usize;
+    let s_total = chunk_a + chunk_b;
+    let val = |h: usize, s: usize, d: usize| {
+        (h as f32) * 100.0 + (s as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+    let build = |s_lo: usize, s_hi: usize| -> Vec<f32> {
+        let s = s_hi - s_lo;
+        let mut out = vec![0.0_f32; kv_h * s * head_dim];
+        for h in 0..kv_h {
+            for si in 0..s {
+                for d in 0..head_dim {
+                    out[(h * s + si) * head_dim + d] = val(h, s_lo + si, d);
+                }
+            }
+        }
+        out
+    };
+    // Same layer_idx so both caches share the same static rotor table.
+    let mut qref = QuantRotorV3::new(vec![1, kv_h as i32, 0, head_dim as i32], 64, 7);
+    qref.append(
+        &build(0, s_total),
+        &[1, kv_h as i32, s_total as i32, head_dim as i32],
+    )
+    .unwrap();
+    let reference = qref.dequant().unwrap();
+
+    let mut qv = QuantRotorV3::new(vec![1, kv_h as i32, 0, head_dim as i32], 64, 7);
+    qv.append(
+        &build(0, chunk_a),
+        &[1, kv_h as i32, chunk_a as i32, head_dim as i32],
+    )
+    .unwrap();
+    qv.append(
+        &build(chunk_a, s_total),
+        &[1, kv_h as i32, chunk_b as i32, head_dim as i32],
+    )
+    .unwrap();
+    let multi = qv.dequant().unwrap();
+
+    assert_eq!(multi.len(), reference.len());
+    let max_abs = multi
+        .iter()
+        .zip(reference.iter())
+        .fold(0.0_f32, |m, (a, b)| m.max((a - b).abs()));
+    assert!(
+        max_abs < 1.0,
+        "rotor3 multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — head↔seq scramble"
+    );
+    let _ = ROTOR3_V_BITS;
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
@@ -159,17 +159,25 @@ impl QuantRotorV4 {
                 "QuantRotorV4::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
+        let b = new_shape[0] as usize;
+        let kv_h = new_shape[1] as usize;
+        let new_seq = new_shape[2] as usize;
         let head_dim = new_shape[3] as usize;
-        let n_tokens_total =
-            (new_shape[0] as usize) * (new_shape[1] as usize) * (new_shape[2] as usize);
+        let n_tokens_total = b * kv_h * new_seq;
 
         if self.rotors.is_empty() {
             let n_groups = n_groups_for(head_dim);
             self.rotors = make_rotor_table(self.layer_idx, self.head_idx, n_groups);
         }
 
+        // Store each chunk sequence-major so the per-append blocks share one
+        // layout; the static rotor table is group-position-keyed (not token),
+        // so the reorder leaves it correct. See [`super::QuantIsoV3::append`].
+        let seq_major =
+            super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
+
         let (codes, scales, norms) =
-            rotor4_encode(f32_data, &self.rotors, head_dim).map_err(|e: RotorQuantError| {
+            rotor4_encode(&seq_major, &self.rotors, head_dim).map_err(|e: RotorQuantError| {
                 rmlx_core::error::Error::Mlx(format!("rotor4 encode: {e}"))
             })?;
 
@@ -293,6 +301,12 @@ impl QuantRotorV4 {
         } else if out.len() > total_elems {
             out.truncate(total_elems);
         }
+        // Blocks are sequence-major (see `append`); reorder back to head-major
+        // `[B, kv_h, S, D]`.
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v4_tests.rs
@@ -117,3 +117,61 @@ fn quant_rotor_v4_deep_clone() {
     assert_eq!(cloned.layer_idx, qv.layer_idx);
     assert_eq!(cloned.bits, ROTOR4_V_BITS, "bits tag preserved in clone");
 }
+
+/// Multi-append with `kv_h > 1` must match a single-shot append of the
+/// concatenated head-major buffer (head↔seq layout invariant). The static
+/// rotor table is group-position-keyed (not token); per-(head, token, dim)
+/// distinct values surface any head transposition as a large error.
+#[test]
+fn quant_rotor_v4_multi_append_matches_single_shot_gqa() {
+    let kv_h = 3_usize;
+    let head_dim = 96_usize;
+    let chunk_a = 2_usize;
+    let chunk_b = 3_usize;
+    let s_total = chunk_a + chunk_b;
+    let val = |h: usize, s: usize, d: usize| {
+        (h as f32) * 100.0 + (s as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+    let build = |s_lo: usize, s_hi: usize| -> Vec<f32> {
+        let s = s_hi - s_lo;
+        let mut out = vec![0.0_f32; kv_h * s * head_dim];
+        for h in 0..kv_h {
+            for si in 0..s {
+                for d in 0..head_dim {
+                    out[(h * s + si) * head_dim + d] = val(h, s_lo + si, d);
+                }
+            }
+        }
+        out
+    };
+    let mut qref = QuantRotorV4::new(vec![1, kv_h as i32, 0, head_dim as i32], 64, 7);
+    qref.append(
+        &build(0, s_total),
+        &[1, kv_h as i32, s_total as i32, head_dim as i32],
+    )
+    .unwrap();
+    let reference = qref.dequant().unwrap();
+
+    let mut qv = QuantRotorV4::new(vec![1, kv_h as i32, 0, head_dim as i32], 64, 7);
+    qv.append(
+        &build(0, chunk_a),
+        &[1, kv_h as i32, chunk_a as i32, head_dim as i32],
+    )
+    .unwrap();
+    qv.append(
+        &build(chunk_a, s_total),
+        &[1, kv_h as i32, chunk_b as i32, head_dim as i32],
+    )
+    .unwrap();
+    let multi = qv.dequant().unwrap();
+
+    assert_eq!(multi.len(), reference.len());
+    let max_abs = multi
+        .iter()
+        .zip(reference.iter())
+        .fold(0.0_f32, |m, (a, b)| m.max((a - b).abs()));
+    assert!(
+        max_abs < 1.0,
+        "rotor4 multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — head↔seq scramble"
+    );
+}

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -526,11 +526,42 @@ shape), but `QuantPlanarK` additionally exposes its packed codes buffer to the
 kernels read the packed buffer with a head-major `(b, kv_h, kv_seq, head_dim)`
 indexing, so a sequence-major storage relayout would also have to relayout the
 fused-QK / flash kernels — a coordinated MSL-kernel change beyond the
-storage-local fix. The Iso / Rotor `Vec<Blocks>` codecs (`QuantIsoV3/V4`,
-`QuantIsoK3/K4`, `QuantRotorV3/V4`, `QuantRotorK3/K4`) share the CPU-blocks
-cross-block reshape and are affected on the same post-hydrate multi-append path;
-their rotation/quaternion sidebands need the reorder applied per codec with its
-own GPU proof.
+storage-local fix.
+
+### 5.7.3 The Iso / Rotor `Vec<Blocks>` codecs use the same sequence-major rule
+
+The rotation-KV `Vec<Blocks>` codecs — `QuantIsoV3` / `QuantIsoV4`,
+`QuantIsoK3` / `QuantIsoK4`, `QuantRotorV3` / `QuantRotorV4`,
+`QuantRotorK3` / `QuantRotorK4` — accumulate one `*Blocks` entry per `append`
+and concatenate them on `dequant`, with the caller reshaping head-major
+`[B, kv_h, S, D]`. That is the **same** cross-block head transposition as
+`QuantV` (a multi-append GQA cache with `kv_h > 1` scrambles per-head values).
+Each `append` now reorders the head-major chunk heads↔seq before encoding and
+`dequant` reorders back to the logical `[B, kv_h, S, D]`; for a single chunk
+(cold prefill) the two reorders cancel.
+
+These codecs are **per-token-row positional** (the codec sees `n_tokens` rows
+of `head_dim`; it does not interpret the B / kv_h / S axes), so the sideband
+parameters stay correctly associated after the value reorder:
+
+- **Quaternions / per-(token, group) scale + norm** (Iso): keyed by row
+  position, so they permute together with the value rows. The iso fast-mode
+  quaternion is the constant `FIXED_QUAT` for every group regardless.
+- **Static rotor table / QJL projection matrix** (Rotor): keyed by
+  group-position-within-`head_dim` (rotor) or by the JL projection (QJL), not
+  by token — the reorder leaves them untouched. The **per-token** QJL sideband
+  (`qjl_codes` / `qjl_norms`) permutes with the value rows.
+
+`QuantIsoV3` is the one GPU-resident member: its `append_gpu` adds
+`Array::contiguous` after the heads↔seq transpose before the iso3 encode kernel
+(raw-linear-index MSL kernel; lazy-transpose strides are ignored), and both
+`dequant_gpu` paths (mirror fast-path and CPU-staged `from_bytes`) reshape the
+flat decode to `[B, S, kv_h, D]` then transpose back. The remaining seven are
+CPU-only (`QuantIsoK3` also drives the shared iso3 dequant kernel via the
+CPU-staged path; iso4 / rotor have no MSL kernel). The `.kvb` SSD format is
+byte-stable — only the token-row order **within** a block changes, and spill
+and dequant agree on sequence-major. GPU round-trip verified on `QuantIsoV3`
+(two-append GQA vs single-shot, `kv_h=1` control).
 
 ### 5.8 TurboQuant requires Flash Attention
 

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -1550,6 +1550,26 @@ No NaN/Inf, no infinite loops, 8-token generations complete. Decode TPS
 reflects CPU-heavy V dequant on the initial version; GPU encode path reduces
 overhead.
 
+**Sequence-major buffer layout (whole Iso / Rotor family).** Every `Vec<Blocks>`
+rotation-KV codec — `QuantIsoV3` / `QuantIsoV4`, `QuantIsoK3` / `QuantIsoK4`,
+`QuantRotorV3` / `QuantRotorV4`, `QuantRotorK3` / `QuantRotorK4` — accumulates
+one `*Blocks` entry per `append` and concatenates them on `dequant`. Because
+the caller reshapes the concatenation head-major `[B, kv_h, S, D]`, a head-major
+per-block store transposes per-head values across a multi-append GQA cache
+(`kv_h > 1`, e.g. the post-SSD-hydrate decode-append path) — the same head
+scramble fixed for `QuantK` / `QuantV`. Each `append` now reorders the
+head-major chunk heads↔seq (`[B, new_seq, kv_h, D]`) before encoding and
+`dequant` reorders back; single-chunk cold prefill is the identity. The codec is
+per-token-row positional, so the sidebands stay correctly associated: Iso
+per-(token, group) scale/norm and the constant `FIXED_QUAT` quaternion permute
+with the rows; the Rotor static rotor table and QJL projection are
+group/projection-keyed (untouched) while the per-token QJL `qjl_codes` /
+`qjl_norms` permute with the rows. `QuantIsoV3` is the only GPU-resident member
+and adds `Array::contiguous` after the heads↔seq transpose before its
+raw-linear-index MSL encode kernel. The `.kvb` SSD format is byte-stable (only
+the token-row order within a block changes). GPU round-trip verified on
+`QuantIsoV3` (two-append GQA vs single-shot). See `docs/KV_CACHE.md` §5.7.3.
+
 ---
 
 ### iso4 codec


### PR DESCRIPTION
## Summary

Extends the #80/#108 multi-append-after-SSD-hydrate layout fix to all 8 Iso/Rotor rotation-KV `Vec<Blocks>` codecs. **Part 2 of #105** (does not close it — PlanarQuant remains).

Bug class: per-append head-major blocks concatenated then head-major-reshaped on dequant scrambles per-head values on a multi-append after SSD hydrate with `kv_heads > 1`.

Fixed: `QuantIsoK3/K4/V3/V4`, `QuantRotorK3/K4/V3/V4` — each `append` now stores chunks sequence-major (`seq_layout::transpose_heads_seq`) before encode and `dequant` reorders back (`transpose_seq_heads`), matching the merged template. The GPU-resident members (`QuantIsoV3`, `QuantIsoK3`, shared iso3 MSL kernel) materialize with `Array::contiguous` before the raw-linear-index kernel; the other 6 are CPU-only.

These codecs are **per-token-row positional** (they process `n_tokens` rows of `head_dim` and never interpret B/kv_h/S), so the value-row reorder carries all row-keyed sidebands (scales, norms, QJL codes) consistently, while static position/feature-keyed sidebands (rotor permutation table, QJL projection matrix, IsoQuant `FIXED_QUAT`) are untouched by construction.

## Validation

- **CPU:** fail-before/pass-after multi-append GQA round-trips for all 8 codecs (scramble ~166 → quant noise), per-(head,token,dim)-distinct fixtures; full kv-quant CPU suite 318 pass.
- **Real Metal GPU:** `iso_v3` + `iso_k3` multi-append-vs-single-shot round-trips at quant noise (<1.0); GPU-vs-CPU dequant parity; 10 iso fused-QK GPU tests pass.
- **End-to-end serve** (Bonsai, `Qwen3ForCausalLM`, kv_heads=8 — HydratedTail decodes off hydrated K): Iso3Sym and Iso4Sym + SSD tier — `.kvb` spill → RAM-miss hydrate → coherent post-hydrate multi-append decode (`nan_count=0`).
- **No perf regression** (canary within thermal band; fix confined to iso/rotor codec files, off the steady-state decode hot path).
- `make lint` clean, `cargo fmt --all` clean.

## Remaining (#105 stays open)

- **`QuantPlanarK` / `QuantPlanarV`** — the last member of this class; couples to the `planar_fused_qk` / `planar_flash_decode` MSL kernels (`gpu_packed_view`, head-major indexed) on the post-hydrate decode path, needing a coordinated seq-major-aware kernel change. Documented in `docs/KV_CACHE.md` §5.7.2.

Part of #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)