### PR TITLE
chore(ci): pin least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ on:
   pull_request:
     branches: [main]
 
+# Both jobs only check out the repo and compile — no PR comments, no releases,
+# no package writes. Pinning least-privilege here rather than relying on the
+# repo-level default keeps the scope explicit, survives the workflow being
+# copied, and does not silently widen if that default is ever changed.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Closes the two open CodeQL code-scanning alerts, both `actions/missing-workflow-permissions` (medium):

- [#1](https://github.com/Pushkinist/rMLX/security/code-scanning/1) — `ci.yml` job `fmt`
- [#2](https://github.com/Pushkinist/rMLX/security/code-scanning/2) — `ci.yml` job `build + clippy`

## What was wrong

`.github/workflows/ci.yml` declared no `permissions` key at the root or on either job, so `GITHUB_TOKEN` fell back to the repository default.

## Actual exposure: none, today

```
$ gh api repos/Pushkinist/rMLX/actions/permissions/workflow
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
```

The default is already read-only, so no job was ever handed a write-scoped token. This is hardening, not an incident.

## Why fix it anyway

The read-only guarantee lives in *repo settings*, not in the repo:

- invisible to anyone reading the workflow,
- silently widens if the org/repo default is ever flipped to read-write,
- does not travel if the workflow is copied to another repo.

That matters more than usual here because the `build` job runs `cargo clippy` / `cargo build`, which execute `build.rs` for every transitive dependency. Any supply-chain compromise in that tree runs with whatever scope the token happens to carry.

## The fix

Root-level `permissions: contents: read`, inherited by both jobs. Neither writes anything — they check out and compile. No PR comments, no releases, no package pushes.

No behavior change: the token already had exactly this scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)