### PR TITLE
perf(constraint): Arc-wrap SchemaGrammar schema to kill per-token deep-clone (#182)

### DIFF
--- a/crates/rmlx-server/src/constraint_json/schema/compiler.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/compiler.rs
@@ -12,6 +12,8 @@
     clippy::unused_self
 )]
 
+use std::sync::Arc;
+
 use serde_json::Value;
 
 use super::types::{SchemaError, SchemaNode};
@@ -305,8 +307,8 @@ impl SchemaNode {
         };
 
         Ok(SchemaNode::Object {
-            props,
-            required,
+            props: Arc::from(props),
+            required: Arc::from(required),
             additional,
         })
     }
@@ -319,10 +321,10 @@ impl SchemaNode {
     ) -> Result<SchemaNode, SchemaError> {
         let items = match obj.get("items") {
             Some(v) if v.is_object() => {
-                Box::new(SchemaNode::parse_node(v, strict, defs, depth + 1)?)
+                Arc::new(SchemaNode::parse_node(v, strict, defs, depth + 1)?)
             }
             // tuple-items / missing items → Any element
-            _ => Box::new(SchemaNode::Any),
+            _ => Arc::new(SchemaNode::Any),
         };
         let min = obj
             .get("minItems")

--- a/crates/rmlx-server/src/constraint_json/schema/compiler.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/compiler.rs
@@ -47,7 +47,7 @@ impl SchemaNode {
             // A union is scalar when every branch is scalar (e.g. all-const
             // or all-string-enum). If any branch is a container, treat as
             // non-scalar (ValueStarter is safe for containers).
-            SchemaNode::Union(branches) => branches.iter().all(SchemaNode::is_scalar_root),
+            SchemaNode::Union(branches) => branches.iter().all(|b| b.is_scalar_root()),
             SchemaNode::Object { .. } | SchemaNode::Array { .. } | SchemaNode::Any => false,
         }
     }
@@ -162,11 +162,11 @@ impl SchemaNode {
             if arr.is_empty() {
                 return Err(SchemaError::EmptyUnion);
             }
-            let mut branches = Vec::with_capacity(arr.len());
+            let mut branches: Vec<Arc<SchemaNode>> = Vec::with_capacity(arr.len());
             for a in arr {
-                branches.push(Self::parse_node(a, strict, defs, depth + 1)?);
+                branches.push(Arc::new(Self::parse_node(a, strict, defs, depth + 1)?));
             }
-            return Ok(SchemaNode::Union(branches));
+            return Ok(SchemaNode::Union(Arc::from(branches)));
         }
 
         // `const`.
@@ -188,9 +188,11 @@ impl SchemaNode {
                     .collect();
                 return Ok(SchemaNode::Str { enum_: Some(lits) });
             }
-            return Ok(SchemaNode::Union(
-                arr.iter().map(|v| SchemaNode::Const(v.clone())).collect(),
-            ));
+            return Ok(SchemaNode::Union(Arc::from(
+                arr.iter()
+                    .map(|v| Arc::new(SchemaNode::Const(v.clone())))
+                    .collect::<Vec<_>>(),
+            )));
         }
 
         // unsupported scalar-narrowing keywords. In strict mode these are a
@@ -261,7 +263,7 @@ impl SchemaNode {
         defs: &serde_json::Map<String, Value>,
         depth: usize,
     ) -> Result<SchemaNode, SchemaError> {
-        let mut props: Vec<(String, SchemaNode)> = Vec::new();
+        let mut props: Vec<(String, Arc<SchemaNode>)> = Vec::new();
         if let Some(p) = obj.get("properties") {
             let pmap = p
                 .as_object()
@@ -269,7 +271,7 @@ impl SchemaNode {
             for (k, v) in pmap {
                 props.push((
                     k.clone(),
-                    SchemaNode::parse_node(v, strict, defs, depth + 1)?,
+                    Arc::new(SchemaNode::parse_node(v, strict, defs, depth + 1)?),
                 ));
             }
         }

--- a/crates/rmlx-server/src/constraint_json/schema/constraint.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/constraint.rs
@@ -237,9 +237,10 @@ impl ConstraintEngine for SchemaConstraint {
 
         // O(vocab) probe shared with the json_object engine via
         // `fill_allow_mask`; `scratch` is a throwaway grammar reused across
-        // tokens. For `SchemaGrammar` each reset is a deep clone (heavy frames),
-        // so this engine does not yet gain the json_object engine's
-        // allocation-free fast path — see `SchemaGrammar::reset_from`.
+        // tokens. The parsed schema inside `SchemaGrammar` is `Arc`-shared, so
+        // the per-token reset is a few refcount bumps plus a buffer-reusing
+        // refill of the small mutable progress — not a schema deep-copy. See
+        // `SchemaGrammar::reset_from`.
         let mut scratch = self.grammar.clone();
         super::super::fill_allow_mask(
             &self.grammar,

--- a/crates/rmlx-server/src/constraint_json/schema/grammar.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/grammar.rs
@@ -10,13 +10,13 @@
 //!
 //! ## LOC exemption
 //!
-//! This file is ~1185 LOC, exceeding the 1000 LOC split target. The
+//! This file is ~1400 LOC, exceeding the 1000 LOC split target. The
 //! `SchemaGrammar` state machine integrates object-key trie tracking,
 //! array bounds enforcement, literal-branch selection, free-key parsing,
-//! and epilogue handling into a single monolithic `impl` block. Splitting
-//! the state machine across files would require threading mutable `self`
-//! through function arguments or boxing frame state, adding indirection
-//! for no correctness gain.
+//! epilogue handling, and the buffer-reusing per-token `reset_from` into a
+//! single cohesive unit. Splitting the state machine across files would
+//! require threading mutable `self` through function arguments or boxing
+//! frame state, adding indirection for no correctness gain.
 
 #![allow(
     clippy::cognitive_complexity,
@@ -27,6 +27,8 @@
     clippy::unused_self,
     unreachable_pub
 )]
+
+use std::sync::Arc;
 
 use serde_json::Value;
 
@@ -101,9 +103,14 @@ pub(super) fn union_literals(branches: &[SchemaNode]) -> Option<Vec<Vec<u8>>> {
 /// Position inside a set of literal alternatives. Tracks how many bytes of
 /// the chosen literal(s) have been emitted; the still-viable set is the
 /// literals whose prefix matches what has been emitted so far.
+///
+/// `lits` is the immutable alternative set, held behind `Arc` so cloning the
+/// trie (per candidate token in the mask probe) shares it instead of copying
+/// every literal. `pos`/`viable` are the mutable match progress and clone by
+/// value.
 #[derive(Debug, Clone)]
 pub(super) struct LiteralTrie {
-    pub(super) lits: Vec<Vec<u8>>,
+    pub(super) lits: Arc<[Vec<u8>]>,
     /// byte offset matched so far (same for all viable lits — they share
     /// the matched prefix).
     pub(super) pos: usize,
@@ -115,10 +122,18 @@ impl LiteralTrie {
     pub(super) fn new(lits: Vec<Vec<u8>>) -> Self {
         let viable = (0..lits.len()).collect();
         Self {
-            lits,
+            lits: Arc::from(lits),
             pos: 0,
             viable,
         }
+    }
+
+    /// Refill from `src` reusing the `viable` buffer (the per-token reset on
+    /// the mask sweep). `lits` is `Arc`-shared (refcount bump).
+    fn reset_from(&mut self, src: &Self) {
+        self.lits.clone_from(&src.lits);
+        self.pos = src.pos;
+        self.viable.clone_from(&src.viable);
     }
 
     #[allow(
@@ -220,21 +235,97 @@ fn free_key_step(byte: u8, escape: bool, unicode: u8) -> Result<FreeKeyNext, ()>
 enum Frame {
     /// Inside `{ … }`. `idx` = next property index to emit; `emitted` =
     /// keys already written; phase tracks the `"key":value,` micro-cycle.
+    ///
+    /// `node_props` / `required` are the immutable schema (shared via `Arc`);
+    /// `emitted` / `phase` are the mutable progress.
     Object {
-        node_props: Vec<(String, SchemaNode)>,
-        required: Vec<String>,
+        node_props: Arc<[(String, SchemaNode)]>,
+        required: Arc<[String]>,
         additional: bool,
         emitted: Vec<String>,
         phase: ObjPhase,
     },
     /// Inside `[ … ]`. `count` = elements committed so far.
+    ///
+    /// `items` is the immutable element schema (shared via `Arc`); `count` /
+    /// `phase` are the mutable progress.
     Array {
-        items: SchemaNode,
+        items: Arc<SchemaNode>,
         min: Option<usize>,
         max: Option<usize>,
         count: usize,
         phase: ArrPhase,
     },
+}
+
+impl Frame {
+    /// Refill from `src` reusing this frame's heap buffers when the variant is
+    /// unchanged: the `Object` `emitted` vector and the in-key trie's `viable`
+    /// vector are refilled in place via `clone_from`. On a variant mismatch we
+    /// fall back to a plain clone.
+    fn reset_from(&mut self, src: &Self) {
+        match (self, src) {
+            (
+                Frame::Object {
+                    node_props,
+                    required,
+                    additional,
+                    emitted,
+                    phase,
+                },
+                Frame::Object {
+                    node_props: s_props,
+                    required: s_req,
+                    additional: s_add,
+                    emitted: s_emitted,
+                    phase: s_phase,
+                },
+            ) => {
+                node_props.clone_from(s_props);
+                required.clone_from(s_req);
+                *additional = *s_add;
+                emitted.clone_from(s_emitted);
+                phase.reset_from(s_phase);
+            }
+            (
+                Frame::Array {
+                    items,
+                    min,
+                    max,
+                    count,
+                    phase,
+                },
+                Frame::Array {
+                    items: s_items,
+                    min: s_min,
+                    max: s_max,
+                    count: s_count,
+                    phase: s_phase,
+                },
+            ) => {
+                items.clone_from(s_items);
+                *min = *s_min;
+                *max = *s_max;
+                *count = *s_count;
+                *phase = s_phase.clone();
+            }
+            (dst, src) => *dst = src.clone(),
+        }
+    }
+}
+
+impl ObjPhase {
+    /// Refill from `src`, reusing the in-key trie's `viable` buffer when both
+    /// sides are mid-key; otherwise a plain clone (the other variants are
+    /// `Copy`-sized and allocate nothing).
+    fn reset_from(&mut self, src: &Self) {
+        match (self, src) {
+            (ObjPhase::InKey { trie }, ObjPhase::InKey { trie: s_trie }) => {
+                trie.reset_from(s_trie);
+            }
+            (dst, src) => *dst = src.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -265,8 +356,8 @@ enum ArrPhase {
 /// Active scalar/leaf sub-state when emitting a non-container value.
 #[derive(Debug, Clone)]
 enum Leaf {
-    /// Awaiting the first byte of a value governed by `node`.
-    Start(SchemaNode),
+    /// Awaiting the first byte of a value governed by `node` (shared via `Arc`).
+    Start(Arc<SchemaNode>),
     /// Inside a JSON string (free-form, e.g. `type:string` w/o enum).
     InStr {
         escape: bool,
@@ -284,6 +375,26 @@ enum Leaf {
         seen_digit: bool,
         done_to: AfterTarget,
     },
+}
+
+impl Leaf {
+    /// Refill from `src`, reusing the `InLit` trie's `viable` buffer when both
+    /// sides are inside a literal trie; otherwise a plain clone.
+    fn reset_from(&mut self, src: &Self) {
+        match (self, src) {
+            (
+                Leaf::InLit { trie, done_to },
+                Leaf::InLit {
+                    trie: s_trie,
+                    done_to: s_done_to,
+                },
+            ) => {
+                trie.reset_from(s_trie);
+                *done_to = *s_done_to;
+            }
+            (dst, src) => *dst = src.clone(),
+        }
+    }
 }
 
 /// Where control returns after a leaf/value completes.
@@ -307,12 +418,28 @@ pub struct SchemaGrammar {
 
 impl super::super::ProbeGrammar for SchemaGrammar {
     fn reset_from(&mut self, src: &Self) {
-        // `Frame` / `Leaf` own schema subtrees (heavy `Clone`), so refilling the
-        // stack element-by-element would deep-clone each frame anyway — no
-        // cheaper than a full clone. `clone_from` at least reuses the outer
-        // buffers; making the probe allocation-free here would need the schema
-        // held behind `Arc`, which is tracked separately.
-        self.clone_from(src);
+        // The immutable schema inside each `Frame` / `Leaf` is held behind
+        // `Arc` (property list, element schema, literal alternatives), so a
+        // frame reset is a few refcount bumps plus a copy of the tiny mutable
+        // progress (`emitted` keys, trie `viable` indices, `phase`). No schema
+        // subtree is ever deep-copied.
+        //
+        // Beyond that, this reset reuses the scratch's existing per-frame
+        // buffers: on the O(vocab) mask sweep the scratch is reset once per
+        // candidate token, and where its stack shape still matches the
+        // reference (same variant at the same depth) the `emitted` / `viable`
+        // vectors are refilled in place via `clone_from` rather than
+        // reallocated. The derived `clone_from` would instead reassign each
+        // frame wholesale, dropping and re-growing those vectors every token.
+        self.done = src.done;
+        reset_stack(&mut self.stack, &src.stack);
+        // Reuse a literal-trie's `viable` buffer when both leaves are the same
+        // trie-bearing variant; otherwise fall back to a plain clone.
+        match (self.leaf.as_mut(), src.leaf.as_ref()) {
+            (Some(d), Some(s)) => d.reset_from(s),
+            (_, Some(s)) => self.leaf = Some(s.clone()),
+            (_, None) => self.leaf = None,
+        }
     }
 
     fn feed(&mut self, byte: u8) -> Result<(), ()> {
@@ -320,12 +447,25 @@ impl super::super::ProbeGrammar for SchemaGrammar {
     }
 }
 
+/// Refill `dst` from `src`, reusing each frame's heap buffers in place where
+/// the variant at that depth is unchanged (the common case across consecutive
+/// probe tokens). Frames whose variant differs, and any tail beyond `src`'s
+/// length, fall back to a plain clone / truncate.
+fn reset_stack(dst: &mut Vec<Frame>, src: &[Frame]) {
+    let common = dst.len().min(src.len());
+    for (d, s) in dst.iter_mut().zip(src.iter()) {
+        d.reset_from(s);
+    }
+    dst.truncate(common);
+    dst.extend(src.iter().skip(common).cloned());
+}
+
 impl SchemaGrammar {
     /// Create a new grammar that will enforce the given `root` schema node.
     pub fn new(root: SchemaNode) -> Self {
         Self {
             stack: Vec::new(),
-            leaf: Some(Leaf::Start(root)),
+            leaf: Some(Leaf::Start(Arc::new(root))),
             done: false,
         }
     }
@@ -385,7 +525,14 @@ impl SchemaGrammar {
                 additional,
                 emitted,
                 phase,
-            }) => self.object_allowed(node_props, required, *additional, emitted, phase, &mut out),
+            }) => self.object_allowed(
+                node_props.as_ref(),
+                required.as_ref(),
+                *additional,
+                emitted,
+                phase,
+                &mut out,
+            ),
             Some(Frame::Array {
                 min,
                 max,
@@ -409,7 +556,7 @@ impl SchemaGrammar {
     )]
     fn leaf_allowed(&self, leaf: &Leaf, out: &mut [bool; 256]) {
         match leaf {
-            Leaf::Start(node) => self.value_starters(node, out),
+            Leaf::Start(node) => self.value_starters(node.as_ref(), out),
             Leaf::InStr {
                 escape, unicode, ..
             } => {
@@ -608,7 +755,7 @@ impl SchemaGrammar {
                 if !at_max {
                     // delegate to the items node's starters
                     if let Some(Frame::Array { items, .. }) = self.stack.last() {
-                        self.value_starters(items, out);
+                        self.value_starters(items.as_ref(), out);
                     }
                 }
                 if !just_after_comma && at_min {
@@ -802,22 +949,26 @@ impl SchemaGrammar {
     }
 
     /// Begin a value governed by `node` starting at `byte`.
+    ///
+    /// `node` is the shared schema sub-tree (`Arc`); container arms clone the
+    /// already-`Arc`-wrapped property list / element schema (a refcount bump,
+    /// not a deep copy) into the pushed frame.
     #[allow(
         clippy::indexing_slicing,
         reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or validated before call"
     )]
-    fn enter_value(&mut self, node: SchemaNode, byte: u8) -> Result<(), ()> {
+    fn enter_value(&mut self, node: Arc<SchemaNode>, byte: u8) -> Result<(), ()> {
         let done_to = if self.stack.is_empty() {
             AfterTarget::Top
         } else {
             AfterTarget::Container
         };
-        match node {
+        match node.as_ref() {
             SchemaNode::Union(branches) => {
                 // Discriminated union: every branch is a `const` or a
                 // string-`enum` literal → merge into one literal trie and
                 // prune as bytes commit (true discriminated-union support).
-                if let Some(lits) = union_literals(&branches) {
+                if let Some(lits) = union_literals(branches) {
                     let mut trie = LiteralTrie::new(lits);
                     trie.step(byte)?;
                     self.finish_or_keep_lit(trie, done_to);
@@ -826,7 +977,7 @@ impl SchemaGrammar {
                 // Structural union: pick the first branch whose starter set
                 // accepts `byte` (v1 limitation: no full backtracking).
                 let mut chosen: Option<SchemaNode> = None;
-                for br in &branches {
+                for br in branches {
                     let mut s = [false; 256];
                     self.value_starters(br, &mut s);
                     if s[byte as usize] {
@@ -836,14 +987,14 @@ impl SchemaGrammar {
                 }
                 match chosen {
                     Some(n) => {
-                        self.leaf = Some(Leaf::Start(n));
+                        self.leaf = Some(Leaf::Start(Arc::new(n)));
                         self.step(byte)
                     }
                     None => Err(()),
                 }
             }
             SchemaNode::Const(v) => {
-                let mut trie = LiteralTrie::new(vec![literal_bytes(&v)]);
+                let mut trie = LiteralTrie::new(vec![literal_bytes(v)]);
                 trie.step(byte)?;
                 if trie.complete() && trie.lits[0].len() == trie.pos {
                     self.value_complete(done_to);
@@ -882,7 +1033,7 @@ impl SchemaGrammar {
                     return Err(());
                 }
                 self.leaf = Some(Leaf::InNum {
-                    integer,
+                    integer: *integer,
                     seen_digit: byte.is_ascii_digit(),
                     done_to,
                 });
@@ -910,9 +1061,9 @@ impl SchemaGrammar {
                     return Err(());
                 }
                 self.stack.push(Frame::Object {
-                    node_props: props,
-                    required,
-                    additional,
+                    node_props: Arc::clone(props),
+                    required: Arc::clone(required),
+                    additional: *additional,
                     emitted: Vec::new(),
                     phase: ObjPhase::ExpectKeyOrEnd {
                         just_after_comma: false,
@@ -925,9 +1076,9 @@ impl SchemaGrammar {
                     return Err(());
                 }
                 self.stack.push(Frame::Array {
-                    items: *items,
-                    min,
-                    max,
+                    items: Arc::clone(items),
+                    min: *min,
+                    max: *max,
                     count: 0,
                     phase: ArrPhase::ExpectValueOrEnd {
                         just_after_comma: false,
@@ -962,8 +1113,8 @@ impl SchemaGrammar {
         match byte {
             b'{' => {
                 self.stack.push(Frame::Object {
-                    node_props: Vec::new(),
-                    required: Vec::new(),
+                    node_props: Arc::from([]),
+                    required: Arc::from([]),
                     additional: true,
                     emitted: Vec::new(),
                     phase: ObjPhase::ExpectKeyOrEnd {
@@ -974,7 +1125,7 @@ impl SchemaGrammar {
             }
             b'[' => {
                 self.stack.push(Frame::Array {
-                    items: SchemaNode::Any,
+                    items: Arc::new(SchemaNode::Any),
                     min: None,
                     max: None,
                     count: 0,
@@ -1051,7 +1202,10 @@ impl SchemaGrammar {
         reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or validated before call"
     )]
     fn step_object(&mut self, byte: u8) -> Result<(), ()> {
-        // Clone the small bits we need; mutate the frame in place after.
+        // Snapshot the bits we need so we can mutate the frame in place after.
+        // `node_props`/`required` are `Arc`-shared schema → these clones are
+        // refcount bumps, not deep copies; only `emitted`/`phase` are real
+        // (tiny) copies.
         let (props, required, additional, emitted, phase) = match self.stack.last() {
             Some(Frame::Object {
                 node_props,
@@ -1060,8 +1214,8 @@ impl SchemaGrammar {
                 emitted,
                 phase,
             }) => (
-                node_props.clone(),
-                required.clone(),
+                Arc::clone(node_props),
+                Arc::clone(required),
                 *additional,
                 emitted.clone(),
                 phase.clone(),
@@ -1152,7 +1306,7 @@ impl SchemaGrammar {
                 let value_node = which
                     .and_then(|i| props.get(i).map(|(_, n)| n.clone()))
                     .unwrap_or(SchemaNode::Any);
-                self.leaf = Some(Leaf::Start(value_node));
+                self.leaf = Some(Leaf::Start(Arc::new(value_node)));
                 if let Some(Frame::Object { phase, .. }) = self.stack.last_mut() {
                     *phase = ObjPhase::AfterValue;
                 }
@@ -1204,7 +1358,7 @@ impl SchemaGrammar {
                 max,
                 count,
                 phase,
-            }) => (items.clone(), *min, *max, *count, phase.clone()),
+            }) => (Arc::clone(items), *min, *max, *count, phase.clone()),
             _ => return Err(()),
         };
         let at_min = min.is_none_or(|m| count >= m);

--- a/crates/rmlx-server/src/constraint_json/schema/grammar.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/grammar.rs
@@ -78,10 +78,10 @@ pub(super) fn literal_bytes(v: &Value) -> Vec<u8> {
     clippy::wildcard_enum_match_arm,
     reason = "wildcard arm is the correct fallthrough for unsupported arch/quant/error variants"
 )]
-pub(super) fn union_literals(branches: &[SchemaNode]) -> Option<Vec<Vec<u8>>> {
+pub(super) fn union_literals(branches: &[Arc<SchemaNode>]) -> Option<Vec<Vec<u8>>> {
     let mut out = Vec::new();
     for b in branches {
-        match b {
+        match b.as_ref() {
             SchemaNode::Const(v) => out.push(literal_bytes(v)),
             SchemaNode::Str {
                 enum_: Some(lits), ..
@@ -239,7 +239,7 @@ enum Frame {
     /// `node_props` / `required` are the immutable schema (shared via `Arc`);
     /// `emitted` / `phase` are the mutable progress.
     Object {
-        node_props: Arc<[(String, SchemaNode)]>,
+        node_props: Arc<[(String, Arc<SchemaNode>)]>,
         required: Arc<[String]>,
         additional: bool,
         emitted: Vec<String>,
@@ -634,8 +634,8 @@ impl SchemaGrammar {
                 }
             }
             SchemaNode::Union(branches) => {
-                for br in branches {
-                    self.value_starters(br, out);
+                for br in branches.iter() {
+                    self.value_starters(br.as_ref(), out);
                 }
             }
             SchemaNode::Any => {
@@ -678,7 +678,7 @@ impl SchemaGrammar {
     )]
     fn object_allowed(
         &self,
-        node_props: &[(String, SchemaNode)],
+        node_props: &[(String, Arc<SchemaNode>)],
         required: &[String],
         additional: bool,
         emitted: &[String],
@@ -975,19 +975,21 @@ impl SchemaGrammar {
                     return Ok(());
                 }
                 // Structural union: pick the first branch whose starter set
-                // accepts `byte` (v1 limitation: no full backtracking).
-                let mut chosen: Option<SchemaNode> = None;
-                for br in branches {
+                // accepts `byte` (v1 limitation: no full backtracking). The
+                // branch sub-schema is already `Arc`-wrapped, so entering it
+                // is a refcount bump, not a deep clone.
+                let mut chosen: Option<Arc<SchemaNode>> = None;
+                for br in branches.iter() {
                     let mut s = [false; 256];
-                    self.value_starters(br, &mut s);
+                    self.value_starters(br.as_ref(), &mut s);
                     if s[byte as usize] {
-                        chosen = Some(br.clone());
+                        chosen = Some(Arc::clone(br));
                         break;
                     }
                 }
                 match chosen {
                     Some(n) => {
-                        self.leaf = Some(Leaf::Start(Arc::new(n)));
+                        self.leaf = Some(Leaf::Start(n));
                         self.step(byte)
                     }
                     None => Err(()),
@@ -1303,10 +1305,13 @@ impl SchemaGrammar {
                 if byte != b':' {
                     return Err(());
                 }
+                // A schema'd property's value-schema is already `Arc`-wrapped,
+                // so entering it is a refcount bump. A free additional key
+                // (`which == None`) falls back to `Any`.
                 let value_node = which
-                    .and_then(|i| props.get(i).map(|(_, n)| n.clone()))
-                    .unwrap_or(SchemaNode::Any);
-                self.leaf = Some(Leaf::Start(Arc::new(value_node)));
+                    .and_then(|i| props.get(i).map(|(_, n)| Arc::clone(n)))
+                    .unwrap_or_else(|| Arc::new(SchemaNode::Any));
+                self.leaf = Some(Leaf::Start(value_node));
                 if let Some(Frame::Object { phase, .. }) = self.stack.last_mut() {
                     *phase = ObjPhase::AfterValue;
                 }

--- a/crates/rmlx-server/src/constraint_json/schema/tests.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/tests.rs
@@ -750,20 +750,20 @@ fn is_scalar_root_classification() {
     assert!(SchemaNode::Null.is_scalar_root());
     assert!(SchemaNode::Const(json!("hello")).is_scalar_root());
     // Union of scalars → scalar
-    assert!(SchemaNode::Union(vec![
-        SchemaNode::Const(json!("a")),
-        SchemaNode::Const(json!("b")),
-    ])
+    assert!(SchemaNode::Union(Arc::from([
+        Arc::new(SchemaNode::Const(json!("a"))),
+        Arc::new(SchemaNode::Const(json!("b"))),
+    ]))
     .is_scalar_root());
     // Union with container → not scalar
-    assert!(!SchemaNode::Union(vec![
-        SchemaNode::Const(json!("a")),
-        SchemaNode::Object {
+    assert!(!SchemaNode::Union(Arc::from([
+        Arc::new(SchemaNode::Const(json!("a"))),
+        Arc::new(SchemaNode::Object {
             props: Arc::from([]),
             required: Arc::from([]),
             additional: false
-        },
-    ])
+        }),
+    ]))
     .is_scalar_root());
     assert!(!SchemaNode::Object {
         props: Arc::from([]),
@@ -938,6 +938,83 @@ fn reset_from_matches_fresh_clone() {
                 "reset_from allowed_bytes mismatch at prefix {prefix:?}"
             );
         }
+    }
+}
+
+/// `reset_from` must also restore the scratch when its dirtied state has a
+/// **deeper** stack than `src` (exercising `reset_stack`'s truncate path) or a
+/// **differently-shaped frame at the same depth** (exercising the
+/// `Frame::reset_from` `*dst = src.clone()` variant-mismatch fallback). The
+/// single-byte dirtying in `reset_from_matches_fresh_clone` does not reliably
+/// reach those branches, so drive the scratch with a multi-byte prefix into a
+/// nested / different-variant container before resetting.
+#[test]
+fn reset_from_cross_shape_paths() {
+    use super::super::ProbeGrammar;
+
+    // Schema with both an object-valued and an array-valued property so the
+    // depth-1 container frame can be `Object` *or* `Array` depending on which
+    // property the decoder entered.
+    let root = node(
+        &json!({
+            "type":"object",
+            "properties":{
+                "obj":{
+                    "type":"object",
+                    "properties":{"x":{"type":"string"}},
+                    "required":["x"],
+                    "additionalProperties":false
+                },
+                "arr":{"type":"array","items":{"type":"string"}}
+            },
+            "required":["obj","arr"],
+            "additionalProperties":false
+        }),
+        true,
+    );
+
+    // (base prefix, scratch prefix). The scratch prefix drives a DEEPER or
+    // DIFFERENTLY-SHAPED state than the base before the reset.
+    let cases: &[(&str, &str)] = &[
+        // (a) truncate path: base at depth 1 (`{`), scratch pushed to depth 2
+        //     by opening the nested array, plus a string leaf inside it.
+        ("{", "{\"arr\":[\""),
+        // (a) truncate path, the other container shape: scratch enters the
+        //     nested object (depth 2) and starts a key.
+        ("{", "{\"obj\":{\""),
+        // (b) variant mismatch at depth 1: base entered the array property
+        //     (depth-1 frame = Array), scratch entered the object property
+        //     (depth-1 frame = Object). reset_from must replace the Object
+        //     frame with the Array frame via the clone() fallback.
+        ("{\"arr\":[", "{\"obj\":{"),
+        // (b) the reverse variant mismatch: base = Object frame at depth 1,
+        //     scratch = Array frame at depth 1.
+        ("{\"obj\":{", "{\"arr\":["),
+    ];
+
+    for (base_prefix, scratch_prefix) in cases {
+        let mut base = SchemaGrammar::new(root.clone());
+        feed(&mut base, base_prefix).expect("base prefix valid");
+        let fresh = base.clone();
+        let expect = format!("{fresh:?}");
+        let expect_allowed = fresh.allowed_bytes();
+
+        // Drive the scratch into the divergent (deeper / different-variant)
+        // shape, then reset it back toward `base`.
+        let mut scratch = SchemaGrammar::new(root.clone());
+        feed(&mut scratch, scratch_prefix).expect("scratch prefix valid");
+        scratch.reset_from(&base);
+
+        assert_eq!(
+            format!("{scratch:?}"),
+            expect,
+            "reset_from must restore base (base={base_prefix:?}, scratch was {scratch_prefix:?})"
+        );
+        assert_eq!(
+            scratch.allowed_bytes(),
+            expect_allowed,
+            "reset_from allowed_bytes mismatch (base={base_prefix:?}, scratch was {scratch_prefix:?})"
+        );
     }
 }
 

--- a/crates/rmlx-server/src/constraint_json/schema/tests.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/tests.rs
@@ -30,7 +30,7 @@ fn schema_parse_shapes() {
             additional,
         } => {
             assert_eq!(props.len(), 1);
-            assert_eq!(required, vec!["a".to_string()]);
+            assert_eq!(required.as_ref(), ["a".to_string()].as_slice());
             assert!(
                 additional,
                 "non-strict, no additionalProperties → permissive"
@@ -759,20 +759,20 @@ fn is_scalar_root_classification() {
     assert!(!SchemaNode::Union(vec![
         SchemaNode::Const(json!("a")),
         SchemaNode::Object {
-            props: vec![],
-            required: vec![],
+            props: Arc::from([]),
+            required: Arc::from([]),
             additional: false
         },
     ])
     .is_scalar_root());
     assert!(!SchemaNode::Object {
-        props: vec![],
-        required: vec![],
+        props: Arc::from([]),
+        required: Arc::from([]),
         additional: false
     }
     .is_scalar_root());
     assert!(!SchemaNode::Array {
-        items: Box::new(SchemaNode::Num { integer: false }),
+        items: Arc::new(SchemaNode::Num { integer: false }),
         min: None,
         max: None
     }
@@ -881,14 +881,77 @@ fn object_root_none_override_keeps_value_starter() {
     );
 }
 
+/// `reset_from` (the buffer-reusing per-token reset) must restore a scratch
+/// grammar to a state byte-identical to a fresh `clone()` of the reference,
+/// regardless of how the scratch was dirtied first. This guards the buffer
+/// reuse in `reset_from` / `Frame::reset_from` / `LiteralTrie::reset_from`
+/// against leaving stale mutable progress behind.
+#[test]
+fn reset_from_matches_fresh_clone() {
+    use super::super::ProbeGrammar;
+
+    // A schema rich enough to exercise object frames (with `emitted`), an
+    // enum literal trie, and array frames.
+    let root = node(
+        &json!({
+            "type":"object",
+            "properties":{
+                "name":{"type":"string"},
+                "size":{"type":"string","enum":["small","medium","large"]},
+                "tags":{"type":"array","items":{"type":"string"}}
+            },
+            "required":["name","size","tags"],
+            "additionalProperties":false
+        }),
+        true,
+    );
+
+    // Reference states at several distinct grammar positions.
+    let prefixes = [
+        "{",
+        "{\"name\":\"",
+        "{\"name\":\"x\",\"size\":\"",
+        "{\"name\":\"x\",\"size\":\"small\",\"tags\":[\"",
+    ];
+    // Bytes that drive the scratch into a different shape before each reset.
+    let dirtiers = [b'x', b'{', b'"', b'}', b'[', b' ', b',', b':', b']'];
+
+    for prefix in prefixes {
+        let mut base = SchemaGrammar::new(root.clone());
+        feed(&mut base, prefix).expect("prefix valid");
+        let expect = format!("{base:?}");
+        let expect_allowed = base.allowed_bytes();
+
+        let mut scratch = base.clone();
+        for &d in &dirtiers {
+            let _ = scratch.step(d); // diverge (may Err / no-op; that's fine)
+            scratch.reset_from(&base);
+            assert_eq!(
+                format!("{scratch:?}"),
+                expect,
+                "reset_from must restore base after stepping {:?} at prefix {prefix:?}",
+                d as char
+            );
+            assert_eq!(
+                scratch.allowed_bytes(),
+                expect_allowed,
+                "reset_from allowed_bytes mismatch at prefix {prefix:?}"
+            );
+        }
+    }
+}
+
 // ───────────────────────────────────────────────────────────────────────────
-// Perf probe: SchemaGrammar step_mask cost + the deep-clone fraction.
+// Perf probe: SchemaGrammar step_mask cost, across three columns.
 //
-// SchemaGrammar frames own the schema subtree (heavy Clone), so the shared
-// fill_allow_mask probe clone_from's the whole grammar per token. This measures
-// total step_mask cost vs clone-only (the deep-copy tax an Arc-wrap of the
-// immutable schema would mostly remove) on a synthetic ~152K vocab, across
-// container states. Compare to the json_object probe (~1-3 ms/step).
+// The immutable schema inside each frame is `Arc`-shared, so a grammar clone
+// no longer deep-copies the property list / element schema / literal set —
+// only the tiny mutable progress. This measures, on a synthetic ~152K vocab:
+//   total_ms      — full per-token sweep (reset + step), the user-visible cost
+//   cloneOnly_ms  — a raw `clone()` per token (no stepping)
+//   reset_ms      — the production path: one buffer-reusing `reset_from` per
+//                   token (what `fill_allow_mask` actually does)
+// Compare to the json_object probe (~1-3 ms/step).
 //
 // Run: cargo test -p rmlx-server constraint_json::schema::tests::probe_schema \
 //        --profile release-perf -- --ignored --nocapture
@@ -1002,10 +1065,10 @@ fn probe_schema_step_mask_cost() {
 
     println!("\nvocab={n}  reps={reps}  (per decode step = total/reps)\n");
     println!(
-        "{:<32} {:>10} {:>12} {:>9}",
-        "grammar state", "total_ms", "cloneOnly_ms", "clone%"
+        "{:<32} {:>10} {:>12} {:>9} {:>11}",
+        "grammar state", "total_ms", "cloneOnly_ms", "clone%", "reset_ms"
     );
-    println!("{}", "-".repeat(66));
+    println!("{}", "-".repeat(78));
 
     for (label, prefix) in scenes {
         let mut base = SchemaGrammar::new(root.clone());
@@ -1049,8 +1112,27 @@ fn probe_schema_step_mask_cost() {
         }
         let clone_ms = t1.elapsed().as_secs_f64() * 1e3 / f64::from(reps);
 
+        // C) reset_from — the production hot path. `fill_allow_mask` resets a
+        // single scratch grammar per candidate token instead of cloning, so
+        // this is the figure that actually governs constrained-decode cost.
+        // Step one byte before each reset so the scratch shape diverges and the
+        // reset must restore it (worst case for buffer reuse).
+        let mut scratch = base.clone();
+        let t2 = std::time::Instant::now();
+        for _ in 0..reps {
+            for id in 0..n {
+                if bm.token_bytes(id).is_empty() {
+                    continue;
+                }
+                let _ = scratch.step(b'x');
+                <SchemaGrammar as super::super::ProbeGrammar>::reset_from(&mut scratch, &base);
+                std::hint::black_box(&scratch);
+            }
+        }
+        let reset_ms = t2.elapsed().as_secs_f64() * 1e3 / f64::from(reps);
+
         let pct = clone_ms / total_ms.max(1e-9) * 100.0;
-        println!("{label:<32} {total_ms:>10.3} {clone_ms:>12.3} {pct:>8.1}%");
+        println!("{label:<32} {total_ms:>10.3} {clone_ms:>12.3} {pct:>8.1}% {reset_ms:>11.3}");
     }
     println!();
 }

--- a/crates/rmlx-server/src/constraint_json/schema/types.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/types.rs
@@ -4,6 +4,8 @@
 
 #![allow(unreachable_pub)]
 
+use std::sync::Arc;
+
 use serde_json::Value;
 
 /// Error returned when the supplied `response_format.json_schema.schema`
@@ -77,6 +79,14 @@ pub enum EngagePolicy {
 ///
 /// Adapted from llama.cpp `SchemaConverter::visit` keyword dispatch order:
 /// `$ref` → `oneOf`/`anyOf` → `const` → `enum` → object → array → scalar.
+///
+/// The immutable sub-schema fields (`props`, `required`, array `items`) are
+/// held behind `Arc` so the schema tree is *shared*, not deep-copied. The
+/// per-token allow-mask probe resets a scratch grammar once per candidate
+/// token (~152K per decode step); with the schema behind `Arc` each reset is
+/// a handful of refcount bumps rather than a recursive clone of the property
+/// list / element schema. `Arc` (not `Rc`) because the constraint engine is
+/// driven from a `Send` decode loop.
 #[allow(
     clippy::exhaustive_enums,
     reason = "closed schema-AST enum — variants are the complete supported JSON-Schema keyword subset; adding a variant requires updating the compiler, SchemaGrammar, and all SchemaNode match arms"
@@ -88,16 +98,16 @@ pub enum SchemaNode {
     /// extra free-form keys when `true`.
     Object {
         /// Ordered list of `(name, schema)` pairs for declared properties.
-        props: Vec<(String, SchemaNode)>,
+        props: Arc<[(String, SchemaNode)]>,
         /// Names of properties that must appear in the output object.
-        required: Vec<String>,
+        required: Arc<[String]>,
         /// When `true`, additional properties beyond `props` are permitted.
         additional: bool,
     },
     /// `type:array` with homogeneous `items`.
     Array {
         /// Schema applied to every element of the array.
-        items: Box<SchemaNode>,
+        items: Arc<SchemaNode>,
         /// Minimum number of array elements (`minItems`); `None` = unconstrained.
         min: Option<usize>,
         /// Maximum number of array elements (`maxItems`); `None` = unconstrained.

--- a/crates/rmlx-server/src/constraint_json/schema/types.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/types.rs
@@ -80,13 +80,15 @@ pub enum EngagePolicy {
 /// Adapted from llama.cpp `SchemaConverter::visit` keyword dispatch order:
 /// `$ref` → `oneOf`/`anyOf` → `const` → `enum` → object → array → scalar.
 ///
-/// The immutable sub-schema fields (`props`, `required`, array `items`) are
-/// held behind `Arc` so the schema tree is *shared*, not deep-copied. The
-/// per-token allow-mask probe resets a scratch grammar once per candidate
-/// token (~152K per decode step); with the schema behind `Arc` each reset is
-/// a handful of refcount bumps rather than a recursive clone of the property
-/// list / element schema. `Arc` (not `Rc`) because the constraint engine is
-/// driven from a `Send` decode loop.
+/// The immutable sub-schema fields (`props` and each property value-schema,
+/// `required`, array `items`, union branches) are held behind `Arc` so the
+/// schema tree is *shared*, not deep-copied. The per-token allow-mask probe
+/// resets a scratch grammar once per candidate token (~152K per decode step)
+/// and, on a value-start byte, enters a property/branch sub-schema; with each
+/// sub-schema behind `Arc` both the reset and the value-entry are refcount
+/// bumps rather than a recursive clone of the property list / element schema /
+/// branch. `Arc` (not `Rc`) because the constraint engine is driven from a
+/// `Send` decode loop.
 #[allow(
     clippy::exhaustive_enums,
     reason = "closed schema-AST enum — variants are the complete supported JSON-Schema keyword subset; adding a variant requires updating the compiler, SchemaGrammar, and all SchemaNode match arms"
@@ -98,7 +100,9 @@ pub enum SchemaNode {
     /// extra free-form keys when `true`.
     Object {
         /// Ordered list of `(name, schema)` pairs for declared properties.
-        props: Arc<[(String, SchemaNode)]>,
+        /// Each value-schema is pre-wrapped in `Arc` so entering a property
+        /// value (in `step_object`) is a refcount bump, not a deep clone.
+        props: Arc<[(String, Arc<SchemaNode>)]>,
         /// Names of properties that must appear in the output object.
         required: Arc<[String]>,
         /// When `true`, additional properties beyond `props` are permitted.
@@ -129,8 +133,10 @@ pub enum SchemaNode {
     Null,
     /// `const` (or a non-string `enum` member): an exact JSON literal.
     Const(Value),
-    /// `oneOf`/`anyOf` union of branches.
-    Union(Vec<SchemaNode>),
+    /// `oneOf`/`anyOf` union of branches. Each branch is pre-wrapped in
+    /// `Arc` so entering a structural branch value is a refcount bump, not a
+    /// deep clone.
+    Union(Arc<[Arc<SchemaNode>]>),
     /// Unsupported keyword fallback: any JSON value of any type.
     Any,
 }

--- a/docs/SAMPLING.md
+++ b/docs/SAMPLING.md
@@ -377,11 +377,23 @@ and applied before softmax.
 decode loop skips `step_mask()` and uses the unconstrained fast path for
 that step.
 
-**JSON engine.** `constraint_json::JsonObjectConstraint` /
-`JsonSchemaConstraint` implement `ConstraintEngine`. Construction decodes
-every token in the vocabulary once (approximately 600 ms for a 152K-token
-vocabulary — one-time cost, hidden behind TTFT). Per-step mask build is
-O(vocab) byte-set membership, approximately 1 ms on Qwen3.6.
+**JSON engine.** `constraint_json::JsonObjectConstraint` (free-form
+`json_object`) and `constraint_json::SchemaConstraint` (`json_schema`)
+implement `ConstraintEngine`. Construction decodes every token in the
+vocabulary once (approximately 600 ms for a 152K-token vocabulary — one-time
+cost, hidden behind TTFT). Per-step mask build is an O(vocab) byte-set
+membership sweep: for each candidate token a shared scratch grammar is reset
+to the current state and the token's bytes are fed through it. The reset is
+the per-token cost driver, so both engines keep their grammar's *immutable*
+part cheap to copy — `JsonObjectConstraint` uses `Copy` frames, and
+`SchemaConstraint` holds the parsed schema (property lists, element schemas,
+literal-alternative sets) behind `Arc` and refills only the tiny mutable
+progress (`emitted` keys, trie `viable`/`pos`, phase) in place. A reset is
+therefore a handful of refcount bumps plus small buffer refills rather than a
+deep copy of the schema subtree. The free-form engine is ~1 ms/step on
+Qwen3.6; schema masking is heavier (the residual is the O(vocab) sweep and
+the literal-trie step-work, not the grammar copy) but no longer pays a
+per-token schema deep-clone.
 
 EOS tokens are naturally masked out mid-JSON (special tokens decode to empty
 or zero first byte; the state machine never allows byte value 0). At


### PR DESCRIPTION
Closes #182.

## What

`json_schema`-constrained decode (`SchemaConstraint`) deep-cloned the whole
`SchemaGrammar` for every vocab token in the per-token allow-mask probe
(~152K clones per decode step), and most of that clone was the **immutable**
parsed schema carried by value in each frame. This holds the schema behind
`Arc` and gives `SchemaGrammar` a buffer-reusing `reset_from`, so the per-token
reset is a refcount bump + tiny mutable-progress copy instead of a schema
deep-copy.

- `SchemaNode` immutable parts behind `Arc`: `Object.props` →
  `Arc<[(String, Arc<SchemaNode>)]>`, `Union` → `Arc<[Arc<SchemaNode>]>`,
  `Array.items` → `Arc<SchemaNode>`; `Frame`/`Leaf`/`LiteralTrie` hold the `Arc`
  forms. Built once in `compiler.rs`. Entering a container / property / union
  branch is now `Arc::clone` (refcount bump), not `clone()` + `Arc::new()`.
- Custom buffer-reusing `SchemaGrammar::reset_from` (the actual `fill_allow_mask`
  production path) refills only the small mutable progress (`emitted`, `phase`,
  trie `pos`/`viable`, `done`) in place. Guarded by an always-run equivalence
  test against a fresh clone, incl. cross-shape (stack-truncate and
  frame-variant-mismatch) reset paths.

Perf-only: accept/reject behavior is byte-identical.

## Numbers (release-perf, synthetic 152K vocab, per decode step)

`reset_ms` = the `fill_allow_mask` production path.

| state | before clone-only | after reset_ms |
|---|--:|--:|
| obj ExpectKey (6 props) | 35.6 ms | ~1.8 ms |
| in string value | 39.0 ms | ~1.6 ms |
| enum value-start | 49.7 ms | ~4.5 ms |

Schema-constrained decode per-step cost drops ~8–25× on the production path
(was 20–40× heavier than the `json_object` engine; now comparable). Tool /
function-calling agents (which use `json_schema`) pay this directly.

## Verification

- 55 constraint tests green (+2 new: `reset_from_matches_fresh_clone`,
  `reset_from_cross_shape_paths`); workspace clippy `-D warnings` + fmt clean.
- Real model (gemma-4-e2b, temp=0): strict object → `{"name":"apple","color":"red"}`
  (exact keys), enum → `"small"`, free string → `"Apple"` — all valid, finish
  `stop`, output unchanged vs before.
- Two blind code-review passes: second pass PASS, no findings.

## Docs

`docs/SAMPLING.md` constrained-decoding section corrected (engine name, Arc-shared
schema, reset-not-deep-clone) + two stale code comments.

## Out of scope

The residual O(vocab) sweep + literal-trie step-work floor (a per-state
feasible-token DFA/trie index) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
