### PR TITLE
fix(constraint): stop schema decode whitespace loop + share allow-mask probe (json_object 2×)

### DIFF
--- a/crates/rmlx-server/src/constraint_json/mod.rs
+++ b/crates/rmlx-server/src/constraint_json/mod.rs
@@ -609,6 +609,76 @@ impl TokenBytesMap {
     }
 }
 
+// ────────────────── shared allow-mask probe ──────────────────────────────────
+
+/// A grammar the shared allow-mask probe can drive: cheaply reset to a
+/// reference state, then fed one byte at a time. Implemented by both the
+/// free-form [`JsonGrammar`] and the schema-driven `SchemaGrammar` so the
+/// O(vocab) mask sweep — the hot loop of every constrained decode step — lives
+/// in one place instead of being duplicated per engine.
+pub(crate) trait ProbeGrammar {
+    /// Overwrite `self` with `src`'s state, reusing `self`'s own buffers where
+    /// the frame type allows (no per-call allocation for a `Copy` frame stack).
+    fn reset_from(&mut self, src: &Self);
+
+    /// Advance one byte. `Err(())` means the byte is illegal at the current
+    /// position; the caller stops feeding that candidate token.
+    fn feed(&mut self, byte: u8) -> Result<(), ()>;
+}
+
+impl ProbeGrammar for JsonGrammar {
+    fn reset_from(&mut self, src: &Self) {
+        // `state` is `Copy`; `Frame` is `Copy`, so refilling the stack is a
+        // memcpy into the reused buffer — no per-token allocation.
+        self.state = src.state;
+        self.stack.clear();
+        self.stack.extend_from_slice(&src.stack);
+    }
+
+    fn feed(&mut self, byte: u8) -> Result<(), ()> {
+        self.step(byte)
+    }
+}
+
+/// Fill `mask` (length `vocab_size`) with the per-token allow bits by feeding
+/// each token's decoded bytes through `grammar`'s current state. `scratch` is a
+/// throwaway grammar reused across tokens so the probe allocates at most once
+/// per decode step (when the frame type is `Copy`) instead of once per token.
+///
+/// Cost on a ~152K vocab is ~1–3 ms per decode step on the constrained path:
+/// most tokens are rejected on their first byte, so the average probe is far
+/// shorter than a full token and the once-assumed "~1M ops" never materializes.
+/// The dominant remaining term is the O(vocab) sweep itself, which only a
+/// per-state feasible-token index would remove.
+pub(crate) fn fill_allow_mask<G: ProbeGrammar>(
+    grammar: &G,
+    scratch: &mut G,
+    bytes_map: &TokenBytesMap,
+    vocab_size: usize,
+    mask: &mut [bool],
+) {
+    let n = bytes_map.vocab_size().min(vocab_size);
+    for id in 0..n {
+        let bytes = bytes_map.token_bytes(id);
+        if bytes.is_empty() {
+            continue; // specials decode to "" → never allowed mid-grammar
+        }
+        scratch.reset_from(grammar);
+        let mut ok = true;
+        for &b in bytes {
+            if scratch.feed(b).is_err() {
+                ok = false;
+                break;
+            }
+        }
+        if ok {
+            if let Some(m) = mask.get_mut(id) {
+                *m = true;
+            }
+        }
+    }
+}
+
 // ────────────────── ConstraintEngine impl ────────────────────────────────────
 
 /// `ConstraintEngine` for `response_format: json_object`. Holds the
@@ -787,29 +857,19 @@ impl ConstraintEngine for JsonObjectConstraint {
             }
             return &self.mask;
         }
-        // Per-step correctness: a candidate token is allowed only if ALL
-        // its bytes pass through a clone of the current grammar. This is
-        // the cost of stateful grammars; ~248K * avg_token_len ~ 1M
-        // simple ops per decode step on Qwen3.6 → ~5–20 ms per step,
-        // entirely on the constrained path.
-        let n = self.bytes_map.vocab_size.min(vocab_size);
-        for id in 0..n {
-            let bytes = self.bytes_map.token_bytes(id);
-            if bytes.is_empty() {
-                continue; // specials decode to "" → never allowed mid-grammar
-            }
-            let mut g = self.grammar.clone();
-            let mut ok = true;
-            for &b in bytes {
-                if g.step(b).is_err() {
-                    ok = false;
-                    break;
-                }
-            }
-            if ok {
-                self.mask[id] = true;
-            }
-        }
+        // Per-step correctness: a candidate token is allowed only if ALL its
+        // bytes feed cleanly through the current grammar. The O(vocab) probe is
+        // shared with the schema engine via `fill_allow_mask`; `scratch` is a
+        // throwaway grammar reused across tokens so the sweep allocates at most
+        // once per decode step (see the helper for the cost model).
+        let mut scratch = self.grammar.clone();
+        fill_allow_mask(
+            &self.grammar,
+            &mut scratch,
+            &self.bytes_map,
+            vocab_size,
+            &mut self.mask,
+        );
         &self.mask
     }
 

--- a/crates/rmlx-server/src/constraint_json/schema/constraint.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/constraint.rs
@@ -235,37 +235,37 @@ impl ConstraintEngine for SchemaConstraint {
             return &self.mask;
         }
 
-        let n = self.bytes_map.vocab_size().min(vocab_size);
-        let mut allowed_count = 0usize;
-        let mut byte60_allowed_ids: Vec<usize> = Vec::new();
-        for id in 0..n {
-            let bytes = self.bytes_map.token_bytes(id);
-            if bytes.is_empty() {
-                continue;
-            }
-            let mut g = self.grammar.clone();
-            let mut ok = true;
-            for &b in bytes {
-                if g.step(b).is_err() {
-                    ok = false;
-                    break;
-                }
-            }
-            if ok {
-                self.mask[id] = true;
-                allowed_count += 1;
-                if bytes.first() == Some(&60) {
-                    byte60_allowed_ids.push(id);
-                }
-            }
-        }
-        tracing::debug!(
-            allowed_count,
-            byte60_allowed = byte60_allowed_ids.len(),
-            byte60_examples = ?&byte60_allowed_ids[..byte60_allowed_ids.len().min(5)],
-            grammar_done = self.grammar.done,
-            "SchemaConstraint::step_mask result"
+        // O(vocab) probe shared with the json_object engine via
+        // `fill_allow_mask`; `scratch` is a throwaway grammar reused across
+        // tokens. For `SchemaGrammar` each reset is a deep clone (heavy frames),
+        // so this engine does not yet gain the json_object engine's
+        // allocation-free fast path — see `SchemaGrammar::reset_from`.
+        let mut scratch = self.grammar.clone();
+        super::super::fill_allow_mask(
+            &self.grammar,
+            &mut scratch,
+            &self.bytes_map,
+            vocab_size,
+            &mut self.mask,
         );
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            let allowed_count = self.mask.iter().filter(|&&b| b).count();
+            let n = self.bytes_map.vocab_size().min(vocab_size);
+            let byte60_allowed_ids: Vec<usize> = (0..n)
+                .filter(|&id| {
+                    self.mask.get(id) == Some(&true)
+                        && self.bytes_map.token_bytes(id).first() == Some(&60)
+                })
+                .take(5)
+                .collect();
+            tracing::debug!(
+                allowed_count,
+                byte60_allowed = byte60_allowed_ids.len(),
+                byte60_examples = ?byte60_allowed_ids,
+                grammar_done = self.grammar.done,
+                "SchemaConstraint::step_mask result"
+            );
+        }
         &self.mask
     }
 

--- a/crates/rmlx-server/src/constraint_json/schema/grammar.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/grammar.rs
@@ -636,9 +636,28 @@ impl SchemaGrammar {
             return Err(());
         }
 
-        // Whitespace handling: a no-op except it can close an open number.
-        let in_str = matches!(self.leaf, Some(Leaf::InStr { .. }));
-        if !in_str && WS.contains(&byte) {
+        // Whitespace handling. JSON allows insignificant whitespace only
+        // *between* tokens — never inside a string, literal, enum, or before
+        // the root value. Treating it as an unconditional no-op let a greedy
+        // (temp=0) decoder loop on JSON-legal whitespace forever instead of
+        // emitting the value, so we no-op it only where the spec actually
+        // permits it:
+        let ws_noop = match &self.leaf {
+            // Inside a string, literal, or enum trie: whitespace is never an
+            // insignificant separator. String whitespace is content (handled by
+            // `step_instr`); a literal/enum can't contain mid-token whitespace.
+            // Reject it (don't skip) so the trie advances and a greedy decoder
+            // can't loop.
+            Some(Leaf::InStr { .. } | Leaf::InLit { .. }) => false,
+            // Value-start: leading whitespace before an *interior* value is
+            // valid JSON (`: <ws> value`), but before the *root* value it is a
+            // pointless no-op a greedy decoder loops on, so reject it there.
+            Some(Leaf::Start(_)) => !self.stack.is_empty(),
+            // Inside a number, trailing whitespace closes it (below); structural
+            // whitespace between tokens inside a container is insignificant.
+            Some(Leaf::InNum { .. }) | None => true,
+        };
+        if ws_noop && WS.contains(&byte) {
             if let Some(Leaf::InNum { seen_digit, .. }) = &self.leaf {
                 if *seen_digit {
                     self.close_leaf();
@@ -765,7 +784,11 @@ impl SchemaGrammar {
                     });
                     Ok(())
                 }
-                0 => Err(()),
+                // Raw C0 control bytes (incl. tab / newline / CR) are illegal
+                // inside a JSON string — they must be escaped. Rejecting them
+                // also stops a greedy decoder from looping on raw whitespace
+                // inside a free-form string value.
+                0..=0x1f => Err(()),
                 _ => {
                     self.leaf = Some(Leaf::InStr {
                         escape: false,

--- a/crates/rmlx-server/src/constraint_json/schema/grammar.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/grammar.rs
@@ -305,6 +305,21 @@ pub struct SchemaGrammar {
     pub(super) done: bool,
 }
 
+impl super::super::ProbeGrammar for SchemaGrammar {
+    fn reset_from(&mut self, src: &Self) {
+        // `Frame` / `Leaf` own schema subtrees (heavy `Clone`), so refilling the
+        // stack element-by-element would deep-clone each frame anyway — no
+        // cheaper than a full clone. `clone_from` at least reuses the outer
+        // buffers; making the probe allocation-free here would need the schema
+        // held behind `Arc`, which is tracked separately.
+        self.clone_from(src);
+    }
+
+    fn feed(&mut self, byte: u8) -> Result<(), ()> {
+        self.step(byte)
+    }
+}
+
 impl SchemaGrammar {
     /// Create a new grammar that will enforce the given `root` schema node.
     pub fn new(root: SchemaNode) -> Self {

--- a/crates/rmlx-server/src/constraint_json/schema/tests.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/tests.rs
@@ -880,3 +880,177 @@ fn object_root_none_override_keeps_value_starter() {
         "ValueStarter: must NOT engage on non-structural token"
     );
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// Perf probe: SchemaGrammar step_mask cost + the deep-clone fraction.
+//
+// SchemaGrammar frames own the schema subtree (heavy Clone), so the shared
+// fill_allow_mask probe clone_from's the whole grammar per token. This measures
+// total step_mask cost vs clone-only (the deep-copy tax an Arc-wrap of the
+// immutable schema would mostly remove) on a synthetic ~152K vocab, across
+// container states. Compare to the json_object probe (~1-3 ms/step).
+//
+// Run: cargo test -p rmlx-server constraint_json::schema::tests::probe_schema \
+//        --profile release-perf -- --ignored --nocapture
+// ───────────────────────────────────────────────────────────────────────────
+
+struct LcgS(u64);
+impl LcgS {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+    fn below(&mut self, n: u64) -> u64 {
+        self.next_u64() % n
+    }
+}
+
+#[allow(
+    clippy::indexing_slicing,
+    reason = "letter index bounded by rng.below(letters.len())"
+)]
+fn realistic_vocab(n: usize) -> Arc<TokenBytesMap> {
+    let structural: &[&[u8]] = &[
+        b"{",
+        b"}",
+        b"[",
+        b"]",
+        b"\"",
+        b":",
+        b",",
+        b" ",
+        b"\n",
+        b"\t",
+        b"0",
+        b"1",
+        b"2",
+        b"-",
+        b"true",
+        b"false",
+        b"null",
+        b"\"name\"",
+        b"\"color\"",
+        b"\"size\"",
+        b"small",
+        b"medium",
+    ];
+    let mut owned: Vec<Vec<u8>> = structural.iter().map(|s| s.to_vec()).collect();
+    let mut rng = LcgS(0x1234_5678_9abc_def0);
+    let letters = b"abcdefghijklmnopqrstuvwxyz";
+    while owned.len() < n {
+        let len = match rng.below(100) {
+            0..=14 => 1,
+            15..=39 => 2,
+            40..=64 => 4,
+            65..=84 => 6,
+            _ => 9,
+        };
+        let mut t: Vec<u8> = Vec::with_capacity(len + 1);
+        match rng.below(100) {
+            0..=19 => t.push(b' '),
+            20..=24 => t.push(b'"'),
+            _ => {}
+        }
+        for _ in 0..len {
+            let idx = rng.below(letters.len() as u64) as usize;
+            t.push(letters[idx]);
+        }
+        owned.push(t);
+    }
+    owned.truncate(n);
+    let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+    synthetic_bm(&refs)
+}
+
+#[test]
+#[ignore = "perf probe — run manually with --ignored --nocapture"]
+fn probe_schema_step_mask_cost() {
+    let vocab_n = 152_064usize;
+    let bm = realistic_vocab(vocab_n);
+    let n = bm.vocab_size();
+    let reps = 30u32;
+
+    // A realistic strict object: 6 properties incl. an enum. Frames on the
+    // stack carry these property schemas → the deep-clone tax.
+    let root = node(
+        &json!({
+            "type":"object",
+            "properties":{
+                "name":{"type":"string"},"color":{"type":"string"},
+                "size":{"type":"string","enum":["small","medium","large"]},
+                "count":{"type":"integer"},"ripe":{"type":"boolean"},
+                "origin":{"type":"string"}
+            },
+            "required":["name","color","size","count","ripe","origin"],
+            "additionalProperties":false
+        }),
+        true,
+    );
+
+    // (label, valid JSON prefix → reaches the probed grammar state)
+    let scenes: &[(&str, &str)] = &[
+        ("obj ExpectKey (6 props)", "{"),
+        ("in string value", "{\"name\":\""),
+        (
+            "enum value-start (InLit)",
+            "{\"name\":\"a\",\"color\":\"b\",\"size\":\"",
+        ),
+    ];
+
+    println!("\nvocab={n}  reps={reps}  (per decode step = total/reps)\n");
+    println!(
+        "{:<32} {:>10} {:>12} {:>9}",
+        "grammar state", "total_ms", "cloneOnly_ms", "clone%"
+    );
+    println!("{}", "-".repeat(66));
+
+    for (label, prefix) in scenes {
+        let mut base = SchemaGrammar::new(root.clone());
+        feed(&mut base, prefix).expect("prefix must be valid for the schema");
+        let mut mask = vec![false; n];
+
+        // A) clone-per-token + step (current fill_allow_mask behaviour).
+        let t0 = std::time::Instant::now();
+        for _ in 0..reps {
+            mask.fill(false);
+            for (id, m) in mask.iter_mut().enumerate() {
+                let bytes = bm.token_bytes(id);
+                if bytes.is_empty() {
+                    continue;
+                }
+                let mut g = base.clone();
+                let mut ok = true;
+                for &b in bytes {
+                    if g.step(b).is_err() {
+                        ok = false;
+                        break;
+                    }
+                }
+                if ok {
+                    *m = true;
+                }
+            }
+        }
+        let total_ms = t0.elapsed().as_secs_f64() * 1e3 / f64::from(reps);
+
+        // B) clone-only — the deep-copy tax (no stepping).
+        let t1 = std::time::Instant::now();
+        for _ in 0..reps {
+            for id in 0..n {
+                if bm.token_bytes(id).is_empty() {
+                    continue;
+                }
+                let g = base.clone();
+                std::hint::black_box(&g);
+            }
+        }
+        let clone_ms = t1.elapsed().as_secs_f64() * 1e3 / f64::from(reps);
+
+        let pct = clone_ms / total_ms.max(1e-9) * 100.0;
+        println!("{label:<32} {total_ms:>10.3} {clone_ms:>12.3} {pct:>8.1}%");
+    }
+    println!();
+}

--- a/crates/rmlx-server/src/constraint_json/schema/tests.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/tests.rs
@@ -539,6 +539,102 @@ fn scalar_root_enum_immediate_engage() {
     assert!(m2[2], "EOS must be allowed when grammar is done/clamped");
 }
 
+/// Regression: leading whitespace before the root value must NOT be allowed.
+/// JSON permits it, but treating WS as a no-op let a greedy (temp=0) decoder
+/// loop on JSON-legal whitespace forever instead of emitting the value —
+/// scalar/enum roots were the worst case. The mask must allow `"` but reject
+/// whitespace-only tokens.
+#[test]
+fn scalar_root_rejects_leading_whitespace() {
+    // Vocab: 0=`"` 1=space 2=newline 3=`  ` 4=`"small"` 5=EOS(empty)
+    let bm = synthetic_bm(&[b"\"", b" ", b"\n", b"  ", b"\"small\"", b""]);
+    let n = node(&json!({"type":"string","enum":["small","large"]}), false);
+    let mut c = SchemaConstraint::from_parts(bm, vec![5], n, None);
+    let (quote, space, newline, dbl_space, quoted_val) = {
+        let m = c.step_mask(6);
+        (m[0], m[1], m[2], m[3], m[4])
+    };
+    assert!(c.engaged, "Immediate policy engages at first step_mask");
+    assert!(quote, "`\"` must be allowed at root value-start");
+    assert!(
+        quoted_val,
+        "`\"small\"` must be allowed at root value-start"
+    );
+    assert!(!space, "single space must NOT be allowed (would loop)");
+    assert!(!newline, "newline must NOT be allowed");
+    assert!(!dbl_space, "double-space must NOT be allowed");
+}
+
+/// The root-whitespace rejection must NOT affect interior whitespace: a
+/// pretty-printed object must still validate end-to-end.
+#[test]
+fn object_root_allows_interior_whitespace() {
+    let n = node(
+        &json!({"type":"object","properties":{"k":{"type":"string"}},"required":["k"],"additionalProperties":false}),
+        true,
+    );
+    let mut g = SchemaGrammar::new(n);
+    feed(&mut g, "{\n  \"k\": \"v\"\n}").expect("pretty-printed object must validate");
+    assert!(g.is_done(), "object must complete");
+}
+
+/// Step a clone of `g` by one byte. A failed `step` leaves the real grammar's
+/// `leaf` taken, so probing several candidate bytes from one state needs a
+/// fresh clone each time.
+fn probe_byte(g: &SchemaGrammar, b: u8) -> Result<(), ()> {
+    let mut c = g.clone();
+    c.step(b)
+}
+
+/// Regression: whitespace *inside* an enum/literal must be rejected, not
+/// skipped. After the opening `"` the grammar is mid-literal; treating a
+/// newline there as a no-op let a greedy decoder loop on `"\n\n…` forever.
+#[test]
+fn enum_literal_rejects_interior_whitespace() {
+    let n = node(&json!({"type":"string","enum":["small","large"]}), false);
+    let mut base = SchemaGrammar::new(n);
+    base.step(b'"')
+        .expect("opening quote starts the enum literal");
+    assert!(
+        probe_byte(&base, b'\n').is_err(),
+        "newline mid-literal rejected"
+    );
+    assert!(
+        probe_byte(&base, b' ').is_err(),
+        "space mid-literal rejected"
+    );
+    assert!(
+        probe_byte(&base, b's').is_ok(),
+        "`s` advances toward \"small\""
+    );
+}
+
+/// Regression: a raw (unescaped) control char inside a string is illegal JSON
+/// and must be rejected — this also stops the whitespace loop for free-form
+/// `type:string` values. Printable bytes (incl. space) stay valid content.
+#[test]
+fn free_string_rejects_raw_control_chars() {
+    let n = node(&json!({"type":"string"}), false);
+    let mut base = SchemaGrammar::new(n);
+    base.step(b'"').expect("opening quote starts the string");
+    assert!(
+        probe_byte(&base, b'\n').is_err(),
+        "raw newline rejected in string"
+    );
+    assert!(
+        probe_byte(&base, b'\t').is_err(),
+        "raw tab rejected in string"
+    );
+    assert!(
+        probe_byte(&base, b'a').is_ok(),
+        "ordinary char is valid content"
+    );
+    assert!(
+        probe_byte(&base, b' ').is_ok(),
+        "space (0x20) is valid content"
+    );
+}
+
 /// scalar-root integer: the constraint must engage immediately and the
 /// grammar must reject `.` (integer forbids decimal point).
 #[test]

--- a/crates/rmlx-server/src/constraint_json/tests.rs
+++ b/crates/rmlx-server/src/constraint_json/tests.rs
@@ -413,3 +413,231 @@ fn diagnose_gemma_token_bytes() {
     // non-printable; the engagement logic must handle them gracefully.
     eprintln!("[diagnose_gemma] done");
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// Empirical probe: clone-per-token vs scratch-reuse cost in step_mask.
+//
+// Reproduces the production step_mask inner loop (mod.rs) three ways and times
+// each across grammar states of increasing nesting depth, on a synthetic
+// ~152K-token vocab with a BPE-like byte-length distribution. Answers:
+//   (b) ~ms per decode step on the constrained path,
+//   (c) what fraction is per-token clone allocation vs irreducible step work,
+//   (d) whether eliminating the alloc (scratch reuse) is worth it, or whether
+//       the cost is algorithmic (vocab-wide probe → DFA/trie index).
+//
+// Run: cargo test -p rmlx-server constraint_json::tests::probe_step_mask \
+//        --profile release-perf -- --ignored --nocapture
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Deterministic LCG — no PRNG dep, reproducible vocab.
+struct Lcg(u64);
+impl Lcg {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+    fn below(&mut self, n: u64) -> u64 {
+        self.next_u64() % n
+    }
+}
+
+/// Build a realistic ~`n`-token vocab: structural JSON tokens up front, then
+/// BPE-like text tokens (mean ~4-5 bytes, some space/quote prefixed).
+#[allow(
+    clippy::indexing_slicing,
+    reason = "letter index is bounded by rng.below(letters.len())"
+)]
+fn realistic_vocab(n: usize) -> Arc<TokenBytesMap> {
+    let structural: &[&[u8]] = &[
+        b"{",
+        b"}",
+        b"[",
+        b"]",
+        b"\"",
+        b":",
+        b",",
+        b" ",
+        b"\n",
+        b"\t",
+        b"0",
+        b"1",
+        b"2",
+        b"3",
+        b"4",
+        b"5",
+        b"6",
+        b"7",
+        b"8",
+        b"9",
+        b"-",
+        b".",
+        b"true",
+        b"false",
+        b"null",
+        b"\"a\"",
+        b"\"name\"",
+        b"\"id\"",
+        b" \"x",
+        b"\"value\"",
+    ];
+    let mut owned: Vec<Vec<u8>> = Vec::with_capacity(n);
+    for s in structural {
+        owned.push(s.to_vec());
+    }
+    let mut rng = Lcg(0x1234_5678_9abc_def0);
+    let letters = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    while owned.len() < n {
+        // length weighted 1..12, mean ~4-5
+        let len = match rng.below(100) {
+            0..=14 => 1,
+            15..=39 => 2,
+            40..=64 => 4,
+            65..=84 => 6,
+            85..=94 => 9,
+            _ => 12,
+        };
+        let mut t: Vec<u8> = Vec::with_capacity(len + 1);
+        match rng.below(100) {
+            0..=19 => t.push(b' '),  // Ġ-style space prefix
+            20..=24 => t.push(b'"'), // quote-prefixed
+            _ => {}
+        }
+        for _ in 0..len {
+            let idx = rng.below(letters.len() as u64) as usize;
+            t.push(letters[idx]);
+        }
+        owned.push(t);
+    }
+    owned.truncate(n);
+    let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+    synthetic_bytes_map(&refs)
+}
+
+/// Drive the grammar to the state reached after consuming `prefix`.
+#[allow(
+    clippy::expect_used,
+    reason = "prefixes are static valid-JSON fragments authored in this test"
+)]
+fn grammar_at(prefix: &str) -> JsonGrammar {
+    let mut g = JsonGrammar::new();
+    for &b in prefix.as_bytes() {
+        g.step(b).expect("prefix must be valid JSON-so-far");
+    }
+    g
+}
+
+#[test]
+#[ignore = "perf probe — run manually with --ignored --nocapture"]
+fn probe_step_mask_clone_vs_scratch() {
+    let vocab_n = 152_064usize;
+    let bm = realistic_vocab(vocab_n);
+    let n = bm.vocab_size();
+    let reps = 30u32;
+
+    // (label, json-prefix). Depth = open-frame count after the prefix.
+    let scenes: &[(&str, &str)] = &[
+        ("Start top-value (depth0)", ""),
+        ("ObjectExpectKey (depth1)", "{"),
+        ("ExpectValue (depth1)", "{\"a\":"),
+        ("Nested ExpectValue (depth3)", "{\"a\":{\"b\":{\"c\":"),
+        (
+            "Nested ExpectValue (depth8)",
+            "{\"a\":[{\"b\":[{\"c\":[{\"d\":[",
+        ),
+        ("InString value (depth1)", "{\"a\":\""),
+    ];
+
+    println!("\nvocab={n}  reps={reps}  (figures are per-decode-step = total/reps)\n");
+    println!(
+        "{:<30} {:>10} {:>10} {:>7} {:>11} {:>9}",
+        "grammar state", "clone_ms", "scrch_ms", "speedup", "allocOnly", "legal"
+    );
+    println!("{}", "-".repeat(82));
+
+    for (label, prefix) in scenes {
+        let g = grammar_at(prefix);
+        let mut mask = vec![false; n];
+
+        // A) clone-per-token — current production logic (mod.rs:796).
+        let t0 = std::time::Instant::now();
+        let mut legal = 0usize;
+        for _ in 0..reps {
+            mask.fill(false);
+            for (id, m) in mask.iter_mut().enumerate() {
+                let bytes = bm.token_bytes(id);
+                if bytes.is_empty() {
+                    continue;
+                }
+                let mut gg = g.clone();
+                let mut ok = true;
+                for &b in bytes {
+                    if gg.step(b).is_err() {
+                        ok = false;
+                        break;
+                    }
+                }
+                if ok {
+                    *m = true;
+                }
+            }
+            legal = mask.iter().filter(|&&m| m).count();
+        }
+        let clone_ms = t0.elapsed().as_secs_f64() * 1e3 / f64::from(reps);
+        let mask_a = mask.clone();
+
+        // B) scratch-reuse — one grammar, refilled via clear()+extend (no alloc
+        //    after warm-up). state is Copy; stack reuses its heap buffer.
+        let t1 = std::time::Instant::now();
+        let mut scratch = JsonGrammar::new();
+        for _ in 0..reps {
+            mask.fill(false);
+            for (id, m) in mask.iter_mut().enumerate() {
+                let bytes = bm.token_bytes(id);
+                if bytes.is_empty() {
+                    continue;
+                }
+                scratch.state = g.state;
+                scratch.stack.clear();
+                scratch.stack.extend_from_slice(&g.stack);
+                let mut ok = true;
+                for &b in bytes {
+                    if scratch.step(b).is_err() {
+                        ok = false;
+                        break;
+                    }
+                }
+                if ok {
+                    *m = true;
+                }
+            }
+        }
+        let scratch_ms = t1.elapsed().as_secs_f64() * 1e3 / f64::from(reps);
+        // Correctness: scratch-reuse must produce a byte-identical allow-mask.
+        assert_eq!(
+            mask, mask_a,
+            "scratch mask diverges from clone mask at {label}"
+        );
+
+        // C) alloc-only — isolate the clone() heap cost (no stepping).
+        let t2 = std::time::Instant::now();
+        for _ in 0..reps {
+            for id in 0..n {
+                if bm.token_bytes(id).is_empty() {
+                    continue;
+                }
+                let gg = g.clone();
+                std::hint::black_box(&gg);
+            }
+        }
+        let alloc_ms = t2.elapsed().as_secs_f64() * 1e3 / f64::from(reps);
+
+        let speedup = clone_ms / scratch_ms.max(1e-9);
+        println!(
+            "{label:<30} {clone_ms:>10.3} {scratch_ms:>10.3} {speedup:>7.2} {alloc_ms:>11.3} {legal:>9}"
+        );
+    }
+    println!();
+}


### PR DESCRIPTION
## What

Two things in the constrained-decode (`response_format`) path, plus the
microbenches that motivated them.

### 1. Fix: schema decode looping on JSON-legal whitespace

A greedy (temp=0) decoder under a `json_schema` constraint could emit
insignificant whitespace forever instead of the value. `SchemaGrammar` treated
whitespace as a no-op in positions where JSON does not actually permit it:

- **Mid-literal/enum (`Leaf::InLit`)** — after the opening `"` the grammar sat
  in the enum trie and no-op'd every newline, never advancing. Output looped as
  `"\n\n  \n…` and hit `max_tokens`.
- **Root value-start (`Leaf::Start`, empty stack)** — leading whitespace before
  the top-level value let the decoder loop before emitting anything.
- **Free string (`step_instr`)** — raw C0 control bytes (`\n`, `\t`) were
  accepted, which is illegal unescaped JSON and the same loop hazard for
  `type:string` values.

The whitespace no-op is now an explicit per-leaf match: allowed only between
tokens inside a container, before an interior value, and to close a number;
rejected inside strings/literals and before the root value. Raw control bytes
in strings are rejected.

### 2. Perf/refactor: share the allow-mask probe across both engines

`JsonObjectConstraint` and `SchemaConstraint` had a copy-pasted O(vocab) inner
loop that clones the grammar per token to build the per-step allow-mask.
Extracted one generic kernel `fill_allow_mask` over a small `ProbeGrammar`
trait (`reset_from` + `feed`).

- `JsonGrammar::reset_from` is a memcpy into a reused scratch grammar (`state`
  is `Copy`, `Frame` is `Copy`) → the `json_object` probe now allocates at most
  once per decode step instead of once per token: **1.7–2.6× faster** at engaged
  depth ≥ 1, free at depth 0. Mask is byte-identical (asserted in the probe).
- `SchemaGrammar::reset_from` is `clone_from`: its frames own schema subtrees
  (heavy `Clone`), so it shares the loop but does not yet gain the
  allocation-free path. That is tracked in #182 (Arc-wrap the immutable schema —
  measured 10–30× on string/enum-heavy schemas).
- Schema diagnostics moved behind `tracing::enabled!(DEBUG)` so the info-level
  hot path no longer pays an extra vocab scan.
- Corrected the stale cost comment (`~1M ops / 5–20 ms per step` → measured
  ~1–3 ms on a 152K vocab; most tokens reject on their first byte).

### 3. Tests: two `#[ignore]` perf probes

- `probe_step_mask_clone_vs_scratch` (json_object) — clone vs scratch vs
  alloc-only across grammar depths; asserts mask equivalence.
- `probe_schema_step_mask_cost` (schema) — total vs clone-only fraction; the
  data behind #182.

## Verification

- 53 constraint tests green (4 new regression tests: enum interior WS, root WS,
  raw control chars, interior-WS preserved); full rmlx-server lib suite green.
- clippy `-D warnings` + fmt clean.
- Real model (gemma-4-e2b, temp=0): enum-scalar → `"small"` (stop, was a
  whitespace loop hitting `length`); free string → `"Apple"` (stop);
  `json_schema` object and `json_object` unchanged and valid.

## Follow-ups (not in this PR)

- #182 — Arc-wrap `SchemaGrammar` schema nodes (the schema-engine 10–30×).
- Per-state feasible-token DFA/trie index (removes the O(vocab) sweep itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
