### PR TITLE
fix(loader): pre-flight reject unsupported weight-quant bit-widths (#208)

### DIFF
--- a/crates/rmlx-models/src/arch/loader.rs
+++ b/crates/rmlx-models/src/arch/loader.rs
@@ -51,6 +51,9 @@ pub struct LoadOpts {
 /// # Errors
 /// Returns `Error::Config` if `config.json` cannot be read or parsed.
 /// Returns `Error::Model` if the architecture is not yet supported.
+/// Returns `Error::Quant` if the declared affine weight-quant bit-width (the
+/// global default or a `tensor_overrides` entry) is unsupported by this
+/// build's MLX/mlx-c.
 /// Returns `Error::Loader` / `Error::Mlx` if weight loading fails.
 #[tracing::instrument(skip_all, fields(model_dir = %model_dir.display()))]
 pub fn load_model(model_dir: &Path, _device: Device, opts: &LoadOpts) -> Result<Architecture> {
@@ -306,28 +309,66 @@ pub fn load_model(model_dir: &Path, _device: Device, opts: &LoadOpts) -> Result<
 /// Reject a declared weight-quant bit-width this build's mlx-c has no
 /// dequant kernel for.
 ///
-/// Only the affine family (`config.json`'s `quantization.mode`, defaulting to
-/// `"affine"`) has a variable bit-width kernel matrix — `SUPPORTED_BITS`
-/// lists exactly what `crates/rmlx-quant/src/affine.rs` (CPU codec) and this
-/// build's linked mlx-c (GPU `affine_dequantize_*_b_<bits>` /
-/// `quantized_matmul` kernels) both support. `mxfp8`/`mxfp4`/`nvfp4` are
-/// fixed-format (always 8-bit E4M3 / 4-bit E2M1 elements) and carry no
-/// equivalent variable-width risk, so they are not checked here.
+/// Only the literal `"affine"` mode (`config.json`'s `quantization.mode`,
+/// defaulting to `"affine"` when absent) has a variable bit-width kernel
+/// matrix — `SUPPORTED_BITS` lists exactly what
+/// `crates/rmlx-quant/src/affine.rs` (CPU codec) and this build's linked
+/// mlx-c (GPU `affine_dequantize_*_b_<bits>` / `quantized_matmul` kernels)
+/// both support. Every other mode string — a known fixed-format mode
+/// (`mxfp8`/`mxfp4`/`nvfp4`) or an unrecognized future one — is left alone.
+/// Gating on the exact string (rather than `QuantMode::from`'s
+/// "unknown -> affine" resolver-convenience fallback) matters here: treating
+/// an unrecognized mode as affine would false-reject a future fixed-format
+/// mode whose element width happens to fall outside the affine set.
 ///
-/// Checks the model's global default only (`cfg.quantization`); per-tensor
-/// overrides inherit that default's bit-width in every known snapshot.
+/// Checks the model's global default *and* every `quantization.tensor_overrides`
+/// entry (one level deep — the schema is a flat tensor-name -> params map,
+/// not recursive, matching how every arch's `resolve_quant` looks overrides
+/// up). A supported global bit-width does not guarantee every override is
+/// supported: a config can declare a supported `bits` globally and still
+/// carry a `tensor_overrides` entry with an unsupported affine `bits` for one
+/// tensor, which would die at that tensor's first prefill exactly like the
+/// global case (`rmlx-loader/src/config_tests.rs::load_config_accepts_normal_tensor_overrides`
+/// documents this schema is real and accepted by `load_config`).
 fn preflight_weight_quant(cfg: &rmlx_loader::ModelConfig, arch_str: &str) -> Result<()> {
     let Some(q) = cfg.quantization.as_ref() else {
         return Ok(());
     };
-    if crate::layers::QuantMode::from(q.mode_or_default()) != crate::layers::QuantMode::Affine {
+    let default_mode = q.mode_or_default();
+    check_affine_bits(default_mode, q.bits, None, arch_str)?;
+
+    if let Some(overrides) = q.tensor_overrides.as_ref() {
+        for (tensor_name, ov) in overrides {
+            // An override's own `mode`, when present and non-empty, wins;
+            // otherwise it inherits the resolved global default mode — same
+            // rule `layers::quant::resolve_quant` applies at actual dequant
+            // time (the `.biases`-sibling force-affine rule is a tensor-data
+            // fact this config-only preflight cannot see, and is not needed
+            // here: it only ever narrows a non-affine mode *to* affine, and
+            // affine is exactly the mode this check already inspects).
+            let mode = ov
+                .mode
+                .as_deref()
+                .filter(|m| !m.is_empty())
+                .unwrap_or(default_mode);
+            check_affine_bits(mode, ov.bits, Some(tensor_name), arch_str)?;
+        }
+    }
+    Ok(())
+}
+
+/// Shared affine-bits gate for both the global default and a single
+/// `tensor_overrides` entry. `tensor` is `None` for the global check, `Some`
+/// for an override (named in the error so the operator knows which tensor
+/// triggered it).
+fn check_affine_bits(mode: &str, bits: u8, tensor: Option<&str>, arch_str: &str) -> Result<()> {
+    if mode != "affine" {
         return Ok(());
     }
-    if rmlx_quant::affine::SUPPORTED_BITS.contains(&q.bits) {
+    if rmlx_quant::affine::SUPPORTED_BITS.contains(&bits) {
         return Ok(());
     }
 
-    let bits = q.bits;
     let supported = rmlx_quant::affine::SUPPORTED_BITS
         .iter()
         .map(u8::to_string)
@@ -338,13 +379,15 @@ fn preflight_weight_quant(cfg: &rmlx_loader::ModelConfig, arch_str: &str) -> Res
     } else {
         ""
     };
+    let tensor_ctx = tensor.map_or_else(String::new, |t| format!(" (tensor_overrides['{t}'])"));
     let msg = format!(
         "weight quant bits={bits} (affine) unsupported by this build's MLX/mlx-c \
-         (supported: {supported}){hint}"
+         (supported: {supported}){hint}{tensor_ctx}"
     );
     tracing::error!(
         arch = arch_str,
         bits,
+        tensor = tensor.unwrap_or(""),
         supported = %supported,
         "arch::load_model: {msg}"
     );

--- a/crates/rmlx-models/src/arch/loader.rs
+++ b/crates/rmlx-models/src/arch/loader.rs
@@ -80,6 +80,14 @@ pub fn load_model(model_dir: &Path, _device: Device, opts: &LoadOpts) -> Result<
         )));
     }
 
+    // Pre-flight: reject a weight-quant bit-width this build's mlx-c cannot
+    // dequantize, before any tensor I/O or GPU dispatch. Without this, an
+    // unsupported bit-width (e.g. 1-bit affine) "loads" successfully — MLX
+    // only tries to compile the dequant kernel lazily, at first prefill — and
+    // the model then dies per-token with a buried Metal kernel error instead
+    // of failing cleanly here.
+    preflight_weight_quant(&cfg, arch_str)?;
+
     // -- Phase 1: mmap -------------------------------------------------------
     let t_mmap_start = Instant::now();
     match load_shard_index(model_dir).and_then(|idx| ShardSet::open(model_dir, &idx)) {
@@ -295,6 +303,54 @@ pub fn load_model(model_dir: &Path, _device: Device, opts: &LoadOpts) -> Result<
     Ok(arch)
 }
 
+/// Reject a declared weight-quant bit-width this build's mlx-c has no
+/// dequant kernel for.
+///
+/// Only the affine family (`config.json`'s `quantization.mode`, defaulting to
+/// `"affine"`) has a variable bit-width kernel matrix — `SUPPORTED_BITS`
+/// lists exactly what `crates/rmlx-quant/src/affine.rs` (CPU codec) and this
+/// build's linked mlx-c (GPU `affine_dequantize_*_b_<bits>` /
+/// `quantized_matmul` kernels) both support. `mxfp8`/`mxfp4`/`nvfp4` are
+/// fixed-format (always 8-bit E4M3 / 4-bit E2M1 elements) and carry no
+/// equivalent variable-width risk, so they are not checked here.
+///
+/// Checks the model's global default only (`cfg.quantization`); per-tensor
+/// overrides inherit that default's bit-width in every known snapshot.
+fn preflight_weight_quant(cfg: &rmlx_loader::ModelConfig, arch_str: &str) -> Result<()> {
+    let Some(q) = cfg.quantization.as_ref() else {
+        return Ok(());
+    };
+    if crate::layers::QuantMode::from(q.mode_or_default()) != crate::layers::QuantMode::Affine {
+        return Ok(());
+    }
+    if rmlx_quant::affine::SUPPORTED_BITS.contains(&q.bits) {
+        return Ok(());
+    }
+
+    let bits = q.bits;
+    let supported = rmlx_quant::affine::SUPPORTED_BITS
+        .iter()
+        .map(u8::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    let hint = if bits == 1 {
+        "; 1-bit needs ml-explore/mlx#3161 (unreleased)"
+    } else {
+        ""
+    };
+    let msg = format!(
+        "weight quant bits={bits} (affine) unsupported by this build's MLX/mlx-c \
+         (supported: {supported}){hint}"
+    );
+    tracing::error!(
+        arch = arch_str,
+        bits,
+        supported = %supported,
+        "arch::load_model: {msg}"
+    );
+    Err(Error::Quant(msg))
+}
+
 /// Pre-warm the GDN Metal kernel by dispatching one `gated_delta_step_gpu`
 /// call at the production chunk shape, compiling its Metal program at load
 /// time so the first real request pays no kernel-compile cost.
@@ -497,3 +553,7 @@ fn resolve_bos_id(model_dir: &Path) -> Result<u32> {
         model_dir.display()
     )))
 }
+
+#[cfg(test)]
+#[path = "loader_tests.rs"]
+mod loader_tests;

--- a/crates/rmlx-models/src/arch/loader_tests.rs
+++ b/crates/rmlx-models/src/arch/loader_tests.rs
@@ -8,6 +8,17 @@ fn cfg_with_quant(json: &str) -> rmlx_loader::ModelConfig {
     serde_json::from_str(json).unwrap()
 }
 
+/// Same join logic `check_affine_bits` uses for the error message's
+/// `supported: ...` list — derived from `SUPPORTED_BITS` rather than
+/// hardcoded, so the assertion tracks the constant instead of duplicating it.
+fn supported_bits_csv() -> String {
+    rmlx_quant::affine::SUPPORTED_BITS
+        .iter()
+        .map(u8::to_string)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 /// Concrete regression case: `prism-ml__Bonsai-27B-mlx-1bit`
 /// (`quantization.bits=1`, no `mode` -> defaults to affine). No dequant
 /// kernel exists for 1-bit affine in this build's mlx-c; the pre-flight must
@@ -28,7 +39,7 @@ fn rejects_1bit_affine_default_mode() {
         "error should name the quant mode: {msg}"
     );
     assert!(
-        msg.contains("supported: 2,3,4,5,6,8"),
+        msg.contains(&format!("supported: {}", supported_bits_csv())),
         "error should list the supported set: {msg}"
     );
     assert!(
@@ -96,4 +107,54 @@ fn rejects_other_unsupported_bits_without_the_1bit_hint() {
     let msg = err.to_string();
     assert!(msg.contains("bits=7"), "{msg}");
     assert!(!msg.contains("mlx#3161"), "hint is 1-bit specific: {msg}");
+}
+
+/// Real-shaped regression case: `mlx-community__Qwen3.6-35B-A3B-8bit`-style
+/// config carries a supported global `bits` (per-arch `resolve_quant` inherits
+/// the global mode when an override omits its own `mode`, so a bare
+/// `{"group_size":..,"bits":..}` override entry — the exact shape real
+/// snapshots use — is affine by inheritance here too) alongside a
+/// `tensor_overrides` entry with an unsupported affine `bits`. A global-only
+/// check would false-accept this and defer the same load-then-die failure to
+/// that tensor's first prefill; the override map must be scanned too.
+#[test]
+#[allow(clippy::expect_used)]
+fn rejects_unsupported_affine_tensor_override_despite_supported_global_bits() {
+    let cfg = cfg_with_quant(
+        r#"{"quantization":{"group_size":64,"bits":4,"mode":"affine",
+        "tensor_overrides":{"language_model.model.layers.0.mlp.gate":{"group_size":64,"bits":1}}}}"#,
+    );
+    let err = preflight_weight_quant(&cfg, "test")
+        .expect_err("unsupported affine bits in a tensor_overrides entry must be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("bits=1"), "{msg}");
+    assert!(
+        msg.contains("language_model.model.layers.0.mlp.gate"),
+        "error should name the offending tensor: {msg}"
+    );
+}
+
+/// A supported global bit-width with a *supported* tensor_overrides entry
+/// must still load — the override scan must not false-reject a valid config
+/// (no-regression guard for the override-walk added by finding 1).
+#[test]
+fn accepts_supported_affine_tensor_override() {
+    let cfg = cfg_with_quant(
+        r#"{"quantization":{"group_size":64,"bits":8,"mode":"affine",
+        "tensor_overrides":{"language_model.model.layers.0.mlp.gate":{"group_size":64,"bits":8}}}}"#,
+    );
+    assert!(preflight_weight_quant(&cfg, "test").is_ok());
+}
+
+/// An unrecognized/future `mode` string paired with an out-of-affine-set
+/// `bits` must be skipped (accepted), not resolved to `"affine"` and
+/// false-rejected. Exercises the exact-string gate from finding 2 —
+/// `QuantMode::from`'s "unknown -> Affine" fallback would wrongly reject
+/// this if it were still used for the gate.
+#[test]
+fn unknown_mode_with_out_of_set_bits_is_not_false_rejected() {
+    let cfg = cfg_with_quant(
+        r#"{"quantization":{"group_size":32,"bits":7,"mode":"some_future_format"}}"#,
+    );
+    assert!(preflight_weight_quant(&cfg, "test").is_ok());
 }

--- a/crates/rmlx-models/src/arch/loader_tests.rs
+++ b/crates/rmlx-models/src/arch/loader_tests.rs
@@ -1,0 +1,99 @@
+use super::*;
+
+/// Parse a minimal `config.json` body into `ModelConfig` for the pre-flight
+/// tests below. Only the `quantization` block matters for
+/// `preflight_weight_quant`; every other field takes its serde default.
+#[allow(clippy::unwrap_used)]
+fn cfg_with_quant(json: &str) -> rmlx_loader::ModelConfig {
+    serde_json::from_str(json).unwrap()
+}
+
+/// Concrete regression case: `prism-ml__Bonsai-27B-mlx-1bit`
+/// (`quantization.bits=1`, no `mode` -> defaults to affine). No dequant
+/// kernel exists for 1-bit affine in this build's mlx-c; the pre-flight must
+/// reject it with the exact, actionable message.
+#[test]
+#[allow(clippy::expect_used)]
+fn rejects_1bit_affine_default_mode() {
+    let cfg = cfg_with_quant(r#"{"quantization":{"group_size":128,"bits":1}}"#);
+    let err = preflight_weight_quant(&cfg, "Qwen3_5ForConditionalGeneration")
+        .expect_err("bits=1 affine must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("bits=1"),
+        "error should name the offending bits: {msg}"
+    );
+    assert!(
+        msg.contains("(affine)"),
+        "error should name the quant mode: {msg}"
+    );
+    assert!(
+        msg.contains("supported: 2,3,4,5,6,8"),
+        "error should list the supported set: {msg}"
+    );
+    assert!(
+        msg.contains("mlx#3161"),
+        "1-bit case should point at the tracking issue: {msg}"
+    );
+}
+
+/// `prism-ml/Ternary-Bonsai-8B-mlx-2bit`-shaped config: `bits=2`, affine
+/// default mode. Must load — this is a real, working production snapshot.
+#[test]
+fn accepts_2bit_affine() {
+    let cfg = cfg_with_quant(r#"{"quantization":{"group_size":128,"bits":2}}"#);
+    assert!(preflight_weight_quant(&cfg, "Qwen3ForCausalLM").is_ok());
+}
+
+/// Every affine bit-width this build's codec supports must pass.
+#[test]
+fn accepts_all_supported_affine_bits() {
+    for bits in rmlx_quant::affine::SUPPORTED_BITS {
+        let json =
+            format!(r#"{{"quantization":{{"group_size":64,"bits":{bits},"mode":"affine"}}}}"#);
+        let cfg = cfg_with_quant(&json);
+        assert!(
+            preflight_weight_quant(&cfg, "test").is_ok(),
+            "bits={bits} is in SUPPORTED_BITS and must not be rejected"
+        );
+    }
+}
+
+/// An unsupported bits value is only checked under the affine mode — a
+/// non-affine mode (mxfp8/mxfp4/nvfp4) has its own fixed-format kernel and
+/// must not be false-rejected by the affine bit-width set.
+#[test]
+fn non_affine_mode_skips_the_affine_bits_check() {
+    let cfg = cfg_with_quant(r#"{"quantization":{"group_size":32,"bits":7,"mode":"mxfp4"}}"#);
+    assert!(preflight_weight_quant(&cfg, "Gemma4ForConditionalGeneration").is_ok());
+}
+
+/// `gemma-4-e4b-it-mxfp8`-shaped config: real production mxfp8 checkpoint.
+/// Must load unchanged (no-regression guard for the concrete positive-proof
+/// model list).
+#[test]
+fn accepts_real_mxfp8_shape() {
+    let cfg = cfg_with_quant(r#"{"quantization":{"group_size":32,"bits":8,"mode":"mxfp8"}}"#);
+    assert!(preflight_weight_quant(&cfg, "Gemma4ForConditionalGeneration").is_ok());
+}
+
+/// A model with no `quantization` block at all (bf16 / unquantized, or a
+/// PARO checkpoint that only carries `quantization_config`) must not be
+/// touched by this check.
+#[test]
+fn no_quantization_block_is_a_no_op() {
+    let cfg = cfg_with_quant(r#"{"architectures":["Qwen3ForCausalLM"]}"#);
+    assert!(preflight_weight_quant(&cfg, "Qwen3ForCausalLM").is_ok());
+}
+
+/// An unsupported bits value that is not the concrete 1-bit case gets the
+/// same rejection shape, minus the 1-bit-specific hint.
+#[test]
+#[allow(clippy::expect_used)]
+fn rejects_other_unsupported_bits_without_the_1bit_hint() {
+    let cfg = cfg_with_quant(r#"{"quantization":{"group_size":64,"bits":7,"mode":"affine"}}"#);
+    let err = preflight_weight_quant(&cfg, "test").expect_err("bits=7 affine must be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("bits=7"), "{msg}");
+    assert!(!msg.contains("mlx#3161"), "hint is 1-bit specific: {msg}");
+}

--- a/crates/rmlx-quant/src/affine.rs
+++ b/crates/rmlx-quant/src/affine.rs
@@ -65,6 +65,13 @@ pub struct AffineParams {
 
 // ── Validation ────────────────────────────────────────────────────────────────
 
+/// Affine bit-widths this build's dequant codec supports — CPU (`dequant_to_f32`
+/// below) and GPU (mlx-c `affine_dequantize_*` / `quantized_matmul` kernels)
+/// alike. Single source of truth: `validate_params` and any load-time
+/// pre-flight check (e.g. `rmlx_models::arch::loader`) must both read this
+/// constant rather than re-deriving the set.
+pub const SUPPORTED_BITS: [u8; 6] = [2, 3, 4, 5, 6, 8];
+
 /// Cold helper: construct the "bits not supported" error.
 ///
 /// Marked `#[cold]` so LLVM places this large `format!` block away from the hot
@@ -135,9 +142,8 @@ fn err_out_len(got: usize, exp: usize, rows: usize, cols: usize) -> Error {
 }
 
 fn validate_params(params: &AffineParams) -> Result<()> {
-    match params.bits {
-        2 | 3 | 4 | 5 | 6 | 8 => {}
-        b => return Err(err_bits(b)),
+    if !SUPPORTED_BITS.contains(&params.bits) {
+        return Err(err_bits(params.bits));
     }
     match params.group_size {
         32 | 64 | 128 => {}

--- a/docs/ADDING_A_MODEL.md
+++ b/docs/ADDING_A_MODEL.md
@@ -78,7 +78,12 @@ Run these in order before declaring a new arch done.
 
 1. **Smoke-probe the snapshot.** Short generation, reject incoherent output —
    CLAUDE.md hard rule 6. Every new snapshot / quant gets a smoke probe before
-   it enters the registry. Surface and flags: `docs/CLI.md`.
+   it enters the registry. Surface and flags: `docs/CLI.md`. Before the smoke
+   probe even loads weights, `arch::load_model` (point 7) pre-flights the
+   declared affine `bits` against `rmlx_quant::affine::SUPPORTED_BITS` — a new
+   arch needs no extra code for this; it fires for every arch string
+   uniformly. Only add to it if a new *quant mode* (not arch) introduces its
+   own variable-bit-width kernel matrix — see `docs/WEIGHT_QUANTS.md` §4.4.
 2. **Add a golden-token test.** Temperature-0, byte-identical output against a
    recorded reference. Gate it with:
    ```

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -201,8 +201,11 @@ Top-level `config.json` (same flat layout as Qwen2).
 
 ### Weight quantization
 
-Full coverage: bf16, affine (any group/bits), mxfp8. Bonsai-8B uses `g128 b2`
-(2-bit ternary affine — the `prism-ml/Ternary-Bonsai-8B-mlx-2bit` snapshot).
+Full coverage: bf16, affine (any group/bits in `{2,3,4,5,6,8}` — see
+`docs/WEIGHT_QUANTS.md` §4.4), mxfp8. Bonsai-8B uses `g128 b2` (2-bit ternary
+affine — the `prism-ml/Ternary-Bonsai-8B-mlx-2bit` snapshot). An affine
+`bits` value outside the supported set (e.g. an unreleased 1-bit checkpoint)
+is rejected at load, before the server advertises the model.
 
 ### KV quantization
 
@@ -347,6 +350,13 @@ uniformity cast to float (affine) scales — gated on `scales.dtype()`, not on t
 arch or global quant mode, so a mixed checkpoint loads both codecs correctly. The
 PARO variant (`Qwen3_5ForConditionalGeneration`) uses a paroquant layout detected
 by the `is_paroquant` signal in `KvCacheBuilder::resolve_default`.
+
+Affine `bits` is gated at load to `{2,3,4,5,6,8}` (`docs/WEIGHT_QUANTS.md`
+§4.4) — e.g. `prism-ml/Bonsai-27B-mlx-1bit` (structurally identical to the
+2-bit `Ternary-Bonsai-27B-mlx-2bit` sibling, `quantization.bits=1`) fails at
+load with a clear error rather than loading and then dying per-token at
+first prefill (no 1-bit `affine_dequantize` kernel in stock mlx-c; unreleased
+upstream, ml-explore/mlx#3161).
 
 ### KV quantization
 

--- a/docs/WEIGHT_QUANTS.md
+++ b/docs/WEIGHT_QUANTS.md
@@ -235,6 +235,17 @@ stored little-endian.
 The `q8_g128` path has a GPU (Metal) kernel; all other affine variants
 dequant on the CPU path during model load.
 
+**Load-time bit-width gate.** `bits` outside `{2,3,4,5,6,8}` (e.g. an
+unreleased 1-bit affine checkpoint) has no dequant kernel in either the CPU
+codec (`affine.rs::validate_params`) or the linked mlx-c's GPU
+`affine_dequantize_*` / `quantized_matmul` kernels. `rmlx_models::arch::loader`
+pre-flights the model's declared `quantization.bits` against
+`rmlx_quant::affine::SUPPORTED_BITS` before any tensor I/O — an unsupported
+bit-width fails the load immediately with one clear error instead of
+"loading" successfully and then dying per-token at first prefill with a
+buried Metal kernel-load error. See `docs/ADDING_A_MODEL.md` for how this
+gate composes with a new architecture.
+
 ### 4.5 Dequant cost
 
 Affine dequant runs once at model load, not per-token. The cost is linear

--- a/docs/WEIGHT_QUANTS.md
+++ b/docs/WEIGHT_QUANTS.md
@@ -239,7 +239,8 @@ dequant on the CPU path during model load.
 unreleased 1-bit affine checkpoint) has no dequant kernel in either the CPU
 codec (`affine.rs::validate_params`) or the linked mlx-c's GPU
 `affine_dequantize_*` / `quantized_matmul` kernels. `rmlx_models::arch::loader`
-pre-flights the model's declared `quantization.bits` against
+pre-flights the model's declared `quantization.bits` — the global default
+*and* every `quantization.tensor_overrides` entry — against
 `rmlx_quant::affine::SUPPORTED_BITS` before any tensor I/O — an unsupported
 bit-width fails the load immediately with one clear error instead of
 "loading" successfully and then dying per-token at first prefill with a


### PR DESCRIPTION
Closes #208.

## Problem
When a model's weight-quant bit-width has no dequant kernel in the linked mlx-c (concrete case: `bits=1` affine), rMLX loaded the graph "successfully", advertised the model on `/v1/models`, then died **per-token** at generation with 48× `Unable to load kernel affine_dequantize_bfloat16_t_gs_128_b_1` and returned a generic 503. Confusing load-then-die instead of a clean rejection.

## Fix
Load-time pre-flight in `arch::load_model`, before any tensor mmap:
- Validates the resolved **affine** weight-quant `bits` against the shared `rmlx_quant::affine::SUPPORTED_BITS` = `{2,3,4,5,6,8}`.
- Checks the **global default and every `tensor_overrides` entry** (a config can carry a supported global bit-width with an unsupported affine override — proven by `config_tests.rs::load_config_accepts_normal_tensor_overrides`).
- Gates on the **exact `"affine"` mode string** (not the lossy `QuantMode::from` fallback), so unknown/novel fixed-format modes are skipped, never false-rejected.
- Non-affine modes (mxfp8/mxfp4/nvfp4/awq) and configs without a `quantization` block are no-ops.

On mismatch, one clear error at load:
```
weight quant bits=1 (affine) unsupported by this build's MLX/mlx-c (supported: 2,3,4,5,6,8); 1-bit needs ml-explore/mlx#3161 (unreleased)
```

## Proof (real models, temp=0)
- **Negative** — `Bonsai-27B-mlx-1bit`: now fails at LOAD (exit 3) with the single clear error, no per-token spam, no 503 loop.
- **No-regression** (incl. two models with real per-tensor overrides): gemma-4-e4b-mxfp8, **gemma-4-26b-a4b-mxfp8** (router/gate overrides), **Qwen3.6-35B-A3B-8bit** (gate overrides), Bonsai-8B 2bit, Bonsai-27B 2bit — all load + serve coherent text.
- 12 loader unit tests green, covering all supported bits, the affine/non-affine gate, the override-reject path, and the unknown-mode-skip path.

## Docs
Updated `docs/WEIGHT_QUANTS.md`, `docs/MODELS.md`, `docs/ADDING_A_MODEL.md`.

Reviewed by blind rust-reviewer; the per-tensor-override false-accept it flagged (MEDIUM) is closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)