### PR TITLE
fix(baseline): error loudly on GPU prompt truncation instead of silent-halving (#213)

### DIFF
--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -18,15 +18,61 @@ use rmlx_mlx::Device;
 use rmlx_models::arch;
 use tracing::{info, info_span, warn};
 
-/// Maximum prompt token count.
+/// Default prompt token cap.
 ///
 /// Raised from the historical 4096 (which silently truncated CPU-mode runs to
 /// keep per-step times sane) to 65_536 so the bench harness can submit
-/// full 8k+ canonical prompts. The cap exists only as a sanity guard against
-/// pathologically large inputs; with the KV cache and chunked prefill in place,
-/// per-step time no longer scales with raw prompt length and the historic
-/// truncation rationale no longer applies.
+/// full 8k+ canonical prompts. On `--device cpu` this remains a genuine sanity
+/// guard: CPU forward is O(N^2), so a pathologically long prompt makes a bench
+/// run take pathologically long. On `--device gpu` that rationale does not
+/// apply -- per-step time no longer scales with raw prompt length once the KV
+/// cache and chunked prefill are in place -- so exceeding this default on GPU
+/// is treated as a hard error rather than a silent truncation (see
+/// `resolve_prompt_truncation`).
 pub(crate) const MAX_PROMPT_TOKENS: usize = 65_536;
+
+/// Decide how to handle a tokenized prompt longer than `max_prompt_tokens`.
+///
+/// Returns the effective prompt length to use (`Ok`), or an error when
+/// silently truncating would misrepresent the measurement.
+///
+/// - Prompt fits under the cap: no-op, returns the prompt length unchanged.
+/// - `--device cpu`: always silently truncates (with a `warn!`) -- CPU
+///   forward is genuinely O(N^2), so the cap is a real sanity guard and the
+///   historical behavior is preserved.
+/// - `--device gpu` with an *explicit* `--max-prompt-tokens` or
+///   `--allow-truncate`: the caller opted in, so truncate with a `warn!`
+///   exactly as before.
+/// - `--device gpu` with the default cap and no opt-in: a truncated run would
+///   silently record a shorter measurement that looks like a full-length one,
+///   so this is a hard error instead of a WARN-only truncation.
+pub(crate) fn resolve_prompt_truncation(
+    prompt_len: usize,
+    max_prompt_tokens: usize,
+    device: Device,
+    cap_is_explicit: bool,
+    allow_truncate: bool,
+) -> anyhow::Result<usize> {
+    if prompt_len <= max_prompt_tokens {
+        return Ok(prompt_len);
+    }
+
+    if device == Device::Cpu || cap_is_explicit || allow_truncate {
+        warn!(
+            original = prompt_len,
+            cap = max_prompt_tokens,
+            "baseline: prompt truncated to cap"
+        );
+        return Ok(max_prompt_tokens);
+    }
+
+    Err(anyhow::anyhow!(
+        "prompt has {prompt_len} tokens, exceeding the default --max-prompt-tokens cap of \
+         {max_prompt_tokens} on --device gpu. Silently truncating would record a shorter run \
+         that looks like a full-length measurement. Pass --max-prompt-tokens {prompt_len} (or \
+         higher) to measure the full prompt, or --allow-truncate to opt into truncation."
+    ))
+}
 
 /// Escape a field value for RFC 4180 CSV: wrap in double-quotes if the value
 /// contains a comma, double-quote, or newline, escaping interior double-quotes
@@ -136,8 +182,10 @@ pub(crate) fn compute_phase_timing(
 /// Record a performance baseline for the given model snapshot.
 ///
 /// Steps:
-/// 1. Parse device, read prompt file, tokenize, truncate to `max_prompt_tokens`
-///    (CLI-configurable; defaults to `MAX_PROMPT_TOKENS`).
+/// 1. Parse device, read prompt file, tokenize, then resolve against
+///    `max_prompt_tokens` (CLI-configurable; defaults to `MAX_PROMPT_TOKENS`)
+///    via `resolve_prompt_truncation` -- truncates on `--device cpu` or an
+///    explicit opt-in, errors loudly on `--device gpu` with the default cap.
 /// 2. `arch::load_model` -- capture `load_ms`.
 /// 3. `arch.generate_greedy` -- per-token `step_fn` callback captures wall-clock
 /// so prefill (TTFT) and steady-state decode are timed SEPARATELY.
@@ -160,6 +208,8 @@ pub(crate) fn run_baseline(
     kv_quant_override: Option<rmlx_kv_quant::KvQuant>,
     max_ctx_override: Option<i32>,
     max_prompt_tokens: usize,
+    cap_is_explicit: bool,
+    allow_truncate: bool,
     yarn_override: Option<rmlx_models::qwen3::YarnOverride>,
     sink: &EventRecorder,
     record_args: Option<BaselineRecordArgs<'_>>,
@@ -191,15 +241,17 @@ pub(crate) fn run_baseline(
 
     let mut prompt_ids: Vec<u32> = encoding.get_ids().to_vec();
 
-    // Truncate to `max_prompt_tokens` (CLI-configurable; CPU forward time is O(N^2)).
-    if prompt_ids.len() > max_prompt_tokens {
-        warn!(
-            original = prompt_ids.len(),
-            cap = max_prompt_tokens,
-            "baseline: prompt truncated to cap"
-        );
-        prompt_ids.truncate(max_prompt_tokens);
-    }
+    // Truncate to `max_prompt_tokens` when the cap allows it; on GPU with the
+    // default (non-explicit) cap this is a hard error instead -- see
+    // `resolve_prompt_truncation`.
+    let effective_len = resolve_prompt_truncation(
+        prompt_ids.len(),
+        max_prompt_tokens,
+        device,
+        cap_is_explicit,
+        allow_truncate,
+    )?;
+    prompt_ids.truncate(effective_len);
     let prompt_token_count = prompt_ids.len();
 
     info!(

--- a/crates/rmlx-cli/src/commands/baseline_tests.rs
+++ b/crates/rmlx-cli/src/commands/baseline_tests.rs
@@ -266,6 +266,15 @@ fn resolve_prompt_truncation_under_cap_is_a_noop_on_cpu() {
     assert_eq!(len, 1_000);
 }
 
+/// Equality boundary on the GPU-default (no opt-in) path: a prompt exactly
+/// at the cap must not error -- pins the `<=` guard against a `<` mutation.
+#[test]
+fn resolve_prompt_truncation_gpu_at_cap_exactly_is_a_noop() {
+    let len = resolve_prompt_truncation(65_536, 65_536, Device::Gpu, false, false)
+        .expect("prompt exactly at the default cap must not error");
+    assert_eq!(len, 65_536);
+}
+
 /// The bug this fixes: a >65536-token prompt on `--device gpu` with the
 /// default cap and no opt-in must fail loudly, not silently truncate down to
 /// a shorter measurement that looks like a full-length one.

--- a/crates/rmlx-cli/src/commands/baseline_tests.rs
+++ b/crates/rmlx-cli/src/commands/baseline_tests.rs
@@ -247,3 +247,68 @@ fn build_record_git_sha_blank_string_is_null() {
 
     assert!(rec["git_sha"].is_null());
 }
+
+// ── resolve_prompt_truncation ────────────────────────────────────────────
+// Model-agnostic: pure function over (prompt_len, cap, device, flags), no
+// model load / GPU context involved.
+
+#[test]
+fn resolve_prompt_truncation_under_cap_is_a_noop_on_gpu() {
+    let len =
+        resolve_prompt_truncation(1_000, 65_536, Device::Gpu, false, false).expect("under cap");
+    assert_eq!(len, 1_000);
+}
+
+#[test]
+fn resolve_prompt_truncation_under_cap_is_a_noop_on_cpu() {
+    let len =
+        resolve_prompt_truncation(1_000, 65_536, Device::Cpu, false, false).expect("under cap");
+    assert_eq!(len, 1_000);
+}
+
+/// The bug this fixes: a >65536-token prompt on `--device gpu` with the
+/// default cap and no opt-in must fail loudly, not silently truncate down to
+/// a shorter measurement that looks like a full-length one.
+#[test]
+fn resolve_prompt_truncation_gpu_default_cap_over_limit_errors_loudly() {
+    let err = resolve_prompt_truncation(131_072, 65_536, Device::Gpu, false, false)
+        .expect_err("must error, not silently truncate");
+    let msg = err.to_string();
+    assert!(msg.contains("131072"), "{msg}");
+    assert!(msg.contains("65536"), "{msg}");
+    assert!(msg.contains("--max-prompt-tokens"), "{msg}");
+    assert!(msg.contains("--allow-truncate"), "{msg}");
+}
+
+#[test]
+fn resolve_prompt_truncation_gpu_explicit_cap_over_limit_truncates() {
+    // An explicit `--max-prompt-tokens` is itself the opt-in.
+    let len = resolve_prompt_truncation(131_072, 65_536, Device::Gpu, true, false)
+        .expect("explicit cap truncates instead of erroring");
+    assert_eq!(len, 65_536);
+}
+
+#[test]
+fn resolve_prompt_truncation_gpu_allow_truncate_over_limit_truncates() {
+    let len = resolve_prompt_truncation(131_072, 65_536, Device::Gpu, false, true)
+        .expect("--allow-truncate opts into truncation");
+    assert_eq!(len, 65_536);
+}
+
+/// `--device gpu` measuring the full length requires raising the cap; when
+/// the caller does that, the full prompt is measured (not truncated).
+#[test]
+fn resolve_prompt_truncation_gpu_full_length_when_cap_raised() {
+    let len = resolve_prompt_truncation(131_072, 131_072, Device::Gpu, true, false)
+        .expect("prompt exactly at the raised cap");
+    assert_eq!(len, 131_072);
+}
+
+#[test]
+fn resolve_prompt_truncation_cpu_over_limit_always_truncates() {
+    // CPU forward is genuinely O(N^2); the historical silent-truncate
+    // behavior is preserved regardless of explicit/allow-truncate flags.
+    let len = resolve_prompt_truncation(131_072, 65_536, Device::Cpu, false, false)
+        .expect("cpu always truncates");
+    assert_eq!(len, 65_536);
+}

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -1020,8 +1020,8 @@ enum Cmd {
         #[arg(long, visible_alias = "ctx-max")]
         max_ctx: Option<u32>,
         /// Truncate the tokenized prompt to at most this many tokens. Defaults to
-        /// the built-in cap (see long-help). Passing this flag explicitly opts
-        /// into truncation on `--device gpu`; raise it to bench longer contexts
+        /// the built-in cap (65536). Passing this flag explicitly opts into
+        /// truncation on `--device gpu`; raise it to bench longer contexts
         /// (e.g. 128k) without truncation. Must be >= 1.
         #[arg(long, value_name = "N")]
         max_prompt_tokens: Option<usize>,

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -1019,12 +1019,19 @@ enum Cmd {
         /// set.
         #[arg(long, visible_alias = "ctx-max")]
         max_ctx: Option<u32>,
-        /// Truncate the tokenized prompt to at most this many tokens (CPU forward
-        /// is O(N^2), so a cap guards against pathological bench times). Defaults
-        /// to the built-in cap; raise it to bench longer contexts (e.g. 128k).
-        /// Must be >= 1.
-        #[arg(long, value_name = "N", default_value_t = commands::baseline::MAX_PROMPT_TOKENS)]
-        max_prompt_tokens: usize,
+        /// Truncate the tokenized prompt to at most this many tokens. Defaults to
+        /// the built-in cap (see long-help). Passing this flag explicitly opts
+        /// into truncation on `--device gpu`; raise it to bench longer contexts
+        /// (e.g. 128k) without truncation. Must be >= 1.
+        #[arg(long, value_name = "N")]
+        max_prompt_tokens: Option<usize>,
+        /// Opt into silently truncating a too-long prompt to the default
+        /// `--max-prompt-tokens` cap on `--device gpu` instead of erroring.
+        /// `--device cpu` always truncates (real O(N^2) forward cost) regardless
+        /// of this flag. Has no effect when `--max-prompt-tokens` is passed
+        /// explicitly (that is itself an opt-in to truncation).
+        #[arg(long, default_value_t = false)]
+        allow_truncate: bool,
         /// Free-form label stamped into the metrics record's `notes` column
         /// (used by the bench harness to group cells under a campaign name).
         #[arg(long)]
@@ -1903,6 +1910,7 @@ fn main() -> Result<()> {
             kv_group_size,
             max_ctx,
             max_prompt_tokens,
+            allow_truncate,
             label: bench_label,
             record,
             git_sha,
@@ -1910,7 +1918,10 @@ fn main() -> Result<()> {
             yarn_factor,
             yarn_original_max,
         } => {
-            let max_prompt_tokens = parse_max_prompt_tokens(max_prompt_tokens)?;
+            let cap_is_explicit = max_prompt_tokens.is_some();
+            let max_prompt_tokens = parse_max_prompt_tokens(
+                max_prompt_tokens.unwrap_or(commands::baseline::MAX_PROMPT_TOKENS),
+            )?;
             // --kv-preset pre-resolution. resolve_preset_arg runs the
             // auto-selector for KvPresetArg::Auto.
             let (dev, kv_quant_resolved, max_ctx_override) = if let Some(preset_arg) = kv_preset {
@@ -2034,6 +2045,8 @@ fn main() -> Result<()> {
                 Some(kv_quant_resolved),
                 max_ctx_override,
                 max_prompt_tokens,
+                cap_is_explicit,
+                allow_truncate,
                 yarn_override,
                 &sink,
                 record_args,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -304,9 +304,42 @@ rmlx baseline --model /path/to/snapshot --prompt-tokens 4096 --label "8k-bench"
 | `--kv-bits` | float | — | Bit-width alias. Mutually exclusive with `--kv-quant` and `--cache-type-*`. |
 | `--kv-group-size` | usize | 64 | Group size for `--kv-bits`. |
 | `--max-ctx` / `--ctx-max` | u32 | (from model) | KV cache buffer token capacity. Must be ≥ 256 when set. |
+| `--max-prompt-tokens` | usize | 65536 | Cap on the tokenized prompt length. See "Prompt-length cap" below — behavior differs by `--device`. Must be ≥ 1 when set. |
+| `--allow-truncate` | bool flag | off | Opt into silently truncating a too-long prompt to the `--max-prompt-tokens` cap on `--device gpu` instead of erroring. No effect on `--device cpu` (always truncates) or when `--max-prompt-tokens` is passed explicitly (that is itself an opt-in). |
 | `--label` | string | — | Free-form campaign label stamped into the metrics record's `notes` column. |
 | `--record` | bool flag | off | Emit a §8.5 `RunRecord` to the metrics buffer and ingest into `runs.db` in-process. |
 | `--git-sha` | string | — | Commit SHA to stamp on the emitted record's `git_sha` column (only meaningful with `--record`). Provenance the caller supplies — the binary does not and cannot determine the commit it was built from. Absent by default (`git_sha` is `NULL`). |
+
+#### Prompt-length cap
+
+`--max-prompt-tokens` guards against pathologically long prompts inflating
+bench time. The two devices have genuinely different behavior once the
+tokenized prompt exceeds the cap:
+
+- **`--device cpu`**: always truncates (with a `tracing::warn!`), matching the
+  historical behavior. CPU forward is O(N²), so the cap is a real sanity
+  guard against unbounded per-step cost.
+- **`--device gpu`** with the **default** cap (`--max-prompt-tokens` not
+  passed) and no `--allow-truncate`: **hard error**, not a truncation. Per-step
+  time no longer scales with raw prompt length on GPU once the KV cache and
+  chunked prefill are in place, so silently truncating would record a
+  shorter run that looks like a valid full-length measurement — a
+  long-context bench footgun. Raise the cap explicitly
+  (`--max-prompt-tokens <N>`) to measure the full prompt, or pass
+  `--allow-truncate` to opt into the old silent-truncate behavior.
+- **`--device gpu`** with an **explicit** `--max-prompt-tokens` or with
+  `--allow-truncate` set: truncates with a `tracing::warn!`, same as CPU —
+  the caller has explicitly opted in.
+
+```bash
+# 128k prompt on GPU: raise the cap to measure it in full (no truncation).
+rmlx baseline --model /path/to/snapshot --prompt-tokens 131072 \
+  --device gpu --max-ctx 131072 --max-prompt-tokens 131072
+
+# 128k prompt on GPU, default cap: errors loudly instead of silently
+# recording a 65536-token run under a 128k label.
+rmlx baseline --model /path/to/snapshot --prompt-tokens 131072 --device gpu
+```
 
 ---
 


### PR DESCRIPTION
## Summary
Closes #213. `rmlx baseline --device gpu` silently truncated prompts >65536 tokens to `MAX_PROMPT_TOKENS`, so a 128k run recorded a 65k-length KV-MB that *looked* like a valid 128k measurement — a measurement footgun.

Now, on `--device gpu`, an over-cap prompt is a **loud hard error** unless the caller opts in with `--max-prompt-tokens <N>` or the new `--allow-truncate`. CPU mode is unchanged (its O(N²) forward rationale is real → still silently truncates with a WARN).

## Changes
- `crates/rmlx-cli/src/commands/baseline.rs` — new `resolve_prompt_truncation()`; GPU + default cap + over-length → error (fails fast, before model load).
- `crates/rmlx-cli/src/main.rs` — `--max-prompt-tokens` now `Option<usize>` (explicit-vs-default detectable); new `--allow-truncate`; help states the concrete `65536` default.
- `crates/rmlx-cli/src/commands/baseline_tests.rs` — 8 model-agnostic unit tests incl. the `len == cap` equality boundary.
- `docs/CLI.md` — "Prompt-length cap" subsection + flag docs.

## Proof
- Gate: `make lint` clean, `cargo test -p rmlx-cli` 230 passed (×2).
- Real model (gemma-4-e2b, 153261-token fixture):
  - default GPU → **exit 1**, errors in 0.37s *before* model load: `prompt has 153261 tokens, exceeding the default --max-prompt-tokens cap of 65536 … or --allow-truncate to opt into truncation.`
  - `--allow-truncate --max-prompt-tokens 256` → **exit 0**, WARN + real measurement emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)