### PR TITLE
chore(release): 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-06-30
+
+Qwen3.5-family model-loading correctness and a CI-gateable smoke probe. The
+weight-quant loaders no longer corrupt mxfp8/mxfp4 scales, dense Qwen3.5 mxfp8
+checkpoints now load via fact-driven dispatch (no longer hardwired to the PARO
+path), and `rmlx info --probe-smoke` returns distinct exit codes so a load
+failure can no longer masquerade as success. No breaking changes.
+
+### Added
+
+- **Dense Qwen3.5 mxfp8 loader + fact-driven dispatch.** Both
+  `Qwen3_5ForConditionalGeneration` and `Qwen3_5MoeForConditionalGeneration`
+  now route by checkpoint facts, not the arch string: `is_paroquant()` selects
+  the PARO vs the standard loader (the two share an arch string and differ only
+  by `quantization_config.quant_method`), a shared `resolve_prefix` probes shard
+  headers for the tensor prefix, and the MLP block is chosen per layer by tensor
+  presence (dense SwiGLU vs sparse MoE). A defensive guard hard-errors if a PARO
+  checkpoint ships MoE expert tensors. Dense Qwen3.5 mxfp8 snapshots now serve
+  end-to-end. (#191, closes #189)
+
+### Fixed
+
+- **mxfp8/mxfp4 uint8 E8M0 scales corrupted at load → MoE prefill crash.** The
+  Qwen3.5-MoE and Qwen3 loaders blanket-cast every quantized `.scales` tensor to
+  bf16, which is correct for affine (float) scales but corrupts mxfp's uint8 E8M0
+  scales, crashing the first prefill with `dequantize: Scale type must be uint8`.
+  A new per-tensor `bf16_scales` gate casts only float scales and passes uint8
+  scales through verbatim. (#190, closes #188)
+
+### Changed
+
+- **`rmlx info --probe-smoke` now returns distinct exit codes for CI gating.**
+  Previously every non-`Broken*` outcome — including a supported-arch load
+  failure and an inconclusive zero-token run — exited 0, so a loader regression
+  read as a pass. Exit codes are now `0` ok, `1` broken, `3` load-fail, `4`
+  inconclusive, `5` unsupported (`2` is reserved for clap arg-parse errors).
+  `healthcheck` marks load-fail / inconclusive / broken as Red and unsupported
+  as a non-fatal skip. (#193, closes #192)
+- Bumped `anyhow` 1.0.102 → 1.0.103 (fixes a Stacked-Borrows UB in
+  `Error::downcast_mut`) and `uuid` 1.23.3 → 1.23.4. (#187)
+
 ## [0.2.7] - 2026-06-28
 
 Constrained-decode hot-path and Gemma4-unified vision tuning. The `json_schema`
@@ -574,7 +615,8 @@ inference + conversion backend for Apple Silicon — no Python at runtime.
 - Speculative drafters validated against their verifiers: Qwen 3.6 MTP sidecar
   and the Gemma 4 assistant drafter.
 
-[Unreleased]: https://github.com/Pushkinist/rMLX/compare/v0.2.7...HEAD
+[Unreleased]: https://github.com/Pushkinist/rMLX/compare/v0.2.8...HEAD
+[0.2.8]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.8
 [0.2.7]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.7
 [0.2.6]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.6
 [0.2.5]: https://github.com/Pushkinist/rMLX/releases/tag/v0.2.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,7 +1924,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmlx-audio"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "miniz_oxide 0.9.1",
  "rmlx-core",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-cli"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "libc",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-kv-quant"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "rmlx-core",
  "rmlx-mlx",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-kv-ssd"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "rmlx-core",
  "rmlx-kv-quant",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-loader"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "memmap2",
  "rayon",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-metrics"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "csv",
  "regex-lite",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-mlx"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bindgen",
  "rmlx-core",
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-models"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "criterion",
  "image",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-quant"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "criterion",
  "rmlx-core",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-runtime"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "rmlx-core",
  "rmlx-mlx",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "rmlx-server"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release 0.2.8 — Qwen3.5-family model-loading correctness + CI-gateable smoke probe.

Content since v0.2.7:
- **#191** (closes #189) — dense Qwen3.5 mxfp8 loader + fact-driven dispatch (`is_paroquant`, dynamic prefix probe, per-layer dense/MoE detection, PARO×MoE guard).
- **#190** (closes #188) — keep uint8 E8M0 mxfp8/mxfp4 scales intact (`bf16_scales` per-tensor dtype gate); fixes the Qwen3.5-MoE mxfp8 prefill crash.
- **#193** (closes #192) — `rmlx info --probe-smoke` distinct exit codes (0/1/3/4/5) for CI gating.
- **#187** — bump anyhow 1.0.102→1.0.103, uuid 1.23.3→1.23.4.

Version bumped in `[workspace.package]`; `Cargo.lock` regenerated; `CHANGELOG.md` `[0.2.8]` section added. No breaking changes.

Local gate (full `make ci` hangs on the unrelated audio `long_form_regression` test): `cargo fmt --check` clean, `make lint` clean, release build clean, `rmlx --version` → 0.2.8, Bonsai probe-smoke verdict ok. The four PRs were each CI-green + real-model-proven at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)