### PR TITLE
fix(prompt-cache): refuse over-cap snapshot admission — kill warm-cache 128k decode stall (#212)

### DIFF
--- a/crates/rmlx-models/src/bitnet/generate.rs
+++ b/crates/rmlx-models/src/bitnet/generate.rs
@@ -377,15 +377,16 @@ pub fn generate_greedy(
                     };
                     PROMPT_CACHE.with_inner_mut(|guard| {
                         if let Some(cache) = guard.as_mut() {
-                            cache.push(entry);
-                            let stats = cache.stats();
-                            tracing::debug!(
-                                prompt_len = prompt_ids.len(),
-                                cache_hits = stats.hits,
-                                cache_misses = stats.misses,
-                                cache_bytes = stats.bytes,
-                                "bitnet generate_greedy: pushed snapshot to prompt cache (miss path)"
-                            );
+                            if cache.push(entry).is_some() {
+                                let stats = cache.stats();
+                                tracing::debug!(
+                                    prompt_len = prompt_ids.len(),
+                                    cache_hits = stats.hits,
+                                    cache_misses = stats.misses,
+                                    cache_bytes = stats.bytes,
+                                    "bitnet generate_greedy: pushed snapshot to prompt cache (miss path)"
+                                );
+                            }
                         }
                     });
                 }

--- a/crates/rmlx-models/src/gemma3/generate.rs
+++ b/crates/rmlx-models/src/gemma3/generate.rs
@@ -394,15 +394,16 @@ pub fn generate_greedy<'a>(
                     };
                     PROMPT_CACHE.with_inner_mut(|guard| {
                         if let Some(cache) = guard.as_mut() {
-                            cache.push(entry);
-                            let stats = cache.stats();
-                            tracing::debug!(
-                                prompt_len = prompt_ids.len(),
-                                cache_hits = stats.hits,
-                                cache_misses = stats.misses,
-                                cache_bytes = stats.bytes,
-                                "gemma3 generate_greedy: pushed snapshot to prompt cache (miss path)"
-                            );
+                            if cache.push(entry).is_some() {
+                                let stats = cache.stats();
+                                tracing::debug!(
+                                    prompt_len = prompt_ids.len(),
+                                    cache_hits = stats.hits,
+                                    cache_misses = stats.misses,
+                                    cache_bytes = stats.bytes,
+                                    "gemma3 generate_greedy: pushed snapshot to prompt cache (miss path)"
+                                );
+                            }
                         }
                     });
                 }

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -630,7 +630,7 @@ pub fn generate_greedy<'a>(
                             // above. Stacks with `layout_key` (XOR) exactly like
                             // the SSD-tier salt.
                             let lk = crate::gemma4::prompt_cache::active_layout_key();
-                            cache.push(Gemma4Entry {
+                            let stored = cache.push(Gemma4Entry {
                                 prompt_token_ids: prompt_ids.to_vec(),
                                 block_hashes: crate::prompt_cache::chained_block_hashes_seeded(
                                     prompt_ids,
@@ -644,13 +644,15 @@ pub fn generate_greedy<'a>(
                                 kv_quant: Some(kv_quant),
                                 is_ssd_hydrated: false,
                             });
-                            tracing::debug!(
-                                prompt_len = prompt_ids.len(),
-                                token_id = last_id,
-                                n_slots = cache.slots.len(),
-                                cache_path = if is_prefix { "prefix" } else { "miss" },
-                                "gemma4 generate_greedy: full-prompt snapshot saved"
-                            );
+                            if stored.is_some() {
+                                tracing::debug!(
+                                    prompt_len = prompt_ids.len(),
+                                    token_id = last_id,
+                                    n_slots = cache.slots.len(),
+                                    cache_path = if is_prefix { "prefix" } else { "miss" },
+                                    "gemma4 generate_greedy: full-prompt snapshot saved"
+                                );
+                            }
                         }
                     });
                 }

--- a/crates/rmlx-models/src/laguna/generate.rs
+++ b/crates/rmlx-models/src/laguna/generate.rs
@@ -445,15 +445,16 @@ pub fn generate_greedy(
                     };
                     PROMPT_CACHE.with_inner_mut(|guard| {
                         if let Some(cache) = guard.as_mut() {
-                            cache.push(entry);
-                            let stats = cache.stats();
-                            tracing::debug!(
-                                prompt_len = prompt_ids.len(),
-                                cache_hits = stats.hits,
-                                cache_misses = stats.misses,
-                                cache_bytes = stats.bytes,
-                                "laguna generate_greedy: pushed snapshot to prompt cache (miss path)"
-                            );
+                            if cache.push(entry).is_some() {
+                                let stats = cache.stats();
+                                tracing::debug!(
+                                    prompt_len = prompt_ids.len(),
+                                    cache_hits = stats.hits,
+                                    cache_misses = stats.misses,
+                                    cache_bytes = stats.bytes,
+                                    "laguna generate_greedy: pushed snapshot to prompt cache (miss path)"
+                                );
+                            }
                         }
                     });
                 }

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -794,12 +794,12 @@ impl<E: PromptCacheEntry> PromptCache<E> {
         // Existing (smaller, valid) slots are left intact — evicting them to
         // make room for an entry that still could not fit would only thrash.
         if new_bytes > self.max_bytes {
-            tracing::debug!(
+            tracing::warn!(
                 entry_bytes = new_bytes,
                 max_bytes = self.max_bytes,
                 n_slots = self.slots.len(),
-                "prompt cache: snapshot KV exceeds RAM cap — not admitted \
-                 (a repeat request re-prefills instead of reusing an over-cap slot)"
+                "prompt cache: snapshot KV exceeds RAM cap — not admitted; \
+                 raise --prompt-cache-ram-gb to cache this context"
             );
             return None;
         }

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -603,11 +603,19 @@ impl<E: PromptCacheEntry> PromptCache<E> {
         self.ssd = Some(source);
         match result {
             Ok(Some(entry)) => {
-                self.push(entry);
-                self.stats.ssd_hits += 1;
-                // `push` appended at the end (after any eviction); the new
-                // entry is the last slot.
-                Some(self.slots.len() - 1)
+                if let Some(idx) = self.push(entry) {
+                    self.stats.ssd_hits += 1;
+                    Some(idx)
+                } else {
+                    // Reconstructed block's KV alone exceeds the RAM cap, so it
+                    // was refused admission — a hydrate that cannot be resident
+                    // is a miss; the caller re-prefills.
+                    tracing::debug!(
+                        prompt_len = prompt_ids.len(),
+                        "ssd-hydrate: reconstructed block exceeds RAM cap — treating as miss"
+                    );
+                    None
+                }
             }
             Ok(None) => None,
             Err(e) => {
@@ -755,9 +763,17 @@ impl<E: PromptCacheEntry> PromptCache<E> {
 
     /// Push a new entry, evicting LRU slot(s) as needed.
     ///
-    /// Eviction order:
+    /// Returns `Some(slot_index)` of the newly-stored slot, or `None` when the
+    /// entry was refused admission (its own KV alone exceeds the RAM cap — see
+    /// the over-cap guard below).
+    ///
+    /// Admission + eviction order:
+    /// 0. Over-cap guard: if the incoming entry's KV alone exceeds `max_bytes`,
+    ///    refuse admission (return `None`) WITHOUT evicting any existing slot.
     /// 1. While `total_kv_bytes + new_entry_bytes > max_bytes` and slots
+    ///    remain: evict the LRU slot.
     /// 2. If `slots.len() == capacity`: drop the slot with the smallest
+    ///    `last_used_seq`.
     ///
     /// Either cap can trigger independently. Each eviction increments
     /// `stats.evictions`.
@@ -765,8 +781,28 @@ impl<E: PromptCacheEntry> PromptCache<E> {
         clippy::indexing_slicing,
         reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
     )]
-    pub(crate) fn push(&mut self, entry: E) {
+    pub(crate) fn push(&mut self, entry: E) -> Option<usize> {
         let new_bytes = entry.kv_bytes();
+
+        // --- Over-cap admission guard ---
+        // A single snapshot whose resident KV alone exceeds the cap must not be
+        // admitted. Admitting it violates the cap and, worse, the next warm
+        // (Exact) hit deep-clones the slot and copy-on-writes the full-size KV
+        // on the first decode append — doubling peak residency and stalling
+        // decode. Refusing admission bounds peak memory to one live copy; the
+        // repeat request simply re-prefills, exactly like the cold request.
+        // Existing (smaller, valid) slots are left intact — evicting them to
+        // make room for an entry that still could not fit would only thrash.
+        if new_bytes > self.max_bytes {
+            tracing::debug!(
+                entry_bytes = new_bytes,
+                max_bytes = self.max_bytes,
+                n_slots = self.slots.len(),
+                "prompt cache: snapshot KV exceeds RAM cap — not admitted \
+                 (a repeat request re-prefills instead of reusing an over-cap slot)"
+            );
+            return None;
+        }
 
         // --- RAM-cap eviction ---
         let mut total: u64 = self.slots.iter().map(|s| s.entry.kv_bytes()).sum();
@@ -802,6 +838,7 @@ impl<E: PromptCacheEntry> PromptCache<E> {
             last_used_seq: self.seq,
             slot_uid,
         });
+        Some(self.slots.len() - 1)
     }
 
     /// Evict the slot at `idx` and bump `stats.evictions`.

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -1225,6 +1225,49 @@ fn ssd_miss_leaves_ram_untouched() {
     assert_eq!(cache.slots.len(), 0);
 }
 
+/// over-cap admission guard applies to the SSD-hydrate path too: a
+/// reconstructed block whose `kv_bytes()` alone exceeds the RAM cap is
+/// refused admission by `push`, so `hydrate_from_ssd` must surface it as a
+/// miss — NOT a served hit. `stats().ssd_hits` must NOT be bumped for an
+/// entry that was never actually stored in RAM.
+#[test]
+#[allow(
+    clippy::clone_on_ref_ptr,
+    reason = "intentional Arc::clone — explicit form aids grep for shared-ownership transfer sites"
+)]
+fn ssd_hydrate_over_cap_entry_is_not_counted_as_hit() {
+    let prompt: Vec<u32> = make_ids(2 * BLOCK_TOKENS); // kv_bytes() = 512 * 8 = 4096
+                                                       // Cap strictly below the entry the mock source will reconstruct.
+    let tiny_cap = (prompt.len() as u64 * 8) - 1;
+    let mut cache: PromptCache<TestEntry> = PromptCache::with_max_bytes(4, tiny_cap);
+    let calls = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    cache.set_ssd_source(Box::new(MockSource {
+        entry_ids: prompt.clone(),
+        calls: calls.clone(),
+    }));
+
+    let slot = cache.hydrate_from_ssd(&prompt);
+    assert!(
+        slot.is_none(),
+        "an over-cap reconstructed block must surface as a miss"
+    );
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "the source was queried exactly once"
+    );
+    assert_eq!(
+        cache.stats().ssd_hits,
+        0,
+        "an over-cap hydrate must NOT be counted as a served ssd_hit"
+    );
+    assert_eq!(
+        cache.slots.len(),
+        0,
+        "the over-cap block must not occupy a RAM slot"
+    );
+}
+
 /// correctness: a partial hit truncates to exactly the matched block
 /// boundary, so the re-prefilled tail starts at the correct absolute
 /// position `matched_blocks * BLOCK_TOKENS`. A wrong truncation length here

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -731,6 +731,95 @@ fn evictions_counter_tracked() {
     assert_eq!(cache.stats().evictions, 2, "two evictions after 4th push");
 }
 
+/// Over-cap admission guard: a single snapshot whose KV alone exceeds the RAM
+/// cap must NOT be admitted. Admitting it violates the cap and, on the next
+/// warm (Exact) hit, forces a second full-size residency (deep_clone +
+/// copy-on-write of the whole KV on the first decode append) — the warm-cache
+/// decode stall on large-KV codecs. Refusing admission bounds peak memory to a
+/// single live copy and makes the repeat request re-prefill, exactly like the
+/// cold request (warm ≈ cold). Model- and codec-agnostic.
+#[test]
+fn over_cap_snapshot_is_not_admitted() {
+    let n = 2 * BLOCK_TOKENS; // 512 ids → kv_bytes() = 512 * 8 = 4096
+    let entry_bytes = n as u64 * 8;
+
+    // Cap strictly below one entry → the entry alone cannot fit.
+    let tiny_cap = entry_bytes - 1;
+    let mut cache: PromptCache<TestEntry> = PromptCache::with_max_bytes(4, tiny_cap);
+
+    let prompt = make_ids(n);
+    // Cold "store": the over-cap entry is refused admission.
+    let stored = cache.push(TestEntry::new(prompt.clone()));
+    assert!(
+        stored.is_none(),
+        "an over-cap snapshot must be refused admission"
+    );
+    assert_eq!(
+        cache.slots.len(),
+        0,
+        "no slot is created for an over-cap snapshot"
+    );
+
+    // Warm request for the SAME prompt: a Miss (re-prefill), NOT an Exact hit on
+    // an over-cap slot — the invariant that removes the warm-cache stall.
+    let warm = cache.find_best_prefix(&prompt, FNV_OFFSET);
+    assert!(
+        warm.is_none(),
+        "warm request must miss (re-prefill), not reuse an over-cap slot"
+    );
+
+    // An entry that DOES fit the cap is still admitted (guard is exactly at the
+    // boundary: `new_bytes > max_bytes`, so `== max_bytes` fits).
+    let mut ok_cache: PromptCache<TestEntry> = PromptCache::with_max_bytes(4, entry_bytes);
+    let ok_stored = ok_cache.push(TestEntry::new(prompt.clone()));
+    assert_eq!(ok_stored, Some(0), "an entry that fits the cap is admitted");
+    assert!(
+        ok_cache.find_best_prefix(&prompt, FNV_OFFSET).is_some(),
+        "a fitting entry is reusable"
+    );
+}
+
+/// Refusing an over-cap snapshot must leave existing (valid, smaller) slots
+/// intact — the guard never evicts to make room for something that still could
+/// not fit.
+#[test]
+fn over_cap_refusal_preserves_existing_slots() {
+    let small_n = BLOCK_TOKENS; // 256 ids → 2048 bytes
+    let small_bytes = small_n as u64 * 8;
+    // Cap holds the small entry but not the large one.
+    let cap = small_bytes + 100;
+    let mut cache: PromptCache<TestEntry> = PromptCache::with_max_bytes(4, cap);
+
+    let small_prompt: Vec<u32> = (0..small_n as u32).map(|x| x * 2).collect();
+    assert_eq!(
+        cache.push(TestEntry::new(small_prompt.clone())),
+        Some(0),
+        "the small entry fits and is admitted"
+    );
+
+    // Over-cap entry (distinct prompt so it cannot prefix-match): refused, and
+    // the pre-existing small slot survives with no eviction.
+    let big_prompt: Vec<u32> = (0..(4 * BLOCK_TOKENS) as u32).map(|x| x * 2 + 1).collect();
+    assert!(
+        cache.push(TestEntry::new(big_prompt)).is_none(),
+        "the over-cap entry is refused admission"
+    );
+    assert_eq!(
+        cache.slots.len(),
+        1,
+        "the valid small slot is left untouched by the over-cap refusal"
+    );
+    assert_eq!(
+        cache.stats().evictions,
+        0,
+        "an over-cap refusal evicts nothing"
+    );
+    assert!(
+        cache.find_best_prefix(&small_prompt, FNV_OFFSET).is_some(),
+        "the small slot is still reusable after the refusal"
+    );
+}
+
 /// C1: long-prompt block-aligned partial hit.
 ///
 /// Cache a 4096-token prompt (16 full 256-tok blocks). Query with a

--- a/crates/rmlx-models/src/qwen2/generate.rs
+++ b/crates/rmlx-models/src/qwen2/generate.rs
@@ -436,15 +436,16 @@ pub fn generate_greedy(
                     };
                     PROMPT_CACHE.with_inner_mut(|guard| {
                         if let Some(cache) = guard.as_mut() {
-                            cache.push(entry);
-                            let stats = cache.stats();
-                            tracing::debug!(
-                                prompt_len = prompt_ids.len(),
-                                cache_hits = stats.hits,
-                                cache_misses = stats.misses,
-                                cache_bytes = stats.bytes,
-                                "qwen2 generate_greedy: pushed snapshot to prompt cache (miss path)"
-                            );
+                            if cache.push(entry).is_some() {
+                                let stats = cache.stats();
+                                tracing::debug!(
+                                    prompt_len = prompt_ids.len(),
+                                    cache_hits = stats.hits,
+                                    cache_misses = stats.misses,
+                                    cache_bytes = stats.bytes,
+                                    "qwen2 generate_greedy: pushed snapshot to prompt cache (miss path)"
+                                );
+                            }
                         }
                     });
                 }

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -2154,15 +2154,16 @@ pub fn generate_greedy<'a>(
                     };
                     QWEN3_PROMPT_CACHE.with_inner_mut(|guard| {
                         if let Some(cache) = guard.as_mut() {
-                            cache.push(entry);
-                            let stats = cache.stats();
-                            tracing::debug!(
-                                prompt_len = prompt_ids.len(),
-                                cache_hits = stats.hits,
-                                cache_misses = stats.misses,
-                                cache_bytes = stats.bytes,
-                                "qwen3 generate_greedy: pushed snapshot to prompt cache (miss path)"
-                            );
+                            if cache.push(entry).is_some() {
+                                let stats = cache.stats();
+                                tracing::debug!(
+                                    prompt_len = prompt_ids.len(),
+                                    cache_hits = stats.hits,
+                                    cache_misses = stats.misses,
+                                    cache_bytes = stats.bytes,
+                                    "qwen3 generate_greedy: pushed snapshot to prompt cache (miss path)"
+                                );
+                            }
                         }
                     });
                 }

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -376,7 +376,7 @@ pub fn generate_greedy<'a>(
                         PROMPT_CACHE.with_inner_mut(|guard| {
                             if let Some(cache) = guard.as_mut() {
                                 let lk = crate::qwen3_5_moe::prompt_cache::active_layout_key();
-                                cache.push(Qwen35MoeEntry {
+                                let stored = cache.push(Qwen35MoeEntry {
                                     prompt_token_ids: prompt_ids.to_vec(),
                                     block_hashes: crate::prompt_cache::chained_block_hashes_seeded(
                                         prompt_ids,
@@ -391,12 +391,14 @@ pub fn generate_greedy<'a>(
                                     kv_quant: Some(kv_quant),
                                     is_ssd_hydrated: false,
                                 });
-                                tracing::debug!(
-                                    prompt_len = prompt_ids.len(),
-                                    token_id = last_id,
-                                    n_slots = cache.slots.len(),
-                                    "qwen3_5moe generate_greedy: hydrated-tail — saved full snapshot"
-                                );
+                                if stored.is_some() {
+                                    tracing::debug!(
+                                        prompt_len = prompt_ids.len(),
+                                        token_id = last_id,
+                                        n_slots = cache.slots.len(),
+                                        "qwen3_5moe generate_greedy: hydrated-tail — saved full snapshot"
+                                    );
+                                }
                             }
                         });
                     }
@@ -567,7 +569,7 @@ pub fn generate_greedy<'a>(
                             // salt chained walk with the active layout_key. When
                             // tier is OFF, helper returns 0 ⇒ legacy un-salted digests.
                             let lk = crate::qwen3_5_moe::prompt_cache::active_layout_key();
-                            cache.push(Qwen35MoeEntry {
+                            let stored = cache.push(Qwen35MoeEntry {
                                 prompt_token_ids: prompt_ids.to_vec(),
                                 block_hashes: crate::prompt_cache::chained_block_hashes_seeded(
                                     prompt_ids,
@@ -582,12 +584,14 @@ pub fn generate_greedy<'a>(
                                 kv_quant: Some(kv_quant),
                                 is_ssd_hydrated: false,
                             });
-                            tracing::debug!(
-                                prompt_len = prompt_ids.len(),
-                                token_id = last_id,
-                                n_slots = cache.slots.len(),
-                                "qwen3_5moe generate_greedy: prompt cache MISS — saved snapshot"
-                            );
+                            if stored.is_some() {
+                                tracing::debug!(
+                                    prompt_len = prompt_ids.len(),
+                                    token_id = last_id,
+                                    n_slots = cache.slots.len(),
+                                    "qwen3_5moe generate_greedy: prompt cache MISS — saved snapshot"
+                                );
+                            }
                         }
                     });
                 }

--- a/crates/rmlx-models/src/qwen3_vl_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_vl_moe/generate.rs
@@ -306,15 +306,16 @@ pub fn generate_greedy(
                     };
                     PROMPT_CACHE.with_inner_mut(|guard| {
                         if let Some(cache) = guard.as_mut() {
-                            cache.push(entry);
-                            let stats = cache.stats();
-                            tracing::debug!(
-                                prompt_len = prompt_ids.len(),
-                                cache_hits = stats.hits,
-                                cache_misses = stats.misses,
-                                cache_bytes = stats.bytes,
-                                "qwen3_vl_moe generate_greedy: pushed snapshot to prompt cache (miss path)"
-                            );
+                            if cache.push(entry).is_some() {
+                                let stats = cache.stats();
+                                tracing::debug!(
+                                    prompt_len = prompt_ids.len(),
+                                    cache_hits = stats.hits,
+                                    cache_misses = stats.misses,
+                                    cache_bytes = stats.bytes,
+                                    "qwen3_vl_moe generate_greedy: pushed snapshot to prompt cache (miss path)"
+                                );
+                            }
                         }
                     });
                 }

--- a/docs/PROMPT_CACHE.md
+++ b/docs/PROMPT_CACHE.md
@@ -270,8 +270,12 @@ full re-prefill. The Exact path verifies token identity by comparing
 `find_best_prefix` hit and every `push` advance it. Each slot carries a
 `last_used_seq` stamped at its last access.
 
-`push` runs two eviction passes before appending the new entry:
+`push` runs an admission guard, then two eviction passes, before appending the
+new entry:
 
+0. **Over-cap admission guard**: if the incoming entry's KV alone exceeds
+   `max_bytes`, the entry is **not admitted** — `push` returns `None` without
+   evicting any existing slot. See "Over-cap admission" below.
 1. **RAM cap**: while `total_kv_bytes + new_entry_bytes > max_bytes`, evict
    the slot with the smallest `last_used_seq`.
 2. **Slot count cap**: if `slots.len() == capacity`, evict the slot with the
@@ -279,7 +283,33 @@ full re-prefill. The Exact path verifies token identity by comparing
 
 Either cap triggers independently; the smaller cap wins. Each eviction
 increments `stats.evictions` and calls `spill_evicted` (the SSD sink
-hook, if attached).
+hook, if attached). `push` returns `Some(slot_index)` when the entry is stored
+and `None` when the admission guard rejects it.
+
+### Over-cap admission
+
+A single snapshot whose resident KV alone exceeds `max_bytes` is **refused
+admission** rather than stored above the cap. Without this guard, an empty (or
+near-empty) cache would happily store one entry many times larger than the cap —
+the RAM-cap eviction loop only evicts *other* slots and never refuses the
+incoming entry — silently violating the documented cap.
+
+The refusal is not just bookkeeping hygiene: admitting an over-cap snapshot is
+what caused the large-KV **warm-cache decode stall**. The next identical (warm)
+request takes the Exact path, which `deep_clone`s the stored snapshot
+(refcount-shared, no copy) and then, on the first decode append, triggers MLX
+copy-on-write of the whole KV — a *second* full-size residency. For a
+bf16-mirror KV codec at long context (tens of GB), that doubling pushes total
+residency past physical RAM and stalls decode with a single multi-hundred-second
+pause (steady-state `itl` stays healthy; only the aggregate craters).
+
+Refusing admission bounds peak residency to one live copy: the repeat request
+re-prefills exactly like the cold request instead of reusing an over-cap slot,
+so warm decode ≈ cold decode. The guard is model- and codec-agnostic — it keys
+off `entry.kv_bytes()` versus the cap, never an arch or codec name. Existing
+(smaller, valid) slots are left intact; the guard never evicts to make room for
+something that still could not fit. An SSD hydrate whose reconstructed block is
+over-cap is likewise treated as a miss (the caller re-prefills).
 
 The RAM cap is set once at process start:
 
@@ -511,10 +541,13 @@ Each run uses a fresh `RMLX_HOME` tempdir for hermeticity.
 | Env fallback | `RMLX_PROMPT_CACHE_MAX_BYTES` — bytes, decimal (undocumented compat). |
 | Default | 2 GiB. |
 | Scope | Process-global `OnceLock`; first call to `install_ram_cap` wins. |
+| Admission guard | `push`: an entry whose KV alone exceeds `max_bytes` is refused (`push` → `None`), no eviction. See "Over-cap admission". |
 | Eviction trigger | `push`: evicts LRU slots until `total_kv_bytes + new_entry_bytes <= max_bytes`. |
 
 The RAM cap and the slot count cap (`--prompt-cache-slots`) are independent.
-Either can trigger eviction first on a given `push`.
+Either can trigger eviction first on a given `push`. The over-cap admission
+guard runs first: a snapshot larger than the whole cap is never stored (it would
+both violate the cap and cause the warm-cache decode stall on reuse).
 
 ---
 


### PR DESCRIPTION
## Summary
Closes #212. `*_sym` bf16-mirror KV codecs stalled warm-cache decode at 128k. Real root cause (re-diagnosed): `PromptCache::push` **admitted a snapshot whose KV is larger than the entire RAM prompt-cache cap** — the RAM-cap loop only evicts *other* slots, it never refuses the incoming entry. The next identical (warm) request takes the Exact path, `deep_clone`s that oversized snapshot and copy-on-writes the whole KV on the first decode append → a second full-size residency (~30 GB → ~60 GB at 128k) → exceeds physical RAM → decode stalls (aggregate craters while `itl_p50` stays healthy). It is *not* mid-decode eviction of the active prefix (refcounting already pins that).

**Fix (model- and codec-agnostic):** `push` refuses admission of any entry whose `kv_bytes()` exceeds `max_bytes` (returns `None` without evicting or mutating); `hydrate_from_ssd` treats an over-cap reconstructed block as a miss (not counted as an `ssd_hit`). Warm requests then re-prefill cleanly instead of COW-doubling into an OOM stall.

## Changes
- `crates/rmlx-models/src/prompt_cache.rs` — over-cap admission guard (`new_bytes > max_bytes` → refuse, no eviction); `push` → `Option<usize>`; `warn!` on refusal with an actionable message (raise `--prompt-cache-ram-gb`).
- 8 arch `generate.rs` sites — success log now gated on `push(...).is_some()` so it no longer claims a save that didn't happen.
- `crates/rmlx-models/src/prompt_cache_tests.rs` — 3 tests: over-cap not admitted, refusal preserves existing slots, SSD over-cap hydrate → miss (`ssd_hits==0`).
- `docs/PROMPT_CACHE.md` — over-cap admission policy.

## Proof
- Gate: `make lint` clean; `cargo test -p rmlx-models` 694 passed.
- Real model (Bonsai-8B-2bit + `iso3_sym` + `--prompt-cache-ram-gb 0.05`, forcing the over-cap precondition on a small model):
  - **OLD:** warm request was an EXACT HIT reusing a **1.795 GB** KV admitted under a **53.7 MB** cap (34× violation) → COW-double.
  - **NEW:** warm re-prefills clean (no exact hit, `cache_bytes=0`, `hits=0`); warm decode **88.55 TPS ≈ cold 85.06 TPS**, no aggregate-vs-itl divergence.

The true 128k crater on Bonsai-27B needs the ~30→60 GB doubling to exceed RAM (not cheaply reproducible); the small-model over-cap precondition + unit tests stand in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)