### PR TITLE
docs(gemma4): e4b QAT complex-image vision is a checkpoint limit, not a bug (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Gemma 4 e4b QAT complex-image vision is a checkpoint limitation, not a bug.**
+  Investigated degenerate / hallucinated output from the `e4b-it-qat-mxfp4` and
+  `-qat-nvfp4` snapshots on high-detail screenshots (#153). The e4b QAT
+  snapshots share a byte-identical SigLIP `vision_tower` and clipped-linear
+  bounds with `e4b-it-mxfp8`; the unquantized `qat-bf16` checkpoint degrades on
+  dense images identically to the fp4 variants, and the `mlx_vlm` Python
+  reference reproduces the same failure on the same snapshots. So this is an
+  intrinsic quality limit of the e4b QAT checkpoint on complex images, not an
+  fp4-dequant defect — rMLX output is reference-faithful. No code change;
+  `docs/MODELS.md` now documents the behavior and recommends `e4b-it-mxfp8` for
+  complex-image OCR. (#153)
+
 ## [0.2.4] - 2026-06-19
 
 Vision, KV, and embedding-lookup bug-fix batch for Qwen3-VL and Gemma 4, plus a

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -779,10 +779,14 @@ unquantized bf16 (plain weights, no `.scales`); affine at any group/bits —
 including affine-int4 with per-group `.biases` zero-points (Google QAT
 snapshots); and the microscaling formats mxfp4 / nvfp4. On this bandwidth-bound
 arch, 4-bit packed weights decode faster than mxfp8 (runtime `quantized_matmul`,
-weights stay packed). mxfp4 is the recommended 4-bit format: nvfp4 loads and runs
-but the MLX nvfp4 kernel currently yields degraded output on these snapshots.
-Per-tensor quant overrides (router weights, QAT MLP blocks) are read from the
-inline `quantization` dict.
+weights stay packed). mxfp4 is the recommended 4-bit format. Per-tensor quant
+overrides (router weights, QAT MLP blocks) are read from the inline
+`quantization` dict.
+
+The Google QAT e4b 4-bit snapshots (`qat-mxfp4`, `qat-nvfp4`, `qat-4bit`) are
+text-strong but degrade on high-detail images — a checkpoint property, not a
+codec bug, reproduced identically by the `mlx_vlm` reference. See
+[Modalities → e4b QAT checkpoints](#e4b-qat-checkpoints--complex-image-vision-quality).
 
 ### KV quantization
 
@@ -801,6 +805,25 @@ shared KV to consumer layers, so `Mixed` mode also works.
 Text, image, and audio input. rMLX implements all three towers:
 - Vision: SigLIP-style ViT + VisionPooler + soft-token scatter.
 - Audio: Conformer encoder + output projection + scatter.
+
+#### e4b QAT checkpoints — complex-image vision quality
+
+The Google QAT e4b snapshots (`*-qat-bf16`, `*-qat-mxfp4`, `*-qat-nvfp4`,
+`*-qat-4bit`) share one byte-identical SigLIP `vision_tower` and one
+byte-identical set of clipped-linear bounds with the non-QAT `e4b-it-mxfp8`
+snapshot — only the QAT-trained language-model weights and the multimodal
+projection differ. On **simple, low-detail** images all QAT variants transcribe
+correctly. On **high-detail / high-patch-count** images (e.g. a full-resolution
+screenshot preprocessing to ~272 soft tokens) every QAT variant — including the
+unquantized `qat-bf16` — produces hallucinated or repetitive output, while
+`e4b-it-mxfp8` reads the same image correctly.
+
+This is an intrinsic quality limitation of the e4b QAT *checkpoint* on dense
+images, not a quantization-codec defect: `qat-bf16` (no fp4 dequant at all)
+fails the same way as `qat-mxfp4` / `qat-nvfp4`, and the `mlx_vlm` Python
+reference reproduces the identical failure on the same QAT snapshots. rMLX
+output is reference-faithful. For reliable complex-image OCR use
+`e4b-it-mxfp8`; treat e4b QAT as text-strong but unreliable on dense images.
 
 ### Unified (encoder-free) vision — `Gemma4UnifiedForConditionalGeneration` (12B)
 


### PR DESCRIPTION
## Resolves #153 — not a bug (re-scoped)

Investigated #153 (e4b `qat-mxfp4` / `qat-nvfp4` produce degenerate/hallucinated output on a high-detail screenshot while `e4b-it-mxfp8` reads it). The issue framed this as an rMLX fp4-dequant defect. A blind bisect **falsifies** that and shows rMLX is reference-faithful — the limitation is in the QAT checkpoint.

### Evidence
| model | fp4 dequant? | complex screenshot | simple image |
|---|---|---|---|
| `e4b-it-mxfp8` | no | reads correctly | reads |
| `qat-bf16` (same QAT weights, **unquantized**) | **no** | **hallucinates** | reads |
| `qat-mxfp4` | yes | hallucinates | reads ("HELLO WORLD 1234") |
| `qat-nvfp4` | yes | degenerate repetition | reads |
| `mlx_vlm` 0.5.0 reference, same QAT snapshots | — | **fails identically** | reads |

- The e4b QAT snapshots share a **byte-identical** SigLIP `vision_tower` and clipped-linear bounds with `e4b-it-mxfp8` (`crates/rmlx-models/src/gemma4/vision/mod.rs` runs the tower in f32 — no fp4 there). The fp4 codec is only touched by `embed_vision.embedding_projection`, which goes through MLX `quantized_matmul` (`crates/rmlx-models/src/layers/linear.rs:143`), not the rMLX CPU codec.
- **`qat-bf16` has no fp4 dequant at all and degrades identically** → the fp4 codec is not the cause (internal control, no Python needed).
- **`mlx_vlm` (the canonical MLX VLM reference) reproduces the same hallucination** on the same QAT snapshots + image, and reads the simple image. rMLX matches the reference.

### Conclusion
Intrinsic quality limit of the **e4b QAT checkpoint** on complex / high-patch-count images — not an rMLX bug. A code patch would make rMLX diverge from the reference and would be wrong. Per CLAUDE.md hard rule 7 ("document the truth"), the fix is documentation:

- `docs/MODELS.md` — new "e4b QAT checkpoints — complex-image vision quality" subsection; **corrects** the prior line that wrongly pinned the degradation on the nvfp4 kernel (it is QAT-checkpoint-wide: bf16/mxfp4/nvfp4/4bit alike).
- `CHANGELOG.md` — `[Unreleased] → Documentation` entry.

Recommendation: use `e4b-it-mxfp8` for complex-image OCR; treat e4b QAT as text-strong but unreliable on dense images.

No code change. `cargo fmt --check` + `cargo clippy -p rmlx-models -p rmlx-quant` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)