### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Closes #198.

## Why

`cargo audit` and `cargo deny` flag **`crossbeam-epoch 0.9.18`** under [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204). The advisory's stated fix is `>= 0.9.20`.

The crate is a **transitive** dependency (`criterion` → `rayon` → `crossbeam-*`), so no manifest change is needed — a lockfile bump is sufficient.

## What changed

```
Updating crossbeam-epoch v0.9.18 -> v0.9.20

Cargo.lock | 4 ++--
1 file changed, 2 insertions(+), 2 deletions(-)
```

No `Cargo.toml`, no `deny.toml`. Nothing else in the lockfile moved.

## Verification

```
$ cargo deny --all-features check
advisories ok, bans ok, licenses ok, sources ok

$ cargo audit
warning: 1 allowed warning found      # `paste` unmaintained — pre-existing, already ignored in deny.toml

$ make ci
exit 0
```

`make ci` is now green **end to end**. It had been red on `deny` + `audit` since the advisory landed — every local pre-push gate was failing those two stages, and CI does not run them, so the red was invisible to GitHub. That's now resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
