### PR TITLE
docs: document single-stream concurrency model + decouple README from version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ KV families (TurboQuant, IsoQuant, PlanarQuant, RotorQuant, ParoQuant) that no
 other MLX server offers. Works as a local backend for any OpenAI/Anthropic-compatible
 coding agent (Claude Code, Cursor, Aider, OpenCode).
 
-> Status: **0.2.4** — feature-complete native MLX backend: OpenAI- and
+> Status: **feature-complete native MLX backend** — OpenAI- and
 > Anthropic-compatible text, tool/function calling, streaming, image + audio
 > input, embeddings, and a multi-model registry. Apple Silicon only (Metal).
-> See [What works](#what-works).
+> Latest release version: see the badge above. See [What works](#what-works).
 
 ## Why
 
@@ -268,6 +268,12 @@ internal path deps omit a version (`deny.toml` sets `allow-wildcard-paths`).
 3. `make tag` — derives `v<version>` from `Cargo.toml`, creates the annotated
    tag.
 4. `git push origin v<version>`, then cut the GitHub release from the tag.
+
+This README is **not** version-bumped per release: the badge above tracks
+GitHub releases automatically, and the Status line carries no version number.
+Edit `README.md` only when capabilities materially change (a new modality,
+architecture family, or endpoint). The full release flow — changelog, signing,
+Homebrew bottle, tap — lives in [`docs/RELEASING.md`](docs/RELEASING.md).
 
 ## License
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -24,6 +24,13 @@ crates are `publish = false`). There is no separate `VERSION` file.
    (Keep a Changelog format) and the matching `[<version>]:` link at the
    bottom. This is the durable, in-repo record and the source of the Release
    body.
+
+   > **Do not version-bump `README.md`.** The README is intentionally decoupled
+   > from the release steps: its version badge (`shields.io/github/v/release`)
+   > tracks GitHub Releases automatically, and the Status line carries no version
+   > number. `CHANGELOG.md` is the per-release doc edit; the README changes only
+   > when capabilities materially change (a new modality, architecture family, or
+   > endpoint) — never for a routine version bump.
 3. **Gate:** `make ci` green (fmt + clippy + test + deny + audit).
 4. **Tag:** `make tag` → creates annotated `v<version>` from `Cargo.toml`.
    Push it: `git push origin v<version>`.

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -132,6 +132,42 @@ used only at the HTTP boundary (axum handlers, SSE channel receive) and for
 file I/O. The GPU gate mutex inside each generator ensures at most one blocking
 thread executes a forward pass at any instant.
 
+### Concurrency model — single-stream by design
+
+rMLX serves requests **serially, one generation at a time**. This is a
+deliberate design choice, not a missing feature, and it shapes the latency
+profile under load.
+
+**What happens with concurrent requests.** The 1-permit `gpu_queue` semaphore
+admits requests in strict FIFO order; the permit is held for the *entire*
+decode and released only on completion. There is **no continuous batching** and
+**no cross-sequence interleave**: the decode loop processes a single sequence,
+and a request's chunked prefill runs to completion before that request's own
+decode begins. Concretely, request B does not make progress while request A is
+running — B waits behind A's whole generation (prefill **and** decode), then
+runs in full. Per-arch prefill chunking (`prefill_chunk_for`) is a
+per-request memory/watchdog bound, not a scheduler that interleaves A's prefill
+chunks with B's decode steps.
+
+**Why this is the right fit.** Apple Silicon gives one exclusive Metal context
+per process, and rMLX enforces a single MLX process per machine (claim file).
+The target workload is **single-user / agent-driving**, where exactly one
+generation is in flight at a time — the regime where a native Rust decode loop
+is at its strongest (no interpreter or async-scheduler overhead between tokens).
+A serial engine wins single-stream latency precisely because it does not pay for
+batching machinery it would not use.
+
+**Implication under load.** Because requests serialize, aggregate throughput
+stays roughly flat as concurrency rises (no batching speedup), and a request's
+end-to-end latency grows roughly linearly with the number of requests queued
+ahead of it. `max_queue_depth` (HTTP 429) bounds memory under burst, and the
+optional adaptive-admission controller sheds load under SLA pressure — but
+neither adds parallelism. **High-concurrency multi-tenant serving is explicitly
+out of scope**: there is no in-process continuous batching or vLLM-style
+chunked-prefill-interleaved scheduler. To serve many simultaneous users, run a
+pool of rMLX processes behind a load balancer (one Metal context each), rather
+than expecting a single process to scale up internally.
+
 ---
 
 ## Routes


### PR DESCRIPTION
## Summary

Two documentation changes, no code touched.

**1. Document the single-stream concurrency model (SERVER.md).**
A benchmark study (Rust-vs-Python LLM inference) prompted a check of how rMLX
behaves under concurrent load. A code investigation confirmed the engine
serializes every generation behind the 1-permit FIFO GPU gate — no continuous
batching, no cross-sequence prefill/decode interleave; request B waits behind
request A's entire generation. SERVER.md never stated this. Added a
**"Concurrency model — single-stream by design"** subsection that:
- describes the serial behavior precisely (1-permit semaphore held for the whole decode; per-request chunked prefill is a memory bound, not a cross-sequence scheduler),
- frames it as the right fit for the single-MLX-process-per-Mac, single-user / agent-driving target (the regime a native Rust decode loop is strongest in),
- states the implication honestly (flat aggregate throughput, p50 grows ~linearly with queue depth) and that high-concurrency multi-tenant serving is out of scope — run a pool of processes behind a load balancer instead.

Cross-checked the other docs: no contradicting multi-tenant/throughput-under-load claims exist elsewhere.

**2. Decouple README from per-release version bumps.**
The README Status line hardcoded `0.2.4` — a third copy of a value that already
lives in `Cargo.toml` (single source) and the live shields.io release badge, so
it drifted (Cargo.toml was already at 0.2.5). Removed the number from the Status
line (badge still shows the live version) and added a release-process rule in
both the README Releasing section and `docs/RELEASING.md`: README is edited only
when capabilities materially change, never for a routine version bump.

## Test
- All markdown hygiene pre-commit hooks pass on the three changed files.
- SERVER.md concurrency claims verified against the actual server/runtime code (1-permit FIFO, single-sequence decode loop, per-request chunked prefill).
- 0 hardcoded version literals remain in README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)