### PR TITLE
feat(ci): scalar_f32 f32-leak gate for arch-layer code (#170)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         bench-codec-cell \
         smoke-codec-matrix \
         e2e \
-        file-size-report check-no-inline-tests
+        file-size-report check-no-inline-tests check-no-scalar-f32-leak
 
 help:
 	@awk 'BEGIN{FS=":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -162,9 +162,13 @@ file-size-report: ## advisory: print source files >1000 LOC (non-failing)
 check-no-inline-tests: ## CI gate: fail if any non-test.rs file has inline #[cfg(test)] mod tests { ... }
 	@bash scripts/check_no_inline_tests.sh
 
+check-no-scalar-f32-leak: ## CI gate: fail if arch-layer code has unguarded scalar_f32( not followed by .astype(
+	@bash scripts/check_no_scalar_f32_leak.sh
+
 # ---- one-shot CI gate -------------------------------------------------
 ci: fmt-check lint test deny audit ci-metrics ## full pre-merge gate: fmt + clippy + test + deny + audit + metrics-sanity + inline-test gate
 	@bash scripts/check_no_inline_tests.sh
+	@bash scripts/check_no_scalar_f32_leak.sh
 	@bash scripts/file_size_report.sh || true
 	@echo "ci ok"
 

--- a/crates/rmlx-models/src/bitnet/model.rs
+++ b/crates/rmlx-models/src/bitnet/model.rs
@@ -76,9 +76,9 @@ impl BitNetMlp {
         let up = self.up_proj.forward(x, device)?;
 
         let gate_act = {
-            // relu2: max(x,0)^2
+            // relu2: max(x,0)^2 — zero adopts gate dtype to avoid f32 promotion.
             use rmlx_mlx::{maximum, scalar_f32};
-            let zero = scalar_f32(0.0);
+            let zero = scalar_f32(0.0).astype(gate.dtype(), device)?;
             let pos = maximum(&gate, &zero, device)?;
             multiply(&pos, &pos, device)?
         };

--- a/crates/rmlx-models/src/gemma3/model.rs
+++ b/crates/rmlx-models/src/gemma3/model.rs
@@ -112,10 +112,12 @@ impl Gemma3Text {
     ) -> Result<Array> {
         // Embed tokens → [1, seq, hidden].
         let h = self.embed_tokens.forward(ids_arr, device)?;
-        // Embedding scale: sqrt(hidden_size).
+        // Embedding scale: sqrt(hidden_size). Adopt activation dtype so a
+        // strong-f32 scalar does not upcast the embedding stream.
         // Reference: gemma3_text.py Gemma3Model.__call__ line 190:
         // `h *= mx.array(self.args.hidden_size**0.5, mx.bfloat16).astype(h.dtype)`
-        let embed_scale = scalar_f32((self.cfg.hidden_size as f32).sqrt());
+        let embed_scale =
+            scalar_f32((self.cfg.hidden_size as f32).sqrt()).astype(h.dtype(), device)?;
         let h = multiply(&h, &embed_scale, device)?;
         let h = h.reshape(&[1, seq, self.cfg.hidden_size as i32], device)?;
         self.forward_h(h, seq, caches, device)
@@ -192,9 +194,10 @@ impl Gemma3Text {
             None => self.embed_tokens.as_linear(&h_last, device)?,
         };
 
-        // Final logit softcapping (optional — null in medgemma).
+        // Final logit softcapping (optional — null in medgemma). Adopt the
+        // logit dtype so a strong-f32 cap scalar does not upcast the stream.
         let logits = if let Some(cap) = self.cfg.final_logit_softcapping {
-            let cap_arr = scalar_f32(cap);
+            let cap_arr = scalar_f32(cap).astype(logits.dtype(), device)?;
             let scaled = divide(&logits, &cap_arr, device)?;
             let t = tanh(&scaled, device)?;
             multiply(&t, &cap_arr, device)?

--- a/crates/rmlx-models/src/gemma3/vision.rs
+++ b/crates/rmlx-models/src/gemma3/vision.rs
@@ -106,7 +106,7 @@ impl LayerNorm {
     fn forward(&self, x: &Array, device: Device) -> Result<Array> {
         let mut keep = x.shape();
         let d = *keep.last().expect("layer_norm: empty shape");
-        let inv_d = scalar_f32(1.0 / d as f32);
+        let inv_d = scalar_f32(1.0 / d as f32); // f32-ok: SigLIP tower runs entirely in f32
 
         // keepdims shape: replace last dim with 1.
         *keep.last_mut().unwrap() = 1;
@@ -122,7 +122,7 @@ impl LayerNorm {
             &inv_d,
             device,
         )?;
-        let denom = sqrt(&add(&var, &scalar_f32(self.eps), device)?, device)?;
+        let denom = sqrt(&add(&var, &scalar_f32(self.eps), device)?, device)?; // f32-ok: SigLIP tower runs entirely in f32
         let normed = divide(&xc, &denom, device)?;
         let scaled = multiply(&normed, &self.weight, device)?;
         add(&scaled, &self.bias, device)
@@ -274,7 +274,7 @@ impl MultiModalProjector {
         // reshape into [b, vh, tps, k, tps, k] then mean over the two k axes.
         // (Non-overlapping pool == block average == reshape + reduce.)
         let blocked = g.reshape(&[b, vh, tps, k, tps, k], device)?;
-        let inv_k = scalar_f32(1.0 / k as f32);
+        let inv_k = scalar_f32(1.0 / k as f32); // f32-ok: SigLIP tower runs entirely in f32
         let m1 = multiply(&sum_axis(&blocked, 5, device)?, &inv_k, device)?; // [b,vh,tps,k,tps]
         let pooled = multiply(&sum_axis(&m1, 3, device)?, &inv_k, device)?; // [b,vh,tps,tps]
 
@@ -598,7 +598,8 @@ pub fn build_inputs_embeds(
     let ids_i32: Vec<i32> = input_ids.iter().map(|&x| x as i32).collect();
     let ids_arr = Array::from_bytes(i32_bytes(&ids_i32), &[seq as i32], Dtype::I32)?;
     let h_raw = model.embed_tokens.forward(&ids_arr, device)?;
-    let embed_scale = scalar_f32((model.cfg.hidden_size as f32).sqrt());
+    let embed_scale =
+        scalar_f32((model.cfg.hidden_size as f32).sqrt()).astype(h_raw.dtype(), device)?;
     let mut embeds = multiply(&h_raw, &embed_scale, device)?;
     embeds = embeds.reshape(&[1, seq as i32, hidden], device)?;
     let embeds_dtype = embeds.dtype();
@@ -771,7 +772,7 @@ pub fn load_vision_tower(
     // `RMSNorm` from language.py: `rms_norm(x, 1.0 + weight, eps)`). rMLX's
     // `rms_norm` uses the weight as-is, so pre-shift `weight + 1.0` at load.
     let soft_emb_norm_w_raw = load_f32(&shards, "multi_modal_projector.mm_soft_emb_norm.weight")?;
-    let soft_emb_norm_w = add(&soft_emb_norm_w_raw, &scalar_f32(1.0), Device::Cpu)?;
+    let soft_emb_norm_w = add(&soft_emb_norm_w_raw, &scalar_f32(1.0), Device::Cpu)?; // f32-ok: both operands are f32 weights loaded via load_f32
     let projector = MultiModalProjector {
         soft_emb_norm_w,
         input_projection_w: load_f32(&shards, "multi_modal_projector.mm_input_projection_weight")?,

--- a/crates/rmlx-models/src/gemma4/audio/mod.rs
+++ b/crates/rmlx-models/src/gemma4/audio/mod.rs
@@ -681,10 +681,12 @@ impl AudioEncoder {
         let upper_diag = max_past + max_future;
         let ctx = chunk + max_past + max_future;
 
-        let ones_cc = rmlx_mlx::broadcast_to(&scalar_f32(1.0), &[ctx, chunk], device)?; // f32-ok: causal mask is f32; audio tower f32
-                                                                                        // lower_causal = tril(ones(context, chunk)).T -> [chunk, context].
+        // f32-ok: causal validity mask is a float 0/1 array; audio tower runs entirely in f32
+        let ones_cc = rmlx_mlx::broadcast_to(&scalar_f32(1.0), &[ctx, chunk], device)?;
+        // lower_causal = tril(ones(context, chunk)).T -> [chunk, context].
         let lower_causal = tril(&ones_cc, 0, device)?.transpose(&[1, 0], device)?;
-        let ones_cc2 = rmlx_mlx::broadcast_to(&scalar_f32(1.0), &[chunk, ctx], device)?; // f32-ok: audio tower f32
+        // f32-ok: audio tower f32
+        let ones_cc2 = rmlx_mlx::broadcast_to(&scalar_f32(1.0), &[chunk, ctx], device)?;
         let upper_causal = tril(&ones_cc2, upper_diag, device)?; // [chunk, context]
                                                                  // mask = lower * upper (float 0/1; downstream uses >=0.5 as valid).
         multiply(&lower_causal, &upper_causal, device)

--- a/crates/rmlx-models/src/gemma4/audio/mod.rs
+++ b/crates/rmlx-models/src/gemma4/audio/mod.rs
@@ -69,7 +69,7 @@ fn i32_bytes(v: &[i32]) -> &[u8] {
 
 /// `relu(x)` via `maximum(x, 0)`.
 fn relu(x: &Array, device: Device) -> Result<Array> {
-    let zero = scalar_f32(0.0);
+    let zero = scalar_f32(0.0); // f32-ok: audio tower runs entirely in f32 (weights upcast at load)
     maximum(x, &zero, device)
 }
 
@@ -105,12 +105,12 @@ impl ChannelLayerNorm {
     fn forward(&self, x: &Array, device: Device) -> Result<Array> {
         let last = (x.ndim() - 1) as i32;
         let dim = x.shape()[x.ndim() - 1] as f32;
-        let inv_n = scalar_f32(1.0 / dim);
+        let inv_n = scalar_f32(1.0 / dim); // f32-ok: audio tower runs entirely in f32 (weights upcast at load)
         let mean = multiply(&sum_axis_keepdims(x, last, device)?, &inv_n, device)?;
-        let centered = add(x, &multiply(&mean, &scalar_f32(-1.0), device)?, device)?;
+        let centered = add(x, &multiply(&mean, &scalar_f32(-1.0), device)?, device)?; // f32-ok: audio tower f32
         let sq = multiply(&centered, &centered, device)?;
         let var = multiply(&sum_axis_keepdims(&sq, last, device)?, &inv_n, device)?;
-        let denom = rmlx_mlx::sqrt(&add(&var, &scalar_f32(self.eps), device)?, device)?;
+        let denom = rmlx_mlx::sqrt(&add(&var, &scalar_f32(self.eps), device)?, device)?; // f32-ok: audio tower f32
         let normed = rmlx_mlx::divide(&centered, &denom, device)?;
         multiply(&normed, &self.weight, device)
     }
@@ -141,7 +141,7 @@ impl SscpConvBlock {
         // Zero out invalid positions: x = where(mask[:, :, None, None], 0, x).
         let mask_b = mask.reshape(&[b, t, 1, 1], device)?;
         let zeros = rmlx_mlx::zeros(&[b, t, f, c], Dtype::F32, device)?;
-        let mask_bool = rmlx_mlx::greater_equal(&mask_b, &scalar_f32(0.5), device)?;
+        let mask_bool = rmlx_mlx::greater_equal(&mask_b, &scalar_f32(0.5), device)?; // f32-ok: mask_b is f32 (audio tower f32)
         let mask_bcast = rmlx_mlx::broadcast_to(&mask_bool, &[b, t, f, c], device)?;
         let x = where_cond(&mask_bcast, &zeros, x, device)?;
 
@@ -213,8 +213,8 @@ struct ConformerFeedForward {
 impl ConformerFeedForward {
     fn forward(&self, x: &Array, device: Device) -> Result<Array> {
         let residual = x;
-        let lo = scalar_f32(-self.gradient_clipping);
-        let hi = scalar_f32(self.gradient_clipping);
+        let lo = scalar_f32(-self.gradient_clipping); // f32-ok: audio tower f32
+        let hi = scalar_f32(self.gradient_clipping); // f32-ok: audio tower f32
         let h = clip(x, &lo, &hi, device)?;
         let h = self.pre_layer_norm.forward(&h, device)?;
         let h = self.ffw_layer_1.forward(&h, device)?;
@@ -222,7 +222,7 @@ impl ConformerFeedForward {
         let h = self.ffw_layer_2.forward(&h, device)?;
         let h = clip(&h, &lo, &hi, device)?;
         let h = self.post_layer_norm.forward(&h, device)?;
-        let scaled = multiply(&h, &scalar_f32(self.residual_weight), device)?;
+        let scaled = multiply(&h, &scalar_f32(self.residual_weight), device)?; // f32-ok: audio tower f32
         add(residual, &scaled, device)
     }
 }
@@ -437,10 +437,10 @@ impl AudioAttention {
         let scale = softplus(&self.per_dim_scale, device)?;
         let q = multiply(
             &q,
-            &multiply(&scale, &scalar_f32(self.q_scale), device)?,
+            &multiply(&scale, &scalar_f32(self.q_scale), device)?, // f32-ok: audio tower f32
             device,
         )?;
-        let k = multiply(&k, &scalar_f32(self.k_scale), device)?;
+        let k = multiply(&k, &scalar_f32(self.k_scale), device)?; // f32-ok: audio tower f32
 
         let query_blocks = self.convert_to_block(&q, device)?; // [B, U, W, N, H]
         let key_blocks = self.extract_block_context(&k, device)?; // [B, U, C, N, H]
@@ -450,8 +450,8 @@ impl AudioAttention {
         // Block validity: valid = 1 - mask, extracted to [B, U, C].
         let mask_f = mask.astype(Dtype::F32, device)?;
         let valid = add(
-            &scalar_f32(1.0),
-            &multiply(&mask_f, &scalar_f32(-1.0), device)?,
+            &scalar_f32(1.0), // f32-ok: mask_f is cast to F32 above; audio tower f32
+            &multiply(&mask_f, &scalar_f32(-1.0), device)?, // f32-ok: audio tower f32
             device,
         )?;
         let extracted_valid = self.extract_block_context(&valid, device)?; // [B, U, C]
@@ -469,16 +469,16 @@ impl AudioAttention {
 
         // logits = rel_pos; softcap; mask invalid.
         let logits = self.rel_pos_logits(&query_blocks, &key_blocks, device)?;
-        let cap = scalar_f32(self.softcap);
-        let inv_cap = scalar_f32(1.0 / self.softcap);
+        let cap = scalar_f32(self.softcap); // f32-ok: audio tower f32
+        let inv_cap = scalar_f32(1.0 / self.softcap); // f32-ok: audio tower f32
         let logits = multiply(
             &tanh(&multiply(&logits, &inv_cap, device)?, device)?,
             &cap,
             device,
         )?;
-        let cond_bool = rmlx_mlx::greater_equal(&cond, &scalar_f32(0.5), device)?;
+        let cond_bool = rmlx_mlx::greater_equal(&cond, &scalar_f32(0.5), device)?; // f32-ok: cond is f32; audio tower f32
         let invalid = rmlx_mlx::broadcast_to(
-            &scalar_f32(self.invalid_logits_value),
+            &scalar_f32(self.invalid_logits_value), // f32-ok: audio tower f32
             &logits.shape(),
             device,
         )?;
@@ -556,8 +556,8 @@ impl ConformerLightConv1d {
             device,
         )?;
 
-        let lo = scalar_f32(-self.gradient_clipping);
-        let hi = scalar_f32(self.gradient_clipping);
+        let lo = scalar_f32(-self.gradient_clipping); // f32-ok: audio tower f32
+        let hi = scalar_f32(self.gradient_clipping); // f32-ok: audio tower f32
         let h = clip(&h, &lo, &hi, device)?;
         let h = self.conv_norm.forward(&h, device)?;
         let h = rmlx_mlx::silu(&h, device)?;
@@ -594,8 +594,8 @@ impl ConformerBlock {
         causal_valid_mask: &Array,
         device: Device,
     ) -> Result<Array> {
-        let lo = scalar_f32(-self.gradient_clipping);
-        let hi = scalar_f32(self.gradient_clipping);
+        let lo = scalar_f32(-self.gradient_clipping); // f32-ok: audio tower f32
+        let hi = scalar_f32(self.gradient_clipping); // f32-ok: audio tower f32
 
         let x = self.feed_forward1.forward(x, device)?;
 
@@ -615,8 +615,8 @@ impl ConformerBlock {
         let (b, t) = (s[0], s[1]);
         let mask_f = mask.astype(Dtype::F32, device)?;
         let validity = add(
-            &scalar_f32(1.0),
-            &multiply(&mask_f, &scalar_f32(-1.0), device)?,
+            &scalar_f32(1.0), // f32-ok: mask_f is cast to F32 above; audio tower f32
+            &multiply(&mask_f, &scalar_f32(-1.0), device)?, // f32-ok: audio tower f32
             device,
         )?
         .reshape(&[b, t, 1], device)?;
@@ -681,10 +681,10 @@ impl AudioEncoder {
         let upper_diag = max_past + max_future;
         let ctx = chunk + max_past + max_future;
 
-        let ones_cc = rmlx_mlx::broadcast_to(&scalar_f32(1.0), &[ctx, chunk], device)?;
-        // lower_causal = tril(ones(context, chunk)).T -> [chunk, context].
+        let ones_cc = rmlx_mlx::broadcast_to(&scalar_f32(1.0), &[ctx, chunk], device)?; // f32-ok: causal mask is f32; audio tower f32
+                                                                                        // lower_causal = tril(ones(context, chunk)).T -> [chunk, context].
         let lower_causal = tril(&ones_cc, 0, device)?.transpose(&[1, 0], device)?;
-        let ones_cc2 = rmlx_mlx::broadcast_to(&scalar_f32(1.0), &[chunk, ctx], device)?;
+        let ones_cc2 = rmlx_mlx::broadcast_to(&scalar_f32(1.0), &[chunk, ctx], device)?; // f32-ok: audio tower f32
         let upper_causal = tril(&ones_cc2, upper_diag, device)?; // [chunk, context]
                                                                  // mask = lower * upper (float 0/1; downstream uses >=0.5 as valid).
         multiply(&lower_causal, &upper_causal, device)
@@ -726,7 +726,7 @@ impl AudioEncoder {
             mask = mask.slice(&[0, 0], &[b, keep], &[1, 1], device)?;
         }
         let mask_b = mask.reshape(&[b, keep, 1], device)?;
-        let mask_bool = rmlx_mlx::greater_equal(&mask_b, &scalar_f32(0.5), device)?;
+        let mask_bool = rmlx_mlx::greater_equal(&mask_b, &scalar_f32(0.5), device)?; // f32-ok: mask_b derives from mask which is f32; audio tower f32
         let mask_bool = if keep == t {
             rmlx_mlx::broadcast_to(&mask_bool, &[b, t, hidden], device)?
         } else {
@@ -982,7 +982,8 @@ pub fn build_audio_inputs_embeds(
     let ids_i32: Vec<i32> = input_ids.iter().map(|&x| x as i32).collect();
     let ids_arr = Array::from_bytes(i32_bytes(&ids_i32), &[seq as i32], Dtype::I32)?;
     let h_raw = model.embed_tokens.forward(&ids_arr, device)?;
-    let embed_scale = scalar_f32((model.cfg.hidden_size as f32).sqrt());
+    let embed_scale =
+        scalar_f32((model.cfg.hidden_size as f32).sqrt()).astype(h_raw.dtype(), device)?;
     let mut embeds = multiply(&h_raw, &embed_scale, device)?;
     embeds = embeds.reshape(&[1, seq as i32, hidden], device)?;
     let embeds_dtype = embeds.dtype();

--- a/crates/rmlx-models/src/gemma4/audio/unified.rs
+++ b/crates/rmlx-models/src/gemma4/audio/unified.rs
@@ -305,7 +305,8 @@ pub fn build_unified_audio_inputs_embeds(
     let ids_i32: Vec<i32> = input_ids.iter().map(|&x| x as i32).collect();
     let ids_arr = Array::from_i32_slice(&ids_i32, &[seq as i32])?;
     let h_raw = model.embed_tokens.forward(&ids_arr, device)?;
-    let embed_scale = scalar_f32((model.cfg.hidden_size as f32).sqrt());
+    let embed_scale =
+        scalar_f32((model.cfg.hidden_size as f32).sqrt()).astype(h_raw.dtype(), device)?;
     let mut embeds = multiply(&h_raw, &embed_scale, device)?;
     embeds = embeds.reshape(&[1, seq as i32, hidden], device)?;
     let embeds_dtype = embeds.dtype();

--- a/crates/rmlx-models/src/gemma4/layers/kernels.rs
+++ b/crates/rmlx-models/src/gemma4/layers/kernels.rs
@@ -331,6 +331,9 @@ pub(crate) fn softcap_fused(x: &Array, cap: f32, device: Device) -> Result<Array
         device_tag: softcap_device_tag(device),
     };
     let compiled = softcap_get_or_compile(key, device)?;
+    // f32-ok: cap is a Python float in the reference (mlx-lm logit_softcap); passing it as a
+    // 0-D F32 scalar to compile_shapeless matches the reference exactly. The compiled closure
+    // is keyed on x.dtype() and MLX traces the mixed-precision graph at compile time.
     let cap_arr = scalar_f32(cap);
     let mut outs = compiled.apply(&[&cap_arr, x])?;
     outs.pop()

--- a/crates/rmlx-models/src/gemma4/layers/kernels.rs
+++ b/crates/rmlx-models/src/gemma4/layers/kernels.rs
@@ -331,9 +331,12 @@ pub(crate) fn softcap_fused(x: &Array, cap: f32, device: Device) -> Result<Array
         device_tag: softcap_device_tag(device),
     };
     let compiled = softcap_get_or_compile(key, device)?;
-    // f32-ok: cap is a Python float in the reference (mlx-lm logit_softcap); passing it as a
-    // 0-D F32 scalar to compile_shapeless matches the reference exactly. The compiled closure
-    // is keyed on x.dtype() and MLX traces the mixed-precision graph at compile time.
+    // f32-ok: cap is a Python float (weak type) in mlx-lm's logit_softcap — it runs at the
+    // activation dtype there. Here cap_arr is a strong F32 scalar, which diverges from the
+    // reference in dtype. This is safe because softcap_fused is applied to TERMINAL pre-sampling
+    // logits only: the output is never written to the KV cache or the residual stream, so the
+    // F32 promotion does not propagate. Changing to astype(x.dtype()) would be numerically
+    // equivalent for BF16 logits but is intentionally left as F32 to match the compile key.
     let cap_arr = scalar_f32(cap);
     let mut outs = compiled.apply(&[&cap_arr, x])?;
     outs.pop()

--- a/crates/rmlx-models/src/gemma4/model.rs
+++ b/crates/rmlx-models/src/gemma4/model.rs
@@ -931,7 +931,7 @@ impl Gemma4Text {
         let ids_arr = Array::from_i32_slice(&ids, &[1])?;
         let e = self.embed_tokens.forward(&ids_arr, device)?;
         let e = e.reshape(&[1, 1, self.cfg.hidden_size as i32], device)?;
-        let scale = scalar_f32((self.cfg.hidden_size as f32).sqrt());
+        let scale = scalar_f32((self.cfg.hidden_size as f32).sqrt()).astype(e.dtype(), device)?;
         multiply(&e, &scale, device)
     }
 

--- a/crates/rmlx-models/src/gemma4/vision/mod.rs
+++ b/crates/rmlx-models/src/gemma4/vision/mod.rs
@@ -544,7 +544,7 @@ impl VisionModel {
         let h2 = h.reshape(&[seq as i32, hidden], device)?;
         let pooled = matmul(&w_arr, &h2, device)?;
         let root = (self.cfg.hidden_size as f32).sqrt();
-        let root_arr = rmlx_mlx::scalar_f32(root);
+        let root_arr = rmlx_mlx::scalar_f32(root); // f32-ok: SigLIP vision tower runs entirely in f32 (pooled is f32)
         let pooled = multiply(&pooled, &root_arr, device)?;
         pooled.reshape(&[1, num_soft as i32, hidden], device)
     }
@@ -849,7 +849,8 @@ pub fn build_inputs_embeds(
     let ids_i32: Vec<i32> = input_ids.iter().map(|&x| x as i32).collect();
     let ids_arr = Array::from_bytes(i32_bytes(&ids_i32), &[seq as i32], Dtype::I32)?;
     let h_raw = model.embed_tokens.forward(&ids_arr, device)?;
-    let embed_scale = rmlx_mlx::scalar_f32((model.cfg.hidden_size as f32).sqrt());
+    let embed_scale = rmlx_mlx::scalar_f32((model.cfg.hidden_size as f32).sqrt())
+        .astype(h_raw.dtype(), device)?;
     let mut embeds = multiply(&h_raw, &embed_scale, device)?;
     embeds = embeds.reshape(&[1, seq as i32, hidden], device)?;
     let embeds_dtype = embeds.dtype();

--- a/crates/rmlx-models/src/gemma4/vision/unified.rs
+++ b/crates/rmlx-models/src/gemma4/vision/unified.rs
@@ -200,13 +200,13 @@ impl LayerNorm {
         let dim = *shape.last().unwrap_or(&1) as f32;
         // mean over last axis (keepdims for broadcast).
         let sum = sum_axis_keepdims(&x, axis, device)?;
-        let mean = multiply(&sum, &scalar_f32(1.0 / dim), device)?;
+        let mean = multiply(&sum, &scalar_f32(1.0 / dim), device)?; // f32-ok: x is cast to f32 on entry (line above)
         let centered = subtract(&x, &mean, device)?;
         // var = mean(centered^2)
         let sq = multiply(&centered, &centered, device)?;
         let sq_sum = sum_axis_keepdims(&sq, axis, device)?;
-        let var = multiply(&sq_sum, &scalar_f32(1.0 / dim), device)?;
-        let denom = rmlx_mlx::sqrt(&add(&var, &scalar_f32(self.eps), device)?, device)?;
+        let var = multiply(&sq_sum, &scalar_f32(1.0 / dim), device)?; // f32-ok: x is cast to f32 on entry
+        let denom = rmlx_mlx::sqrt(&add(&var, &scalar_f32(self.eps), device)?, device)?; // f32-ok: x is cast to f32 on entry
         let normed = rmlx_mlx::divide(&centered, &denom, device)?;
         let scaled = multiply(&normed, &self.weight, device)?;
         add(&scaled, &self.bias, device)
@@ -606,7 +606,8 @@ pub fn build_unified_inputs_embeds(
     let ids_i32: Vec<i32> = input_ids.iter().map(|&x| x as i32).collect();
     let ids_arr = Array::from_bytes(i32_bytes(&ids_i32), &[seq as i32], Dtype::I32)?;
     let h_raw = model.embed_tokens.forward(&ids_arr, device)?;
-    let embed_scale = scalar_f32((model.cfg.hidden_size as f32).sqrt());
+    let embed_scale =
+        scalar_f32((model.cfg.hidden_size as f32).sqrt()).astype(h_raw.dtype(), device)?;
     let mut embeds = multiply(&h_raw, &embed_scale, device)?;
     embeds = embeds.reshape(&[1, seq as i32, hidden], device)?;
     let embeds_dtype = embeds.dtype();

--- a/crates/rmlx-models/src/jina_v4/model.rs
+++ b/crates/rmlx-models/src/jina_v4/model.rs
@@ -94,7 +94,11 @@ impl LoraDelta {
     fn apply(&self, base: &Array, x: &Array, device: Device) -> Result<Array> {
         let xa = rmlx_mlx::matmul(x, &self.a.transpose(&[1, 0], device)?, device)?;
         let xab = rmlx_mlx::matmul(&xa, &self.b.transpose(&[1, 0], device)?, device)?;
-        let scaled = multiply(&xab, &scalar_f32(self.scaling), device)?;
+        let scaled = multiply(
+            &xab,
+            &scalar_f32(self.scaling).astype(xab.dtype(), device)?,
+            device,
+        )?;
         add(base, &scaled, device)
     }
 }

--- a/crates/rmlx-models/src/jina_v4/pooling.rs
+++ b/crates/rmlx-models/src/jina_v4/pooling.rs
@@ -44,7 +44,7 @@ fn l2_normalize_last(x: &Array, device: Device) -> Result<Array> {
     let s = sum_axis(&sq, last, device)?;
     let s = expand_dims(&s, last, device)?;
     // ‖x‖₂ = sqrt(sum(x²) + 1e-12); 1e-12 matches F.normalize's eps clamp.
-    let s = add(&s, &scalar_f32(1e-12), device)?;
+    let s = add(&s, &scalar_f32(1e-12), device)?; // f32-ok: pooling output is converted to Vec<f32>; f32 precision is intentional here
     let norm = sqrt(&s, device)?;
     divide(x, &norm, device)
 }
@@ -98,7 +98,7 @@ pub(super) fn single_vector(
     let shape = hidden.shape(); // [1, seq, hidden]
     let seq = shape[1];
     let summed = sum_axis(hidden, 1, device)?; // -> [1, hidden]
-    let pooled = divide(&summed, &scalar_f32(seq as f32), device)?;
+    let pooled = divide(&summed, &scalar_f32(seq as f32), device)?; // f32-ok: output is Vec<f32> via to_f32_vec; f32 precision intentional
     let normed = l2_normalize_last(&pooled, device)?; // [1, hidden]
 
     match truncate_dim {
@@ -159,7 +159,7 @@ pub(super) fn single_vector_image_span(
         device,
     )?;
     let summed = sum_axis(&slice, 1, device)?; // -> [1, hidden]
-    let pooled = divide(&summed, &scalar_f32(span as f32), device)?;
+    let pooled = divide(&summed, &scalar_f32(span as f32), device)?; // f32-ok: output is Vec<f32> via to_f32_vec; f32 precision intentional
     let normed = l2_normalize_last(&pooled, device)?; // [1, hidden]
 
     match truncate_dim {

--- a/crates/rmlx-models/src/laguna/moe.rs
+++ b/crates/rmlx-models/src/laguna/moe.rs
@@ -182,7 +182,8 @@ impl SparseMoeBlock {
             self.experts
                 .forward(&x_flat, &routing_weights, &expert_indices, device)?;
 
-        let scale_arr = rmlx_mlx::scalar_f32(self.routed_scaling_factor);
+        let scale_arr =
+            rmlx_mlx::scalar_f32(self.routed_scaling_factor).astype(routed_out.dtype(), device)?;
         let routed_scaled = multiply(&routed_out, &scale_arr, device)?;
         let combined = add(&routed_scaled, &shared_out, device)?;
 

--- a/crates/rmlx-models/src/laguna/moe.rs
+++ b/crates/rmlx-models/src/laguna/moe.rs
@@ -182,8 +182,7 @@ impl SparseMoeBlock {
             self.experts
                 .forward(&x_flat, &routing_weights, &expert_indices, device)?;
 
-        let scale_arr =
-            rmlx_mlx::scalar_f32(self.routed_scaling_factor).astype(routed_out.dtype(), device)?;
+        let scale_arr = rmlx_mlx::scalar_f32(self.routed_scaling_factor);
         let routed_scaled = multiply(&routed_out, &scale_arr, device)?;
         let combined = add(&routed_scaled, &shared_out, device)?;
 

--- a/crates/rmlx-models/src/qwen3_vl_moe/vision.rs
+++ b/crates/rmlx-models/src/qwen3_vl_moe/vision.rs
@@ -102,7 +102,7 @@ impl LayerNorm {
     fn forward(&self, x: &Array, device: Device) -> Result<Array> {
         let mut keep = x.shape();
         let d = *keep.last().expect("layer_norm: empty shape");
-        let inv_d = rmlx_mlx::scalar_f32(1.0 / d as f32);
+        let inv_d = rmlx_mlx::scalar_f32(1.0 / d as f32); // f32-ok: Qwen3-VL-MoE vision tower runs entirely in f32
         *keep.last_mut().unwrap() = 1;
 
         let mean = multiply(
@@ -116,7 +116,7 @@ impl LayerNorm {
             &inv_d,
             device,
         )?;
-        let denom = sqrt(&add(&var, &rmlx_mlx::scalar_f32(self.eps), device)?, device)?;
+        let denom = sqrt(&add(&var, &rmlx_mlx::scalar_f32(self.eps), device)?, device)?; // f32-ok: Qwen3-VL-MoE vision tower f32
         let normed = divide(&xc, &denom, device)?;
         let scaled = multiply(&normed, &self.weight, device)?;
         add(&scaled, &self.bias, device)

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -401,7 +401,11 @@ impl DFlashDrafter {
         match &self.rope_freqs {
             Some(freqs) => {
                 let scaled = if (self.rope_mscale - 1.0).abs() > 1e-6 {
-                    multiply(x, &scalar_f32(self.rope_mscale), device)?
+                    multiply(
+                        x,
+                        &scalar_f32(self.rope_mscale).astype(x.dtype(), device)?,
+                        device,
+                    )?
                 } else {
                     x.try_clone()?
                 };
@@ -514,7 +518,7 @@ impl DFlashDrafter {
             )?;
             let mut logits = verifier.logits_from_hidden(&row, device)?;
             if let Some(cap) = self.cfg.final_logit_softcapping {
-                let cap_arr = scalar_f32(cap);
+                let cap_arr = scalar_f32(cap).astype(logits.dtype(), device)?;
                 let scaled = divide(&logits, &cap_arr, device)?;
                 let t = tanh(&scaled, device)?;
                 logits = multiply(&t, &cap_arr, device)?;

--- a/docs/ADDING_A_MODEL.md
+++ b/docs/ADDING_A_MODEL.md
@@ -107,8 +107,10 @@ Run these in order before declaring a new arch done.
    ```rust
    scalar_f32(x).astype(operand.dtype(), device)?
    ```
-   This must appear either on the same line as `scalar_f32(` or on the
-   immediately following line (for multi-line method chains).
+   The `.astype(` call may appear on the same line as `scalar_f32(` or anywhere
+   in the immediately following continuation lines of the same method chain
+   (lines that do not yet end the statement). Note: `.astype(Dtype::F32, …)` is
+   NOT a guard — it preserves the F32 scalar and the gate will still flag it.
 
    **Allowlisting a genuine f32-only scalar** (e.g. inside a vision tower or
    audio encoder that runs entirely in f32, or a scalar passed to an f32-only
@@ -119,7 +121,7 @@ Run these in order before declaring a new arch done.
    let inv_k = scalar_f32(1.0 / k as f32);
    ```
    The reason must be specific enough to explain why the f32 promotion is safe
-   (e.g. "tower is f32", "output is Vec<f32>", "passed to compile_shapeless").
+   (e.g. "tower is f32", "output is Vec<f32>", "terminal pre-sampling logits").
 
    Run `make check-no-scalar-f32-leak` before pushing any new arch or new layer.
 

--- a/docs/ADDING_A_MODEL.md
+++ b/docs/ADDING_A_MODEL.md
@@ -97,6 +97,31 @@ Run these in order before declaring a new arch done.
    ```
    Never hand-edit `BENCHMARK_CHAMPIONS.md`. Ingest path, schema, and operating
    rules: `docs/METRICS_DB.md`.
+5. **Pass the f32-leak gate.** The CI gate `make check-no-scalar-f32-leak` scans
+   every file under `crates/rmlx-models/src/` for unguarded `scalar_f32(` calls.
+   A `scalar_f32(x)` combined with a BF16 activation silently upcasts the
+   residual stream, Q/K/V tensors, and the KV cache to F32 — this class of bug
+   has shipped multiple times and is invisible at review.
+
+   **Canonical form for scalars that enter the activation stream:**
+   ```rust
+   scalar_f32(x).astype(operand.dtype(), device)?
+   ```
+   This must appear either on the same line as `scalar_f32(` or on the
+   immediately following line (for multi-line method chains).
+
+   **Allowlisting a genuine f32-only scalar** (e.g. inside a vision tower or
+   audio encoder that runs entirely in f32, or a scalar passed to an f32-only
+   API): add `// f32-ok: <reason>` on the same line or in the comment block
+   directly above the `scalar_f32(` call:
+   ```rust
+   // f32-ok: SigLIP tower runs entirely in f32 (weights upcast at load)
+   let inv_k = scalar_f32(1.0 / k as f32);
+   ```
+   The reason must be specific enough to explain why the f32 promotion is safe
+   (e.g. "tower is f32", "output is Vec<f32>", "passed to compile_shapeless").
+
+   Run `make check-no-scalar-f32-leak` before pushing any new arch or new layer.
 
 ---
 

--- a/scripts/check_no_scalar_f32_leak.sh
+++ b/scripts/check_no_scalar_f32_leak.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# scripts/check_no_scalar_f32_leak.sh — CI gate: flag unguarded scalar_f32( in arch-layer code.
+#
+# PROBLEM
+# -------
+# Calling scalar_f32(x) creates a strong-F32 scalar Array. When that Array is
+# then combined (multiply / add / divide / etc.) with a BF16 activation, MLX
+# promotes the result to F32, silently contaminating the residual stream, Q/K/V,
+# and the KV cache. This class of bug has shipped at least three times in rMLX
+# and is invisible at review because the call site looks harmless.
+#
+# WHAT THIS GATE CHECKS
+# ---------------------
+# Every non-test .rs file under crates/rmlx-models/src/ is scanned for lines
+# that:
+#   (a) contain scalar_f32( (as actual code, not a pure line comment), AND
+#   (b) are NOT followed by .astype( on the SAME LINE, AND
+#   (c) are NOT followed by .astype( on the NEXT NON-BLANK LINE
+#       (handles multi-line method chains where .astype is wrapped to the
+#       next line — but only when the scalar_f32 line does not end the
+#       statement, i.e. does not end with ';' or '{' after stripping
+#       trailing whitespace), AND
+#   (d) do NOT have an  // f32-ok: <reason>  marker on the SAME LINE, OR on
+#       ANY preceding comment line that is part of the contiguous comment block
+#       immediately above the scalar_f32( line.
+#
+# ALLOWLISTING
+# ------------
+# To allow a genuine f32-only scalar (e.g. one consumed by a raw-f32 param or
+# inside a module where every tensor is already f32):
+#   - Same-line:   scalar_f32(x) // f32-ok: <reason>
+#   - Preceding:   // f32-ok: <reason>
+#                  let s = scalar_f32(x);
+#     (the marker may appear in a multi-line comment block directly above)
+#
+# THE CANONICAL FIX
+# -----------------
+# scalar_f32(x).astype(operand.dtype(), device)?
+#
+# Exit 0 = clean. Exit 1 = violation found.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Arch-layer scope: all .rs files under crates/rmlx-models/src/.
+# Excludes test files (*_tests.rs, files under tests/ directories).
+SCAN_DIR="${REPO_ROOT}/crates/rmlx-models/src"
+
+violations=()
+
+while IFS= read -r -d '' f; do
+    # Use awk to scan each file.
+    #
+    # State machine:
+    #   in_comment_block  — currently inside a contiguous run of // comment lines
+    #   block_has_f32ok   — the current/recent comment block contained // f32-ok:
+    #   pending           — scalar_f32( seen; awaiting next non-blank line for
+    #                       multi-line chain check
+    #   pending_line/text — saved location of the pending scalar_f32( line
+    #   found             — 1 if any violation detected (drives exit code)
+    #
+    # Transition logic:
+    #   On a pure comment line (^[[:space:]]*//) :
+    #     - Still in (or entering) a comment block.
+    #     - If it contains "// f32-ok:", set block_has_f32ok = 1.
+    #
+    #   On a blank line:
+    #     - Ends the comment block (reset in_comment_block and block_has_f32ok).
+    #     - If pending, skip blank lines.
+    #
+    #   On any other (code) line:
+    #     - The comment block ended with the preceding comments; capture
+    #       block_has_f32ok as prev_f32ok, then reset in_comment_block.
+    #     - Check pending from previous iteration.
+    #     - If line contains scalar_f32( (not in a pure comment):
+    #         * same-line // f32-ok:   → OK
+    #         * prev_f32ok             → OK
+    #         * same-line .astype(     → OK
+    #         * terminated statement (ends with ; or {) → violation
+    #         * else                   → set pending
+    #     - Reset prev_f32ok / block state for next line.
+
+    awk -v file="$f" '
+        BEGIN {
+            in_comment_block = 0
+            block_has_f32ok  = 0
+            prev_f32ok       = 0
+            pending          = 0
+            pending_line     = 0
+            pending_text     = ""
+            found            = 0
+        }
+
+        # ---- blank line -------------------------------------------------------
+        /^[[:space:]]*$/ {
+            if (!pending) {
+                # Blank line ends any comment block.
+                in_comment_block = 0
+                block_has_f32ok  = 0
+                prev_f32ok       = 0
+            }
+            next
+        }
+
+        # ---- pure comment line ------------------------------------------------
+        /^[[:space:]]*\/\// {
+            in_comment_block = 1
+            if (index($0, "// f32-ok:") > 0) block_has_f32ok = 1
+            next
+        }
+
+        # ---- code line (anything that is not blank and not a pure comment) ----
+        {
+            # Capture whether the preceding comment block had f32-ok.
+            # (In the previous iteration a code line already cleared these, so
+            # prev_f32ok here reflects the most recent comment block directly
+            # above this code line.)
+            if (in_comment_block) {
+                # We were in a comment block; its f32-ok status is now available.
+                prev_f32ok = block_has_f32ok
+            }
+            # Reset the comment-block state now that we have a code line.
+            in_comment_block = 0
+            block_has_f32ok  = 0
+
+            # Handle any pending check from the previous code line.
+            if (pending) {
+                if (index($0, ".astype(") > 0) {
+                    # Multi-line chain resolved — OK.
+                    pending = 0
+                } else {
+                    # Next code line has no .astype( → violation.
+                    print file ":" pending_line ": unguarded scalar_f32(  →  " pending_text
+                    found = 1
+                    pending = 0
+                }
+                # After resolving pending, continue to check this line for
+                # its own scalar_f32( (fall through).
+            }
+
+            # Check this code line for scalar_f32(.
+            if (index($0, "scalar_f32(") > 0) {
+                # (a) Same-line f32-ok allowlist.
+                if (index($0, "// f32-ok:") > 0) { prev_f32ok = 0; next }
+                # (b) Preceding comment block had f32-ok.
+                if (prev_f32ok) { prev_f32ok = 0; next }
+                # (c) Same-line .astype( chain.
+                if (index($0, ".astype(") > 0) { prev_f32ok = 0; next }
+                # (d) Is the statement terminated on this line?
+                stripped = $0
+                gsub(/^[[:space:]]+/, "", stripped)
+                gsub(/[[:space:]]+$/, "", stripped)
+                last_ch = substr(stripped, length(stripped), 1)
+                if (last_ch == ";" || last_ch == "{") {
+                    # Statement ends here — violation.
+                    print file ":" NR ": unguarded scalar_f32(  →  " $0
+                    found = 1
+                    prev_f32ok = 0
+                    next
+                }
+                # Non-terminated: defer to next non-blank code line.
+                pending      = 1
+                pending_line = NR
+                pending_text = $0
+                prev_f32ok   = 0
+                next
+            }
+
+            # Not a scalar_f32( line — just update prev_f32ok for next line.
+            prev_f32ok = (index($0, "// f32-ok:") > 0)
+        }
+
+        END {
+            # Unresolved pending at EOF.
+            if (pending) {
+                print file ":" pending_line ": unguarded scalar_f32(  →  " pending_text
+                found = 1
+            }
+            exit !found
+        }
+    ' "$f" 2>/dev/null && violations+=("$f")
+done < <(
+    find "${SCAN_DIR}" -name "*.rs" \
+        -not -path "*/target/*" \
+        -not -path "*/tests/*" \
+        -not -name "*_tests.rs" \
+        -print0
+)
+
+if [ ${#violations[@]} -gt 0 ]; then
+    echo "" >&2
+    echo "CANONICAL FIX: scalar_f32(x).astype(operand.dtype(), device)?" >&2
+    echo "" >&2
+    echo "To allowlist a genuine f32-only scalar, add an inline marker:" >&2
+    echo "  // f32-ok: <reason why f32 is safe here>" >&2
+    echo "  (on the same line as scalar_f32, or in the comment block immediately above)" >&2
+    echo "" >&2
+    exit 1
+fi
+
+echo "OK: no unguarded scalar_f32( in arch-layer code."

--- a/scripts/check_no_scalar_f32_leak.sh
+++ b/scripts/check_no_scalar_f32_leak.sh
@@ -11,27 +11,45 @@
 #
 # WHAT THIS GATE CHECKS
 # ---------------------
-# Every non-test .rs file under crates/rmlx-models/src/ is scanned for lines
-# that:
+# Every non-test .rs file under crates/rmlx-models/src/ is scanned (excluding
+# out-of-scope arch directories: laguna/, dr_venus/) for lines that:
 #   (a) contain scalar_f32( (as actual code, not a pure line comment), AND
-#   (b) are NOT followed by .astype( on the SAME LINE, AND
-#   (c) are NOT followed by .astype( on the NEXT NON-BLANK LINE
-#       (handles multi-line method chains where .astype is wrapped to the
-#       next line — but only when the scalar_f32 line does not end the
-#       statement, i.e. does not end with ';' or '{' after stripping
-#       trailing whitespace), AND
-#   (d) do NOT have an  // f32-ok: <reason>  marker on the SAME LINE, OR on
+#   (b) are NOT followed by a non-F32 .astype( on the SAME LINE, AND
+#   (c) are NOT followed by a non-F32 .astype( within the immediately following
+#       continuation lines of the same multi-line chain expression (lines that
+#       do not terminate the statement — i.e. no trailing ';' or '}' after
+#       stripping whitespace), AND
+#   (d) do NOT have a  // f32-ok: <reason>  marker on the SAME LINE, OR on
 #       ANY preceding comment line that is part of the contiguous comment block
 #       immediately above the scalar_f32( line.
 #
+# WHAT COUNTS AS A GUARD
+# ----------------------
+# A guarding .astype( call MUST NOT target Dtype::F32 (which preserves the
+# scalar f32 rather than casting to the activation dtype). The following forms
+# are rejected as guards (false guards — they keep the f32):
+#   .astype(Dtype::F32,        → rejected (explicit F32 target)
+#   .astype(F32,               → rejected
+#   .astype(rmlx_mlx::Dtype::F32,  → rejected
+# Any other .astype( target (e.g. Dtype::Bf16, operand.dtype(), x.dtype(),
+# Dtype::I32, …) is accepted as a legitimate guard.
+#
+# SCOPE EXCLUSIONS
+# ----------------
+# Out-of-scope arch directories are excluded from the scan:
+#   laguna/      — excluded (not bench-provable, out of scope per project rules)
+#   dr_venus/    — excluded (same reason, defensive)
+#
 # ALLOWLISTING
 # ------------
-# To allow a genuine f32-only scalar (e.g. one consumed by a raw-f32 param or
-# inside a module where every tensor is already f32):
+# To allow a genuine f32-only scalar (e.g. inside a vision tower or audio
+# encoder that runs entirely in f32, or a scalar passed to an f32-only API):
 #   - Same-line:   scalar_f32(x) // f32-ok: <reason>
 #   - Preceding:   // f32-ok: <reason>
 #                  let s = scalar_f32(x);
-#     (the marker may appear in a multi-line comment block directly above)
+#   The marker may appear in a multi-line comment block directly above the
+#   scalar_f32( line. The reason must be specific (e.g. "tower is f32",
+#   "output is Vec<f32>", "passed to compile_shapeless", "terminal logits").
 #
 # THE CANONICAL FIX
 # -----------------
@@ -44,7 +62,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Arch-layer scope: all .rs files under crates/rmlx-models/src/.
-# Excludes test files (*_tests.rs, files under tests/ directories).
+# Excludes test files, and out-of-scope arch directories.
 SCAN_DIR="${REPO_ROOT}/crates/rmlx-models/src"
 
 violations=()
@@ -55,33 +73,50 @@ while IFS= read -r -d '' f; do
     # State machine:
     #   in_comment_block  — currently inside a contiguous run of // comment lines
     #   block_has_f32ok   — the current/recent comment block contained // f32-ok:
-    #   pending           — scalar_f32( seen; awaiting next non-blank line for
+    #   prev_f32ok        — the preceding comment block had f32-ok (set when the
+    #                       first code line after the block is reached)
+    #   pending           — scalar_f32( seen; awaiting continuation lines for a
     #                       multi-line chain check
     #   pending_line/text — saved location of the pending scalar_f32( line
     #   found             — 1 if any violation detected (drives exit code)
     #
-    # Transition logic:
-    #   On a pure comment line (^[[:space:]]*//) :
-    #     - Still in (or entering) a comment block.
-    #     - If it contains "// f32-ok:", set block_has_f32ok = 1.
+    # Key invariant: a guarding .astype( MUST NOT target F32.
+    # is_f32_astype(line): returns 1 when the line contains .astype( targeting F32.
+    # has_good_astype(line): .astype( present AND is NOT an F32 target.
     #
-    #   On a blank line:
-    #     - Ends the comment block (reset in_comment_block and block_has_f32ok).
-    #     - If pending, skip blank lines.
-    #
-    #   On any other (code) line:
-    #     - The comment block ended with the preceding comments; capture
-    #       block_has_f32ok as prev_f32ok, then reset in_comment_block.
-    #     - Check pending from previous iteration.
-    #     - If line contains scalar_f32( (not in a pure comment):
-    #         * same-line // f32-ok:   → OK
-    #         * prev_f32ok             → OK
-    #         * same-line .astype(     → OK
-    #         * terminated statement (ends with ; or {) → violation
-    #         * else                   → set pending
-    #     - Reset prev_f32ok / block state for next line.
+    # Pending (multi-line chain) logic:
+    #   Once pending is set, keep scanning continuation lines (lines that do not
+    #   terminate the statement, i.e. do not end with ';' or '}').  Accept if any
+    #   continuation carries a non-F32 .astype(.  Emit a violation only when a
+    #   terminating line is reached without having seen a non-F32 .astype(.
 
     awk -v file="$f" '
+        function is_f32_astype(line,    p) {
+            # Returns 1 if the line contains .astype( targeting F32 — not a guard.
+            p = index(line, ".astype(Dtype::F32")
+            if (p > 0) return 1
+            p = index(line, ".astype(F32")
+            if (p > 0) return 1
+            p = index(line, ".astype(rmlx_mlx::Dtype::F32")
+            if (p > 0) return 1
+            return 0
+        }
+
+        function has_good_astype(line) {
+            # Returns 1 if .astype( is present AND it is NOT an F32 target.
+            if (index(line, ".astype(") == 0) return 0
+            return !is_f32_astype(line)
+        }
+
+        function is_terminated(line,    s) {
+            # Returns 1 if the line ends a statement (trailing ; or }).
+            s = line
+            gsub(/^[[:space:]]+/, "", s)
+            gsub(/[[:space:]]+$/, "", s)
+            c = substr(s, length(s), 1)
+            return (c == ";" || c == "}")
+        }
+
         BEGIN {
             in_comment_block = 0
             block_has_f32ok  = 0
@@ -95,7 +130,6 @@ while IFS= read -r -d '' f; do
         # ---- blank line -------------------------------------------------------
         /^[[:space:]]*$/ {
             if (!pending) {
-                # Blank line ends any comment block.
                 in_comment_block = 0
                 block_has_f32ok  = 0
                 prev_f32ok       = 0
@@ -110,33 +144,28 @@ while IFS= read -r -d '' f; do
             next
         }
 
-        # ---- code line (anything that is not blank and not a pure comment) ----
+        # ---- code line --------------------------------------------------------
         {
-            # Capture whether the preceding comment block had f32-ok.
-            # (In the previous iteration a code line already cleared these, so
-            # prev_f32ok here reflects the most recent comment block directly
-            # above this code line.)
+            # Capture preceding comment block f32-ok status on first code line.
             if (in_comment_block) {
-                # We were in a comment block; its f32-ok status is now available.
                 prev_f32ok = block_has_f32ok
             }
-            # Reset the comment-block state now that we have a code line.
             in_comment_block = 0
             block_has_f32ok  = 0
 
-            # Handle any pending check from the previous code line.
+            # Handle pending multi-line chain from a previous scalar_f32( line.
             if (pending) {
-                if (index($0, ".astype(") > 0) {
-                    # Multi-line chain resolved — OK.
+                if (has_good_astype($0)) {
+                    # Chain resolved with a non-F32 .astype( — OK.
                     pending = 0
-                } else {
-                    # Next code line has no .astype( → violation.
+                } else if (is_terminated($0)) {
+                    # Statement terminated without a non-F32 .astype( → violation.
                     print file ":" pending_line ": unguarded scalar_f32(  →  " pending_text
                     found = 1
                     pending = 0
                 }
-                # After resolving pending, continue to check this line for
-                # its own scalar_f32( (fall through).
+                # else: non-terminated continuation — keep pending open, scan next line.
+                # Fall through to check this line for its own scalar_f32(.
             }
 
             # Check this code line for scalar_f32(.
@@ -145,21 +174,20 @@ while IFS= read -r -d '' f; do
                 if (index($0, "// f32-ok:") > 0) { prev_f32ok = 0; next }
                 # (b) Preceding comment block had f32-ok.
                 if (prev_f32ok) { prev_f32ok = 0; next }
-                # (c) Same-line .astype( chain.
-                if (index($0, ".astype(") > 0) { prev_f32ok = 0; next }
-                # (d) Is the statement terminated on this line?
-                stripped = $0
-                gsub(/^[[:space:]]+/, "", stripped)
-                gsub(/[[:space:]]+$/, "", stripped)
-                last_ch = substr(stripped, length(stripped), 1)
-                if (last_ch == ";" || last_ch == "{") {
-                    # Statement ends here — violation.
+                # (c) Same-line non-F32 .astype( chain.
+                if (has_good_astype($0)) { prev_f32ok = 0; next }
+                # (d) Same-line .astype( that targets F32 — counts as NO guard.
+                # (falls through to the termination check below)
+
+                # (e) Is the statement terminated on this line?
+                if (is_terminated($0)) {
+                    # Terminated with no guard → violation.
                     print file ":" NR ": unguarded scalar_f32(  →  " $0
                     found = 1
                     prev_f32ok = 0
                     next
                 }
-                # Non-terminated: defer to next non-blank code line.
+                # Non-terminated: enter pending state to scan continuation lines.
                 pending      = 1
                 pending_line = NR
                 pending_text = $0
@@ -167,12 +195,11 @@ while IFS= read -r -d '' f; do
                 next
             }
 
-            # Not a scalar_f32( line — just update prev_f32ok for next line.
+            # Not a scalar_f32( line.
             prev_f32ok = (index($0, "// f32-ok:") > 0)
         }
 
         END {
-            # Unresolved pending at EOF.
             if (pending) {
                 print file ":" pending_line ": unguarded scalar_f32(  →  " pending_text
                 found = 1
@@ -185,12 +212,15 @@ done < <(
         -not -path "*/target/*" \
         -not -path "*/tests/*" \
         -not -name "*_tests.rs" \
+        -not -path "*/laguna/*" \
+        -not -path "*/dr_venus/*" \
         -print0
 )
 
 if [ ${#violations[@]} -gt 0 ]; then
     echo "" >&2
     echo "CANONICAL FIX: scalar_f32(x).astype(operand.dtype(), device)?" >&2
+    echo "  NOTE: .astype(Dtype::F32, ...) does NOT count as a guard." >&2
     echo "" >&2
     echo "To allowlist a genuine f32-only scalar, add an inline marker:" >&2
     echo "  // f32-ok: <reason why f32 is safe here>" >&2


### PR DESCRIPTION
## Summary

Closes #170 — adds a CI grep gate that flags the recurring f32-leak idiom (`scalar_f32(...)` strong-f32 Array × bf16 activation stream → f32 promotion → f32 KV-cache contamination) in arch-layer code, so the bad pattern is hard to introduce. Same class fixed per-arch in #44 (Gemma4), #51 (Gemma4 MoE router), #168 (Qwen3 dense). Part of the f32-KV-leak hardening tracked in #172.

## The gate

`scripts/check_no_scalar_f32_leak.sh` (wired into `make ci` + standalone `make check-no-scalar-f32-leak`, mirroring `check-no-inline-tests`). Scans `crates/rmlx-models/src/` and flags a `scalar_f32(` use UNLESS:
- a **non-F32** `.astype(...)` guards it on the same line, OR within a multi-line method chain (pending stays open across non-terminated continuation lines), OR
- the line / a preceding comment carries an `// f32-ok: <reason>` marker.

Hardening details:
- **`.astype(Dtype::F32, …)` is NOT accepted as a guard** — it keeps the scalar f32 and doesn't prevent the leak (`is_f32_astype` / `has_good_astype`).
- **Out-of-scope arches excluded** (`*/laguna/*`, `*/dr_venus/*`) per the CLAUDE.md "do not bench, do not optimize: Laguna, DR-Venus" rule — the in-scope gate never force-touches frozen arches.

## The gate found 13 real f32 leaks — all fixed (verified correctness-preserving vs mlx-lm)

Applying the gate to the current tree surfaced 13 genuine unguarded `scalar_f32(` sites leaking f32 into bf16 streams; each fixed with the canonical `.astype(operand.dtype())` idiom and confirmed against mlx-lm reference numerics:
- **embed_scale** (`sqrt(hidden_size)`) on bf16 embeddings — gemma3 model+vision, gemma4 model + vision×2 + audio×2 (canonical #44 class; reference upcasts identically).
- **softcap** cap_arr — gemma3 + dflash (terminal pre-sampling logits; reference computes at activation dtype).
- **rope_mscale** — dflash. **LoRA scaling** — jina_v4 (reference casts to activation dtype). **relu zero** — bitnet (0.0 exact → value-identical, prevents promotion). **routed_scaling** — laguna (reverted; out-of-scope).
- ~22 legitimately-f32 sites (SigLIP/audio vision towers run f32-throughout, pooling outputs are `Vec<f32>`, LayerNorm casts x→f32 on entry) marked `// f32-ok: <reason>`.

`docs/ADDING_A_MODEL.md` gains a verification step documenting the gate, the canonical idiom, the `// f32-ok:` escape hatch, and the `.astype(F32)`-is-not-a-guard rule.

## Proof

**Gate (6-way):** clean-tree EXIT 0; planted unguarded `scalar_f32` → RED; `.astype(Dtype::F32)` + bf16-multiply → RED; `// f32-ok:` → pass; `.astype(operand.dtype())` → pass; multi-line `.astype` chain → pass.

**Real-model (the 13 fixes change numerics on real arches — proven on the in-scope touched ones):**
- `scripts/perf_canary.sh`: Bonsai 132.6, Gemma4-e4b 78.4, Qwen3.6 96.7 TPS — all within ±1% of baseline (Gemma4-e4b embed-scale path touched).
- Gemma4-e4b text (temp=0): "The capital of France is Paris." — coherent/correct.
- Gemma4-12B unified (vision/audio embed_scale touched): red PNG → "Red"; 440 Hz WAV → coherent, no crash.
- jina-v4 `/v1/embeddings` (LoRA scaling touched): cos(cat,dog)=0.7348 > cos(cat,quantum)=0.3501, all 2048 dims finite.
- `make lint` clean; `cargo test -p rmlx-{models,runtime,quant}` 740 passed.

## Out-of-scope note (not in this PR)

BitNet `/v1/chat` currently fails on a **pre-existing** cross-thread Metal-eval bug in the prompt-cache `exit_prefill` quantization path (`Array::eval: no Stream(gpu, 0)`), reproducible on `main` and unrelated to this branch (the relu-zero fix is decode-path-only and value-identical). Flagged for a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
