### PR TITLE
perf(prefill): fix Qwen3.6 GDN prefill chunk (4× TTFT, #155) + gemma4 chunk tune

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,11 @@ temp=0; per-family grids under [`docs/models/`](docs/models)):
   decode there is weight-bandwidth-bound, so KV quant buys little. (31b dense
   trails slightly — bandwidth physics.)
 
-The current weak spot is **prefill / time-to-first-token**: roughly 40–50×
-slower than `mlx-lm` at short context. It is an active optimization target, not
-a decode problem — steady-state throughput is unaffected.
+**Prefill / time-to-first-token** is at parity with `mlx-lm`: a direct
+`mlx-lm` run on the same 35B-A3B snapshot measures ≈ 2.7k–3.6k prompt tok/s,
+versus rMLX's ≈ 3.0k — both bandwidth-bound at roughly the same level. (An
+earlier draft cited a ~40–50× prefill deficit; that came from a non-physical
+baseline and has been retracted after a direct measurement.)
 
 ## Requirements
 

--- a/crates/rmlx-models/src/arch/loader.rs
+++ b/crates/rmlx-models/src/arch/loader.rs
@@ -226,10 +226,11 @@ pub fn load_model(model_dir: &Path, _device: Device, opts: &LoadOpts) -> Result<
         "arch::load_model: warmup phase complete"
     );
 
-    // -- Phase 5: GDN compile-cache pre-warm ----------------------------------
-    // For Qwen3_5Moe models: pre-trace `gated_delta_prefill_ops` at the
-    // qwen3_5_moe prefill chunk size so the compile-cache is hot before the
-    // first real request.
+    // -- Phase 5: GDN kernel pre-warm -----------------------------------------
+    // For Qwen3_5Moe models: pre-dispatch the `gated_delta_step_gpu` Metal
+    // kernel at the qwen3_5_moe prefill chunk size so its Metal program is
+    // compiled before the first real request (the kernel now serves both
+    // prefill and decode — see qwen3_5_moe::gated_delta_net).
     if _device == Device::Gpu {
         if let Architecture::Qwen3_5Moe(ref m) = arch {
             let t_gdn_warm = Instant::now();
@@ -246,7 +247,7 @@ pub fn load_model(model_dir: &Path, _device: Device, opts: &LoadOpts) -> Result<
                 hv,
                 dk,
                 dv,
-                "arch::load_model: pre-warm gated_delta_prefill_ops"
+                "arch::load_model: pre-warm gated_delta_step_gpu kernel"
             );
             let warmup_result = gdn_warmup(b, gdn_warmup_t, hk, hv, dk, dv);
             match warmup_result {
@@ -290,8 +291,9 @@ pub fn load_model(model_dir: &Path, _device: Device, opts: &LoadOpts) -> Result<
     Ok(arch)
 }
 
-/// Pre-warm the GDN compile-cache by running one traced call of
-/// `gated_delta_prefill_ops` at the production chunk shape.
+/// Pre-warm the GDN Metal kernel by dispatching one `gated_delta_step_gpu`
+/// call at the production chunk shape, compiling its Metal program at load
+/// time so the first real request pays no kernel-compile cost.
 ///
 /// Extracted from `load_model` to keep that function below 200 LOC.
 fn gdn_warmup(b: i32, t: i32, hk: i32, hv: i32, dk: i32, dv: i32) -> Result<()> {
@@ -311,7 +313,7 @@ fn gdn_warmup(b: i32, t: i32, hk: i32, hv: i32, dk: i32, dv: i32) -> Result<()> 
     let g = zeros_f32(&[b, t, hv])?;
     let beta = zeros_bf16(&[b, t, hv])?;
     let state_in = zeros_f32(&[b, hv, dv, dk])?;
-    let (y_out, s_out) = crate::gated_delta_msl::gated_delta_prefill_ops(
+    let (y_out, s_out) = crate::gated_delta_msl::gated_delta_step_gpu(
         &q,
         &k,
         &v,

--- a/crates/rmlx-models/src/gated_delta_msl.rs
+++ b/crates/rmlx-models/src/gated_delta_msl.rs
@@ -345,23 +345,17 @@ pub fn gated_delta_step_gpu(
     Ok((y, state_out))
 }
 
-// ── Ops-based prefill (parallel graph build) ──────────────────────────────────
+// ── Ops-based prefill (reference / equivalence oracle) ────────────────────────
 //
-// For prefill (T ≥ 256) the sequential MSL kernel's `for t in 0..T` loop
-// serialises all T timesteps inside a single Metal dispatch. Because the
-// loop-carried state dependency prevents Metal from exploiting any ILP, the
-// GPU stalls while one timestep finishes before the next starts.
-//
-// This function builds the same computation as a lazy MLX ops graph — one
-// element-wise op node per step — and lets MLX's scheduler emit back-to-back
-// device kernels with optimal memory reuse. The complete graph is evaluated
-// in one shot by the caller (`mx_eval` is implicitly triggered when the output
-// array is consumed).
-//
-// Performance characteristic (matches mlx-lm's `gated_delta_ops` with
-// `@mx.compile`): MLX fuses independent per-head computations and schedules
-// memory traffic optimally. At T=256+ this is substantially faster than the
-// sequential MSL path. At T=1 (decode) use `gated_delta_step_gpu` instead.
+// NOT on the production path. Production prefill and decode both run
+// `gated_delta_step_gpu` (the MSL kernel) at every T — see
+// `qwen3_5_moe::gated_delta_net`. This function builds the same recurrence as a
+// lazy MLX ops graph (one element-wise node per timestep) and mirrors mlx-lm's
+// `gated_delta_ops` (the `use_kernel=False` fallback). It is retained as the
+// equivalence oracle that `gated_delta_msl_tests` checks `gated_delta_step_gpu`
+// against. It is NOT a faster prefill path: the per-step graph build explodes to
+// ~184K nodes at T=256 and ~1.47M at T=2048 across the 30 GDN layers, which is
+// exactly why the kernel — one dispatch with the T-loop in registers — wins.
 //
 // # Algorithm
 //
@@ -394,8 +388,10 @@ pub fn gated_delta_step_gpu(
 
 /// Ops-based GatedDeltaNet prefill: builds a lazy MLX graph over T timesteps.
 ///
-/// Use when `T ≥ 256`. For decode (T = 1) prefer [`gated_delta_step_gpu`]
-/// which dispatches a single compact Metal kernel per step.
+/// Reference / test-only equivalence oracle — production no longer dispatches
+/// this. Both prefill and decode run [`gated_delta_step_gpu`] (the MSL kernel)
+/// at every T; this exists so `gated_delta_msl_tests` can assert the kernel
+/// matches the ops-graph numerics within fp16 tolerance.
 ///
 /// # Inputs
 ///

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -320,9 +320,10 @@ pub fn generate_greedy<'a>(
     // with the enter_prefill/exit_prefill bracketing (raw-BF16 →
     // one-shot quantize).
     //
-    // Chunk size is per-arch; default 512 for gemma4 (large vocab + dense
-    // SWA layers benefit from amortized FFI/flush overhead). Override via
-    // `RMLX_PREFILL_CHUNK` (global) or `RMLX_PREFILL_CHUNK_GEMMA4`
+    // Chunk size is per-arch; default 1024 for gemma4 (large vocab + dense
+    // SWA layers benefit from amortized FFI/flush overhead; a real-model sweep
+    // put the TTFT sweet spot at 1024 — 2048 regresses the e4b dense path).
+    // Override via `RMLX_PREFILL_CHUNK` (global) or `RMLX_PREFILL_CHUNK_GEMMA4`
     // (per-arch).
     let prefill_chunk = crate::prefill_chunk::prefill_chunk_for("gemma4");
     let prefill_t0 = Instant::now();
@@ -411,7 +412,7 @@ pub fn generate_greedy<'a>(
 
     // ------------------------------------------------------------------
     // Prefill: encode the prompt in `prefill_chunk` token chunks (default
-    // 512 for gemma4; see binding at top of path-B section). Per chunk we
+    // 1024 for gemma4; see binding at top of path-B section). Per chunk we
     // eval the KV-cache prefill_raw buffers (not the logits) to flush the
     // Metal command buffer under the ~10s watchdog while letting MLX skip
     // the wasted lm_head matmul for non-final chunks via lazy graph

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -430,8 +430,8 @@ pub fn generate_greedy<'a>(
     // quantize-dequantized on every chunk. exit_prefill() quantizes the
     // whole sequence in one shot when the loop completes.
     //
-    // Non-MoE arch — chunk well below the gated_delta ts>=256 threshold
-    // that only Qwen3.5MoE worries about (see `gated_delta_prefill_ops`).
+    // Non-MoE arch with no GatedDeltaNet layers — the prefill chunk only
+    // trades off per-chunk full-attention/KV cost vs dispatch count.
     // ------------------------------------------------------------------
     // Phase span: prefill. Entered once per generate_greedy call, not per token.
     // Visible in samply/Instruments as a single region covering the full prefill.

--- a/crates/rmlx-models/src/prefill_chunk.rs
+++ b/crates/rmlx-models/src/prefill_chunk.rs
@@ -7,8 +7,11 @@
 //!   command-buffer flush overhead, lowering the time-to-first-token on
 //!   long prompts.
 //! - **Metal GPU watchdog** — chunks too large blow past the ~10 s
-//!   command-buffer budget. Qwen3.5MoE's `gated_delta_prefill_ops` is
-//!   particularly sensitive (Qwen3.5MoE `gated_delta_prefill_ops`).
+//!   command-buffer budget per forward pass. The cost is the per-chunk
+//!   full-attention + KV work; Qwen3.5MoE's GatedDeltaNet runs the
+//!   `gated_delta_step_gpu` kernel (T-loop in registers, grid independent of
+//!   T) so it scales gracefully with chunk size rather than exploding a lazy
+//!   graph.
 //! - **First-call compile cost** — `compile_shapeless` traces a fresh
 //!   Metal program per unique input shape; bigger chunks mean a heavier
 //!   first-call trace before warmup populates the cache.
@@ -122,15 +125,18 @@ pub fn module_key_for_class(arch_class: &str) -> &'static str {
 fn arch_default(arch: &str) -> Option<usize> {
     match arch {
         "qwen3" => Some(256),
-        // qwen3_5_moe stays at 64. Spec proposed 256 with pre-warm;
-        // p0b-ttft bench measured chunk=256 cold TTFT REGRESSED
-        // by +15% at 8K and +80% at 32K vs chunk=64 — gated_delta_prefill_ops
-        // at T=256 has a substantially heavier lazy graph (~184K nodes/chunk)
-        // than at T=64, dwarfing the per-chunk FFI savings. Pre-warm
-        // mitigates only the first-chunk compile cost. Larger chunks still
-        // available via `RMLX_PREFILL_CHUNK_QWEN3_5_MOE=256` for users who
-        // want to test it.
-        "qwen3_5_moe" => Some(64),
+        // qwen3_5_moe: 2048, matching mlx-lm's prefill_step_size. The GDN
+        // recurrence now always runs the `gated_delta_step_gpu` Metal kernel
+        // (one dispatch, T-loop in registers) instead of flipping to the
+        // ops-graph path at T>=256 — so a large chunk no longer explodes the
+        // lazy graph; it just means fewer, bigger forward passes and far fewer
+        // per-chunk KV-state evals. A real-model sweep on Qwen3.6-35B-A3B-8bit
+        // (kv-none) measured TTFT improving monotonically 64→2048 with no Metal
+        // watchdog trip: 4k 4240→1065ms (4.0x), 8k 9008→2136ms (4.2x), 16k
+        // 19489→4712ms (4.1x); decode TPS unchanged (the decode kernel is the
+        // same at every chunk size). Override via
+        // `RMLX_PREFILL_CHUNK_QWEN3_5_MOE`.
+        "qwen3_5_moe" => Some(2048),
         // qwen3_vl_moe: plain GQA MoE (no GDN linear attention), so it tolerates
         // the same large chunk as gemma4. Native image tiling produces thousands
         // of soft tokens; a single-shot forward over the full prompt trips the

--- a/crates/rmlx-models/src/prefill_chunk.rs
+++ b/crates/rmlx-models/src/prefill_chunk.rs
@@ -138,14 +138,22 @@ fn arch_default(arch: &str) -> Option<usize> {
         // `RMLX_PREFILL_CHUNK_QWEN3_5_MOE`.
         "qwen3_5_moe" => Some(2048),
         // qwen3_vl_moe: plain GQA MoE (no GDN linear attention), so it tolerates
-        // the same large chunk as gemma4. Native image tiling produces thousands
-        // of soft tokens; a single-shot forward over the full prompt trips the
-        // Metal ~10s GPU watchdog, so the image prefill is chunked at 512.
+        // a large text chunk. Kept at 512 for the image path: native image
+        // tiling produces thousands of soft tokens, and a single-shot forward
+        // over the full prompt trips the Metal ~10s GPU watchdog, so the image
+        // prefill is chunked at 512.
         "qwen3_vl_moe" => Some(512),
         "gemma3" => Some(256),
-        // gemma4 default 512: p0b-ttft bench measured -30% cold TTFT at 8K
-        // and -12% at 32K vs chunk=64 with no Metal watchdog at max-ctx 64K.
-        "gemma4" => Some(512),
+        // gemma4 default 1024. A real-model kv-none sweep (e4b dense + 26b-a4b
+        // MoE) found 1024 the shared TTFT sweet spot: e4b 4k 602→565ms / 8k
+        // 1234→1179ms (~+6%/+4.5% vs 512), 26b 4k 1578→1302ms / 8k 3285→2743ms
+        // (~+17% vs 512), decode unchanged, no Metal watchdog, coherent at
+        // 4k/8k/16k. chunk=2048 REGRESSES the e4b dense path (722ms @4k — a
+        // sliding-window/exec-unit cliff above 1024 = 2×window), so it is NOT
+        // the shared default; the 26b MoE gains a further ~5% at 2048 but the
+        // shared key keeps 1024 to protect e4b. Override via
+        // `RMLX_PREFILL_CHUNK_GEMMA4`.
+        "gemma4" => Some(1024),
         "qwen2" => Some(256),
         // laguna currently lacks tuning data; preserve its pre-tuning value
         // of 256 (was hardcoded as `PREFILL_CHUNK = 256` before this module

--- a/crates/rmlx-models/src/prefill_chunk_tests.rs
+++ b/crates/rmlx-models/src/prefill_chunk_tests.rs
@@ -13,7 +13,7 @@ fn defaults_match_recommendations() {
     assert_eq!(arch_default("qwen3_5_moe"), Some(2048));
     assert_eq!(arch_default("qwen3_vl_moe"), Some(512));
     assert_eq!(arch_default("gemma3"), Some(256));
-    assert_eq!(arch_default("gemma4"), Some(512));
+    assert_eq!(arch_default("gemma4"), Some(1024));
     assert_eq!(arch_default("qwen2"), Some(256));
     assert_eq!(arch_default("laguna"), Some(256));
     assert_eq!(arch_default("bitnet"), Some(64));
@@ -68,14 +68,14 @@ fn module_key_resolves_to_arch_default_chunk() {
         return;
     }
     // qwen3_5_moe resolves to its own 2048 default (GDN kernel handles any T),
-    // distinct from gemma4's 512.
+    // distinct from gemma4's 1024.
     let key = module_key_for_class("Qwen3_5MoeForConditionalGeneration");
     assert_eq!(prefill_chunk_for(key), 2048);
     assert_eq!(
         prefill_chunk_for(module_key_for_class("Gemma4ForConditionalGeneration")),
-        512
+        1024
     );
-    // Unknown class resolves through "" to FALLBACK, not gemma4's 512.
+    // Unknown class resolves through "" to FALLBACK, not gemma4's default.
     assert_eq!(
         prefill_chunk_for(module_key_for_class("TotallyUnknownArch")),
         FALLBACK

--- a/crates/rmlx-models/src/prefill_chunk_tests.rs
+++ b/crates/rmlx-models/src/prefill_chunk_tests.rs
@@ -10,7 +10,7 @@ fn defaults_match_recommendations() {
         return;
     }
     assert_eq!(arch_default("qwen3"), Some(256));
-    assert_eq!(arch_default("qwen3_5_moe"), Some(64));
+    assert_eq!(arch_default("qwen3_5_moe"), Some(2048));
     assert_eq!(arch_default("qwen3_vl_moe"), Some(512));
     assert_eq!(arch_default("gemma3"), Some(256));
     assert_eq!(arch_default("gemma4"), Some(512));
@@ -67,9 +67,10 @@ fn module_key_resolves_to_arch_default_chunk() {
     if env::var("RMLX_PREFILL_CHUNK").is_ok() {
         return;
     }
-    // qwen3_5_moe's small conservative chunk must win over gemma4's 512 default.
+    // qwen3_5_moe resolves to its own 2048 default (GDN kernel handles any T),
+    // distinct from gemma4's 512.
     let key = module_key_for_class("Qwen3_5MoeForConditionalGeneration");
-    assert_eq!(prefill_chunk_for(key), 64);
+    assert_eq!(prefill_chunk_for(key), 2048);
     assert_eq!(
         prefill_chunk_for(module_key_for_class("Gemma4ForConditionalGeneration")),
         512

--- a/crates/rmlx-models/src/qwen3_5_moe/gated_delta_net.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/gated_delta_net.rs
@@ -225,62 +225,56 @@ impl GatedDeltaNet {
         };
 
         // ── Recurrence dispatch ───────────────────────────────────────────
-        // Two paths:
-        // T < 256 (decode + small prefill chunks): sequential MSL kernel —
-        // compact single dispatch, state lives in GPU registers.
-        // T >= 256 (prefill): ops-based graph — Rust loop builds a lazy MLX
-        // graph over T steps; MLX schedules all T ops in one GPU pass.
-        // `gated_delta_prefill_ops` handles the GQA repeat internally and
-        // works entirely in f32 (state precision), so q/k/v/beta dtype
-        // normalisation for the Metal kernel is not needed here.
+        // Always the sequential MSL kernel `gated_delta_step_gpu`, for both
+        // decode (T=1) and prefill (T=chunk). It is a byte-for-byte port of
+        // mlx-lm 0.31's `gated_delta_kernel`, which mlx-lm itself uses for the
+        // whole prompt (`use_kernel=True` default): the `for t in 0..T` loop
+        // runs inside one Metal dispatch with the recurrent state in registers
+        // while the `B*Hv*Dv*32` threads supply the parallelism. The
+        // per-timestep loop is sequential WITHIN a thread, but the GPU hides
+        // that latency across heads/dims — so a single dispatch over a large T
+        // beats both small chunks (more dispatches) and the ops-graph path
+        // (`gated_delta_prefill_ops`), whose Rust per-step graph build explodes
+        // to ~184K–1.47M lazy nodes at T=256..2048.
+        //
+        // Chaining the kernel across prefill chunks is numerically exact: the
+        // f32 `state_in`→`state_out` carries between calls, so chunked prefill
+        // equals a single full-prompt call, and the prefill→decode handoff now
+        // shares one reduction order (decode already used this kernel).
         let g_f32 = if g_full.dtype() == Dtype::F32 {
             g_full
         } else {
             g_full.astype(Dtype::F32, device)?
         };
 
-        let (y_bf16, state_out) = if ts >= 256 {
-            // Prefill ops path: no dtype unification needed (ops path casts internally).
-            crate::gated_delta_msl::gated_delta_prefill_ops(
-                &q4_scaled_full,
-                &k4_scaled_full,
-                &v4,
-                &g_f32,
-                &beta_full,
-                &state_in,
-                device,
-            )?
+        // Unify q/k/v/beta to a single dtype before the kernel — MLX affine
+        // INT4 matmul returns the input dtype but scalar Bf16 multiplications
+        // can silently promote to F32. Use v4's dtype as ground truth.
+        let target_dtype = v4.dtype();
+        let q4_scaled_full = if q4_scaled_full.dtype() == target_dtype {
+            q4_scaled_full
         } else {
-            // Sequential MSL kernel path (decode / small chunk prefill).
-            // Unify q/k/v/beta to a single dtype before the kernel — MLX affine
-            // INT4 matmul returns the input dtype but scalar Bf16 multiplications
-            // can silently promote to F32. Use v4's dtype as ground truth.
-            let target_dtype = v4.dtype();
-            let q4_scaled_full = if q4_scaled_full.dtype() == target_dtype {
-                q4_scaled_full
-            } else {
-                q4_scaled_full.astype(target_dtype, device)?
-            };
-            let k4_scaled_full = if k4_scaled_full.dtype() == target_dtype {
-                k4_scaled_full
-            } else {
-                k4_scaled_full.astype(target_dtype, device)?
-            };
-            let beta_full = if beta_full.dtype() == target_dtype {
-                beta_full
-            } else {
-                beta_full.astype(target_dtype, device)?
-            };
-            crate::gated_delta_msl::gated_delta_step_gpu(
-                &q4_scaled_full,
-                &k4_scaled_full,
-                &v4,
-                &g_f32,
-                &beta_full,
-                &state_in,
-                device,
-            )?
+            q4_scaled_full.astype(target_dtype, device)?
         };
+        let k4_scaled_full = if k4_scaled_full.dtype() == target_dtype {
+            k4_scaled_full
+        } else {
+            k4_scaled_full.astype(target_dtype, device)?
+        };
+        let beta_full = if beta_full.dtype() == target_dtype {
+            beta_full
+        } else {
+            beta_full.astype(target_dtype, device)?
+        };
+        let (y_bf16, state_out) = crate::gated_delta_msl::gated_delta_step_gpu(
+            &q4_scaled_full,
+            &k4_scaled_full,
+            &v4,
+            &g_f32,
+            &beta_full,
+            &state_in,
+            device,
+        )?;
 
         // ── Persist recurrent state + conv tail into the cache ────────────
         // mlx-lm reference: `cache[1] = state` and

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -253,8 +253,9 @@ pub fn generate_greedy<'a>(
     // to grow the prefill_raw buffer from zero, ignoring the existing payload,
     // which produces wrong attention and a guard error on resumed caches.
     //
-    // Chunking (same prefill_chunk as Path C): keeps GDN ts < 256 per chunk
-    // to avoid Metal watchdog timeouts on long tails.
+    // Chunking (same prefill_chunk as Path C): bounds the per-chunk forward
+    // (KV write + GDN kernel) so long tails stay under the Metal
+    // command-buffer budget.
     if let Some((mut kv_caches, mut lin_caches, prefix_len)) = hydrated_tail {
         let tail_len = prompt_ids.len() - prefix_len;
         tracing::info!(
@@ -440,28 +441,16 @@ pub fn generate_greedy<'a>(
     // `max_seq_ceiling` caps growth and rejects over-long prompts.
     let (initial_max_seq, max_seq_ceiling) =
         kv_max_seq_and_ceiling(max_ctx_override, model.cfg.max_position_embeddings as i32);
-    // 64-token chunks keep GDN ts < 256 threshold → sequential MSL kernel, no lazy graph explosion.
-    // 2048-token chunks (e0231a4) trigger gated_delta_prefill_ops at ts=2048 → ~1.47M lazy nodes
-    // across 30 GDN layers → Metal GPU watchdog timeout.
-    //
-    // Compile cache is in place (gated_delta_msl.rs). Raising
-    // chunk size to 256 routes chunks to gated_delta_prefill_ops, which on the FIRST
-    // call traces T=256 (~184K lazy nodes) — acceptable for the watchdog, but the trace
-    // cost (~6s) lands on the critical path of the first request without warmup.
-    // The GDN pre-warm (`arch::load_model`) now traces gated_delta_prefill_ops at
-    // model load time, so the first chunk's compile cost is paid at startup.
-    //
-    // p0b-ttft bench: even with pre-warm, chunk=256
-    // REGRESSED cold TTFT by +15% at 8K and +80% at 32K vs chunk=64. Per-chunk
-    // gated_delta_prefill_ops at T=256 is genuinely slower (much heavier lazy
-    // graph per call) than per-chunk at T=64. Default stays at 64; the env
-    // override remains available for users who want to experiment.
-    //
-    // Override via `RMLX_PREFILL_CHUNK` (global) or
-    // `RMLX_PREFILL_CHUNK_QWEN3_5_MOE` (per-arch). Note: the pre-warm uses
-    // the chunk size resolved at load time
-    // (`gdn_warmup_t = prefill_chunk_for("qwen3_5_moe")` in arch.rs); set
-    // the env BEFORE `rmlx serve` for the warmup to match.
+    // Prefill chunk for qwen3_5_moe defaults to 2048 (see prefill_chunk.rs for
+    // the sweep behind that number). The GDN recurrence runs the
+    // `gated_delta_step_gpu` kernel at any T, so a large chunk does NOT route to
+    // the ops-graph path that used to explode the lazy graph — it just means
+    // fewer, bigger forward passes and far fewer per-chunk KV-state evals, which
+    // is where the prefill/TTFT win comes from. Override via
+    // `RMLX_PREFILL_CHUNK` (global) or `RMLX_PREFILL_CHUNK_QWEN3_5_MOE`
+    // (per-arch); the GDN kernel pre-warm in `arch::load_model` reads the same
+    // resolved chunk, so set the env BEFORE `rmlx serve` for the warmup shape to
+    // match.
     let prefill_chunk = crate::prefill_chunk::prefill_chunk_for("qwen3_5_moe");
 
     // Path C: cache miss — full prefill from scratch

--- a/crates/rmlx-server/src/admission_tests.rs
+++ b/crates/rmlx-server/src/admission_tests.rs
@@ -393,17 +393,18 @@ fn prefill_chunk_global_state_serial() {
 
     // Scenario D: the prefill-chunk fallback honors the loaded model's arch, not
     // the hardcoded gemma4 default. With `arch = "qwen3_5_moe"` the controller's
-    // `current` starts from that arch's default (64), so the first overload lower
-    // sets an override <= 64. Under the old hardcoded-"gemma4" bug `current` would
-    // have started at 512, so the first lower would land at 256 > 64 — the bound
-    // below discriminates the two. Note: `arch_default` MUST be captured BEFORE
-    // driving the controller, while the override is cleared — `prefill_chunk_for`
-    // returns the runtime override (highest precedence) once one is set, so reading
-    // it after the lower would self-corrupt the bound.
+    // `current` starts from that arch's default (2048), so the first overload
+    // lower halves it to 1024. Under the old hardcoded-"gemma4" bug `current`
+    // would have started at 512 and the first lower would land at 256 — so an
+    // exact `resolved == arch_default / 2` assertion discriminates the two
+    // (1024 vs 256). Note: `arch_default` MUST be captured BEFORE driving the
+    // controller, while the override is cleared — `prefill_chunk_for` returns the
+    // runtime override (highest precedence) once one is set, so reading it after
+    // the lower would self-corrupt the bound.
     {
         // No runtime override → tick_prefill_chunk reads the arch default.
         rmlx_models::prefill_chunk::set_prefill_chunk(0);
-        // Capture the true arch default (=64) before any lower pollutes the global.
+        // Capture the true arch default before any lower pollutes the global.
         let arch_default = rmlx_models::prefill_chunk::prefill_chunk_for("qwen3_5_moe");
 
         let ctrl = ControllerHandle::new(
@@ -426,14 +427,17 @@ fn prefill_chunk_global_state_serial() {
             ctrl.tick_force();
         }
 
-        // The lower must have set an override; it must start from the qwen3_5_moe
-        // default (64), not gemma4's 512.
+        // The lower must have set an override; the first overload lower halves
+        // the qwen3_5_moe arch default (2048 → 1024). Under the old gemma4-512
+        // bug it would be 256, so the exact-equality check discriminates.
         let resolved = rmlx_models::prefill_chunk::runtime_override()
             .expect("D: overload must lower the chunk and set a runtime override");
-        assert!(
-            resolved <= arch_default,
-            "D: first lower must start from qwen3_5_moe default ({arch_default}=64), \
-             not gemma4's 512; got {resolved}"
+        assert_eq!(
+            resolved,
+            arch_default / 2,
+            "D: first lower must halve the qwen3_5_moe default ({arch_default} → {}), \
+             not start from gemma4's 512; got {resolved}",
+            arch_default / 2
         );
         rmlx_models::prefill_chunk::set_prefill_chunk(0);
     }

--- a/crates/rmlx-server/src/admission_tests.rs
+++ b/crates/rmlx-server/src/admission_tests.rs
@@ -395,9 +395,9 @@ fn prefill_chunk_global_state_serial() {
     // the hardcoded gemma4 default. With `arch = "qwen3_5_moe"` the controller's
     // `current` starts from that arch's default (2048), so the first overload
     // lower halves it to 1024. Under the old hardcoded-"gemma4" bug `current`
-    // would have started at 512 and the first lower would land at 256 — so an
-    // exact `resolved == arch_default / 2` assertion discriminates the two
-    // (1024 vs 256). Note: `arch_default` MUST be captured BEFORE driving the
+    // would have started at gemma4's default (1024) and the first lower would
+    // land at 512 — so an exact `resolved == arch_default / 2` assertion
+    // discriminates the two (1024 vs 512). Note: `arch_default` MUST be captured BEFORE driving the
     // controller, while the override is cleared — `prefill_chunk_for` returns the
     // runtime override (highest precedence) once one is set, so reading it after
     // the lower would self-corrupt the bound.
@@ -428,15 +428,15 @@ fn prefill_chunk_global_state_serial() {
         }
 
         // The lower must have set an override; the first overload lower halves
-        // the qwen3_5_moe arch default (2048 → 1024). Under the old gemma4-512
-        // bug it would be 256, so the exact-equality check discriminates.
+        // the qwen3_5_moe arch default (2048 → 1024). Under the old gemma4-default
+        // bug it would be 512, so the exact-equality check discriminates.
         let resolved = rmlx_models::prefill_chunk::runtime_override()
             .expect("D: overload must lower the chunk and set a runtime override");
         assert_eq!(
             resolved,
             arch_default / 2,
             "D: first lower must halve the qwen3_5_moe default ({arch_default} → {}), \
-             not start from gemma4's 512; got {resolved}",
+             not start from gemma4's default; got {resolved}",
             arch_default / 2
         );
         rmlx_models::prefill_chunk::set_prefill_chunk(0);

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -343,6 +343,14 @@ Text only. No vision or audio tower.
 - **GDN recurrent layers.** Unique to this architecture family. The recurrent
   state enables efficient autoregressive decoding without growing KV caches for
   those layers.
+- **GDN prefill = decode kernel.** Both prefill and decode run the
+  `gated_delta_step_gpu` Metal kernel (port of mlx-lm's `gated_delta_kernel`):
+  the per-timestep recurrence loops inside one dispatch with the state in
+  registers, parallelised across heads/dims. Chaining it across prefill chunks
+  is f32-state-exact, so a large `prefill_chunk` (2048, matching mlx-lm's
+  `prefill_step_size`) is the fast path — it does NOT route to the lazy ops-graph
+  reference (`gated_delta_prefill_ops`, now test-only). This is the prefill/TTFT
+  lever; small chunks multiply forward passes and per-chunk KV-state evals.
 - **Speculative decoding fully wired.** `forward_seq_last_k_with_cache`,
   `forward_verify_capture`, `forward_verify_capture_hot`,
   `forward_verify_capture_chunked`, `logits_from_hidden`, `embed_tokens_raw`

--- a/docs/models/gemma4/rMLX.md
+++ b/docs/models/gemma4/rMLX.md
@@ -55,6 +55,13 @@ serve), so rMLX cells compare directly. Bar (§0.1): WIN / TIE-on-CI-overlap / L
   not a dependable Gemma4 win — drafter accept-rate is the whole story.
 - **Prefill/TTFT is still brutal on the big models** — 31b dense `none` 128k cold
   prefill **477 s**; the lever there is prefill, not decode.
+- **Prefill chunk raised 512 → 1024** (one shared `arch_default("gemma4")`). A
+  warm-TTFT kv-none sweep put 1024 at the sweet spot: e4b 4k 602→565 ms / 8k
+  1234→1179 ms (~+6 %/+4.5 %), 26b-a4b 4k 1578→1302 ms / 8k 3285→2743 ms (~+17 %),
+  decode flat, no watchdog. `chunk=2048` *regresses* the e4b dense path (window=512
+  exec-unit cliff) so it is not the shared default; the 26b would gain a further
+  ~5 % at 2048 but the shared key stays 1024 to protect e4b. The cold long-ctx
+  numbers above predate this and are unrefreshed.
 
 ---
 

--- a/docs/models/qwen3.6/SIBLINGS.md
+++ b/docs/models/qwen3.6/SIBLINGS.md
@@ -125,12 +125,15 @@ bandwidth utilization (kernel efficiency), NOT quant — recoverable in rMLX on 
 same weights. The literal "2×" is mostly an artifact of uncontrolled generation
 + caching.**
 
-**Bigger real gap found (decode is fine; prefill is not):** rMLX `baseline` @ 4k
-shows **TTFT ≈ 6.9 s, prefill ≈ 580 tok/s** vs mlx-lm TTFT ≈ 144 ms. rMLX
-prefill at short context is ~40–50× slower than mlx-lm — the genuine
-optimization target, far more impactful than the contaminated decode "2×". Needs
-its own investigation (chunked-prefill path / first-prefill graph cost on the
-MoE) in the improvement plan.
+**Prefill gap — investigated and RESOLVED (was a chunk-size bug + a flawed
+baseline):** rMLX `baseline` @ 4k once showed **TTFT ≈ 6.9 s, prefill ≈ 580
+tok/s**, attributed at the time to a "~40–50× vs mlx-lm (144 ms)" deficit. Both
+numbers were wrong. The 6.9 s was a GatedDeltaNet chunk-size bug (prefill pinned
+at chunk=64); fixing it (GDN kernel-always → chunk 2048) brought 4k TTFT to
+≈ 1.06 s (~3050 tok/s). The "mlx-lm 144 ms / 28000 tok/s" baseline is
+non-physical — a direct mlx-lm 0.31.3 run on this snapshot measures ≈ 2.7k–3.6k
+prompt tok/s, i.e. mlx-lm is only ~1.1–1.2× faster. Prefill is bandwidth-bound;
+rMLX is at mlx-lm parity. No structural prefill deficit remains.
 
 **To settle ollama honestly (later):** re-measure with `num_predict=256`, prompt
 caching disabled, and confirm full-context attention — then its decode TPS is

--- a/docs/models/qwen3.6/rMLX.md
+++ b/docs/models/qwen3.6/rMLX.md
@@ -18,8 +18,13 @@ Step-by-step execution — one cell per run.
   +12–15% (kv-none), confirmed path-equivalent to the sibling harness (−0.2%).
 - **Best KV: rotor3 / iso3** (rotation codecs) — +1.9% over none at 128k. Turbo
   codecs *lose* at long ctx (V-dequant overhead). At 8k all 8-bit-K codecs tie.
-- **The real deficit is prefill/TTFT**, ~40–50× slower than mlx-lm at short ctx —
-  the #1 improvement-plan target.
+- **Prefill/TTFT was the dominant deficit** (~40–50× slower than mlx-lm at short
+  ctx). **Now largely closed**: the GatedDeltaNet recurrence always runs the
+  `gated_delta_step_gpu` kernel (instead of flipping to a lazy ops-graph at
+  T≥256), which lets the prefill chunk rise 64→2048 (mlx-lm's `prefill_step_size`).
+  A kv-none warm-TTFT sweep measured **4.0–4.2× lower TTFT** at 4k/8k/16k with no
+  decode change and no Metal watchdog through 64k. The §2a grid below is the
+  pre-fix `rmlx baseline` record; a protocol-matched re-bench is pending. See §4 ①.
 - **Speculative barely helps:** MTP +4.2% (best drafter), DFlash −37%, Eagle3
   −39% (now works after the crash fix, but low accept ~0.27 → net loss). Spec-loop
   overhead eats the accept gain.
@@ -203,11 +208,21 @@ the overhead.
 
 Ranked by impact:
 
-1. **Prefill / TTFT — the dominant deficit.** rMLX prefill is ~40–50× slower than
-   mlx-lm at short ctx (4k TTFT 6.9s vs ~144ms) and degrades with length (prefill
-   596→419 tok/s as 4k→128k; TTFT 6.9s→132s→5m12s). Decode is fine; **prefill is
-   where rMLX loses wall-clock.** Profile the MoE first-prefill path (chunked
-   prefill, expert gather, graph compile). Highest-value fix.
+1. **Prefill / TTFT — the dominant deficit. LARGELY RESOLVED.** rMLX prefill was
+   ~40–50× slower than mlx-lm at short ctx (4k TTFT 6.9s vs ~144ms), degrading
+   with length (prefill 596→419 tok/s as 4k→128k). Root cause: the GatedDeltaNet
+   recurrence flipped from the `gated_delta_step_gpu` Metal kernel to a lazy
+   ops-graph at T≥256 (~184K nodes at T=256, ~1.47M at T=2048 across 30 GDN
+   layers), which pinned the prefill chunk at 64 — so a 4k prompt ran ~64 forward
+   passes + 63 KV-state evals where mlx-lm runs ~2. Fix: the GDN now always uses
+   the kernel (one dispatch, T-loop in registers; chaining across chunks is
+   f32-state-exact and matches mlx-lm's `use_kernel=True` default), unblocking a
+   chunk rise to 2048 (mlx-lm's `prefill_step_size`). A kv-none warm-TTFT sweep
+   on this snapshot measured TTFT 4k 4240→1065ms (4.0×), 8k 9008→2136ms (4.2×),
+   16k 19489→4712ms (4.1×); 32k/64k complete with no Metal watchdog; the 3-family
+   decode canary is unchanged. **Still open:** rMLX prefill remains above mlx-lm
+   in absolute terms (per-chunk host-side mask build, post-prefill prompt-cache
+   eval on the TTFT path) — a further, smaller lever.
 2. **Decode kernel headroom.** rMLX wins the tier but sits ~half of M5-Max roofline
    (≈340 GB/s of ~600). llama.cpp/ollama saturate more. Tighter MoE decode kernels
    (expert gather + dequant fusion) could extend the lead. `--fused-qk` is

--- a/docs/models/qwen3.6/rMLX.md
+++ b/docs/models/qwen3.6/rMLX.md
@@ -18,13 +18,18 @@ Step-by-step execution — one cell per run.
   +12–15% (kv-none), confirmed path-equivalent to the sibling harness (−0.2%).
 - **Best KV: rotor3 / iso3** (rotation codecs) — +1.9% over none at 128k. Turbo
   codecs *lose* at long ctx (V-dequant overhead). At 8k all 8-bit-K codecs tie.
-- **Prefill/TTFT was the dominant deficit** (~40–50× slower than mlx-lm at short
-  ctx). **Now largely closed**: the GatedDeltaNet recurrence always runs the
-  `gated_delta_step_gpu` kernel (instead of flipping to a lazy ops-graph at
-  T≥256), which lets the prefill chunk rise 64→2048 (mlx-lm's `prefill_step_size`).
-  A kv-none warm-TTFT sweep measured **4.0–4.2× lower TTFT** at 4k/8k/16k with no
-  decode change and no Metal watchdog through 64k. The §2a grid below is the
-  pre-fix `rmlx baseline` record; a protocol-matched re-bench is pending. See §4 ①.
+- **Prefill/TTFT — FIXED, now at parity with mlx-lm.** The GatedDeltaNet
+  recurrence flipped from the `gated_delta_step_gpu` kernel to a lazy ops-graph at
+  T≥256, which pinned the prefill chunk at 64 and made rMLX ~7× slower than its
+  own potential. Fix: GDN always uses the kernel → chunk rises 64→2048 (mlx-lm's
+  `prefill_step_size`). A kv-none warm-TTFT sweep measured **4.0–4.2× lower TTFT**
+  (4k 4240→1065ms, 8k 9008→2136ms) with no decode change, no Metal watchdog
+  through 64k. **The earlier "~40–50× slower than mlx-lm / 4k TTFT 144ms" claim
+  was a measurement error** — a direct mlx-lm 0.31.3 run on this exact snapshot +
+  prompts measures **2711–3606 prompt tok/s** (4k/8k), i.e. ~1.1–1.2× of rMLX's
+  ~3050 tok/s; the cited 28000 tok/s exceeds the M5 Max bandwidth ceiling and is
+  non-physical. Prefill is bandwidth-bound; both backends sit at ~the same level.
+  The §2a grid below is the pre-fix `rmlx baseline` record. See §4 ①.
 - **Speculative barely helps:** MTP +4.2% (best drafter), DFlash −37%, Eagle3
   −39% (now works after the crash fix, but low accept ~0.27 → net loss). Spec-loop
   overhead eats the accept gain.
@@ -200,7 +205,8 @@ the overhead.
 
 > **Phase B verdict: rMLX baseline (kv none) WINS decode at every prompt size**
 > (+12–15%) vs the champion mlx-lm-turboquant. KV-quant variants (Phase C) may
-> push further. The deficit is prefill/TTFT, not decode (§4).
+> push further. Prefill/TTFT (once the apparent deficit) is now at mlx-lm parity
+> after the chunk fix — see §4 ①.
 
 ---
 
@@ -208,21 +214,28 @@ the overhead.
 
 Ranked by impact:
 
-1. **Prefill / TTFT — the dominant deficit. LARGELY RESOLVED.** rMLX prefill was
-   ~40–50× slower than mlx-lm at short ctx (4k TTFT 6.9s vs ~144ms), degrading
-   with length (prefill 596→419 tok/s as 4k→128k). Root cause: the GatedDeltaNet
-   recurrence flipped from the `gated_delta_step_gpu` Metal kernel to a lazy
-   ops-graph at T≥256 (~184K nodes at T=256, ~1.47M at T=2048 across 30 GDN
-   layers), which pinned the prefill chunk at 64 — so a 4k prompt ran ~64 forward
-   passes + 63 KV-state evals where mlx-lm runs ~2. Fix: the GDN now always uses
-   the kernel (one dispatch, T-loop in registers; chaining across chunks is
-   f32-state-exact and matches mlx-lm's `use_kernel=True` default), unblocking a
-   chunk rise to 2048 (mlx-lm's `prefill_step_size`). A kv-none warm-TTFT sweep
-   on this snapshot measured TTFT 4k 4240→1065ms (4.0×), 8k 9008→2136ms (4.2×),
-   16k 19489→4712ms (4.1×); 32k/64k complete with no Metal watchdog; the 3-family
-   decode canary is unchanged. **Still open:** rMLX prefill remains above mlx-lm
-   in absolute terms (per-chunk host-side mask build, post-prefill prompt-cache
-   eval on the TTFT path) — a further, smaller lever.
+1. **Prefill / TTFT — RESOLVED; rMLX is at mlx-lm parity.** rMLX prefill was ~7×
+   slower than its own potential (NOT the "40–50× vs mlx-lm" originally claimed —
+   see below), degrading with length. Root cause: the GatedDeltaNet recurrence
+   flipped from the `gated_delta_step_gpu` Metal kernel to a lazy ops-graph at
+   T≥256 (~184K nodes at T=256, ~1.47M at T=2048 across 30 GDN layers), which
+   pinned the prefill chunk at 64 — so a 4k prompt ran ~64 forward passes + 63
+   KV-state evals where mlx-lm runs ~2. Fix: the GDN now always uses the kernel
+   (one dispatch, T-loop in registers; chaining across chunks is f32-state-exact
+   and matches mlx-lm's `use_kernel=True` default), unblocking a chunk rise to
+   2048 (mlx-lm's `prefill_step_size`). A kv-none warm-TTFT sweep measured TTFT 4k
+   4240→1065ms (4.0×), 8k 9008→2136ms (4.2×), 16k 19489→4712ms (4.1×); 32k/64k
+   complete with no Metal watchdog; the 3-family decode canary is unchanged.
+   **Baseline correction:** the original "~40–50× slower / 4k TTFT 144ms" was a
+   measurement error. A direct mlx-lm 0.31.3 run on this exact snapshot + prompts
+   measures **2711/3301 tok/s @4k (cold/warm), 3606 @8k** — vs rMLX's ~3050 tok/s,
+   i.e. mlx-lm is only **1.08–1.18×** faster, not 48×. The cited 28000 tok/s is
+   non-physical (exceeds M5-Max bandwidth ~5×). Prefill is bandwidth-bound and
+   both backends sit at ~the same level; the residual ~10–18% is ordinary
+   cross-impl kernel variance (host-side mask build is one small contributor),
+   not a structural deficit. **Investigated + dropped:** moving the post-prefill
+   prompt-cache store off the TTFT path — measured at 2.9ms (0.17% of TTFT), no
+   measurable win, reverted.
 2. **Decode kernel headroom.** rMLX wins the tier but sits ~half of M5-Max roofline
    (≈340 GB/s of ~600). llama.cpp/ollama saturate more. Tighter MoE decode kernels
    (expert gather + dequant fusion) could extend the lead. `--fused-qk` is


### PR DESCRIPTION
## Summary

Fixes #155 (Qwen3.6 prefill/TTFT). The root cause was a GatedDeltaNet chunk-size bug, **not** a kernel deficit — and the issue's "~40–50× slower than mlx-lm" premise turned out to be a flawed baseline.

### 1. Qwen3.6 — GDN kernel-always + chunk 64→2048 (`424087c`)
The GatedDeltaNet recurrence flipped from the `gated_delta_step_gpu` Metal kernel to a lazy ops-graph at `T≥256` (~184K nodes at T=256, ~1.47M at T=2048 across 30 GDN layers), which pinned the prefill chunk at **64**. A 4k prompt therefore ran ~64 forward passes + 63 KV-state evals where mlx-lm runs ~2.

The kernel is a byte-for-byte port of mlx-lm's `gated_delta_kernel`, which mlx-lm uses for the whole prompt (`use_kernel=True` default). Making the GDN always use it (chaining across chunks is f32-state-exact) unblocks raising the chunk to 2048 (mlx-lm's `prefill_step_size`).

**Real-model sweep (kv-none, warm TTFT):**

| ctx | before | after | speedup |
|---|---|---|---|
| 4k | 4240 ms | 1065 ms | 4.0× |
| 8k | 9008 ms | 2136 ms | 4.2× |
| 16k | 19489 ms | 4712 ms | 4.1× |

No decode regression (3-family canary: Bonsai 109.5, gemma4-e4b 78.4, Qwen3.6 99.8 TPS), no Metal watchdog through 64k, output coherent. `gated_delta_prefill_ops` retained as the test-only equivalence oracle.

### 2. Gemma 4 — chunk 512→1024 (`b019d26`)
Gemma 4 prefill was already healthy (no GDN). A real-model sweep found 1024 the shared TTFT sweet spot: e4b 4k +6% / 8k +4.5%, 26b-a4b 4k +17% / 8k +17%, decode flat, no watchdog, coherent at 4k/8k/16k. `chunk=2048` *regresses* the e4b dense path (window=512 exec-unit cliff), so the shared `arch_default("gemma4")` stays 1024.

### 3. Baseline correction (`7d3d497`)
The "~40–50× slower / 4k TTFT 144ms / 28000 tok/s" claim was a measurement error (exceeds the M5-Max bandwidth ceiling, non-physical). A direct **mlx-lm 0.31.3** run on the same snapshot + prompts measures **2711/3301 tok/s @4k (cold/warm), 3606 @8k** vs rMLX's ~3050 — mlx-lm is only **1.1–1.2×** faster. **rMLX prefill is at mlx-lm parity** (both bandwidth-bound). README, `docs/models/qwen3.6/rMLX.md`, and `SIBLINGS.md` retract the claim. Also recorded: moving the post-prefill prompt-cache store off the TTFT path was investigated and dropped (measured 2.9ms = 0.17% of TTFT).

## Verification
- `make lint` + `cargo fmt --check` + `cargo check --all-targets` clean.
- Tests: `prefill_chunk` 8/8, GDN kernel↔ops equivalence 6/6, admission 23/23.
- rust-reviewer: no CRITICAL/HIGH; all findings addressed.
- Real-model proven on Qwen3.6-35B-A3B-8bit + gemma-4-e4b/26b-a4b.

Closes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)