### PR TITLE
fix(probe-smoke): distinct exit codes for CI gating (load-fail/inconclusive/unsupported)

### DIFF
--- a/crates/rmlx-cli/src/commands/healthcheck.rs
+++ b/crates/rmlx-cli/src/commands/healthcheck.rs
@@ -455,10 +455,12 @@ fn check_smoke(path: &Path) -> CheckLine {
                     Status::Red,
                     "smoke probe verdict: inconclusive (too few steps to confirm)".to_owned(),
                 ),
+                // An unsupported architecture is not a deploy failure — this
+                // registry entry is simply skipped by this build.
                 SmokeExitCode::Unsupported => CheckLine::new(
                     format!("smoke:{id}"),
-                    Status::Red,
-                    "smoke probe verdict: unsupported architecture".to_owned(),
+                    Status::Info,
+                    "smoke probe: skipped (architecture not supported by this build)".to_owned(),
                 ),
             }
         }

--- a/crates/rmlx-cli/src/commands/healthcheck.rs
+++ b/crates/rmlx-cli/src/commands/healthcheck.rs
@@ -432,19 +432,34 @@ fn check_smoke(path: &Path) -> CheckLine {
         None, // max_ctx_override = auto
         &sink,
     ) {
-        Ok(broken) => {
-            if broken {
-                CheckLine::new(
-                    format!("smoke:{id}"),
-                    Status::Red,
-                    "smoke probe verdict: broken (BrokenPunctLoop or BrokenNan)".to_owned(),
-                )
-            } else {
-                CheckLine::new(
+        Ok(exit_code) => {
+            use crate::commands::info::SmokeExitCode;
+            match exit_code {
+                SmokeExitCode::Ok => CheckLine::new(
                     format!("smoke:{id}"),
                     Status::Green,
                     "smoke probe verdict: ok".to_owned(),
-                )
+                ),
+                SmokeExitCode::Broken => CheckLine::new(
+                    format!("smoke:{id}"),
+                    Status::Red,
+                    "smoke probe verdict: broken (BrokenPunctLoop or BrokenNan)".to_owned(),
+                ),
+                SmokeExitCode::LoadFail => CheckLine::new(
+                    format!("smoke:{id}"),
+                    Status::Red,
+                    "smoke probe verdict: load-fail (supported arch failed to load)".to_owned(),
+                ),
+                SmokeExitCode::Inconclusive => CheckLine::new(
+                    format!("smoke:{id}"),
+                    Status::Red,
+                    "smoke probe verdict: inconclusive (too few steps to confirm)".to_owned(),
+                ),
+                SmokeExitCode::Unsupported => CheckLine::new(
+                    format!("smoke:{id}"),
+                    Status::Red,
+                    "smoke probe verdict: unsupported architecture".to_owned(),
+                ),
             }
         }
         Err(e) => CheckLine::new(

--- a/crates/rmlx-cli/src/commands/info.rs
+++ b/crates/rmlx-cli/src/commands/info.rs
@@ -40,9 +40,14 @@ use tracing::{info, warn};
 /// Exit-code outcome for `--probe-smoke`.
 ///
 /// The variant maps 1:1 to the process exit code the caller passes to
-/// `std::process::exit`. Values 0 and 1 are kept identical to the
-/// pre-existing behaviour; 3/4/5 are newly distinct outcomes that
-/// previously collapsed into the exit-0 path.
+/// `std::process::exit`:
+///
+/// - `0` = coherent output; snapshot is healthy.
+/// - `1` = incoherent output (`BrokenPunctLoop` or `BrokenNan`).
+/// - `3` = supported architecture failed to load (I/O, missing weight, shape
+///   mismatch, MLX error, or config error).
+/// - `4` = verdict is `Inconclusive` — too few steps to confirm health.
+/// - `5` = architecture is not handled by this build (unsupported).
 ///
 /// `2` is deliberately absent — clap reserves it for argument-parse errors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,8 +67,39 @@ pub(crate) enum SmokeExitCode {
 
 impl SmokeExitCode {
     /// Convert to the integer exit code passed to `std::process::exit`.
+    #[must_use]
     pub(crate) fn as_i32(self) -> i32 {
         self as i32
+    }
+}
+
+/// Classify a model-load error into a [`SmokeExitCode`].
+///
+/// `Error::Model` and `Error::ArchUnsupported` both indicate that the
+/// architecture is not handled by this build → exit 5 (`Unsupported`).
+/// Every other error indicates a supported architecture that failed to load
+/// (I/O, missing shard, MLX error, …) → exit 3 (`LoadFail`).
+// Error is #[non_exhaustive]; a wildcard arm is required.
+#[allow(
+    clippy::wildcard_enum_match_arm,
+    reason = "Error is #[non_exhaustive]; catch-all is required for forward compatibility"
+)]
+pub(crate) fn classify_load_error(e: &rmlx_core::error::Error) -> SmokeExitCode {
+    match e {
+        rmlx_core::error::Error::Model(_) | rmlx_core::error::Error::ArchUnsupported { .. } => {
+            SmokeExitCode::Unsupported
+        }
+        _ => SmokeExitCode::LoadFail,
+    }
+}
+
+/// Classify a [`rmlx_models::SmokeVerdict`] into a [`SmokeExitCode`].
+pub(crate) fn classify_verdict(v: &rmlx_models::SmokeVerdict) -> SmokeExitCode {
+    match v {
+        rmlx_models::SmokeVerdict::Ok => SmokeExitCode::Ok,
+        rmlx_models::SmokeVerdict::BrokenPunctLoop { .. }
+        | rmlx_models::SmokeVerdict::BrokenNan { .. } => SmokeExitCode::Broken,
+        rmlx_models::SmokeVerdict::Inconclusive { .. } => SmokeExitCode::Inconclusive,
     }
 }
 
@@ -417,19 +453,20 @@ pub(crate) fn run_info(
         info!(arch = %arch, ?device, "smoke_probe: loading model via arch::load_model");
 
         // Load model via architecture dispatch.
-        // Error::Model → architecture not handled by this build (exit 5).
+        // Error::Model / Error::ArchUnsupported → arch not handled (exit 5).
         // Any other error → supported arch failed to load (exit 3).
         let model = match arch::load_model(model_path, device, &arch::LoadOpts::default()) {
             Ok(m) => m,
-            Err(rmlx_core::error::Error::Model(ref msg)) => {
-                warn!(error = %msg, "smoke_probe: architecture not supported");
-                println!("smoke_probe: skipped (unsupported arch: {msg})");
-                return Ok(SmokeExitCode::Unsupported);
-            }
             Err(e) => {
-                warn!(error = %e, "smoke_probe: supported arch failed to load");
-                println!("smoke_probe: load-fail ({e})");
-                return Ok(SmokeExitCode::LoadFail);
+                let code = classify_load_error(&e);
+                if code == SmokeExitCode::Unsupported {
+                    warn!(error = %e, "smoke_probe: architecture not supported");
+                    println!("smoke_probe: skipped (unsupported arch: {e})");
+                } else {
+                    warn!(error = %e, "smoke_probe: supported arch failed to load");
+                    println!("smoke_probe: load-fail ({e})");
+                }
+                return Ok(code);
             }
         };
         print_load_phases_json();
@@ -569,13 +606,7 @@ pub(crate) fn run_info(
 
         info!(verdict = %verdict_str, n_steps, max_abs_overall, "smoke_probe complete");
 
-        let exit_code = match verdict {
-            rmlx_models::SmokeVerdict::Ok => SmokeExitCode::Ok,
-            rmlx_models::SmokeVerdict::BrokenPunctLoop { .. }
-            | rmlx_models::SmokeVerdict::BrokenNan { .. } => SmokeExitCode::Broken,
-            rmlx_models::SmokeVerdict::Inconclusive { .. } => SmokeExitCode::Inconclusive,
-        };
-        return Ok(exit_code);
+        return Ok(classify_verdict(&verdict));
     }
 
     Ok(SmokeExitCode::Ok)

--- a/crates/rmlx-cli/src/commands/info.rs
+++ b/crates/rmlx-cli/src/commands/info.rs
@@ -37,10 +37,41 @@ use tracing::{info, warn};
 /// `device` is used for forward and smoke probes when enabled.
 /// `kv_quant_override` is forwarded to `generate_greedy` when `probe_smoke` is true.
 /// `None` = auto (arch default from `KvCacheBuilder`); `Some(q)` = explicit override.
+/// Exit-code outcome for `--probe-smoke`.
+///
+/// The variant maps 1:1 to the process exit code the caller passes to
+/// `std::process::exit`. Values 0 and 1 are kept identical to the
+/// pre-existing behaviour; 3/4/5 are newly distinct outcomes that
+/// previously collapsed into the exit-0 path.
+///
+/// `2` is deliberately absent — clap reserves it for argument-parse errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SmokeExitCode {
+    /// Coherent output; snapshot is healthy.
+    Ok = 0,
+    /// Incoherent output (`BrokenPunctLoop` or `BrokenNan`).
+    Broken = 1,
+    /// Supported architecture failed to load (I/O, missing weight, shape
+    /// mismatch, MLX error, or config error).
+    LoadFail = 3,
+    /// Verdict is `Inconclusive` — too few steps to confirm health.
+    Inconclusive = 4,
+    /// Architecture is not handled by this build (unsupported).
+    Unsupported = 5,
+}
+
+impl SmokeExitCode {
+    /// Convert to the integer exit code passed to `std::process::exit`.
+    pub(crate) fn as_i32(self) -> i32 {
+        self as i32
+    }
+}
+
 /// `max_ctx_override` is forwarded to `generate_greedy` when `probe_smoke` is true.
 /// `None` = derive from mpe (capped at 4096); `Some(n)` = use `n` directly.
 ///
-/// Returns `true` when the smoke probe detects a broken snapshot (caller exits 1).
+/// Returns the [`SmokeExitCode`] that represents the probe outcome.
+/// When `probe_smoke` is `false` the return value is always [`SmokeExitCode::Ok`].
 #[allow(
     clippy::unwrap_used,
     reason = "Mutex::lock() cannot poison; Option/Result unwrap on values established by construction in this fn"
@@ -53,7 +84,7 @@ pub(crate) fn run_info(
     kv_quant_override: Option<rmlx_kv_quant::KvQuant>,
     max_ctx_override: Option<i32>,
     sink: &EventRecorder,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<SmokeExitCode> {
     let cfg = load_config(model_path).map_err(|e| anyhow::anyhow!("load_config: {e}"))?;
     let idx = load_shard_index(model_path).map_err(|e| anyhow::anyhow!("load_shard_index: {e}"))?;
 
@@ -385,13 +416,20 @@ pub(crate) fn run_info(
     if probe_smoke {
         info!(arch = %arch, ?device, "smoke_probe: loading model via arch::load_model");
 
-        // Load model via architecture dispatch -- returns Error::Model for unsupported arches.
+        // Load model via architecture dispatch.
+        // Error::Model → architecture not handled by this build (exit 5).
+        // Any other error → supported arch failed to load (exit 3).
         let model = match arch::load_model(model_path, device, &arch::LoadOpts::default()) {
             Ok(m) => m,
+            Err(rmlx_core::error::Error::Model(ref msg)) => {
+                warn!(error = %msg, "smoke_probe: architecture not supported");
+                println!("smoke_probe: skipped (unsupported arch: {msg})");
+                return Ok(SmokeExitCode::Unsupported);
+            }
             Err(e) => {
-                warn!(error = %e, "smoke_probe: arch not supported or load failed");
-                println!("smoke_probe: skipped ({e})");
-                return Ok(false);
+                warn!(error = %e, "smoke_probe: supported arch failed to load");
+                println!("smoke_probe: load-fail ({e})");
+                return Ok(SmokeExitCode::LoadFail);
             }
         };
         print_load_phases_json();
@@ -531,16 +569,16 @@ pub(crate) fn run_info(
 
         info!(verdict = %verdict_str, n_steps, max_abs_overall, "smoke_probe complete");
 
-        // Exit 1 on broken snapshot.
-        let is_broken = matches!(
-            verdict,
+        let exit_code = match verdict {
+            rmlx_models::SmokeVerdict::Ok => SmokeExitCode::Ok,
             rmlx_models::SmokeVerdict::BrokenPunctLoop { .. }
-                | rmlx_models::SmokeVerdict::BrokenNan { .. }
-        );
-        return Ok(is_broken);
+            | rmlx_models::SmokeVerdict::BrokenNan { .. } => SmokeExitCode::Broken,
+            rmlx_models::SmokeVerdict::Inconclusive { .. } => SmokeExitCode::Inconclusive,
+        };
+        return Ok(exit_code);
     }
 
-    Ok(false)
+    Ok(SmokeExitCode::Ok)
 }
 
 /// Run a single-token forward pass and return `(top_token_id, max_logit)`.
@@ -775,6 +813,10 @@ pub(crate) fn opt_u32(v: Option<u32>) -> String {
         None => "—".to_owned(),
     }
 }
+
+#[cfg(test)]
+#[path = "info_tests.rs"]
+mod info_tests;
 
 /// Print a JSON load-phase timing line if `read_load_phases()` returns `Some`.
 ///

--- a/crates/rmlx-cli/src/commands/info_tests.rs
+++ b/crates/rmlx-cli/src/commands/info_tests.rs
@@ -1,0 +1,168 @@
+//! Unit tests for the smoke-probe exit-code mapping in `info.rs`.
+
+use super::SmokeExitCode;
+use rmlx_models::SmokeVerdict;
+
+// ---------------------------------------------------------------------------
+// SmokeExitCode::as_i32 — all five codes
+// ---------------------------------------------------------------------------
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn smoke_exit_code_ok_is_zero() {
+    assert_eq!(SmokeExitCode::Ok.as_i32(), 0);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn smoke_exit_code_broken_is_one() {
+    assert_eq!(SmokeExitCode::Broken.as_i32(), 1);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn smoke_exit_code_load_fail_is_three() {
+    assert_eq!(SmokeExitCode::LoadFail.as_i32(), 3);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn smoke_exit_code_inconclusive_is_four() {
+    assert_eq!(SmokeExitCode::Inconclusive.as_i32(), 4);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn smoke_exit_code_unsupported_is_five() {
+    assert_eq!(SmokeExitCode::Unsupported.as_i32(), 5);
+}
+
+// ---------------------------------------------------------------------------
+// SmokeVerdict → SmokeExitCode mapping — inline helper mirrors run_info logic
+// ---------------------------------------------------------------------------
+
+fn verdict_to_exit_code(v: &SmokeVerdict) -> SmokeExitCode {
+    match v {
+        SmokeVerdict::Ok => SmokeExitCode::Ok,
+        SmokeVerdict::BrokenPunctLoop { .. } | SmokeVerdict::BrokenNan { .. } => {
+            SmokeExitCode::Broken
+        }
+        SmokeVerdict::Inconclusive { .. } => SmokeExitCode::Inconclusive,
+    }
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn verdict_ok_maps_to_exit_0() {
+    assert_eq!(verdict_to_exit_code(&SmokeVerdict::Ok).as_i32(), 0);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn verdict_broken_punct_loop_maps_to_exit_1() {
+    let v = SmokeVerdict::BrokenPunctLoop {
+        dominant_piece: ".".to_owned(),
+        distinct_ids: 1,
+    };
+    assert_eq!(verdict_to_exit_code(&v).as_i32(), 1);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn verdict_broken_nan_maps_to_exit_1() {
+    let v = SmokeVerdict::BrokenNan { at_step: 0 };
+    assert_eq!(verdict_to_exit_code(&v).as_i32(), 1);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn verdict_inconclusive_maps_to_exit_4() {
+    let v = SmokeVerdict::Inconclusive {
+        reason: "eos at step 1".to_owned(),
+    };
+    assert_eq!(verdict_to_exit_code(&v).as_i32(), 4);
+}
+
+// ---------------------------------------------------------------------------
+// Load-error variants — exit 3 vs exit 5
+// ---------------------------------------------------------------------------
+
+// Error is #[non_exhaustive]; a wildcard arm is required even after listing all
+// known variants. Allow it here — the important branch is Model vs everything else.
+#[allow(
+    clippy::wildcard_enum_match_arm,
+    reason = "Error is #[non_exhaustive]; catch-all is required for forward compatibility"
+)]
+fn load_err_to_exit_code(e: &rmlx_core::error::Error) -> SmokeExitCode {
+    match e {
+        rmlx_core::error::Error::Model(_) => SmokeExitCode::Unsupported,
+        _ => SmokeExitCode::LoadFail,
+    }
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn load_error_model_maps_to_exit_5() {
+    let e = rmlx_core::error::Error::Model("arch not supported".to_owned());
+    assert_eq!(load_err_to_exit_code(&e).as_i32(), 5);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn load_error_loader_maps_to_exit_3() {
+    let e = rmlx_core::error::Error::Loader("missing shard".to_owned());
+    assert_eq!(load_err_to_exit_code(&e).as_i32(), 3);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn load_error_config_maps_to_exit_3() {
+    let e = rmlx_core::error::Error::Config("malformed config".to_owned());
+    assert_eq!(load_err_to_exit_code(&e).as_i32(), 3);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn load_error_mlx_maps_to_exit_3() {
+    let e = rmlx_core::error::Error::Mlx("metal error".to_owned());
+    assert_eq!(load_err_to_exit_code(&e).as_i32(), 3);
+}

--- a/crates/rmlx-cli/src/commands/info_tests.rs
+++ b/crates/rmlx-cli/src/commands/info_tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for the smoke-probe exit-code mapping in `info.rs`.
 
-use super::SmokeExitCode;
+use super::{classify_load_error, classify_verdict, SmokeExitCode};
 use rmlx_models::SmokeVerdict;
 
 // ---------------------------------------------------------------------------
@@ -53,18 +53,8 @@ fn smoke_exit_code_unsupported_is_five() {
 }
 
 // ---------------------------------------------------------------------------
-// SmokeVerdict → SmokeExitCode mapping — inline helper mirrors run_info logic
+// classify_verdict — all SmokeVerdict variants
 // ---------------------------------------------------------------------------
-
-fn verdict_to_exit_code(v: &SmokeVerdict) -> SmokeExitCode {
-    match v {
-        SmokeVerdict::Ok => SmokeExitCode::Ok,
-        SmokeVerdict::BrokenPunctLoop { .. } | SmokeVerdict::BrokenNan { .. } => {
-            SmokeExitCode::Broken
-        }
-        SmokeVerdict::Inconclusive { .. } => SmokeExitCode::Inconclusive,
-    }
-}
 
 #[test]
 #[allow(
@@ -72,7 +62,7 @@ fn verdict_to_exit_code(v: &SmokeVerdict) -> SmokeExitCode {
     reason = "test assertions; panic is the desired failure mode"
 )]
 fn verdict_ok_maps_to_exit_0() {
-    assert_eq!(verdict_to_exit_code(&SmokeVerdict::Ok).as_i32(), 0);
+    assert_eq!(classify_verdict(&SmokeVerdict::Ok).as_i32(), 0);
 }
 
 #[test]
@@ -85,7 +75,7 @@ fn verdict_broken_punct_loop_maps_to_exit_1() {
         dominant_piece: ".".to_owned(),
         distinct_ids: 1,
     };
-    assert_eq!(verdict_to_exit_code(&v).as_i32(), 1);
+    assert_eq!(classify_verdict(&v).as_i32(), 1);
 }
 
 #[test]
@@ -95,7 +85,7 @@ fn verdict_broken_punct_loop_maps_to_exit_1() {
 )]
 fn verdict_broken_nan_maps_to_exit_1() {
     let v = SmokeVerdict::BrokenNan { at_step: 0 };
-    assert_eq!(verdict_to_exit_code(&v).as_i32(), 1);
+    assert_eq!(classify_verdict(&v).as_i32(), 1);
 }
 
 #[test]
@@ -107,25 +97,13 @@ fn verdict_inconclusive_maps_to_exit_4() {
     let v = SmokeVerdict::Inconclusive {
         reason: "eos at step 1".to_owned(),
     };
-    assert_eq!(verdict_to_exit_code(&v).as_i32(), 4);
+    assert_eq!(classify_verdict(&v).as_i32(), 4);
 }
 
 // ---------------------------------------------------------------------------
-// Load-error variants — exit 3 vs exit 5
+// classify_load_error — Error::Model and Error::ArchUnsupported → exit 5;
+// all other variants → exit 3.
 // ---------------------------------------------------------------------------
-
-// Error is #[non_exhaustive]; a wildcard arm is required even after listing all
-// known variants. Allow it here — the important branch is Model vs everything else.
-#[allow(
-    clippy::wildcard_enum_match_arm,
-    reason = "Error is #[non_exhaustive]; catch-all is required for forward compatibility"
-)]
-fn load_err_to_exit_code(e: &rmlx_core::error::Error) -> SmokeExitCode {
-    match e {
-        rmlx_core::error::Error::Model(_) => SmokeExitCode::Unsupported,
-        _ => SmokeExitCode::LoadFail,
-    }
-}
 
 #[test]
 #[allow(
@@ -134,7 +112,19 @@ fn load_err_to_exit_code(e: &rmlx_core::error::Error) -> SmokeExitCode {
 )]
 fn load_error_model_maps_to_exit_5() {
     let e = rmlx_core::error::Error::Model("arch not supported".to_owned());
-    assert_eq!(load_err_to_exit_code(&e).as_i32(), 5);
+    assert_eq!(classify_load_error(&e).as_i32(), 5);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions; panic is the desired failure mode"
+)]
+fn load_error_arch_unsupported_maps_to_exit_5() {
+    let e = rmlx_core::error::Error::ArchUnsupported {
+        arch: "SomeNewArchForGeneration".to_owned(),
+    };
+    assert_eq!(classify_load_error(&e).as_i32(), 5);
 }
 
 #[test]
@@ -144,7 +134,7 @@ fn load_error_model_maps_to_exit_5() {
 )]
 fn load_error_loader_maps_to_exit_3() {
     let e = rmlx_core::error::Error::Loader("missing shard".to_owned());
-    assert_eq!(load_err_to_exit_code(&e).as_i32(), 3);
+    assert_eq!(classify_load_error(&e).as_i32(), 3);
 }
 
 #[test]
@@ -154,7 +144,7 @@ fn load_error_loader_maps_to_exit_3() {
 )]
 fn load_error_config_maps_to_exit_3() {
     let e = rmlx_core::error::Error::Config("malformed config".to_owned());
-    assert_eq!(load_err_to_exit_code(&e).as_i32(), 3);
+    assert_eq!(classify_load_error(&e).as_i32(), 3);
 }
 
 #[test]
@@ -164,5 +154,5 @@ fn load_error_config_maps_to_exit_3() {
 )]
 fn load_error_mlx_maps_to_exit_3() {
     let e = rmlx_core::error::Error::Mlx("metal error".to_owned());
-    assert_eq!(load_err_to_exit_code(&e).as_i32(), 3);
+    assert_eq!(classify_load_error(&e).as_i32(), 3);
 }

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -834,8 +834,11 @@ enum Cmd {
         /// Token 2 (BOS) is used. Requires the model to be Gemma4ForConditionalGeneration.
         #[arg(long, default_value_t = false)]
         probe_forward: bool,
-        /// Run the 8-token smoke probe and classify the snapshot for the broken-punct-loop
-        /// hazard described in CLAUDE.md. Exits 1 if BrokenPunctLoop or BrokenNan.
+        /// Run the 8-token smoke probe and classify the snapshot.
+        ///
+        /// Exit codes: 0 = ok (coherent), 1 = broken (BrokenPunctLoop or BrokenNan),
+        /// 3 = load-fail (supported arch failed to load), 4 = inconclusive (too few steps),
+        /// 5 = unsupported (architecture not handled). Exit 2 is reserved by clap.
         #[arg(long, default_value_t = false)]
         probe_smoke: bool,
         /// KV cache quantization: "auto" (arch default), "bf16" (unquantised cache; alias "none"), "k8v4", "k8v8", or "planar".
@@ -1816,7 +1819,7 @@ fn main() -> Result<()> {
             } else {
                 None
             };
-            let broken = run_info(
+            let exit_code = run_info(
                 &model,
                 probe_forward,
                 probe_smoke,
@@ -1825,8 +1828,9 @@ fn main() -> Result<()> {
                 max_ctx_override,
                 &sink,
             )?;
-            if broken {
-                std::process::exit(1);
+            let code = exit_code.as_i32();
+            if code != 0 {
+                std::process::exit(code);
             }
         }
         Cmd::Healthcheck {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -256,7 +256,7 @@ rmlx info --model /path/to/snapshot --probe-smoke
 | `--model` | path | — | Path to the model snapshot directory. Required unless `--list-cache-types` is set. |
 | `--device` | `cpu \| gpu` | `gpu` | Device for probe passes (`--probe-forward`, `--probe-smoke`). |
 | `--probe-forward` | bool flag | off | Run a single-token forward pass and print the top-1 token + max logit. |
-| `--probe-smoke` | bool flag | off | Run the 8-token smoke probe and classify the snapshot. Exit 1 on `BrokenPunctLoop` or `BrokenNan`. |
+| `--probe-smoke` | bool flag | off | Run the 8-token smoke probe and classify the snapshot. Exit codes: `0` = ok, `1` = broken (`BrokenPunctLoop`/`BrokenNan`), `3` = load-fail (supported arch failed to load), `4` = inconclusive (too few steps), `5` = unsupported arch. `2` is reserved by clap for argument errors. |
 | `--kv-quant` | string | `auto` | KV cache quantization preset. |
 | `--kv-preset` | string | — | Named KV-cache preset. Mutually exclusive with `--kv-quant`, `--cache-type-k`, `--cache-type-v`, `--kv-bits`. Values: `auto` (hardware-aware selector), `fp16`, `q8`, `speed`, `quality`, `planar`, `k_only_planar`. |
 | `--cache-type-k` / `--ctk` | string | — | Per-side K codec. Mutually exclusive with `--kv-quant`. |
@@ -929,7 +929,7 @@ rmlx info --model /path/to/snapshot
 # List all supported KV cache codecs
 rmlx info --list-cache-types
 
-# Offline smoke probe — exits 1 on BrokenPunctLoop / BrokenNan
+# Offline smoke probe — exit 0=ok, 1=broken, 3=load-fail, 4=inconclusive, 5=unsupported
 rmlx info --model /path/to/snapshot --probe-smoke
 ```
 


### PR DESCRIPTION
## Summary

`rmlx info --probe-smoke` previously exited **0** on genuine failures, so it could not gate CI / registry-add:
- a supported arch that fails to load collapsed into the same `skipped` branch as a benign unsupported arch (`Ok(false)` → exit 0) — this is what masked the dense-Qwen3.5 load regression (#189);
- a prefill crash swallowed to zero tokens → `Inconclusive` → exit 0.

Now the probe returns distinct exit codes.

## Exit-code scheme

| Code | Meaning | Source |
|---|---|---|
| 0 | `ok` — coherent | `SmokeVerdict::Ok` |
| 1 | `broken` — incoherent | `BrokenPunctLoop` / `BrokenNan` (unchanged) |
| 3 | `load-fail` — supported arch failed to load | `Error::Loader` / `Error::Config` / `Error::Mlx` … |
| 4 | `inconclusive` — generated too few steps to confirm | `SmokeVerdict::Inconclusive` |
| 5 | `unsupported` — arch not handled | `Error::Model` / `Error::ArchUnsupported` |

`2` is deliberately skipped — clap uses exit 2 for argument-parse errors; overloading it would make a CI wrapper unable to tell bad flags from a load failure.

## Implementation

- New `SmokeExitCode` enum (explicit discriminants, `as_i32()`); `run_info` returns it instead of a lossy `bool`; `main.rs` exits with the code.
- Two `pub(crate)` classifier functions are the single source of truth, called by both `run_info` and the unit tests:
  - `classify_load_error(&Error)` → `Error::Model | Error::ArchUnsupported` ⇒ `Unsupported` (5); all other variants ⇒ `LoadFail` (3). Covers **both** unsupported paths `arch::load_model` can emit (the early `is_arch_supported` guard and the no-impl-arm catch-all).
  - `classify_verdict(&SmokeVerdict)` → ok/broken/inconclusive.
- `decode_loop.rs`'s `Ok(None)` prefill-swallow is left untouched (it is the serve-path graceful-degrade); only the probe's exit layer changed.
- `healthcheck.rs` (a second consumer of the probe) updated: `Broken`/`LoadFail`/`Inconclusive` → `Status::Red` (a supported model that can't load or can't confirm health is a real readiness failure — previously hidden as Green); `Unsupported` → `Status::Info` (skip, non-fatal — matches the existing "skipped" convention, so a registry with a not-yet-supported arch does not fail the healthcheck).

## Files

`crates/rmlx-cli/src/commands/info.rs`, `info_tests.rs`, `healthcheck.rs`, `main.rs`, `docs/CLI.md`.

## Verification

- `make lint` clean, `cargo test -p rmlx-cli` 206 passed, `make check-no-inline-tests` OK.
- 14 unit tests assert the full outcome→code mapping via the production classifier fns, including `Error::Model`→5 **and** `Error::ArchUnsupported`→5 distinctly, and all verdict variants (broken→1 and inconclusive→4, which aren't reproducible e2e).
- **Real-model proof** (`$?` checked, release binary, single MLX process):
  - ok → `0` (Ternary-Bonsai-8B).
  - load-fail → `3` (supported-arch dir with a corrupt weight shard).
  - unsupported → `5` (config with `architectures: ["SomeUnknownArchForGeneration"]`).

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)
