### PR TITLE
chore: satisfy clippy 1.97 lints (unblocks CI on main)

### DIFF
--- a/crates/rmlx-core/src/paths.rs
+++ b/crates/rmlx-core/src/paths.rs
@@ -185,10 +185,7 @@ fn workspace_root() -> Option<PathBuf> {
         if cur.join("Cargo.lock").is_file() {
             return Some(cur.to_path_buf());
         }
-        match cur.parent() {
-            Some(p) => cur = p,
-            None => return None,
-        }
+        cur = cur.parent()?;
     }
 }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
@@ -89,7 +89,7 @@ fn quant_rotor_k3_qjl_default_on() {
     // the encoder/decoder ran without panic. The QJL toggle lift is verified
     // by the dedicated lift test below.
     let _decoded = qk.dequant().unwrap();
-    assert!(qk.blocks.len() == 1);
+    assert_eq!(qk.blocks.len(), 1);
 }
 
 #[test]

--- a/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
@@ -92,7 +92,7 @@ fn kv_quant_mismatch_evicts_and_misses() {
         .find_best_prefix(&prompt_ids, FNV_OFFSET)
         .expect("block hit");
     let entry_quant = cache.slots[slot_idx].entry.kv_quant;
-    assert!(entry_quant != Some(runtime_quant));
+    assert_ne!(entry_quant, Some(runtime_quant));
     cache.evict_slot(slot_idx);
 
     assert_eq!(cache.slots.len(), 0);
@@ -125,7 +125,7 @@ fn kv_quant_legacy_none_evicts_and_misses() {
     let (slot_idx, _) = cache
         .find_best_prefix(&prompt_ids, FNV_OFFSET)
         .expect("block hit");
-    assert!(cache.slots[slot_idx].entry.kv_quant != Some(runtime_quant));
+    assert_ne!(cache.slots[slot_idx].entry.kv_quant, Some(runtime_quant));
     cache.evict_slot(slot_idx);
     assert_eq!(cache.slots.len(), 0);
     assert_eq!(cache.stats().evictions, 1);

--- a/crates/rmlx-server/src/constraint_json/mod.rs
+++ b/crates/rmlx-server/src/constraint_json/mod.rs
@@ -91,7 +91,7 @@ pub mod schema;
 pub use schema::{EngagePolicy, SchemaConstraint, SchemaError, SchemaNode};
 
 /// Whitespace bytes allowed outside strings.
-const WS: [u8; 4] = [b' ', b'\t', b'\n', b'\r'];
+const WS: [u8; 4] = *b" \t\n\r";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum JsonState {

--- a/crates/rmlx-server/src/constraint_json/schema/grammar.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/grammar.rs
@@ -35,7 +35,7 @@ use serde_json::Value;
 use super::types::SchemaNode;
 
 /// Whitespace bytes allowed outside strings (mirrors `super::super::WS`).
-pub(super) const WS: [u8; 4] = [b' ', b'\t', b'\n', b'\r'];
+pub(super) const WS: [u8; 4] = *b" \t\n\r";
 
 // ────────────────── fence-suppression helper ────────────────────────────────
 

--- a/crates/rmlx-server/src/constraint_json/schema/tests.rs
+++ b/crates/rmlx-server/src/constraint_json/schema/tests.rs
@@ -914,7 +914,7 @@ fn reset_from_matches_fresh_clone() {
         "{\"name\":\"x\",\"size\":\"small\",\"tags\":[\"",
     ];
     // Bytes that drive the scratch into a different shape before each reset.
-    let dirtiers = [b'x', b'{', b'"', b'}', b'[', b' ', b',', b':', b']'];
+    let dirtiers = *b"x{\"}[ ,:]";
 
     for prefix in prefixes {
         let mut base = SchemaGrammar::new(root.clone());

--- a/crates/rmlx-server/src/openai/generate.rs
+++ b/crates/rmlx-server/src/openai/generate.rs
@@ -80,15 +80,13 @@ pub(super) fn extract_top_level_json_value(text: &str) -> Option<String> {
     // syntactically bad), advance past it and try the next candidate.
     let mut search_from = 0usize;
     loop {
-        let start = match bytes[search_from..].iter().position(|&b| {
+        let off = bytes[search_from..].iter().position(|&b| {
             matches!(
                 b,
                 b'{' | b'[' | b'"' | b't' | b'f' | b'n' | b'-' | b'0'..=b'9'
             )
-        }) {
-            Some(off) => search_from + off,
-            None => return None,
-        };
+        })?;
+        let start = search_from + off;
 
         let result = try_extract_at(bytes, text, start);
         if let Some(v) = result {


### PR DESCRIPTION
## Why

Rust **1.97.0** stable shipped on 2026-07-07 with new clippy lints. CI pins the toolchain to `stable` (`dtolnay/rust-toolchain@stable`), and the workspace gate is `clippy -D warnings` — so the new lints became **hard errors** the moment 1.97 landed.

`main` has not been CI'd since **2026-06-30**, when the toolchain was still 1.96. It is therefore **latently red**: every PR opened against this repo today fails `build + clippy` regardless of its content. #199 is the first one to surface it.

Local dev is unaffected because Homebrew's `rust` is still on 1.96.1 — which is exactly why `make ci` passes locally and CI does not.

## What changed

Seven sites, three lints, **all in pre-existing code**:

| Lint | Sites |
|---|---|
| `question_mark` | `rmlx-core/src/paths.rs`, `rmlx-server/src/openai/generate.rs` |
| `byte_char_slices` | `rmlx-server/src/constraint_json/{mod.rs, schema/grammar.rs, schema/tests.rs}` |
| `bool_assert_comparison` | `rmlx-kv-quant/…/quant_rotor_k3_tests.rs`, `rmlx-models/src/gemma4/prompt_cache_tests.rs` |

Every rewrite is semantically identical:

- `match cur.parent() { Some(p) => cur = p, None => return None }` → `cur = cur.parent()?;`
- `[b' ', b'\t', b'\n', b'\r']` → `*b" \t\n\r"` — same `[u8; 4]`, same bytes.
- `assert!(a == b)` → `assert_eq!(a, b)` — same predicate, better failure message.

```
7 files changed, 10 insertions(+), 15 deletions(-)
```

## Verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` (the exact CI command) — **clean under 1.97.0 and under 1.96.1**, so this does not trade one toolchain's red for another's.
- Test suites for all four affected crates pass.

## Worth deciding separately

CI tracks `stable` unpinned, so this will recur on every Rust release — a new lint can turn `main` red without a single line changing. Options: pin the toolchain in `ci.yml` (predictable, needs manual bumps), or keep tracking stable and accept periodic sweeps like this one. Not changed here; flagging it.

The workspace `rust-version` stays at **1.95** — none of these fixes require a newer compiler, and bumping the MSRV is a user-facing decision, not a lint cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
