### PR TITLE
chore(release): bump Homebrew formula to v0.2.2

### DIFF
--- a/packaging/homebrew/rmlx.rb
+++ b/packaging/homebrew/rmlx.rb
@@ -21,8 +21,8 @@
 class Rmlx < Formula
   desc "Rust-native, single-binary MLX inference + conversion backend for Apple Silicon"
   homepage "https://github.com/Pushkinist/rMLX"
-  url "https://github.com/Pushkinist/rMLX/archive/refs/tags/v0.2.1.tar.gz"
-  sha256 "a10d2d15560e957d98458a4e5c597e3e299ed2f6faa83b8c21792e1e7d0a70fd"
+  url "https://github.com/Pushkinist/rMLX/archive/refs/tags/v0.2.2.tar.gz"
+  sha256 "cd7a6ee2b0d341476296a6bf9789b23c766921de1ebeac5bec1156415fa5e8c0"
   license any_of: ["MIT", "Apache-2.0"]
   head "https://github.com/Pushkinist/rMLX.git", branch: "main"
 


### PR DESCRIPTION
Bumps `packaging/homebrew/rmlx.rb` url → v0.2.2 and sha256 to the matching GitHub source tarball (verified stable across repeated fetches: `cd7a6ee…`). Follows the v0.2.2 tag + release. `make tap-sync` pushes this to the tap after merge.