### PR TITLE
feat(kv-quant): bf16 floor at none-path cache store boundary (#169)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,17 @@ ci-perf:         ## pre-push gate under release-perf (separate from make ci; run
 	$(MAKE) test-perf
 	@echo "ci-perf ok"
 
-# model-check: run only the model-logic crates (rmlx-models, rmlx-runtime, rmlx-quant).
-# Excludes server, CLI, and metrics churn. The #[ignore] integration tests stay
-# skipped here — this target completes <30 s without any model present.
-model-check:     ## cargo test -p rmlx-{models,runtime,quant} only (no server/cli/metrics; <30s, no model needed)
-	cargo test -p rmlx-models -p rmlx-runtime -p rmlx-quant
+# model-check: run only the model-logic crates (rmlx-models, rmlx-runtime,
+# rmlx-quant) plus the KV-codec crate (rmlx-kv-quant). Excludes server, CLI, and
+# metrics churn. The #[ignore] integration tests stay skipped here — this target
+# runs without any model present.
+#
+# rmlx-kv-quant is included so the cache-level bf16 store-boundary floor (the
+# model-agnostic f32-KV guard) is checked at every integration run: its
+# bytes-per-element invariant tests (resident_bytes_tests) trip CI the moment a
+# future arch leaks f32 into the unquantised KV store.
+model-check:     ## cargo test -p rmlx-{models,runtime,quant,kv-quant} (no server/cli/metrics; no model needed)
+	cargo test -p rmlx-models -p rmlx-runtime -p rmlx-quant -p rmlx-kv-quant
 
 # model-check-full: run the model-logic unit tests (same as model-check) PLUS the
 # per-arch golden-token integration tests gated by RMLX_KV_TEST_MODEL.

--- a/crates/rmlx-kv-quant/src/kvcache/resident_bytes_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/resident_bytes_tests.rs
@@ -14,6 +14,11 @@
 //! 3. Two independently populated layers sum correctly.
 //! 4. `KvStorage::None` contributes 0; only `KvCache::decode_fp16_k/v` are
 //!    counted.
+//!
+//! Also pins the **bf16 store-boundary floor** (the model-agnostic f32-KV
+//! guard): an f32 K/V fed through the prefill-seed and decode-store paths must
+//! land in the cache as bf16 (2 B/elem), so a future upstream f32 leak fails
+//! fast on the bytes-per-element invariant instead of silently doubling KV.
 
 use super::core::KvCache;
 use crate::KvQuant;
@@ -31,6 +36,20 @@ fn bf16_zeros(b: i32, kv_h: i32, seq: i32, d: i32) -> Array {
     // bf16 = 2 bytes per element; zero-fill.
     let bytes = vec![0u8; n * 2];
     Array::from_bytes(&bytes, &[b, kv_h, seq, d], Dtype::Bf16).unwrap()
+}
+
+/// Build a `[B, kv_h, seq, D]` **f32** Array with small non-zero values on CPU.
+///
+/// Models the f32-KV leak: an upstream f32 scalar promoted the attention stream
+/// to f32, so the cache receives f32 (4 B/elem) K/V at the store boundary.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper — panic on failure is the desired outcome"
+)]
+fn f32_ramp(b: i32, kv_h: i32, seq: i32, d: i32) -> Array {
+    let n = (b * kv_h * seq * d) as usize;
+    let data: Vec<f32> = (0..n).map(|i| (i % 13) as f32 * 0.01).collect();
+    Array::from_f32_slice(&data, &[b, kv_h, seq, d]).unwrap()
 }
 
 // ── tests ──────────────────────────────────────────────────────────────────
@@ -221,4 +240,138 @@ fn layer_sum_is_additive() {
         per_layer * 2,
         "sum across two identical layers must equal 2 × per-layer"
     );
+}
+
+// ── bf16 store-boundary floor (model-agnostic f32-KV guard) ──────────────────
+//
+// These pin the cache-level bf16 floor: the unquantised (`KvQuant::None`) /
+// warm-TTFT store boundary casts incoming K/V to bf16 regardless of the
+// inbound dtype, so a future upstream f32 leak can never silently double
+// resident KV. The detector is the stored-buffer dtype (2 B/elem) — if the
+// cast is removed, an f32 input stores at 4 B/elem and these go RED.
+
+/// f32 K/V fed through the **prefill seed** path (`update_prefill_raw` →
+/// `exit_prefill`) is stored as bf16 — the seed dtype is floored independent of
+/// the inbound f32 stream.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test — panics are the intended failure mode"
+)]
+fn f32_prefill_seed_is_stored_bf16() {
+    const B: i32 = 1;
+    const KV_H: i32 = 2;
+    const SEQ: i32 = 16;
+    const D: i32 = 64;
+    let device = Device::Cpu;
+
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::None, 256);
+    let k = f32_ramp(B, KV_H, SEQ, D);
+    let v = f32_ramp(B, KV_H, SEQ, D);
+    assert_eq!(k.dtype(), Dtype::F32, "input K is f32 (the leak case)");
+
+    cache.enter_prefill();
+    cache.update(&k, &v, device).unwrap();
+    cache.exit_prefill(device).unwrap();
+
+    let (sk, sv) = cache
+        .decode_fp16_kv()
+        .expect("None-path prefill seed must populate decode_fp16_k/v");
+    assert_eq!(
+        sk.dtype(),
+        Dtype::Bf16,
+        "f32 K must be floored to bf16 at the prefill store boundary"
+    );
+    assert_eq!(
+        sv.dtype(),
+        Dtype::Bf16,
+        "f32 V must be floored to bf16 at the prefill store boundary"
+    );
+
+    // Bytes-per-element invariant: 2 buffers × B × kv_h × SEQ × D × 2 (bf16).
+    let elems_per_buf = (B * KV_H * SEQ * D) as u64;
+    let expected = 2 * elems_per_buf * 2;
+    assert_eq!(
+        cache.resident_bytes(),
+        expected,
+        "resident KV must be 2 B/elem (bf16), not 4 B/elem (f32 leak)"
+    );
+    // Explicit bytes/elem == 2 derivation, independent of the formula above.
+    let bytes_per_elem = cache.resident_bytes() / (2 * elems_per_buf);
+    assert_eq!(bytes_per_elem, 2, "stored KV must be 2 bytes per element");
+}
+
+/// f32 K/V fed through the **decode store** path (`update_decode_fp16`, the
+/// post-`exit_prefill` per-step append) is stored as bf16 — the decode mirror
+/// stays floored, not just the prefill seed.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test — panics are the intended failure mode"
+)]
+fn f32_decode_store_is_stored_bf16() {
+    const B: i32 = 1;
+    const KV_H: i32 = 2;
+    const SEQ: i32 = 8;
+    const D: i32 = 64;
+    let device = Device::Cpu;
+
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::None, 256);
+    // Prefill with bf16 so the decode-store path (not the prefill path) is the
+    // one under test on the following f32 step.
+    let pk = bf16_zeros(B, KV_H, SEQ, D);
+    let pv = bf16_zeros(B, KV_H, SEQ, D);
+    cache.enter_prefill();
+    cache.update(&pk, &pv, device).unwrap();
+    cache.exit_prefill(device).unwrap();
+
+    // One decode step with an f32 K/V (the per-token leak case).
+    let dk = f32_ramp(B, KV_H, 1, D);
+    let dv = f32_ramp(B, KV_H, 1, D);
+    assert_eq!(
+        dk.dtype(),
+        Dtype::F32,
+        "decode-step K is f32 (the leak case)"
+    );
+    cache.update(&dk, &dv, device).unwrap();
+
+    let (sk, sv) = cache
+        .decode_fp16_kv()
+        .expect("decode mirror must be populated after a decode step");
+    assert_eq!(
+        sk.dtype(),
+        Dtype::Bf16,
+        "f32 K must be floored to bf16 at the decode store boundary"
+    );
+    assert_eq!(
+        sv.dtype(),
+        Dtype::Bf16,
+        "f32 V must be floored to bf16 at the decode store boundary"
+    );
+}
+
+/// Control: a bf16 input stays bf16 (the floor is idempotent — the steady state
+/// after the per-arch source fixes is a pure no-op).
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test — panics are the intended failure mode"
+)]
+fn bf16_input_stays_bf16_no_op() {
+    const B: i32 = 1;
+    const KV_H: i32 = 2;
+    const SEQ: i32 = 16;
+    const D: i32 = 64;
+    let device = Device::Cpu;
+
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::None, 256);
+    let k = bf16_zeros(B, KV_H, SEQ, D);
+    let v = bf16_zeros(B, KV_H, SEQ, D);
+    cache.enter_prefill();
+    cache.update(&k, &v, device).unwrap();
+    cache.exit_prefill(device).unwrap();
+
+    let (sk, sv) = cache.decode_fp16_kv().expect("seed must be populated");
+    assert_eq!(sk.dtype(), Dtype::Bf16, "bf16 K stays bf16");
+    assert_eq!(sv.dtype(), Dtype::Bf16, "bf16 V stays bf16");
 }

--- a/crates/rmlx-kv-quant/src/kvcache/resident_bytes_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/resident_bytes_tests.rs
@@ -348,6 +348,20 @@ fn f32_decode_store_is_stored_bf16() {
         Dtype::Bf16,
         "f32 V must be floored to bf16 at the decode store boundary"
     );
+
+    // Bytes-per-element invariant on the resident buffer: SEQ+1 positions
+    // filled (SEQ-token prefill + 1 decode step), 2 buffers (K and V), each
+    // element bf16 = 2 bytes.  If the decode store silently kept f32 the
+    // resident_bytes() would be 2× larger and this assertion would catch it
+    // independently of any slice_update dtype-coercion behaviour.
+    let filled = (SEQ + 1) as u64; // prefill offset + one decode step
+    let elems_per_buf = (B * KV_H) as u64 * filled * D as u64;
+    let expected_bytes = 2 * elems_per_buf * 2; // 2 buffers × 2 B/elem (bf16)
+    assert_eq!(
+        cache.resident_bytes(),
+        expected_bytes,
+        "resident KV must be 2 B/elem (bf16) after decode step; f32 storage would produce 4 B/elem"
+    );
 }
 
 /// Control: a bf16 input stays bf16 (the floor is idempotent — the steady state

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -39,6 +39,31 @@ fn layer_idx_u32(layer_idx: usize) -> u32 {
     layer_idx as u32
 }
 
+/// Model-agnostic bf16 floor for the unquantised (`KvQuant::None`) / warm-TTFT
+/// cache store boundary.
+///
+/// The `decode_fp16_k/v` mirror is bf16 by contract (that is what every sibling
+/// MLX backend stores for unquantised KV, and the only sensible value), but the
+/// incoming K/V inherit whatever dtype the model's attention stream happened to
+/// produce. A single f32 scalar leaking into that stream upstream silently
+/// promotes K/V to f32 and doubles resident KV. Casting here at the store
+/// boundary caps the memory damage regardless of arch — defence-in-depth on top
+/// of the per-arch source fixes, not a replacement for them (upstream f32
+/// compute stays f32; this only floors what the cache *stores*).
+///
+/// Idempotent: when the input is already bf16 (the steady state after the
+/// per-arch fixes) this returns `None` after a cheap dtype check — no `astype`
+/// launch on the decode hot path. Only a non-bf16 input materialises the cast.
+/// Callers fold the result with `result.as_ref().unwrap_or(new_k)`.
+#[inline]
+fn cast_store_bf16(arr: &Array, device: Device) -> Result<Option<Array>> {
+    if arr.dtype() == Dtype::Bf16 {
+        Ok(None)
+    } else {
+        Ok(Some(arr.astype(Dtype::Bf16, device)?))
+    }
+}
+
 /// Encode a KV chunk (`new_kv`, shape `[B, kv_h, S, D]`) via the iso4
 /// MSL kernel and return the resulting CPU [`IsoBlocks`].
 ///
@@ -902,6 +927,16 @@ impl KvCache {
         new_v: &Array,
         device: Device,
     ) -> Result<(Array, Array)> {
+        // bf16 floor: the raw prefill buffer becomes the warm-TTFT decode seed
+        // (the unquantised K/V the cache stores). Cast at the store boundary so
+        // an upstream f32 leak cannot double resident KV — the capacity grow,
+        // the buffer alloc, and the slice_update below all then see bf16.
+        // Idempotent: a no-op when already bf16.
+        let k_cast = cast_store_bf16(new_k, device)?;
+        let v_cast = cast_store_bf16(new_v, device)?;
+        let new_k = k_cast.as_ref().unwrap_or(new_k);
+        let new_v = v_cast.as_ref().unwrap_or(new_v);
+
         let shape = new_k.shape();
         let b = shape[0];
         let kv_h = shape[1];
@@ -2943,6 +2978,15 @@ impl KvCache {
         max_seq: i32,
         device: Device,
     ) -> Result<(Array, Array)> {
+        // bf16 floor: the unquantised / warm-TTFT decode mirror is bf16 by
+        // contract. Cast at the store boundary so an upstream f32 leak can never
+        // double resident KV (idempotent — a no-op when already bf16). The
+        // resulting `dtype` below then sizes the resident buffer in bf16 too.
+        let k_cast = cast_store_bf16(new_k, device)?;
+        let v_cast = cast_store_bf16(new_v, device)?;
+        let new_k = k_cast.as_ref().unwrap_or(new_k);
+        let new_v = v_cast.as_ref().unwrap_or(new_v);
+
         let shape = new_k.shape();
         let b = shape[0];
         let kv_h = shape[1];

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -590,6 +590,27 @@ byte-stable — only the token-row order **within** a block changes, and spill
 and dequant agree on sequence-major. GPU round-trip verified on `QuantIsoV3`
 (two-append GQA vs single-shot, `kv_h=1` control).
 
+### 5.7.4 The unquantised store boundary floors K/V to bf16
+
+The `KvQuant::None` / warm-TTFT decode mirror (`decode_fp16_k/v`) is bf16 by
+contract — the dtype every sibling MLX backend stores for unquantised KV. But the
+incoming K/V inherit whatever dtype the model's attention stream happened to
+produce, so a single f32 scalar leaking upstream (Gemma4 mxfp8 stream, Qwen3
+fp16 norm/scale params — both fixed per-arch) silently promoted the cache to f32
+and doubled resident KV, found months later in a bench.
+
+The store boundary therefore **casts incoming K/V to bf16 independent of the
+inbound dtype**, at the single model-agnostic choke point every arch funnels
+through (`update_prefill_raw` for the seed, `update_decode_fp16` for the decode
+append, both in `rmlx-kv-quant`). The cast is idempotent (a `dtype == Bf16`
+check, no `astype` on the already-bf16 hot path) so it is pure insurance. It is
+**defense-in-depth, not a substitute for the per-arch source fix**: it caps the
+*memory* damage but leaves any upstream f32 *compute* (RoPE / SDPA) still f32.
+The bytes-per-element detector (an f32 input must store as 2 B/elem) lives in
+`resident_bytes_tests.rs` and runs under `make model-check` (now `-p
+rmlx-kv-quant`), so a future arch leak trips CI. Full reference:
+`docs/KV_QUANT.md` §`KvStorage::None`.
+
 ### 5.8 TurboQuant requires Flash Attention
 
 The `tq4` V-side path is only valid through the Flash Attention dispatch.

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -394,6 +394,34 @@ records only `max_seq`; the actual arrays are owned by `KvCache` directly.
 current token offset into the pre-allocated buffer. SDPA uses
 `scaled_dot_product_attention` on the raw bf16 arrays.
 
+**Cache-boundary bf16 floor (model-agnostic f32-KV guard).** The store boundary
+casts incoming K/V to bf16 **independent of the inbound dtype**, so the resident
+buffer is bf16 regardless of what the model's attention stream produced. Both
+store sites that funnel into `decode_fp16_k/v` apply the floor:
+
+- `update_prefill_raw` (the warm-TTFT seed buffer that `exit_prefill` slices
+  into the decode mirror), and
+- `update_decode_fp16` (the per-step decode append; the cast also sizes the
+  resident `zeros(...)` allocation in bf16).
+
+The cast is **idempotent** — a cheap `dtype == Bf16` check returns the input
+untouched (no `astype` launch) in the steady state that the per-arch source
+fixes already produce, so it is pure insurance with negligible hot-path cost.
+This is **defense-in-depth, not a substitute for the per-arch fix**: it caps the
+*memory* damage of an upstream f32 leak (it cannot store f32) but does not fix
+the *compute* slowdown — any upstream f32 arithmetic (RoPE / SDPA) stays f32.
+The per-arch source fixes (Gemma4 §"Gemma4 global `--kv-quant none` KV is bf16",
+Qwen3 §"Qwen3 dense `--kv-quant none` KV is bf16") remain the real fix; this
+floor is the structural guard that makes the leak class impossible to re-create
+silently.
+
+The detector is a bytes-per-element invariant in
+`crates/rmlx-kv-quant/src/kvcache/resident_bytes_tests.rs`: an f32 K/V fed
+through the prefill-seed and decode-store paths must land as bf16 (2 B/elem). It
+is wired into `make model-check` (which now runs `-p rmlx-kv-quant`), so a future
+arch that leaks f32 into the unquantised KV store trips CI at integration instead
+of being found months later in a bench.
+
 **Memory cost**: `2 · B · kv_h · max_seq · head_dim · 2 bytes` per layer.
 At 128K context on a 35B-A3B model this is tens of gigabytes. Reserve for
 short-context parity benches only.

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -404,6 +404,14 @@ store sites that funnel into `decode_fp16_k/v` apply the floor:
 - `update_decode_fp16` (the per-step decode append; the cast also sizes the
   resident `zeros(...)` allocation in bf16).
 
+The K-only / V-only decode helper `update_decode_fp16_v_only` (used by the
+IsoKOnly and RotorKOnly asymmetric codecs to write their bf16 V mirror without
+disturbing the quantized K store) writes V in whatever dtype the codec provides,
+which is bf16 by codec contract — it is **not** floored here because it is a
+quantized-codec path, not the `KvQuant::None` / warm-TTFT path, and touching it
+would violate the hard rule that the floor must not reach into quantized codec
+internals.
+
 The cast is **idempotent** — a cheap `dtype == Bf16` check returns the input
 untouched (no `astype` launch) in the steady state that the per-arch source
 fixes already produce, so it is pure insurance with negligible hot-path cost.


### PR DESCRIPTION
## Summary

Closes #169 — makes the f32-KV-leak class **structurally impossible regardless of arch** by casting `--kv-quant none` / warm-TTFT K/V to bf16 at the single cache-store boundary, plus a bytes-per-element invariant test so any future regression fails fast.

Per-arch source fixes (#44 Gemma4, #51 Gemma4 MoE router, #168 Qwen3 dense) each stop one upstream f32 leak. This adds the **model-agnostic floor + detector** behind them: the resident `none`-path cache can no longer silently inherit f32, so the next arch that introduces an f32 scalar caps the memory damage at bf16 instead of a 2× KV blowup found months later in a bench.

> Defense-in-depth, **not** a substitute for the per-arch source fix — casting at the store boundary caps memory but leaves any upstream f32 compute still f32. The source fix remains the primary perf lever.

## Fix

A small idempotent `cast_store_bf16` helper applied at the two store sites that funnel into the shared `decode_fp16_k/v` buffers:
- **Decode store** (`update_decode_fp16`) and **prefill seed** (`update_prefill_raw`) — the cast shadows `new_k`/`new_v` at fn top, so the inherited `dtype`, the resident `zeros(...)` alloc, and the `slice_update` all see bf16. `exit_prefill` slices the now-bf16 buffer, so no separate change.
- **Idempotent**: `dtype == Bf16` skips `astype` → zero extra alloc/copy on the steady-state (already-bf16) decode path.
- **Scope-tight**: quantized code/scale paths (q8/turbo/planar) read `new_k`/`new_v` independently (`astype(F32)` internally) and are untouched. The K-only ISO/Rotor `update_decode_fp16_v_only` codec path is deliberately not floored (documented).

## Detector

- 3 invariant tests in `resident_bytes_tests.rs`: f32 K/V through the **prefill seed** and through a **decode step** both store bf16 (asserted via `resident_bytes()` bytes-per-elem, which keys off the real stored dtype), plus a bf16-stays-bf16 no-op control. Confirmed RED-on-removal (revert cast → `assertion left: F32, right: Bf16`).
- `make model-check` now also runs `-p rmlx-kv-quant`, so a future arch leak trips CI at integration, not in a bench.

## Real-model proof (no regression — floor is a no-op post-#168)

- 3-family coherence at `--kv-quant none` temp=0: Bonsai ✓, Gemma4-e4b ✓, Qwen3.6 ✓.
- Bonsai `none`-KV derives to exactly **2 B/elem (bf16)** on a real serve.
- `scripts/perf_canary.sh`: Bonsai 132.95, Gemma4-e4b 78.15, Qwen3.6 99.88 — all within run-to-run noise of baseline.

## Gate

`make check`, `make lint` (clippy -D warnings), `cargo fmt --check`, `make model-check` (exit 0) — all clean; `rmlx-kv-quant` 322 passed.

## Docs

`docs/KV_QUANT.md` (bf16 store-boundary floor section under `KvStorage::None` + V-only codec-path scope note), `docs/KV_CACHE.md` (invariant note).

> Part of the f32-KV-leak hardening tracked in #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
