### PR TITLE
docs: add 'brew trust' step to Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ less install.sh && bash install.sh
 
 ```sh
 brew tap Pushkinist/rmlx
+brew trust Pushkinist/rmlx   # one-time: Homebrew now requires explicitly trusting third-party taps
 brew install rmlx
 ```
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -110,10 +110,14 @@ cosign verify-blob \
 **Homebrew (build from source):**
 ```sh
 brew tap Pushkinist/rmlx
+brew trust Pushkinist/rmlx   # one-time: Homebrew refuses to load formulae from untrusted third-party taps
 brew install rmlx
 brew test rmlx
 rmlx --version
 ```
+> Recent Homebrew versions block third-party taps until trusted — a fresh
+> `brew install rmlx` fails with `Refusing to load formula … from untrusted tap`
+> until `brew trust Pushkinist/rmlx` is run once.
 
 Local formula check before publishing:
 ```sh


### PR DESCRIPTION
Recent Homebrew versions refuse to load formulae from untrusted third-party taps. A fresh `brew tap Pushkinist/rmlx` + `brew install rmlx` now fails with:

```
Error: Refusing to load formula pushkinist/rmlx/rmlx from untrusted tap pushkinist/rmlx.
Run `brew trust pushkinist/rmlx` ...
```

Add the one-time `brew trust Pushkinist/rmlx` step to the README install section and the RELEASING.md Homebrew verify path so new users (and the release verification flow) don't trip on it.

Docs-only; no code change. Verified live while installing v0.2.2 (`brew trust` → `brew upgrade rmlx` → 0.2.2 built from source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)