### PR TITLE
chore(release): 0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-06-28
+
+Constrained-decode hot-path and Gemma4-unified vision tuning. The `json_schema`
+and `json_object` per-token allow-mask probes no longer deep-clone their grammar
+across the ~152K-token vocab on every decode step, and a whitespace stall in
+schema-constrained decode is fixed. Gemma4-unified gains a per-request image-token
+budget. No breaking changes.
+
+### Added
+
+- **Per-request + CLI image-token budget for Gemma4-unified vision.** A
+  `image_max_tokens` request field (and matching CLI flag) caps soft image
+  tokens per request; default 280, ceiling 1120. Lets callers trade vision
+  fidelity for prefill cost on the unified any-to-any path. (#181, closes #180)
+
+### Fixed
+
+- **Schema-constrained decode whitespace loop.** Under `response_format:
+  json_schema`, enum / scalar leaves accepted insignificant whitespace in
+  states where it must be rejected (inside a literal, inside a string, at the
+  root scalar start), letting temp=0 decode loop on `\n`. The allow-mask now
+  matches whitespace per-leaf-state and rejects raw control chars (`0x00..=0x1f`)
+  inside strings. (#183)
+
+### Performance
+
+- **`json_schema` constrained decode no longer deep-clones the schema per
+  vocab token.** The allow-mask probe reset a scratch `SchemaGrammar` ~152K
+  times per decode step, deep-copying the immutable parsed schema each reset.
+  The schema is now held behind `Arc` (`Object.props`, `Union`, `Array.items`),
+  so entering a container/property/union branch is a refcount bump and the
+  per-token reset reuses buffers in place. Per-step cost on the production path
+  drops ~8–25× (was 20–40× heavier than the `json_object` engine; now
+  comparable). Tool / function-calling agents pay this directly. (#184,
+  closes #182)
+- **`json_object` constrained decode allow-mask reset is scratch-reused.** The
+  `JsonGrammar` reset became a state copy + `Vec` clear/extend (the stack frame
+  is `Copy`) instead of a fresh clone per vocab token — ~2× on the per-step
+  probe. The two engines now share one `fill_allow_mask` kernel over a
+  `ProbeGrammar` trait. (#183)
+
 ## [0.2.6] - 2026-06-24
 
 f32-KV-leak class hardening. The `--kv-quant none` KV cache no longer widens to
@@ -533,7 +574,8 @@ inference + conversion backend for Apple Silicon — no Python at runtime.
 - Speculative drafters validated against their verifiers: Qwen 3.6 MTP sidecar
   and the Gemma 4 assistant drafter.
 
-[Unreleased]: https://github.com/Pushkinist/rMLX/compare/v0.2.6...HEAD
+[Unreleased]: https://github.com/Pushkinist/rMLX/compare/v0.2.7...HEAD
+[0.2.7]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.7
 [0.2.6]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.6
 [0.2.5]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.5
 [0.2.4]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,7 +1924,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmlx-audio"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "miniz_oxide 0.9.1",
  "rmlx-core",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "libc",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-kv-quant"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "rmlx-core",
  "rmlx-mlx",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-kv-ssd"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "rmlx-core",
  "rmlx-kv-quant",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-loader"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "memmap2",
  "rayon",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-metrics"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "csv",
  "regex-lite",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-mlx"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bindgen",
  "rmlx-core",
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-models"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "criterion",
  "image",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-quant"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "criterion",
  "rmlx-core",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-runtime"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "rmlx-core",
  "rmlx-mlx",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-server"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Release 0.2.7

Bumps `[workspace.package].version` 0.2.6 → 0.2.7 and adds the `## [0.2.7]`
CHANGELOG section. Version-only metadata change plus changelog; no code touched.

### Included since v0.2.6

- **#181** (closes #180) — per-request + CLI image-token budget for Gemma4-unified vision (`image_max_tokens`, default 280, ceiling 1120).
- **#183** — schema-constrained decode whitespace-loop fix + shared `fill_allow_mask` kernel + `json_object` scratch-reuse (~2×).
- **#184** (closes #182) — Arc-wrap `SchemaGrammar` schema, killing the per-token deep-clone (~8–25× on the `json_schema` production path).

### Gate

- `cargo fmt --all --check` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo build --workspace --release` green.
- No exact-version literal assertions in code/tests (all uses are `env!("CARGO_PKG_VERSION")`), so the bump cannot regress the suite.

Homebrew formula bump (url + sha + bottle) follows as a separate PR per the release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
