### PR TITLE
fix(kv): share the quant store across shared-KV layers, not a bf16 dequant (#228)

### DIFF
--- a/crates/rmlx-cli/examples/shared_source_realmodel_probe.rs
+++ b/crates/rmlx-cli/examples/shared_source_realmodel_probe.rs
@@ -1,13 +1,13 @@
-// Returning-KV real-model proof probe.
+// Shared-KV producer real-model proof probe.
 //
 // Drives a model through prefill + 64-token decode and reports BOTH the
 // TurboFlash dispatch counter and the fused-QK dispatch counter
-// delta plus decode-only TPS. Use with Gemma4 to verify the returning-KV
-// routing extension reaches the dispatch chain.
+// delta plus decode-only TPS. Use with any shared-KV model to verify the
+// cross-layer-KV producer routing reaches the dispatch chain.
 //
 // Usage:
 //   RMLX_TURBO_FLASH=1 cargo run --profile release-perf -p rmlx-cli \
-//     --example returning_kv_realmodel_probe -- <model_path> <codec> <kernel> "<prompt>"
+//     --example shared_source_realmodel_probe -- <model_path> <codec> <kernel> "<prompt>"
 //
 //   <kernel> : turbo_flash | fused_qk
 //
@@ -46,7 +46,7 @@ fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 5 {
         eprintln!(
-            "usage: returning_kv_realmodel_probe <model_path> <codec> <kernel> <prompt>\n  \
+            "usage: shared_source_realmodel_probe <model_path> <codec> <kernel> <prompt>\n  \
              codec : k8v4 | k8v8 | tsym3 | tsym4 | ...\n  \
              kernel: turbo_flash | fused_qk"
         );

--- a/crates/rmlx-kv-quant/src/kvcache/core.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/core.rs
@@ -424,7 +424,7 @@ impl KvCache {
     /// Returns the bf16 K buffer accumulated during prefill, in the layout
     /// `[1, n_kv_heads, S, head_dim]`. Populated only when the cache ran
     /// through the bf16 path (`KvQuant::None`) or when the Mixed/RotK paths
-    /// surfaced the bf16 accumulator via `update_and_sdpa_returning_kv`.
+    /// surfaced the bf16 accumulator via `update_and_sdpa_shared_source`.
     ///
     /// Intended exclusively for the offline `rmlx kv-calibrate
     /// --recipe head_budget` pass, which needs a host-side view of the

--- a/crates/rmlx-kv-quant/src/kvcache/mod.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/mod.rs
@@ -50,6 +50,7 @@ mod fused_qk_dispatch;
 mod fused_qk_shadow;
 mod helpers;
 mod sdpa;
+mod shared_kv;
 mod update;
 
 // Warm-TTFT shortcut regression for PlanarK.
@@ -64,8 +65,13 @@ mod warm_ttft_cross_codec_tests;
 
 // Cross-layer-KV producer dispatch-chain extension.
 #[cfg(test)]
-#[path = "returning_kv_tests.rs"]
-mod returning_kv_tests;
+#[path = "shared_source_tests.rs"]
+mod shared_source_tests;
+
+// Shared-KV consumers attend the producer's quant store, not a bf16 dequant.
+#[cfg(test)]
+#[path = "shared_kv_tests.rs"]
+mod shared_kv_tests;
 
 // Dynamic grow + hard cap for `update_prefill_raw`.
 #[cfg(test)]
@@ -95,6 +101,7 @@ mod rotor_flash_dispatch_tests;
 
 pub use core::KvCache;
 pub use fused_qk_dispatch::fused_qk_total_dispatch_count;
+pub use shared_kv::SharedKv;
 // `FusedQkLayout` / `FusedQkShadow` are crate-internal
 // only; they carry mlx-rs `Array` in their storage and would leak the
 // upstream type if exposed. Downstream callers don't need them — the

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -338,7 +338,7 @@ impl KvCache {
         clippy::indexing_slicing,
         reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
     )]
-    fn update_and_sdpa_rot_k_tq4v_returning_kv(
+    fn update_and_sdpa_rot_k_tq4v_shared_source(
         &mut self,
         queries: &Array,
         new_k: &Array,
@@ -450,7 +450,7 @@ impl KvCache {
                         Err(e) => {
                             tracing::warn!(
                                 reason = %e,
-                                "rot_k_fwht_rotate_gpu failed in returning_kv; \
+                                "rot_k_fwht_rotate_gpu failed on the shared-KV producer path; \
                                  falling back to v1 matmul Q rotation"
                             );
                             crate::rot_k::rotate_last_axis(queries, r, device)?
@@ -858,7 +858,7 @@ impl KvCache {
         // bf16 K/V for downstream shared-KV consumers.
         if self.quant.uses_rot_k_tq4v_path() {
             tracing::Span::current().record("path", "rot_k_tq4v");
-            let (out, k_full, v_full) = self.update_and_sdpa_rot_k_tq4v_returning_kv(
+            let (out, k_full, v_full) = self.update_and_sdpa_rot_k_tq4v_shared_source(
                 queries,
                 new_k,
                 new_v,
@@ -964,7 +964,7 @@ impl KvCache {
                     "fused kernel dispatched on the shared-KV producer path — \
                      consumers attend the quant store"
                 );
-                let kv_len = self.offset;
+                let kv_len = planar_k_accumulated_seq(&self.storage)?;
                 return Ok(Some((out, kv_len)));
             }
         }
@@ -1112,14 +1112,15 @@ impl KvCache {
                 )
             }
             KvStorage::PlanarK { .. } => {
-                Self::check_shared_kv_len(kv_len, self.offset)?;
-                let v_full = self.slice_decode_fp16_v(self.offset, device)?;
+                let kv_seq = planar_k_accumulated_seq(&self.storage)?;
+                Self::check_shared_kv_len(kv_len, kv_seq)?;
+                let v_full = self.slice_decode_fp16_v(kv_seq, device)?;
                 self.planar_k_flash_over_store(
                     queries,
                     &v_full,
                     scale,
                     additive_mask,
-                    self.offset,
+                    kv_seq,
                     device,
                 )
             }
@@ -1131,22 +1132,35 @@ impl KvCache {
         }
     }
 
-    /// Materialise the bf16 `(K, V)` held by a store-backed share.
+    /// Materialise the `(K, V)` held by a store-backed share, as tensors.
     ///
     /// Cold path only — for callers that need K/V *tensors* rather than
     /// attention output (e.g. handing a verifier's representative K/V to a
     /// separate drafter model). This pays the full-prefix dequant the fused
     /// kernel exists to avoid, so never call it per decode step.
+    ///
+    /// # Dtype
+    ///
+    /// The pair comes back at the **V mirror's dtype** — the activation-stream
+    /// dtype the model pushed into this cache (bf16 in production). K is cast to
+    /// match it.
+    ///
+    /// That cast is load-bearing, in both directions:
+    ///
+    /// * The rotor stores dequantise through a `Vec<f32>`, so K arrives F32.
+    ///   Handing an F32 K to a downstream model's attention alongside a bf16 V
+    ///   promotes that model's whole stream to f32 and doubles its KV residency.
+    /// * Hard-coding bf16 instead would be the mirror-image bug on a cache whose
+    ///   stream is wider: K would be silently downcast away from what the cache
+    ///   actually holds. Following V keeps the pair faithful to the stream.
     #[allow(
         clippy::wildcard_enum_match_arm,
         reason = "the wildcard arm returns Err — it never selects a concrete codec, so a new \
                   storage variant fails loudly here instead of being silently decoded as another"
     )]
-    pub fn materialise_shared_kv_bf16(
-        &self,
-        kv_len: i32,
-        device: Device,
-    ) -> Result<(Array, Array)> {
+    pub fn materialise_shared_kv(&self, kv_len: i32, device: Device) -> Result<(Array, Array)> {
+        let v_full = self.slice_decode_fp16_v(kv_len, device)?;
+        let stream_dtype = v_full.dtype();
         let k_full = match &self.storage {
             KvStorage::RotorKOnly3 { k: Some(ks), .. } => {
                 Self::check_shared_kv_len(kv_len, rotor_k_accumulated_seq(&self.storage)?)?;
@@ -1157,8 +1171,8 @@ impl KvCache {
                 f32_vec_to_array(&ks.dequant()?, &ks.shape)?
             }
             KvStorage::PlanarK { k: Some(ks), .. } => {
-                Self::check_shared_kv_len(kv_len, self.offset)?;
-                let (k_recon, k_arr) = ks.dequantize_choice(device, Dtype::Bf16)?;
+                Self::check_shared_kv_len(kv_len, planar_k_accumulated_seq(&self.storage)?)?;
+                let (k_recon, k_arr) = ks.dequantize_choice(device, stream_dtype)?;
                 match k_arr {
                     Some(arr) => arr,
                     None => f32_vec_to_array(&k_recon, &ks.shape)?,
@@ -1166,12 +1180,27 @@ impl KvCache {
             }
             other => {
                 return Err(Error::Mlx(format!(
-                    "materialise_shared_kv_bf16: storage variant {} holds no store-backed share",
+                    "materialise_shared_kv: storage variant {} holds no store-backed share",
                     storage_variant_name(other)
                 )))
             }
         };
-        let v_full = self.slice_decode_fp16_v(kv_len, device)?;
+        let k_full = if k_full.dtype() == stream_dtype {
+            k_full
+        } else {
+            k_full.astype(stream_dtype, device)?
+        };
+        // Defence-in-depth: K and V go to the same downstream attention, so a
+        // dtype split between them would promote its stream to the wider of the
+        // two. The cast above should make this unreachable.
+        if k_full.dtype() != v_full.dtype() {
+            return Err(Error::Mlx(format!(
+                "materialise_shared_kv: K dtype {:?} != V dtype {:?} — a shared K/V pair \
+                 must be one dtype or it promotes the consumer's attention stream",
+                k_full.dtype(),
+                v_full.dtype()
+            )));
+        }
         Ok((k_full, v_full))
     }
 
@@ -1902,6 +1931,27 @@ fn rotor_k_accumulated_seq(storage: &KvStorage) -> Result<i32> {
     shape.get(2).copied().ok_or_else(|| {
         Error::Mlx(format!(
             "rotor_k_fused: rotor K store shape {shape:?} has no seq axis"
+        ))
+    })
+}
+
+/// Accumulated sequence length held by the active PlanarK store.
+///
+/// Sibling of [`rotor_k_accumulated_seq`], and for the same reason: the store's
+/// own `shape[2]` is the length the packed buffers were written against, so it —
+/// not [`KvCache::offset`] — is what the kernel attends and what a shared-KV
+/// consumer must size its mask from.
+fn planar_k_accumulated_seq(storage: &KvStorage) -> Result<i32> {
+    let KvStorage::PlanarK { k: Some(ks), .. } = storage else {
+        return Err(Error::KvStorageMismatch {
+            expected: "PlanarK with a live K buffer",
+            got: storage_variant_name(storage),
+        });
+    };
+    ks.shape.get(2).copied().ok_or_else(|| {
+        Error::Mlx(format!(
+            "planar_k_fused: PlanarK store shape {:?} has no seq axis",
+            ks.shape
         ))
     })
 }

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -19,7 +19,8 @@ use crate::planar_fused_qk_msl::planar_fused_qk;
 use crate::rotor_flash_decode_msl::{rotor_flash_decode_sdpa, ROTOR_FLASH_HEAD_DIM_MAX};
 use crate::storage::KvStorage;
 
-use super::helpers::storage_variant_name;
+use super::helpers::{f32_vec_to_array, storage_variant_name};
+use super::shared_kv::SharedKv;
 use super::KvCache;
 
 impl KvCache {
@@ -59,7 +60,7 @@ impl KvCache {
     }
 
     /// Inner Mixed-precision path shared by [`KvCache::update_and_sdpa_mixed`]
-    /// (the non-shared-KV hot path) and [`KvCache::update_and_sdpa_returning_kv`]
+    /// (the non-shared-KV hot path) and [`KvCache::update_and_sdpa_shared_source`]
     /// (cross-layer-KV archs such as Gemma4).
     ///
     /// `want_kv` controls whether the accumulated **bf16** K/V is surfaced for a
@@ -323,7 +324,7 @@ impl KvCache {
         )
     }
 
-    /// -review CRITICAL 1: `update_and_sdpa_returning_kv` variant for
+    /// -review CRITICAL 1: `update_and_sdpa_shared_source` variant for
     /// RotKTq4V. Runs the same K/V update and SDPA as
     /// `update_and_sdpa_rot_k_tq4v` but additionally surfaces the dequantized
     /// bf16 `(K, V)` so Gemma4 shared-KV consumer layers can receive them.
@@ -526,7 +527,7 @@ impl KvCache {
         // which disagrees with the ring-capped SWA attention mask on the
         // window-crossing chunk. Route rotating caches through the legacy
         // `update()` path (ring first) so the K shape matches the mask — same
-        // fix as `update_and_sdpa_returning_kv`. See `with_quant_max_seq_window`.
+        // fix as `update_and_sdpa_shared_source`. See `with_quant_max_seq_window`.
         if self.rotating.is_some() {
             tracing::Span::current().record("path", "rotating");
             let (k_full, v_full) = self.update(new_k, new_v, device)?;
@@ -747,36 +748,44 @@ impl KvCache {
     }
 
     /// Sibling of [`KvCache::update_and_sdpa`] for archs with **cross-layer KV
-    /// sharing** (e.g. Gemma3 / Gemma4). Returns the accumulated post-update
-    /// `(K, V)` alongside the SDPA output so the caller can hand the K/V
-    /// downstream to shared-KV consumer layers.
+    /// sharing**: runs this producer layer's own update + SDPA and reports what
+    /// its downstream consumer layers can attend over, as a [`SharedKv`].
     ///
-    /// For [`KvQuant::Mixed`] the fused quantized SDPA stores K/V as
-    /// quant 3-tuples, so this method routes through
-    /// [`KvCache::update_and_sdpa_mixed_inner`] with `want_kv = true`, which
-    /// surfaces the accumulated **bf16** K/V (the prefill-raw buffer during
-    /// prefill, the maintained `decode_fp16_k/v` during decode) — the same
-    /// values the quantized SDPA was computed from. All other quants (`None`,
-    /// `K8V4`, `K8V8`, `Planar`) route through [`KvCache::update`], which
-    /// dequantises and returns the accumulated bf16/fp32 K/V the wrapper needs.
+    /// The dispatch chain mirrors [`KvCache::update_and_sdpa`] arm for arm —
+    /// that symmetry is the contract. A codec that has a fused decode kernel
+    /// must reach it here too; if it does not, the producer is pushed onto the
+    /// legacy bf16 path and the fused kernel is silently dead for every model
+    /// with a shared-KV topology.
+    ///
+    /// Which [`SharedKv`] variant a step yields is decided by the codec, not by
+    /// the arch:
+    ///
+    /// * The fused-over-quant-store arms ([`Self::update_and_sdpa_planar_k_fused`],
+    ///   [`Self::update_and_sdpa_rotor_k_fused`]) never materialise bf16 K/V, so
+    ///   they yield [`SharedKv::Store`] and consumers re-enter the same kernel
+    ///   via [`Self::sdpa_shared`].
+    /// * Every other arm — rotating (SWA) rings, [`KvQuant::Mixed`] / RotK
+    ///   (which surface the bf16 accumulator the quantized SDPA was computed
+    ///   from), the TurboFlash / fused-QK dispatches (which maintain a bf16
+    ///   mirror anyway), and the legacy [`KvCache::update`] fallthrough — has a
+    ///   bf16 `(K, V)` in hand already and yields [`SharedKv::Bf16`], which all
+    ///   consumers share without a second materialisation.
     ///
     /// The SWA `rotating.is_some()` short-circuit inside [`KvCache::update`]
     /// still applies — SWA layers stay bf16 even when `self.quant` requests a
     /// non-rotation codec. No SWA-specific branching is needed here.
-    ///
-    /// Task 9: wrapped with a debug-level span (sibling of `update_and_sdpa`).
     #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(
         level = "debug",
-        name = "update_and_sdpa_returning_kv",
+        name = "update_and_sdpa_shared_source",
         skip(self, queries, new_k, new_v, additive_mask, mask_mode, scale, device),
         fields(
             kv_quant = %self.quant,
             offset = self.offset,
-            path = "returning_kv_legacy",
+            path = tracing::field::Empty,
         )
     )]
-    pub fn update_and_sdpa_returning_kv(
+    pub fn update_and_sdpa_shared_source(
         &mut self,
         queries: &Array,
         new_k: &Array,
@@ -785,7 +794,7 @@ impl KvCache {
         mask_mode: &str,
         additive_mask: Option<&Array>,
         device: Device,
-    ) -> Result<(Array, Array, Array)> {
+    ) -> Result<(Array, SharedKv)> {
         // SWA (rotating) layers stay bf16 for EVERY quant, including
         // Mixed/RotK (mlx-lm `RotatingKVCache.to_quantized` raises
         // NotImplementedError; see `with_quant_max_seq_window`). The
@@ -799,6 +808,7 @@ impl KvCache {
         // honors the ring first) keeps Mixed consistent with None/K8V8/K8V4/
         // Planar, all of which already reach the ring via `update()`.
         if self.rotating.is_some() {
+            tracing::Span::current().record("path", "rotating");
             let (k_full, v_full) = self.update(new_k, new_v, device)?;
             let out = scaled_dot_product_attention(
                 queries,
@@ -809,7 +819,7 @@ impl KvCache {
                 additive_mask,
                 device,
             )?;
-            return Ok((out, k_full, v_full));
+            return Ok((out, SharedKv::Bf16(k_full, v_full)));
         }
 
         // Mixed dequant-before-share. The fused quantized SDPA stores K/V
@@ -821,6 +831,7 @@ impl KvCache {
         // same path; the shared-KV consumer sees unrotated bf16 K (the SDPA
         // helper rotates Q internally, never the surfaced K).
         if self.quant.uses_mixed_path() {
+            tracing::Span::current().record("path", "mixed");
             let (out, kv) = self.update_and_sdpa_mixed_inner(
                 queries,
                 new_k,
@@ -832,20 +843,21 @@ impl KvCache {
             )?;
             let (k_full, v_full) = kv.ok_or_else(|| {
                 Error::Mlx(
-                    "update_and_sdpa_returning_kv: Mixed path returned no bf16 K/V \
+                    "update_and_sdpa_shared_source: Mixed path returned no bf16 K/V \
                      (want_kv=true must always surface the accumulator)"
                         .into(),
                 )
             })?;
-            return Ok((out, k_full, v_full));
+            return Ok((out, SharedKv::Bf16(k_full, v_full)));
         }
 
-        // / -review CRITICAL 1: RotKTq4V must be explicitly routed
-        // here before the `update()` fallthrough. `update()` returns an error for
-        // RotKTq4V ("Contract violation"), crashing Gemma4 shared-KV layers that
-        // call this method. Mirror the Mixed branch: run the hybrid SDPA and
-        // surface the dequantized bf16 K/V for downstream shared-KV consumers.
+        // RotKTq4V must be explicitly routed here before the `update()`
+        // fallthrough. `update()` returns an error for RotKTq4V ("Contract
+        // violation"), crashing shared-KV layers that call this method. Mirror
+        // the Mixed branch: run the hybrid SDPA and surface the dequantized
+        // bf16 K/V for downstream shared-KV consumers.
         if self.quant.uses_rot_k_tq4v_path() {
+            tracing::Span::current().record("path", "rot_k_tq4v");
             let (out, k_full, v_full) = self.update_and_sdpa_rot_k_tq4v_returning_kv(
                 queries,
                 new_k,
@@ -855,22 +867,31 @@ impl KvCache {
                 additive_mask,
                 device,
             )?;
-            return Ok((out, k_full, v_full));
+            return Ok((out, SharedKv::Bf16(k_full, v_full)));
         }
 
-        // TurboFlash + fused-QK dispatch hooks for cross-layer-KV producer
-        // layers (Gemma4). The dispatch chain mirrors the one in
-        // `update_and_sdpa`; we surface bf16 (K, V) by slicing the
-        // `decode_fp16_k/v` mirrors that those dispatch paths already
-        // maintain. Returns `None` when no dispatch arm is eligible — the
-        // legacy bf16 fallback below then runs unchanged.
-        if let Some((out, k_full, v_full)) =
-            self.try_dispatch_returning_kv(queries, new_k, new_v, scale, additive_mask, device)?
+        // Fused-over-quant-store arms. These read the packed store directly and
+        // deliberately never materialise a bf16 K prefix, so the share they
+        // hand downstream is the store itself. Same gates and same order as the
+        // matching arms in `update_and_sdpa` — a consumer of this cache
+        // re-enters the identical kernel through `sdpa_shared`.
+        if let Some((out, kv_len)) =
+            self.try_dispatch_shared_store(queries, new_k, new_v, scale, additive_mask, device)?
         {
-            tracing::Span::current().record("path", "returning_kv_dispatch");
-            return Ok((out, k_full, v_full));
+            return Ok((out, SharedKv::Store { kv_len }));
         }
 
+        // TurboFlash + fused-QK dispatch hooks. These maintain the bf16
+        // `decode_fp16_k/v` mirrors regardless, so the share is those exact
+        // tensors sliced to the current offset. Returns `None` when no arm is
+        // eligible — the legacy bf16 fallback below then runs unchanged.
+        if let Some((out, k_full, v_full)) =
+            self.try_dispatch_shared_bf16(queries, new_k, new_v, scale, additive_mask, device)?
+        {
+            return Ok((out, SharedKv::Bf16(k_full, v_full)));
+        }
+
+        tracing::Span::current().record("path", "legacy");
         let (k_full, v_full) = self.update(new_k, new_v, device)?;
         let out = scaled_dot_product_attention(
             queries,
@@ -881,11 +902,107 @@ impl KvCache {
             additive_mask,
             device,
         )?;
-        Ok((out, k_full, v_full))
+        Ok((out, SharedKv::Bf16(k_full, v_full)))
+    }
+
+    /// Run the fused-over-quant-store dispatch arms for a cross-layer-KV
+    /// producer layer, returning `(out, kv_len)` on a hit.
+    ///
+    /// Mirrors arms 1b / 1c of [`Self::update_and_sdpa`] — including their
+    /// pre-mutation gates — so a shared-KV producer reaches exactly the kernels
+    /// a non-sharing model reaches. `kv_len` is the store length the kernel
+    /// attended, which downstream consumers size their mask from.
+    ///
+    /// Returns `Ok(None)` when no arm is eligible, leaving the cache untouched
+    /// for the caller's next arm.
+    ///
+    /// General mechanism: nothing here is arch-specific. Every gate is keyed on
+    /// the codec's storage variant and the step's shape.
+    #[allow(clippy::too_many_arguments)]
+    fn try_dispatch_shared_store(
+        &mut self,
+        queries: &Array,
+        new_k: &Array,
+        new_v: &Array,
+        scale: f32,
+        additive_mask: Option<&Array>,
+        device: Device,
+    ) -> Result<Option<(Array, i32)>> {
+        let q_seq_is_decode = queries.shape().get(2).copied().unwrap_or(0) == 1;
+
+        // PlanarK fused-QK / flash-decode. The warm-TTFT gate mirrors
+        // `update_and_sdpa`: while the bf16 K seed is live every other codec
+        // decodes off it, so PlanarK must not be the sole codec re-encoding K
+        // through its lossy kernel every step.
+        if matches!(self.storage, KvStorage::PlanarK { .. })
+            && planar_fused_qk_enabled()
+            && device == Device::Gpu
+            && q_seq_is_decode
+        {
+            if self.decode_fp16_k.is_some() {
+                tracing::debug!(
+                    target: "rmlx_kv_quant::warm_ttft",
+                    path = "warm_ttft_bypass",
+                    codec = "PlanarK",
+                    offset = self.offset,
+                    "PlanarK shared-source dispatcher skipping fused-QK / \
+                     flash-decode kernels — bf16 K seed is live (warm-TTFT)"
+                );
+            } else if let Some(out) = self.update_and_sdpa_planar_k_fused(
+                queries,
+                new_k,
+                new_v,
+                scale,
+                additive_mask,
+                device,
+            )? {
+                tracing::Span::current().record("path", "planar_k_fused");
+                tracing::debug!(
+                    target: "rmlx_kv_quant::shared_kv",
+                    kernel = "planar_k_fused",
+                    offset = self.offset,
+                    "fused kernel dispatched on the shared-KV producer path — \
+                     consumers attend the quant store"
+                );
+                let kv_len = self.offset;
+                return Ok(Some((out, kv_len)));
+            }
+        }
+
+        // Rotor K-only flash-decode. Without it this codec CPU-dequants the
+        // whole K prefix every decode step with the GPU idle.
+        if matches!(
+            self.storage,
+            KvStorage::RotorKOnly3 { .. } | KvStorage::RotorKOnly4 { .. }
+        ) && device == Device::Gpu
+            && !rotor_k_store_uses_qjl(&self.storage)
+            && q_seq_is_decode
+        {
+            if let Some(out) = self.update_and_sdpa_rotor_k_fused(
+                queries,
+                new_k,
+                new_v,
+                scale,
+                additive_mask,
+                device,
+            )? {
+                tracing::debug!(
+                    target: "rmlx_kv_quant::shared_kv",
+                    kernel = "rotor_flash",
+                    offset = self.offset,
+                    "fused kernel dispatched on the shared-KV producer path — \
+                     consumers attend the quant store"
+                );
+                let kv_len = rotor_k_accumulated_seq(&self.storage)?;
+                return Ok(Some((out, kv_len)));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Run the TurboFlash / fused-QK dispatch chain in the cross-layer-KV
-    /// (`update_and_sdpa_returning_kv`) context and surface the bf16 `(K, V)`
+    /// (`update_and_sdpa_shared_source`) context and surface the bf16 `(K, V)`
     /// consumed by shared-KV consumer layers.
     ///
     /// The chain mirrors `update_and_sdpa`:
@@ -906,11 +1023,10 @@ impl KvCache {
     /// gates off). This preserves Gemma4's default (gates OFF) behaviour
     /// bit-for-bit.
     ///
-    /// General mechanism: nothing here is Gemma4-specific. Any future
-    /// architecture that uses `update_and_sdpa_returning_kv` (medgemma,
-    /// Laguna, etc.) reaches the same dispatch chain.
+    /// General mechanism: nothing here is arch-specific. Any architecture that
+    /// uses `update_and_sdpa_shared_source` reaches the same dispatch chain.
     #[allow(clippy::too_many_arguments)]
-    fn try_dispatch_returning_kv(
+    fn try_dispatch_shared_bf16(
         &mut self,
         queries: &Array,
         new_k: &Array,
@@ -923,11 +1039,12 @@ impl KvCache {
         if let Some(out) =
             self.sdpa_dispatch_no_lock(queries, new_k, new_v, scale, additive_mask, device)?
         {
+            tracing::Span::current().record("path", "flash");
             tracing::debug!(
-                target: "rmlx_kv_quant::returning_kv",
+                target: "rmlx_kv_quant::shared_kv",
                 kernel = "turbo_flash",
                 offset = self.offset,
-                "TurboFlash dispatched on returning_kv path"
+                "TurboFlash dispatched on the shared-KV producer path"
             );
             let (k_full, v_full) = self.slice_decode_fp16_for_consumer(new_k, new_v, device)?;
             return Ok(Some((out, k_full, v_full)));
@@ -938,11 +1055,12 @@ impl KvCache {
         if let Some(out) =
             self.try_fused_qk_dispatch(queries, new_k, new_v, scale, additive_mask, device)?
         {
+            tracing::Span::current().record("path", "fused_qk");
             tracing::debug!(
-                target: "rmlx_kv_quant::returning_kv",
+                target: "rmlx_kv_quant::shared_kv",
                 kernel = "fused_qk",
                 offset = self.offset,
-                "fused-QK dispatched on returning_kv path"
+                "fused-QK dispatched on the shared-KV producer path"
             );
             let (k_full, v_full) = self.slice_decode_fp16_for_consumer(new_k, new_v, device)?;
             return Ok(Some((out, k_full, v_full)));
@@ -951,12 +1069,168 @@ impl KvCache {
         Ok(None)
     }
 
+    /// Consumer-side SDPA over the K/V a **producer** layer accumulated in this
+    /// cache, for a cross-layer-KV (shared-KV) topology.
+    ///
+    /// Read-only: no append, no offset advance. The producer already ran its
+    /// own `update_and_sdpa_shared_source` for this step; this only re-enters
+    /// the same fused kernel with the consumer's own `queries`.
+    ///
+    /// Only reachable when the producer reported [`SharedKv::Store`], i.e. the
+    /// codec ran a fused-over-quant-store kernel. `kv_len` is the length the
+    /// producer reported; it is checked against the store rather than trusted,
+    /// so a producer/consumer desync errors instead of silently attending the
+    /// wrong prefix.
+    ///
+    /// An unrecognised storage variant is an error, never a fallback: falling
+    /// back would answer with a different codec's numbers under the same name.
+    #[allow(
+        clippy::wildcard_enum_match_arm,
+        reason = "the wildcard arm returns Err — it never selects a concrete codec, so a new \
+                  storage variant fails loudly here instead of being silently decoded as another"
+    )]
+    pub fn sdpa_shared(
+        &self,
+        queries: &Array,
+        scale: f32,
+        additive_mask: Option<&Array>,
+        kv_len: i32,
+        device: Device,
+    ) -> Result<Array> {
+        match &self.storage {
+            KvStorage::RotorKOnly3 { .. } | KvStorage::RotorKOnly4 { .. } => {
+                let kv_seq = rotor_k_accumulated_seq(&self.storage)?;
+                Self::check_shared_kv_len(kv_len, kv_seq)?;
+                let v_full = self.slice_decode_fp16_v(kv_seq, device)?;
+                self.rotor_k_flash_over_store(
+                    queries,
+                    &v_full,
+                    scale,
+                    additive_mask,
+                    kv_seq,
+                    device,
+                )
+            }
+            KvStorage::PlanarK { .. } => {
+                Self::check_shared_kv_len(kv_len, self.offset)?;
+                let v_full = self.slice_decode_fp16_v(self.offset, device)?;
+                self.planar_k_flash_over_store(
+                    queries,
+                    &v_full,
+                    scale,
+                    additive_mask,
+                    self.offset,
+                    device,
+                )
+            }
+            other => Err(Error::Mlx(format!(
+                "sdpa_shared: storage variant {} has no fused-over-store consumer path — a \
+                 producer must not report a store-backed share for it",
+                storage_variant_name(other)
+            ))),
+        }
+    }
+
+    /// Materialise the bf16 `(K, V)` held by a store-backed share.
+    ///
+    /// Cold path only — for callers that need K/V *tensors* rather than
+    /// attention output (e.g. handing a verifier's representative K/V to a
+    /// separate drafter model). This pays the full-prefix dequant the fused
+    /// kernel exists to avoid, so never call it per decode step.
+    #[allow(
+        clippy::wildcard_enum_match_arm,
+        reason = "the wildcard arm returns Err — it never selects a concrete codec, so a new \
+                  storage variant fails loudly here instead of being silently decoded as another"
+    )]
+    pub fn materialise_shared_kv_bf16(
+        &self,
+        kv_len: i32,
+        device: Device,
+    ) -> Result<(Array, Array)> {
+        let k_full = match &self.storage {
+            KvStorage::RotorKOnly3 { k: Some(ks), .. } => {
+                Self::check_shared_kv_len(kv_len, rotor_k_accumulated_seq(&self.storage)?)?;
+                f32_vec_to_array(&ks.dequant()?, &ks.shape)?
+            }
+            KvStorage::RotorKOnly4 { k: Some(ks), .. } => {
+                Self::check_shared_kv_len(kv_len, rotor_k_accumulated_seq(&self.storage)?)?;
+                f32_vec_to_array(&ks.dequant()?, &ks.shape)?
+            }
+            KvStorage::PlanarK { k: Some(ks), .. } => {
+                Self::check_shared_kv_len(kv_len, self.offset)?;
+                let (k_recon, k_arr) = ks.dequantize_choice(device, Dtype::Bf16)?;
+                match k_arr {
+                    Some(arr) => arr,
+                    None => f32_vec_to_array(&k_recon, &ks.shape)?,
+                }
+            }
+            other => {
+                return Err(Error::Mlx(format!(
+                    "materialise_shared_kv_bf16: storage variant {} holds no store-backed share",
+                    storage_variant_name(other)
+                )))
+            }
+        };
+        let v_full = self.slice_decode_fp16_v(kv_len, device)?;
+        Ok((k_full, v_full))
+    }
+
+    /// Reject a producer/consumer length desync rather than attend the wrong
+    /// prefix. The two are written and read one step apart on the same cache,
+    /// so a mismatch is an internal invariant break.
+    fn check_shared_kv_len(reported: i32, actual: i32) -> Result<()> {
+        if reported == actual {
+            Ok(())
+        } else {
+            Err(Error::Mlx(format!(
+                "shared-KV length desync: producer reported kv_len={reported}, store holds \
+                 {actual}"
+            )))
+        }
+    }
+
+    /// Read-only slice of the bf16 V accumulator to `kv_seq` positions.
+    ///
+    /// Matches what `update_decode_fp16_v_only` returns to the producer on the
+    /// same step, so producer and consumer attend the identical V window.
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "bounds established by the rank-4 check immediately above"
+    )]
+    fn slice_decode_fp16_v(&self, kv_seq: i32, device: Device) -> Result<Array> {
+        let v_buf = self.decode_fp16_v.as_ref().ok_or_else(|| {
+            Error::Mlx(
+                "decode_fp16_v missing on a store-backed share — the fused arms maintain it on \
+                 every append, so this is an internal invariant violation"
+                    .to_owned(),
+            )
+        })?;
+        let v_shape = v_buf.shape();
+        if v_shape.len() != 4 {
+            return Err(Error::Mlx(format!(
+                "decode_fp16_v rank != 4, got {v_shape:?}"
+            )));
+        }
+        if kv_seq > v_shape[2] {
+            return Err(Error::Mlx(format!(
+                "shared-KV length {kv_seq} exceeds the bf16 V mirror (v_seq={})",
+                v_shape[2]
+            )));
+        }
+        v_buf.slice(
+            &[0_i32; 4],
+            &[v_shape[0], v_shape[1], kv_seq, v_shape[3]],
+            &[1_i32; 4],
+            device,
+        )
+    }
+
     /// Slice the bf16 K/V mirror to the current `self.offset` so a
     /// shared-KV consumer layer sees the same bf16 prefix the dispatch
     /// kernels operated on.
     ///
     /// Assumes the caller has just successfully dispatched a kernel from
-    /// `try_dispatch_returning_kv`. Both dispatch arms maintain
+    /// `try_dispatch_shared_bf16`. Both dispatch arms maintain
     /// `decode_fp16_k` / `decode_fp16_v` (TurboFlash via `update_decode_fp16`
     /// at `update_and_sdpa_k8v4_flash_inner`; fused-QK via
     /// `update_decode_fp16` inside `try_fused_qk_dispatch`).
@@ -1100,11 +1374,11 @@ impl KvCache {
         let k_f32_empty: Vec<f32> = Vec::new();
         ks.append(&k_f32_empty, &new_shape, new_k, device, max_seq)?;
 
-        // GPU packed view — `None` means buffers not populated (CPU path or
-        // very first call corner cases); fall through to legacy.
-        let Some((codes_arr, scales_arr, rot32_arr)) = ks.gpu_packed_view(device)? else {
+        // GPU buffers not populated (CPU path or very first call corner cases):
+        // fall through to legacy BEFORE any further mutation.
+        if ks.gpu_packed_view(device)?.is_none() {
             return Ok(None);
-        };
+        }
         let k_shape = ks.shape.clone();
         // k_shape = [B, kv_h, S, head_dim].
         if k_shape.len() != 4 {
@@ -1112,10 +1386,7 @@ impl KvCache {
                 "planar_k_fused: K shape rank != 4, got {k_shape:?}"
             )));
         }
-        let b = k_shape[0];
-        let kv_h = k_shape[1];
         let kv_seq = k_shape[2];
-        let head_dim = k_shape[3];
 
         // CRITICAL: advance `self.offset` BEFORE calling
         // `update_decode_fp16_v_only`.  The V-only helper (and the full
@@ -1139,6 +1410,75 @@ impl KvCache {
         // waste an O(seq) bf16 K buffer every decode step.  Mirrors the
         // pattern from `update_iso_k_only_3`/`_4`.
         let v_full = self.update_decode_fp16_v_only(new_v, max_seq, device)?;
+
+        // Past this point the cache is already mutated (store appended, offset
+        // advanced, bf16 V accumulated), so `Ok(None)` is no longer available —
+        // it would send the caller into the legacy `update()` path, which
+        // appends a second time. Every not-eligible condition is screened
+        // above.
+        let out =
+            self.planar_k_flash_over_store(queries, &v_full, scale, additive_mask, kv_seq, device)?;
+        Ok(Some(out))
+    }
+
+    /// Run the PlanarK fused-QK / flash-decode chain over the K already packed
+    /// in this cache's store — no append, no offset advance.
+    ///
+    /// Split out of [`Self::update_and_sdpa_planar_k_fused`] so a shared-KV
+    /// **consumer** layer can attend the producer's store through the exact
+    /// same kernels the producer used, instead of the producer having to
+    /// materialise bf16 K/V for it.
+    ///
+    /// `kv_seq` is the accumulated store length and `v_full` the matching bf16
+    /// V prefix; both come from the caller so producer and consumer read the
+    /// identical window.
+    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "all index uses validated by the shape contracts at function entry"
+    )]
+    fn planar_k_flash_over_store(
+        &self,
+        queries: &Array,
+        v_full: &Array,
+        scale: f32,
+        additive_mask: Option<&Array>,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Array> {
+        let KvStorage::PlanarK { k, .. } = &self.storage else {
+            return Err(Error::KvStorageMismatch {
+                expected: "PlanarK",
+                got: storage_variant_name(&self.storage),
+            });
+        };
+        let Some(ks) = k.as_ref() else {
+            return Err(Error::Mlx(
+                "planar_k_fused: K store absent after a maintained append — internal invariant \
+                 violated"
+                    .to_owned(),
+            ));
+        };
+        let Some((codes_arr, scales_arr, rot32_arr)) = ks.gpu_packed_view(device)? else {
+            return Err(Error::Mlx(
+                "planar_k_fused: GPU packed view absent after a maintained append — internal \
+                 invariant violated"
+                    .to_owned(),
+            ));
+        };
+        let k_shape = &ks.shape;
+        if k_shape.len() != 4 {
+            return Err(Error::Mlx(format!(
+                "planar_k_fused: K shape rank != 4, got {k_shape:?}"
+            )));
+        }
+        // The store the packed view was written from is the one source of truth
+        // for the attended length. A divergence would silently attend the wrong
+        // prefix rather than error.
+        Self::check_shared_kv_len(kv_seq, k_shape[2])?;
+        let b = k_shape[0];
+        let kv_h = k_shape[1];
+        let head_dim = k_shape[3];
 
         // Q shape: [B, n_q_heads, q_seq, head_dim].  GQA: heads_per_kv =
         // n_q_heads / kv_h (must divide evenly).
@@ -1179,7 +1519,7 @@ impl KvCache {
                 &codes_arr,
                 &scales_arr,
                 &rot32_arr,
-                &v_full,
+                v_full,
                 additive_mask,
                 b,
                 kv_h,
@@ -1190,12 +1530,11 @@ impl KvCache {
                 scale,
                 device,
             )?;
-            let out = if flash_out.dtype() == queries.dtype() {
-                flash_out
+            return if flash_out.dtype() == queries.dtype() {
+                Ok(flash_out)
             } else {
-                flash_out.astype(queries.dtype(), device)?
+                flash_out.astype(queries.dtype(), device)
             };
-            return Ok(Some(out));
         }
 
         // Pre-softmax scores via fused QK kernel — bits=4 (K-side PlanarK is
@@ -1232,12 +1571,11 @@ impl KvCache {
         let out = out_g.reshape(&[b, n_q_heads, 1, head_dim], device)?;
         // Match the legacy SDPA output dtype (bf16/f16 callers); softmax may
         // have promoted to f32.
-        let out = if out.dtype() == queries.dtype() {
-            out
+        if out.dtype() == queries.dtype() {
+            Ok(out)
         } else {
-            out.astype(queries.dtype(), device)?
-        };
-        Ok(Some(out))
+            out.astype(queries.dtype(), device)
+        }
     }
 
     /// Flash-decode dispatch for the rotor K-only storage variants
@@ -1282,7 +1620,6 @@ impl KvCache {
                 "rotor_k_fused: new_k rank != 4, got {new_shape:?}"
             )));
         }
-        let head_dim = new_shape[3];
         let new_seq = new_shape[2];
 
         // Shape gates — checked BEFORE any mutation so a reject is a clean
@@ -1297,13 +1634,12 @@ impl KvCache {
         let prev_seq = self.offset;
         // Not a rotor K-only cache: the caller's gate should have kept us out.
         // Fall through rather than mutate.
-        let bits = if matches!(self.storage, KvStorage::RotorKOnly3 { .. }) {
-            3_u8
-        } else if matches!(self.storage, KvStorage::RotorKOnly4 { .. }) {
-            4_u8
-        } else {
+        if !matches!(
+            self.storage,
+            KvStorage::RotorKOnly3 { .. } | KvStorage::RotorKOnly4 { .. }
+        ) {
             return Ok(None);
-        };
+        }
         self.rotor_k_gpu_append(new_k, &new_shape, device)?;
 
         // CRITICAL: advance `self.offset` BEFORE `update_decode_fp16_v_only` —
@@ -1333,12 +1669,65 @@ impl KvCache {
         // condition is screened at the call-site gate and by
         // `rotor_flash_shape_ok` BEFORE any mutation; reaching here without a
         // ring means an internal invariant broke, so fail loudly.
+        let out =
+            self.rotor_k_flash_over_store(queries, &v_full, scale, additive_mask, kv_seq, device)?;
+        Ok(Some(out))
+    }
+
+    /// Run the rotor flash-decode kernel over the K already packed in this
+    /// cache's store — no append, no offset advance.
+    ///
+    /// Split out of [`Self::update_and_sdpa_rotor_k_fused`] so a shared-KV
+    /// **consumer** layer can attend the producer's store through the exact
+    /// same kernel the producer used, instead of the producer having to
+    /// materialise bf16 K/V for it.
+    ///
+    /// `kv_seq` is the accumulated store length and `v_full` the matching bf16
+    /// V prefix; both come from the caller so producer and consumer read the
+    /// identical window.
+    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "all index uses validated by the shape contracts at function entry"
+    )]
+    fn rotor_k_flash_over_store(
+        &self,
+        queries: &Array,
+        v_full: &Array,
+        scale: f32,
+        additive_mask: Option<&Array>,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Array> {
+        // Select the bit width from the live storage variant. No wildcard arm:
+        // an unexpected variant must not be decoded with another codec's
+        // kernel.
+        let bits: u8 = if matches!(self.storage, KvStorage::RotorKOnly3 { .. }) {
+            3
+        } else if matches!(self.storage, KvStorage::RotorKOnly4 { .. }) {
+            4
+        } else {
+            return Err(Error::KvStorageMismatch {
+                expected: "RotorKOnly3 | RotorKOnly4",
+                got: storage_variant_name(&self.storage),
+            });
+        };
         let Some((codes, scales, norms, rotors)) = self.rotor_k_packed_view(kv_seq, device)? else {
             return Err(Error::Mlx(format!(
                 "rotor_k_fused: GPU ring absent after a maintained append \
                  (kv_seq={kv_seq}, bits={bits}) — internal invariant violated"
             )));
         };
+
+        let v_shape = v_full.shape();
+        if v_shape.len() != 4 {
+            return Err(Error::Mlx(format!(
+                "rotor_k_fused: V rank != 4, got {v_shape:?}"
+            )));
+        }
+        let b = v_shape[0];
+        let kv_h = v_shape[1];
+        let head_dim = v_shape[3];
 
         let q_shape = queries.shape();
         if q_shape.len() != 4 {
@@ -1354,8 +1743,6 @@ impl KvCache {
                 "rotor_k_fused: q_seq must be 1 (decode-only), got {q_seq}"
             )));
         }
-        let b = new_shape[0];
-        let kv_h = new_shape[1];
         if n_q_heads % kv_h != 0 {
             return Err(Error::Mlx(format!(
                 "rotor_k_fused: n_q_heads={n_q_heads} not divisible by kv_h={kv_h}"
@@ -1375,7 +1762,7 @@ impl KvCache {
                 &scales,
                 &norms,
                 &rotors,
-                &v_full,
+                v_full,
                 additive_mask,
                 b,
                 kv_h,
@@ -1391,7 +1778,7 @@ impl KvCache {
                 &scales,
                 &norms,
                 &rotors,
-                &v_full,
+                v_full,
                 additive_mask,
                 b,
                 kv_h,
@@ -1408,12 +1795,11 @@ impl KvCache {
                 )))
             }
         };
-        let out = if flash_out.dtype() == queries.dtype() {
-            flash_out
+        if flash_out.dtype() == queries.dtype() {
+            Ok(flash_out)
         } else {
-            flash_out.astype(queries.dtype(), device)?
-        };
-        Ok(Some(out))
+            flash_out.astype(queries.dtype(), device)
+        }
     }
 
     /// Shape gates for the rotor flash-decode kernel, evaluated before any

--- a/crates/rmlx-kv-quant/src/kvcache/shared_kv.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/shared_kv.rs
@@ -1,0 +1,132 @@
+//! Cross-layer KV sharing: what a producer layer hands to its consumers.
+//!
+//! Some architectures declare a **shared-KV topology**: a run of layers do not
+//! project their own K/V but attend over the K/V a designated earlier
+//! ("producer") layer accumulated. The producer holds the [`KvCache`]; the
+//! consumers hold none.
+//!
+//! A consumer does not need bf16 *tensors* — it needs **access to the
+//! producer's K/V**. The quantized store already provides that. Handing over a
+//! dequantized tensor forces the producer to materialise bf16 K/V, which is
+//! exactly what a fused flash-decode-over-quant kernel exists to avoid: it
+//! would strand every fused codec on any shared-KV model.
+//!
+//! [`SharedKv`] therefore lets the **codec** decide which of the two it can
+//! offer, and the consumer runs the matching attention either way. The model on
+//! top never chooses — it only reports the sharing topology.
+
+use rmlx_core::error::{Error, Result};
+use rmlx_mlx::{scaled_dot_product_attention, Array, Device};
+
+use crate::kvcache::KvCache;
+
+/// The producer layer's K/V, as offered to shared-KV consumer layers.
+///
+/// Produced by [`KvCache::update_and_sdpa_shared_source`], consumed by
+/// [`SharedKv::sdpa`]. Which variant a step yields is decided by the codec's
+/// own decode dispatch, never by the architecture on top.
+#[allow(missing_debug_implementations)]
+#[allow(
+    clippy::exhaustive_enums,
+    reason = "closed protocol enum — the two ways a producer can offer its K/V. Deliberately \
+              exhaustive so a third kind breaks compilation at every consumer match instead of \
+              silently falling into a wildcard arm that reads the wrong K/V"
+)]
+pub enum SharedKv {
+    /// The producer's own SDPA already materialised bf16 `(K, V)`, so consumers
+    /// reuse those exact tensors — one materialisation, N consumers.
+    ///
+    /// This is what every codec without a live fused decode kernel yields, plus
+    /// every prefill step and every rotating (SWA) layer.
+    Bf16(Array, Array),
+    /// The producer ran a fused decode kernel straight off its quant store and
+    /// never materialised bf16 K/V. Consumers re-run the same fused kernel
+    /// against that store via [`SharedKv::sdpa`].
+    ///
+    /// `kv_len` is the number of K/V positions the producer attended — the
+    /// value a consumer must size its mask's key dim from, exactly as it would
+    /// read `k.shape()[2]` off a [`SharedKv::Bf16`] tensor.
+    Store {
+        /// Accumulated K/V positions held by the producer's store.
+        kv_len: i32,
+    },
+}
+
+impl SharedKv {
+    /// Number of K/V positions a consumer will attend over.
+    ///
+    /// A consumer's mask is built from the **producer's** length, never from
+    /// the model-wide offset: the two can legitimately disagree after a
+    /// speculative partial-accept rollback.
+    pub fn kv_len(&self) -> Result<i32> {
+        match self {
+            Self::Bf16(k, _) => k.shape().get(2).copied().ok_or_else(|| {
+                Error::Mlx(format!(
+                    "SharedKv::Bf16: K shape {:?} has no seq axis",
+                    k.shape()
+                ))
+            }),
+            Self::Store { kv_len } => Ok(*kv_len),
+        }
+    }
+
+    /// Run a consumer layer's SDPA over the producer's K/V.
+    ///
+    /// `producer` is the cache the K/V lives in. It is only read for
+    /// [`Self::Store`]; pass `None` on cacheless forwards (which can only ever
+    /// yield [`Self::Bf16`]).
+    ///
+    /// The `Store` arm re-enters the producer's own fused decode kernel through
+    /// [`KvCache::sdpa_shared`] — no bf16 materialisation, no second append.
+    pub fn sdpa(
+        &self,
+        producer: Option<&KvCache>,
+        queries: &Array,
+        scale: f32,
+        mask_mode: &str,
+        additive_mask: Option<&Array>,
+        device: Device,
+    ) -> Result<Array> {
+        match self {
+            Self::Bf16(k, v) => {
+                scaled_dot_product_attention(queries, k, v, scale, mask_mode, additive_mask, device)
+            }
+            Self::Store { kv_len } => {
+                let cache = producer.ok_or_else(|| {
+                    Error::Mlx(
+                        "SharedKv::Store: no producer cache supplied — a store-backed share can \
+                         only be produced by a cache-holding layer"
+                            .to_owned(),
+                    )
+                })?;
+                cache.sdpa_shared(queries, scale, additive_mask, *kv_len, device)
+            }
+        }
+    }
+
+    /// Materialise the producer's K/V as bf16 tensors.
+    ///
+    /// For callers that genuinely need *tensors* rather than attention output —
+    /// e.g. handing a verifier's representative K/V to a separate drafter
+    /// model. **Not** for the attention hot path: on a [`Self::Store`] share
+    /// this pays the full-prefix dequant the fused kernel exists to avoid.
+    pub fn materialise_bf16(
+        &self,
+        producer: Option<&KvCache>,
+        device: Device,
+    ) -> Result<(Array, Array)> {
+        match self {
+            Self::Bf16(k, v) => Ok((k.try_clone()?, v.try_clone()?)),
+            Self::Store { kv_len } => {
+                let cache = producer.ok_or_else(|| {
+                    Error::Mlx(
+                        "SharedKv::Store: no producer cache supplied — cannot materialise bf16 \
+                         K/V without the store it lives in"
+                            .to_owned(),
+                    )
+                })?;
+                cache.materialise_shared_kv_bf16(*kv_len, device)
+            }
+        }
+    }
+}

--- a/crates/rmlx-kv-quant/src/kvcache/shared_kv.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/shared_kv.rs
@@ -104,13 +104,18 @@ impl SharedKv {
         }
     }
 
-    /// Materialise the producer's K/V as bf16 tensors.
+    /// Materialise the producer's K/V as tensors.
     ///
     /// For callers that genuinely need *tensors* rather than attention output —
     /// e.g. handing a verifier's representative K/V to a separate drafter
     /// model. **Not** for the attention hot path: on a [`Self::Store`] share
     /// this pays the full-prefix dequant the fused kernel exists to avoid.
-    pub fn materialise_bf16(
+    ///
+    /// The pair comes back at the activation-stream dtype (bf16 in production);
+    /// K and V always agree, so a consumer's attention is never promoted to a
+    /// wider dtype by one half of the pair. See
+    /// [`KvCache::materialise_shared_kv`].
+    pub fn materialise(
         &self,
         producer: Option<&KvCache>,
         device: Device,
@@ -120,12 +125,12 @@ impl SharedKv {
             Self::Store { kv_len } => {
                 let cache = producer.ok_or_else(|| {
                     Error::Mlx(
-                        "SharedKv::Store: no producer cache supplied — cannot materialise bf16 \
-                         K/V without the store it lives in"
+                        "SharedKv::Store: no producer cache supplied — cannot materialise K/V \
+                         without the store it lives in"
                             .to_owned(),
                     )
                 })?;
-                cache.materialise_shared_kv_bf16(*kv_len, device)
+                cache.materialise_shared_kv(*kv_len, device)
             }
         }
     }

--- a/crates/rmlx-kv-quant/src/kvcache/shared_kv_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/shared_kv_tests.rs
@@ -183,10 +183,128 @@ fn store_share_kv_len_tracks_producer_offset() {
     }
 }
 
-/// A store-backed share must never be silently answered from a cache that does
-/// not hold it. Both the missing-producer and the length-desync cases error.
+/// `materialise` must return K at the **stream dtype**, never a raw f32 dequant.
+///
+/// The pair goes to a separate downstream model's attention, so a K wider than
+/// V promotes that model's whole stream — the KV-promotion class this codebase
+/// has closed repeatedly. The rotor store dequantises through a `Vec<f32>`, so
+/// K arrives F32 and the cast to V's dtype is load-bearing: drop it and a bf16
+/// stream silently gets an f32 K.
+///
+/// Pinned against a **bf16** producer specifically, because that is the
+/// production shape — the other tests here push F32 K/V, which would hide the
+/// bug (F32 K matches an F32 V by accident).
 #[test]
-fn store_share_refuses_missing_producer_and_length_desync() {
+#[allow(
+    clippy::indexing_slicing,
+    reason = "test asserts on a known rank-4 shape"
+)]
+fn materialise_casts_k_to_the_stream_dtype() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let device = Device::Gpu;
+    let mut cache = seeded_cache();
+
+    // bf16 K/V, as a real model pushes.
+    let bf16 = |data: &[f32], shape: &[i32]| -> Array {
+        f32_array(data, shape)
+            .astype(Dtype::Bf16, device)
+            .expect("cast to bf16")
+    };
+    let pf = (PREFILL * KV_H * HEAD_DIM) as usize;
+    let k = bf16(&lcg_data(pf, 1), &[1, KV_H, PREFILL, HEAD_DIM]);
+    let v = bf16(&lcg_data(pf, 2), &[1, KV_H, PREFILL, HEAD_DIM]);
+    let q = bf16(
+        &lcg_data((PREFILL * N_Q_HEADS * HEAD_DIM) as usize, 3),
+        &[1, N_Q_HEADS, PREFILL, HEAD_DIM],
+    );
+    cache
+        .update_and_sdpa_shared_source(&q, &k, &v, scale(), "causal", None, device)
+        .expect("bf16 prefill");
+    cache.exit_prefill(device).expect("exit_prefill");
+
+    let one = (KV_H * HEAD_DIM) as usize;
+    let k1 = bf16(&lcg_data(one, 11), &[1, KV_H, 1, HEAD_DIM]);
+    let v1 = bf16(&lcg_data(one, 21), &[1, KV_H, 1, HEAD_DIM]);
+    let q1 = bf16(
+        &lcg_data((N_Q_HEADS * HEAD_DIM) as usize, 31),
+        &[1, N_Q_HEADS, 1, HEAD_DIM],
+    );
+    let (out, share) = cache
+        .update_and_sdpa_shared_source(&q1, &k1, &v1, scale(), "", None, device)
+        .expect("bf16 decode");
+    out.eval().expect("out eval");
+    assert!(
+        matches!(share, SharedKv::Store { .. }),
+        "precondition: this must be a store-backed share, or the test proves nothing"
+    );
+
+    let (k_m, v_m) = share
+        .materialise(Some(&cache), device)
+        .expect("materialise a store-backed share");
+    assert_eq!(
+        v_m.dtype(),
+        Dtype::Bf16,
+        "precondition: the V mirror carries the bf16 stream dtype"
+    );
+    assert_eq!(
+        k_m.dtype(),
+        Dtype::Bf16,
+        "materialised K must follow the stream dtype — a raw f32 dequant here \
+         promotes the consumer model's attention stream to f32"
+    );
+    assert_eq!(k_m.dtype(), v_m.dtype(), "K and V must agree on dtype");
+    assert_eq!(
+        k_m.shape()[2],
+        share.kv_len().expect("kv_len"),
+        "materialised K must span the shared length"
+    );
+}
+
+/// `check_shared_kv_len` is the guard between a producer/consumer length desync
+/// and a silently-wrong attended prefix: a consumer that reads one key too many
+/// or too few gets a plausible-looking answer, not an error. Pin both
+/// directions against a live store — stubbing the guard to `Ok(())` must turn
+/// this red.
+#[test]
+fn store_share_refuses_length_desync_against_live_store() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let device = Device::Gpu;
+    let mut cache = prefilled_producer();
+    let share = producer_decode_step(&mut cache, 0);
+    let live = share.kv_len().expect("kv_len");
+
+    let q = f32_array(
+        &lcg_data((N_Q_HEADS * HEAD_DIM) as usize, 77),
+        &[1, N_Q_HEADS, 1, HEAD_DIM],
+    );
+    // Sanity: the honest length must succeed, or the negatives below prove
+    // nothing (they would fail for an unrelated reason).
+    cache
+        .sdpa_shared(&q, scale(), None, live, device)
+        .expect("the live store length must be accepted");
+
+    for wrong in [live + 1, live - 1] {
+        assert!(
+            cache.sdpa_shared(&q, scale(), None, wrong, device).is_err(),
+            "sdpa_shared accepted kv_len={wrong} against a store holding {live} — a \
+             desync must error, not attend the wrong prefix"
+        );
+        assert!(
+            cache.materialise_shared_kv(wrong, device).is_err(),
+            "materialise_shared_kv accepted kv_len={wrong} against a store \
+             holding {live} — a desync must error"
+        );
+    }
+}
+
+/// A store-backed share must never be silently answered from a cache that does
+/// not hold it: no producer supplied, or a codec with no fused-over-store path.
+#[test]
+fn store_share_refuses_missing_producer_and_wrong_codec() {
     let device = Device::Gpu;
     let share = SharedKv::Store { kv_len: 8 };
     let q = f32_array(
@@ -198,7 +316,7 @@ fn store_share_refuses_missing_producer_and_length_desync() {
         "a store-backed share with no producer cache must error, not guess"
     );
     assert!(
-        share.materialise_bf16(None, device).is_err(),
+        share.materialise(None, device).is_err(),
         "materialising a store-backed share with no producer cache must error"
     );
 

--- a/crates/rmlx-kv-quant/src/kvcache/shared_kv_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/shared_kv_tests.rs
@@ -1,0 +1,247 @@
+//! Cross-layer KV sharing must not defeat the fused decode kernels.
+//!
+//! A producer layer in a shared-KV topology routes through
+//! `update_and_sdpa_shared_source`. If that chain lacks the fused-over-store
+//! arms `update_and_sdpa` has, the producer is pushed onto the legacy bf16 path
+//! and **every** fused decode kernel is silently dead for **every** model with
+//! KV sharing — regardless of arch or codec. These tests pin the two halves of
+//! the contract:
+//!
+//! 1. a shared-KV producer reaches the same kernel a non-sharing model reaches;
+//! 2. a consumer attends the producer's quant store through that same kernel,
+//!    rather than forcing a bf16 materialisation.
+//!
+//! # No env dependence
+//!
+//! Like `rotor_flash_dispatch_tests`, these seed the rotor store with a
+//! pre-built rotor table, which pins the codec's QJL decision for the store's
+//! lifetime independently of the process-global toggle.
+
+use super::{KvCache, SharedKv};
+use crate::clifford::make_rotor_table;
+use crate::quant::KvQuant;
+use crate::rotor_flash_decode_msl::rotor_flash_decode_dispatch_count;
+use crate::rotorquant::n_groups_for;
+use crate::storage::{KvStorage, QuantRotorK3};
+use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
+use rmlx_mlx::{Array, Device, Dtype};
+
+const MAX_SEQ: i32 = 512;
+const KV_H: i32 = 2;
+const N_Q_HEADS: i32 = 8;
+const HEAD_DIM: i32 = 128;
+const PREFILL: i32 = 24;
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn f32_array(data: &[f32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::F32).expect("f32_array")
+}
+
+/// Rotor3 K-only cache with QJL pinned off, so the flash kernel is eligible.
+fn seeded_cache() -> KvCache {
+    let rotors = make_rotor_table(0, 0, n_groups_for(HEAD_DIM as usize));
+    let storage = KvStorage::RotorKOnly3 {
+        k: Some(QuantRotorK3::from_cpu_blocks(
+            rotors,
+            None,
+            Vec::new(),
+            vec![1, KV_H, 0, HEAD_DIM],
+            MAX_SEQ,
+            0,
+        )),
+        max_seq: MAX_SEQ,
+    };
+    KvCache::from_storage(storage, KvQuant::RotorKOnly3, 0, 0)
+}
+
+fn scale() -> f32 {
+    1.0 / (HEAD_DIM as f32).sqrt()
+}
+
+/// Prefill a producer cache through the shared-source entry point and leave it
+/// decode-ready, exactly as a cross-layer-KV arch does.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn prefilled_producer() -> KvCache {
+    let device = Device::Gpu;
+    let mut cache = seeded_cache();
+    let pf = (PREFILL * KV_H * HEAD_DIM) as usize;
+    let k = f32_array(&lcg_data(pf, 1), &[1, KV_H, PREFILL, HEAD_DIM]);
+    let v = f32_array(&lcg_data(pf, 2), &[1, KV_H, PREFILL, HEAD_DIM]);
+    let q = f32_array(
+        &lcg_data((PREFILL * N_Q_HEADS * HEAD_DIM) as usize, 3),
+        &[1, N_Q_HEADS, PREFILL, HEAD_DIM],
+    );
+    let (_out, share) = cache
+        .update_and_sdpa_shared_source(&q, &k, &v, scale(), "causal", None, device)
+        .expect("prefill update_and_sdpa_shared_source");
+    // Prefill is not decode-only, so no fused arm may fire: the share is bf16.
+    assert!(
+        matches!(share, SharedKv::Bf16(_, _)),
+        "a prefill chunk must yield a bf16 share — the fused arms are decode-only"
+    );
+    cache.exit_prefill(device).expect("exit_prefill");
+    cache
+}
+
+/// One decode step on the producer. Returns the share it offers consumers.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn producer_decode_step(cache: &mut KvCache, step: u64) -> SharedKv {
+    let device = Device::Gpu;
+    let one = (KV_H * HEAD_DIM) as usize;
+    let k1 = f32_array(&lcg_data(one, 10 + step), &[1, KV_H, 1, HEAD_DIM]);
+    let v1 = f32_array(&lcg_data(one, 20 + step), &[1, KV_H, 1, HEAD_DIM]);
+    let q1 = f32_array(
+        &lcg_data((N_Q_HEADS * HEAD_DIM) as usize, 30 + step),
+        &[1, N_Q_HEADS, 1, HEAD_DIM],
+    );
+    let (out, share) = cache
+        .update_and_sdpa_shared_source(&q1, &k1, &v1, scale(), "", None, device)
+        .expect("decode update_and_sdpa_shared_source");
+    out.eval().expect("producer out eval");
+    share
+}
+
+/// The defect: a shared-KV producer must reach the same fused kernel a
+/// non-sharing model reaches. Before the fix this chain had no rotor arm at all
+/// and every step fell through to `update()`'s O(seq) CPU dequant, so the
+/// dispatch delta was 0 no matter what the codec supported.
+#[test]
+fn shared_source_producer_dispatches_flash_kernel() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let mut cache = prefilled_producer();
+    let before = rotor_flash_decode_dispatch_count();
+    for step in 0..4_u64 {
+        let share = producer_decode_step(&mut cache, step);
+        assert!(
+            matches!(share, SharedKv::Store { .. }),
+            "a fused decode step must share the quant store, not a bf16 dequant"
+        );
+    }
+    let delta = rotor_flash_decode_dispatch_count() - before;
+    assert!(
+        delta >= 4,
+        "update_and_sdpa_shared_source did not reach the rotor flash kernel on all 4 \
+         decode steps (delta={delta}) — a shared-KV topology is still forcing the \
+         codec onto the legacy bf16 path"
+    );
+}
+
+/// A consumer attends the producer's store through the same kernel — the
+/// producer never materialises bf16 K/V on its behalf.
+#[test]
+fn shared_consumer_attends_store_through_flash_kernel() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let device = Device::Gpu;
+    let mut cache = prefilled_producer();
+    let share = producer_decode_step(&mut cache, 0);
+
+    // Consumer Q: its own projection, same shape contract as the producer's.
+    let q_c = f32_array(
+        &lcg_data((N_Q_HEADS * HEAD_DIM) as usize, 99),
+        &[1, N_Q_HEADS, 1, HEAD_DIM],
+    );
+    let before = rotor_flash_decode_dispatch_count();
+    let out = share
+        .sdpa(Some(&cache), &q_c, scale(), "", None, device)
+        .expect("consumer sdpa over the producer's store");
+    out.eval().expect("consumer out eval");
+    let delta = rotor_flash_decode_dispatch_count() - before;
+
+    assert!(
+        delta >= 1,
+        "consumer SDPA did not reach the flash kernel (delta={delta}) — it is \
+         reading a dequantized bf16 tensor instead of the producer's store"
+    );
+    assert_eq!(
+        out.shape(),
+        vec![1, N_Q_HEADS, 1, HEAD_DIM],
+        "consumer output shape"
+    );
+}
+
+/// The consumer's mask is sized from the **producer's** K length. A store-backed
+/// share must report exactly what a bf16 share's `k.shape()[2]` would have.
+#[test]
+fn store_share_kv_len_tracks_producer_offset() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let mut cache = prefilled_producer();
+    for step in 0..3_u64 {
+        let share = producer_decode_step(&mut cache, step);
+        assert_eq!(
+            share.kv_len().expect("kv_len"),
+            cache.offset(),
+            "share kv_len must equal the producer's post-update offset — a \
+             consumer sizes its mask from it"
+        );
+    }
+}
+
+/// A store-backed share must never be silently answered from a cache that does
+/// not hold it. Both the missing-producer and the length-desync cases error.
+#[test]
+fn store_share_refuses_missing_producer_and_length_desync() {
+    let device = Device::Gpu;
+    let share = SharedKv::Store { kv_len: 8 };
+    let q = f32_array(
+        &lcg_data((N_Q_HEADS * HEAD_DIM) as usize, 7),
+        &[1, N_Q_HEADS, 1, HEAD_DIM],
+    );
+    assert!(
+        share.sdpa(None, &q, scale(), "", None, device).is_err(),
+        "a store-backed share with no producer cache must error, not guess"
+    );
+    assert!(
+        share.materialise_bf16(None, device).is_err(),
+        "materialising a store-backed share with no producer cache must error"
+    );
+
+    // A non-store codec must refuse a store-backed consumer read outright
+    // rather than answer with some other codec's numbers.
+    let cache = KvCache::with_quant_max_seq(KvQuant::None, MAX_SEQ);
+    assert!(
+        cache.sdpa_shared(&q, scale(), None, 8, device).is_err(),
+        "sdpa_shared on a storage variant with no fused-over-store path must error"
+    );
+}
+
+/// `KvQuant::None` keeps the bf16 contract: the share is the stored tensors and
+/// consumers read them exactly as before.
+#[test]
+fn none_quant_shares_bf16_unchanged() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let device = Device::Gpu;
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::None, MAX_SEQ);
+    let one = (KV_H * HEAD_DIM) as usize;
+    let k1 = f32_array(&lcg_data(one, 1), &[1, KV_H, 1, HEAD_DIM]);
+    let v1 = f32_array(&lcg_data(one, 2), &[1, KV_H, 1, HEAD_DIM]);
+    let q1 = f32_array(
+        &lcg_data((N_Q_HEADS * HEAD_DIM) as usize, 3),
+        &[1, N_Q_HEADS, 1, HEAD_DIM],
+    );
+    let (_out, share) = cache
+        .update_and_sdpa_shared_source(&q1, &k1, &v1, scale(), "", None, device)
+        .expect("None-quant shared source");
+    match &share {
+        SharedKv::Bf16(k, v) => {
+            assert_eq!(k.shape(), vec![1, KV_H, 1, HEAD_DIM], "shared K shape");
+            assert_eq!(v.shape(), vec![1, KV_H, 1, HEAD_DIM], "shared V shape");
+        }
+        SharedKv::Store { .. } => {
+            panic!("KvQuant::None has no quant store to share — must stay bf16")
+        }
+    }
+    assert_eq!(share.kv_len().expect("kv_len"), 1, "bf16 share kv_len");
+    let out = share
+        .sdpa(Some(&cache), &q1, scale(), "", None, device)
+        .expect("bf16 consumer sdpa");
+    out.eval().expect("bf16 consumer eval");
+}

--- a/crates/rmlx-kv-quant/src/kvcache/shared_source_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/shared_source_tests.rs
@@ -53,7 +53,7 @@ const TEST_PREFILL_SEQ: i32 = 64;
 /// is unconditional on CPU hosts regardless of `RMLX_TURBO_FLASH` or
 /// `RMLX_FUSED_QK` env-var state. It does NOT prove that GPU dispatch works.
 #[test]
-fn returning_kv_cpu_device_suppresses_all_dispatch_arms() {
+fn shared_source_cpu_device_suppresses_all_dispatch_arms() {
     // Defensive: clear gates if a prior process / test latched them. These
     // gates use OnceLock so the value is per-process; the test relies on the
     // canonical default-off state.
@@ -121,7 +121,7 @@ fn returning_kv_cpu_device_suppresses_all_dispatch_arms() {
 /// dispatch path — shape correctness after TurboFlash dispatch is verified
 /// in `crates/rmlx-kv-quant/tests/shared_source_dispatch.rs`.
 #[test]
-fn returning_kv_cpu_device_legacy_fallback_surfaces_full_prefix_shape() {
+fn shared_source_cpu_device_legacy_fallback_surfaces_full_prefix_shape() {
     let device = Device::Cpu;
     let mut cache = KvCache::with_quant_max_seq(KvQuant::K8V4, TEST_MAX_SEQ);
 

--- a/crates/rmlx-kv-quant/src/kvcache/shared_source_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/shared_source_tests.rs
@@ -1,7 +1,7 @@
-//! CPU-device behaviour pins for `update_and_sdpa_returning_kv`.
+//! CPU-device behaviour pins for `update_and_sdpa_shared_source`.
 //!
 //! These tests run on `Device::Cpu` and pin two structural properties of the
-//! `update_and_sdpa_returning_kv` code path that hold independently of GPU
+//! `update_and_sdpa_shared_source` code path that hold independently of GPU
 //! availability:
 //!
 //! * **CPU-device dispatch gating**: with `Device::Cpu`, both
@@ -18,10 +18,11 @@
 //!
 //! **What these tests do NOT cover**: GPU kernel dispatch (delta > 0).
 //! That is covered by the integration test at
-//! `crates/rmlx-kv-quant/tests/returning_kv_dispatch.rs` which runs
+//! `crates/rmlx-kv-quant/tests/shared_source_dispatch.rs` which runs
 //! under `#[ignore]` and requires `--test-threads=1` and a Metal GPU.
 
 use super::core::KvCache;
+use super::SharedKv;
 use crate::kvcache::fused_qk_total_dispatch_count;
 use crate::turbo_flash_msl::turbo_flash_dispatch_count;
 use crate::KvQuant;
@@ -72,12 +73,12 @@ fn returning_kv_cpu_device_suppresses_all_dispatch_arms() {
     let n_q_pref: usize = q_pref_shape.iter().map(|&d| d as usize).product();
     let q_pref = f32_arr(&vec![0.333f32; n_q_pref], &q_pref_shape);
 
-    // Prefill via the returning_kv entry — mirrors Gemma4's call site.
+    // Prefill via the shared-source entry — mirrors Gemma4's call site.
     let tf_before = turbo_flash_dispatch_count();
     let fqk_before = fused_qk_total_dispatch_count();
-    let (_out, _k, _v) = cache
-        .update_and_sdpa_returning_kv(&q_pref, &k_pref, &v_pref, 1.0, "causal", None, device)
-        .expect("prefill returning_kv");
+    let (_out, _share) = cache
+        .update_and_sdpa_shared_source(&q_pref, &k_pref, &v_pref, 1.0, "causal", None, device)
+        .expect("prefill shared source");
     cache.exit_prefill(device).expect("exit_prefill");
 
     // Decode step 1 — q_seq = 1.
@@ -89,9 +90,9 @@ fn returning_kv_cpu_device_suppresses_all_dispatch_arms() {
     let n_q_step: usize = q_step_shape.iter().map(|&d| d as usize).product();
     let q_step = f32_arr(&vec![0.666f32; n_q_step], &q_step_shape);
 
-    let (_out2, _k2, _v2) = cache
-        .update_and_sdpa_returning_kv(&q_step, &k_step, &v_step, 1.0, "", None, device)
-        .expect("decode returning_kv");
+    let (_out2, _share2) = cache
+        .update_and_sdpa_shared_source(&q_step, &k_step, &v_step, 1.0, "", None, device)
+        .expect("decode shared source");
 
     let tf_after = turbo_flash_dispatch_count();
     let fqk_after = fused_qk_total_dispatch_count();
@@ -111,14 +112,14 @@ fn returning_kv_cpu_device_suppresses_all_dispatch_arms() {
 /// CPU-device legacy shape contract: surfaced K/V is shaped `[B, kv_h, offset, D]`.
 ///
 /// The shared-KV consumer (Gemma4 cross-layer-KV) depends on `(K, V)` being
-/// shaped `[B, kv_h, offset, D]` after `update_and_sdpa_returning_kv`. This
+/// shaped `[B, kv_h, offset, D]` after `update_and_sdpa_shared_source`. This
 /// test exercises a decode step on `Device::Cpu` (where all dispatch arms
 /// gate off) and verifies the legacy bf16 fallback surfaces the full kv
 /// prefix with the correct shape.
 ///
 /// This pins the legacy-path shape contract. It does NOT exercise the GPU
 /// dispatch path — shape correctness after TurboFlash dispatch is verified
-/// in `crates/rmlx-kv-quant/tests/returning_kv_dispatch.rs`.
+/// in `crates/rmlx-kv-quant/tests/shared_source_dispatch.rs`.
 #[test]
 fn returning_kv_cpu_device_legacy_fallback_surfaces_full_prefix_shape() {
     let device = Device::Cpu;
@@ -133,8 +134,8 @@ fn returning_kv_cpu_device_legacy_fallback_surfaces_full_prefix_shape() {
     let n_q_pref: usize = q_pref_shape.iter().map(|&d| d as usize).product();
     let q_pref = f32_arr(&vec![0.033f32; n_q_pref], &q_pref_shape);
     let _ = cache
-        .update_and_sdpa_returning_kv(&q_pref, &k_pref, &v_pref, 1.0, "causal", None, device)
-        .expect("prefill returning_kv");
+        .update_and_sdpa_shared_source(&q_pref, &k_pref, &v_pref, 1.0, "causal", None, device)
+        .expect("prefill shared source");
     cache.exit_prefill(device).expect("exit_prefill");
 
     let step_kv_shape = [1_i32, TEST_KV_H, 1, TEST_HEAD_DIM];
@@ -145,10 +146,14 @@ fn returning_kv_cpu_device_legacy_fallback_surfaces_full_prefix_shape() {
     let n_q_step: usize = q_step_shape.iter().map(|&d| d as usize).product();
     let q_step = f32_arr(&vec![0.066f32; n_q_step], &q_step_shape);
 
-    let (_out, k_full, v_full) = cache
-        .update_and_sdpa_returning_kv(&q_step, &k_step, &v_step, 1.0, "", None, device)
-        .expect("decode returning_kv");
+    let (_out, share) = cache
+        .update_and_sdpa_shared_source(&q_step, &k_step, &v_step, 1.0, "", None, device)
+        .expect("decode shared source");
 
+    // Every dispatch arm gates off on CPU, so this is the legacy bf16 share.
+    let SharedKv::Bf16(k_full, v_full) = &share else {
+        panic!("the CPU legacy fallback must surface a bf16 share");
+    };
     let expected = [1_i32, TEST_KV_H, TEST_PREFILL_SEQ + 1, TEST_HEAD_DIM];
     assert_eq!(
         k_full.shape(),

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -4268,7 +4268,7 @@ impl KvCache {
     /// behaviour to [`Self::update_and_sdpa_k8v4_flash`] except
     /// `RMLX_TURBO_FLASH_LOCK=1` is ignored: the bf16 `decode_fp16_k/v`
     /// mirror MUST stay current every decode step, because the caller
-    /// (`update_and_sdpa_returning_kv`) slices it to surface bf16 (K, V) for
+    /// (`update_and_sdpa_shared_source`) slices it to surface bf16 (K, V) for
     /// shared-KV consumer layers. Lock-on would freeze the mirror at the
     /// prefill prefix and silently drop decode tokens from the surfaced K/V.
     pub(super) fn update_and_sdpa_k8v4_flash_no_lock(
@@ -4378,7 +4378,7 @@ impl KvCache {
         // `flash_*` is quantised from `decode_fp16_k/v`. After that the
         // mirror is frozen at the prefill prefix.
         // Cross-layer-KV consumers (Gemma4) require the bf16 mirror to be
-        // updated every step so `update_and_sdpa_returning_kv` can slice it
+        // updated every step so `update_and_sdpa_shared_source` can slice it
         // back to the consumer. `force_lock_off` short-circuits the lock-on
         // optimisation in that case. Non-cross-layer-KV callers (the public
         // entry point) keep the optimisation.
@@ -4756,7 +4756,7 @@ impl KvCache {
     }
 
     /// Sibling of [`Self::sdpa_dispatch`] used by
-    /// `update_and_sdpa_returning_kv` (cross-layer-KV producers). Forces the
+    /// `update_and_sdpa_shared_source` (cross-layer-KV producers). Forces the
     /// TurboFlash lock-on optimisation OFF so the bf16 mirror stays current.
     pub(super) fn sdpa_dispatch_no_lock(
         &mut self,

--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -82,7 +82,7 @@ pub mod turbo_k4_fused_qk_msl;
 pub mod turboquant;
 pub mod turboquant_msl;
 
-pub use kvcache::KvCache;
+pub use kvcache::{KvCache, SharedKv};
 pub use linear_attn::LinearAttnCache;
 pub use quant::{validate_rotor_k_asym_v, KvQuant, KvQuantParseError, KV_MAX_SEQ_DEFAULT};
 

--- a/crates/rmlx-kv-quant/tests/shared_source_dispatch.rs
+++ b/crates/rmlx-kv-quant/tests/shared_source_dispatch.rs
@@ -1,6 +1,6 @@
-// GPU integration test: `update_and_sdpa_returning_kv` dispatch chain.
+// GPU integration test: `update_and_sdpa_shared_source` dispatch chain.
 //
-// Drives the public `KvCache::update_and_sdpa_returning_kv` path (Gemma4's
+// Drives the public `KvCache::update_and_sdpa_shared_source` path (Gemma4's
 // entry point) with K8V4 storage, head_dim=128. Asserts:
 //
 //   1. `RMLX_TURBO_FLASH=1` + `RMLX_TURBO_FLASH_MIN=0` (zero threshold so
@@ -19,7 +19,7 @@
 //   * When the dispatch errors, panic instead of skip.
 //
 // `#[ignore]` because it needs the Metal GPU. Run via:
-//   cargo test -p rmlx-kv-quant --test returning_kv_dispatch -- --ignored --test-threads=1
+//   cargo test -p rmlx-kv-quant --test shared_source_dispatch -- --ignored --test-threads=1
 //
 // Preflight: `pkill -f "rmlx serve" || true; rm -f /tmp/rmlx.*.claim`.
 // CLAUDE.md hard rule 8 (single MLX process): integration runner serialises
@@ -36,8 +36,27 @@
 )]
 
 use rmlx_kv_quant::turbo_flash_msl::turbo_flash_dispatch_count;
-use rmlx_kv_quant::{KvCache, KvQuant};
+use rmlx_kv_quant::{KvCache, KvQuant, SharedKv};
 use rmlx_mlx::{Array, Device, Dtype};
+
+/// Unwrap a producer's share into `(out, K, V)`.
+///
+/// K8V4 / `None` storage has no fused-over-store arm (TurboFlash and fused-QK
+/// both maintain the bf16 mirror), so the share here is always bf16. A `Store`
+/// share would mean a dispatch gate regressed.
+#[allow(
+    clippy::panic,
+    reason = "test helper: a Store share on a K8V4/None cache is a gate regression, and must fail the test loudly"
+)]
+fn split_bf16_share(pair: (Array, SharedKv)) -> (Array, Array, Array) {
+    let (out, share) = pair;
+    match share {
+        SharedKv::Bf16(k, v) => (out, k, v),
+        SharedKv::Store { .. } => {
+            panic!("expected a bf16 share — K8V4/None maintain the bf16 mirror")
+        }
+    }
+}
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -86,7 +105,7 @@ const HEAD_DIM: i32 = 128;
 const PREFILL_SEQ: i32 = 64;
 const MAX_SEQ: i32 = 4096;
 
-/// Build a K8V4 cache prefilled with 64 tokens via `update_and_sdpa_returning_kv`.
+/// Build a K8V4 cache prefilled with 64 tokens via `update_and_sdpa_shared_source`.
 fn build_prefilled_cache(
     device: Device,
     prefill_k: &Array,
@@ -97,10 +116,10 @@ fn build_prefilled_cache(
     let mut cache = KvCache::with_quant_max_seq(KvQuant::K8V4, MAX_SEQ);
     cache.enter_prefill();
     let _ = cache
-        .update_and_sdpa_returning_kv(
+        .update_and_sdpa_shared_source(
             prefill_q, prefill_k, prefill_v, scale, "causal", None, device,
         )
-        .expect("prefill returning_kv");
+        .expect("prefill shared source");
     cache.exit_prefill(device).expect("exit_prefill");
     assert_eq!(cache.offset(), PREFILL_SEQ, "cache offset after prefill");
     cache
@@ -108,7 +127,7 @@ fn build_prefilled_cache(
 
 // ── Test 1: RMLX_TURBO_FLASH=1 — dispatch fires, bf16 mirror surfaced ────────
 
-/// GPU: `update_and_sdpa_returning_kv` with TurboFlash ON must dispatch and
+/// GPU: `update_and_sdpa_shared_source` with TurboFlash ON must dispatch and
 /// surface the bf16 mirror K unchanged.
 ///
 /// With `RMLX_TURBO_FLASH=1` + `RMLX_TURBO_FLASH_MIN=0`:
@@ -117,8 +136,8 @@ fn build_prefilled_cache(
 ///
 /// `RMLX_RETURNING_KV_STRICT=1` turns a delta=0 skip into a panic.
 #[test]
-#[ignore = "GPU Metal context: cargo test -p rmlx-kv-quant --test returning_kv_dispatch -- --ignored --test-threads=1"]
-fn returning_kv_turbo_flash_on_dispatch_fires_and_surfaces_bf16_mirror() {
+#[ignore = "GPU Metal context: cargo test -p rmlx-kv-quant --test shared_source_dispatch -- --ignored --test-threads=1"]
+fn shared_source_turbo_flash_on_dispatch_fires_and_surfaces_bf16_mirror() {
     if skip_if_no_gpu() {
         return;
     }
@@ -172,18 +191,18 @@ fn returning_kv_turbo_flash_on_dispatch_fires_and_surfaces_bf16_mirror() {
 
     let tf_before = turbo_flash_dispatch_count();
     let result =
-        cache.update_and_sdpa_returning_kv(&q_dec, &new_k, &new_v, scale, "", None, device);
+        cache.update_and_sdpa_shared_source(&q_dec, &new_k, &new_v, scale, "", None, device);
     let tf_after = turbo_flash_dispatch_count();
 
-    let (_, k_surfaced, _) = match result {
+    let (_, k_surfaced, _) = match result.map(split_bf16_share) {
         Ok(triple) => triple,
         Err(e) => {
             eprintln!(
-                "TF=1: update_and_sdpa_returning_kv errored: {e} (skipping dispatch/parity assert)"
+                "TF=1: update_and_sdpa_shared_source errored: {e} (skipping dispatch/parity assert)"
             );
             assert!(
                 !strict,
-                "RMLX_RETURNING_KV_STRICT=1 — update_and_sdpa_returning_kv errored ({e}), \
+                "RMLX_RETURNING_KV_STRICT=1 — update_and_sdpa_shared_source errored ({e}), \
                  but strict mode requires the dispatch to succeed"
             );
             return;
@@ -222,14 +241,16 @@ fn returning_kv_turbo_flash_on_dispatch_fires_and_surfaces_bf16_mirror() {
     let mut ref_cache = KvCache::with_quant_max_seq(KvQuant::None, MAX_SEQ);
     ref_cache.enter_prefill();
     let _ = ref_cache
-        .update_and_sdpa_returning_kv(
+        .update_and_sdpa_shared_source(
             &q_pref, &prefill_k, &prefill_v, scale, "causal", None, device,
         )
         .expect("ref prefill");
     ref_cache.exit_prefill(device).expect("ref exit_prefill");
-    let (_, k_ref, _) = ref_cache
-        .update_and_sdpa_returning_kv(&q_dec, &new_k, &new_v, scale, "", None, device)
-        .expect("ref decode");
+    let (_, k_ref, _) = split_bf16_share(
+        ref_cache
+            .update_and_sdpa_shared_source(&q_dec, &new_k, &new_v, scale, "", None, device)
+            .expect("ref decode"),
+    );
 
     let k_surf_bytes = array_to_bf16_bytes(&k_surfaced, device);
     let k_ref_bytes = array_to_bf16_bytes(&k_ref, device);
@@ -252,11 +273,11 @@ fn returning_kv_turbo_flash_on_dispatch_fires_and_surfaces_bf16_mirror() {
 
 // ── Test 2: RMLX_TURBO_FLASH=0 — dispatch stays dormant ─────────────────────
 
-/// GPU: `update_and_sdpa_returning_kv` with TurboFlash OFF — dispatch must
+/// GPU: `update_and_sdpa_shared_source` with TurboFlash OFF — dispatch must
 /// stay dormant and the legacy fallback must surface correctly-shaped K/V.
 #[test]
-#[ignore = "GPU Metal context: cargo test -p rmlx-kv-quant --test returning_kv_dispatch -- --ignored --test-threads=1"]
-fn returning_kv_turbo_flash_off_dispatch_stays_dormant() {
+#[ignore = "GPU Metal context: cargo test -p rmlx-kv-quant --test shared_source_dispatch -- --ignored --test-threads=1"]
+fn shared_source_turbo_flash_off_dispatch_stays_dormant() {
     if skip_if_no_gpu() {
         return;
     }
@@ -307,9 +328,11 @@ fn returning_kv_turbo_flash_off_dispatch_stays_dormant() {
         .expect("bf16 q_dec");
 
     let tf_before = turbo_flash_dispatch_count();
-    let (_, k_surfaced, v_surfaced) = cache
-        .update_and_sdpa_returning_kv(&q_dec, &new_k, &new_v, scale, "", None, device)
-        .expect("decode returning_kv with TF=0");
+    let (_, k_surfaced, v_surfaced) = split_bf16_share(
+        cache
+            .update_and_sdpa_shared_source(&q_dec, &new_k, &new_v, scale, "", None, device)
+            .expect("decode shared source with TF=0"),
+    );
     let tf_after = turbo_flash_dispatch_count();
 
     let delta = tf_after - tf_before;

--- a/crates/rmlx-kv-quant/tests/shared_source_dispatch.rs
+++ b/crates/rmlx-kv-quant/tests/shared_source_dispatch.rs
@@ -6,7 +6,7 @@
 //   1. `RMLX_TURBO_FLASH=1` + `RMLX_TURBO_FLASH_MIN=0` (zero threshold so
 //      TurboFlash fires on a short kv_seq):
 //      a. `turbo_flash_dispatch_count()` delta > 0 after a decode step (the
-//         kernel actually fired on the returning_kv path, not just gated).
+//         kernel actually fired on the shared-KV producer path, not just gated).
 //      b. The bf16 K surfaced to the consumer is byte-identical to slicing
 //         `decode_fp16_k` — proving the dispatch path surfaced the mirror
 //         rather than a flash-transformed K.
@@ -14,7 +14,7 @@
 //   2. `RMLX_TURBO_FLASH=0` (control group):
 //      Same prefill + decode; dispatch delta == 0 (gate correctly suppressed).
 //
-// `RMLX_RETURNING_KV_STRICT=1` — strict mode (used by CI):
+// `RMLX_SHARED_SOURCE_STRICT=1` — strict mode (used by CI):
 //   * When env=ON and delta == 0, panic instead of skip.
 //   * When the dispatch errors, panic instead of skip.
 //
@@ -92,7 +92,7 @@ fn skip_if_no_gpu() -> bool {
 }
 
 fn is_strict() -> bool {
-    std::env::var("RMLX_RETURNING_KV_STRICT").as_deref() == Ok("1")
+    std::env::var("RMLX_SHARED_SOURCE_STRICT").as_deref() == Ok("1")
 }
 
 // ── test parameters ───────────────────────────────────────────────────────────
@@ -134,7 +134,7 @@ fn build_prefilled_cache(
 ///   a. `turbo_flash_dispatch_count()` delta > 0 (kernel fired).
 ///   b. Surfaced K bytes == bf16 reference K bytes (mirror, not flash-transformed).
 ///
-/// `RMLX_RETURNING_KV_STRICT=1` turns a delta=0 skip into a panic.
+/// `RMLX_SHARED_SOURCE_STRICT=1` turns a delta=0 skip into a panic.
 #[test]
 #[ignore = "GPU Metal context: cargo test -p rmlx-kv-quant --test shared_source_dispatch -- --ignored --test-threads=1"]
 fn shared_source_turbo_flash_on_dispatch_fires_and_surfaces_bf16_mirror() {
@@ -202,7 +202,7 @@ fn shared_source_turbo_flash_on_dispatch_fires_and_surfaces_bf16_mirror() {
             );
             assert!(
                 !strict,
-                "RMLX_RETURNING_KV_STRICT=1 — update_and_sdpa_shared_source errored ({e}), \
+                "RMLX_SHARED_SOURCE_STRICT=1 — update_and_sdpa_shared_source errored ({e}), \
                  but strict mode requires the dispatch to succeed"
             );
             return;
@@ -214,13 +214,13 @@ fn shared_source_turbo_flash_on_dispatch_fires_and_surfaces_bf16_mirror() {
 
     if delta == 0 {
         eprintln!(
-            "TF=1: HOLD-soft — TurboFlash did not fire on the returning_kv path \
+            "TF=1: HOLD-soft — TurboFlash did not fire on the shared-KV producer path \
              (expected when head_dim not in {{128,256}} or kv_seq below threshold). \
              Skipping byte-identity assertion."
         );
         assert!(
             !strict,
-            "RMLX_RETURNING_KV_STRICT=1 — turbo_flash_dispatch_count did not increment; \
+            "RMLX_SHARED_SOURCE_STRICT=1 — turbo_flash_dispatch_count did not increment; \
              the kernel is expected to fire with RMLX_TURBO_FLASH=1 + RMLX_TURBO_FLASH_MIN=0 \
              at head_dim=128 in strict mode"
         );

--- a/crates/rmlx-models/src/gemma3/attention.rs
+++ b/crates/rmlx-models/src/gemma3/attention.rs
@@ -189,7 +189,7 @@ impl Attention {
         // Route through `KvCache::update_and_sdpa` —
         // the universal wrapper that fuses cache update + SDPA and dispatches
         // to the Mixed, K8V4-flash, or legacy path based on quant type.
-        // No cross-layer KV sharing in Gemma3, so the `_returning_kv` sibling
+        // No cross-layer KV sharing in Gemma3, so the `_shared_source` sibling
         // is not needed.
         let attn_out = if let Some(c) = cache {
             c.update_and_sdpa(&q, &k, &v, self.scale, mask_mode, mask_ref, device)?

--- a/crates/rmlx-models/src/gemma4/decoder_layer.rs
+++ b/crates/rmlx-models/src/gemma4/decoder_layer.rs
@@ -5,7 +5,7 @@ use rmlx_mlx::{add, multiply, Array, Device};
 use tracing::debug_span;
 
 use crate::layers::{Mlp, RmsNorm};
-use rmlx_kv_quant::KvCache;
+use rmlx_kv_quant::{KvCache, SharedKv};
 
 use super::layers::{geglu_fused, Attention, Gemma4MoeBlock, PerLayerInput};
 
@@ -51,14 +51,14 @@ impl DecoderLayer {
     pub(super) fn forward(
         &self,
         x: &Array,
-        shared_kv: Option<(&Array, &Array)>,
+        shared_kv: Option<(&SharedKv, Option<&KvCache>)>,
         per_layer_input: Option<&Array>,
         offset: i32,
         cache: Option<&mut KvCache>,
         kv_is_rotating: bool,
         bidi_overlay: Option<&Array>,
         device: Device,
-    ) -> Result<(Array, Option<(Array, Array)>)> {
+    ) -> Result<(Array, Option<SharedKv>)> {
         // Attention sub-layer.
         let residual = x.try_clone()?;
         let h = self.input_norm.forward(x, device)?;

--- a/crates/rmlx-models/src/gemma4/layers/mask_tests.rs
+++ b/crates/rmlx-models/src/gemma4/layers/mask_tests.rs
@@ -23,6 +23,7 @@
 //! the mask key dim from `k_seq` to `k_seq + 1` and making
 //! `guard_invariant_producer_offset_matches_k_seq` RED.
 
+use rmlx_kv_quant::SharedKv;
 use rmlx_mlx::{Array, Device, Dtype};
 
 use super::{build_attn_mask, consumer_effective_offset, producer_effective_offset, LayerType};
@@ -257,6 +258,62 @@ fn guard_invariant_consumer_mask_matches_shared_k_len() {
         shape[3] < base_offset + seq,
         "offset-based sizing (base_offset + seq) would have been wider — the \
          #32-part-2 broadcast crash"
+    );
+}
+
+/// The consumer branch now reads its `total_kv_len` from `SharedKv::kv_len()`
+/// instead of `k.shape()[2]`, because a store-backed share has no bf16 K tensor
+/// to measure. That is a change to the producer→consumer interface the mask
+/// depends on, so pin it: for a bf16 share `kv_len()` must be *exactly*
+/// `k.shape()[2]`, i.e. the mask sizing is unchanged by the new interface.
+///
+/// A store-backed share's `kv_len()` is pinned to the producer's post-update
+/// offset in `rmlx_kv_quant::kvcache::shared_kv_tests`, which is the same
+/// quantity `k.shape()[2]` carries on the bf16 path.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test asserts on known-good shapes; unwrap/expect failures are the assertion"
+)]
+fn shared_kv_len_reproduces_k_shape_sizing() {
+    let seq = 5;
+    let k_seq = 3222; // producer's post-update K length
+    let kv_h = 2;
+    let head_dim = 4;
+
+    // A bf16 share carrying a K of exactly `k_seq` keys.
+    let n = (kv_h * k_seq * head_dim) as usize;
+    let k = Array::from_f32_slice(&vec![0.5_f32; n], &[1, kv_h, k_seq, head_dim]).unwrap();
+    let v = Array::from_f32_slice(&vec![0.25_f32; n], &[1, kv_h, k_seq, head_dim]).unwrap();
+    let share = SharedKv::Bf16(k, v);
+
+    assert_eq!(
+        share.kv_len().unwrap(),
+        k_seq,
+        "a bf16 share's kv_len must equal k.shape()[2] — the value the consumer \
+         branch sized its mask from before the sharing interface changed"
+    );
+
+    // …and it drives the identical mask the old sizing produced.
+    let effective_offset = consumer_effective_offset(share.kv_len().unwrap(), seq);
+    let (mask, mode) = build_attn_mask(
+        LayerType::FullAttention,
+        seq,
+        effective_offset,
+        share.kv_len().unwrap(),
+        false,
+        512,
+        None,
+        Device::Cpu,
+    )
+    .unwrap();
+    assert_eq!(mode, "array");
+    assert_eq!(
+        mask.expect("array mode must carry a mask array").shape()[3],
+        k_seq,
+        "mask key dim must still equal the producer's K length"
     );
 }
 

--- a/crates/rmlx-models/src/gemma4/layers/mod.rs
+++ b/crates/rmlx-models/src/gemma4/layers/mod.rs
@@ -31,7 +31,7 @@ use rmlx_mlx::{
 };
 
 use crate::layers::{Linear, RmsNorm};
-use rmlx_kv_quant::KvCache;
+use rmlx_kv_quant::{KvCache, SharedKv};
 
 use super::config::LayerType;
 
@@ -148,16 +148,20 @@ impl Attention {
         reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
     )]
     #[allow(clippy::too_many_arguments)]
+    /// `shared_kv` is the cross-layer-KV share for a consumer layer: the
+    /// producer's [`SharedKv`] plus the cache it lives in (`None` on cacheless
+    /// forwards, which can only ever yield [`SharedKv::Bf16`]). `None` marks a
+    /// layer that projects and caches its own K/V.
     pub(super) fn forward(
         &self,
         x: &Array,
-        shared_kv: Option<(&Array, &Array)>,
+        shared_kv: Option<(&SharedKv, Option<&KvCache>)>,
         offset: i32,
         cache: Option<&mut KvCache>,
         kv_is_rotating: bool,
         bidi_overlay: Option<&Array>,
         device: Device,
-    ) -> Result<(Array, Option<(Array, Array)>)> {
+    ) -> Result<(Array, Option<SharedKv>)> {
         let shape = x.shape(); // [batch, seq, hidden]
         let batch = shape[0];
         let seq = shape[1];
@@ -191,14 +195,14 @@ impl Attention {
         // Q on non-shared path: qk_norm_fused with K (see else branch).
         //
         // Cache-holding layers route SDPA through
-        // `KvCache::update_and_sdpa_returning_kv` — the universal wrapper's
-        // shared-KV variant that returns the accumulated `(K, V)` so the
-        // source-of-shared-KV layers can also fill `new_kv` for downstream
-        // consumers. `cache` is consumed here; below we branch on whether the
+        // `KvCache::update_and_sdpa_shared_source` — the universal wrapper's
+        // shared-KV variant that reports what downstream consumers can attend
+        // (the producer's bf16 tensors, or its quant store when a fused decode
+        // kernel ran). `cache` is consumed here; below we branch on whether the
         // wrapper has already run (`attn_out_holder`) or we still need a
-        // direct `scaled_dot_product_attention` on shared / cacheless K/V.
+        // consumer-side SDPA over the share.
         let mut attn_out_holder: Option<Array> = None;
-        let (q, k, v, new_kv) = if let Some((sk, sv)) = shared_kv {
+        let (q, new_kv) = if shared_kv.is_some() {
             // Shared KV: q_norm runs alone, then transpose + RoPE on Q.
             let q = self.q_norm.forward(&q, device)?;
             let q = q.transpose(&[0, 2, 1, 3], device)?; // [B, H, S, D]
@@ -219,7 +223,7 @@ impl Attention {
                     rope_with_freqs(&q, self.head_dim as i32, false, 1.0, offset, freqs, device)?
                 }
             };
-            (q, sk.try_clone()?, sv.try_clone()?, None)
+            (q, None)
         } else {
             let k_proj = self.k_proj.as_ref().ok_or_else(|| {
                 Error::Model("Attention: has_kv=false but no shared_kv provided".to_owned())
@@ -310,7 +314,7 @@ impl Attention {
             // offset from the non-rotating producer. RoPE still uses the
             // model-wide `offset` (absolute position); only the mask's key dim
             // is bound to the producer's own K length. See
-            // `update_and_sdpa_returning_kv` (rotating short-circuit) for the
+            // `update_and_sdpa_shared_source` (rotating short-circuit) for the
             // sibling Mixed-path fix this generalises.
             if let Some(c) = cache {
                 let producer_offset = c.offset();
@@ -331,12 +335,12 @@ impl Attention {
                     device,
                 )?;
                 // Cache-holding layer: route through the shared-KV variant of
-                // the universal wrapper. Returns (out, k_full, v_full) so the
-                // accumulated K/V can be handed to downstream consumer layers
-                // via `stored_kvs[layer_idx]` in `gemma4/model.rs`. : the
-                // wrapper now supports Mixed via dequant-before-share (returns
-                // the accumulated bf16 K/V), alongside None/K8V4/K8V8/Planar.
-                let (attn_out, k_full, v_full) = c.update_and_sdpa_returning_kv(
+                // the universal wrapper. Returns (out, share) where `share` is
+                // what downstream consumer layers attend — handed to them via
+                // `stored_kvs[layer_idx]` in `gemma4/model.rs`. The codec
+                // decides whether that share is bf16 tensors or the quant store
+                // itself; this layer neither knows nor cares.
+                let (attn_out, share) = c.update_and_sdpa_shared_source(
                     &q,
                     &k,
                     &v,
@@ -351,7 +355,7 @@ impl Attention {
                 // later layer hit the opaque mlx-c broadcast error.
                 if let Some(mask) = mask_holder_pre.as_ref() {
                     let mask_kv = mask.shape()[3];
-                    let k_seq = k_full.shape()[2];
+                    let k_seq = share.kv_len()?;
                     if mask_kv != k_seq {
                         return Err(Error::Model(format!(
                             "Gemma4 attention mask key dim {mask_kv} != K seq dim {k_seq} \
@@ -361,12 +365,7 @@ impl Attention {
                     }
                 }
                 attn_out_holder = Some(attn_out);
-                (
-                    q,
-                    k_full.try_clone()?,
-                    v_full.try_clone()?,
-                    Some((k_full, v_full)),
-                )
+                (q, Some(share))
             } else {
                 // No-cache forward (e.g. eval path with `caches: None`). The
                 // freshly-computed K is exactly `offset + seq` long, so size the
@@ -387,8 +386,6 @@ impl Attention {
                     bidi_overlay,
                     device,
                 )?;
-                let k_new = k.try_clone()?;
-                let v_new = v.try_clone()?;
                 let attn_out = scaled_dot_product_attention(
                     &q,
                     &k,
@@ -399,7 +396,7 @@ impl Attention {
                     device,
                 )?;
                 attn_out_holder = Some(attn_out);
-                (q, k, v, Some((k_new, v_new)))
+                (q, Some(SharedKv::Bf16(k, v)))
             }
         };
 
@@ -413,7 +410,7 @@ impl Attention {
         let _ = repeat_kv;
 
         // SDPA: cache-holding and no-cache-non-shared branches dispatched
-        // inline above (cache-holding via `update_and_sdpa_returning_kv`,
+        // inline above (cache-holding via `update_and_sdpa_shared_source`,
         // no-cache via direct SDPA). The shared-KV consumer branch reaches
         // this point with `attn_out_holder == None`; run direct SDPA here on
         // the upstream-shared K/V.
@@ -431,9 +428,11 @@ impl Attention {
             out
         } else {
             // Shared-KV consumer branch: K is fetched from the producer layer
-            // (`shared_kv`), not freshly projected here. Its seq dim
-            // (`k.shape()[2]`) is the ground truth for how many keys SDPA
-            // attends. Size the mask's key dim from that actual K length, NOT
+            // (`shared_kv`), not freshly projected here. The producer's K
+            // length (`share.kv_len()`) is the ground truth for how many keys
+            // SDPA attends — it is `k.shape()[2]` for a bf16 share and the
+            // store's accumulated length for a store-backed one.
+            // Size the mask's key dim from that actual K length, NOT
             // from the model-wide `offset` (#32 part 2): across a speculative
             // partial-accept verify rollback the producer cache is rolled back
             // while the model-wide `offset` (`cache_base_offset`, taken from the
@@ -452,7 +451,14 @@ impl Attention {
             // which is already baked into the producer's K length. No regression
             // on ordinary prefill/decode; the value only diverges (correctly)
             // when a rollback desynced `offset` from the K it shares.
-            let total_kv_len = k.shape()[2]; // [B, kv_heads, total_kv, D]
+            let (share, producer) = shared_kv.ok_or_else(|| {
+                Error::Model(
+                    "Gemma4 attention reached the consumer branch with no shared KV — a layer \
+                     that neither holds a cache nor receives a share cannot attend anything"
+                        .to_owned(),
+                )
+            })?;
+            let total_kv_len = share.kv_len()?;
             if total_kv_len < seq {
                 return Err(Error::Model(format!(
                     "Gemma4 consumer/shared-KV K seq dim {total_kv_len} < query seq {seq} \
@@ -485,7 +491,7 @@ impl Attention {
                     )));
                 }
             }
-            scaled_dot_product_attention(&q, &k, &v, 1.0, mask_mode, mask_holder.as_ref(), device)?
+            share.sdpa(producer, &q, 1.0, mask_mode, mask_holder.as_ref(), device)?
         };
         // [B, H, S, D] -> [B, S, H*D]
         let attn_out = attn_out.transpose(&[0, 2, 1, 3], device)?;

--- a/crates/rmlx-models/src/gemma4/model.rs
+++ b/crates/rmlx-models/src/gemma4/model.rs
@@ -19,7 +19,7 @@ use rmlx_mlx::{multiply, scalar_f32, Array, Device};
 use tracing::debug;
 
 use crate::layers::Embedding;
-use rmlx_kv_quant::KvCache;
+use rmlx_kv_quant::{KvCache, SharedKv};
 
 use super::config::Gemma4TextConfig;
 use super::decoder_layer::DecoderLayer;
@@ -197,19 +197,19 @@ impl Gemma4Text {
         let per_layer_inputs = self.compute_per_layer_inputs(&ids_arr, &h, device)?;
 
         // KV accumulation for shared-KV layers (same pattern as forward_arr/forward_h).
-        let mut stored_kvs: Vec<Option<(Array, Array)>> =
+        let mut stored_kvs: Vec<Option<SharedKv>> =
             (0..self.cfg.num_hidden_layers).map(|_| None).collect();
 
         let mut h = h;
         for (layer_idx, layer) in self.layers.iter().enumerate() {
             debug!(layer = layer_idx, "gemma4 forward_seq_logits_all layer");
             let prev_idx = self.previous_kvs[layer_idx];
+            // Cacheless forward: a producer here never runs a fused
+            // decode kernel, so every share is bf16 and carries no cache.
             let shared_kv = if prev_idx == layer_idx {
                 None
             } else {
-                stored_kvs[prev_idx]
-                    .as_ref()
-                    .map(|(k, v)| (k as &Array, v as &Array))
+                stored_kvs[prev_idx].as_ref().map(|s| (s, None))
             };
             let per_layer = per_layer_inputs.as_ref().map(|pli| &pli[layer_idx]);
             let (new_h, new_kv) = layer.forward(
@@ -411,7 +411,7 @@ impl Gemma4Text {
         let per_layer_inputs = self.compute_per_layer_inputs(ids_arr, &h, device)?;
 
         // KV storage: index = previous_kvs[layer_idx], value = (K, V) from that layer.
-        let mut stored_kvs: Vec<Option<(Array, Array)>> =
+        let mut stored_kvs: Vec<Option<SharedKv>> =
             (0..self.cfg.num_hidden_layers).map(|_| None).collect();
 
         let mut h = h;
@@ -432,12 +432,12 @@ impl Gemma4Text {
             None => {
                 for (layer_idx, layer) in self.layers.iter().enumerate() {
                     let prev_idx = self.previous_kvs[layer_idx];
+                    // Cacheless forward: a producer here never runs a fused
+                    // decode kernel, so every share is bf16 and carries no cache.
                     let shared_kv = if prev_idx == layer_idx {
                         None
                     } else {
-                        stored_kvs[prev_idx]
-                            .as_ref()
-                            .map(|(k, v)| (k as &Array, v as &Array))
+                        stored_kvs[prev_idx].as_ref().map(|s| (s, None))
                     };
                     let per_layer = per_layer_inputs.as_ref().map(|pli| &pli[layer_idx]);
                     let (new_h, new_kv) = layer.forward(
@@ -459,19 +459,20 @@ impl Gemma4Text {
             Some(cs) => {
                 for (layer_idx, layer) in self.layers.iter().enumerate() {
                     let prev_idx = self.previous_kvs[layer_idx];
-                    let shared_kv = if prev_idx == layer_idx {
-                        None
-                    } else {
-                        stored_kvs[prev_idx]
-                            .as_ref()
-                            .map(|(k, v)| (k as &Array, v as &Array))
-                    };
                     let per_layer = per_layer_inputs.as_ref().map(|pli| &pli[layer_idx]);
-                    // Shared-KV layers don't have their own cache entry; pass None.
-                    let cache = if prev_idx == layer_idx {
-                        Some(&mut cs[layer_idx])
+                    // A consumer layer reads an EARLIER layer's cache (the
+                    // sharing map always points back to the last non-shared
+                    // layer of the same type), so split the slice and hand the
+                    // producer cache over immutably: a store-backed share is
+                    // attended straight off it. Producer layers take their own
+                    // slot mutably. Shared-KV layers have no cache entry of
+                    // their own.
+                    let (head, tail) = cs.split_at_mut(layer_idx);
+                    let (cache, shared_kv) = if prev_idx == layer_idx {
+                        (tail.get_mut(0), None)
                     } else {
-                        None
+                        let producer = head.get(prev_idx);
+                        (None, stored_kvs[prev_idx].as_ref().map(|s| (s, producer)))
                     };
                     let (new_h, new_kv) = layer.forward(
                         &h,
@@ -552,7 +553,7 @@ impl Gemma4Text {
 
         let per_layer_inputs = self.compute_per_layer_inputs(ids_arr, &h, device)?;
 
-        let mut stored_kvs: Vec<Option<(Array, Array)>> =
+        let mut stored_kvs: Vec<Option<SharedKv>> =
             (0..self.cfg.num_hidden_layers).map(|_| None).collect();
 
         let mut h = h;
@@ -570,12 +571,12 @@ impl Gemma4Text {
             None => {
                 for (layer_idx, layer) in self.layers.iter().enumerate() {
                     let prev_idx = self.previous_kvs[layer_idx];
+                    // Cacheless forward: a producer here never runs a fused
+                    // decode kernel, so every share is bf16 and carries no cache.
                     let shared_kv = if prev_idx == layer_idx {
                         None
                     } else {
-                        stored_kvs[prev_idx]
-                            .as_ref()
-                            .map(|(k, v)| (k as &Array, v as &Array))
+                        stored_kvs[prev_idx].as_ref().map(|s| (s, None))
                     };
                     let per_layer = per_layer_inputs.as_ref().map(|pli| &pli[layer_idx]);
                     let (new_h, new_kv) = layer.forward(
@@ -597,18 +598,19 @@ impl Gemma4Text {
             Some(cs) => {
                 for (layer_idx, layer) in self.layers.iter().enumerate() {
                     let prev_idx = self.previous_kvs[layer_idx];
-                    let shared_kv = if prev_idx == layer_idx {
-                        None
-                    } else {
-                        stored_kvs[prev_idx]
-                            .as_ref()
-                            .map(|(k, v)| (k as &Array, v as &Array))
-                    };
                     let per_layer = per_layer_inputs.as_ref().map(|pli| &pli[layer_idx]);
-                    let cache = if prev_idx == layer_idx {
-                        Some(&mut cs[layer_idx])
+                    // A consumer layer reads an EARLIER layer's cache (the
+                    // sharing map always points back to the last non-shared
+                    // layer of the same type), so split the slice and hand the
+                    // producer cache over immutably: a store-backed share is
+                    // attended straight off it. Producer layers take their own
+                    // slot mutably.
+                    let (head, tail) = cs.split_at_mut(layer_idx);
+                    let (cache, shared_kv) = if prev_idx == layer_idx {
+                        (tail.get_mut(0), None)
                     } else {
-                        None
+                        let producer = head.get(prev_idx);
+                        (None, stored_kvs[prev_idx].as_ref().map(|s| (s, producer)))
                     };
                     let (new_h, new_kv) = layer.forward(
                         &h,
@@ -695,7 +697,7 @@ impl Gemma4Text {
 
         let per_layer_inputs = self.compute_per_layer_inputs(&ids_arr, &h, device)?;
 
-        let mut stored_kvs: Vec<Option<(Array, Array)>> =
+        let mut stored_kvs: Vec<Option<SharedKv>> =
             (0..self.cfg.num_hidden_layers).map(|_| None).collect();
 
         let mut h = h;
@@ -712,12 +714,12 @@ impl Gemma4Text {
             None => {
                 for (layer_idx, layer) in self.layers.iter().enumerate() {
                     let prev_idx = self.previous_kvs[layer_idx];
+                    // Cacheless forward: a producer here never runs a fused
+                    // decode kernel, so every share is bf16 and carries no cache.
                     let shared_kv = if prev_idx == layer_idx {
                         None
                     } else {
-                        stored_kvs[prev_idx]
-                            .as_ref()
-                            .map(|(k, v)| (k as &Array, v as &Array))
+                        stored_kvs[prev_idx].as_ref().map(|s| (s, None))
                     };
                     let per_layer = per_layer_inputs.as_ref().map(|pli| &pli[layer_idx]);
                     let (new_h, new_kv) = layer.forward(
@@ -739,18 +741,19 @@ impl Gemma4Text {
             Some(cs) => {
                 for (layer_idx, layer) in self.layers.iter().enumerate() {
                     let prev_idx = self.previous_kvs[layer_idx];
-                    let shared_kv = if prev_idx == layer_idx {
-                        None
-                    } else {
-                        stored_kvs[prev_idx]
-                            .as_ref()
-                            .map(|(k, v)| (k as &Array, v as &Array))
-                    };
                     let per_layer = per_layer_inputs.as_ref().map(|pli| &pli[layer_idx]);
-                    let cache = if prev_idx == layer_idx {
-                        Some(&mut cs[layer_idx])
+                    // A consumer layer reads an EARLIER layer's cache (the
+                    // sharing map always points back to the last non-shared
+                    // layer of the same type), so split the slice and hand the
+                    // producer cache over immutably: a store-backed share is
+                    // attended straight off it. Producer layers take their own
+                    // slot mutably.
+                    let (head, tail) = cs.split_at_mut(layer_idx);
+                    let (cache, shared_kv) = if prev_idx == layer_idx {
+                        (tail.get_mut(0), None)
                     } else {
-                        None
+                        let producer = head.get(prev_idx);
+                        (None, stored_kvs[prev_idx].as_ref().map(|s| (s, producer)))
                     };
                     let (new_h, new_kv) = layer.forward(
                         &h,
@@ -832,7 +835,7 @@ impl Gemma4Text {
 
         let per_layer_inputs = self.compute_per_layer_inputs(&ids_arr, &h, device)?;
 
-        let mut stored_kvs: Vec<Option<(Array, Array)>> =
+        let mut stored_kvs: Vec<Option<SharedKv>> =
             (0..self.cfg.num_hidden_layers).map(|_| None).collect();
 
         let mut h = h;
@@ -845,18 +848,15 @@ impl Gemma4Text {
         let cs = &mut *caches;
         for (layer_idx, layer) in self.layers.iter().enumerate() {
             let prev_idx = self.previous_kvs[layer_idx];
-            let shared_kv = if prev_idx == layer_idx {
-                None
-            } else {
-                stored_kvs[prev_idx]
-                    .as_ref()
-                    .map(|(k, v)| (k as &Array, v as &Array))
-            };
             let per_layer = per_layer_inputs.as_ref().map(|pli| &pli[layer_idx]);
-            let cache = if prev_idx == layer_idx {
-                Some(&mut cs[layer_idx])
+            // See `forward_h`: consumers read an earlier layer's cache, so the
+            // slice splits into the producer half and this layer's own slot.
+            let (head, tail) = cs.split_at_mut(layer_idx);
+            let (cache, shared_kv) = if prev_idx == layer_idx {
+                (tail.get_mut(0), None)
             } else {
-                None
+                let producer = head.get(prev_idx);
+                (None, stored_kvs[prev_idx].as_ref().map(|s| (s, producer)))
             };
             let (new_h, new_kv) = layer.forward(
                 &h,
@@ -876,11 +876,17 @@ impl Gemma4Text {
 
         // Representative shared K/V: highest-index cache-holding layer of each
         // type (last-wins, matching the Python dict-overwrite semantics).
+        //
+        // The drafter is a separate model with its own attention, so this is
+        // one of the few callers that needs K/V *tensors* rather than attention
+        // output: a store-backed share is materialised here, paying the dequant
+        // the fused decode kernel avoids on the hot path.
+        let cs = &*caches;
         let pick = |want: super::config::LayerType| -> Option<(Array, Array)> {
             for i in (0..self.cfg.num_hidden_layers).rev() {
                 if self.cfg.layer_types[i] == want {
-                    if let Some((kk, vv)) = &stored_kvs[i] {
-                        return Some((kk.try_clone().ok()?, vv.try_clone().ok()?));
+                    if let Some(share) = &stored_kvs[i] {
+                        return share.materialise_bf16(cs.get(i), device).ok();
                     }
                 }
             }

--- a/crates/rmlx-models/src/gemma4/model.rs
+++ b/crates/rmlx-models/src/gemma4/model.rs
@@ -54,6 +54,32 @@ fn cache_base_offset(caches: Option<&[KvCache]>) -> i32 {
         .map_or(0, |c| c.offset())
 }
 
+/// Split the per-layer cache slice at `layer_idx` into the producer half and
+/// this layer's own slot.
+///
+/// A shared-KV consumer always reads an **earlier** layer's cache
+/// (`build_previous_kvs` points every shared layer back at the last non-shared
+/// layer of the same type), so the producer is always in `head` and this layer's
+/// own slot is always `tail[0]`. Splitting is what lets a consumer hold the
+/// producer cache immutably — a store-backed share is attended straight off it —
+/// while a producer holds its own slot mutably.
+///
+/// The slot is mandatory: `split_at_mut` happily returns an empty tail when the
+/// slice is shorter than the model, and a `None` producer slot would silently
+/// drop the layer into the cacheless branch — SDPA over freshly-projected K/V
+/// with no history and no append, i.e. a wrong answer rather than an error.
+fn split_layer_caches(cs: &mut [KvCache], layer_idx: usize) -> Result<(&[KvCache], &mut KvCache)> {
+    let n = cs.len();
+    let (head, tail) = cs.split_at_mut(layer_idx);
+    let own = tail.first_mut().ok_or_else(|| {
+        rmlx_core::error::Error::Model(format!(
+            "gemma4: cache slice holds {n} entries but layer {layer_idx} needs its own slot — \
+             callers must pass one cache per layer"
+        ))
+    })?;
+    Ok((head, own))
+}
+
 /// `<start_of_image>` / `<end_of_image>` marker token ids, as `i32` for the
 /// id-scan loop below. The canonical source of truth is `super::vision`
 /// (`u32`); cast here at the i32 boundary so there is one definition.
@@ -467,9 +493,9 @@ impl Gemma4Text {
                     // attended straight off it. Producer layers take their own
                     // slot mutably. Shared-KV layers have no cache entry of
                     // their own.
-                    let (head, tail) = cs.split_at_mut(layer_idx);
+                    let (head, own) = split_layer_caches(cs, layer_idx)?;
                     let (cache, shared_kv) = if prev_idx == layer_idx {
-                        (tail.get_mut(0), None)
+                        (Some(own), None)
                     } else {
                         let producer = head.get(prev_idx);
                         (None, stored_kvs[prev_idx].as_ref().map(|s| (s, producer)))
@@ -605,9 +631,9 @@ impl Gemma4Text {
                     // producer cache over immutably: a store-backed share is
                     // attended straight off it. Producer layers take their own
                     // slot mutably.
-                    let (head, tail) = cs.split_at_mut(layer_idx);
+                    let (head, own) = split_layer_caches(cs, layer_idx)?;
                     let (cache, shared_kv) = if prev_idx == layer_idx {
-                        (tail.get_mut(0), None)
+                        (Some(own), None)
                     } else {
                         let producer = head.get(prev_idx);
                         (None, stored_kvs[prev_idx].as_ref().map(|s| (s, producer)))
@@ -748,9 +774,9 @@ impl Gemma4Text {
                     // producer cache over immutably: a store-backed share is
                     // attended straight off it. Producer layers take their own
                     // slot mutably.
-                    let (head, tail) = cs.split_at_mut(layer_idx);
+                    let (head, own) = split_layer_caches(cs, layer_idx)?;
                     let (cache, shared_kv) = if prev_idx == layer_idx {
-                        (tail.get_mut(0), None)
+                        (Some(own), None)
                     } else {
                         let producer = head.get(prev_idx);
                         (None, stored_kvs[prev_idx].as_ref().map(|s| (s, producer)))
@@ -851,9 +877,9 @@ impl Gemma4Text {
             let per_layer = per_layer_inputs.as_ref().map(|pli| &pli[layer_idx]);
             // See `forward_h`: consumers read an earlier layer's cache, so the
             // slice splits into the producer half and this layer's own slot.
-            let (head, tail) = cs.split_at_mut(layer_idx);
+            let (head, own) = split_layer_caches(cs, layer_idx)?;
             let (cache, shared_kv) = if prev_idx == layer_idx {
-                (tail.get_mut(0), None)
+                (Some(own), None)
             } else {
                 let producer = head.get(prev_idx);
                 (None, stored_kvs[prev_idx].as_ref().map(|s| (s, producer)))
@@ -881,23 +907,27 @@ impl Gemma4Text {
         // one of the few callers that needs K/V *tensors* rather than attention
         // output: a store-backed share is materialised here, paying the dequant
         // the fused decode kernel avoids on the hot path.
+        // A materialisation failure (length desync, missing bf16 V mirror,
+        // unsupported storage variant, absent producer cache) is propagated, not
+        // swallowed: collapsing it into "no K/V captured" would report a cause
+        // that is never the real one.
         let cs = &*caches;
-        let pick = |want: super::config::LayerType| -> Option<(Array, Array)> {
+        let pick = |want: super::config::LayerType| -> Result<Option<(Array, Array)>> {
             for i in (0..self.cfg.num_hidden_layers).rev() {
                 if self.cfg.layer_types[i] == want {
                     if let Some(share) = &stored_kvs[i] {
-                        return share.materialise_bf16(cs.get(i), device).ok();
+                        return share.materialise(cs.get(i), device).map(Some);
                     }
                 }
             }
-            None
+            Ok(None)
         };
-        let sliding_kv = pick(super::config::LayerType::SlidingAttention).ok_or_else(|| {
+        let sliding_kv = pick(super::config::LayerType::SlidingAttention)?.ok_or_else(|| {
             rmlx_core::error::Error::Model(
                 "forward_hidden_states_shared_kv: no sliding-layer K/V captured".into(),
             )
         })?;
-        let full_kv = pick(super::config::LayerType::FullAttention).ok_or_else(|| {
+        let full_kv = pick(super::config::LayerType::FullAttention)?.ok_or_else(|| {
             rmlx_core::error::Error::Model(
                 "forward_hidden_states_shared_kv: no full-layer K/V captured".into(),
             )

--- a/crates/rmlx-models/src/kv_cache/cache_type.rs
+++ b/crates/rmlx-models/src/kv_cache/cache_type.rs
@@ -838,7 +838,7 @@ pub enum ResolveError {
 
     // The former `SharedKvIncompatibleWithMixed` variant was removed.
     // Gemma3 / Gemma4 cross-layer KV sharing now supports `Mixed` via
-    // dequant-before-share in `KvCache::update_and_sdpa_returning_kv`,
+    // dequant-before-share in `KvCache::update_and_sdpa_shared_source`,
     // so the combination is valid.
     /// No defined `KvQuant` mapping for this `(K, V)` tuple.
     ///
@@ -1528,7 +1528,7 @@ fn is_qwen_moe(arch: &str) -> bool {
 /// changes cannot bypass the invariant.
 ///
 /// The former guard that rejected `Mixed` on Gemma3 / Gemma4 (cross-layer KV
-/// sharing) was removed. `KvCache::update_and_sdpa_returning_kv` supports
+/// sharing) was removed. `KvCache::update_and_sdpa_shared_source` supports
 /// `Mixed` via dequant-before-share — it surfaces the accumulated bf16 K/V
 /// (prefill-raw during prefill, maintained `decode_fp16` during decode) to
 /// the shared-KV consumer layers.

--- a/crates/rmlx-models/src/kv_cache/tests.rs
+++ b/crates/rmlx-models/src/kv_cache/tests.rs
@@ -1097,7 +1097,7 @@ mod tests {
                 .update_and_sdpa_shared_source(
                     &q_pref, &k_pref, &v_pref, scale, "causal", None, device,
                 )
-                .expect("Mixed prefill via returning_kv must succeed"),
+                .expect("Mixed prefill via the shared-source path must succeed"),
         );
         cache.exit_prefill(device).expect("exit_prefill failed");
 
@@ -1496,7 +1496,7 @@ mod tests {
     /// regression: a Mixed-quant SWA (rotating) cache driven across a
     /// window-crossing prefill chunk must NOT broadcast-fail.
     ///
-    /// Before , `update_and_sdpa[_returning_kv]` short-circuited Mixed to
+    /// Previously, `update_and_sdpa[_shared_source]` short-circuited Mixed to
     /// `update_prefill_raw` (full, uncapped K of length `offset + seq`) BEFORE
     /// honoring the rotating ring. But the Gemma4 SWA attention mask is sized
     /// to the ring's window-capped K (`offset.min(window-1) + seq`). On the

--- a/crates/rmlx-models/src/kv_cache/tests.rs
+++ b/crates/rmlx-models/src/kv_cache/tests.rs
@@ -11,9 +11,29 @@ mod tests {
     };
     use rmlx_kv_quant::kvcache::KvCache;
     use rmlx_kv_quant::storage::KvStorage;
-    use rmlx_kv_quant::{KvQuant, KV_MAX_SEQ_DEFAULT};
+    use rmlx_kv_quant::{KvQuant, SharedKv, KV_MAX_SEQ_DEFAULT};
     use rmlx_loader::KvCalibration;
     use rmlx_mlx::{Array, Device, Dtype};
+
+    /// Unwrap a producer's share into `(out, K, V)`.
+    ///
+    /// Every cache in this module runs on `Device::Cpu`, on a rotating ring, or
+    /// on the Mixed path — none of which can reach a fused-over-store arm — so
+    /// the share is always bf16 here. A `Store` share would mean a dispatch gate
+    /// regressed, hence the panic rather than a silent dequant.
+    #[allow(
+        clippy::panic,
+        reason = "test helper: a Store share on a CPU/rotating/Mixed cache is a gate regression, and must fail the test loudly"
+    )]
+    fn split_bf16_share(pair: (Array, SharedKv)) -> (Array, Array, Array) {
+        let (out, share) = pair;
+        match share {
+            SharedKv::Bf16(k, v) => (out, k, v),
+            SharedKv::Store { .. } => {
+                panic!("expected a bf16 share — no fused-over-store arm is eligible here")
+            }
+        }
+    }
 
     // Helper: make a [B, kv_h, S, D] F32 array with deterministic LCG data in [-1, 1].
     #[allow(
@@ -924,14 +944,14 @@ mod tests {
 
     /// Smoke test for the cross-layer-KV-sharing sibling wrapper on the K8V8
     /// path: build a cache, seed it with 16 tokens, run one decode step via
-    /// `update_and_sdpa_returning_kv`, assert the call returns three arrays
+    /// `update_and_sdpa_shared_source`, assert the call returns three arrays
     /// with the expected shapes.
     #[test]
     #[allow(
         clippy::expect_used,
         reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
     )]
-    fn update_and_sdpa_returning_kv_k8v8_smoke() {
+    fn update_and_sdpa_shared_source_k8v8_smoke() {
         let device = Device::Cpu;
         let n_kv_heads: i32 = 4;
         let head_dim: i32 = 128;
@@ -951,9 +971,11 @@ mod tests {
         cache
             .update(&k_pref, &v_pref, device)
             .expect("K8V8 prefill failed");
-        let (out, k_full, v_full) = cache
-            .update_and_sdpa_returning_kv(&queries, &new_k, &new_v, scale, "", None, device)
-            .expect("update_and_sdpa_returning_kv K8V8 failed");
+        let (out, k_full, v_full) = split_bf16_share(
+            cache
+                .update_and_sdpa_shared_source(&queries, &new_k, &new_v, scale, "", None, device)
+                .expect("update_and_sdpa_shared_source K8V8 failed"),
+        );
 
         // After one decode step on top of the 16-token prefill: total = 17.
         let total_kv: i32 = prefill_seq + 1;
@@ -982,7 +1004,7 @@ mod tests {
         clippy::expect_used,
         reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
     )]
-    fn update_and_sdpa_returning_kv_k8v4_smoke() {
+    fn update_and_sdpa_shared_source_k8v4_smoke() {
         let device = Device::Cpu;
         let n_kv_heads: i32 = 4;
         let head_dim: i32 = 128;
@@ -1002,9 +1024,11 @@ mod tests {
         cache
             .update(&k_pref, &v_pref, device)
             .expect("K8V4 prefill failed");
-        let (out, k_full, v_full) = cache
-            .update_and_sdpa_returning_kv(&queries, &new_k, &new_v, scale, "", None, device)
-            .expect("update_and_sdpa_returning_kv K8V4 failed");
+        let (out, k_full, v_full) = split_bf16_share(
+            cache
+                .update_and_sdpa_shared_source(&queries, &new_k, &new_v, scale, "", None, device)
+                .expect("update_and_sdpa_shared_source K8V4 failed"),
+        );
 
         let total_kv: i32 = prefill_seq + 1;
         assert_eq!(out.shape(), vec![1, n_kv_heads, 1, head_dim]);
@@ -1012,7 +1036,7 @@ mod tests {
         assert_eq!(v_full.shape(), vec![1, n_kv_heads, total_kv, head_dim]);
     }
 
-    /// `update_and_sdpa_returning_kv` now SUPPORTS Mixed caches via
+    /// `update_and_sdpa_shared_source` now SUPPORTS Mixed caches via
     /// dequant-before-share. The fused quantized SDPA stores K/V as quant
     /// 3-tuples, but the wrapper surfaces the accumulated bf16 K/V (prefill-raw
     /// during prefill, maintained `decode_fp16_k/v` during decode) so a
@@ -1042,7 +1066,7 @@ mod tests {
         clippy::unwrap_used,
         reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
     )]
-    fn update_and_sdpa_returning_kv_mixed_shared_kv() {
+    fn update_and_sdpa_shared_source_mixed_shared_kv() {
         let device = Device::Cpu;
         let n_kv_heads: i32 = 4;
         let head_dim: i32 = 128;
@@ -1068,9 +1092,13 @@ mod tests {
 
         // Prefill through the shared-KV wrapper — must NOT error for Mixed.
         cache.enter_prefill();
-        let (out_pref, k_pre_full, v_pre_full) = cache
-            .update_and_sdpa_returning_kv(&q_pref, &k_pref, &v_pref, scale, "causal", None, device)
-            .expect("Mixed prefill via returning_kv must succeed");
+        let (out_pref, k_pre_full, v_pre_full) = split_bf16_share(
+            cache
+                .update_and_sdpa_shared_source(
+                    &q_pref, &k_pref, &v_pref, scale, "causal", None, device,
+                )
+                .expect("Mixed prefill via returning_kv must succeed"),
+        );
         cache.exit_prefill(device).expect("exit_prefill failed");
 
         assert_eq!(out_pref.shape(), vec![1, n_kv_heads, prefill_seq, head_dim]);
@@ -1091,9 +1119,11 @@ mod tests {
         );
 
         // One decode step: extend the prefix by exactly one token.
-        let (out, k_full, v_full) = cache
-            .update_and_sdpa_returning_kv(&queries, &new_k, &new_v, scale, "", None, device)
-            .expect("update_and_sdpa_returning_kv Mixed decode must succeed");
+        let (out, k_full, v_full) = split_bf16_share(
+            cache
+                .update_and_sdpa_shared_source(&queries, &new_k, &new_v, scale, "", None, device)
+                .expect("update_and_sdpa_shared_source Mixed decode must succeed"),
+        );
 
         let total_kv: i32 = prefill_seq + 1;
         assert_eq!(out.shape(), vec![1, n_kv_heads, 1, head_dim]);
@@ -1152,9 +1182,13 @@ mod tests {
         });
 
         cache.enter_prefill();
-        let (out_pref, _k_full, v_full) = cache
-            .update_and_sdpa_returning_kv(&q_pref, &k_pref, &v_pref, scale, "causal", None, device)
-            .expect("2-bit V Mixed prefill must succeed");
+        let (out_pref, _k_full, v_full) = split_bf16_share(
+            cache
+                .update_and_sdpa_shared_source(
+                    &q_pref, &k_pref, &v_pref, scale, "causal", None, device,
+                )
+                .expect("2-bit V Mixed prefill must succeed"),
+        );
         cache.exit_prefill(device).expect("exit_prefill failed");
 
         assert_eq!(v_full.shape(), vec![1, n_kv_heads, prefill_seq, head_dim]);
@@ -1513,9 +1547,11 @@ mod tests {
         let (v1, _) = make_lcg_array(shape1, 0x3333_3333_u64);
         // First chunk: offset == 0 -> "causal", no explicit mask (matches
         // Gemma4 SWA prefill at offset 0).
-        let (_o1, _k1f, _v1f) = cache
-            .update_and_sdpa_returning_kv(&q1, &k1, &v1, scale, "causal", None, device)
-            .expect("chunk 1 prefill must succeed");
+        let (_o1, _k1f, _v1f) = split_bf16_share(
+            cache
+                .update_and_sdpa_shared_source(&q1, &k1, &v1, scale, "causal", None, device)
+                .expect("chunk 1 prefill must succeed"),
+        );
         assert_eq!(cache.offset(), c1);
 
         // Chunk 2: crosses the window. Build the SWA mask the way Gemma4 does:
@@ -1531,9 +1567,11 @@ mod tests {
 
         // Pre-fix: this errored with the (…,c2,c2+offset) vs (…,c2,eff+c2)
         // broadcast mismatch. Post-fix: Ok, K capped at the window.
-        let (out, k_full, v_full) = cache
-            .update_and_sdpa_returning_kv(&q2, &k2, &v2, scale, "array", Some(&mask), device)
-            .expect("window-crossing Mixed SWA chunk must not broadcast-fail");
+        let (out, k_full, v_full) = split_bf16_share(
+            cache
+                .update_and_sdpa_shared_source(&q2, &k2, &v2, scale, "array", Some(&mask), device)
+                .expect("window-crossing Mixed SWA chunk must not broadcast-fail"),
+        );
 
         // The crux: the ring's K length must equal the mask's key dimension
         // (`eff_offset + c2`), i.e. the window-capped length the mlx-lm

--- a/crates/rmlx-models/src/laguna/attention.rs
+++ b/crates/rmlx-models/src/laguna/attention.rs
@@ -157,7 +157,7 @@ impl Attention {
         // Route through `KvCache::update_and_sdpa` —
         // the universal wrapper that fuses cache update + SDPA and dispatches
         // to the Mixed, K8V4-flash, or legacy path based on quant type.
-        // No cross-layer KV sharing in Laguna, so the `_returning_kv` sibling
+        // No cross-layer KV sharing in Laguna, so the `_shared_source` sibling
         // is not needed.
         let attn_out = if let Some(c) = cache {
             c.update_and_sdpa(&q, &k, &v, self.scale, mask_mode, mask_ref, device)?

--- a/crates/rmlx-models/src/qwen3_5_moe/attention.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/attention.rs
@@ -139,7 +139,7 @@ impl FullAttention {
         // Route through `KvCache::update_and_sdpa` —
         // the universal wrapper that fuses cache update + SDPA and dispatches
         // to the Mixed, K8V4-flash, or legacy path based on quant type.
-        // No cross-layer KV sharing in Qwen3.5MoE, so the `_returning_kv`
+        // No cross-layer KV sharing in Qwen3.5MoE, so the `_shared_source`
         // sibling is not needed.
         let attn = if let Some(c) = cache {
             c.update_and_sdpa(

--- a/crates/rmlx-models/tests/niah_long_context.rs
+++ b/crates/rmlx-models/tests/niah_long_context.rs
@@ -29,12 +29,13 @@
 //! each in a fresh process.
 //!
 //! A parallel **planar_flash_decode** family of cells (`niah_pflash_*`) consult
-//! `RMLX_PLANAR_FLASH_DECODE` and force `KvQuant::PlanarK`. Only
-//! `Qwen3ForCausalLM` (Bonsai) routes through `update_and_sdpa_planar_k_fused`;
+//! `RMLX_PLANAR_FLASH_DECODE` and force `KvQuant::PlanarK`. Bonsai
+//! (`Qwen3ForCausalLM`) reaches `update_and_sdpa_planar_k_fused` and dispatches;
 //! Qwen3.6 MoE rejects `PlanarK` outright at `validate_resolved`
-//! (`QwenMoePlanarKRejected`), and Gemma4 routes through
-//! `update_and_sdpa_shared_source` (same shape as the TurboFlash Unreachable
-//! case for that arch).
+//! (`QwenMoePlanarKRejected`); Gemma4 reaches the same fused arm via
+//! `update_and_sdpa_shared_source` but stays dormant behind the warm-TTFT
+//! bf16-K-seed gate. See [`FlashRouting`] — dormancy is always a gate, never a
+//! property of cross-layer KV sharing.
 //!
 //! # KV mode
 //!
@@ -341,21 +342,38 @@ fn run_one(
     }
 }
 
-/// Routing capability for the dispatch assertion.
+/// Expected kernel-dispatch outcome for a cell, in ON mode.
 ///
-/// `Reachable` — the arch routes through `KvCache::sdpa_dispatch` (e.g.
-/// Qwen3 / Qwen3.6). In ON mode the MSL kernel MUST fire; delta > 0.
+/// `Reachable` — the MSL kernel MUST fire; delta > 0.
 ///
-/// `Unreachable` — the arch routes through `update_and_sdpa_shared_source`
-/// (e.g. Gemma4 — cross-layer KV sharing requires the accumulated bf16
-/// K/V to be returned alongside SDPA out, which `turbo_flash_sdpa` does
-/// not produce). The kernel is structurally never invoked; the ON run is
-/// equivalent to OFF. Documented limitation; not a bug to chase from this
-/// review-fix cluster.
+/// `Dormant` — the kernel must NOT fire; delta == 0, so the ON run measures the
+/// legacy fallback and is equivalent to OFF.
+///
+/// **Dormancy is a gate/config fact, per cell — never a structural property of
+/// cross-layer KV sharing.** An earlier version of this comment claimed the
+/// shared-KV producer path "structurally never invokes" the kernel because it
+/// must return accumulated bf16 K/V alongside the SDPA output. Both halves are
+/// false: `update_and_sdpa_shared_source` reaches the TurboFlash, fused-QK,
+/// planar and rotor arms exactly as `update_and_sdpa` does, and a producer that
+/// runs a fused arm hands consumers `SharedKv::Store` rather than materialising
+/// bf16 (see `docs/KV_QUANT.md`). The measured reason per `Dormant` cell:
+///
+/// * **Gemma4 + Turbo** — TurboFlash requires `head_dim ∈ {128, 256}`; Gemma4's
+///   global layers are `head_dim=512`, so the kernel's own shape gate rejects
+///   them (`update_and_sdpa_k8v4_flash_inner`). Nothing to do with KV sharing.
+/// * **Gemma4 + Pflash** — the warm-TTFT bf16-K-seed gate keeps the PlanarK
+///   kernels dormant while the seed is live (`sdpa.rs`, `warm_ttft_bypass`).
+/// * **Qwen3.6 + Pflash** — the arch rejects `KvQuant::PlanarK` at
+///   `validate_resolved`, so the codec never runs at all.
+///
+/// Each of those is a gate that can move. Re-check the affected cells whenever
+/// the TurboFlash shape gate, the warm-TTFT gate, or a `validate_resolved`
+/// rejection changes — a cell going `delta > 0` means re-classify as
+/// `Reachable`, not that the kernel misfired.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum FlashRouting {
     Reachable,
-    Unreachable,
+    Dormant,
 }
 
 fn run_cell(model_path: &Path, ctx: usize, depth: f32, routing: FlashRouting) {
@@ -460,29 +478,25 @@ fn run_cell_kind(
                 model_path.display(),
             );
         }
-        ("ON", FlashRouting::Unreachable, _) => {
-            // Documented limitation. For Turbo: this arch's attention layer
-            // routes through `update_and_sdpa_shared_source`, which never
-            // reaches `sdpa_dispatch`. For Pflash: the arch rejects
-            // `KvQuant::PlanarK` at `validate_resolved` (Qwen MoE) or
-            // routes through `update_and_sdpa_shared_source` (Gemma4 cross-
-            // layer KV sharing). Either way the ON run is byte-identical to
-            // OFF and the dispatch counter must remain zero.
+        ("ON", FlashRouting::Dormant, _) => {
+            // A gate — not the shared-KV topology — keeps this cell's kernel
+            // dormant; see `FlashRouting` for the measured per-cell reason.
+            // The ON run is therefore byte-identical to OFF.
             assert_eq!(
                 dispatch_delta,
                 0,
-                "[niah] FAIL: family={family} routing=Unreachable but kernel still \
-                 dispatched (model={} ctx={ctx} depth={depth:.2}). Re-classify \
-                 this cell as Reachable.",
+                "[niah] FAIL: family={family} routing=Dormant but kernel still \
+                 dispatched (model={} ctx={ctx} depth={depth:.2}). A gate moved: \
+                 confirm which one, then re-classify this cell as Reachable.",
                 model_path.display(),
             );
             eprintln!(
-                "[niah] NOTE: family={family} model={} routing=Unreachable — ON \
+                "[niah] NOTE: family={family} model={} routing=Dormant — ON \
                  run measures the legacy fallback, NOT the MSL kernel.",
                 model_path.display(),
             );
         }
-        ("OFF", FlashRouting::Reachable | FlashRouting::Unreachable, _) => {
+        ("OFF", FlashRouting::Reachable | FlashRouting::Dormant, _) => {
             assert_eq!(
                 dispatch_delta,
                 0,
@@ -662,7 +676,7 @@ niah_cell!(
     niah_gemma4_8k_d10,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     8_192,
     0.10
 );
@@ -670,7 +684,7 @@ niah_cell!(
     niah_gemma4_8k_d30,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     8_192,
     0.30
 );
@@ -678,7 +692,7 @@ niah_cell!(
     niah_gemma4_8k_d50,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     8_192,
     0.50
 );
@@ -686,7 +700,7 @@ niah_cell!(
     niah_gemma4_8k_d70,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     8_192,
     0.70
 );
@@ -694,7 +708,7 @@ niah_cell!(
     niah_gemma4_8k_d90,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     8_192,
     0.90
 );
@@ -703,7 +717,7 @@ niah_cell!(
     niah_gemma4_16k_d10,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     16_384,
     0.10
 );
@@ -711,7 +725,7 @@ niah_cell!(
     niah_gemma4_16k_d30,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     16_384,
     0.30
 );
@@ -719,7 +733,7 @@ niah_cell!(
     niah_gemma4_16k_d50,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     16_384,
     0.50
 );
@@ -727,7 +741,7 @@ niah_cell!(
     niah_gemma4_16k_d70,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     16_384,
     0.70
 );
@@ -735,7 +749,7 @@ niah_cell!(
     niah_gemma4_16k_d90,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     16_384,
     0.90
 );
@@ -744,7 +758,7 @@ niah_cell!(
     niah_gemma4_32k_d10,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     32_768,
     0.10
 );
@@ -752,7 +766,7 @@ niah_cell!(
     niah_gemma4_32k_d30,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     32_768,
     0.30
 );
@@ -760,7 +774,7 @@ niah_cell!(
     niah_gemma4_32k_d50,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     32_768,
     0.50
 );
@@ -768,7 +782,7 @@ niah_cell!(
     niah_gemma4_32k_d70,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     32_768,
     0.70
 );
@@ -776,7 +790,7 @@ niah_cell!(
     niah_gemma4_32k_d90,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     32_768,
     0.90
 );
@@ -916,13 +930,13 @@ niah_cell!(
 // Routing:
 // - Bonsai (`Qwen3ForCausalLM`)              → Reachable. Routes through
 //   `KvCache::update_and_sdpa` → `sdpa_dispatch` → `update_and_sdpa_planar_k_fused`.
-// - Qwen3.6 (`Qwen3_5MoeForConditionalGeneration`) → Unreachable. `validate_resolved`
+// - Qwen3.6 (`Qwen3_5MoeForConditionalGeneration`) → Dormant. `validate_resolved`
 //   rejects `KvQuant::PlanarK` outright with `QwenMoePlanarKRejected`. The
 //   cache is never built; the kernel can never dispatch. Cells are kept so
 //   the assertion enforces the routing contract.
-// - Gemma4 (`Gemma4ForConditionalGeneration`) → Unreachable. Routes through
-//   `update_and_sdpa_shared_source` for cross-layer KV sharing (same shape as
-//   the TurboFlash Unreachable case for this arch).
+// - Gemma4 (`Gemma4ForConditionalGeneration`) → Dormant. It DOES reach the same
+//   fused arm via `update_and_sdpa_shared_source`, but the warm-TTFT bf16-K-seed
+//   gate keeps the kernel dormant. Re-check if that gate changes.
 //
 // Bonsai max-pos = 16k (no YARN), so cells cap at 16k — matches the existing
 // TurboFlash Bonsai cells.
@@ -1025,16 +1039,16 @@ niah_pflash_cell!(
     0.90
 );
 
-// ── Qwen3.6 35B-A3B — Unreachable. PlanarK rejected at validate_resolved
+// ── Qwen3.6 35B-A3B — Dormant. PlanarK rejected at validate_resolved
 //   (`QwenMoePlanarKRejected`).  Cells exist so the dispatch-counter
-//   assertion enforces "Unreachable means delta == 0 even with ON". 32k per
+//   assertion enforces "Dormant means delta == 0 even with ON". 32k per
 //   ticket DoD ceiling. ─────────────────────────────────────────────────
 
 niah_pflash_cell!(
     niah_pflash_qwen36_32k_d10,
     "RMLX_TEST_MODEL_QWEN36",
     EXPECTED_ARCHS_QWEN36,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     32_768,
     0.10
 );
@@ -1042,7 +1056,7 @@ niah_pflash_cell!(
     niah_pflash_qwen36_32k_d50,
     "RMLX_TEST_MODEL_QWEN36",
     EXPECTED_ARCHS_QWEN36,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     32_768,
     0.50
 );
@@ -1050,20 +1064,20 @@ niah_pflash_cell!(
     niah_pflash_qwen36_32k_d90,
     "RMLX_TEST_MODEL_QWEN36",
     EXPECTED_ARCHS_QWEN36,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     32_768,
     0.90
 );
 
-// ── Gemma4 e4b — Unreachable. Same shape as the TurboFlash Unreachable
-//   path: this arch routes through `update_and_sdpa_shared_source` for
-//   cross-layer KV sharing. ────────────────────────────────────────────
+// ── Gemma4 e4b — Dormant. The fused arm IS reached via
+//   `update_and_sdpa_shared_source`; the warm-TTFT bf16-K-seed gate is what
+//   keeps the kernel dormant. ──────────────────────────────────────────
 
 niah_pflash_cell!(
     niah_pflash_gemma4_32k_d10,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     32_768,
     0.10
 );
@@ -1071,7 +1085,7 @@ niah_pflash_cell!(
     niah_pflash_gemma4_32k_d50,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     32_768,
     0.50
 );
@@ -1079,7 +1093,7 @@ niah_pflash_cell!(
     niah_pflash_gemma4_32k_d90,
     "RMLX_TEST_MODEL_GEMMA4_E4B",
     EXPECTED_ARCHS_GEMMA4,
-    FlashRouting::Unreachable,
+    FlashRouting::Dormant,
     32_768,
     0.90
 );

--- a/crates/rmlx-models/tests/niah_long_context.rs
+++ b/crates/rmlx-models/tests/niah_long_context.rs
@@ -33,7 +33,7 @@
 //! `Qwen3ForCausalLM` (Bonsai) routes through `update_and_sdpa_planar_k_fused`;
 //! Qwen3.6 MoE rejects `PlanarK` outright at `validate_resolved`
 //! (`QwenMoePlanarKRejected`), and Gemma4 routes through
-//! `update_and_sdpa_returning_kv` (same shape as the TurboFlash Unreachable
+//! `update_and_sdpa_shared_source` (same shape as the TurboFlash Unreachable
 //! case for that arch).
 //!
 //! # KV mode
@@ -346,7 +346,7 @@ fn run_one(
 /// `Reachable` — the arch routes through `KvCache::sdpa_dispatch` (e.g.
 /// Qwen3 / Qwen3.6). In ON mode the MSL kernel MUST fire; delta > 0.
 ///
-/// `Unreachable` — the arch routes through `update_and_sdpa_returning_kv`
+/// `Unreachable` — the arch routes through `update_and_sdpa_shared_source`
 /// (e.g. Gemma4 — cross-layer KV sharing requires the accumulated bf16
 /// K/V to be returned alongside SDPA out, which `turbo_flash_sdpa` does
 /// not produce). The kernel is structurally never invoked; the ON run is
@@ -462,10 +462,10 @@ fn run_cell_kind(
         }
         ("ON", FlashRouting::Unreachable, _) => {
             // Documented limitation. For Turbo: this arch's attention layer
-            // routes through `update_and_sdpa_returning_kv`, which never
+            // routes through `update_and_sdpa_shared_source`, which never
             // reaches `sdpa_dispatch`. For Pflash: the arch rejects
             // `KvQuant::PlanarK` at `validate_resolved` (Qwen MoE) or
-            // routes through `update_and_sdpa_returning_kv` (Gemma4 cross-
+            // routes through `update_and_sdpa_shared_source` (Gemma4 cross-
             // layer KV sharing). Either way the ON run is byte-identical to
             // OFF and the dispatch counter must remain zero.
             assert_eq!(
@@ -921,7 +921,7 @@ niah_cell!(
 //   cache is never built; the kernel can never dispatch. Cells are kept so
 //   the assertion enforces the routing contract.
 // - Gemma4 (`Gemma4ForConditionalGeneration`) → Unreachable. Routes through
-//   `update_and_sdpa_returning_kv` for cross-layer KV sharing (same shape as
+//   `update_and_sdpa_shared_source` for cross-layer KV sharing (same shape as
 //   the TurboFlash Unreachable case for this arch).
 //
 // Bonsai max-pos = 16k (no YARN), so cells cap at 16k — matches the existing
@@ -1056,7 +1056,7 @@ niah_pflash_cell!(
 );
 
 // ── Gemma4 e4b — Unreachable. Same shape as the TurboFlash Unreachable
-//   path: this arch routes through `update_and_sdpa_returning_kv` for
+//   path: this arch routes through `update_and_sdpa_shared_source` for
 //   cross-layer KV sharing. ────────────────────────────────────────────
 
 niah_pflash_cell!(

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -1058,7 +1058,7 @@ token? "frozen" = no (bf16 shortcut); "K-only" = K codec runs, V bf16.
 
 1. `Mixed`/`RotKTq4V` are driven through `update_and_sdpa` (the direct
    `update()` arm errors); the bf16 mirror is surfaced to cross-layer-KV
-   consumers via `update_and_sdpa_returning_kv` (see §10.2 Mixed note).
+   consumers via `update_and_sdpa_shared_source` (see §10.2 Mixed note).
 2. PlanarK was the **sole** codec missing the shortcut; it re-encoded K
    through lossy Lloyd-Max + Givens every decode step, which broke
    `niah_pflash_bonsai_8k_d50` retrieval. The fix (`b1d9dca`) restored the
@@ -1219,7 +1219,7 @@ to bottom; `auto` ties the top cluster within stddev.
 | `q8_g128` / `q6_g64` | —                     | —                        | —       | skip         |
 
 **Mixed is now supported on Gemma4 via dequant-before-share.** The former startup
-rejection is gone. `update_and_sdpa_returning_kv` now surfaces the accumulated
+rejection is gone. `update_and_sdpa_shared_source` now surfaces the accumulated
 **bf16** K/V (prefill-raw buffer during prefill, the maintained `decode_fp16`
 accumulator during decode — the same tensors the fused quantized SDPA was computed
 from) to the cross-layer-KV consumer layers. Verified coherent: e4b

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2600,7 +2600,7 @@ reaches it.
 | Bonsai (`Qwen3ForCausalLM`) | `update_and_sdpa` | **YES** | head_dim 128. Measured 78 dispatches / 8 tokens. |
 | medgemma (`Gemma3ForConditionalGeneration`) | `update_and_sdpa` | **YES** | head_dim 256, no cross-layer KV share. Measured 28 dispatches / 8 tokens. |
 | Qwen2 / Laguna / bitnet / Qwen3-VL-MoE | `update_and_sdpa` | **YES** (by shape) | Same entry point; subject to the shape gates. |
-| Gemma4 (`Gemma4ForConditionalGeneration`) | `update_and_sdpa_returning_kv` (cross-layer KV share) | **NO** | The producer layer's contract is to *return* `k_full` / `v_full` for the 20 consumer layers, which forces a bf16 K materialisation — exactly what this kernel avoids. Making it reachable means sharing the **quantized** store across layers, a separate change. Same unreachable shape as TurboFlash and `planar_flash_decode`. |
+| Any arch with cross-layer KV sharing (e.g. `Gemma4ForConditionalGeneration`) | `update_and_sdpa_shared_source` (cross-layer KV share) | **YES** | The producer runs the same fused arm a non-sharing model runs and reports `SharedKv::Store`; each consumer layer re-enters the same kernel over that store via `KvCache::sdpa_shared`. No bf16 K is materialised. Previously this path had no fused arm at all and every shared-KV model fell back to the O(seq) CPU dequant. |
 | Qwen3.6 (`Qwen3_5MoeForConditionalGeneration`) | rejected at `cache_type::validate_resolved` | NO | Contract A.y — sub-4-bit K on Qwen MoE is a PPL disaster; the cache is never built. |
 
 ### Performance posture
@@ -2665,7 +2665,7 @@ the production switch and sets/removes the env var before the
 | Variant | Eligible? | Notes |
 |---|---|---|
 | `KvStorage::PlanarK { k: QuantPlanarK, .. }` | **YES** | Sole route through `update_and_sdpa_planar_k_fused` → `planar_flash_decode_sdpa`. Requires power-of-two `head_dim`. |
-| Any other `KvStorage` variant | NO | Routed through `mixed_quantized_sdpa` or `update_and_sdpa_returning_kv`. |
+| Any other `KvStorage` variant | NO | Routed through `mixed_quantized_sdpa` or `update_and_sdpa_shared_source`. |
 
 ### Arch reachability
 
@@ -2673,7 +2673,7 @@ the production switch and sets/removes the env var before the
 |---|---|---|---|
 | Bonsai (`Qwen3ForCausalLM`) | `update_and_sdpa` → `sdpa_dispatch` → `update_and_sdpa_planar_k_fused` | **YES** | The only arch that both (a) routes through the fused-QK chain and (b) does not reject PlanarK at validate_resolved. |
 | Qwen3.6 (`Qwen3_5MoeForConditionalGeneration`) | rejected at `cache_type::validate_resolved` | NO | Contract A.y `QwenMoePlanarKRejected` — pre-existing PPL-disaster guard. The cache is never built; the kernel can never dispatch. |
-| Gemma4 (`Gemma4ForConditionalGeneration`) | `update_and_sdpa_returning_kv` (cross-layer KV share) | NO | The attention layer never enters `sdpa_dispatch` (same unreachable shape as TurboFlash). |
+| Any arch with cross-layer KV sharing (e.g. `Gemma4ForConditionalGeneration`) | `update_and_sdpa_shared_source` (cross-layer KV share) | YES | The shared-source chain mirrors `update_and_sdpa` arm for arm, so `sdpa_dispatch` is reached exactly as on a non-sharing model. |
 
 NIAH cells covering all three routes ship in
 `crates/rmlx-models/tests/niah_long_context.rs` (`niah_pflash_*`) and

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -788,7 +788,7 @@ buffer.
 SWA layers whose K/V is produced by the model but immediately overwritten with
 the shared K/V from the preceding full-attention layer. Only the full-attention
 layers write independent K/V into the KV cache; SWA layers read the shared
-tensor supplied by `update_and_sdpa_returning_kv`. This halves the KV memory
+tensor supplied by `update_and_sdpa_shared_source`. This halves the KV memory
 footprint for those layers.
 
 **K=V sharing for full-attention layers (26B/31B).** When `attention_k_eq_v=true`,
@@ -878,7 +878,7 @@ Default resolution by signal:
 - `hidden_size >= 5376` (31B dense): `Planar`.
 
 Cross-layer KV sharing is compatible with all `KvQuant` modes. The
-`update_and_sdpa_returning_kv` path dequantizes to bf16 before passing the
+`update_and_sdpa_shared_source` path dequantizes to bf16 before passing the
 shared KV to consumer layers, so `Mixed` mode also works.
 
 ### Modalities

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -869,15 +869,13 @@ Reproduced live on `gemma-4-e4b-it-mxfp8` with `--cache-type-k q8_g128
 > bf16/K8V8/K8V4/Planar for shared-KV layers, or disable layer-KV sharing for
 > this arch.`
 
-emitted from `KvCache::update_and_sdpa_shared_source` (`kvcache.rs:412`). Gemma4
-genuinely shares KV across layers (`num_kv_shared_layers`, `loader.rs:252-258`),
-and shared-KV layers route through the `returning_kv` path that rejects
-`KvQuant::Mixed`. This is the documented cross-layer-KV-sharing contract behaving correctly. The
-only flaw is *when* it fires — at first prefill (runtime_fail, value 0.00)
-rather than at startup. **ACCEPT** — this is correct-by-design and justifies
-the resolver guard: reject Mixed on the Gemma family at flag resolution and
-exit 78 at startup, so the user sees the error immediately instead of after a
-model load + prefill.
+emitted from the cross-layer-KV producer path. Gemma4 genuinely shares KV across
+layers (`num_kv_shared_layers`, `loader.rs:252-258`), and at the time of this
+run shared-KV layers rejected `KvQuant::Mixed`. **This finding is historical and
+its premise no longer holds**: the `SharedKvIncompatibleWithMixed` rejection was
+removed (`kv_cache/cache_type.rs`) — `KvCache::update_and_sdpa_shared_source`
+supports Mixed via dequant-before-share, so the combination is now valid and no
+resolver guard is needed. Kept for the record of what was measured.
 
 ### H9 — decode forward NOT compiled — characterized (NOT a catastrophe)
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -483,7 +483,7 @@ Identical diagnostic for all four variants with variant name substituted. The co
 **Notes**:
 - Symmetric variants (`rotor3_sym` / `rotor4_sym`) match the corresponding V-only rotor anchors closely (~80–82 Gemma4, ~143–145 Bonsai), confirming the additional K-side rotor encode cost is amortised by the CPU decode path bottleneck.
 - K-only variants (`k_rotor3` / `k_rotor4`) are bottlenecked by the CPU-only rotor K-side decode + optional QJL projection. Bonsai shows wide cross-run variance (run 1 ~40 TPS, run 3 ~49 TPS) due to Metal graph JIT warm-up; Gemma4 is stable (~63–65 TPS). First run should not be treated as a regression floor.
-- **`k_rotor3/4` decode is now a fused MSL flash-decode** over the packed rotor store when `--rotor-qjl off` (`rotor_flash_decode`, see `docs/KV_QUANT.md`); the per-step full-prefix CPU dequant is gone. The anchors above are **not** superseded — they are 2-token short-prompt runs (§ below), where the prefix is empty and the dequant that this kernel removes costs nothing, so they measure a different thing. The kernel's effect scales with prefix length. Measured at a 4k prompt, `--rotor-qjl off`, medians of 3+ runs, before → after: Bonsai-8B `k_rotor3` 1.34 → **17.0**, `k_rotor4` 1.36 → **15.9**; medgemma-4B `k_rotor3` 7.37 → **51.8**, `k_rotor4` 7.34 → **52.1**. The default `--rotor-qjl on` path is unchanged (kernel dormant), as is Gemma4 (`update_and_sdpa_returning_kv` never reaches the kernel).
+- **`k_rotor3/4` decode is now a fused MSL flash-decode** over the packed rotor store when `--rotor-qjl off` (`rotor_flash_decode`, see `docs/KV_QUANT.md`); the per-step full-prefix CPU dequant is gone. The anchors above are **not** superseded — they are 2-token short-prompt runs (§ below), where the prefix is empty and the dequant that this kernel removes costs nothing, so they measure a different thing. The kernel's effect scales with prefix length. Measured at a 4k prompt, `--rotor-qjl off`, medians of 3+ runs, before → after: Bonsai-8B `k_rotor3` 1.34 → **17.0**, `k_rotor4` 1.36 → **15.9**; medgemma-4B `k_rotor3` 7.37 → **51.8**, `k_rotor4` 7.34 → **52.1**. The default `--rotor-qjl on` path is unchanged (kernel dormant), as is Gemma4 (`update_and_sdpa_shared_source` never reaches the kernel).
 - QJL toggle effect on Gemma4 `k_rotor3`: QJL ON = 66.5 TPS, QJL OFF = 73.2 TPS (encode cost). The QJL sideband is correctly stored / round-tripped; cosine lift on reconstructed K is deferred to a follow-up that applies QJL correction at score-time on the SDPA path.
 - All four variants are opt-in only — never an auto baseline.
 - Bonsai long-prompt (10867 tokens) fails with all quant variants (pre-existing SWA-layer zero-chunk bug). Use short prompt for this smoke.
@@ -827,7 +827,7 @@ per-step realloc.
 
 ### H6 — universal-wrapper dispatch — REJECT
 
-The `update_and_sdpa` / `update_and_sdpa_returning_kv` match-arm + indirect call
+The `update_and_sdpa` / `update_and_sdpa_shared_source` match-arm + indirect call
 is single-digit nanoseconds; a Bonsai decode step is ~8.96 ms (millions of ns).
 The wrapper self-time cannot be a measurable share, and the bucket breakdown
 shows decode time is dominated by the forward graph, not dispatch glue.
@@ -869,7 +869,7 @@ Reproduced live on `gemma-4-e4b-it-mxfp8` with `--cache-type-k q8_g128
 > bf16/K8V8/K8V4/Planar for shared-KV layers, or disable layer-KV sharing for
 > this arch.`
 
-emitted from `KvCache::update_and_sdpa_returning_kv` (`kvcache.rs:412`). Gemma4
+emitted from `KvCache::update_and_sdpa_shared_source` (`kvcache.rs:412`). Gemma4
 genuinely shares KV across layers (`num_kv_shared_layers`, `loader.rs:252-258`),
 and shared-KV layers route through the `returning_kv` path that rejects
 `KvQuant::Mixed`. This is the documented cross-layer-KV-sharing contract behaving correctly. The
@@ -1138,7 +1138,7 @@ single-kernel trade-off. A follow-up generalises the contract to other codecs.
   Bonsai is the **sole reachable arch** for `planar_flash_decode_sdpa` today:
   Qwen3.6 MoE rejects `KvQuant::PlanarK` outright at `validate_resolved`
   (Contract A.y, `QwenMoePlanarKRejected`), and Gemma4 routes its
-  attention layer through `update_and_sdpa_returning_kv` for cross-layer KV
+  attention layer through `update_and_sdpa_shared_source` for cross-layer KV
   sharing (same shape as the `Unreachable TurboFlash` case).
 - Forced `--kv-quant planar` (resolves to `KvQuant::PlanarK`).
 - `--max-tokens 100`, `--max-ctx 8192` (4k prompt) / `--max-ctx 16384` (8k prompt).

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -460,7 +460,7 @@ They are read only inside test code (`tests/` and `*_tests.rs` files).
 | `RMLX_NIAH_KV_QUANT` | KV quant name (e.g. `k8v4`) | Override the KV quant used in NIAH long-context harness tests. |
 | `RMLX_APPLE10_STRICT` | `1` | Fail (not warn) on Apple10 head-dim=256 cosine gate below floor. |
 | `RMLX_FUSED_QK_STRICT` | `1` | Fail (not warn) on fused-QK parity tests. |
-| `RMLX_RETURNING_KV_STRICT` | `1` | Fail (not warn) on returning-KV dispatch parity tests. |
+| `RMLX_SHARED_SOURCE_STRICT` | `1` | Fail (not warn) on shared-KV producer dispatch parity tests. |
 | `RMLX_SPARSE_ATTN_STRICT` | `1` | Fail (not warn) on sparse-attn dispatch parity tests. |
 
 ---

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -242,7 +242,7 @@ axis:
   `update_and_sdpa_planar_k_fused` → `planar_flash_decode_sdpa` chain
   activates. Consults `RMLX_PLANAR_FLASH_DECODE`. Bonsai-only Reachable
   arch (Qwen3.6 MoE rejects PlanarK at validate_resolved; Gemma4 routes
-  through `update_and_sdpa_returning_kv`).
+  through `update_and_sdpa_shared_source`).
 
 Neither family sets its env var directly — the kernel gates are
 `OnceLock`-latched. To compare OFF vs ON, run the shell driver:


### PR DESCRIPTION
## Summary
Closes #228. The KV cache is a **model-agnostic protocol**, but any model with shared-KV layers (`num_kv_shared_layers > 0`) routed producers through `update_and_sdpa_returning_kv` — which **had no fused-over-quant-store arms at all** (only TurboFlash + fused-QK, both of which surface bf16 by slicing `decode_fp16_k/v`). So every shared-KV model fell through to `update()`'s O(seq) CPU dequant **regardless of codec**, and every fused decode kernel was silently bypassed.

The bf16 materialisation was the *symptom*; the missing arms were the cause — and they couldn't be bolted on without solving consumer store access, which is exactly the fix.

**Discriminator is topology, not arch:** medgemma (Gemma3, no sharing) already got the full rotor kernel; gemma-4-e2b logged **0 dispatches**.

## Design
New `rmlx_kv_quant::SharedKv` = `Bf16(Array, Array)` | `Store { kv_len }`, keyed off **codec + shape only**. Producers report which; consumers re-enter the same kernel over the producer's store via `KvCache::sdpa_shared`. `Bf16` covers rotating rings, Mixed/RotK, TurboFlash/fused-QK — bit-for-bit unchanged, and one materialisation is shared by N consumers (no N× dequant). `update_and_sdpa_returning_kv` → `update_and_sdpa_shared_source`; the `returning_kv_legacy` tracing field now records the real arm.

## Results (4k, `--rotor-qjl off`, verified paired binaries)
| model | topology | before | after |
|---|---|---|---|
| gemma-4-e2b `k_rotor3` | shared-KV | 33.57 (0 disp) | **68.11** (191 disp) — 2.0× |
| gemma-4-e4b `k_rotor3` | shared-KV | 13.51 (0 disp) | **46.03** (254 disp) — 3.4× |
| gemma-4-e2b `none` | shared-KV bf16 | 136.26 | 133.59 |
| medgemma-4B `k_rotor3` | no sharing | 55.89 | 56.94 |
| Bonsai-8B `k_rotor3` | no sharing | 20.74 | 20.42 (medians, n=11 — both binaries show low outliers; machine noise) |

All five token-identical to the pre-fix dequant reference; e2b `k_rotor3` == `none`.

## Notable
- **dtype:** `materialise_shared_kv_bf16` returned **F32** K to the MTP drafter (the f32-KV-promotion class of #44/#51/#168). Fixed by casting K to the **V mirror's actual dtype** — not a hard-coded bf16, because V is not unconditionally bf16 either (`slice_decode_fp16_v` returns whatever the model pushed), so forcing bf16 would silently downcast a wider stream. Method renamed `materialise_shared_kv` since it can't promise bf16; dtype-agreement guard added.
- **`FlashRouting::Unreachable` → `Dormant`:** the old doc ("structurally never invoked … requires bf16 K/V returned alongside SDPA out") was falsified by this PR. Re-measured: Gemma4+Turbo `dispatch_delta=0` is a **TurboFlash `head_dim=512 ∉ {128,256}` shape gate** — unrelated to KV sharing, and wrong even before this change. Each Dormant cell now carries its true cause.
- Producer cache slot is now mandatory (`tail.get_mut(0)` could silently take the no-cache branch — no history, no append).
- Test-only env `RMLX_RETURNING_KV_STRICT` → `RMLX_SHARED_SOURCE_STRICT` (no users outside its test + docs row).

## Testing
`cargo test -p rmlx-kv-quant -p rmlx-models` **1075 passed**; `make lint` clean; `make check-metal-format` OK; `msl` CI job validates the kernels. Both new guards verified **non-vacuous** (stubbing `check_shared_kv_len` reds the desync test; removing the dtype cast reds the dtype test).

## Unblocks
#218/#219/#220 now only need adding to `try_dispatch_shared_store` + `sdpa_shared`.

Note: `k_rotor3` still trails `none` on e2b (68 vs ~134) — the rotor codec is a memory play at long context, not a 4k decode win. This removes the blocker, not that tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)