### PR TITLE
fix(kv-quant): sequence-major layout for PlanarQuant K/V + packed-K kernels

### DIFF
--- a/crates/rmlx-kv-quant/src/planar_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/planar_flash_decode_msl.rs
@@ -190,10 +190,11 @@ fn build_flash_header(bits: u8) -> Result<String> {
 // and accumulates the softmax-weighted contribution in a per-thread register.
 //
 // Buffer layout (must match `add_input` order in `planar_flash_decode_sdpa`):
+// K buffers are SEQUENCE-major (`[B, kv_seq, kv_h, ...]`); V stays head-major.
 // 0. query     : f32  [B * n_q_heads * head_dim]
-// 1. k_codes   : u32  [B * kv_h * kv_seq * (head_dim / 32) * 4]
-// 2. k_scales  : f32  [B * kv_h * kv_seq * (head_dim / 2)]
-// 3. k_rot32   : u32  [B * kv_h * kv_seq * (head_dim / 16)]
+// 1. k_codes   : u32  [B * kv_seq * kv_h * (head_dim / 32) * 4]
+// 2. k_scales  : f32  [B * kv_seq * kv_h * (head_dim / 2)]
+// 3. k_rot32   : u32  [B * kv_seq * kv_h * (head_dim / 16)]
 // 4. v_flat    : bf16 / f16 / f32 [B * kv_h * kv_seq * head_dim] (native dtype)
 // 5. mask_flat : f32  [B * n_q_heads * kv_seq] or [1] dummy when no mask
 // 6. scale_arr : f32  [1]
@@ -295,7 +296,11 @@ fn build_p1_kernel_source() -> String {
 
     for (uint t = tile_start; t < tile_end; t++) {{
         // ── Decode K[tid] for this (b, kv_h_idx, t) ──────────────────────
-        uint kv_tok          = (b * kv_h + kv_h_idx) * kv_seq + t;
+        // K packing is SEQUENCE-major (`[B, S, kv_h, D]`): per token all heads
+        // are contiguous, matching QuantPlanarK's chunk-append layout. (V below
+        // stays head-major — it is the separate bf16 decode mirror, not the
+        // planar-packed buffer.)
+        uint kv_tok          = (b * kv_seq + t) * kv_h + kv_h_idx;
         uint codes_tok_off   = kv_tok * codes_words_per_tok;
         uint scales_tok_off  = kv_tok * scales_pairs_per_tok;
         uint rot_tok_off     = kv_tok * rot_words_per_tok;

--- a/crates/rmlx-kv-quant/src/planar_flash_decode_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/planar_flash_decode_msl_tests.rs
@@ -176,8 +176,16 @@ fn run_parity_with_v_dtype(
         }
     };
 
+    // K packing is sequence-major (`[B, S, kv_h, D]`) — the layout the
+    // fused-QK / flash-decode kernels index. Transpose the head-major `k_arr`
+    // heads↔seq and materialize before packing so the packed buffer matches.
+    let k_seq = k_arr
+        .transpose(&[0, 2, 1, 3], Device::Gpu)
+        .expect("transpose k seq-major")
+        .contiguous(Device::Gpu)
+        .expect("contiguous k seq-major");
     let (codes, scales, rot32) =
-        planar_quantize_v4_gpu(&k_arr, Device::Gpu).expect("planar_quantize_v4_gpu");
+        planar_quantize_v4_gpu(&k_seq, Device::Gpu).expect("planar_quantize_v4_gpu");
 
     // ── Flash output ─────────────────────────────────────────────────────
     let flash = planar_flash_decode_sdpa(

--- a/crates/rmlx-kv-quant/src/planar_fused_qk_msl.rs
+++ b/crates/rmlx-kv-quant/src/planar_fused_qk_msl.rs
@@ -159,11 +159,11 @@ fn build_qk_header(bits: u8) -> Result<String> {
 //   dims[2] = kv_h           (number of K/V heads)
 //   dims[3] = heads_per_kv   (n_q_heads / kv_h)
 //
-// Inputs:
+// Inputs (K buffers are SEQUENCE-major: `[B, S_kv, kv_h, D]` element order):
 //   query  : float[B * n_q_heads * D]  (Q for the new token)
-//   codes  : uint [B * kv_h * S_kv * (D/8)]   — packed 4-bit codes
-//   scales : float[B * kv_h * S_kv * (D/2)]   — per-pair scale (f32)
-//   rot32  : uint [B * kv_h * S_kv * (D/16)]  — 4-bit rotation index per pair
+//   codes  : uint [B * S_kv * kv_h * (D/8)]   — packed 4-bit codes
+//   scales : float[B * S_kv * kv_h * (D/2)]   — per-pair scale (f32)
+//   rot32  : uint [B * S_kv * kv_h * (D/16)]  — 4-bit rotation index per pair
 //   scale_arr : float[1]   — softmax pre-scale (1/sqrt(d))
 //
 // Output:
@@ -222,7 +222,11 @@ fn build_qk_kernel_source(bits: u8) -> String {
     uint kv_h_idx  = hq / heads_per_kv;
 
     // Token-base offsets into K's per-(b, kv_h_idx, s_kv) record.
-    uint kv_tok          = (b * kv_h + kv_h_idx) * kv_seq + s_kv;
+    // K packing is SEQUENCE-major (`[B, S, kv_h, D]` element order): per token
+    // all heads are contiguous. This matches QuantPlanarK's storage, whose
+    // chunk appends land at a per-token (all-heads) offset; a head-major base
+    // would scramble heads↔seq after a multi-token append at prev_seq > 0.
+    uint kv_tok          = (b * kv_seq + s_kv) * kv_h + kv_h_idx;
     // Codes layout (axis-agnostic across 3-bit / 4-bit): every group of 32
     // elements occupies exactly 4 u32 words (4-bit packs 8 vals/word;
     // 3-bit packs 10 vals/word with 2 wasted bits — but still 4 words/group).

--- a/crates/rmlx-kv-quant/src/planar_fused_qk_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/planar_fused_qk_msl_tests.rs
@@ -30,6 +30,52 @@ fn array_to_f32(a: &Array) -> Vec<f32> {
         .collect()
 }
 
+/// Pack a head-major `[B, kv_h, S, D]` K array into the SEQUENCE-major packed
+/// buffers the fused-QK / flash-decode kernels now expect (`[B, S, kv_h, D]`
+/// element order). Returns the dequantized **head-major** K (for the CPU
+/// reference) alongside the packed buffers.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn pack_v4_seq_major(k_arr: &Array, k_shape: &[i32]) -> (Array, Array, Array, Vec<f32>) {
+    let seq_shape = [k_shape[0], k_shape[2], k_shape[1], k_shape[3]];
+    let k_seq = k_arr
+        .transpose(&[0, 2, 1, 3], Device::Gpu)
+        .expect("transpose")
+        .contiguous(Device::Gpu)
+        .expect("contiguous");
+    let (codes, scales, rot32) =
+        planar_quantize_v4_gpu(&k_seq, Device::Gpu).expect("v4 quantize seq-major");
+    // Dequant in seq-major shape, transpose back to head-major for the ref.
+    let dq_seq = planar_dequantize_v4_gpu(&codes, &scales, &rot32, &seq_shape, Device::Gpu)
+        .expect("v4 dequant seq-major");
+    let dq_hm = dq_seq
+        .transpose(&[0, 2, 1, 3], Device::Gpu)
+        .expect("transpose back")
+        .contiguous(Device::Gpu)
+        .expect("contiguous back");
+    (codes, scales, rot32, array_to_f32(&dq_hm))
+}
+
+/// 3-bit sibling of [`pack_v4_seq_major`].
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn pack_v3_seq_major(k_arr: &Array, k_shape: &[i32]) -> (Array, Array, Array, Vec<f32>) {
+    let seq_shape = [k_shape[0], k_shape[2], k_shape[1], k_shape[3]];
+    let k_seq = k_arr
+        .transpose(&[0, 2, 1, 3], Device::Gpu)
+        .expect("transpose")
+        .contiguous(Device::Gpu)
+        .expect("contiguous");
+    let (codes, scales, rot32) =
+        planar_quantize_v3_gpu(&k_seq, Device::Gpu).expect("v3 quantize seq-major");
+    let dq_seq = planar_dequantize_v3_gpu(&codes, &scales, &rot32, &seq_shape, Device::Gpu)
+        .expect("v3 dequant seq-major");
+    let dq_hm = dq_seq
+        .transpose(&[0, 2, 1, 3], Device::Gpu)
+        .expect("transpose back")
+        .contiguous(Device::Gpu)
+        .expect("contiguous back");
+    (codes, scales, rot32, array_to_f32(&dq_hm))
+}
+
 fn ref_qk_scores(
     q: &[f32],
     k: &[f32],
@@ -84,7 +130,7 @@ fn planar_fused_qk_v4_matches_reference() {
     let q_data = lcg_data(q_n, 0xBEEF_5678_u64);
     let q_arr = make_f32_array(&q_data, &q_shape);
 
-    let (codes, scales, rot32) = planar_quantize_v4_gpu(&k_arr, Device::Gpu).expect("v4 quantize");
+    let (codes, scales, rot32, k_dequant_vec) = pack_v4_seq_major(&k_arr, &k_shape);
     let fused = planar_fused_qk(
         &q_arr,
         &codes,
@@ -101,9 +147,6 @@ fn planar_fused_qk_v4_matches_reference() {
     )
     .expect("fused QK kernel");
 
-    let k_dequant = planar_dequantize_v4_gpu(&codes, &scales, &rot32, &k_shape, Device::Gpu)
-        .expect("v4 dequant");
-    let k_dequant_vec = array_to_f32(&k_dequant);
     let ref_scores = ref_qk_scores(
         &q_data,
         &k_dequant_vec,
@@ -153,7 +196,7 @@ fn planar_fused_qk_v3_matches_reference() {
     let q_data = lcg_data(q_n, 0xFACE_8765_u64);
     let q_arr = make_f32_array(&q_data, &q_shape);
 
-    let (codes, scales, rot32) = planar_quantize_v3_gpu(&k_arr, Device::Gpu).expect("v3 quantize");
+    let (codes, scales, rot32, k_dequant_vec) = pack_v3_seq_major(&k_arr, &k_shape);
     let fused = planar_fused_qk(
         &q_arr,
         &codes,
@@ -170,9 +213,6 @@ fn planar_fused_qk_v3_matches_reference() {
     )
     .expect("fused QK kernel");
 
-    let k_dequant = planar_dequantize_v3_gpu(&codes, &scales, &rot32, &k_shape, Device::Gpu)
-        .expect("v3 dequant");
-    let k_dequant_vec = array_to_f32(&k_dequant);
     let ref_scores = ref_qk_scores(
         &q_data,
         &k_dequant_vec,
@@ -221,7 +261,7 @@ fn planar_fused_qk_mha_heads_per_kv_one() {
     let q_data = lcg_data(q_n, 0xCCCC_DDDD_u64);
     let q_arr = make_f32_array(&q_data, &q_shape);
 
-    let (codes, scales, rot32) = planar_quantize_v4_gpu(&k_arr, Device::Gpu).expect("v4 quantize");
+    let (codes, scales, rot32, k_dequant_vec) = pack_v4_seq_major(&k_arr, &k_shape);
     let fused = planar_fused_qk(
         &q_arr,
         &codes,
@@ -238,9 +278,6 @@ fn planar_fused_qk_mha_heads_per_kv_one() {
     )
     .expect("fused QK kernel");
 
-    let k_dequant = planar_dequantize_v4_gpu(&codes, &scales, &rot32, &k_shape, Device::Gpu)
-        .expect("v4 dequant");
-    let k_dequant_vec = array_to_f32(&k_dequant);
     let ref_scores = ref_qk_scores(
         &q_data,
         &k_dequant_vec,
@@ -290,7 +327,7 @@ fn planar_fused_qk_v4_head_dim_256() {
     let q_data = lcg_data(q_n, 0x2560_0002_u64);
     let q_arr = make_f32_array(&q_data, &q_shape);
 
-    let (codes, scales, rot32) = planar_quantize_v4_gpu(&k_arr, Device::Gpu).expect("v4 quantize");
+    let (codes, scales, rot32, k_dequant_vec) = pack_v4_seq_major(&k_arr, &k_shape);
     let fused = planar_fused_qk(
         &q_arr,
         &codes,
@@ -307,9 +344,6 @@ fn planar_fused_qk_v4_head_dim_256() {
     )
     .expect("fused QK kernel");
 
-    let k_dequant = planar_dequantize_v4_gpu(&codes, &scales, &rot32, &k_shape, Device::Gpu)
-        .expect("v4 dequant");
-    let k_dequant_vec = array_to_f32(&k_dequant);
     let ref_scores = ref_qk_scores(
         &q_data,
         &k_dequant_vec,

--- a/crates/rmlx-kv-quant/src/sparse_attn/phase1_score_msl.rs
+++ b/crates/rmlx-kv-quant/src/sparse_attn/phase1_score_msl.rs
@@ -207,7 +207,10 @@ fn build_kernel_source() -> String {
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     for (uint t = tile_start; t < tile_end; t++) {{
-        uint kv_tok          = (b * kv_h + kv_h_idx) * kv_seq + t;
+        // K packing is SEQUENCE-major (`[B, S, kv_h, D]`): per token all heads
+        // are contiguous, matching QuantPlanarK's chunk-append layout. A
+        // head-major base would scramble heads↔seq after a multi-token append.
+        uint kv_tok          = (b * kv_seq + t) * kv_h + kv_h_idx;
         uint codes_tok_off   = kv_tok * codes_words_per_tok;
         uint scales_tok_off  = kv_tok * scales_pairs_per_tok;
         uint rot_tok_off     = kv_tok * rot_words_per_tok;

--- a/crates/rmlx-kv-quant/src/sparse_attn/phase2_sparse_attend_msl.rs
+++ b/crates/rmlx-kv-quant/src/sparse_attn/phase2_sparse_attend_msl.rs
@@ -120,10 +120,11 @@ fn build_header() -> Result<String> {
 // ── Kernel source ────────────────────────────────────────────────────────────
 //
 // Buffer layout (must match `add_input` order in `phase2_sparse_attend`):
+// K buffers are SEQUENCE-major (`[B, kv_seq, kv_h, ...]`); V stays head-major.
 //   0. query           : f32  [n_bh * head_dim]
-//   1. k_codes         : u32  [B * kv_h * kv_seq * (head_dim/32) * 4]
-//   2. k_scales        : f32  [B * kv_h * kv_seq * head_dim/2]
-//   3. k_rot32         : u32  [B * kv_h * kv_seq * head_dim/16]
+//   1. k_codes         : u32  [B * kv_seq * kv_h * (head_dim/32) * 4]
+//   2. k_scales        : f32  [B * kv_seq * kv_h * head_dim/2]
+//   3. k_rot32         : u32  [B * kv_seq * kv_h * head_dim/16]
 //   4. v_flat          : bf16/f16/f32 [B * kv_h * kv_seq * head_dim]
 //   5. all_scores      : f32  [n_bh * kv_seq]  (from Phase 1)
 //   6. head_threshold  : f32  [n_bh]
@@ -234,7 +235,10 @@ fn build_kernel_source() -> String {
         }}
 
         // ── Decode K[tid] for this (b, kv_h_idx, t) ──────────────────────
-        uint kv_tok          = (b * kv_h + kv_h_idx) * kv_seq + t;
+        // K packing is SEQUENCE-major (`[B, S, kv_h, D]`): per token all heads
+        // are contiguous, matching QuantPlanarK's chunk-append layout. (V below
+        // stays head-major — it is the bf16 mirror, not the planar-packed buffer.)
+        uint kv_tok          = (b * kv_seq + t) * kv_h + kv_h_idx;
         uint codes_tok_off   = kv_tok * codes_words_per_tok;
         uint scales_tok_off  = kv_tok * scales_pairs_per_tok;
         uint rot_tok_off     = kv_tok * rot_words_per_tok;

--- a/crates/rmlx-kv-quant/src/sparse_attn/sparse_attn_tests.rs
+++ b/crates/rmlx-kv-quant/src/sparse_attn/sparse_attn_tests.rs
@@ -168,9 +168,17 @@ fn run_parity(
     let v_data = lcg_data(v_n, v_seed);
     let v_arr = make_f32_array(&v_data, &v_shape);
 
-    // ── PlanarQuant pack K ───────────────────────────────────────────────
+    // ── PlanarQuant pack K (sequence-major) ──────────────────────────────
+    // The fused-QK / flash-decode / sparse phase-1/2 kernels index K
+    // sequence-major (`[B, S, kv_h, D]`); transpose the head-major `k_arr`
+    // heads↔seq and materialize before packing so the packed buffer matches.
+    let k_seq = k_arr
+        .transpose(&[0, 2, 1, 3], Device::Gpu)
+        .expect("transpose k seq-major")
+        .contiguous(Device::Gpu)
+        .expect("contiguous k seq-major");
     let (k_codes, k_scales, k_rot32) =
-        planar_quantize_v4_gpu(&k_arr, Device::Gpu).expect("planar_quantize_v4_gpu");
+        planar_quantize_v4_gpu(&k_seq, Device::Gpu).expect("planar_quantize_v4_gpu");
 
     // ── Dense reference (planar flash decode) ────────────────────────────
     let dense = planar_flash_decode_sdpa(

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_k.rs
@@ -24,6 +24,7 @@ use crate::planarquant_msl::{planar_dequantize_v4_gpu, planar_quantize_v4_gpu};
 use crate::planarquant::{planar_dequantize, planar_quantize, PlanarBlocks};
 use crate::turboquant::GROUP_SIZE;
 
+use super::seq_layout::{transpose_heads_seq, transpose_seq_heads};
 use super::KV_PAGE_SIZE;
 
 // ── PlanarQuant K storage ─────────────────────────────────────────────────────
@@ -261,8 +262,31 @@ impl QuantPlanarK {
             let sp = self.gpu_scales_per_step;
             let rw = self.gpu_rotations_words_per_step;
 
-            // Shared kernel (axis-agnostic — see Step 0 decision).
-            let (new_codes, new_scales, new_rotations) = planar_quantize_v4_gpu(k_arr, device)?;
+            // Reorder the chunk to sequence-major `[B, new_seq, kv_h, D]` before
+            // quantizing. The flat GPU buffer accumulates chunks back-to-back at
+            // `prev_seq * words_per_seq`, where `words_per_seq` counts ONE token
+            // across all heads, so the active prefix is sequence-major
+            // (`[B, S, kv_h, D]`): for each token, all heads are contiguous.
+            // The incoming chunk is head-major (`[B, kv_h, new_seq, D]`);
+            // transposing heads↔seq makes the stored layout self-consistent
+            // across any number of appends and any `kv_h`. For a single token
+            // (`new_seq == 1`) the transpose is the identity, so the decode hot
+            // path is byte-unchanged; for a single chunk (`prev_seq == 0`) the
+            // dequant transpose is its inverse, so the cold-prefill round-trip
+            // is exact. PlanarQuant is layout-agnostic (it processes the flat
+            // element stream group-by-group and `D % GROUP_SIZE == 0`, so no
+            // group spans a (head, token) boundary), so the per-group scales are
+            // identical to the head-major grouping — the reorder is bit-exact,
+            // not just within-noise.
+            //
+            // `transpose` yields a strided view; the PlanarQuant MSL kernel reads
+            // its input by raw linear offset (it ignores MLX lazy-transpose
+            // strides), so materialize the heads↔seq permutation into a row-major
+            // buffer here — otherwise the kernel would read the original
+            // head-major bytes and scramble the stored codes.
+            let k_seq_major = k_arr.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
+            let (new_codes, new_scales, new_rotations) =
+                planar_quantize_v4_gpu(&k_seq_major, device)?;
 
             let codes_buf = self.gpu_codes_buf.take().unwrap();
             let scales_buf = self.gpu_scales_buf.take().unwrap();
@@ -290,8 +314,20 @@ impl QuantPlanarK {
                 device,
             )?);
         } else {
-            // CPU path: scalar Rust PlanarQuant (axis-agnostic — same function).
-            let block = planar_quantize(f32_data, GROUP_SIZE, 4, new_shape)?;
+            // CPU mirror of the GPU path: store the chunk sequence-major so the
+            // accumulated blocks share one layout with the GPU buffer (the
+            // spill/hydrate round-trip moves codes between the two). `f32_data`
+            // arrives head-major (`[B, kv_h, new_seq, D]`); reorder it to
+            // `[B, new_seq, kv_h, D]` before quantizing, then record the chunk
+            // shape as `[B, new_seq, kv_h, D]` so `planar_quantize`'s flat
+            // grouping matches the reordered stream.
+            let b = new_shape[0] as usize;
+            let kv_h = new_shape[1] as usize;
+            let new_seq = new_shape[2] as usize;
+            let d = new_shape[3] as usize;
+            let seq_major = transpose_heads_seq(f32_data, b, kv_h, new_seq, d);
+            let seq_major_shape = [new_shape[0], new_shape[2], new_shape[1], new_shape[3]];
+            let block = planar_quantize(&seq_major, GROUP_SIZE, 4, &seq_major_shape)?;
             self.blocks.push(block);
         }
         Ok(())
@@ -326,8 +362,25 @@ impl QuantPlanarK {
                     &[1],
                     device,
                 )?;
-                let out =
-                    planar_dequantize_v4_gpu(&codes, &scales, &rotations, &self.shape, device)?;
+                // The flat buffer is sequence-major (see `append`): the active
+                // prefix lays out as `[B, S, kv_h, D]`. Dequant into that shape,
+                // then transpose heads↔seq back to the logical `[B, kv_h, S, D]`
+                // callers expect. For a single-chunk cache this transpose is the
+                // inverse of the append-side transpose, so the round-trip is
+                // exact. `transpose` alone yields a strided view; the raw
+                // byte-readers (SSD spill / hydrate) need a row-major
+                // `[B, kv_h, S, D]` buffer, so force contiguity. This is the
+                // post-hydrate dequant path, off the steady-state decode hot
+                // path, so the copy is acceptable.
+                let seq_major_shape = [self.shape[0], s, self.shape[1], self.shape[3]];
+                let out = planar_dequantize_v4_gpu(
+                    &codes,
+                    &scales,
+                    &rotations,
+                    &seq_major_shape,
+                    device,
+                )?;
+                let out = out.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
                 let out = if out_dtype == Dtype::F32 {
                     out
                 } else {
@@ -337,19 +390,32 @@ impl QuantPlanarK {
             }
             return Ok((Vec::new(), None));
         }
-        // CPU path.
+        // CPU path: blocks are sequence-major (`[B, S, kv_h, D]`, see `append`).
+        // The caller reshapes the returned flat vector to the logical
+        // `[B, kv_h, S, D]`, so reorder heads↔seq back to head-major first.
         let total: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out = Vec::with_capacity(total);
         for block in &self.blocks {
             let slice = planar_dequantize(block)?;
             out.extend_from_slice(&slice);
         }
-        Ok((out, None))
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let d = self.shape[3] as usize;
+        Ok((transpose_seq_heads(&out, b, s, kv_h, d), None))
     }
 
     /// Return the GPU-resident packed K buffers sliced to the accumulated
     /// `S` tokens, **without dequantizing**.  This is the input contract for
-    /// the fused-QK MSL kernel.
+    /// the fused-QK / flash-decode MSL kernels.
+    ///
+    /// The packed prefix is **sequence-major** (`[B, S, kv_h, D]` element
+    /// order — see `append`): per token, all heads are contiguous. The fused-QK
+    /// / flash-decode / sparse-attn phase-1 kernels index it with the
+    /// sequence-major token base `((b * S + s) * kv_h + h)`, NOT the head-major
+    /// `((b * kv_h + h) * S + s)` base. Any new consumer must honour the same
+    /// layout.
     ///
     /// Returns `Ok(None)` when GPU buffers are not present (CPU-only path or
     /// uninitialised cache).

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_k_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_k_tests.rs
@@ -263,7 +263,7 @@ fn quant_planar_k_oneshot_vs_chunked_append_parity() {
     );
 }
 
-// ── Multi-append GQA head/seq-layout regression (the #105-class bug) ──────────
+// ── Multi-append GQA head/seq-layout regression (multi-token-after-prefill scramble) ──
 //
 // The chunked-vs-oneshot parity test above never triggers the head-scramble:
 // its chunked schedule is a multi-token prefill at `prev_seq == 0` followed by
@@ -361,10 +361,10 @@ fn quant_planar_k_cpu_multi_append_gqa_head_layout() {
 }
 
 /// GPU diagnostic: the same multi-append GQA head-layout contract on the Metal
-/// path. This is the path the fused-QK / flash-decode kernels read via
-/// `gpu_packed_view`; the dequant head-major view shares the SAME packed buffer
-/// and index contract, so a head-major dequant pass-here proves the packed
-/// buffer the kernels index is head-major-correct after a multi-token append.
+/// path. This proves the packed buffer round-trips to head-major after a
+/// multi-token append; the kernel-index agreement (fused-QK / flash-decode /
+/// sparse read via `gpu_packed_view`) is covered separately by the fused-QK /
+/// flash / sparse parity tests at `kv_h > 1`.
 #[test]
 #[ignore = "GPU Metal context — cargo test quant_planar_k_gpu_multi_append_gqa -- --ignored --test-threads=1"]
 fn quant_planar_k_gpu_multi_append_gqa_head_layout() {

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_k_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_k_tests.rs
@@ -185,20 +185,44 @@ fn quant_planar_k_oneshot_vs_chunked_append_parity() {
     let recon_a = array_to_f32(&recon_a_opt.expect("A None"));
 
     // ── Path B: prefill chunk then per-token decode appends ──────────────
+    // `data` is head-major `[1, kv_h, total_seq, head_dim]`. Both the prefill
+    // chunk and each per-token decode step must be sliced head-major so they
+    // carry the SAME logical (head, token) values Path A's one-shot append
+    // sees — otherwise the comparison drifts because the chunk schedule feeds
+    // a different tensor, not because the storage diverges. (The old slicing
+    // assumed a token-contiguous layout, which only matched the pre-fix
+    // token-major-write bug.)
     let mut init_shape_b = full_shape.to_vec();
     init_shape_b[2] = 0;
     let mut qpk_b = QuantPlanarK::new(init_shape_b, max_seq);
+    let kv_h_u = kv_h as usize;
+    let total_u = total_seq as usize;
+    let d_u = head_dim as usize;
+    let prefill_u = prefill_seq as usize;
+
+    let mut prefill_data = vec![0.0f32; kv_h_u * prefill_u * d_u];
+    for h in 0..kv_h_u {
+        for s in 0..prefill_u {
+            let src = (h * total_u + s) * d_u;
+            let dst = (h * prefill_u + s) * d_u;
+            prefill_data[dst..dst + d_u].copy_from_slice(&data[src..src + d_u]);
+        }
+    }
     let prefill_shape = [1i32, kv_h, prefill_seq, head_dim];
-    let prefill_elems: usize = prefill_shape.iter().map(|&d| d as usize).product();
-    let prefill_arr = make_f32_array(&data[..prefill_elems], &prefill_shape);
+    let prefill_arr = make_f32_array(&prefill_data, &prefill_shape);
     qpk_b
         .append(&[], &prefill_shape, &prefill_arr, Device::Gpu, max_seq)
         .expect("prefill append B");
-    let per_step_elems = (kv_h * head_dim) as usize;
     let step_shape = [1i32, kv_h, 1, head_dim];
     for step in 0..decode_seq as usize {
-        let off = prefill_elems + step * per_step_elems;
-        let step_arr = make_f32_array(&data[off..off + per_step_elems], &step_shape);
+        let s = prefill_u + step;
+        let mut step_data = vec![0.0f32; kv_h_u * d_u];
+        for h in 0..kv_h_u {
+            let src = (h * total_u + s) * d_u;
+            let dst = h * d_u;
+            step_data[dst..dst + d_u].copy_from_slice(&data[src..src + d_u]);
+        }
+        let step_arr = make_f32_array(&step_data, &step_shape);
         qpk_b
             .append(&[], &step_shape, &step_arr, Device::Gpu, max_seq)
             .expect("decode append B");
@@ -236,6 +260,167 @@ fn quant_planar_k_oneshot_vs_chunked_append_parity() {
         stats_b.mean >= 0.99,
         "chunked mean cosine {:.6} < 0.99",
         stats_b.mean
+    );
+}
+
+// ── Multi-append GQA head/seq-layout regression (the #105-class bug) ──────────
+//
+// The chunked-vs-oneshot parity test above never triggers the head-scramble:
+// its chunked schedule is a multi-token prefill at `prev_seq == 0` followed by
+// SINGLE-token decode appends. A single-token chunk is byte-identical in
+// head-major and sequence-major order, so the token-major write offset
+// (`prev_seq * words_per_seq`) is always correct for it. The scramble needs a
+// MULTI-token append at `prev_seq > 0` — exactly the SSD-hydrate-then-reprefill
+// path: an append whose chunk spans several tokens lands at a token-major
+// offset, but the dequant view reshapes the prefix head-major (`[B, kv_h, S, D]`),
+// transposing one head's new tokens onto another head's prefix.
+//
+// These fixtures build per-(head, token, dim) DISTINCT data so a head/seq swap
+// is visible far above 4-bit planar quant noise: head `h` carries a sinusoid
+// whose frequency scales with `h`, so a head that lands in the wrong slot has a
+// near-zero cosine against the head-major reference.
+
+/// Build `[1, kv_h, seq, d]` head-major f32 data where head `h`'s row at token
+/// `s` is `sin((h+1) * base_freq * (d + s))`. Distinct per head (frequency) and
+/// per token (phase); survives 4-bit planar quant per row at cosine ≈ 1.
+fn head_distinct_data(kv_h: i32, seq: i32, d: i32) -> Vec<f32> {
+    let kv_h = kv_h as usize;
+    let seq = seq as usize;
+    let d = d as usize;
+    let mut out = vec![0.0f32; kv_h * seq * d];
+    let base_freq = 0.05f32;
+    for h in 0..kv_h {
+        for s in 0..seq {
+            for di in 0..d {
+                let phase = (h as f32 + 1.0) * base_freq * ((di + s) as f32);
+                out[(h * seq + s) * d + di] = phase.sin();
+            }
+        }
+    }
+    out
+}
+
+/// CPU diagnostic: a two-chunk append where the SECOND chunk is multi-token and
+/// lands at `prev_seq > 0`. The dequant view must reproduce the head-major
+/// reference for EVERY (head, token) row. Pre-fix this fails on `kv_h > 1`
+/// because the token-major write scrambles heads↔seq.
+#[test]
+fn quant_planar_k_cpu_multi_append_gqa_head_layout() {
+    let kv_h = 4i32;
+    let head_dim = 64i32; // multiple of GROUP_SIZE (32), spans 2 groups per head
+    let chunk0 = 5i32; // prefill chunk
+    let chunk1 = 3i32; // multi-token decode/reprefill chunk at prev_seq > 0
+    let total = chunk0 + chunk1;
+
+    let full = head_distinct_data(kv_h, total, head_dim);
+    let d = head_dim as usize;
+    let total_u = total as usize;
+    let kv_h_u = kv_h as usize;
+
+    // Slice the head-major full tensor into two head-major chunks.
+    let mut chunk0_data = vec![0.0f32; kv_h_u * chunk0 as usize * d];
+    let mut chunk1_data = vec![0.0f32; kv_h_u * chunk1 as usize * d];
+    for h in 0..kv_h_u {
+        for s in 0..chunk0 as usize {
+            let src = (h * total_u + s) * d;
+            let dst = (h * chunk0 as usize + s) * d;
+            chunk0_data[dst..dst + d].copy_from_slice(&full[src..src + d]);
+        }
+        for s in 0..chunk1 as usize {
+            let src = (h * total_u + (chunk0 as usize + s)) * d;
+            let dst = (h * chunk1 as usize + s) * d;
+            chunk1_data[dst..dst + d].copy_from_slice(&full[src..src + d]);
+        }
+    }
+
+    let max_seq = total + 16;
+    let mut qpk = QuantPlanarK::new(vec![1i32, kv_h, 0, head_dim], max_seq);
+    let c0_shape = [1i32, kv_h, chunk0, head_dim];
+    let c1_shape = [1i32, kv_h, chunk1, head_dim];
+    // CPU path ignores the `Array` arg (it uses `f32_data`); a 0-len dummy is fine.
+    let dummy = Array::from_bytes(&[], &[0], Dtype::F32).expect("dummy array");
+    qpk.append(&chunk0_data, &c0_shape, &dummy, Device::Cpu, max_seq)
+        .expect("append chunk0");
+    qpk.append(&chunk1_data, &c1_shape, &dummy, Device::Cpu, max_seq)
+        .expect("append chunk1");
+
+    let (recon, _) = qpk
+        .dequantize_choice(Device::Cpu, Dtype::F32)
+        .expect("dequantize_choice CPU");
+    assert_eq!(recon.len(), full.len(), "recon length mismatch");
+
+    // Per-row cosine against the head-major reference. A head/seq swap pushes
+    // the swapped rows' cosine toward 0; a correct head-major buffer stays ≈ 1.
+    let stats = cosine_similarity_per_row(&full, &recon, d);
+    assert!(
+        stats.min >= 0.97,
+        "CPU multi-append GQA min per-row cosine {:.4} < 0.97 — head/seq scramble \
+         on the multi-token-after-prefill append (kv_h={kv_h})",
+        stats.min,
+    );
+}
+
+/// GPU diagnostic: the same multi-append GQA head-layout contract on the Metal
+/// path. This is the path the fused-QK / flash-decode kernels read via
+/// `gpu_packed_view`; the dequant head-major view shares the SAME packed buffer
+/// and index contract, so a head-major dequant pass-here proves the packed
+/// buffer the kernels index is head-major-correct after a multi-token append.
+#[test]
+#[ignore = "GPU Metal context — cargo test quant_planar_k_gpu_multi_append_gqa -- --ignored --test-threads=1"]
+fn quant_planar_k_gpu_multi_append_gqa_head_layout() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let kv_h = 4i32;
+    let head_dim = 64i32;
+    let chunk0 = 5i32;
+    let chunk1 = 3i32;
+    let total = chunk0 + chunk1;
+    let d = head_dim as usize;
+    let total_u = total as usize;
+    let kv_h_u = kv_h as usize;
+
+    let full = head_distinct_data(kv_h, total, head_dim);
+
+    let mut chunk0_data = vec![0.0f32; kv_h_u * chunk0 as usize * d];
+    let mut chunk1_data = vec![0.0f32; kv_h_u * chunk1 as usize * d];
+    for h in 0..kv_h_u {
+        for s in 0..chunk0 as usize {
+            let src = (h * total_u + s) * d;
+            let dst = (h * chunk0 as usize + s) * d;
+            chunk0_data[dst..dst + d].copy_from_slice(&full[src..src + d]);
+        }
+        for s in 0..chunk1 as usize {
+            let src = (h * total_u + (chunk0 as usize + s)) * d;
+            let dst = (h * chunk1 as usize + s) * d;
+            chunk1_data[dst..dst + d].copy_from_slice(&full[src..src + d]);
+        }
+    }
+
+    let init_shape = vec![1i32, kv_h, 0, head_dim];
+    let max_seq = total + 256;
+    let mut qpk = QuantPlanarK::new(init_shape, max_seq);
+    let c0_shape = [1i32, kv_h, chunk0, head_dim];
+    let c1_shape = [1i32, kv_h, chunk1, head_dim];
+    let c0_arr = make_f32_array(&chunk0_data, &c0_shape);
+    let c1_arr = make_f32_array(&chunk1_data, &c1_shape);
+    qpk.append(&[], &c0_shape, &c0_arr, Device::Gpu, max_seq)
+        .expect("append chunk0 GPU");
+    qpk.append(&[], &c1_shape, &c1_arr, Device::Gpu, max_seq)
+        .expect("append chunk1 GPU");
+
+    let (_, recon_opt) = qpk
+        .dequantize_choice(Device::Gpu, Dtype::F32)
+        .expect("dequantize_choice GPU");
+    let recon = array_to_f32(&recon_opt.expect("GPU dequant returned None"));
+    assert_eq!(recon.len(), full.len(), "GPU recon length mismatch");
+
+    let stats = cosine_similarity_per_row(&full, &recon, d);
+    assert!(
+        stats.min >= 0.97,
+        "GPU multi-append GQA min per-row cosine {:.4} < 0.97 — head/seq scramble \
+         on the multi-token-after-prefill append (kv_h={kv_h})",
+        stats.min,
     );
 }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_v.rs
@@ -24,6 +24,7 @@ use crate::planarquant_msl::{
 use crate::planarquant::{planar_dequantize, planar_quantize, PlanarBlocks};
 use crate::turboquant::GROUP_SIZE;
 
+use super::seq_layout::{transpose_heads_seq, transpose_seq_heads};
 use super::KV_PAGE_SIZE;
 
 // ── PlanarQuant V storage ─────────────────────────────────────────────────────
@@ -292,10 +293,20 @@ impl QuantPlanarV {
             // Since we never re-write the same offset within a sequence, atomic OR over the same
             // bits stays correct.
 
+            // Reorder the chunk to sequence-major `[B, new_seq, kv_h, D]` before
+            // quantizing — the flat buffer accumulates chunks at a per-token
+            // (all-heads) offset (`prev_seq * words_per_seq`), so the prefix is
+            // sequence-major. `dequantize_choice` reads it back with the matching
+            // reshape + transpose. For a single token the transpose is identity
+            // (decode hot path byte-unchanged); for a single chunk it cancels
+            // with the dequant transpose (cold-prefill round-trip exact). The
+            // MSL kernel reads by raw linear offset, so materialize the strided
+            // transpose into a row-major buffer before dispatch.
+            let v_seq_major = v_arr.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
             let (new_codes, new_scales, new_rotations) = if self.bits == 3 {
-                planar_quantize_v3_gpu(v_arr, device)?
+                planar_quantize_v3_gpu(&v_seq_major, device)?
             } else {
-                planar_quantize_v4_gpu(v_arr, device)?
+                planar_quantize_v4_gpu(&v_seq_major, device)?
             };
 
             let codes_buf = self.gpu_codes_buf.take().unwrap();
@@ -324,8 +335,19 @@ impl QuantPlanarV {
                 device,
             )?);
         } else {
-            // CPU path: scalar Rust PlanarQuant (bits from self.bits — 3 or 4).
-            let block = planar_quantize(f32_data, GROUP_SIZE, self.bits, new_shape)?;
+            // CPU mirror of the GPU path: store sequence-major so the blocks
+            // share one layout with the GPU buffer (spill/hydrate moves codes
+            // between the two). `f32_data` arrives head-major
+            // (`[B, kv_h, new_seq, D]`); reorder to `[B, new_seq, kv_h, D]` and
+            // record that chunk shape so `planar_quantize`'s flat grouping
+            // matches the reordered stream.
+            let b = new_shape[0] as usize;
+            let kv_h = new_shape[1] as usize;
+            let new_seq = new_shape[2] as usize;
+            let d = new_shape[3] as usize;
+            let seq_major = transpose_heads_seq(f32_data, b, kv_h, new_seq, d);
+            let seq_major_shape = [new_shape[0], new_shape[2], new_shape[1], new_shape[3]];
+            let block = planar_quantize(&seq_major, GROUP_SIZE, self.bits, &seq_major_shape)?;
             self.blocks.push(block);
         }
         Ok(())
@@ -360,11 +382,19 @@ impl QuantPlanarV {
                     &[1],
                     device,
                 )?;
+                // Flat buffer is sequence-major (see `append`): dequant into
+                // `[B, S, kv_h, D]` then transpose heads↔seq back to the logical
+                // `[B, kv_h, S, D]`. `contiguous` makes the physical layout match
+                // for raw byte-readers (SSD spill / hydrate); this is the
+                // post-hydrate / chunked-prefill dequant path, off the decode hot
+                // path, so the copy is acceptable.
+                let seq_major_shape = [self.shape[0], s, self.shape[1], self.shape[3]];
                 let out = if self.bits == 3 {
-                    planar_dequantize_v3_gpu(&codes, &scales, &rotations, &self.shape, device)?
+                    planar_dequantize_v3_gpu(&codes, &scales, &rotations, &seq_major_shape, device)?
                 } else {
-                    planar_dequantize_v4_gpu(&codes, &scales, &rotations, &self.shape, device)?
+                    planar_dequantize_v4_gpu(&codes, &scales, &rotations, &seq_major_shape, device)?
                 };
+                let out = out.transpose(&[0, 2, 1, 3], device)?.contiguous(device)?;
                 let out = if out_dtype == Dtype::F32 {
                     out
                 } else {
@@ -374,14 +404,20 @@ impl QuantPlanarV {
             }
             return Ok((Vec::new(), None));
         }
-        // CPU path.
+        // CPU path: blocks are sequence-major (`[B, S, kv_h, D]`, see `append`).
+        // The caller reshapes the returned flat vector to the logical
+        // `[B, kv_h, S, D]`, so reorder heads↔seq back to head-major first.
         let total: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out = Vec::with_capacity(total);
         for block in &self.blocks {
             let slice = planar_dequantize(block)?;
             out.extend_from_slice(&slice);
         }
-        Ok((out, None))
+        let b = self.shape[0] as usize;
+        let kv_h = self.shape[1] as usize;
+        let s = self.shape[2] as usize;
+        let d = self.shape[3] as usize;
+        Ok((transpose_seq_heads(&out, b, s, kv_h, d), None))
     }
 
     /// Reconstruct a CPU-path `QuantPlanarV` from serialized PlanarQuant blocks.

--- a/crates/rmlx-models/tests/sparse_attn_dispatch.rs
+++ b/crates/rmlx-models/tests/sparse_attn_dispatch.rs
@@ -295,8 +295,16 @@ fn sparse_attn_dispatches_on_seedless_planar_k() {
     let v_data = lcg_data(v_n, 0x166B_0003);
     let v_arr = make_f32_array(&v_data, &v_shape);
 
+    // K packing is sequence-major (`[B, S, kv_h, D]`) — the layout the
+    // fused-QK / flash-decode / sparse phase-1/2 kernels index. Transpose the
+    // head-major `k_arr` heads↔seq and materialize before packing.
+    let k_seq = k_arr
+        .transpose(&[0, 2, 1, 3], device)
+        .expect("transpose k seq-major")
+        .contiguous(device)
+        .expect("contiguous k seq-major");
     let (k_codes, k_scales, k_rot32) =
-        planar_quantize_v4_gpu(&k_arr, device).expect("planar_quantize_v4_gpu");
+        planar_quantize_v4_gpu(&k_seq, device).expect("planar_quantize_v4_gpu");
 
     let dense = planar_flash_decode_sdpa(
         &q_arr,
@@ -438,8 +446,16 @@ fn sparse_attn_seedless_planar_k_v2_budgets_wire_through() {
     let v_data = lcg_data(v_n, 0x167C_0003);
     let v_arr = make_f32_array(&v_data, &v_shape);
 
+    // K packing is sequence-major (`[B, S, kv_h, D]`) — the layout the
+    // fused-QK / flash-decode / sparse phase-1/2 kernels index. Transpose the
+    // head-major `k_arr` heads↔seq and materialize before packing.
+    let k_seq = k_arr
+        .transpose(&[0, 2, 1, 3], device)
+        .expect("transpose k seq-major")
+        .contiguous(device)
+        .expect("contiguous k seq-major");
     let (k_codes, k_scales, k_rot32) =
-        planar_quantize_v4_gpu(&k_arr, device).expect("planar_quantize_v4_gpu");
+        planar_quantize_v4_gpu(&k_seq, device).expect("planar_quantize_v4_gpu");
     let dense = planar_flash_decode_sdpa(
         &q_arr,
         &k_codes,
@@ -620,8 +636,16 @@ fn sparse_attn_seedless_planar_k_competing_keys_v2_vs_v1() {
     let v_data = lcg_data(v_n, 0x167C_0013);
     let v_arr = make_f32_array(&v_data, &v_shape);
 
+    // K packing is sequence-major (`[B, S, kv_h, D]`) — the layout the
+    // fused-QK / flash-decode / sparse phase-1/2 kernels index. Transpose the
+    // head-major `k_arr` heads↔seq and materialize before packing.
+    let k_seq = k_arr
+        .transpose(&[0, 2, 1, 3], device)
+        .expect("transpose k seq-major")
+        .contiguous(device)
+        .expect("contiguous k seq-major");
     let (k_codes, k_scales, k_rot32) =
-        planar_quantize_v4_gpu(&k_arr, device).expect("planar_quantize_v4_gpu");
+        planar_quantize_v4_gpu(&k_seq, device).expect("planar_quantize_v4_gpu");
     let dense = planar_flash_decode_sdpa(
         &q_arr,
         &k_codes,

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -517,16 +517,43 @@ transpose because the custom quant / dequant MSL kernels read their buffers by
 raw linear index and ignore MLX lazy-transpose strides — a CPU-only test cannot
 catch that; the layout fixes are GPU round-trip verified.
 
-**Not yet covered (same class, deferred):** the PlanarQuant K/V structs
-(`QuantPlanarK` / `QuantPlanarV`) carry the same multi-append head scramble
-(reproduced on GPU: chunked decode vs one-shot diverges by ~4 abs at the Bonsai
-shape), but `QuantPlanarK` additionally exposes its packed codes buffer to the
-`planar_fused_qk` / `planar_flash_decode` MSL kernels via `gpu_packed_view`
-(the post-hydrate decode path, gated on `decode_fp16_k.is_none()`). Those
-kernels read the packed buffer with a head-major `(b, kv_h, kv_seq, head_dim)`
-indexing, so a sequence-major storage relayout would also have to relayout the
-fused-QK / flash kernels — a coordinated MSL-kernel change beyond the
-storage-local fix.
+**Now covered (PlanarQuant K/V — closes the class):** the PlanarQuant structs
+(`QuantPlanarK` / `QuantPlanarV`) carried the same multi-append head scramble
+(reproduced on CPU and GPU: a two-chunk GQA append with `kv_h > 1` and a
+multi-token second chunk drove per-row cosine far negative against the
+head-major reference). `QuantPlanarK` was the hard case because it also exposes
+its packed codes buffer to the `planar_fused_qk` / `planar_flash_decode` MSL
+kernels (and the sparse-attn phase-1/2 kernels) via `gpu_packed_view` on the
+post-hydrate decode path (gated on `decode_fp16_k.is_none()`). Those kernels
+read the packed K buffer **per token**, so the fix is a coordinated change:
+
+- **Storage goes sequence-major** like the rest of the family. `append` reorders
+  the incoming head-major chunk heads↔seq before quantizing (GPU: `transpose`
+  then `Array::contiguous`, because the raw-linear-index MSL kernel ignores
+  lazy-transpose strides; CPU: `transpose_heads_seq` on the flat data with the
+  reordered chunk shape), and `dequantize_choice` reshapes the prefix
+  `[B, S, kv_h, D]` and transposes back to the logical `[B, kv_h, S, D]`.
+- **The packed-K kernels switch to a sequence-major token base.** `planar_fused_qk`,
+  `planar_flash_decode` (P1), and the sparse-attn phase-1/2 score kernels now
+  index K as `kv_tok = (b * kv_seq + s) * kv_h + kv_h_idx` instead of the old
+  head-major `(b * kv_h + kv_h_idx) * kv_seq + s`. The V offset stays head-major
+  in the flash / sparse kernels because V is the separate bf16 decode mirror
+  (`decode_fp16_v`), not the planar-packed buffer.
+
+For a single decode token (`new_seq == 1`) the heads↔seq transpose is the
+identity, so the decode hot path is byte-unchanged; for a single cold-prefill
+chunk (`prev_seq == 0`) the append and dequant transposes cancel. PlanarQuant is
+layout-agnostic (it processes the flat element stream group-by-group and
+`head_dim % GROUP_SIZE == 0`, so no group spans a (head, token) boundary), so
+the reorder is bit-exact, not just within-noise — planar3 and planar4 packing
+are untouched. The `.kvb` SSD format is byte-stable (only the token-row order
+within the buffer changes; spill and dequant agree on sequence-major). With this
+change **the entire multi-append head-scramble class is closed** — every
+flat-buffer quantized KV storage (`QuantK`, `QuantV`, `QuantKTurbo3/4`, paged,
+all eight Iso/Rotor codecs, and now `QuantPlanarK` / `QuantPlanarV`) is
+canonically sequence-major. CPU + GPU round-trip verified (two-append GQA vs
+single-shot, plus the fused-QK / flash-decode / sparse-attn parity suites all
+green on real Metal).
 
 ### 5.7.3 The Iso / Rotor `Vec<Blocks>` codecs use the same sequence-major rule
 

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -1041,6 +1041,29 @@ axis-agnostic at the kernel input level (flat `[B, kv_h, S, D]` with
 **V codec**: unquantised bf16 (lives on `KvCache::decode_fp16_v`, same
 machinery as `KvStorage::None` for the V buffer).
 
+**Buffer layout (sequence-major).** Like every other flat-buffer quantized KV
+storage, the `QuantPlanarK` (and `QuantPlanarV`) buffer stores the filled
+prefix **sequence-major** (`[B, S, kv_h, D]` element order): per token, all
+heads are contiguous. `append` reorders the incoming head-major chunk heads↔seq
+before quantizing (GPU: `transpose` then `Array::contiguous`, since the
+raw-linear-index MSL kernel ignores lazy-transpose strides; CPU: the
+`transpose_heads_seq` mirror), and `dequantize_choice` reshapes the prefix
+`[B, S, kv_h, D]` and transposes back to the logical `[B, kv_h, S, D]`. For a
+single decode token the transpose is the identity (hot path byte-unchanged);
+for a single cold-prefill chunk the two transposes cancel. PlanarQuant is
+layout-agnostic (group-by-group over the flat stream, `head_dim % 32 == 0`, so
+no group spans a (head, token) boundary), so the reorder is **bit-exact** —
+planar3 / planar4 packing untouched. This closes the multi-append head-scramble
+class (the SSD-hydrate-then-reprefill path) for the whole codec family.
+
+Because `QuantPlanarK` also feeds its packed codes to the GPU kernels via
+`gpu_packed_view`, those kernels index K **sequence-major** to match:
+`planar_fused_qk`, `planar_flash_decode` (P1), and the sparse-attn phase-1/2
+score kernels compute the K token base as
+`kv_tok = (b * kv_seq + s) * kv_h + kv_h_idx`. The V offset in the flash /
+sparse kernels stays head-major — V is the separate bf16 decode mirror, not the
+planar-packed buffer.
+
 The K buffer is kept as an independent type (`QuantPlanarK`, layout-identical
 to `QuantPlanarV` but distinct so K and V append paths stay decoupled)
 inside `KvStorage::PlanarK { k, max_seq }`. Layout tag (single source of


### PR DESCRIPTION
## Summary

Fixes the final member of the multi-append-after-SSD-hydrate head-scramble class: PlanarQuant K/V. **Closes #105** — with this, every flat quantized KV storage in the crate is canonically sequence-major.

Bug class (#80): a flat quantized KV buffer written sequence-major but read head-major scrambles per-head K on a multi-append after SSD hydrate with `kv_heads > 1`. PlanarK was the last holdout — deferred because its packed buffer is consumed by the `planar_fused_qk` / `planar_flash_decode` / sparse-attn MSL kernels (via `gpu_packed_view`), which indexed it head-major. A storage-only seq-major flip regressed those kernels (and was reverted in an earlier attempt).

## Fix

Flip PlanarK/V storage to sequence-major **and** update the kernels atomically:
- `QuantPlanarK` / `QuantPlanarV` `append` transposes head-major→sequence-major before quantizing; `dequantize_choice` reshapes `[B,S,kv_h,D]` and transposes back (matching the merged #108/#109 family pattern, shared `seq_layout` helpers).
- The K token base in the 3 packed-K kernels (`planar_fused_qk`, `planar_flash_decode`, sparse-attn phase1+phase2) is remapped head-major `(b*kv_h+h)*kv_seq+s` → sequence-major `(b*kv_seq+s)*kv_h+h` — a pure index remap, no added work.
- V stays head-major: the kernels read V from the bf16 mirror, not the planar-packed buffer, so the V offset is unchanged.

The prior revert failed because it flipped storage without the kernels; this changes both together.

## Validation

- **GPU kernel parity at `kv_h>1`** (the decisive proof — seq-major kernel vs head-major reference): fused-QK max-err <1e-4, flash-decode ~1e-7, sparse-attn cosine ≥0.9997; all GQA tile/head-dim variants.
- **CPU + GPU multi-append round-trip** (kv_h=4, multi-token chunk at `prev_seq>0`): per-row cosine −0.21 (scramble) → ≥0.97 (quant noise).
- **End-to-end serve** (Bonsai, GQA kv_heads=8): PlanarK + SSD spill→evict→hydrate → identical coherent post-hydrate output, `nan_count=0`. (fused-QK is warm-TTFT-dormant on normal serve, so kernel-index correctness rests on the parity suites above; serve corroborates storage hydrate-decode coherence.)
- **No perf regression** (canary): Bonsai +2.9%, Gemma4-e4b +6.9%, Qwen3.6 +2.2% vs anchors (pure index remap; kernels dormant on the steady-state decode path).
- `make lint` clean, `cargo fmt --all` clean. planar3 (#81) and planar4 packing intact; `.kvb` round-trips.

## Closes #105

The whole class is now fixed: QuantK (#80/#103), QuantV + TurboSym + paged (#108), Iso/Rotor ×8 (#109), and PlanarK/V (this PR). Documented in `docs/KV_CACHE.md` §5.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)