### PR TITLE
fix(gemma4): wire native audio input through serve/engine path (#122)

### DIFF
--- a/crates/rmlx-models/src/gemma4/audio/mod.rs
+++ b/crates/rmlx-models/src/gemma4/audio/mod.rs
@@ -652,6 +652,25 @@ impl AudioEncoder {
         &self.cfg
     }
 
+    /// Number of audio soft tokens (`T_sub`) this tower emits for `n_mel_frames`
+    /// input log-mel frames.
+    ///
+    /// The two SSCP conv blocks each apply symmetric (1,1) time padding then a
+    /// stride-2, kernel-3 Conv2d, so each block maps `T -> floor((T - 1)/2) + 1`.
+    /// The server uses this to splice exactly `T_sub` `<|audio|>` placeholders
+    /// into the prompt so the scatter in [`build_audio_inputs_embeds`] aligns by
+    /// construction (mirrors the vision tower's known `num_soft_tokens`).
+    pub fn num_output_frames(&self, n_mel_frames: usize) -> usize {
+        fn conv_stride2(t: usize) -> usize {
+            // floor((t + 2*pad - kernel)/stride) + 1 with pad=1, kernel=3, stride=2.
+            if t == 0 {
+                return 0;
+            }
+            (t - 1) / 2 + 1
+        }
+        conv_stride2(conv_stride2(n_mel_frames))
+    }
+
     /// Build the `[chunk_size, context_size]` local causal+validity mask
     /// (1.0 = valid). Matches `_build_causal_valid_mask`.
     fn build_causal_valid_mask(&self, device: Device) -> Result<Array> {
@@ -868,6 +887,124 @@ pub fn load_audio_tower(model_dir: &Path, cfg: &Gemma4AudioConfig) -> Result<Aud
         layers,
         output_proj,
     })
+}
+
+// ---------------------------------------------------------------------------
+// build multimodal `inputs_embeds` (text + scattered audio features)
+// ---------------------------------------------------------------------------
+
+/// Build the merged `inputs_embeds` for a Gemma4 audio prompt.
+///
+/// Faithful host port of the audio branch of mlx-vlm
+/// `gemma4.py::Model.get_input_embeddings`:
+/// 1. `inputs_embeds = embed_tokens(input_ids) * embed_scale` (scaled text).
+/// 2. Run the Conformer audio tower over the log-mel features →
+///    `[1, T_sub, output_dim]`, then `embed_audio` → `[1, T_sub, hidden]` f32 →
+///    astype to the embedding dtype → scatter into `inputs_embeds` at the
+///    `audio_token_id` positions (the contiguous `<|audio|>` run in the prompt).
+/// 3. The per-layer-input ids mask the audio positions to `0` (mlx-vlm zeroes
+///    multimodal token ids before `get_per_layer_inputs`).
+///
+/// `audio_mel`: `[1, T, feature_size]` log-mel features.
+/// `audio_mel_mask`: `[1, T]` (1.0 = padding/invalid), the inverse of the
+/// feature-extractor attention mask (matching `~input_features_mask` upstream).
+///
+/// Returns `(inputs_embeds [1, seq, hidden], masked_ids [seq])`. Both feed
+/// [`super::model::Gemma4Text::forward_arr_embeds`] via `generate_image`.
+///
+/// Errors if the `audio_token_id` placeholder count in `input_ids` does not
+/// equal the audio tower's `T_sub` output frame count — a misalignment would
+/// scatter audio rows into the wrong positions and produce garbage output. The
+/// server side builds the prompt with exactly `T_sub` placeholders (computed by
+/// [`AudioEncoder::num_output_frames`]) so this is an invariant guard.
+#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+pub fn build_audio_inputs_embeds(
+    model: &super::model::Gemma4Text,
+    encoder: &AudioEncoder,
+    embedder: &super::vision::MultimodalEmbedder,
+    audio_mel: &Array,
+    audio_mel_mask: &Array,
+    audio_token_id: u32,
+    input_ids: &[u32],
+    device: Device,
+) -> Result<(Array, Array)> {
+    let hidden = model.cfg.hidden_size as i32;
+    let seq = input_ids.len();
+
+    // Locate the audio-token positions (one contiguous run per clip, in order).
+    let audio_positions: Vec<usize> = input_ids
+        .iter()
+        .enumerate()
+        .filter(|(_, &t)| t == audio_token_id)
+        .map(|(i, _)| i)
+        .collect();
+
+    // Encode: Conformer tower -> [1, T_sub, output_dim] -> embed_audio ->
+    // [1, T_sub, hidden] f32.
+    let enc = encoder.forward(audio_mel, audio_mel_mask, device)?;
+    let feats = embedder.forward(&enc, device)?;
+    let fs = feats.shape();
+    let t_sub = fs.get(1).copied().unwrap_or(0);
+    if fs.first().copied() != Some(1) || fs.get(2).copied() != Some(hidden) {
+        return Err(Error::Model(format!(
+            "gemma4 audio: audio feature shape {fs:?} != [1, T_sub, {hidden}]"
+        )));
+    }
+    if audio_positions.len() != t_sub as usize {
+        return Err(Error::Model(format!(
+            "gemma4 audio: {} audio-token ({audio_token_id}) positions in prompt != \
+             {t_sub} audio soft tokens (encoder output) — scatter would misalign",
+            audio_positions.len()
+        )));
+    }
+    // The audio run must be contiguous (the processor emits one `<|audio|>` run).
+    let first = audio_positions.first().copied().unwrap_or(0);
+    let contiguous = audio_positions
+        .iter()
+        .enumerate()
+        .all(|(k, &p)| p == first + k);
+    if !contiguous {
+        return Err(Error::Model(format!(
+            "gemma4 audio: audio-token positions are not contiguous (got {audio_positions:?})"
+        )));
+    }
+    info!(
+        audio_tokens = audio_positions.len(),
+        t_sub, seq, "gemma4 audio: building inputs_embeds (token count == soft tokens)"
+    );
+
+    // ---- scaled text embeddings: embed_tokens(ids) * sqrt(hidden) ----------
+    let ids_i32: Vec<i32> = input_ids.iter().map(|&x| x as i32).collect();
+    let ids_arr = Array::from_bytes(i32_bytes(&ids_i32), &[seq as i32], Dtype::I32)?;
+    let h_raw = model.embed_tokens.forward(&ids_arr, device)?;
+    let embed_scale = scalar_f32((model.cfg.hidden_size as f32).sqrt());
+    let mut embeds = multiply(&h_raw, &embed_scale, device)?;
+    embeds = embeds.reshape(&[1, seq as i32, hidden], device)?;
+    let embeds_dtype = embeds.dtype();
+
+    // astype to the embedding dtype (bf16) before scatter, then splice the
+    // contiguous audio run in one slice_update.
+    let feats = feats.astype(embeds_dtype, device)?;
+    embeds = embeds.slice_update(
+        &feats,
+        &[0, first as i32, 0],
+        &[1, (first + t_sub as usize) as i32, hidden],
+        &[1, 1, 1],
+        device,
+    )?;
+
+    // ---- masked ids for per-layer-input gating -----------------------------
+    let mut masked: Vec<i32> = ids_i32;
+    for &p in &audio_positions {
+        masked[p] = 0;
+    }
+    let masked_arr = Array::from_bytes(i32_bytes(&masked), &[seq as i32], Dtype::I32)?;
+
+    Ok((embeds, masked_arr))
 }
 
 /// Construct an [`AudioAttention`], precomputing scalar scales + inv-timescales.

--- a/crates/rmlx-models/src/gemma4/audio/mod.rs
+++ b/crates/rmlx-models/src/gemma4/audio/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! Faithful port of `mlx_vlm/models/gemma4/audio.py`. Pipeline (batch=1):
 //!
-//! log-mel `[B, T, 128]` (from )
+//! log-mel `[B, T, 128]` (from `Gemma4AudioFeatureExtractor`)
 //! -> SSCP: 2× (Conv2d stride-2 + LayerNorm(channels) + ReLU) -> flatten(F·C)
 //! -> `input_proj_linear` -> `[B, T_sub, hidden=1024]`
 //! -> 12 Conformer blocks: FFW1(macaron 0.5) -> Attention -> LightConv1d
@@ -635,7 +635,8 @@ impl ConformerBlock {
 
 /// Gemma4 Conformer audio tower (`audio_tower.*`). Forward consumes log-mel
 /// features `[B, T, 128]` and produces `[B, T_sub, output_proj_dims]` audio
-/// embeddings (fed to `embed_audio` / `MultimodalEmbedder` by ).
+/// embeddings (fed to `embed_audio` / `MultimodalEmbedder` by
+/// [`build_audio_inputs_embeds`]).
 #[allow(missing_debug_implementations)]
 pub struct AudioEncoder {
     cfg: Gemma4AudioConfig,

--- a/crates/rmlx-models/src/gemma4/audio/tests.rs
+++ b/crates/rmlx-models/src/gemma4/audio/tests.rs
@@ -219,6 +219,54 @@ fn gemma4_audio_encoder_forward_shape() {
     );
 }
 
+/// `num_output_frames` must exactly predict the `forward` output length
+/// (`T_sub`) so the server can splice the right number of `<|audio|>`
+/// placeholders before the tower runs. Without this the audio scatter in
+/// `build_audio_inputs_embeds` would misalign and the build would error.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init or validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free; remaining unwrap is on values established by construction"
+)]
+fn gemma4_audio_num_output_frames_matches_forward() {
+    let device = Device::Cpu;
+    let cfg = small_cfg();
+    let enc = synth_tower(&cfg);
+
+    for &t_frames in &[5i32, 17, 64, 100, 257, 513] {
+        let n = (t_frames as usize) * SSCP_INPUT_FEAT_SIZE;
+        let v = vec![0.0f32; n];
+        let mel = Array::from_bytes(
+            f32_bytes(&v),
+            &[1, t_frames, SSCP_INPUT_FEAT_SIZE as i32],
+            Dtype::F32,
+        )
+        .unwrap();
+        let mask = zeros(&[1, t_frames]);
+        let out = enc.forward(&mel, &mask, device).expect("audio forward");
+        out.eval().expect("eval");
+        let actual = out.shape()[1] as usize;
+        let predicted = enc.num_output_frames(t_frames as usize);
+        assert_eq!(
+            predicted, actual,
+            "num_output_frames({t_frames}) = {predicted} != forward T_sub {actual}"
+        );
+    }
+    assert_eq!(
+        enc.num_output_frames(0),
+        0,
+        "zero frames → zero soft tokens"
+    );
+}
+
 /// Real-weights forward (gated on the e4b snapshot, `--ignored`).
 #[test]
 #[ignore = "requires e4b snapshot; run with --ignored"]

--- a/crates/rmlx-models/src/gemma4/mod.rs
+++ b/crates/rmlx-models/src/gemma4/mod.rs
@@ -37,7 +37,7 @@ pub(crate) mod prompt_cache;
 mod tests;
 mod vision;
 
-pub use audio::{load_audio_tower, AudioEncoder};
+pub use audio::{build_audio_inputs_embeds, load_audio_tower, AudioEncoder};
 pub use audio_feature_extractor::{
     AudioFeatError, AudioFeatureExtractorConfig, Gemma4AudioFeatureExtractor,
 };
@@ -53,5 +53,6 @@ pub use preprocessor::{
 pub use prompt_cache::read_cache_stats as gemma4_cache_stats;
 pub use prompt_cache::read_kv_cache_bytes as gemma4_kv_cache_bytes;
 pub use vision::{
-    build_inputs_embeds, load_vision_tower, MultimodalEmbedder, VisionModel, IMAGE_TOKEN_ID,
+    build_inputs_embeds, load_multimodal_embedder, load_vision_tower, MultimodalEmbedder,
+    VisionModel, IMAGE_TOKEN_ID,
 };

--- a/crates/rmlx-models/src/gemma4/vision/mod.rs
+++ b/crates/rmlx-models/src/gemma4/vision/mod.rs
@@ -555,8 +555,6 @@ pub fn load_vision_tower(
     model_dir: &Path,
     cfg: &Gemma4VisionConfig,
 ) -> Result<(VisionModel, MultimodalEmbedder)> {
-    use crate::layers::Linear as CoreLinear;
-
     let idx = load_shard_index(model_dir)?;
     let shards = ShardSet::open(model_dir, &idx)?;
 
@@ -667,7 +665,55 @@ pub fn load_vision_tower(
     };
 
     // MultimodalEmbedder: embed_vision.embedding_projection (quantized if .scales).
-    let proj_base = "embed_vision.embedding_projection";
+    let embedder = load_multimodal_embedder(model_dir, "embed_vision", cfg.rms_norm_eps)?;
+
+    info!(
+        layers = cfg.num_hidden_layers,
+        "gemma4: vision tower + multimodal embedder loaded"
+    );
+    Ok((vision, embedder))
+}
+
+/// Load a Gemma4 [`MultimodalEmbedder`] (`<base>.embedding_projection.*`) from a
+/// snapshot directory. Shared by the vision (`embed_vision`) and audio
+/// (`embed_audio`) towers — both are the identical `RMSNormNoScale -> Linear`
+/// projection into the language-model hidden space, differing only in the
+/// `embedding_dim` of the (possibly quantized) projection weight.
+pub fn load_multimodal_embedder(
+    model_dir: &Path,
+    base: &str,
+    norm_eps: f32,
+) -> Result<MultimodalEmbedder> {
+    use crate::layers::Linear as CoreLinear;
+
+    let idx = load_shard_index(model_dir)?;
+    let shards = ShardSet::open(model_dir, &idx)?;
+
+    fn load_f32(shards: &ShardSet, name: &str) -> Result<Array> {
+        for (_, handle) in shards.iter() {
+            let st = handle.safetensors()?;
+            if let Ok(t) = st.tensor(name) {
+                let tv = rmlx_loader::TensorView {
+                    name,
+                    dtype: t.dtype(),
+                    shape: t.shape().to_vec(),
+                    bytes: t.data(),
+                };
+                let a = Array::from_safetensor_view(&tv)?;
+                return a.astype(Dtype::F32, Device::Cpu);
+            }
+        }
+        Err(Error::Loader(format!(
+            "gemma4 embedder: tensor '{name}' not found in any shard"
+        )))
+    }
+    let has = |name: &str| -> bool {
+        shards
+            .iter()
+            .any(|(_, h)| h.safetensors().is_ok_and(|st| st.tensor(name).is_ok()))
+    };
+
+    let proj_base = format!("{base}.embedding_projection");
     let projection = if has(&format!("{proj_base}.scales")) {
         let weight = load_raw(&shards, &format!("{proj_base}.weight"))?;
         let scales = load_raw(&shards, &format!("{proj_base}.scales"))?;
@@ -691,15 +737,10 @@ pub fn load_vision_tower(
         }
     };
 
-    info!(
-        layers = cfg.num_hidden_layers,
-        "gemma4: vision tower + multimodal embedder loaded"
-    );
-    let embedder = MultimodalEmbedder {
+    Ok(MultimodalEmbedder {
         projection,
-        norm_eps: cfg.rms_norm_eps,
-    };
-    Ok((vision, embedder))
+        norm_eps,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rmlx-models/src/gemma4/vision/mod.rs
+++ b/crates/rmlx-models/src/gemma4/vision/mod.rs
@@ -757,8 +757,11 @@ pub const IMAGE_TOKEN_ID: u32 = 258880;
 /// Faithful host port of mlx-vlm `gemma4.py::Model.get_input_embeddings`:
 /// 1. `inputs_embeds = embed_tokens(input_ids) * embed_scale` (scaled text).
 /// 2. For each image: `embed_vision(vision_tower(pixels))` → `[1, n_soft,
-/// hidden]` f32 → astype bf16 → scatter into `inputs_embeds` at that
+///    hidden]` f32 → astype bf16 → scatter into `inputs_embeds` at that
+///    image's contiguous run of `IMAGE_TOKEN_ID` positions.
 /// 3. The per-layer-input ids mask the image positions to `0` (mlx-vlm
+///    zeroes the soft-token ids so per-layer gating sees text-only ids at
+///    the image positions).
 ///
 /// Returns `(inputs_embeds [1, seq, hidden], masked_ids [seq])`. Both feed
 /// [`super::model::Gemma4Text::forward_arr_embeds`].

--- a/crates/rmlx-server/src/engine/arch_generator.rs
+++ b/crates/rmlx-server/src/engine/arch_generator.rs
@@ -18,6 +18,7 @@ use rmlx_metrics::events::Measurement;
 
 use crate::openai::ItlSample;
 
+use super::audio::{build_audio_prompt, AudioBundle};
 use super::generator::Generator;
 use super::helpers::{
     compute_itl_stats, is_reconstructible_tool_marker, kv_quant_label, record_itl_percentiles,
@@ -76,6 +77,12 @@ pub struct ArchGenerator {
     /// `None` for text-only checkpoints (the image path is then rejected with
     /// a clear error). Wrapped in `Arc` so a clone moves into `spawn_blocking`.
     vision: Option<Arc<VisionBundle>>,
+    /// Gemma4 Conformer audio tower + multimodal embedder + USM feature
+    /// extractor, loaded once at startup when the snapshot ships an
+    /// `audio_config` + `audio_tower.*` weights. `None` for checkpoints without
+    /// an audio path (the `input_audio` path is then rejected with a clear
+    /// error). Wrapped in `Arc` so a clone moves into `spawn_blocking`.
+    audio: Option<Arc<AudioBundle>>,
     /// Shared multimodal encoder-output cache. `None` disables
     /// caching for this generator (e.g. unit-test stubs); production passes
     /// the `AppState.mm_cache` clone via `ModelLoadConfig`.
@@ -330,6 +337,28 @@ impl ArchGenerator {
             _ => None,
         };
 
+        // load the Gemma4 audio tower once when the snapshot ships an
+        // `audio_config` (+ `audio_tower.*` weights). Text-only / vision-only
+        // models return `None` here and the `input_audio` path is rejected at
+        // request time with a clear error. Only the Gemma4 architecture has a
+        // native audio tower today.
+        let audio: Option<Arc<AudioBundle>> = match &model {
+            rmlx_models::arch::Architecture::Gemma4(_) => {
+                match super::audio::load_gemma4_audio_bundle(model_dir) {
+                    Ok(Some(bundle)) => {
+                        tracing::info!(model_id = %model_id, "Gemma4 audio tower loaded (multimodal)");
+                        Some(Arc::new(bundle))
+                    }
+                    Ok(None) => None,
+                    Err(e) => {
+                        tracing::warn!(model_id = %model_id, error = %e, "audio tower load failed — audio input disabled");
+                        None
+                    }
+                }
+            }
+            _ => None,
+        };
+
         // turn the SSD prompt-cache tier ON for this model if configured
         // (`--kv-ssd-cache-gb > 0`). No-op when the tier is OFF (the default):
         // the spiller / hydrator are never installed and decode is
@@ -380,6 +409,7 @@ impl ArchGenerator {
             effective_max_ctx,
             tokenizer_kind,
             vision,
+            audio,
             mm_cache: load_cfg.mm_cache.clone(),
         })
     }
@@ -466,6 +496,10 @@ impl Generator for ArchGenerator {
         // `req_images` is empty for text-only requests (zero extra work).
         let req_images = req.images.clone();
         let vision = self.vision.clone();
+        // base64 `input_audio` clips + the loaded audio bundle (clone of the Arc).
+        // `req_audio` is empty for non-audio requests (zero extra work).
+        let req_audio = req.audio_b64.clone();
+        let audio = self.audio.clone();
         let mm_cache = self.mm_cache.clone();
         // Issue #26: a per-request `kv_quant` override hot-swaps the KV codec on
         // the resident model. When present it takes precedence over the launch
@@ -899,6 +933,43 @@ impl Generator for ArchGenerator {
                     None
                 };
 
+            // audio path — decode the `input_audio` clip, expand the prompt with
+            // the audio soft-token block (`<|audio>` + T_sub×`<|audio|>` +
+            // `<audio|>`), run the Conformer tower, build the scatter-merged
+            // `inputs_embeds`, and decode from embeds. Routed through the same
+            // `generate_image` fused-embeds entry as vision (both carry the
+            // `(aug_ids, embeds, masked_ids)` triple). Submitting `input_audio`
+            // to a model without an audio tower returns a CLEAR error here
+            // (mirroring vision's no-tower rejection) — never a silent drop.
+            // Skipped entirely when images are present (image takes precedence).
+            let audio_inputs: Option<(Vec<u32>, rmlx_mlx::Array, rmlx_mlx::Array)> = if !req_audio
+                .is_empty()
+                && image_inputs.is_none()
+                && !qvl_image
+            {
+                if let Some(ab) = audio.as_ref() {
+                    match build_audio_prompt(model.as_ref(), ab, &req_audio, &prompt_tokens, device)
+                    {
+                        Ok(triple) => Some(triple),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "audio preprocessing failed");
+                            let _ = tx.blocking_send(Err(e));
+                            return;
+                        }
+                    }
+                } else {
+                    let _ = tx.blocking_send(Err(Error::Other(
+                        "this model does not accept audio input (no audio tower)".to_owned(),
+                    )));
+                    return;
+                }
+            } else {
+                None
+            };
+
+            // Image takes precedence over audio when both are present.
+            let multimodal_inputs = image_inputs.or(audio_inputs);
+
             let steps_result = if qvl_image {
                 // SAFETY: qvl_image is true only when vision.as_deref() matched
                 // Some(VisionBundle::Qwen3VlMoe{..}) two lines above, so this
@@ -938,7 +1009,7 @@ impl Generator for ArchGenerator {
                     mm_cache.as_deref(),
                 )
             } else {
-                match image_inputs {
+                match multimodal_inputs {
                     Some((aug_ids, embeds, masked_ids)) => model.generate_image(
                         &tokenizer,
                         &aug_ids,

--- a/crates/rmlx-server/src/engine/arch_generator.rs
+++ b/crates/rmlx-server/src/engine/arch_generator.rs
@@ -28,6 +28,25 @@ use super::image::{build_image_prompt, run_qwen3vl_image, VisionBundle};
 use super::think::ThinkSplitter;
 use super::types::{GenerationRequest, GenerationToken, ModelLoadConfig};
 
+/// Reject the unsupported image + audio combination in a single request.
+///
+/// The fused `generate_image` embeds entry carries a single `(aug_ids, embeds,
+/// masked_ids)` triple, so only one modality block can be scattered per
+/// request. Returns a CLEAR request-level error when BOTH an image and an audio
+/// clip are present (never a silent drop of the audio), and `None` otherwise so
+/// the audio-only / image-only / text-only paths route unchanged.
+fn reject_combined_image_audio(has_image: bool, has_audio: bool) -> Option<Error> {
+    if has_image && has_audio {
+        Some(Error::Other(
+            "combined image + audio input in one request is not supported; \
+             send them in separate turns"
+                .to_owned(),
+        ))
+    } else {
+        None
+    }
+}
+
 // ── ArchGenerator ─────────────────────────────────────────────────────────────
 
 /// Architecture-agnostic HTTP generation engine. Loads any registry arch via
@@ -933,6 +952,22 @@ impl Generator for ArchGenerator {
                     None
                 };
 
+            // Combined image + audio in one request is not supported. Reject
+            // with a CLEAR request-level error rather than silently dropping the
+            // audio (the exact class of bug this audio wiring exists to
+            // eliminate) — surfaced as a proper HTTP error through the same
+            // channel as the other request-rejection paths in this function.
+            if let Some(err) =
+                reject_combined_image_audio(!req_images.is_empty(), !req_audio.is_empty())
+            {
+                tracing::warn!(
+                    model_id = %model_id_for_log,
+                    "rejecting combined image + audio input in one request"
+                );
+                let _ = tx.blocking_send(Err(err));
+                return;
+            }
+
             // audio path — decode the `input_audio` clip, expand the prompt with
             // the audio soft-token block (`<|audio>` + T_sub×`<|audio|>` +
             // `<audio|>`), run the Conformer tower, build the scatter-merged
@@ -941,7 +976,8 @@ impl Generator for ArchGenerator {
             // `(aug_ids, embeds, masked_ids)` triple). Submitting `input_audio`
             // to a model without an audio tower returns a CLEAR error here
             // (mirroring vision's no-tower rejection) — never a silent drop.
-            // Skipped entirely when images are present (image takes precedence).
+            // Image + audio in one request was already rejected above, so here
+            // `image_inputs` is `None` whenever `req_audio` is non-empty.
             let audio_inputs: Option<(Vec<u32>, rmlx_mlx::Array, rmlx_mlx::Array)> = if !req_audio
                 .is_empty()
                 && image_inputs.is_none()
@@ -967,7 +1003,8 @@ impl Generator for ArchGenerator {
                 None
             };
 
-            // Image takes precedence over audio when both are present.
+            // Image and audio are mutually exclusive per request (combined input
+            // rejected above), so at most one of these is `Some`.
             let multimodal_inputs = image_inputs.or(audio_inputs);
 
             let steps_result = if qvl_image {
@@ -1384,3 +1421,7 @@ impl Generator for ArchGenerator {
         Box::pin(token_stream)
     }
 }
+
+#[cfg(test)]
+#[path = "arch_generator_tests.rs"]
+mod arch_generator_tests;

--- a/crates/rmlx-server/src/engine/arch_generator_tests.rs
+++ b/crates/rmlx-server/src/engine/arch_generator_tests.rs
@@ -1,0 +1,58 @@
+//! Model-free routing-guard tests for `ArchGenerator`.
+//!
+//! `reject_combined_image_audio` is the request-level guard that fires before
+//! any tower access, so these tests need no model snapshot. They lock the
+//! invariant that a request carrying BOTH an image and an audio clip is
+//! rejected with a CLEAR error (never a silent drop), while the audio-only,
+//! image-only, and text-only paths route unchanged (no rejection).
+
+use super::reject_combined_image_audio;
+use rmlx_core::Error;
+
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "guard must return Some(err) for the both-present case; .expect() documents that invariant"
+)]
+fn combined_image_and_audio_is_rejected_with_clear_error() {
+    let err = reject_combined_image_audio(true, true)
+        .expect("combined image + audio must be rejected, not silently dropped");
+    // Must surface as a request-level `Other` error (proper HTTP error, not a panic).
+    assert!(
+        matches!(err, Error::Other(_)),
+        "expected Error::Other request-level rejection, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("combined image + audio input in one request is not supported"),
+        "error message must clearly explain the unsupported combination: {msg}"
+    );
+    assert!(
+        msg.contains("separate turns"),
+        "error message must tell the caller to send them in separate turns: {msg}"
+    );
+}
+
+#[test]
+fn audio_only_request_is_not_rejected() {
+    assert!(
+        reject_combined_image_audio(false, true).is_none(),
+        "audio-only request must route to the audio path, not be rejected"
+    );
+}
+
+#[test]
+fn image_only_request_is_not_rejected() {
+    assert!(
+        reject_combined_image_audio(true, false).is_none(),
+        "image-only request must route to the image path, not be rejected"
+    );
+}
+
+#[test]
+fn text_only_request_is_not_rejected() {
+    assert!(
+        reject_combined_image_audio(false, false).is_none(),
+        "text-only request must route to the plain path, not be rejected"
+    );
+}

--- a/crates/rmlx-server/src/engine/audio.rs
+++ b/crates/rmlx-server/src/engine/audio.rs
@@ -1,0 +1,216 @@
+//! Audio-prompt construction helpers shared by ArchGenerator.
+//!
+//! - `AudioBundle` — arch-specific multimodal audio components (loaded once)
+//! - `build_audio_prompt` — Gemma4 audio embedding + token splice
+//!
+//! Mirrors `engine/image.rs` for the vision tower. The Gemma4 Conformer audio
+//! tower turns raw `input_audio` (base64 wav/etc) into audio soft tokens that
+//! are scattered into the prompt at `<|audio|>` placeholder positions.
+
+use std::path::Path;
+
+use rmlx_core::Error;
+
+// ── Gemma4 audio token ids ────────────────────────────────────────────────
+
+/// Gemma4 `<|audio>` begin-of-audio marker token id.
+pub(crate) const GEMMA4_BOA_TOKEN_ID: u32 = 256_000;
+/// Gemma4 `<audio|>` end-of-audio marker token id.
+pub(crate) const GEMMA4_EOA_TOKEN_ID: u32 = 258_883;
+
+/// Sample rate the Gemma4 USM front-end expects (16 kHz mono).
+const GEMMA4_AUDIO_SAMPLE_RATE: u32 = 16_000;
+
+/// bundle of the multimodal components needed to turn `input_audio` bytes into
+/// scattered `inputs_embeds`. Loaded once per model when the snapshot ships an
+/// `audio_config` + `audio_tower.*` weights. One variant per audio-capable
+/// architecture (only Gemma4's Conformer tower today).
+#[allow(missing_debug_implementations)]
+pub(crate) enum AudioBundle {
+    /// Gemma4 Conformer audio tower + multimodal embedder + feature extractor.
+    Gemma4 {
+        encoder: rmlx_models::gemma4::AudioEncoder,
+        embedder: rmlx_models::gemma4::MultimodalEmbedder,
+        feature_extractor: rmlx_models::gemma4::Gemma4AudioFeatureExtractor,
+        audio_token_id: u32,
+    },
+}
+
+/// Load the Gemma4 audio bundle (Conformer tower + `embed_audio` projector +
+/// USM feature extractor) from a snapshot directory.
+///
+/// Returns `Ok(None)` for checkpoints without an `audio_config` (text-only or
+/// vision-only). Errors propagate to the caller, which logs + disables the
+/// audio path (audio input then returns a clear "no audio tower" error).
+pub(crate) fn load_gemma4_audio_bundle(model_dir: &Path) -> rmlx_core::Result<Option<AudioBundle>> {
+    let Some(acfg) = rmlx_models::gemma4::Gemma4AudioConfig::from_model_dir(model_dir)? else {
+        return Ok(None);
+    };
+    let encoder = rmlx_models::gemma4::load_audio_tower(model_dir, &acfg)?;
+    let embedder =
+        rmlx_models::gemma4::load_multimodal_embedder(model_dir, "embed_audio", acfg.rms_norm_eps)?;
+    let feature_extractor = load_gemma4_feature_extractor(model_dir)?;
+    Ok(Some(AudioBundle::Gemma4 {
+        encoder,
+        embedder,
+        feature_extractor,
+        audio_token_id: acfg.audio_token_id,
+    }))
+}
+
+/// Build the Gemma4 USM feature extractor from the snapshot's
+/// `processor_config.json` (`feature_extractor` block). Falls back to the
+/// documented USM defaults when the file or block is absent — the front-end
+/// parameters are fixed for all Gemma 4 checkpoints.
+fn load_gemma4_feature_extractor(
+    model_dir: &Path,
+) -> rmlx_core::Result<rmlx_models::gemma4::Gemma4AudioFeatureExtractor> {
+    use rmlx_models::gemma4::{AudioFeatureExtractorConfig, Gemma4AudioFeatureExtractor};
+
+    let path = model_dir.join("processor_config.json");
+    match std::fs::read_to_string(&path) {
+        Ok(json) => Gemma4AudioFeatureExtractor::from_processor_config_str(&json)
+            .map_err(|e| Error::Other(format!("gemma4 audio feature extractor: {e}"))),
+        Err(_) => {
+            // No processor_config.json — use the fixed USM defaults.
+            Ok(Gemma4AudioFeatureExtractor::from_config(
+                serde_json::from_str::<AudioFeatureExtractorConfig>("{}")
+                    .map_err(|e| Error::Other(format!("gemma4 audio default config: {e}")))?,
+            ))
+        }
+    }
+}
+
+/// Decode + preprocess `input_audio` clips, expand the prompt with per-clip
+/// audio soft-token blocks, run the Conformer tower, and build the
+/// scatter-merged `inputs_embeds`.
+///
+/// Pipeline (mirrors mlx-vlm `processing_gemma4` + `get_input_embeddings`):
+/// 1. base64 → bytes → `WavDecoder` (mono f32, native rate) → resample 16 kHz.
+/// 2. `Gemma4AudioFeatureExtractor::extract` → log-mel `[T, 128]`.
+/// 3. `encoder.num_output_frames(T)` → `T_sub`; splice the audio block
+///    `<|audio>` + `T_sub` × `<|audio|>` + `<audio|>` after the leading token.
+/// 4. `gemma4::build_audio_inputs_embeds` runs the Conformer tower + projector
+///    and scatters the audio soft tokens at the `<|audio|>` positions.
+///
+/// Currently serves exactly one audio clip per request; >1 is rejected with a
+/// clear error rather than silently mis-scattering.
+///
+/// Returns `(augmented_ids, inputs_embeds [1, seq, hidden], masked_ids [seq])`.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: indices bounded by slice length or validated before call"
+)]
+pub(crate) fn build_audio_prompt(
+    arch: &rmlx_models::arch::Architecture,
+    ab: &AudioBundle,
+    audio_b64: &[String],
+    prompt_tokens: &[u32],
+    device: rmlx_mlx::Device,
+) -> rmlx_core::Result<(Vec<u32>, rmlx_mlx::Array, rmlx_mlx::Array)> {
+    if audio_b64.len() != 1 {
+        return Err(Error::Other(format!(
+            "audio input currently serves exactly one audio clip per request (got {})",
+            audio_b64.len()
+        )));
+    }
+
+    let AudioBundle::Gemma4 {
+        encoder,
+        embedder,
+        feature_extractor,
+        audio_token_id,
+    } = ab;
+
+    let model = arch
+        .as_gemma4()
+        .ok_or_else(|| Error::Other("audio input requires the Gemma4 architecture".to_owned()))?;
+
+    // 1. base64 → bytes → mono f32 @ 16 kHz.
+    let raw = audio_b64[0].as_str();
+    // Tolerate a `data:audio/...;base64,` prefix even though the OpenAI shape
+    // carries the bare base64 in `input_audio.data`.
+    let b64 = raw.rsplit_once(',').map_or(raw, |(_, tail)| tail);
+    let bytes = crate::image_io::base64_decode(b64)
+        .map_err(|e| Error::Other(format!("input_audio base64 decode failed: {e}")))?;
+    let (samples, sample_rate) = rmlx_audio::wav::WavDecoder::decode(&bytes)
+        .map_err(|e| Error::Other(format!("input_audio decode failed: {e}")))?;
+    let samples = rmlx_audio::transcribe::resample_to_16k(&samples, sample_rate);
+    let dur_secs = samples.len() as f64 / f64::from(GEMMA4_AUDIO_SAMPLE_RATE);
+
+    // 2. log-mel features [T, 128].
+    let mel = feature_extractor
+        .extract(&samples)
+        .map_err(|e| Error::Other(format!("input_audio mel extraction failed: {e}")))?;
+    let t_mel = mel.len();
+    if t_mel == 0 {
+        return Err(Error::Other(
+            "input_audio produced zero mel frames (clip too short)".to_owned(),
+        ));
+    }
+    let feature_size = mel[0].len();
+
+    // 3. number of audio soft tokens this clip yields (encoder output frames).
+    let t_sub = encoder.num_output_frames(t_mel);
+    if t_sub == 0 {
+        return Err(Error::Other(
+            "input_audio produced zero audio soft tokens (clip too short)".to_owned(),
+        ));
+    }
+
+    tracing::info!(
+        sample_rate,
+        samples = samples.len(),
+        duration_secs = dur_secs,
+        mel_frames = t_mel,
+        feature_size,
+        audio_soft_tokens = t_sub,
+        "Gemma4 audio preprocessed"
+    );
+
+    // Flatten mel into a [1, T, feature_size] f32 array; all-zero padding mask
+    // (single clip, no batch padding → every frame valid; 1.0 = invalid).
+    let mut flat = Vec::with_capacity(t_mel * feature_size);
+    for frame in &mel {
+        flat.extend_from_slice(frame);
+    }
+    let mel_arr = rmlx_mlx::Array::from_f32_slice(&flat, &[1, t_mel as i32, feature_size as i32])?;
+    let mask_arr = rmlx_mlx::Array::from_f32_slice(&vec![0.0_f32; t_mel], &[1, t_mel as i32])?;
+
+    // 4. splice the audio block in after the prompt's leading BOS token so the
+    // clip conditions the whole turn causally (mirrors the image splice).
+    let mut block = Vec::with_capacity(t_sub + 2);
+    block.push(GEMMA4_BOA_TOKEN_ID);
+    block.extend(std::iter::repeat_n(*audio_token_id, t_sub));
+    block.push(GEMMA4_EOA_TOKEN_ID);
+
+    let insert_at = usize::from(!prompt_tokens.is_empty());
+    let mut aug_ids = Vec::with_capacity(prompt_tokens.len() + block.len());
+    aug_ids.extend_from_slice(&prompt_tokens[..insert_at]);
+    aug_ids.extend_from_slice(&block);
+    aug_ids.extend_from_slice(&prompt_tokens[insert_at..]);
+
+    let in_prompt = aug_ids.iter().filter(|&&t| t == *audio_token_id).count();
+    tracing::info!(
+        audio_soft_tokens = t_sub,
+        audio_tokens_in_prompt = in_prompt,
+        aug_len = aug_ids.len(),
+        "built Gemma4 audio prompt"
+    );
+
+    let (embeds, masked_ids) = rmlx_models::gemma4::build_audio_inputs_embeds(
+        model,
+        encoder,
+        embedder,
+        &mel_arr,
+        &mask_arr,
+        *audio_token_id,
+        &aug_ids,
+        device,
+    )?;
+    Ok((aug_ids, embeds, masked_ids))
+}
+
+#[cfg(test)]
+#[path = "audio_tests.rs"]
+mod tests;

--- a/crates/rmlx-server/src/engine/audio_tests.rs
+++ b/crates/rmlx-server/src/engine/audio_tests.rs
@@ -1,0 +1,158 @@
+//! Audio-prompt construction tests.
+//!
+//! The end-to-end load + decode + scatter test is gated on the e4b snapshot
+//! (`RMLX_TEST_MODEL_GEMMA4_E4B`) and skips gracefully when absent. The
+//! base64-prefix-stripping logic is covered model-free.
+
+use super::{
+    build_audio_prompt, load_gemma4_audio_bundle, AudioBundle, GEMMA4_BOA_TOKEN_ID,
+    GEMMA4_EOA_TOKEN_ID,
+};
+
+/// Minimal standard-alphabet base64 encoder (mirror of the crate decoder), so
+/// the test can wrap synthesized WAV bytes into the `input_audio.data` shape.
+fn base64_encode(data: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = u32::from(chunk[0]);
+        let b1 = u32::from(chunk.get(1).copied().unwrap_or(0));
+        let b2 = u32::from(chunk.get(2).copied().unwrap_or(0));
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(ALPHABET[(n >> 18) as usize & 0x3f] as char);
+        out.push(ALPHABET[(n >> 12) as usize & 0x3f] as char);
+        out.push(if chunk.len() > 1 {
+            ALPHABET[(n >> 6) as usize & 0x3f] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHABET[n as usize & 0x3f] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+fn e4b_dir() -> Option<std::path::PathBuf> {
+    std::env::var_os("RMLX_TEST_MODEL_GEMMA4_E4B").map(std::path::PathBuf::from)
+}
+
+/// Synthesize a 2 s 16 kHz mono sine, encode WAV → base64, then run the full
+/// Gemma4 audio prompt build: bundle load, mel extraction, Conformer encode,
+/// soft-token scatter. Asserts the prompt carries exactly `T_sub` `<|audio|>`
+/// placeholders and the fused embeds have the right shape. Gated on the e4b
+/// snapshot; skips gracefully when absent.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction; .expect() message documents the invariant"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "values established by construction earlier in this test"
+)]
+fn gemma4_audio_prompt_build_real_weights() {
+    let Some(dir) = e4b_dir() else {
+        eprintln!("SKIP: RMLX_TEST_MODEL_GEMMA4_E4B not set");
+        return;
+    };
+    if !dir.exists() {
+        eprintln!("SKIP: e4b snapshot absent at {}", dir.display());
+        return;
+    }
+
+    let bundle = load_gemma4_audio_bundle(&dir)
+        .expect("load audio bundle")
+        .expect("snapshot has an audio_config");
+    let AudioBundle::Gemma4 { audio_token_id, .. } = &bundle;
+    let audio_token_id = *audio_token_id;
+
+    // Load the text model so build_audio_prompt can embed + scatter.
+    let model = rmlx_models::arch::load_model(
+        &dir,
+        rmlx_mlx::Device::Cpu,
+        &rmlx_models::arch::LoadOpts::default(),
+    )
+    .expect("load gemma4 text model");
+
+    // 2 s of 16 kHz mono 440 Hz sine.
+    let sr = 16_000u32;
+    let n = (sr as usize) * 2;
+    let samples: Vec<f32> = (0..n)
+        .map(|i| (2.0 * std::f32::consts::PI * 440.0 * i as f32 / sr as f32).sin() * 0.3)
+        .collect();
+    let wav = rmlx_audio::wav::WavEncoder::encode(&samples, sr, 1).expect("encode wav");
+    let b64 = base64_encode(&wav);
+
+    // A short text prompt (no template — the build splices after token 0).
+    let prompt_tokens = vec![2u32, 1234, 5678];
+
+    let (aug_ids, embeds, masked_ids) = build_audio_prompt(
+        &model,
+        &bundle,
+        &[b64],
+        &prompt_tokens,
+        rmlx_mlx::Device::Cpu,
+    )
+    .expect("build audio prompt");
+
+    // BOA + run of <|audio|> + EOA spliced after the leading token.
+    let n_audio = aug_ids.iter().filter(|&&t| t == audio_token_id).count();
+    assert!(n_audio > 0, "expected audio soft tokens in prompt");
+    assert!(
+        aug_ids.contains(&GEMMA4_BOA_TOKEN_ID),
+        "begin-of-audio marker present"
+    );
+    assert!(
+        aug_ids.contains(&GEMMA4_EOA_TOKEN_ID),
+        "end-of-audio marker present"
+    );
+    assert_eq!(
+        aug_ids.len(),
+        prompt_tokens.len() + n_audio + 2,
+        "aug = prompt + audio run + BOA + EOA"
+    );
+
+    embeds.eval().expect("eval embeds");
+    let es = embeds.shape();
+    let hidden = model.as_gemma4().expect("gemma4").cfg.hidden_size as i32;
+    assert_eq!(es[0], 1, "batch");
+    assert_eq!(es[1], aug_ids.len() as i32, "seq == aug_ids");
+    assert_eq!(es[2], hidden, "hidden");
+    assert_eq!(masked_ids.shape()[0], aug_ids.len() as i32, "masked seq");
+}
+
+/// `build_audio_prompt` rejects >1 clip with a clear error (model-free: the
+/// guard fires before any tower access, so a non-existent snapshot is fine —
+/// but we still gate so the bundle is real for the dereference further down).
+#[test]
+fn audio_prompt_multi_clip_rejected() {
+    let Some(dir) = e4b_dir() else {
+        eprintln!("SKIP: RMLX_TEST_MODEL_GEMMA4_E4B not set");
+        return;
+    };
+    if !dir.exists() {
+        return;
+    }
+    let Ok(Some(bundle)) = load_gemma4_audio_bundle(&dir) else {
+        eprintln!("SKIP: no audio bundle");
+        return;
+    };
+    let Ok(model) = rmlx_models::arch::load_model(
+        &dir,
+        rmlx_mlx::Device::Cpu,
+        &rmlx_models::arch::LoadOpts::default(),
+    ) else {
+        eprintln!("SKIP: text model load failed");
+        return;
+    };
+    let two = vec!["AAAA".to_owned(), "BBBB".to_owned()];
+    let err = build_audio_prompt(&model, &bundle, &two, &[2u32], rmlx_mlx::Device::Cpu)
+        .expect_err("two clips must be rejected");
+    assert!(
+        err.to_string().contains("one audio clip"),
+        "clear multi-clip error: {err}"
+    );
+}

--- a/crates/rmlx-server/src/engine/mod.rs
+++ b/crates/rmlx-server/src/engine/mod.rs
@@ -26,6 +26,7 @@
 )]
 
 pub(crate) mod arch_generator;
+pub(crate) mod audio;
 pub(crate) mod generator;
 pub(crate) mod helpers;
 pub(crate) mod image;

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -696,12 +696,23 @@ are f32) — adopt / restore the operand dtype, mirroring mlx-lm's weak-typed
 Python floats. A unit-level dtype-lock test guards this against regression; see
 docs/KV_QUANT.md "Gemma4 global `--kv-quant none` KV is bf16".
 
-**Conformer audio encoder.** Present in e4b and above. The SSCP subsampling
-(two conv stages reducing the time dimension by 4×), Macaron-style FFW blocks
-with `residual_weight=0.5`, chunked local attention, and optional output
-projection implement the Conformer-S architecture from the Gemma4 multimodal
-paper. Audio tokens are marked with `audio_token_id` and scatter-merged into
-the embedding sequence similarly to image tokens.
+**Conformer audio encoder + native audio input.** Present in e4b and above. The
+SSCP subsampling (two conv stages reducing the time dimension by 4×),
+Macaron-style FFW blocks with `residual_weight=0.5`, chunked local attention, and
+optional output projection implement the Conformer-S architecture from the Gemma4
+multimodal paper. Audio tokens are marked with `audio_token_id` (258881 on e4b)
+and scatter-merged into the embedding sequence similarly to image tokens.
+
+The serve path is wired end-to-end: `/v1/chat/completions` `input_audio` content
+parts (base64 WAV/etc.) are decoded → 16 kHz mono → USM log-mel front-end →
+Conformer `audio_tower` → `embed_audio` projection → scattered at the `<|audio|>`
+positions. The server loads the audio tower once at startup (alongside the vision
+tower) when the snapshot ships an `audio_config` + `audio_tower.*` weights;
+text-only / vision-only models reject `input_audio` with a clear `503 no audio
+tower` (never a silent drop). The number of audio soft tokens spliced into the
+prompt (`<|audio>` + `T_sub`×`<|audio|>` + `<audio|>`) is derived from the
+encoder's SSCP downsample so the scatter aligns by construction. See
+`docs/SERVER.md` § "Multimodal content parts".
 
 **Speculative decoding fully wired for Gemma4.** `forward_seq_last_k_with_cache`,
 `forward_hidden_states`, `forward_hidden_states_shared_kv`, `apply_final_norm`,

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -228,6 +228,39 @@ quant for a 128k request, `none` for a short chat) with zero downtime.
 - **Deferred:** live SSD-tier reconfiguration (per-request `kv_ssd` toggle) is
   **not** implemented — see `docs/SSD_TIER.md` § "Live reconfiguration (deferred)".
 
+### Multimodal content parts — image + native audio input
+
+A user message's `content` may be a string (text) or an array of content parts.
+Image and native-audio parts are extracted from the last user message and routed
+through the model's multimodal towers. The tower output (soft tokens) is
+scattered into the prompt at the corresponding placeholder positions, then decode
+runs from the fused `inputs_embeds` (mirroring mlx-vlm `get_input_embeddings`).
+
+| Part `type` | Shape | Tower | Supported arch |
+|---|---|---|---|
+| `text` | `{type:"text", text:"…"}` | — | all |
+| `image_url` | `{type:"image_url", image_url:{url:"<url\|data-URL>"}}` | SigLIP vision | Gemma4, Gemma3, Qwen3-VL-MoE |
+| `input_image` | `{type:"input_image", image_url:"<url>"}` (mlx-vlm shape) | SigLIP vision | same |
+| `input_audio` | `{type:"input_audio", input_audio:{data:"<base64>", format:"wav"}}` | Conformer audio (USM) | **Gemma4** (e4b/26b) |
+
+**Native audio (`input_audio`) — Gemma4.** The base64 payload is decoded
+(`rmlx-audio` symphonia decoder — WAV/MP3/M4A/etc.), downmixed to mono and
+resampled to 16 kHz, run through the Gemma4 USM log-mel front-end, then the
+Conformer `audio_tower` produces `T_sub` audio soft tokens. The prompt is
+spliced with `<|audio>` + `T_sub`×`<|audio|>` + `<audio|>` after the leading
+token, and the soft tokens are scattered at the `<|audio|>` positions. `T_sub`
+is derived from the encoder's SSCP downsample (`≈ mel_frames / 4`), so the
+placeholder count always matches the encoder output (scatter aligns by
+construction). One clip per request; >1 is rejected with a clear error.
+
+**Not-supported path.** Submitting `input_audio` to a model without an audio
+tower (text-only, or a vision-only checkpoint) returns **HTTP 503**
+`"this model does not accept audio input (no audio tower)"` — never a silent
+drop. This mirrors the vision path's `503 no vision tower` rejection.
+
+**Bounds.** Each `input_audio` part is capped at 16 MiB decoded
+(`bounds::MAX_INPUT_AUDIO_BYTES`); larger clips return HTTP 400.
+
 **Non-streaming response** (`stream:false`):
 
 ```json


### PR DESCRIPTION
Closes #122.

## Problem
Gemma4 **native audio input** via `/v1/chat/completions` `input_audio` parts was
silently dropped. The endpoint parsed + bounds-checked `input_audio`, but the
audio was never encoded or injected — the model answered "no audio was provided".
The Conformer `audio_tower` / `AudioEncoder` (`crates/rmlx-models/src/gemma4/audio/mod.rs`)
were fully implemented in `rmlx-models` but had **no caller in `rmlx-server`** —
only the vision tower was wired. e4b/26b mxfp8 ship 751 `audio_tower.*` weights.

## Fix (general — mirrors the vision-tower flow)
- **Load**: `load_gemma4_audio_bundle` loads the Conformer `audio_tower` +
  `embed_audio` projector + USM feature extractor at startup when `audio_tower.*`
  weights are present, alongside the vision tower. Extracted a shared
  `load_multimodal_embedder` (used by both `embed_vision` and `embed_audio`) —
  the vision loader now calls it, behavior-identical.
- **Inject**: `build_audio_prompt` decodes `input_audio` (base64 → 16kHz mono via
  the existing `rmlx-audio` symphonia/resampler path → log-mel), splices
  `<|audio|>` placeholders, runs `AudioEncoder`, and `build_audio_inputs_embeds`
  scatters the audio soft tokens at the audio-token positions via `slice_update`.
  The placeholder count `T_sub = num_output_frames(mel_frames)` (two stride-2
  SSCP convs) must equal the encoder output frames — enforced by an `Err` (not a
  panic) on mismatch. `audio_token_id` comes from `config.json` (not hardcoded).
- **Clear errors, no silent drops**: a model with no audio tower returns a clear
  503 (mirroring vision's "no vision tower"); a request combining an image AND
  audio in one turn is **rejected with a clear error** rather than dropping the
  audio (`reject_combined_image_audio` + `tracing::warn`); >1 audio clip rejected.

## Proof (real model, e4b mxfp8, single-MLX)
| input | before | after |
|---|---|---|
| `say` "The launch is scheduled for Tuesday at noon." | "no audio was provided" | **HTTP 200 → "The launch is scheduled for Tuesday at noon."** (audio tower load line present, `prompt_len` 18→75, `audio_soft_tokens=55`) |
| `say` "The quick brown fox…" (re-confirm) | — | HTTP 200 → verbatim transcription |
| image-only (red PNG, "what color?") | Red | **Red** (vision path intact) |
| text-only ("2+2?") | 4 | **4** |
| audio on a text-only model (Bonsai) | silent "no audio" | **HTTP 503 "no audio tower"** |
| image + audio in one request | audio silently dropped | **HTTP 503 "combined image + audio … send them in separate turns"** |

`make lint` (`-D warnings`) + `make test` green (1098 passed); model-free unit
tests cover the soft-token frame-count invariant and the combined-input guard;
model-gated integration tests (e4b) cover the real audio path. Reviewed by the
rust-reviewer agent; the HIGH (combined-input silent drop) + doc nits fixed in
the second commit. No new deps, no new env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)