### PR TITLE
feat(qwen3.5): dense mxfp8 loader + fact-driven dispatch

### DIFF
--- a/crates/rmlx-models/src/arch/loader.rs
+++ b/crates/rmlx-models/src/arch/loader.rs
@@ -135,24 +135,28 @@ pub fn load_model(model_dir: &Path, _device: Device, opts: &LoadOpts) -> Result<
             tracing::info!(summary = %a.config_summary(), "arch::load_model: loaded Laguna");
             a
         }
-        "Qwen3_5MoeForConditionalGeneration" => {
-            let model = crate::qwen3_5_moe::load_from_path(model_dir)?;
+        // Both Qwen3.5 arch strings share one GatedDeltaNet + FullAttention
+        // hybrid backbone. They differ only in the MLP (dense SwiGLU vs sparse
+        // MoE) and the quant codec (mxfp8 / affine vs ParoQuant INT4). Neither
+        // axis is reliably implied by the arch string: ParoQuant ships
+        // `Qwen3_5ForConditionalGeneration` and so do plain dense mxfp8
+        // checkpoints. Dispatch on checkpoint facts — `is_paroquant()` (i.e.
+        // `quantization_config.quant_method == "paroquant"`) selects the PARO
+        // loader; everything else goes through the standard loader, which then
+        // resolves dense-vs-MoE per layer by which MLP tensors are present.
+        "Qwen3_5MoeForConditionalGeneration" | "Qwen3_5ForConditionalGeneration" => {
+            let model = if cfg.is_paroquant() {
+                tracing::info!(
+                    "arch::load_model: Qwen3.5 PARO checkpoint detected, using PARO loader"
+                );
+                crate::qwen3_5_moe::load_from_path_paro(model_dir)?
+            } else {
+                crate::qwen3_5_moe::load_from_path(model_dir)?
+            };
             let a = Architecture::Qwen3_5Moe(model);
             tracing::info!(
                 summary = %a.config_summary(),
-                "arch::load_model: loaded Qwen3_5Moe"
-            );
-            a
-        }
-        // Dense Qwen3.5 variant (ParoQuant INT4 checkpoints from z-lab).
-        // Shares the same GatedDeltaNet + FullAttention hybrid backbone as the MoE
-        // variant but uses a dense SwiGLU MLP instead of the sparse MoE block.
-        "Qwen3_5ForConditionalGeneration" => {
-            let model = crate::qwen3_5_moe::load_from_path_paro(model_dir)?;
-            let a = Architecture::Qwen3_5Moe(model);
-            tracing::info!(
-                summary = %a.config_summary(),
-                "arch::load_model: loaded Qwen3_5 (PARO dense)"
+                "arch::load_model: loaded Qwen3_5"
             );
             a
         }

--- a/crates/rmlx-models/src/load_util.rs
+++ b/crates/rmlx-models/src/load_util.rs
@@ -242,6 +242,31 @@ impl<'a> Weights<'a> {
         Ok(false)
     }
 
+    /// Resolve the tensor-name prefix a checkpoint uses, by probing shard
+    /// headers for a witness tensor under each candidate.
+    ///
+    /// Different exporters of the same architecture disagree on prefix order:
+    /// MLX-community layouts use `language_model.model.<...>` while ParoQuant
+    /// checkpoints use `model.language_model.<...>`. Rather than hardcode one
+    /// per loader, callers pass the candidate prefixes (most-likely first) and a
+    /// `witness` leaf that every layout carries (e.g. `embed_tokens.weight`);
+    /// the first candidate whose `<prefix>.<witness>` exists wins.
+    ///
+    /// Returns the matching prefix as a `String`. Errors (`Error::Loader`) only
+    /// when no candidate matches — a clear signal the checkpoint layout is
+    /// neither expected form, far better than a downstream "tensor not found".
+    pub(crate) fn resolve_prefix(&self, candidates: &[&str], witness: &str) -> Result<String> {
+        for cand in candidates {
+            if self.has(&format!("{cand}.{witness}"))? {
+                debug!(prefix = cand, witness, "resolve_prefix: matched");
+                return Ok((*cand).to_owned());
+            }
+        }
+        Err(Error::Loader(format!(
+            "resolve_prefix: none of {candidates:?} carry witness tensor '{witness}'"
+        )))
+    }
+
     /// Raw bytes + shape + dtype for `name`, using the same index-first /
     /// header-scan-fallback resolution as [`array`](Weights::array).
     ///

--- a/crates/rmlx-models/src/load_util_tests.rs
+++ b/crates/rmlx-models/src/load_util_tests.rs
@@ -377,8 +377,13 @@ fn scan_only_works_without_index() {
 /// Dense-vs-MoE MLP detection is the per-layer tensor fact the Qwen3.5 loader
 /// keys on: a sparse MoE layer carries `mlp.switch_mlp.gate_proj.weight`; a
 /// dense SwiGLU layer carries `mlp.{gate,up,down}_proj.weight` directly with no
-/// `switch_mlp` router. This mirrors the loader's `has(...switch_mlp...)` probe
-/// so a regression in the witness name fails here, host-side, with no Metal.
+/// `switch_mlp` router.
+///
+/// This asserts on `Weights::has` only — it MIRRORS the witness names the
+/// loader probes, it does not EXERCISE `build_mlp` itself. The real branch is
+/// driven end-to-end in `qwen3_5_moe/loader_tests.rs`, which calls `build_mlp`
+/// and asserts the returned `MlpBlock` variant. This case stays as a focused
+/// `Weights` regression guard at the load_util layer.
 #[test]
 #[allow(
     clippy::unwrap_used,

--- a/crates/rmlx-models/src/load_util_tests.rs
+++ b/crates/rmlx-models/src/load_util_tests.rs
@@ -236,6 +236,79 @@ fn corrupt_propagates_on_header_scan() {
     );
 }
 
+/// `resolve_prefix` picks the candidate whose `<prefix>.<witness>` tensor is
+/// present, in the candidate order given. Covers both real-world Qwen3.5
+/// layouts: MLX-community `language_model.model.*` and ParoQuant
+/// `model.language_model.*`. The witness is the embedding table.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: tempdir / ShardSet open failures should abort the test loudly"
+)]
+fn resolve_prefix_matches_present_layout() {
+    let candidates = ["language_model.model", "model.language_model"];
+    let witness = "embed_tokens.weight";
+
+    // Layout A: MLX-community ordering (ornith dense / MoE mxfp8).
+    {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(
+            dir.path(),
+            "s.safetensors",
+            &[("language_model.model.embed_tokens.weight", 4)],
+        );
+        let shards = ShardSet::open_dir(dir.path()).unwrap();
+        let w = Weights::scan_only(&shards);
+        assert_eq!(
+            w.resolve_prefix(&candidates, witness).unwrap(),
+            "language_model.model"
+        );
+    }
+
+    // Layout B: ParoQuant ordering — the SECOND candidate wins, proving the
+    // helper does not just return the first entry.
+    {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(
+            dir.path(),
+            "s.safetensors",
+            &[("model.language_model.embed_tokens.weight", 4)],
+        );
+        let shards = ShardSet::open_dir(dir.path()).unwrap();
+        let w = Weights::scan_only(&shards);
+        assert_eq!(
+            w.resolve_prefix(&candidates, witness).unwrap(),
+            "model.language_model"
+        );
+    }
+}
+
+/// `resolve_prefix` errors when no candidate carries the witness tensor — a
+/// clear signal of an unexpected layout, never a silent wrong-prefix that
+/// surfaces later as a confusing "tensor not found".
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: tempdir / ShardSet open failures should abort the test loudly"
+)]
+fn resolve_prefix_errors_when_no_candidate_matches() {
+    let dir = tempfile::tempdir().unwrap();
+    write_shard(dir.path(), "s.safetensors", &[("some.other.tensor", 4)]);
+    let shards = ShardSet::open_dir(dir.path()).unwrap();
+    let w = Weights::scan_only(&shards);
+
+    let res = w.resolve_prefix(
+        &["language_model.model", "model.language_model"],
+        "embed_tokens.weight",
+    );
+    assert!(res.is_err(), "no matching prefix must be a hard error");
+    let msg = res.unwrap_err().to_string();
+    assert!(
+        msg.contains("resolve_prefix") && msg.contains("embed_tokens.weight"),
+        "error should name the helper and witness: {msg}"
+    );
+}
+
 /// `has()` is header-based and finds `.scales`/`.biases` siblings the index
 /// omits (the medgemma rule). The index lists only `.weight`; the shard header
 /// carries the siblings.
@@ -299,6 +372,66 @@ fn scan_only_works_without_index() {
     assert!(!w.has("attn.v_proj.weight").unwrap());
     // A truly-absent tensor is a hard error (not a silent miss).
     assert!(w.array("attn.v_proj.weight").is_err());
+}
+
+/// Dense-vs-MoE MLP detection is the per-layer tensor fact the Qwen3.5 loader
+/// keys on: a sparse MoE layer carries `mlp.switch_mlp.gate_proj.weight`; a
+/// dense SwiGLU layer carries `mlp.{gate,up,down}_proj.weight` directly with no
+/// `switch_mlp` router. This mirrors the loader's `has(...switch_mlp...)` probe
+/// so a regression in the witness name fails here, host-side, with no Metal.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: tempdir / ShardSet open failures should abort the test loudly"
+)]
+fn dense_vs_moe_mlp_detection_by_tensors() {
+    let moe_witness = "mlp.switch_mlp.gate_proj.weight";
+
+    // MoE layout (ornith-35b / Qwen3.6-A3B): switch_mlp + shared_expert + router.
+    {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(
+            dir.path(),
+            "s.safetensors",
+            &[
+                ("mlp.gate.weight", 4),
+                ("mlp.switch_mlp.gate_proj.weight", 8),
+                ("mlp.switch_mlp.up_proj.weight", 8),
+                ("mlp.switch_mlp.down_proj.weight", 8),
+                ("mlp.shared_expert.gate_proj.weight", 8),
+            ],
+        );
+        let shards = ShardSet::open_dir(dir.path()).unwrap();
+        let w = Weights::scan_only(&shards);
+        assert!(
+            w.has(moe_witness).unwrap(),
+            "MoE layout must be detected as MoE (switch_mlp present)"
+        );
+    }
+
+    // Dense layout (ornith-9b mxfp8): plain gate/up/down, no switch_mlp router.
+    {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(
+            dir.path(),
+            "s.safetensors",
+            &[
+                ("mlp.gate_proj.weight", 8),
+                ("mlp.up_proj.weight", 8),
+                ("mlp.down_proj.weight", 8),
+            ],
+        );
+        let shards = ShardSet::open_dir(dir.path()).unwrap();
+        let w = Weights::scan_only(&shards);
+        assert!(
+            !w.has(moe_witness).unwrap(),
+            "dense layout must NOT be detected as MoE (no switch_mlp)"
+        );
+        // The dense block's own witnesses are present.
+        assert!(w.has("mlp.gate_proj.weight").unwrap());
+        assert!(w.has("mlp.up_proj.weight").unwrap());
+        assert!(w.has("mlp.down_proj.weight").unwrap());
+    }
 }
 
 /// `linear()` maps onto the shared `layers::Linear`: a `.scales`-less base is

--- a/crates/rmlx-models/src/qwen3_5_moe/config.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/config.rs
@@ -37,9 +37,6 @@ pub struct Qwen3_5MoeConfig {
     pub tie_word_embeddings: bool,
     /// Period at which a full-attention layer replaces a GatedDeltaNet layer.
     pub full_attention_interval: usize,
-    /// Dense SwiGLU FFN intermediate dimension. Used by the dense MLP variant
-    /// (`Qwen3_5ForConditionalGeneration`); 0 for pure-MoE checkpoints.
-    pub intermediate_size: usize,
     /// Total number of MoE experts per layer. 0 marks a dense checkpoint.
     pub num_experts: usize,
     /// Number of experts selected per token.
@@ -133,15 +130,19 @@ impl Qwen3_5MoeConfig {
         // MoE-specific fields are optional: dense Qwen3.5 checkpoints
         // (`Qwen3_5ForConditionalGeneration` with a plain SwiGLU MLP) omit them.
         // `num_experts == 0` is the canonical "dense, no experts" marker the
-        // loader keys its per-layer MLP detection on. `intermediate_size` is the
-        // dense FFN width; `moe_intermediate_size` falls back to it so a dense
+        // loader keys its per-layer MLP detection on. The dense FFN width
+        // (`intermediate_size`) is the fallback for the MoE widths so a dense
         // config still yields a sane value.
         let num_experts = opt_u64!("num_experts", 0);
         let num_experts_per_tok = opt_u64!("num_experts_per_tok", 1);
-        let intermediate_size = opt_u64!("intermediate_size", 0);
-        let moe_intermediate_size = opt_u64!("moe_intermediate_size", intermediate_size as u64);
-        let shared_expert_intermediate_size =
-            opt_u64!("shared_expert_intermediate_size", intermediate_size as u64);
+        let moe_intermediate_size = opt_u64!(
+            "moe_intermediate_size",
+            opt_u64!("intermediate_size", 0) as u64
+        );
+        let shared_expert_intermediate_size = opt_u64!(
+            "shared_expert_intermediate_size",
+            opt_u64!("intermediate_size", 0) as u64
+        );
         let norm_topk_prob = e
             .get("norm_topk_prob")
             .and_then(serde_json::Value::as_bool)
@@ -186,7 +187,6 @@ impl Qwen3_5MoeConfig {
             rms_norm_eps,
             tie_word_embeddings,
             full_attention_interval,
-            intermediate_size,
             num_experts,
             num_experts_per_tok,
             moe_intermediate_size,

--- a/crates/rmlx-models/src/qwen3_5_moe/config.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/config.rs
@@ -37,7 +37,10 @@ pub struct Qwen3_5MoeConfig {
     pub tie_word_embeddings: bool,
     /// Period at which a full-attention layer replaces a GatedDeltaNet layer.
     pub full_attention_interval: usize,
-    /// Total number of MoE experts per layer.
+    /// Dense SwiGLU FFN intermediate dimension. Used by the dense MLP variant
+    /// (`Qwen3_5ForConditionalGeneration`); 0 for pure-MoE checkpoints.
+    pub intermediate_size: usize,
+    /// Total number of MoE experts per layer. 0 marks a dense checkpoint.
     pub num_experts: usize,
     /// Number of experts selected per token.
     pub num_experts_per_tok: usize,
@@ -127,10 +130,18 @@ impl Qwen3_5MoeConfig {
             .and_then(serde_json::Value::as_bool)
             .unwrap_or(false);
         let full_attention_interval = opt_u64!("full_attention_interval", 4);
-        let num_experts = req_u64!("num_experts");
-        let num_experts_per_tok = req_u64!("num_experts_per_tok");
-        let moe_intermediate_size = req_u64!("moe_intermediate_size");
-        let shared_expert_intermediate_size = req_u64!("shared_expert_intermediate_size");
+        // MoE-specific fields are optional: dense Qwen3.5 checkpoints
+        // (`Qwen3_5ForConditionalGeneration` with a plain SwiGLU MLP) omit them.
+        // `num_experts == 0` is the canonical "dense, no experts" marker the
+        // loader keys its per-layer MLP detection on. `intermediate_size` is the
+        // dense FFN width; `moe_intermediate_size` falls back to it so a dense
+        // config still yields a sane value.
+        let num_experts = opt_u64!("num_experts", 0);
+        let num_experts_per_tok = opt_u64!("num_experts_per_tok", 1);
+        let intermediate_size = opt_u64!("intermediate_size", 0);
+        let moe_intermediate_size = opt_u64!("moe_intermediate_size", intermediate_size as u64);
+        let shared_expert_intermediate_size =
+            opt_u64!("shared_expert_intermediate_size", intermediate_size as u64);
         let norm_topk_prob = e
             .get("norm_topk_prob")
             .and_then(serde_json::Value::as_bool)
@@ -175,6 +186,7 @@ impl Qwen3_5MoeConfig {
             rms_norm_eps,
             tie_word_embeddings,
             full_attention_interval,
+            intermediate_size,
             num_experts,
             num_experts_per_tok,
             moe_intermediate_size,
@@ -246,3 +258,7 @@ pub(super) fn extract_quant(
     }
     (gs, bits, mode, overrides)
 }
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/crates/rmlx-models/src/qwen3_5_moe/config_tests.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/config_tests.rs
@@ -24,7 +24,7 @@ fn parse(json: &str) -> Qwen3_5MoeConfig {
 }
 
 /// Dense Qwen3.5 mxfp8 (ornith-style): no MoE fields. `num_experts == 0`,
-/// `intermediate_size` carried, `moe_intermediate_size` falls back to it.
+/// `moe_intermediate_size` falls back to the dense `intermediate_size`.
 #[test]
 fn dense_config_parses_with_zero_experts() {
     let json = r#"{
@@ -54,7 +54,6 @@ fn dense_config_parses_with_zero_experts() {
         cfg.num_experts, 0,
         "dense checkpoint reports zero experts — the loader's dense marker"
     );
-    assert_eq!(cfg.intermediate_size, 1024);
     assert_eq!(
         cfg.moe_intermediate_size, 1024,
         "moe_intermediate_size falls back to dense intermediate_size when absent"

--- a/crates/rmlx-models/src/qwen3_5_moe/config_tests.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/config_tests.rs
@@ -1,0 +1,96 @@
+//! Config-parse tests for `Qwen3_5MoeConfig::from_model_config`.
+//!
+//! The same parser serves both Qwen3.5 arch strings. A dense
+//! `Qwen3_5ForConditionalGeneration` checkpoint omits the MoE-only fields
+//! (`num_experts`, `moe_intermediate_size`, ...) entirely; the parser must
+//! treat those as optional and report `num_experts == 0` — the marker the
+//! loader keys its per-layer dense-vs-MoE MLP selection on. A MoE checkpoint
+//! must still parse its expert counts verbatim.
+
+use super::Qwen3_5MoeConfig;
+
+/// Parse helper: split the JSON into a typed `ModelConfig` plus the raw
+/// `text_config` value, exactly as the loader feeds `from_model_config`.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: malformed inline JSON should abort the test loudly"
+)]
+fn parse(json: &str) -> Qwen3_5MoeConfig {
+    let raw: rmlx_loader::ModelConfig = serde_json::from_str(json).unwrap();
+    let raw_json: serde_json::Value = serde_json::from_str(json).unwrap();
+    let raw_quant = raw_json.get("quantization");
+    let raw_text_config = raw_json.get("text_config");
+    Qwen3_5MoeConfig::from_model_config(&raw, raw_quant, raw_text_config).unwrap()
+}
+
+/// Dense Qwen3.5 mxfp8 (ornith-style): no MoE fields. `num_experts == 0`,
+/// `intermediate_size` carried, `moe_intermediate_size` falls back to it.
+#[test]
+fn dense_config_parses_with_zero_experts() {
+    let json = r#"{
+        "architectures": ["Qwen3_5ForConditionalGeneration"],
+        "dtype": "bfloat16",
+        "quantization": {"group_size": 32, "bits": 8, "mode": "mxfp8"},
+        "text_config": {
+            "num_hidden_layers": 8,
+            "hidden_size": 256,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 64,
+            "intermediate_size": 1024,
+            "vocab_size": 2048,
+            "rms_norm_eps": 1e-6,
+            "full_attention_interval": 4,
+            "linear_num_value_heads": 8,
+            "linear_num_key_heads": 4,
+            "linear_key_head_dim": 32,
+            "linear_value_head_dim": 32,
+            "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.25}
+        }
+    }"#;
+    let cfg = parse(json);
+    assert_eq!(cfg.num_hidden_layers, 8);
+    assert_eq!(
+        cfg.num_experts, 0,
+        "dense checkpoint reports zero experts — the loader's dense marker"
+    );
+    assert_eq!(cfg.intermediate_size, 1024);
+    assert_eq!(
+        cfg.moe_intermediate_size, 1024,
+        "moe_intermediate_size falls back to dense intermediate_size when absent"
+    );
+}
+
+/// MoE Qwen3.5 (A3B-style): expert counts present and parsed verbatim.
+#[test]
+fn moe_config_parses_expert_counts() {
+    let json = r#"{
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "dtype": "bfloat16",
+        "quantization": {"group_size": 32, "bits": 8, "mode": "mxfp8"},
+        "text_config": {
+            "num_hidden_layers": 8,
+            "hidden_size": 256,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 64,
+            "vocab_size": 2048,
+            "rms_norm_eps": 1e-6,
+            "full_attention_interval": 4,
+            "num_experts": 256,
+            "num_experts_per_tok": 8,
+            "moe_intermediate_size": 512,
+            "shared_expert_intermediate_size": 512,
+            "linear_num_value_heads": 8,
+            "linear_num_key_heads": 4,
+            "linear_key_head_dim": 32,
+            "linear_value_head_dim": 32,
+            "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.25}
+        }
+    }"#;
+    let cfg = parse(json);
+    assert_eq!(cfg.num_experts, 256);
+    assert_eq!(cfg.num_experts_per_tok, 8);
+    assert_eq!(cfg.moe_intermediate_size, 512);
+    assert_eq!(cfg.shared_expert_intermediate_size, 512);
+}

--- a/crates/rmlx-models/src/qwen3_5_moe/loader.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/loader.rs
@@ -38,14 +38,68 @@ use super::layers::{Embedding, Linear, ParoRotation, RmsNorm};
 use super::model::Qwen3_5MoeText;
 use super::moe::{DenseMlp, SharedExpert, SparseMoeBlock, SwitchMlp};
 
+/// Build one decoder layer's MLP block, selecting dense vs MoE by tensor facts.
+///
+/// Dense vs MoE is a per-layer checkpoint fact, not an arch-string or
+/// config-flag assumption: a sparse MoE layer carries `mlp.switch_mlp.*` (plus
+/// the `mlp.gate` router and `mlp.shared_expert.*`); a dense SwiGLU layer
+/// carries `mlp.{gate,up,down}_proj` directly with no router. Probing the MoE
+/// witness keeps both standard mxfp8 and affine checkpoints — and any future
+/// mixed layout — on the right path.
+///
+/// `m` is the MLP base (`<prefix>.layers.<i>.mlp`). `lin` is the layer's
+/// shared linear builder (the `load_from_path` adapter that maps the shared
+/// `Linear` onto the arch-local one).
+fn build_mlp(
+    w: &Weights<'_>,
+    m: &str,
+    cfg: &Qwen3_5MoeConfig,
+    lin: &impl Fn(&str) -> Result<Linear>,
+) -> Result<MlpBlock> {
+    if w.has(&format!("{m}.switch_mlp.gate_proj.weight"))? {
+        Ok(MlpBlock::Moe(Box::new(SparseMoeBlock {
+            gate: lin(&format!("{m}.gate"))?,
+            switch_mlp: SwitchMlp {
+                gate_proj: lin(&format!("{m}.switch_mlp.gate_proj"))?,
+                up_proj: lin(&format!("{m}.switch_mlp.up_proj"))?,
+                down_proj: lin(&format!("{m}.switch_mlp.down_proj"))?,
+            },
+            shared_expert: SharedExpert {
+                gate_proj: lin(&format!("{m}.shared_expert.gate_proj"))?,
+                up_proj: lin(&format!("{m}.shared_expert.up_proj"))?,
+                down_proj: lin(&format!("{m}.shared_expert.down_proj"))?,
+            },
+            shared_expert_gate: lin(&format!("{m}.shared_expert_gate"))?,
+            num_experts: cfg.num_experts,
+            top_k: cfg.num_experts_per_tok,
+            norm_topk_prob: cfg.norm_topk_prob,
+        })))
+    } else {
+        Ok(MlpBlock::Dense(Box::new(DenseMlp {
+            gate_proj: lin(&format!("{m}.gate_proj"))?,
+            up_proj: lin(&format!("{m}.up_proj"))?,
+            down_proj: lin(&format!("{m}.down_proj"))?,
+        })))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // load_from_path — standard MoE checkpoint
 // ---------------------------------------------------------------------------
 
-/// Load a Qwen3_5Moe model from a snapshot directory.
+/// Load a standard (non-PARO) Qwen3.5 model from a snapshot directory.
 ///
-/// Expects `config.architectures[0] == "Qwen3_5MoeForConditionalGeneration"`.
-/// Tensor prefix: `language_model.model`.
+/// Serves both arch strings — `Qwen3_5MoeForConditionalGeneration` (sparse MoE)
+/// and `Qwen3_5ForConditionalGeneration` (dense SwiGLU) — and both tensor-prefix
+/// layouts (`language_model.model` / `model.language_model`). The prefix is
+/// resolved from shard headers and each layer's MLP (dense vs MoE) is selected
+/// by which tensors are present, so a single loader covers the mxfp8 and affine
+/// checkpoints regardless of arch string. PARO checkpoints go through
+/// [`load_from_path_paro`] instead (selected upstream by `is_paroquant()`).
+#[allow(
+    clippy::cognitive_complexity,
+    reason = "single cohesive load sequence: prefix resolve + embedding/head + per-layer attn/MLP build. Splitting further would scatter the shared `lin`/`load_rms` closures across helpers for no readability gain — matches the laguna/gemma3 loader convention."
+)]
 pub fn load_from_path(model_dir: &Path) -> Result<Qwen3_5MoeText> {
     let cfg_raw = load_config(model_dir)?;
 
@@ -69,6 +123,16 @@ pub fn load_from_path(model_dir: &Path) -> Result<Qwen3_5MoeText> {
     let idx = load_shard_index(model_dir)?;
     let shards = ShardSet::open(model_dir, &idx)?;
     let w = Weights::new(&shards, &idx);
+
+    // Resolve the tensor prefix from the checkpoint rather than hardcoding it:
+    // MLX-community layouts use `language_model.model.<...>`, other exporters use
+    // `model.language_model.<...>`. The embedding table is the witness leaf every
+    // layout carries.
+    let pfx = w.resolve_prefix(
+        &["language_model.model", "model.language_model"],
+        "embed_tokens.weight",
+    )?;
+    info!(prefix = %pfx, "Qwen3_5: resolved tensor prefix");
 
     let defaults = QuantParams::global(cfg.quant_group_size, cfg.quant_bits, &cfg.quant_mode);
 
@@ -114,8 +178,6 @@ pub fn load_from_path(model_dir: &Path) -> Result<Qwen3_5MoeText> {
             eps: cfg.rms_norm_eps,
         })
     };
-
-    let pfx = "language_model.model";
 
     // Embedding adapter mirrors `lin`: converts shared Embedding
     // (mode: QuantMode) to the arch-local Embedding (mode: String).
@@ -245,24 +307,7 @@ pub fn load_from_path(model_dir: &Path) -> Result<Qwen3_5MoeText> {
             })
         };
 
-        let m = format!("{base}.mlp");
-        let mlp = MlpBlock::Moe(Box::new(SparseMoeBlock {
-            gate: lin(&format!("{m}.gate"))?,
-            switch_mlp: SwitchMlp {
-                gate_proj: lin(&format!("{m}.switch_mlp.gate_proj"))?,
-                up_proj: lin(&format!("{m}.switch_mlp.up_proj"))?,
-                down_proj: lin(&format!("{m}.switch_mlp.down_proj"))?,
-            },
-            shared_expert: SharedExpert {
-                gate_proj: lin(&format!("{m}.shared_expert.gate_proj"))?,
-                up_proj: lin(&format!("{m}.shared_expert.up_proj"))?,
-                down_proj: lin(&format!("{m}.shared_expert.down_proj"))?,
-            },
-            shared_expert_gate: lin(&format!("{m}.shared_expert_gate"))?,
-            num_experts: cfg.num_experts,
-            top_k: cfg.num_experts_per_tok,
-            norm_topk_prob: cfg.norm_topk_prob,
-        }));
+        let mlp = build_mlp(&w, &format!("{base}.mlp"), &cfg, &lin)?;
 
         layers.push(DecoderLayer {
             input_layernorm: load_rms(&format!("{base}.input_layernorm"))?,

--- a/crates/rmlx-models/src/qwen3_5_moe/loader.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/loader.rs
@@ -128,6 +128,15 @@ pub fn load_from_path(model_dir: &Path) -> Result<Qwen3_5MoeText> {
     // MLX-community layouts use `language_model.model.<...>`, other exporters use
     // `model.language_model.<...>`. The embedding table is the witness leaf every
     // layout carries.
+    //
+    // Assumption: the witness (`embed_tokens.weight`) is reachable in a shard
+    // opened by the index-driven `ShardSet::open` above. `resolve_prefix` →
+    // `has` header-scans only the opened shards. A future checkpoint that omits
+    // the witness from `model.safetensors.index.json` yet ships it in an
+    // unopened shard header would hard-error here despite the tensor existing —
+    // the index/header divergence `ShardSet::open_dir` defends against. Latent:
+    // embeddings are always indexed today (the existing `lm_head` probe below
+    // shares this assumption). Pair with `open_dir` if that ever changes.
     let pfx = w.resolve_prefix(
         &["language_model.model", "model.language_model"],
         "embed_tokens.weight",
@@ -327,6 +336,10 @@ pub fn load_from_path(model_dir: &Path) -> Result<Qwen3_5MoeText> {
     })
 }
 
+#[cfg(test)]
+#[path = "loader_tests.rs"]
+mod loader_tests;
+
 // ---------------------------------------------------------------------------
 // load_from_path_paro — PARO dense checkpoint
 // ---------------------------------------------------------------------------
@@ -475,6 +488,25 @@ pub fn load_from_path_paro(model_dir: &Path) -> Result<Qwen3_5MoeText> {
     };
 
     let pfx = "model.language_model";
+
+    // Defense-in-depth: the PARO loader forces `num_experts = 0` and builds
+    // dense MLPs only. A PARO checkpoint that nonetheless ships MoE expert
+    // tensors would silently mis-load as dense, dropping every expert. No such
+    // checkpoint is known, but probe for the MoE witnesses (the sparse router's
+    // `switch_mlp` expert and the always-on `shared_expert`) and hard-error if
+    // present, rather than load wrong. Tensor-presence based, not arch-name
+    // based, so it survives any future PARO MoE layout.
+    for moe_witness in [
+        &format!("{pfx}.layers.0.mlp.switch_mlp.gate_proj.weight"),
+        &format!("{pfx}.layers.0.mlp.shared_expert.gate_proj.weight"),
+    ] {
+        if w.has(moe_witness)? {
+            return Err(Error::Loader(format!(
+                "PARO loader: checkpoint carries MoE expert tensor '{moe_witness}' but the \
+                 PARO path builds dense MLPs only — a PARO MoE checkpoint is not supported"
+            )));
+        }
+    }
 
     let embed_tokens = {
         let (weight, scales, biases) =

--- a/crates/rmlx-models/src/qwen3_5_moe/loader_tests.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/loader_tests.rs
@@ -1,0 +1,164 @@
+//! Host-only tests for the Qwen3.5 loader's per-layer MLP detection.
+//!
+//! `build_mlp` selects dense SwiGLU vs sparse MoE purely by which tensors a
+//! layer carries (`mlp.switch_mlp.gate_proj.weight` ⇒ MoE, otherwise dense).
+//! It only calls `Weights::has` plus a caller-supplied `lin` closure, so a fake
+//! `lin` returning a tiny host-side `Linear::Plain` exercises the real probe
+//! with no Metal claim. These cases drive `build_mlp` directly and assert the
+//! returned `MlpBlock` variant — proving the loader's branch, not a hand-copied
+//! witness string.
+
+use std::path::Path;
+
+use rmlx_loader::ShardSet;
+use rmlx_mlx::Array;
+
+use super::super::config::Qwen3_5MoeConfig;
+use super::super::decoder_layer::MlpBlock;
+use super::super::layers::Linear;
+use super::build_mlp;
+use crate::load_util::Weights;
+
+/// Write a multi-tensor F32 `.safetensors` shard into `dir`. F32 is host-side
+/// in `Array::from_bytes` (no Metal claim), so the loaded weights stay on host.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: temp-file I/O and serialization failures should abort the test loudly"
+)]
+fn write_shard(dir: &Path, filename: &str, tensors: &[(&str, usize)]) {
+    let buffers: Vec<Vec<u8>> = tensors
+        .iter()
+        .map(|&(_, n)| {
+            let mut bytes = Vec::with_capacity(n * 4);
+            for _ in 0..n {
+                bytes.extend_from_slice(&1.0f32.to_le_bytes());
+            }
+            bytes
+        })
+        .collect();
+
+    let views: Vec<(String, safetensors::tensor::TensorView<'_>)> = tensors
+        .iter()
+        .zip(buffers.iter())
+        .map(|(&(name, n), buf)| {
+            let tv = safetensors::tensor::TensorView::new(safetensors::Dtype::F32, vec![n], buf)
+                .unwrap();
+            (name.to_owned(), tv)
+        })
+        .collect();
+
+    let bytes = safetensors::serialize(views, None).unwrap();
+    std::fs::write(dir.join(filename), bytes).unwrap();
+}
+
+/// Minimal MoE config — only `num_experts` / `num_experts_per_tok` /
+/// `norm_topk_prob` are read by `build_mlp`'s MoE branch; the rest are inert.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: malformed inline JSON should abort the test loudly"
+)]
+fn moe_cfg() -> Qwen3_5MoeConfig {
+    let json = r#"{
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "dtype": "bfloat16",
+        "text_config": {
+            "num_hidden_layers": 4,
+            "hidden_size": 256,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 64,
+            "vocab_size": 2048,
+            "rms_norm_eps": 1e-6,
+            "full_attention_interval": 4,
+            "num_experts": 256,
+            "num_experts_per_tok": 8,
+            "moe_intermediate_size": 512,
+            "shared_expert_intermediate_size": 512,
+            "linear_num_value_heads": 8,
+            "linear_num_key_heads": 4,
+            "linear_key_head_dim": 32,
+            "linear_value_head_dim": 32,
+            "rope_parameters": {"rope_theta": 10000000.0, "partial_rotary_factor": 0.25}
+        }
+    }"#;
+    let raw: rmlx_loader::ModelConfig = serde_json::from_str(json).unwrap();
+    let raw_json: serde_json::Value = serde_json::from_str(json).unwrap();
+    Qwen3_5MoeConfig::from_model_config(&raw, None, raw_json.get("text_config")).unwrap()
+}
+
+// `build_mlp` takes `lin: &impl Fn(&str) -> Result<Linear>`. The tests pass a
+// local closure returning a tiny host-side `Linear::Plain` — `build_mlp` only
+// stores whatever `lin` returns, so the dtype/shape is irrelevant to which
+// `MlpBlock` variant it selects. A closure (not a free `fn`) keeps the `Result`
+// return the seam requires without tripping clippy's `unnecessary_wraps` lint.
+
+/// A layer carrying `mlp.switch_mlp.gate_proj.weight` (+ router + shared expert)
+/// builds an `MlpBlock::Moe`.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: tempdir / ShardSet open / Array construction failures should abort the test loudly"
+)]
+fn build_mlp_detects_moe_layout() {
+    let dir = tempfile::tempdir().unwrap();
+    write_shard(
+        dir.path(),
+        "s.safetensors",
+        &[
+            ("mlp.gate.weight", 4),
+            ("mlp.switch_mlp.gate_proj.weight", 8),
+            ("mlp.switch_mlp.up_proj.weight", 8),
+            ("mlp.switch_mlp.down_proj.weight", 8),
+            ("mlp.shared_expert.gate_proj.weight", 8),
+            ("mlp.shared_expert.up_proj.weight", 8),
+            ("mlp.shared_expert.down_proj.weight", 8),
+            ("mlp.shared_expert_gate.weight", 4),
+        ],
+    );
+    let shards = ShardSet::open_dir(dir.path()).unwrap();
+    let w = Weights::scan_only(&shards);
+
+    let fake_lin = |_base: &str| {
+        Ok(Linear::Plain {
+            weight: Array::from_f32_slice(&[1.0], &[1]).unwrap(),
+        })
+    };
+    let block = build_mlp(&w, "mlp", &moe_cfg(), &fake_lin).unwrap();
+    assert!(
+        matches!(block, MlpBlock::Moe(_)),
+        "switch_mlp present ⇒ build_mlp must return MlpBlock::Moe"
+    );
+}
+
+/// A layer carrying plain `mlp.{gate,up,down}_proj.weight` with no `switch_mlp`
+/// router builds an `MlpBlock::Dense`.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: tempdir / ShardSet open / Array construction failures should abort the test loudly"
+)]
+fn build_mlp_detects_dense_layout() {
+    let dir = tempfile::tempdir().unwrap();
+    write_shard(
+        dir.path(),
+        "s.safetensors",
+        &[
+            ("mlp.gate_proj.weight", 8),
+            ("mlp.up_proj.weight", 8),
+            ("mlp.down_proj.weight", 8),
+        ],
+    );
+    let shards = ShardSet::open_dir(dir.path()).unwrap();
+    let w = Weights::scan_only(&shards);
+
+    let fake_lin = |_base: &str| {
+        Ok(Linear::Plain {
+            weight: Array::from_f32_slice(&[1.0], &[1]).unwrap(),
+        })
+    };
+    let block = build_mlp(&w, "mlp", &moe_cfg(), &fake_lin).unwrap();
+    assert!(
+        matches!(block, MlpBlock::Dense(_)),
+        "no switch_mlp router ⇒ build_mlp must return MlpBlock::Dense"
+    );
+}

--- a/docs/ADDING_A_MODEL.md
+++ b/docs/ADDING_A_MODEL.md
@@ -26,7 +26,7 @@ Shared seams live at the crate root (`crates/rmlx-models/src/`) and under
 | 4 | Generate | `<arch>/generate.rs` (or a `<arch>/generate/` dir) | Prompt-cache policy + cache construction + a `forward_step` closure handed to the shared `decode_loop` (`pipelined_decode` / `chunked_prefill` / `choose_token`). No decode-loop copy. |
 | 5 | Prompt cache (optional) | `<arch>/prompt_cache.rs` | `Entry` struct + accessor one-liners impl'ing `PromptCacheEntry`; `kv_bytes` / `truncate_kv_to` and the SSD spill path are inherited. Hydrate = `SsdHydrator::lookup_seeded` + a struct literal. |
 | 6 | Enum variant | `arch/mod.rs` | One `Architecture` variant + the match arms (`forward_seq`, `Debug`, config summary, …). |
-| 7 | Registry string | `arch/registry.rs`, `arch/loader.rs` | ~2 lines: add `architectures[0]` to `KNOWN_ARCHS` and a `load_model` match arm. |
+| 7 | Registry string | `arch/registry.rs`, `arch/loader.rs` | ~2 lines: add `architectures[0]` to `KNOWN_ARCHS` and a `load_model` match arm. When one arch string covers several checkpoint shapes (quant codec, dense vs MoE), branch the match arm on **checkpoint facts** — e.g. `cfg.is_paroquant()`, tensor presence — not on the arch string alone. The Qwen3.5 arm routes PARO vs standard this way. |
 | 8 | SSD attach (optional) | `ssd_tier.rs` | 1 match arm wiring the arch's `PROMPT_CACHE` into `attach_at_load`. |
 | 9 | Prefill chunk default | `prefill_chunk.rs` | 1 row in `arch_default` (omit to take the 64-token fallback). |
 | 10 | Tool / think / vision flags (optional) | `rmlx-server`: `tool_parser.rs`, `engine/think.rs`, `engine/arch_generator.rs` | Only if supported. Tool-call extraction, thinking-tag splitting, image-prompt assembly. |
@@ -44,6 +44,7 @@ list.
 - `load_util.rs` (`crates/rmlx-models/src/load_util.rs`):
   - `Weights::new(shards, idx)` / `Weights::scan_only(shards)` — tensor-fetch handle.
   - `.array(name)`, `.has(name)`, `.raw(name)`, `.linear(...)` — fetch / probe / dequant helpers (replaces hand-rolled `load_array` / `embed` / `linear`).
+  - `.resolve_prefix(candidates, witness) -> Result<String>` — pick the tensor-name prefix the checkpoint actually uses (e.g. `language_model.model` vs `model.language_model`) by probing shard headers for `<prefix>.<witness>`. Use this instead of hardcoding a prefix per loader when an arch ships under more than one layout.
 - `layers/quant.rs` (`crates/rmlx-models/src/layers/quant.rs`):
   - `resolve_quant(tensor_name, has_biases, defaults, overrides) -> Result<QuantParams>` — the shared `.biases`-sibling / affine rule. `QuantParams`, `QuantMode` live here too.
 - `lookup_seeded` lives in **`rmlx-kv-ssd`** (`crates/rmlx-kv-ssd/src/hydrate.rs`, `SsdHydrator::lookup_seeded`) — single-sources the FNV seed so no arch re-types the seed formula.

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -262,10 +262,26 @@ at temp=0.
 
 ---
 
-## Qwen3.5 MoE (`Qwen3_5MoeForConditionalGeneration`)
+## Qwen3.5 (`Qwen3_5MoeForConditionalGeneration` / `Qwen3_5ForConditionalGeneration`)
 
-Also handles `Qwen3_5ForConditionalGeneration` (PARO dense variant). Both route
-to `Architecture::Qwen3_5Moe`.
+One backbone, three checkpoint shapes — all route to `Architecture::Qwen3_5Moe`:
+
+- **Dense mxfp8 / affine** (`Qwen3_5ForConditionalGeneration`, e.g.
+  `ornith-1.0-9b-mxfp8`) — a plain SwiGLU MLP per layer.
+- **Sparse MoE mxfp8 / affine** (`Qwen3_5MoeForConditionalGeneration`, e.g.
+  `ornith-1.0-35b-mxfp8`, `Qwen3.6-35B-A3B`) — `switch_mlp` + `shared_expert` + router.
+- **PARO INT4 dense** (`Qwen3_5ForConditionalGeneration` with a
+  `quantization_config.quant_method == "paroquant"`).
+
+**Fact-driven dispatch.** The arch string alone does NOT determine the loader:
+PARO and plain dense checkpoints share `Qwen3_5ForConditionalGeneration`. The
+arch dispatch keys on the checkpoint itself — `is_paroquant()` selects the PARO
+loader, everything else the standard loader. The standard loader then resolves
+the tensor prefix (`language_model.model` vs `model.language_model`) by probing
+shard headers for the embedding witness, and selects each layer's MLP block
+(dense SwiGLU vs sparse MoE) by which tensors are present
+(`mlp.switch_mlp.*` → MoE; `mlp.{gate,up,down}_proj` → dense). `num_experts`
+defaults to 0 for dense configs that omit the MoE fields.
 
 ### Config schema
 
@@ -280,10 +296,11 @@ Config fields live under `text_config` in `config.json`.
 | `head_dim` | int | optional; derived from `hidden_size / num_attention_heads` if absent |
 | `vocab_size` | int | — |
 | `full_attention_interval` | int | FullAttention every N layers; GDN fills the rest (default 4) |
-| `num_experts` | int | total expert count |
-| `num_experts_per_tok` | int | experts activated per token |
-| `moe_intermediate_size` | int | per-expert FFN width |
-| `shared_expert_intermediate_size` | int | shared dense expert width |
+| `intermediate_size` | int | dense SwiGLU FFN width (dense checkpoints; optional, 0 on pure-MoE) |
+| `num_experts` | int | total expert count; optional, **0 marks a dense checkpoint** |
+| `num_experts_per_tok` | int | experts activated per token (optional, default 1) |
+| `moe_intermediate_size` | int | per-expert FFN width (optional; falls back to `intermediate_size`) |
+| `shared_expert_intermediate_size` | int | shared dense expert width (optional; falls back to `intermediate_size`) |
 | `norm_topk_prob` | bool | normalise top-k router probabilities |
 | `linear_num_value_heads` | int | GDN value head count |
 | `linear_num_key_heads` | int | GDN key head count |
@@ -299,8 +316,10 @@ Config fields live under `text_config` in `config.json`.
 
 **Hybrid FullAttention + GatedDeltaNet (GDN) stack.** The decoder is not a
 uniform transformer. Every `full_attention_interval`-th layer (default every 4th)
-is a standard FullAttention + MoE layer; the remaining layers are GatedDeltaNet
-(linear-attention recurrent) + MoE layers. This means:
+is a standard FullAttention layer; the remaining layers are GatedDeltaNet
+(linear-attention recurrent) layers. The MLP after each attention block is the
+same in both layer kinds — sparse MoE on MoE checkpoints, dense SwiGLU on dense
+checkpoints. This means:
 
 - `needs_lin_caches()` returns `true`. The server allocates a parallel
   `Vec<LinearAttnCache>` alongside the standard `Vec<KvCache>`. The GDN
@@ -309,8 +328,9 @@ is a standard FullAttention + MoE layer; the remaining layers are GatedDeltaNet
   snapshot/restore of this state followed by re-replay of the retained prefix.
 - GDN layers carry separate weight tensors (`linear_attn.*`) not present in
   Qwen2/Qwen3.
-- The model is sparse-MoE throughout; every layer dispatches through
-  `num_experts_per_tok` of `num_experts` experts.
+- MoE checkpoints dispatch every layer through `num_experts_per_tok` of
+  `num_experts` experts; dense checkpoints run a plain SwiGLU FFN
+  (`down(silu(gate(x)) * up(x))`) with no routing.
 
 **Thinking mode.** `supports_thinking()` returns `true` (same behaviour as
 Qwen3 dense).


### PR DESCRIPTION
## Summary

Adds a loader path for dense Qwen3.5 **mxfp8** checkpoints (`Qwen3_5ForConditionalGeneration` — GatedDeltaNet-hybrid backbone + dense SwiGLU MLP). Previously that arch string was routed **unconditionally** to the PARO-INT4 loader (wrong tensor prefix, INT4 embedding requant, MLP modeled as a degenerate 1-expert MoE), so a standard mlx-community dense mxfp8 snapshot failed with `tensor 'model.language_model.embed_tokens.weight' not found`.

## Fix — dispatch + load by checkpoint facts, not arch string

- **Fact-driven dispatch** (`arch/loader.rs`): both `Qwen3_5ForConditionalGeneration` and `Qwen3_5MoeForConditionalGeneration` share one arm; `cfg.is_paroquant()` selects the PARO loader vs the standard loader. This is **required**, not just cleaner — PARO and dense mxfp8 ship the *same* arch string and differ only by `quantization_config.quant_method == "paroquant"`.
- **Dynamic prefix** (`load_util::Weights::resolve_prefix`): probes shard headers for the witness tensor to resolve `language_model.model` vs `model.language_model` instead of a hardcoded per-loader prefix.
- **Dense vs MoE per layer** (`build_mlp`): selects `MlpBlock::Dense` (reuses the existing `DenseMlp`, SwiGLU `down(silu(gate)·up)`) vs `MlpBlock::Moe` by tensor presence. GDN/full-attention backbone is shared with the MoE path, untouched.
- **Config**: MoE-only fields made optional (`num_experts == 0` = dense marker).
- Dense path consumes per-tensor quant codecs via `bf16_scales` (the #188 fix) — mxfp8 uint8 E8M0 scales pass through untouched.

## Review fixes (2nd commit)

- **Defensive PARO×MoE guard:** `load_from_path_paro` hard-errors if MoE expert tensors are present (it builds dense-only), so a hypothetical PARO MoE fails loudly instead of silently dropping experts. Tensor-presence based.
- Documented the `resolve_prefix` index/header assumption at the call site.
- Dropped the speculative `intermediate_size` config field (inlined as the `moe_*` fallback).
- Strengthened the dense/MoE detection test to drive `build_mlp` directly (real assertion, not a `has()` proxy).

## Files

`arch/loader.rs`, `load_util.rs`, `qwen3_5_moe/{loader,config}.rs`, tests `load_util_tests.rs` / `qwen3_5_moe/{config_tests,loader_tests}.rs`, docs `MODELS.md` / `ADDING_A_MODEL.md`.

## Verification

- `make lint` green, `make model-check` green (0 failed), `make check-no-inline-tests` OK.
- New regression tests: `resolve_prefix_matches_present_layout`, `resolve_prefix_errors_when_no_candidate_matches`, `dense_config_parses_with_zero_experts`, `moe_config_parses_expert_counts`, `build_mlp_detects_dense_layout`, `build_mlp_detects_moe_layout`.
- **Real-model proof** (`rmlx info --probe-smoke`, release binary, sequential, single MLX claim):
  - FIX — ornith-1.0-9b dense mxfp8: `prefix=language_model.model`, `experts=0`, `verdict: ok`, coherent (HTTP serve: "capital of France" → Paris; "2+2" → 4).
  - No-regression — ornith-1.0-35b MoE mxfp8 (`experts=256`): `verdict: ok`.
  - No-regression — Qwen3.6-35B-A3B-8bit affine MoE: `verdict: ok`.
  - No-regression — Ternary-Bonsai-8B 2bit (dense Qwen3): `verdict: ok`.
  - No-regression — Gemma4-e4b mxfp8: `verdict: ok`.
  - **PARO path proven** — z-lab__Qwen3.6-27B-PARO (`Qwen3_5ForConditionalGeneration` + krot): "PARO checkpoint detected", `verdict: ok` — dispatch change + new guard do not regress PARO.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
