### PR TITLE
chore(release): bump Homebrew formula to v0.2.8

### DIFF
--- a/packaging/homebrew/rmlx.rb
+++ b/packaging/homebrew/rmlx.rb
@@ -21,14 +21,14 @@
 class Rmlx < Formula
   desc "Rust-native, single-binary MLX inference + conversion backend for Apple Silicon"
   homepage "https://github.com/Pushkinist/rMLX"
-  url "https://github.com/Pushkinist/rMLX/archive/refs/tags/v0.2.7.tar.gz"
-  sha256 "90ca72fe7de2bb0142aa46818672dd15cfb486f70463630e7ddebeea97467fb5"
+  url "https://github.com/Pushkinist/rMLX/archive/refs/tags/v0.2.8.tar.gz"
+  sha256 "faa60f4d8d0bd5f7f3db55650aa80a3fb5bbcacc236fba3ecc486d69cba196ca"
   license any_of: ["MIT", "Apache-2.0"]
   head "https://github.com/Pushkinist/rMLX.git", branch: "main"
 
   bottle do
-    root_url "https://github.com/Pushkinist/rMLX/releases/download/v0.2.7"
-    sha256 cellar: :any, arm64_tahoe: "11afad9841194818cfddd55d7c3fa8c42712372a77606e12528f56190e91ecb2"
+    root_url "https://github.com/Pushkinist/rMLX/releases/download/v0.2.8"
+    sha256 cellar: :any, arm64_tahoe: "58278f85e4f4f9f449c58110afc08b3554a36fe5fcde329bb2830c26f9f10c07"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
Bumps the Homebrew formula to v0.2.8.

- `url` → v0.2.8 source tarball, source `sha256` `faa60f4d…` (verified stable ×3).
- `bottle do` → root_url v0.2.8, arm64_tahoe `58278f85…` (prebuilt bottle uploaded to the v0.2.8 GitHub Release; sha verified against the uploaded asset).

Bottle built locally via `brew install --build-bottle` + `make bottle` (built in 2m19s). Tap synced separately via `make tap-sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)