### PR TITLE
fix(qwen): keep uint8 E8M0 mxfp8/mxfp4 scales intact in loaders

### DIFF
--- a/crates/rmlx-models/src/load_util.rs
+++ b/crates/rmlx-models/src/load_util.rs
@@ -113,6 +113,29 @@ pub(crate) fn bf16_param(a: Array) -> Result<Array> {
     }
 }
 
+/// Cast a quantized layer's `.scales` to BF16 only when they are float.
+///
+/// Affine quant ships float scales; the [`bf16_param`] uniformity cast applies
+/// to keep the dequant output bf16 and avoid an fp16 → f32 promotion leak. But
+/// microscaling codecs (mxfp8 / mxfp4) ship **uint8 E8M0** scales — a shared
+/// per-block exponent, not a float — and MLX's `dequantize` rejects any scale
+/// dtype other than uint8 for those modes. Casting them to bf16 corrupts the
+/// exponents and crashes the kernel.
+///
+/// Gating on `scales.dtype()` (not the arch string or quant-mode string) is the
+/// general rule: the cast follows the per-tensor checkpoint fact and survives
+/// future uint8-scaled codecs without a special case. Float scales (the affine
+/// path) keep the existing uniformity cast; any non-float scale dtype passes
+/// through untouched.
+pub(crate) fn bf16_scales(a: Array) -> Result<Array> {
+    match a.dtype() {
+        Dtype::Bf16 | Dtype::F16 | Dtype::F32 => bf16_param(a),
+        // uint8 E8M0 (mxfp8/mxfp4) and any other non-float scale dtype: leave
+        // the on-disk dtype intact so the dequant kernel's contract holds.
+        Dtype::U8 | Dtype::U32 | Dtype::I32 => Ok(a),
+    }
+}
+
 impl<'a> Weights<'a> {
     /// Index-first fetch: the index locates each tensor's shard, with a
     /// header-scan fallback when the index misses or lies.

--- a/crates/rmlx-models/src/load_util_tests.rs
+++ b/crates/rmlx-models/src/load_util_tests.rs
@@ -488,6 +488,50 @@ fn embedding_maps_to_shared_embedding() {
     }
 }
 
+/// `bf16_scales` must leave a uint8 E8M0 scale tensor (mxfp8 / mxfp4) untouched:
+/// MLX's `dequantize` rejects any scale dtype other than uint8 for those modes,
+/// so casting the shared per-block exponent to bf16 corrupts it and crashes the
+/// kernel at first prefill. The dtype gate is the general rule — it follows the
+/// per-tensor checkpoint fact, not the arch string.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: Array construction failures should abort the test loudly"
+)]
+fn bf16_scales_keeps_uint8_e8m0_intact() {
+    use rmlx_mlx::{Array, Dtype};
+
+    // A uint8 E8M0 scale block as mxfp8 ships it: one shared exponent per group.
+    let u8_scales = Array::from_bytes(&[127u8, 128, 129, 130], &[4], Dtype::U8).unwrap();
+    let out = super::bf16_scales(u8_scales).unwrap();
+    assert_eq!(
+        out.dtype(),
+        Dtype::U8,
+        "mxfp8/mxfp4 uint8 E8M0 scales must survive the loader as uint8"
+    );
+}
+
+/// `bf16_scales` must still apply the float-uniformity cast for affine float
+/// scales: an fp16/f32 scale would otherwise promote `quantized_matmul` output
+/// to f32 and leak into the KV cache. Only non-float scales are exempt.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: Array construction failures should abort the test loudly"
+)]
+fn bf16_scales_casts_float_scales_to_bf16() {
+    use rmlx_mlx::{Array, Dtype};
+
+    // An f32 affine scale tensor: must be lifted to bf16 (uniformity discipline).
+    let f32_scales = Array::from_f32_slice(&[0.5, 0.25, 0.125, 1.0], &[4]).unwrap();
+    let out = super::bf16_scales(f32_scales).unwrap();
+    assert_eq!(
+        out.dtype(),
+        Dtype::Bf16,
+        "affine float scales keep the bf16 uniformity cast"
+    );
+}
+
 /// The `qp` closure may hard-error; `embedding` propagates the error rather
 /// than building an `Embedding`.
 #[test]

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -72,7 +72,7 @@ use crate::kv_cache::{
     kv_max_seq_and_ceiling, kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N,
 };
 use crate::layers::{resolve_quant, QuantParams};
-use crate::load_util::{bf16_param, Weights};
+use crate::load_util::{bf16_param, bf16_scales, Weights};
 use crate::prompt_cache::{
     chained_block_hashes_seeded, ArchPromptCache, Consumed, PromptCacheEntry, ReusePolicy,
     SsdHydrate, FNV_OFFSET,
@@ -2266,8 +2266,10 @@ pub fn load_from_path(model_dir: &Path, yarn_override: Option<&YarnOverride>) ->
                 // then carries F32 through Q/K/V, attention, and the `--kv-quant
                 // none` KV cache — doubling residency. mlx-lm casts every float
                 // weight to a single model dtype at load; force the scale/bias to
-                // BF16 here to match, so the projection output stays BF16.
-                scales: bf16_param(scales)?,
+                // BF16 here to match, so the projection output stays BF16. Only
+                // float scales are cast: mxfp8/mxfp4 ship uint8 E8M0 scales the
+                // dequant kernel requires verbatim (`bf16_scales` gates on dtype).
+                scales: bf16_scales(scales)?,
                 biases: biases.map(bf16_param).transpose()?,
                 group_size,
                 bits,
@@ -2312,8 +2314,9 @@ pub fn load_from_path(model_dir: &Path, yarn_override: Option<&YarnOverride>) ->
                 // snapshots that ship embedding scales at fp16 (e.g. Bonsai),
                 // that produces f32 logits; cast to bf16 at load to keep the
                 // output bf16 — consistent with `lin`'s treatment and
-                // mlx-lm's uniform model-dtype discipline.
-                scales: bf16_param(scales)?,
+                // mlx-lm's uniform model-dtype discipline. uint8 E8M0
+                // (mxfp8/mxfp4) scales pass through (`bf16_scales`).
+                scales: bf16_scales(scales)?,
                 biases: biases.map(bf16_param).transpose()?,
                 group_size,
                 bits,

--- a/crates/rmlx-models/src/qwen3_5_moe/loader.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/loader.rs
@@ -26,7 +26,9 @@ use rmlx_quant::awq::{f16_bits_to_f32, f32_to_f16_bits};
 use tracing::info;
 
 use crate::layers::{resolve_quant, QuantParams};
-use crate::load_util::{bf16_param, load_paro_parts, quantize_embedding_int4, Weights};
+use crate::load_util::{
+    bf16_param, bf16_scales, load_paro_parts, quantize_embedding_int4, Weights,
+};
 
 use super::attention::FullAttention;
 use super::config::Qwen3_5MoeConfig;
@@ -90,7 +92,11 @@ pub fn load_from_path(model_dir: &Path) -> Result<Qwen3_5MoeText> {
                 mode,
             } => Ok(Linear::Quantized {
                 weight,
-                scales: bf16_param(scales)?,
+                // mxfp8/mxfp4 ship uint8 E8M0 scales the dequant kernel
+                // requires verbatim; only float (affine) scales get the
+                // bf16 uniformity cast. `biases` is always float (affine) or
+                // None (mxfp8), so the plain `bf16_param` is correct there.
+                scales: bf16_scales(scales)?,
                 biases: biases.map(bf16_param).transpose()?,
                 group_size,
                 bits,
@@ -129,7 +135,10 @@ pub fn load_from_path(model_dir: &Path) -> Result<Qwen3_5MoeText> {
                 mode,
             } => Embedding::Quantized {
                 weight,
-                scales: bf16_param(scales)?,
+                // Same per-tensor scale-dtype gate as `lin`: uint8 E8M0
+                // (mxfp8/mxfp4) scales pass through, float (affine) scales
+                // get the bf16 uniformity cast.
+                scales: bf16_scales(scales)?,
                 biases: biases.map(bf16_param).transpose()?,
                 group_size,
                 bits,

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -319,9 +319,14 @@ Qwen3 dense).
 
 ### Weight quantization
 
-Same coverage as Qwen3. Known snapshots include 8-bit affine and mxfp8. The PARO
-variant (`Qwen3_5ForConditionalGeneration`) uses a paroquant layout detected by
-the `is_paroquant` signal in `KvCacheBuilder::resolve_default`.
+Same coverage as Qwen3. Known snapshots include 8-bit affine, mxfp8, and mixed
+checkpoints (global mxfp8 with per-tensor affine overrides on the router gates,
+e.g. `ornith-1.0-35b-mxfp8`). mxfp8 / mxfp4 ship **uint8 E8M0** scales (a shared
+per-block exponent); the loader keeps those verbatim and only applies the bf16
+uniformity cast to float (affine) scales — gated on `scales.dtype()`, not on the
+arch or global quant mode, so a mixed checkpoint loads both codecs correctly. The
+PARO variant (`Qwen3_5ForConditionalGeneration`) uses a paroquant layout detected
+by the `is_paroquant` signal in `KvCacheBuilder::resolve_default`.
 
 ### KV quantization
 

--- a/docs/WEIGHT_QUANTS.md
+++ b/docs/WEIGHT_QUANTS.md
@@ -94,6 +94,14 @@ No Infinity in OCP E4M3 FN profile.
 Dequant: w = e4m3_decode(element_byte) × e8m0_decode(scale_byte)
 ```
 
+**Loader scale-dtype contract.** The E8M0 scale byte is an exponent, not a
+float — MLX `dequantize`/`quantized_matmul` reject any scale dtype other than
+`uint8` for the `mxfp8`/`mxfp4` modes. Loaders must keep mxfp8/mxfp4 `.scales`
+at their on-disk `uint8` dtype; the float-uniformity cast that lifts fp16 affine
+scales to bf16 (`load_util::bf16_scales`) is gated on `scales.dtype()` and skips
+non-float scales. Casting an E8M0 scale to bf16 corrupts the exponent and crashes
+the dequant kernel at first prefill (`Scale type must be uint8`).
+
 Primary test target: `mlx-community__gemma-4-e4b-it-mxfp8`.
 
 Source: `crates/rmlx-quant/src/mxfp.rs`, `crates/rmlx-quant/src/fp8.rs`


### PR DESCRIPTION
## Summary

Fixes the Qwen3.5-MoE **mxfp8** prefill crash (`dequantize: Scale type must be uint8 but received type bfloat16`). The loader was blanket-casting every quantized `.scales` tensor through `bf16_param`, which corrupts mxfp8/mxfp4 **uint8 E8M0** scales — fine for affine (float scales), fatal for mxfp.

## Fix — general, per-tensor, model-agnostic

New `load_util::bf16_scales(a)` gates the cast on `a.dtype()`:
- float scales (`Bf16`/`F16`/`F32`) → existing bf16 uniformity cast (preserves the fp16→f32 promotion-leak prevention)
- non-float scales (`U8` E8M0 / `U32` / `I32`) → passed through verbatim

Wired at all production cast sites. The gate keys on the actual scale dtype (a per-tensor checkpoint fact), not an arch string or global quant mode — which is required here because the checkpoint is **mixed quant** (global mxfp8 + per-tensor affine overrides on router gates).

## Scope corrections vs the issue

- The issue named `qwen3_5_moe/mtp_layer.rs` as a same-pattern site — **false**: that path already passes scales through verbatim, no change needed.
- Broader than the issue: the **identical latent bug existed in `qwen3.rs`** (dense Qwen3 loader) for any dense mxfp8 checkpoint. Fixed there too, per the general-fix mandate.

## Files

- `crates/rmlx-models/src/load_util.rs` — `bf16_scales` helper (exhaustive dtype match)
- `crates/rmlx-models/src/qwen3_5_moe/loader.rs` — `lin` + embedding adapter
- `crates/rmlx-models/src/qwen3.rs` — `lin` + embedding adapter
- `crates/rmlx-models/src/load_util_tests.rs` — 2 regression tests (uint8 survives; float→bf16)
- `docs/MODELS.md`, `docs/WEIGHT_QUANTS.md` — scale-dtype loader contract

## Verification

- `make lint` clean (0 warnings), `make model-check` EXIT=0, `make check-no-inline-tests` OK.
- Regression tests pass (`bf16_scales_keeps_uint8_e8m0_intact`, `bf16_scales_casts_float_scales_to_bf16`).
- **Real-model proof** (release binary, sequential, single MLX process):
  - FIX — ornith-1.0-35b mxfp8: `--probe-smoke` → `verdict: ok`, 8 tokens, nan=0 (was: crash + 0 tokens).
  - No-regression — Qwen3.6-35B-A3B-8bit (affine MoE): `verdict: ok`.
  - No-regression — Ternary-Bonsai-8B 2bit (dense Qwen3, edited path): `verdict: ok`.
  - No-regression — Gemma4-e4b mxfp8 (untouched loader): `verdict: ok`.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)
