### PR TITLE
fix(claim): auto-reclaim stale Metal claim on dead holder PID + graceful shutdown

### DIFF
--- a/crates/rmlx-server/src/claim.rs
+++ b/crates/rmlx-server/src/claim.rs
@@ -21,7 +21,7 @@
 //! Those are handled by the unload/stop hints printed on `ClaimError`.
 
 use std::fs::{File, OpenOptions};
-use std::io::Write as _;
+use std::io::{Seek as _, SeekFrom, Write as _};
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 
@@ -78,15 +78,23 @@ impl Drop for MetalClaim {
 /// Returns `Ok(MetalClaim)` on success. The lock is held until the returned
 /// guard is dropped (i.e. until the subcommand exits).
 ///
-/// Returns `ClaimError::AlreadyHeld` if the file already exists *and* is
-/// flock-locked by another process. The holder's PID is read from the file.
+/// Returns `ClaimError::AlreadyHeld` if the file already exists *and* its
+/// holder PID is still alive. The holder's PID is read from the file.
+///
+/// ## Stale-claim auto-reclaim
+/// A claim left behind by a process that died without running `Drop` (SIGTERM,
+/// SIGKILL, crash, power loss) is auto-reclaimed: if the holder PID is provably
+/// **dead** (`kill(pid, 0)` reports no such process) the file is taken over and
+/// a `warn!` is logged. A claim whose holder PID is **alive** is never stolen —
+/// that is the single-MLX-process invariant; two MLX processes on one Metal
+/// context is exactly what the claim prevents.
 pub fn try_claim(port: u16) -> Result<MetalClaim, ClaimError> {
     let path = PathBuf::from(format!("/tmp/rmlx.{port}.claim"));
 
     // --- attempt O_CREAT|O_EXCL -------------------------------------------
     // We try exclusive creation first. If that fails because the file already
-    // exists, we fall through to the flock path which will tell us whether the
-    // owner is still alive.
+    // exists, we fall through to the stale-reclaim path: a dead holder PID lets
+    // us take the file over, a live holder PID is respected.
 
     let file = match OpenOptions::new()
         .write(true)
@@ -95,18 +103,35 @@ pub fn try_claim(port: u16) -> Result<MetalClaim, ClaimError> {
     {
         Ok(f) => f,
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            // File exists — try to open it and read the PID.
+            // File exists — read the holder PID first.
             let holder_pid = read_holder_pid(&path, port)?;
-            // Try to take the flock now; if it succeeds the old owner exited
-            // without cleanup — we can steal the file.
+
+            // SAFETY INVARIANT: never steal a claim whose holder is alive.
+            // A live holder means an MLX process is (or may be) on the GPU.
+            if pid_is_alive(holder_pid) {
+                return Err(ClaimError::AlreadyHeld { port, holder_pid });
+            }
+
+            // Holder is provably dead — its `Drop` never ran (SIGTERM/SIGKILL/
+            // crash). Take the flock to confirm no live fd still holds the lock,
+            // then reclaim. The flock check is belt-and-suspenders on top of the
+            // liveness check: both must agree before we reuse the file.
             let candidate = OpenOptions::new()
                 .write(true)
                 .open(&path)
                 .map_err(|src| ClaimError::Io { port, source: src })?;
             if flock_ex_nb(candidate.as_raw_fd()) {
-                // Stale file, old process gone — we got the lock.
+                tracing::warn!(
+                    port,
+                    stale_pid = holder_pid,
+                    path = %path.display(),
+                    "reclaiming stale Metal claim left by a dead process (no Drop on SIGTERM/SIGKILL/crash)"
+                );
                 candidate
             } else {
+                // PID reads dead but the flock is still held — a live fd exists
+                // (e.g. PID reused, or read race). Refuse rather than risk a
+                // second MLX process on the GPU.
                 return Err(ClaimError::AlreadyHeld { port, holder_pid });
             }
         }
@@ -124,8 +149,15 @@ pub fn try_claim(port: u16) -> Result<MetalClaim, ClaimError> {
     }
 
     // --- write our PID -------------------------------------------------------
+    // Truncate first: when reclaiming a stale file the old PID body may be
+    // longer than ours, so an unconditional write would leave trailing digits
+    // and corrupt the PID a later reader parses.
     let pid = std::process::id();
     let mut f = file;
+    f.set_len(0)
+        .map_err(|src| ClaimError::Io { port, source: src })?;
+    f.seek(SeekFrom::Start(0))
+        .map_err(|src| ClaimError::Io { port, source: src })?;
     write!(f, "{pid}").map_err(|src| ClaimError::Io { port, source: src })?;
     f.flush()
         .map_err(|src| ClaimError::Io { port, source: src })?;
@@ -156,6 +188,31 @@ fn read_holder_pid(path: &PathBuf, port: u16) -> Result<u32, ClaimError> {
     let contents =
         std::fs::read_to_string(path).map_err(|src| ClaimError::Io { port, source: src })?;
     Ok(contents.trim().parse::<u32>().unwrap_or(0))
+}
+
+/// Liveness probe: is the process `pid` currently running?
+///
+/// Uses `kill(pid, 0)` — signal 0 performs the permission/existence check
+/// without sending a signal. `0` (or `EPERM`, meaning the process exists but is
+/// owned by another user) → alive; `ESRCH` → no such process.
+///
+/// A `pid` of `0` (unparsable / empty body) is treated as **alive** so an
+/// unreadable claim is never stolen — the conservative choice for the
+/// single-MLX invariant.
+fn pid_is_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return true;
+    }
+    // SAFETY: kill(2) with signal 0 is safe for any pid; it sends no signal and
+    // only reports existence/permission. errno EPERM also implies the process
+    // exists, so treat a non-ESRCH failure as alive.
+    let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if ret == 0 {
+        return true;
+    }
+    // ret == -1: distinguish ESRCH (dead) from EPERM (alive, other user).
+    let errno = std::io::Error::last_os_error().raw_os_error();
+    errno != Some(libc::ESRCH)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rmlx-server/src/claim.rs
+++ b/crates/rmlx-server/src/claim.rs
@@ -81,13 +81,27 @@ impl Drop for MetalClaim {
 /// Returns `ClaimError::AlreadyHeld` if the file already exists *and* its
 /// holder PID is still alive. The holder's PID is read from the file.
 ///
-/// ## Stale-claim auto-reclaim
-/// A claim left behind by a process that died without running `Drop` (SIGTERM,
-/// SIGKILL, crash, power loss) is auto-reclaimed: if the holder PID is provably
-/// **dead** (`kill(pid, 0)` reports no such process) the file is taken over and
-/// a `warn!` is logged. A claim whose holder PID is **alive** is never stolen —
-/// that is the single-MLX-process invariant; two MLX processes on one Metal
-/// context is exactly what the claim prevents.
+/// ## Safety model: flock primary, PID probe secondary
+/// The load-bearing safety gate is the **flock**, not the PID probe. A live
+/// rMLX process keeps the claim file's fd open for its whole lifetime, so it
+/// holds the exclusive `flock`. Any second process therefore fails
+/// `flock(LOCK_EX | LOCK_NB)` on that file and refuses — a live MLX claim can
+/// never be stolen, regardless of what the PID body says. That is the
+/// single-MLX-process invariant the GPU depends on.
+///
+/// The PID probe is a **secondary stale-file detector**: it lets us recognise
+/// a claim file abandoned by a process that died without running `Drop`
+/// (SIGTERM/SIGKILL/crash/power-loss) so the next start can reuse it instead of
+/// failing forever. A provably **dead** holder PID (`kill(pid, 0)` → ESRCH)
+/// makes the file a reclaim candidate; we then still take the flock to confirm
+/// no live fd holds the file before reusing it.
+///
+/// The only residual race is narrow and fail-safe: a dead holder's PID could be
+/// recycled to an unrelated process between the first read and reclaim. We
+/// guard it by re-reading and re-probing the PID *after* taking the lock (see
+/// below) and by the flock itself. If anything is uncertain we **refuse**
+/// (`AlreadyHeld`) — the error direction is harmless (a transient false
+/// refusal), never the dangerous one (two MLX processes on one Metal context).
 pub fn try_claim(port: u16) -> Result<MetalClaim, ClaimError> {
     let path = PathBuf::from(format!("/tmp/rmlx.{port}.claim"));
 
@@ -106,21 +120,33 @@ pub fn try_claim(port: u16) -> Result<MetalClaim, ClaimError> {
             // File exists — read the holder PID first.
             let holder_pid = read_holder_pid(&path, port)?;
 
-            // SAFETY INVARIANT: never steal a claim whose holder is alive.
-            // A live holder means an MLX process is (or may be) on the GPU.
+            // Secondary stale detector: a provably-dead holder PID marks the
+            // file as a reclaim candidate. A live holder is respected here, but
+            // the real guarantee is the flock below — a live rMLX still holds
+            // its fd, so flock_ex_nb would fail even if this probe misfired.
             if pid_is_alive(holder_pid) {
                 return Err(ClaimError::AlreadyHeld { port, holder_pid });
             }
 
-            // Holder is provably dead — its `Drop` never ran (SIGTERM/SIGKILL/
-            // crash). Take the flock to confirm no live fd still holds the lock,
-            // then reclaim. The flock check is belt-and-suspenders on top of the
-            // liveness check: both must agree before we reuse the file.
+            // Holder is (was) provably dead — its `Drop` never ran (SIGTERM/
+            // SIGKILL/crash). Take the flock: this is the load-bearing gate. If
+            // any live fd still holds the file the lock fails and we refuse.
             let candidate = OpenOptions::new()
                 .write(true)
                 .open(&path)
                 .map_err(|src| ClaimError::Io { port, source: src })?;
             if flock_ex_nb(candidate.as_raw_fd()) {
+                // Lock held. Close the narrow PID-reuse window: between the
+                // first read and now the dead holder's PID could have been
+                // recycled to an unrelated process that grabbed (and released)
+                // the file. Re-read the body and re-probe under the lock; if the
+                // PID changed or is now alive, refuse rather than reclaim. This
+                // is the fail-safe direction — a transient false refusal, never
+                // two MLX processes on the GPU.
+                let confirm_pid = read_holder_pid(&path, port).unwrap_or(0);
+                if confirm_pid != holder_pid || pid_is_alive(confirm_pid) {
+                    return Err(ClaimError::AlreadyHeld { port, holder_pid });
+                }
                 tracing::warn!(
                     port,
                     stale_pid = holder_pid,
@@ -141,7 +167,9 @@ pub fn try_claim(port: u16) -> Result<MetalClaim, ClaimError> {
     // --- acquire exclusive non-blocking flock --------------------------------
     if !flock_ex_nb(file.as_raw_fd()) {
         // We just created the file but couldn't lock it — race with another
-        // starter. Read PID and report.
+        // starter. Read PID and report. holder_pid is often 0 here: neither our
+        // own create nor the racing winner may have written a PID body yet at
+        // this point, so the file is still empty.
         let holder_pid = read_holder_pid(&path, port).unwrap_or(0);
         // Remove the file we just created so we don't leave a stale entry.
         let _ = std::fs::remove_file(&path);

--- a/crates/rmlx-server/src/claim_tests.rs
+++ b/crates/rmlx-server/src/claim_tests.rs
@@ -27,6 +27,89 @@ fn double_claim_same_port_fails() {
     );
 }
 
+/// Write a claim file holding `pid` with no open fd (so no flock is held).
+/// Mimics a process that died without running `Drop` (SIGTERM/SIGKILL/crash).
+fn write_stale_claim(path: &PathBuf, pid: u32) {
+    use std::io::Write as _;
+    let mut f = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .expect("create stale claim file");
+    write!(f, "{pid}").expect("write stale pid");
+    f.flush().expect("flush stale pid");
+    // f dropped here: fd closed, flock released, file persists on disk.
+}
+
+/// A stale claim whose holder PID is dead must be auto-reclaimed: `try_claim`
+/// succeeds and the body is rewritten with the current PID.
+#[test]
+fn stale_dead_pid_is_reclaimed() {
+    let port: u16 = 59880;
+    let path = PathBuf::from(format!("/tmp/rmlx.{port}.claim"));
+    let _ = std::fs::remove_file(&path);
+
+    // 999999 is well above the typical macOS PID ceiling and not alive.
+    assert!(
+        !pid_is_alive(999_999),
+        "test precondition: PID 999999 must be dead"
+    );
+    write_stale_claim(&path, 999_999);
+    assert!(path.exists(), "stale file should exist before reclaim");
+
+    let claim = try_claim(port).expect("stale dead-PID claim must be reclaimed");
+    let body = std::fs::read_to_string(&path).expect("read reclaimed claim body");
+    assert_eq!(
+        body.trim(),
+        std::process::id().to_string(),
+        "reclaimed file must hold our PID, with no trailing stale digits"
+    );
+
+    drop(claim);
+    assert!(!path.exists(), "reclaimed claim must be removed on drop");
+}
+
+/// A claim whose holder PID is ALIVE must never be stolen — the single-MLX
+/// invariant. We use our own PID (guaranteed alive) as the holder.
+#[test]
+fn live_pid_claim_is_refused() {
+    let port: u16 = 59881;
+    let path = PathBuf::from(format!("/tmp/rmlx.{port}.claim"));
+    let _ = std::fs::remove_file(&path);
+
+    let self_pid = std::process::id();
+    assert!(pid_is_alive(self_pid), "our own PID must read as alive");
+    write_stale_claim(&path, self_pid);
+
+    let res = try_claim(port);
+    assert!(
+        matches!(res, Err(ClaimError::AlreadyHeld { holder_pid, .. }) if holder_pid == self_pid),
+        "claim with a live holder PID must be refused, got: {res:?}"
+    );
+    // The live-holder file must be left intact (not stolen, not removed).
+    assert!(
+        path.exists(),
+        "live-holder claim file must be left in place"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read body").trim(),
+        self_pid.to_string(),
+        "live-holder claim body must be untouched"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// `pid_is_alive(0)` is conservatively treated as alive so an unreadable /
+/// empty claim body is never stolen.
+#[test]
+fn pid_zero_treated_as_alive() {
+    assert!(
+        pid_is_alive(0),
+        "PID 0 must be treated as alive (conservative)"
+    );
+}
+
 /// Claim file is removed when the guard is dropped.
 #[test]
 fn claim_file_removed_on_drop() {

--- a/crates/rmlx-server/src/claim_tests.rs
+++ b/crates/rmlx-server/src/claim_tests.rs
@@ -100,6 +100,56 @@ fn live_pid_claim_is_refused() {
     let _ = std::fs::remove_file(&path);
 }
 
+/// A claim file whose body holds a DEAD PID but which still has a live
+/// `flock(LOCK_EX)` held on a second fd must NOT be reclaimed: the flock is the
+/// load-bearing gate, so `try_claim` refuses with `AlreadyHeld` even though the
+/// PID probe reports the body PID as dead. This covers the "PID dead but flock
+/// still held" safety branch that `write_stale_claim` cannot exercise (it
+/// closes its fd, releasing the lock).
+#[test]
+fn flock_held_dead_pid_is_refused() {
+    use std::os::unix::io::AsRawFd as _;
+
+    let port: u16 = 59882;
+    let path = PathBuf::from(format!("/tmp/rmlx.{port}.claim"));
+    let _ = std::fs::remove_file(&path);
+
+    // Write a dead PID into the body, but keep a fd open and an exclusive flock
+    // held on it — mimics a live fd whose recorded PID no longer resolves.
+    assert!(
+        !pid_is_alive(999_999),
+        "test precondition: PID 999999 must be dead"
+    );
+    let holder = {
+        use std::io::Write as _;
+        let mut f = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .expect("create flock-held claim file");
+        write!(f, "999999").expect("write dead pid");
+        f.flush().expect("flush dead pid");
+        f
+    };
+    // SAFETY: holder.as_raw_fd() is a valid open fd for the lifetime of `holder`.
+    let locked = unsafe { libc::flock(holder.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    assert_eq!(
+        locked, 0,
+        "test setup: must acquire flock on the claim file"
+    );
+
+    let res = try_claim(port);
+    assert!(
+        matches!(res, Err(ClaimError::AlreadyHeld { .. })),
+        "flock-held claim must be refused even with a dead PID body, got: {res:?}"
+    );
+    // File must be left intact — not stolen, not removed.
+    assert!(path.exists(), "flock-held claim file must be left in place");
+
+    drop(holder); // release the flock + close fd
+    let _ = std::fs::remove_file(&path);
+}
+
 /// `pid_is_alive(0)` is conservatively treated as alive so an unreadable /
 /// empty claim body is never stolen.
 #[test]

--- a/crates/rmlx-server/src/lib.rs
+++ b/crates/rmlx-server/src/lib.rs
@@ -194,6 +194,7 @@ pub async fn serve(state: AppState, host: &str, port: u16) -> anyhow::Result<()>
 /// Resolve when the process receives SIGINT (Ctrl-C) or SIGTERM (`kill` /
 /// `pkill`). Used as the axum graceful-shutdown trigger so normal teardown —
 /// including the `MetalClaim` `Drop` — runs on signalled exit.
+// cancel-safe: only awaits signal-notification futures; no partial state on drop.
 async fn shutdown_signal() {
     use tokio::signal::unix::{signal, SignalKind};
 

--- a/crates/rmlx-server/src/lib.rs
+++ b/crates/rmlx-server/src/lib.rs
@@ -58,7 +58,7 @@ use axum::routing::{get, post};
 use axum::serve::ListenerExt;
 use axum::Router;
 use serde_json::json;
-use tracing::info;
+use tracing::{info, warn};
 
 pub use admission::{
     spawn_controller_task, AdmissionHandle, ControllerConfig, ControllerHandle, DecisionReason,
@@ -180,9 +180,43 @@ pub async fn serve(state: AppState, host: &str, port: u16) -> anyhow::Result<()>
 
     info!(address = %addr, "rmlx-server listening");
 
+    // Graceful shutdown on SIGTERM/SIGINT so the future returns normally and the
+    // caller's `MetalClaim` guard `Drop` runs — proactively removing the claim
+    // file instead of leaving it for the next start's stale-reclaim path. This
+    // only covers signals tokio can intercept; SIGKILL/crash/power-loss still
+    // rely on acquisition-side stale-reclaim (see `claim::try_claim`).
     axum::serve(listener, router)
+        .with_graceful_shutdown(shutdown_signal())
         .await
         .map_err(|e| anyhow::anyhow!("serve: {e}"))
+}
+
+/// Resolve when the process receives SIGINT (Ctrl-C) or SIGTERM (`kill` /
+/// `pkill`). Used as the axum graceful-shutdown trigger so normal teardown —
+/// including the `MetalClaim` `Drop` — runs on signalled exit.
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(s) => s,
+        Err(e) => {
+            // If we cannot install the SIGTERM handler, fall back to Ctrl-C
+            // only; the default disposition (immediate exit) still applies to
+            // SIGTERM and the next start reclaims the stale claim.
+            warn!(error = %e, "failed to install SIGTERM handler; graceful shutdown limited to SIGINT");
+            tokio::signal::ctrl_c().await.ok();
+            return;
+        }
+    };
+
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            info!("received SIGINT — shutting down gracefully");
+        }
+        _ = sigterm.recv() => {
+            info!("received SIGTERM — shutting down gracefully");
+        }
+    }
 }
 
 // ── Health handler ────────────────────────────────────────────────────────────

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -816,19 +816,37 @@ Apple Silicon exposes a single Metal GPU context per process. rMLX enforces
 a single-process invariant via a POSIX lock file at `/tmp/rmlx.<port>.claim`.
 
 - On `rmlx serve --port <N>`: the claim file for port `N` is written and held
-  for the server lifetime. Shutdown releases the file.
+  for the server lifetime. Shutdown releases the file. The server installs a
+  SIGINT/SIGTERM graceful-shutdown handler, so `Ctrl-C`, `kill`, and `pkill`
+  trigger normal teardown and remove the claim proactively.
 - On `rmlx chat`, `rmlx baseline`, `rmlx eval ppl`, and
   `rmlx info --probe-{forward,smoke}`: the sentinel port `0xCAFE` (51966) is
   used as the claim port, indicating a CLI-side (non-HTTP) GPU holder.
 - `rmlx healthcheck --port <N>` checks for the claim file without holding it.
 
-If another rMLX process already holds the claim, the new process logs an
-error and exits with code `11`. The conflicting PID is included in the error
-message. To recover manually:
+### Stale-claim auto-reclaim
+
+A claim left behind by a process that died without running its cleanup —
+SIGKILL, a crash, or power loss, none of which a signal handler can intercept —
+is reclaimed automatically on the next acquisition. When the claim file already
+exists, rMLX reads the holder PID and probes it with `kill(pid, 0)`:
+
+- Holder PID **dead** → the claim is reclaimed (a `warn` is logged) and startup
+  proceeds. No manual `rm` is needed.
+- Holder PID **alive** → the claim is respected; the new process logs an error
+  and exits with code `11`. A live claim is **never** stolen — that would put
+  two MLX processes on the single Metal context.
+
+If another rMLX process holds the claim (live holder), the conflicting PID is
+included in the error message. To stop it and recover manually:
 
 ```bash
 pkill -f 'rmlx serve' && rm -f /tmp/rmlx.<port>.claim
 ```
+
+(The trailing `rm` is only needed if you kill the holder with `SIGKILL`/`-9`;
+a plain `kill`/`pkill` lets graceful shutdown remove the file, and the next
+serve reclaims any stale file regardless.)
 
 CPU-mode runs (`--device cpu`) skip claim acquisition entirely.
 

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -786,13 +786,19 @@ On call:
 If the file already exists:
 
 - The holder's PID is read from the file body.
-- A non-blocking `flock` is attempted. If it succeeds, the previous owner
-  exited without cleanup (stale file); the lock is stolen.
-- If the lock is held, `ClaimError::AlreadyHeld { port, holder_pid }` is
-  returned.
+- The PID is probed with `kill(pid, 0)`. If the holder is **alive**,
+  `ClaimError::AlreadyHeld { port, holder_pid }` is returned — a live claim is
+  never stolen (the single-MLX invariant).
+- If the holder is **dead** (ESRCH), the claim is stale: it was left by a
+  process that died without running `Drop` (SIGKILL, crash, power loss). A
+  non-blocking `flock` confirms no live fd still holds the lock, the file is
+  reclaimed (truncated, rewritten with our PID), and a `warn` is logged.
 
 `MetalClaim` is a RAII guard. Dropping it removes the claim file and releases
-the lock (the `flock` is released automatically when the fd closes).
+the lock (the `flock` is released automatically when the fd closes). The HTTP
+server installs a SIGINT/SIGTERM graceful-shutdown handler so a signalled
+`rmlx serve` runs `Drop` and removes the claim proactively; SIGKILL/crash are
+covered by the dead-PID reclaim above.
 
 Non-server GPU CLI operations (`rmlx info`, `rmlx chat`, `rmlx baseline`) use
 the sentinel port `0xCAFE` (51966) to represent "a single-shot GPU op in


### PR DESCRIPTION
## Summary

`rmlx serve` left a stale `/tmp/rmlx.<port>.claim` when terminated via SIGTERM/SIGKILL/crash — the `MetalClaim` RAII `Drop` only runs on normal exit, so the next serve had to clear a dead-owner claim by hand.

Closes #107.

## Fix

**Primary — acquisition-side auto-reclaim (handles SIGKILL/crash, which no signal handler can):** `try_claim` reads the holder PID and probes `kill(pid, 0)`. Alive → refuse (`AlreadyHeld`, exit 11). Dead (ESRCH) → take the exclusive flock, **re-read + re-probe the PID under the held lock**, and only then reclaim (truncate + rewrite PID) with a `warn!`. PID 0 → treated alive (conservative).

**Secondary — graceful shutdown:** a `tokio::signal` handler (SIGINT + SIGTERM) wired into `axum … with_graceful_shutdown`, so a signalled serve returns its future normally and `Drop` removes the claim proactively.

Also fixed a latent trailing-stale-digit bug: the reclaim path `set_len(0)` + seek-0 before writing the new PID.

## Safety

The **flock is the load-bearing gate**: a live `rmlx` holds its claim's open fd, so `flock_ex_nb` fails for anyone else → a live MLX claim can never be stolen (no two MLX processes on the GPU). The PID probe is a secondary detector for a stale file whose holder is gone, and the re-read-under-lock closes the PID-reuse window in the fail-safe direction (refuse-when-uncertain). The module docs now state this accurately (flock-primary / PID-secondary). No bypass/force flag added.

## Validation

- Unit (`cargo test -p rmlx-server --lib claim`): 6 pass — `stale_dead_pid_is_reclaimed`, `live_pid_claim_is_refused` (uses the real live PID, asserts file untouched), `pid_zero_treated_as_alive`, and `flock_held_dead_pid_is_refused` (a flock-held file with a dead-PID body is never reclaimed).
- **Real serve:** (a) a LIVE serve's claim is respected by a second serve (exit 11, not stolen); (b) a SIGKILL'd serve's stale dead-PID claim is auto-reclaimed by the next serve (warn + acquire); (c) SIGTERM → graceful shutdown removes the claim via `Drop`.
- `make lint` clean, `cargo fmt --all` clean.

## Docs

- `docs/CLI.md` + `docs/SERVER.md` — claim-file lifecycle: dead-PID auto-reclaim (warn) vs live refusal (exit 11), and graceful-shutdown behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)