### PR TITLE
fix(kv-ssd): inject opened index into startup_maintenance to kill OnceLock test race

### DIFF
--- a/crates/rmlx-kv-ssd/src/ssd_tier.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_tier.rs
@@ -283,7 +283,20 @@ pub fn prepare_attach(
     } else {
         cfg.per_namespace_budget_bytes
     };
-    startup_maintenance(namespace.as_ref(), effective_per_ns);
+    // Open the namespace index here — this is the single `paths::home()`
+    // resolution on the attach path — then hand the opened handle to the
+    // maintenance routine. Keeping the open at the boundary means the
+    // maintenance logic itself takes its root explicitly (the index already
+    // carries it) and never re-resolves the process-global home, which is
+    // what makes it testable against an injected temp dir.
+    match SsdKvIndex::open(namespace.as_ref()) {
+        Ok(index) => startup_maintenance(&index, namespace.as_ref(), effective_per_ns),
+        Err(e) => tracing::warn!(
+            namespace = %namespace,
+            error = %e,
+            "ssd-tier startup index open failed; skipping maintenance"
+        ),
+    }
 
     Some(AttachInfo {
         namespace: namespace.into_owned(),
@@ -293,15 +306,20 @@ pub fn prepare_attach(
     })
 }
 
-/// Open the namespace index, prune missing blocks, then evict LRU until the
-/// persisted footprint is within `budget_bytes`. Best-effort: any error is
-/// `warn!`ed and maintenance is skipped (the spiller opens its own index on
-/// its drain thread regardless).
+/// Prune missing blocks from an already-opened namespace index, then evict LRU
+/// until the persisted footprint is within `budget_bytes`. Best-effort: any
+/// error is `warn!`ed and the remaining steps proceed (the spiller opens its
+/// own index on its drain thread regardless).
+///
+/// Takes the opened `index` explicitly rather than resolving it from the
+/// process-global home — the caller owns the one `paths::home()` resolution on
+/// the attach path. This keeps the routine root-injectable (tests open against
+/// a temp dir) and free of the `OnceLock` ordering hazard.
 #[allow(
     clippy::cognitive_complexity,
-    reason = "index open → prune → evict → prometheus hooks: four sequential \
-              best-effort operations each with their own error arms; splitting would \
-              obscure the linear maintenance sequence"
+    reason = "prune → evict → prometheus hooks: sequential best-effort operations \
+              each with their own error arms; splitting would obscure the linear \
+              maintenance sequence"
 )]
 #[allow(
     clippy::semicolon_if_nothing_returned,
@@ -309,14 +327,7 @@ pub fn prepare_attach(
               tracing::info! / tracing::warn! in match arms are the last expression, \
               and the surrounding match itself is a statement"
 )]
-fn startup_maintenance(namespace: &str, budget_bytes: u64) {
-    let index = match SsdKvIndex::open(namespace) {
-        Ok(idx) => idx,
-        Err(e) => {
-            tracing::warn!(namespace, error = %e, "ssd-tier startup index open failed; skipping maintenance");
-            return;
-        }
-    };
+fn startup_maintenance(index: &SsdKvIndex, namespace: &str, budget_bytes: u64) {
     match index.prune_missing() {
         Ok(n) if n > 0 => {
             tracing::info!(

--- a/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
@@ -178,8 +178,12 @@ fn wipe_is_noop_on_v2_namespace() {
 
 /// Startup maintenance: an over-budget namespace index is evicted until the
 /// on-disk footprint is within budget, and the evicted `.kvb` files are
-/// deleted from disk. Also exercises `prune_missing`. Hermetic via an
-/// `RMLX_HOME` tempdir.
+/// deleted from disk. Also exercises `prune_missing`.
+///
+/// Hermetic via an explicit temp dir injected into `SsdKvIndex::open_at` and
+/// `startup_maintenance` — the routine takes its opened index by reference, so
+/// the test never resolves the process-global `paths::home()` `OnceLock` and is
+/// immune to its set-once-per-process ordering hazard under parallel runs.
 #[test]
 #[allow(
     clippy::unwrap_used,
@@ -187,23 +191,14 @@ fn wipe_is_noop_on_v2_namespace() {
 )]
 fn startup_maintenance_prunes_and_evicts_to_budget() {
     let tmp = tempfile::TempDir::new().unwrap();
-    // SAFETY: edition 2021; single-threaded test, set before paths::home()
-    // is first resolved in this process for this namespace.
-    std::env::set_var("RMLX_HOME", tmp.path());
-
     let ns = "test-ns";
-    let dir = rmlx_core::paths::kv_cache_dir(ns);
-    // `rmlx_core::paths::home()` is a OnceLock — if a prior test in
-    // this process resolved it before the `RMLX_HOME` set above, the dir
-    // path resolves into the workspace `.rmlx/` and may carry a stale v1
-    // schema DB. Wipe the namespace dir first so the fixture below starts
-    // from a clean v2-schema state every time.
-    let _ = std::fs::remove_dir_all(&dir);
-    let _ = std::fs::create_dir_all(&dir);
+    let dir = tmp.path().join(ns);
+    std::fs::create_dir_all(&dir).unwrap();
+    let db_path = dir.join("index.db");
     let lk: u64 = 0xa1b2_c3d4_e5f6_a7b8;
 
     {
-        let idx = SsdKvIndex::open(ns).unwrap();
+        let idx = SsdKvIndex::open_at(&db_path).unwrap();
         // Three 1000-byte real files + one ghost row (file never written).
         for name in ["aaa", "bbb", "ccc"] {
             let p = dir.join(format!("{name}.kvb"));
@@ -215,18 +210,16 @@ fn startup_maintenance_prunes_and_evicts_to_budget() {
         assert_eq!(idx.total_bytes().unwrap(), 3000 + 9999);
     }
 
-    startup_maintenance(ns, 1500);
+    let idx = SsdKvIndex::open_at(&db_path).unwrap();
+    startup_maintenance(&idx, ns, 1500);
 
-    let idx2 = SsdKvIndex::open(ns).unwrap();
-    assert!(idx2.lookup("ghost", lk).unwrap().is_none());
-    assert!(idx2.total_bytes().unwrap() <= 1500);
+    assert!(idx.lookup("ghost", lk).unwrap().is_none());
+    assert!(idx.total_bytes().unwrap() <= 1500);
     let surviving_files = ["aaa", "bbb", "ccc"]
         .iter()
         .filter(|n| dir.join(format!("{n}.kvb")).exists())
         .count();
     assert!(surviving_files <= 1);
-
-    std::env::remove_var("RMLX_HOME");
 }
 
 /// unit test: double `install_config` returns `Err(SsdTierAlreadyInstalled)`.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -454,3 +454,22 @@ They are read only inside test code (`tests/` and `*_tests.rs` files).
 | `RMLX_FUSED_QK_STRICT` | `1` | Fail (not warn) on fused-QK parity tests. |
 | `RMLX_RETURNING_KV_STRICT` | `1` | Fail (not warn) on returning-KV dispatch parity tests. |
 | `RMLX_SPARSE_ATTN_STRICT` | `1` | Fail (not warn) on sparse-attn dispatch parity tests. |
+
+---
+
+## In-process tests must not rely on the `paths::home()` `OnceLock`
+
+`rmlx_core::paths::home()` caches its resolved root in a `OnceLock` — fixed
+for the lifetime of the process. In-process unit tests share one process, so a
+test that does `std::env::set_var("RMLX_HOME", tmp)` and then reads a
+`paths::*` path **races every other test in the same binary**: whichever test
+resolves `home()` first pins the root, and a later `set_var` is silently
+ignored. The path then points at the workspace `.rmlx/` instead of the temp
+dir, which both flakes the test and leaks artifacts into the checkout.
+
+For in-process tests, **inject the root explicitly** — pass a temp path to the
+routine under test (open SQLite via `SsdKvIndex::open_at(&db_path)`, write
+fixture files under the temp dir) rather than going through `paths::home()`.
+Setting `RMLX_HOME` is only hermetic for **subprocess** tests
+(`Command::new(...).env("RMLX_HOME", tmp)`), where the child gets a fresh
+`OnceLock`.


### PR DESCRIPTION
## Summary

Fixes a workspace-wide test-isolation flake: `startup_maintenance_prunes_and_evicts_to_budget` (`rmlx-kv-ssd`) passed in isolation but flaked under `cargo test --workspace`.

Closes #106.

## Root cause

`startup_maintenance` opened its index internally via `SsdKvIndex::open(namespace)` → `kv_cache_dir(namespace)` → `rmlx_core::paths::home()`, which resolves through a `OnceLock` (cached once per process). The test set `RMLX_HOME` via `env::set_var`, but if any other crate's test resolved `home()` first, the root pinned to the workspace `.rmlx/` and the test ran against the checkout (confirmed by a leaked `.rmlx/cache/kv/test-ns/`; reproduced 2/20 pre-fix).

## Fix

Inject the dependency instead of resolving the global:
- `SsdKvIndex::open(namespace)` moves up to the `prepare_attach` boundary — exactly where `home()` resolution already happened on the production attach path — and `startup_maintenance` now takes `&SsdKvIndex`. The routine no longer calls `home()` (it already operated on row-stored absolute paths).
- The test opens via `SsdKvIndex::open_at(&temp_db)` (an existing API) and writes fixtures under a `TempDir`, removing the `set_var`/`OnceLock` dependency entirely.
- `paths.rs` is untouched: production `home()` keeps its 3-tier resolution.

Production behavior is unchanged — same DB path, opened exactly once, correct borrow lifetime, same warn-and-skip error handling (verified by review).

## Validation

- `cargo test --workspace` ×20 and `cargo test -p rmlx-kv-ssd` ×20 (the binary where the race lived): **0 failures**; the workspace `.rmlx/cache/kv/test-ns` leak is gone.
- `cargo test -p rmlx-core`: green — `paths::home()` behavior unchanged.
- Audited all in-process `env::set_var("RMLX_HOME")` — this was the only `OnceLock`-hazardous case; other `RMLX_HOME` uses are subprocess `Command::env` (hermetic).
- `make lint` clean, `cargo fmt --all` clean.

## Docs

- `docs/TESTING.md` — note: in-process tests must inject the root (`open_at` / temp dir), not rely on the `paths::home()` `OnceLock`; `RMLX_HOME` is only hermetic for subprocess tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)