### PR TITLE
chore(release): 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-06-24
+
+f32-KV-leak class hardening. The `--kv-quant none` KV cache no longer widens to
+f32 on the Qwen3 path, and the leak is now structurally closed for every
+architecture. Headline: Qwen3-dense (Bonsai-8B-2bit) `none` decode is ~+32…+87 %
+across 4k–64k and now beats the mlx-lm reference at every context, with KV
+residency halved. No breaking changes.
+
+### Fixed
+
+- **Qwen3 dense (`Qwen3ForCausalLM`) `--kv-quant none` KV stored f32, not bf16.**
+  Bonsai ships RMSNorm weights and quant scales/biases as fp16; bf16 activations
+  × fp16 params promoted the residual — and the K/V projection outputs — to f32,
+  so the cache stored f32 (4 B/element). Casting all Qwen3 float params to bf16
+  at load (`bf16_param`) keeps the stream and the cache bf16. On Bonsai-8B-2bit:
+  none-KV halved (≈0.53× the f32 MB), decode +32 / +47 / +68 / +82 / +87 % at
+  4k / 8k / 16k / 32k / 64k, and prefill ~0.55×. (#168)
+- **Qwen3.6 MoE (`Qwen3_5MoeForConditionalGeneration`) hardened to bf16-param
+  parity**, including the GatedDeltaNet norm + conv1d weights; audited clean for
+  the same f32-KV leak. (#171)
+
+### Added
+
+- **Model-agnostic bf16 floor at the KV-cache store boundary.** The
+  `--kv-quant none` cache casts K/V to bf16 at the single store choke point, so
+  no architecture can store f32 there regardless of upstream dtype — a durable
+  backstop for the per-arch fixes. Bytes-per-element invariant test wired into
+  `make model-check`. (#169)
+- **CI gate `make check-no-scalar-f32-leak`** flags unguarded `scalar_f32(` in
+  arch-layer code (the f32-leak idiom). Surfaced and fixed 13 latent leaks across
+  gemma3, gemma4 vision/audio, jina, bitnet, and dflash. (#170)
+
+### Dependencies
+
+- safetensors 0.7→0.8, rusqlite 0.32→0.40, miniz_oxide 0.8→0.9, plus the
+  cargo-minor-patch group; CI `actions/checkout` 6→7 and `Swatinem/rust-cache`.
+  (#162–167)
+
+### Security
+
+- memmap2 0.9.10 → 0.9.11, clearing **RUSTSEC-2026-0186** (unsound out-of-bounds
+  `offset`/`len` in `advise_range` / `flush_range`). rMLX maps safetensors
+  read-only and does not call the affected functions, so it was not reachable —
+  bumped to keep the advisory gate clean.
+
+### Docs
+
+- Bonsai-8B (2-bit) full rMLX KV-quant matrix + sibling-backend champions. (#177)
+
 ## [0.2.5] - 2026-06-20
 
 Prefill / time-to-first-token fix for the MoE families, plus a baseline
@@ -484,7 +533,8 @@ inference + conversion backend for Apple Silicon — no Python at runtime.
 - Speculative drafters validated against their verifiers: Qwen 3.6 MTP sidecar
   and the Gemma 4 assistant drafter.
 
-[Unreleased]: https://github.com/Pushkinist/rMLX/compare/v0.2.5...HEAD
+[Unreleased]: https://github.com/Pushkinist/rMLX/compare/v0.2.6...HEAD
+[0.2.6]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.6
 [0.2.5]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.5
 [0.2.4]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.4
 [0.2.3]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,9 +1352,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -1924,7 +1924,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmlx-audio"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "miniz_oxide 0.9.1",
  "rmlx-core",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-cli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
  "libc",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-kv-quant"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "rmlx-core",
  "rmlx-mlx",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-kv-ssd"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "rmlx-core",
  "rmlx-kv-quant",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-loader"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "memmap2",
  "rayon",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-metrics"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "csv",
  "regex-lite",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-mlx"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bindgen",
  "rmlx-core",
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-models"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "criterion",
  "image",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-quant"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "criterion",
  "rmlx-core",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-runtime"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "rmlx-core",
  "rmlx-mlx",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-server"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release 0.2.6. Version bump + CHANGELOG. No breaking changes.

**Headline:** f32-KV-leak class hardening. The `--kv-quant none` KV cache no longer widens to f32 on the Qwen3 path, and the leak is now structurally closed for every architecture. Qwen3-dense (Bonsai-8B-2bit) `none` decode is ~+32…+87 % across 4k–64k and now beats the mlx-lm reference at every context, with KV residency halved.

- **Fixed** — Qwen3 dense fp16-param → f32 KV leak (#168); Qwen3.6 MoE bf16-param parity + audit (#171).
- **Added** — model-agnostic bf16 floor at the KV cache store boundary (#169); `make check-no-scalar-f32-leak` CI gate, fixed 13 latent leaks (#170).
- **Dependencies** — safetensors 0.8, rusqlite 0.40, miniz_oxide 0.9, cargo-minor-patch group, CI action bumps (#162–167).
- **Security** — memmap2 0.9.11, clears RUSTSEC-2026-0186 (not reachable in rMLX; bumped to keep the advisory gate clean).
- **Docs** — Bonsai-8B full rMLX KV-quant matrix + sibling champions (#177).

Gate: `make ci` green locally (fmt + clippy + test + deny + audit). Regression smoke: Gemma4-e4b + Qwen3.6-35B at none/k8v4/k8v8 — no degradation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
