### PR TITLE
fix(server): report a dead decode stream as a failure, not a clean stop (#235)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         smoke-codec-matrix \
         e2e \
         file-size-report check-no-inline-tests check-no-scalar-f32-leak \
+        check-no-decode-swallow \
         check-metal-compiles check-metal-format
 
 help:
@@ -166,6 +167,9 @@ check-no-inline-tests: ## CI gate: fail if any non-test.rs file has inline #[cfg
 check-no-scalar-f32-leak: ## CI gate: fail if arch-layer code has unguarded scalar_f32( not followed by .astype(
 	@bash scripts/check_no_scalar_f32_leak.sh
 
+check-no-decode-swallow: ## CI gate: fail if a decode-step failure breaks instead of propagating (would report as finish_reason="length")
+	@bash scripts/check_no_decode_swallow.sh
+
 # METAL_STRICT=--strict turns a missing toolchain into a hard failure instead of
 # a skip. CI sets it (the macOS runner ships the toolchain, so a skip there would
 # mean the gate protected nothing); local runs leave it empty and skip.
@@ -181,6 +185,7 @@ check-metal-format: ## CI gate: every KV .metal kernel is clang-format clean (sk
 ci: fmt-check lint test deny audit ci-metrics ## full pre-merge gate: fmt + clippy + test + deny + audit + metrics-sanity + inline-test + MSL gates
 	@bash scripts/check_no_inline_tests.sh
 	@bash scripts/check_no_scalar_f32_leak.sh
+	@bash scripts/check_no_decode_swallow.sh
 	@bash scripts/check_metal_format.sh
 	@bash scripts/check_metal_compiles.sh
 	@bash scripts/file_size_report.sh || true

--- a/crates/rmlx-models/src/bitnet/generate.rs
+++ b/crates/rmlx-models/src/bitnet/generate.rs
@@ -483,15 +483,19 @@ fn decode_loop(
 
     for step_idx in 1..n_tokens {
         let fwd_t0 = Instant::now();
+        // A failed forward aborts the request: returning the tokens produced so
+        // far reports as a normal short generation and hides the failure from
+        // the caller. Propagate to the server's error channel.
         let decode_logits = match model.forward_arr(&y, 1, Some(&mut *caches), device) {
             Ok(l) => l,
             Err(e) => {
-                warn!(
+                tracing::error!(
                     step = step_idx,
+                    emitted = steps.len(),
                     error = %e,
-                    "bitnet generate_greedy: decode step failed, stopping early"
+                    "bitnet generate_greedy: decode step failed, aborting generation"
                 );
-                break;
+                return Err(e);
             }
         };
         *forward_total_ns += fwd_t0.elapsed().as_nanos();

--- a/crates/rmlx-models/src/bitnet/generate.rs
+++ b/crates/rmlx-models/src/bitnet/generate.rs
@@ -11,10 +11,10 @@
 
 use std::time::Instant;
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{argmax, Array, Device, Dtype};
 use rmlx_runtime::{count_nan_in_bytes, max_abs_from_bytes};
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::constraint::ConstraintEngine;
 use crate::kv_cache::{kv_quant_for_layer, LAYER_ADAPTIVE_HEAD_N, LAYER_ADAPTIVE_TAIL_N};
@@ -200,10 +200,13 @@ pub fn generate_greedy(
         c.enter_prefill();
     }
 
+    // A failed prefill aborts the request. Returning the (empty) step list
+    // instead reaches the operator as the engine's generic zero-token backstop,
+    // which names nothing — the real cause (a Metal fault, a store refusing an
+    // append) is erased. Propagate it verbatim.
     let mut last_logits: Option<Array> = None;
-    let mut prefill_ok = true;
     let n_chunks = prompt_ids.len().div_ceil(prefill_chunk);
-    'prefill: for (chunk_idx, chunk) in prompt_ids.chunks(prefill_chunk).enumerate() {
+    for (chunk_idx, chunk) in prompt_ids.chunks(prefill_chunk).enumerate() {
         let is_last = chunk_idx + 1 == n_chunks;
         match model.forward_seq_with_cache(chunk, Some(&mut caches), device) {
             Ok(logits) => {
@@ -212,42 +215,42 @@ pub fn generate_greedy(
                 } else {
                     for c in &caches {
                         if let Err(e) = c.eval_prefill_state() {
-                            warn!(
+                            tracing::error!(
                                 error = %e,
                                 chunk_len = chunk.len(),
-                                "bitnet generate_greedy: prefill chunk cache evaluation failed"
+                                "bitnet generate_greedy: prefill chunk cache evaluation failed, \
+                                 aborting generation"
                             );
-                            prefill_ok = false;
-                            break 'prefill;
+                            return Err(e);
                         }
                     }
                 }
             }
             Err(e) => {
-                warn!(
+                tracing::error!(
                     error = %e,
                     prompt_len = prompt_ids.len(),
-                    "bitnet generate_greedy: prefill chunk failed, returning empty"
+                    "bitnet generate_greedy: prefill chunk failed, aborting generation"
                 );
-                prefill_ok = false;
-                break 'prefill;
+                return Err(e);
             }
         }
     }
 
     for c in &mut caches {
         if let Err(e) = c.exit_prefill(device) {
-            warn!(error = %e, "bitnet generate_greedy: exit_prefill quantization failed");
-            prefill_ok = false;
-            break;
+            tracing::error!(
+                error = %e,
+                "bitnet generate_greedy: exit_prefill quantization failed, aborting generation"
+            );
+            return Err(e);
         }
     }
 
-    if !prefill_ok {
-        return Ok(steps);
-    }
     let Some(prefill_logits) = last_logits else {
-        return Ok(steps);
+        return Err(Error::Other(
+            "bitnet generate_greedy: prefill produced no logits (empty prompt)".to_owned(),
+        ));
     };
 
     let prefill_ns = prefill_t0.elapsed().as_nanos();

--- a/crates/rmlx-models/src/decode_loop.rs
+++ b/crates/rmlx-models/src/decode_loop.rs
@@ -292,16 +292,23 @@ pub(crate) fn pipelined_decode(
     for step_idx in 1..ctx.n_tokens {
         let step_t0 = Instant::now();
         let fwd_t0 = Instant::now();
+        // A failed forward aborts the request. Returning the tokens produced so
+        // far would be reported as a normal short generation
+        // (`finish_reason="length"`) — indistinguishable from hitting the token
+        // cap, so no caller, bench harness, or smoke probe could tell a dead
+        // stream from a healthy one. The error propagates to the server, which
+        // has an error channel on every surface.
         let decode_logits = match forward_step(&y) {
             Ok(l) => l,
             Err(e) => {
-                tracing::warn!(
+                tracing::error!(
                     arch = ctx.arch,
                     step = step_idx,
+                    emitted = steps.len(),
                     error = %e,
-                    "decode step failed, stopping early"
+                    "decode step failed, aborting generation"
                 );
-                break;
+                return Err(e);
             }
         };
 

--- a/crates/rmlx-models/src/decode_loop_tests.rs
+++ b/crates/rmlx-models/src/decode_loop_tests.rs
@@ -648,7 +648,6 @@ fn scripted_failing<'r>(
 /// regression gate, smoke probes) reads exactly those two signals, so a dead
 /// stream would pass all of them.
 #[test]
-#[allow(clippy::unwrap_used)]
 #[allow(
     clippy::expect_used,
     reason = "test-only: expect_err IS the assertion — an Ok here is the regression under test, and its panic names it"

--- a/crates/rmlx-models/src/decode_loop_tests.rs
+++ b/crates/rmlx-models/src/decode_loop_tests.rs
@@ -615,6 +615,85 @@ fn pipelined_decode_lp_k_captures() {
     );
 }
 
+/// A scripted forward that serves `rows` and then fails on call `fail_at`
+/// (0-based over calls into the loop), simulating a decode step that dies
+/// mid-stream — a store refusing an append, a Metal dispatch fault, etc.
+#[allow(clippy::unwrap_used)]
+fn scripted_failing<'r>(
+    rows: &'r [Vec<f32>],
+    calls: &'r Cell<usize>,
+    fail_at: usize,
+) -> impl FnMut(&Array) -> Result<Array> + 'r {
+    move |_y: &Array| {
+        let i = calls.get();
+        calls.set(i + 1);
+        if i == fail_at {
+            return Err(Error::Other("simulated decode step failure".to_owned()));
+        }
+        Ok(logits(
+            &rows
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| rows.last().unwrap().clone()),
+        ))
+    }
+}
+
+/// A decode step that fails must abort the request, not return the tokens
+/// produced so far.
+///
+/// Swallowing the error and breaking hands the caller a short token list that
+/// the server reports as `finish_reason="length"` — byte-identical to hitting
+/// the token cap. Every automated gate we have (bench harness, canary,
+/// regression gate, smoke probes) reads exactly those two signals, so a dead
+/// stream would pass all of them.
+#[test]
+#[allow(clippy::unwrap_used)]
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: expect_err IS the assertion — an Ok here is the regression under test, and its panic names it"
+)]
+fn pipelined_decode_propagates_step_failure() {
+    let _g = mlx_guard();
+    let tk = tiny_tokenizer(4);
+    let cfg = greedy_cfg();
+    let pen = no_penalties();
+    let mut rng = Pcg32::new(1);
+    // Never argmax an EOS id: the only way out of this loop is the failure.
+    let rows = vec![vec![0.0, 9.0, 0.0, 0.0]];
+    let calls = Cell::new(0);
+    let eos = [3u32];
+    let mut hist: Vec<u32> = vec![0];
+    let mut steps: Vec<ProbeStep> = vec![ProbeStep {
+        token_id: 0,
+        piece: "t0".to_string().into_boxed_str(),
+        max_abs_logit: 0.0,
+        nan_count: 0,
+        logprobs: None,
+    }];
+    let mut step_fn = |_: &ProbeStep| None;
+    let mut c = ctx(
+        &tk,
+        4,
+        32,
+        &eos,
+        &mut step_fn,
+        None,
+        &cfg,
+        &mut rng,
+        &pen,
+        &mut hist,
+        true,
+    );
+    // Two clean steps, then the third forward fails.
+    let err = pipelined_decode(&mut c, 0, &mut steps, scripted_failing(&rows, &calls, 2))
+        .expect_err("a failed decode step must surface as Err, not a short Ok generation");
+    assert!(
+        err.to_string().contains("simulated decode step failure"),
+        "the underlying cause must reach the caller verbatim, got: {err}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // chunked_prefill
 // ---------------------------------------------------------------------------

--- a/crates/rmlx-models/src/laguna/generate.rs
+++ b/crates/rmlx-models/src/laguna/generate.rs
@@ -559,15 +559,19 @@ fn decode_loop(
     for step_idx in 1..n_tokens {
         let step_t0 = Instant::now();
         let fwd_t0 = Instant::now();
+        // A failed forward aborts the request: returning the tokens produced so
+        // far reports as a normal short generation and hides the failure from
+        // the caller. Propagate to the server's error channel.
         let decode_logits = match model.forward_seq_with_cache(&[cur_id], Some(caches), device) {
             Ok(l) => l,
             Err(e) => {
-                tracing::warn!(
+                tracing::error!(
                     step = step_idx,
+                    emitted = steps.len(),
                     error = %e,
-                    "laguna generate_greedy: decode step failed, stopping early"
+                    "laguna generate_greedy: decode step failed, aborting generation"
                 );
-                break;
+                return Err(e);
             }
         };
         let fwd_dt = fwd_t0.elapsed().as_nanos();

--- a/crates/rmlx-models/src/laguna/generate.rs
+++ b/crates/rmlx-models/src/laguna/generate.rs
@@ -15,7 +15,7 @@
 )]
 use std::time::Instant;
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{argmax, Array, Device, Dtype};
 
 use crate::constraint::ConstraintEngine;
@@ -273,11 +273,14 @@ pub fn generate_greedy(
     for c in &mut caches {
         c.enter_prefill();
     }
+    // A failed prefill aborts the request. Returning the (empty) step list
+    // instead reaches the operator as the engine's generic zero-token backstop,
+    // which names nothing — the real cause (a Metal fault, a store refusing an
+    // append) is erased. Propagate it verbatim.
     let prefill_logits = {
         let mut last_logits: Option<Array> = None;
-        let mut prefill_ok = true;
         let n_chunks = prompt_ids.len().div_ceil(prefill_chunk);
-        'prefill: for (chunk_idx, chunk) in prompt_ids.chunks(prefill_chunk).enumerate() {
+        for (chunk_idx, chunk) in prompt_ids.chunks(prefill_chunk).enumerate() {
             let is_last = chunk_idx + 1 == n_chunks;
             match model.forward_seq_with_cache(chunk, Some(&mut caches), device) {
                 Ok(logits) => {
@@ -286,39 +289,42 @@ pub fn generate_greedy(
                     } else {
                         for c in &caches {
                             if let Err(e) = c.eval_prefill_state() {
-                                tracing::warn!(
+                                tracing::error!(
                                     error = %e,
                                     chunk_len = chunk.len(),
-                                    "laguna generate_greedy: prefill chunk cache eval failed"
+                                    "laguna generate_greedy: prefill chunk cache eval failed, \
+                                     aborting generation"
                                 );
-                                prefill_ok = false;
-                                break 'prefill;
+                                return Err(e);
                             }
                         }
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(
+                    tracing::error!(
                         error = %e,
                         prompt_len = prompt_ids.len(),
-                        "laguna generate_greedy: prefill chunk failed, returning empty"
+                        "laguna generate_greedy: prefill chunk failed, aborting generation"
                     );
-                    prefill_ok = false;
-                    break 'prefill;
+                    return Err(e);
                 }
             }
         }
         for c in &mut caches {
             if let Err(e) = c.exit_prefill(device) {
-                tracing::warn!(error = %e, "laguna generate_greedy: exit_prefill quantization failed");
-                prefill_ok = false;
-                break;
+                tracing::error!(
+                    error = %e,
+                    "laguna generate_greedy: exit_prefill quantization failed, aborting generation"
+                );
+                return Err(e);
             }
         }
-        if !prefill_ok || last_logits.is_none() {
-            return Ok(steps);
-        }
-        last_logits.unwrap()
+        let Some(l) = last_logits else {
+            return Err(Error::Other(
+                "laguna generate_greedy: prefill produced no logits (empty prompt)".to_owned(),
+            ));
+        };
+        l
     };
 
     let logits_flat = prefill_logits.reshape(&[1, vocab], device)?;

--- a/crates/rmlx-models/src/qwen2/generate.rs
+++ b/crates/rmlx-models/src/qwen2/generate.rs
@@ -14,7 +14,7 @@
 
 use std::time::Instant;
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{argmax, Array, Device, Dtype};
 
 use crate::constraint::ConstraintEngine;
@@ -267,11 +267,14 @@ pub fn generate_greedy(
     for c in &mut caches {
         c.enter_prefill();
     }
+    // A failed prefill aborts the request. Returning the (empty) step list
+    // instead reaches the operator as the engine's generic zero-token backstop,
+    // which names nothing — the real cause (a Metal fault, a store refusing an
+    // append) is erased. Propagate it verbatim.
     let prefill_logits = {
         let mut last_logits: Option<Array> = None;
-        let mut prefill_ok = true;
         let n_chunks = prompt_ids.len().div_ceil(prefill_chunk);
-        'prefill: for (chunk_idx, chunk) in prompt_ids.chunks(prefill_chunk).enumerate() {
+        for (chunk_idx, chunk) in prompt_ids.chunks(prefill_chunk).enumerate() {
             let is_last = chunk_idx + 1 == n_chunks;
             match model.forward_seq_with_cache(chunk, Some(&mut caches), device) {
                 Ok(logits) => {
@@ -280,39 +283,42 @@ pub fn generate_greedy(
                     } else {
                         for c in &caches {
                             if let Err(e) = c.eval_prefill_state() {
-                                tracing::warn!(
+                                tracing::error!(
                                     error = %e,
                                     chunk_len = chunk.len(),
-                                    "qwen2 generate_greedy: prefill chunk cache eval failed"
+                                    "qwen2 generate_greedy: prefill chunk cache eval failed, \
+                                     aborting generation"
                                 );
-                                prefill_ok = false;
-                                break 'prefill;
+                                return Err(e);
                             }
                         }
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(
+                    tracing::error!(
                         error = %e,
                         prompt_len = prompt_ids.len(),
-                        "qwen2 generate_greedy: prefill chunk failed, returning empty"
+                        "qwen2 generate_greedy: prefill chunk failed, aborting generation"
                     );
-                    prefill_ok = false;
-                    break 'prefill;
+                    return Err(e);
                 }
             }
         }
         for c in &mut caches {
             if let Err(e) = c.exit_prefill(device) {
-                tracing::warn!(error = %e, "qwen2 generate_greedy: exit_prefill quantization failed");
-                prefill_ok = false;
-                break;
+                tracing::error!(
+                    error = %e,
+                    "qwen2 generate_greedy: exit_prefill quantization failed, aborting generation"
+                );
+                return Err(e);
             }
         }
-        if !prefill_ok || last_logits.is_none() {
-            return Ok(steps);
-        }
-        last_logits.unwrap()
+        let Some(l) = last_logits else {
+            return Err(Error::Other(
+                "qwen2 generate_greedy: prefill produced no logits (empty prompt)".to_owned(),
+            ));
+        };
+        l
     };
 
     let logits_flat = prefill_logits.reshape(&[1, vocab], device)?;

--- a/crates/rmlx-models/src/qwen2/generate.rs
+++ b/crates/rmlx-models/src/qwen2/generate.rs
@@ -549,15 +549,19 @@ fn decode_loop(
     for step_idx in 1..n_tokens {
         let step_t0 = Instant::now();
         let fwd_t0 = Instant::now();
+        // A failed forward aborts the request: returning the tokens produced so
+        // far reports as a normal short generation and hides the failure from
+        // the caller. Propagate to the server's error channel.
         let decode_logits = match model.forward_arr(&y, 1, Some(&mut *caches), device) {
             Ok(l) => l,
             Err(e) => {
-                tracing::warn!(
+                tracing::error!(
                     step = step_idx,
+                    emitted = steps.len(),
                     error = %e,
-                    "qwen2 generate_greedy: decode step failed, stopping early"
+                    "qwen2 generate_greedy: decode step failed, aborting generation"
                 );
-                break;
+                return Err(e);
             }
         };
 

--- a/crates/rmlx-server/src/anthropic/errors.rs
+++ b/crates/rmlx-server/src/anthropic/errors.rs
@@ -121,3 +121,33 @@ pub(crate) fn engine_error_response(e: &rmlx_core::Error) -> Response {
         _ => service_unavailable(&e.to_string()),
     }
 }
+
+/// The stable `type` key an engine error carries in the Anthropic error
+/// envelope.
+///
+/// Mirrors the arms of [`engine_error_response`] above. A stream that dies
+/// mid-flight cannot reuse that function — the HTTP status and headers are
+/// already sent — but must still name the failure identically, so a client sees
+/// the same `type` for the same fault whether it streamed the response or not.
+///
+/// Deliberately NOT shared with the OpenAI surface: these strings carry this
+/// surface's `_error` suffix (`service_unavailable_error`,
+/// `internal_server_error`) and diverge from OpenAI's by design. Type strings
+/// are per-surface; only the OOM keys coincide. Keep this in step with
+/// `engine_error_response`, not with the OpenAI mirror.
+#[allow(
+    clippy::wildcard_enum_match_arm,
+    reason = "mirrors engine_error_response: every unenumerated variant maps to the service_unavailable_error envelope there"
+)]
+pub(super) fn engine_error_type(e: &rmlx_core::Error) -> &'static str {
+    use rmlx_core::OomPhase;
+    match e {
+        rmlx_core::Error::SmokeProbe(_) => "internal_server_error",
+        rmlx_core::Error::Oom { phase, .. } => match phase {
+            OomPhase::LoadWeights => "oom_during_load",
+            OomPhase::LoadKvCache => "oom_kv_cache",
+            OomPhase::Generation => "oom_mid_stream",
+        },
+        _ => "service_unavailable_error",
+    }
+}

--- a/crates/rmlx-server/src/anthropic/streaming.rs
+++ b/crates/rmlx-server/src/anthropic/streaming.rs
@@ -527,6 +527,11 @@ pub(super) async fn generate_streaming(
                         ));
                     }
 
+                    // Set when a token arrives as an engine error. The epilogue
+                    // reads it to terminate the stream as a failure instead of
+                    // a completion.
+                    let mut stream_error: Option<rmlx_core::Error> = None;
+
                     // `loop { match ... }` is intentional: the loop has
                     // multiple control-flow exits (return, continue,
                     // break). Refactoring to `while let Some(Ok(tok)) =
@@ -734,10 +739,46 @@ pub(super) async fn generate_streaming(
                                 // count mid-stream failures as failed requests.
                                 lifetime_requests_failed
                                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                tracing::error!(
+                                    error = %e,
+                                    "generation stream failed mid-flight, emitting error event"
+                                );
+                                // Hand the error to the epilogue. Breaking
+                                // without it would run the normal terminal
+                                // triplet, whose stop_reason resolves through
+                                // the `None` fallback to "end_turn" — reporting
+                                // a dead stream as a natural completion.
+                                stream_error = Some(e);
                                 break;
                             }
                             None => break,
                         }
+                    }
+
+                    // A stream that died has no completion to report. Terminate
+                    // with the failure instead of the normal terminal triplet,
+                    // whose stop_reason would resolve through the `None`
+                    // fallback to "end_turn" and report the dead stream as a
+                    // natural completion. Anthropic's streaming protocol
+                    // carries this as a native `error` event, so no
+                    // client-visible schema is invented here.
+                    //
+                    // The success-only bookkeeping below is skipped on purpose:
+                    // `requests_failed` is already counted at the error site,
+                    // and a failed request must not add itself to
+                    // `requests_completed` or emit completion-token metrics.
+                    if let Some(e) = stream_error {
+                        let payload = json!({
+                            "type": "error",
+                            "error": {
+                                "type": crate::openai::errors::engine_error_type(&e),
+                                "message": e.to_string(),
+                            }
+                        });
+                        return Some((
+                            Ok::<Event, std::convert::Infallible>(sse_event("error", &payload)),
+                            AnthropicState::Done,
+                        ));
                     }
 
                     // ── Epilogue ──────────────────────────────────────────

--- a/crates/rmlx-server/src/anthropic/streaming.rs
+++ b/crates/rmlx-server/src/anthropic/streaming.rs
@@ -771,7 +771,7 @@ pub(super) async fn generate_streaming(
                         let payload = json!({
                             "type": "error",
                             "error": {
-                                "type": crate::openai::errors::engine_error_type(&e),
+                                "type": super::errors::engine_error_type(&e),
                                 "message": e.to_string(),
                             }
                         });

--- a/crates/rmlx-server/src/anthropic/tests.rs
+++ b/crates/rmlx-server/src/anthropic/tests.rs
@@ -32,6 +32,82 @@ fn assert_mem_fields(err: &Value) {
     }
 }
 
+fn engine_error_cases() -> Vec<rmlx_core::Error> {
+    use rmlx_core::OomPhase;
+    vec![
+        rmlx_core::Error::SmokeProbe("nan".to_owned()),
+        rmlx_core::Error::Oom {
+            phase: OomPhase::LoadWeights,
+            requested_bytes: None,
+            peak_alloc_mb: None,
+            msg: "oom".to_owned(),
+        },
+        rmlx_core::Error::Oom {
+            phase: OomPhase::LoadKvCache,
+            requested_bytes: None,
+            peak_alloc_mb: None,
+            msg: "oom".to_owned(),
+        },
+        rmlx_core::Error::Oom {
+            phase: OomPhase::Generation,
+            requested_bytes: None,
+            peak_alloc_mb: None,
+            msg: "oom".to_owned(),
+        },
+        // wildcard arm — the common case for a mid-decode engine fault.
+        rmlx_core::Error::Mlx("device error".to_owned()),
+        rmlx_core::Error::Other("engine panic".to_owned()),
+    ]
+}
+
+/// This surface's `engine_error_type` must name every error exactly as this
+/// surface's `engine_error_response` spells it.
+///
+/// `/v1/messages` streaming can only use the former (its status and headers are
+/// already sent) while blocking uses the latter. Drift means a streamed client
+/// sees a different `type` than a blocking one for the identical fault.
+#[tokio::test]
+async fn engine_error_type_matches_response() {
+    for e in &engine_error_cases() {
+        let (_status, _retry, body) = oom_parts(e).await;
+        let from_response = body["error"]["type"]
+            .as_str()
+            .unwrap_or_else(|| panic!("response body carries no error.type for {e:?}: {body}"));
+        assert_eq!(
+            from_response,
+            errors::engine_error_type(e),
+            "anthropic engine_error_type drifted from anthropic engine_error_response for {e:?}"
+        );
+    }
+}
+
+/// The Anthropic type strings deliberately diverge from OpenAI's: this surface
+/// carries an `_error` suffix on its non-OOM types. Pinned so nobody
+/// "deduplicates" the two mirrors into one shared function — that collapse is
+/// exactly what made `/v1/messages` streaming emit OpenAI spellings.
+///
+/// Only the OOM keys coincide, and that is intentional.
+#[test]
+fn engine_error_type_diverges_from_openai_surface() {
+    assert_eq!(
+        errors::engine_error_type(&rmlx_core::Error::Mlx("x".to_owned())),
+        "service_unavailable_error"
+    );
+    assert_eq!(
+        errors::engine_error_type(&rmlx_core::Error::SmokeProbe("x".to_owned())),
+        "internal_server_error"
+    );
+    // The OpenAI surface spells the same two faults without the suffix.
+    assert_eq!(
+        crate::openai::errors::engine_error_type(&rmlx_core::Error::Mlx("x".to_owned())),
+        "service_unavailable"
+    );
+    assert_eq!(
+        crate::openai::errors::engine_error_type(&rmlx_core::Error::SmokeProbe("x".to_owned())),
+        "internal_error"
+    );
+}
+
 #[tokio::test]
 async fn j3_oom_load_weights_507_retry() {
     let e = rmlx_core::Error::Oom {

--- a/crates/rmlx-server/src/openai/errors.rs
+++ b/crates/rmlx-server/src/openai/errors.rs
@@ -303,7 +303,11 @@ pub(crate) fn engine_error_response(e: &rmlx_core::Error) -> Response {
 /// cannot reuse that function — the HTTP status and headers are already sent —
 /// but it must still name the failure identically, so a client sees the same
 /// `type` for the same fault whether it streamed the response or not. Keep the
-/// two in step.
+/// two in step; `engine_error_type_matches_response` fails if they drift.
+///
+/// OpenAI-surface strings only. The Anthropic surface has its own mirror
+/// (`anthropic::errors::engine_error_type`) because its type strings carry an
+/// `_error` suffix; do not call this one from there.
 #[allow(
     clippy::wildcard_enum_match_arm,
     reason = "wildcard arm mirrors engine_error_response: every unenumerated variant maps to the same service_unavailable envelope there"

--- a/crates/rmlx-server/src/openai/errors.rs
+++ b/crates/rmlx-server/src/openai/errors.rs
@@ -297,6 +297,30 @@ pub(crate) fn engine_error_response(e: &rmlx_core::Error) -> Response {
     }
 }
 
+/// The stable `type` key an engine error carries in the OpenAI error envelope.
+///
+/// Mirrors the arms of [`engine_error_response`]. A stream that dies mid-flight
+/// cannot reuse that function — the HTTP status and headers are already sent —
+/// but it must still name the failure identically, so a client sees the same
+/// `type` for the same fault whether it streamed the response or not. Keep the
+/// two in step.
+#[allow(
+    clippy::wildcard_enum_match_arm,
+    reason = "wildcard arm mirrors engine_error_response: every unenumerated variant maps to the same service_unavailable envelope there"
+)]
+pub(crate) fn engine_error_type(e: &rmlx_core::Error) -> &'static str {
+    use rmlx_core::OomPhase;
+    match e {
+        rmlx_core::Error::SmokeProbe(_) => "internal_error",
+        rmlx_core::Error::Oom { phase, .. } => match phase {
+            OomPhase::LoadWeights => "oom_during_load",
+            OomPhase::LoadKvCache => "oom_kv_cache",
+            OomPhase::Generation => "oom_mid_stream",
+        },
+        _ => "service_unavailable",
+    }
+}
+
 /// F8: classify an `rmlx_core::Error` into an `ApiErrorCategory`.
 ///
 /// Mirrors the match arms in `engine_error_response` so the same logic

--- a/crates/rmlx-server/src/openai/streaming.rs
+++ b/crates/rmlx-server/src/openai/streaming.rs
@@ -168,6 +168,26 @@ pub(super) fn chunk_to_event(chunk: &ChatCompletionChunk) -> Event {
     Event::default().data(serde_json::to_string(chunk).unwrap_or_default())
 }
 
+/// Build the terminal error event for a stream that died mid-flight.
+///
+/// By the time a token errors the HTTP status is already 200 and the headers are
+/// gone, so the response payload is the only channel left to say the stream did
+/// not complete. Without this the client sees the deltas it already received
+/// followed by a bare `[DONE]` — a truncated answer that looks finished.
+///
+/// Shape mirrors the blocking route's OpenAI error envelope
+/// (`{"error":{"message","type"}}`), so the same fault reads the same either
+/// way. `type` is the stable automation key, `message` is human.
+pub(super) fn error_event(e: &rmlx_core::Error) -> Event {
+    let body = serde_json::json!({
+        "error": {
+            "message": e.to_string(),
+            "type": crate::openai::errors::engine_error_type(e),
+        }
+    });
+    Event::default().data(serde_json::to_string(&body).unwrap_or_default())
+}
+
 // ── Token handler ─────────────────────────────────────────────────────────────
 
 /// Map one input token to zero-or-more SSE events, updating `state`.
@@ -185,7 +205,16 @@ pub(crate) fn handle_streaming_token(
             state
                 .lifetime_requests_failed
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            return vec![Ok(Event::default().data("[DONE]"))];
+            tracing::error!(
+                error = %e,
+                "generation stream failed mid-flight, emitting error event"
+            );
+            // Emit the error and nothing else. No `finish_reason` chunk: this
+            // stream has no finish reason, and claiming one would report the
+            // failure as a completion. The caller chains the terminating
+            // `[DONE]` onto every stream, so emitting one here would duplicate
+            // it.
+            return vec![Ok(error_event(&e))];
         }
         Ok(t) => t,
     };

--- a/crates/rmlx-server/src/openai/tests.rs
+++ b/crates/rmlx-server/src/openai/tests.rs
@@ -1930,7 +1930,7 @@ fn f8_successful_streaming_path_increments_no_error_counter() {
 }
 
 /// F8: an engine error token increments the correct category counter in the
-/// streaming path and emits a `[DONE]` sentinel.
+/// streaming path and terminates the stream with an error event + `[DONE]`.
 #[test]
 fn f8_engine_error_in_streaming_increments_counter() {
     let mut state = StreamState {
@@ -1968,12 +1968,26 @@ fn f8_engine_error_in_streaming_increments_counter() {
         Err(rmlx_core::Error::Mlx("device error".to_owned()));
     let events = handle_streaming_token(err_item, &mut state);
 
-    // Must emit exactly one [DONE] sentinel.
-    assert_eq!(events.len(), 1, "error token must emit exactly one event");
-    let ev_debug = format!("{:?}", events[0].as_ref().unwrap());
+    // Exactly one event: the error payload. A bare terminator would leave the
+    // client holding a truncated answer that looks complete, and the caller
+    // chains the `[DONE]` itself — emitting one here would duplicate it.
+    assert_eq!(
+        events.len(),
+        1,
+        "error token must emit exactly the error event"
+    );
+    let err_debug = format!("{:?}", events[0].as_ref().unwrap());
     assert!(
-        ev_debug.contains("[DONE]"),
-        "error event must be [DONE], got: {ev_debug}"
+        err_debug.contains("\\\"error\\\"") && err_debug.contains("device error"),
+        "error event must carry the OpenAI error envelope naming the cause, got: {err_debug}"
+    );
+    assert!(
+        err_debug.contains("service_unavailable"),
+        "error envelope must carry the stable `type` key automation asserts on, got: {err_debug}"
+    );
+    assert!(
+        !err_debug.contains("[DONE]"),
+        "the terminator is chained by the caller, not emitted here, got: {err_debug}"
     );
 
     // Upstream counter must be 1.

--- a/crates/rmlx-server/src/openai/tests.rs
+++ b/crates/rmlx-server/src/openai/tests.rs
@@ -26,6 +26,57 @@ async fn oom_parts(e: &rmlx_core::Error) -> (StatusCode, Option<String>, Value) 
     (status, retry, body)
 }
 
+/// `engine_error_type` must name every error exactly as `engine_error_response`
+/// spells it in the body it builds.
+///
+/// The two are hand-maintained mirrors of the same variant match, and a stream
+/// that dies mid-flight can only use the former (its status and headers are long
+/// gone) while the blocking route uses the latter. Any drift means one client
+/// sees a different `type` than another for the identical fault — on the key
+/// automation asserts on. A comment cannot enforce that; this test can.
+///
+/// Covers one representative per arm, including the wildcard.
+#[tokio::test]
+async fn engine_error_type_matches_response() {
+    use rmlx_core::OomPhase;
+    let cases: Vec<rmlx_core::Error> = vec![
+        rmlx_core::Error::SmokeProbe("nan".to_owned()),
+        rmlx_core::Error::Oom {
+            phase: OomPhase::LoadWeights,
+            requested_bytes: None,
+            peak_alloc_mb: None,
+            msg: "oom".to_owned(),
+        },
+        rmlx_core::Error::Oom {
+            phase: OomPhase::LoadKvCache,
+            requested_bytes: None,
+            peak_alloc_mb: None,
+            msg: "oom".to_owned(),
+        },
+        rmlx_core::Error::Oom {
+            phase: OomPhase::Generation,
+            requested_bytes: None,
+            peak_alloc_mb: None,
+            msg: "oom".to_owned(),
+        },
+        // wildcard arm — the common case for a mid-decode engine fault.
+        rmlx_core::Error::Mlx("device error".to_owned()),
+        rmlx_core::Error::Other("engine panic".to_owned()),
+    ];
+    for e in &cases {
+        let (_status, _retry, body) = oom_parts(e).await;
+        let from_response = body["error"]["type"]
+            .as_str()
+            .unwrap_or_else(|| panic!("response body carries no error.type for {e:?}: {body}"));
+        assert_eq!(
+            from_response,
+            errors::engine_error_type(e),
+            "engine_error_type drifted from engine_error_response for {e:?} — \
+             a streamed client would see a different `type` than a blocking one"
+        );
+    }
+}
+
 fn assert_mem_fields(err: &Value) {
     // J4 fields must always be present (value may be null if read_proc_mem
     // failed, but the key must exist). On macOS CI they are real numbers.

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -439,10 +439,12 @@ stop. A stream that dies mid-flight instead terminates with Anthropic's native
 
 ```
 event: error
-data: {"type":"error","error":{"type":"service_unavailable","message":"…"}}
+data: {"type":"error","error":{"type":"service_unavailable_error","message":"…"}}
 ```
 
-A `/v1/messages` stream without a `message_stop` did not complete.
+A `/v1/messages` stream without a `message_stop` did not complete. The `type`
+carries this surface's `_error` suffix — matching what `/v1/messages` returns
+for the same fault on the blocking path, not the OpenAI spelling.
 
 `"stop_sequence"` is **never** produced by `map_stop_reason`. It is set
 exclusively by the stop-matching path in `blocking.rs` /

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -371,6 +371,23 @@ a populated `usage` object is appended before `[DONE]`.
 alongside the content delta. Chunks that carry no content token (role preamble,
 tool_call, usage chunk) omit the field.
 
+**Mid-stream failure**: when generation dies after the stream has started, the
+HTTP status is already `200`, so the failure is reported in the payload — an
+error event in the same envelope the blocking route returns, emitted in place
+of (never alongside) a terminal `finish_reason` chunk:
+
+```
+data: {"error":{"message":"…","type":"service_unavailable"}}
+
+data: [DONE]
+```
+
+A stream that carries no `finish_reason` chunk did **not** complete. Clients and
+harnesses must treat the absence of a terminal `finish_reason` — or the presence
+of an `error` key — as a failure, never as a short answer. `finish_reason` is
+never `"error"`: that value is not in the OpenAI enum, and the Anthropic mapping
+below would launder it into a successful `stop_reason`.
+
 ### Stop-sequence truncation
 
 The `stop` parameter (OpenAI `stop`, Anthropic `stop_sequences`) truncates the
@@ -414,6 +431,18 @@ Anthropic `stop_reason` field via `map_stop_reason` in
 | `"length"` (token cap) | `"max_tokens"` |
 | `"tool_calls"` | `"tool_use"` |
 | anything else / `None` | `"end_turn"` |
+
+The `anything else / None → "end_turn"` row is why a failed generation must
+never reach this mapping: it resolves every unknown reason to a *successful*
+stop. A stream that dies mid-flight instead terminates with Anthropic's native
+`error` event and emits no `message_delta` / `message_stop`:
+
+```
+event: error
+data: {"type":"error","error":{"type":"service_unavailable","message":"…"}}
+```
+
+A `/v1/messages` stream without a `message_stop` did not complete.
 
 `"stop_sequence"` is **never** produced by `map_stop_reason`. It is set
 exclusively by the stop-matching path in `blocking.rs` /

--- a/scripts/check_no_decode_swallow.sh
+++ b/scripts/check_no_decode_swallow.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# scripts/check_no_decode_swallow.sh — CI gate: a failed decode step must
+# propagate, never be swallowed into a short-but-successful generation.
+#
+# THE BUG THIS PINS
+#   A decode step that errored used to log a warning and `break`, handing the
+#   caller the tokens produced so far. The server then saw a non-EOS last token
+#   and reported `finish_reason="length"` — byte-identical to hitting the token
+#   cap. Every automated gate in this repo (bench harness, perf canary,
+#   regression gate, smoke probes) reads exactly `finish_reason` + token counts,
+#   so a stream that died mid-flight passed all of them.
+#
+# WHY A GREP GATE
+#   The decode loop is copied per-arch (the shared pipelined loop plus the
+#   bitnet / laguna / qwen2 hand-written ones). A unit test needs a concrete
+#   `&Model` per arch, so the per-arch copies are effectively untestable at unit
+#   scope — and a fix hand-applied to some copies but not others is precisely
+#   the "looks complete, isn't" failure this rule exists to prevent. The shared
+#   loop carries a real unit test (`pipelined_decode_propagates_step_failure`);
+#   this gate covers every copy of the shape.
+#
+# THE RULE
+#   Every `decode step failed` log site must `return Err` within the next few
+#   lines. A `break` there is the swallow.
+#
+# Exit 0 = clean. Exit 1 = violation found.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+ANCHOR='decode step failed'
+# Lines of context after the anchor in which the verdict must appear. The log
+# macro spans several lines (fields, message, closing paren) before the control
+# flow; 8 covers the widest current site with room to spare.
+CONTEXT=8
+
+violations=0
+
+# Every site that logs the anchor, as "file:line".
+while IFS= read -r site; do
+    [ -z "${site}" ] && continue
+    f="${site%%:*}"
+    ln="${site##*:}"
+    end=$((ln + CONTEXT))
+    window="$(sed -n "${ln},${end}p" "${f}")"
+    if ! printf '%s' "${window}" | grep -q 'return Err'; then
+        echo "VIOLATION: ${f}:${ln} — 'decode step failed' is not followed by 'return Err' within ${CONTEXT} lines."
+        printf '%s\n' "${window}" | sed 's/^/    | /'
+        violations=$((violations + 1))
+    fi
+done < <(grep -rn --include='*.rs' -F "${ANCHOR}" crates/ | grep -v '_tests\.rs:' | cut -d: -f1,2 || true)
+
+if [ "${violations}" -gt 0 ]; then
+    echo
+    echo "FAIL: ${violations} decode-step failure site(s) swallow the error."
+    echo "A decode step that fails must abort the request — returning the tokens"
+    echo "produced so far is reported as finish_reason=\"length\", indistinguishable"
+    echo "from a clean token-cap stop, and every automated gate reads that field."
+    exit 1
+fi
+
+echo "OK: every decode-step failure site propagates (no swallow)."


### PR DESCRIPTION
## Summary
Closes #235. A failed decode step was reported to callers as **`finish_reason:"length"`** — byte-identical to a clean token-limit stop. Four decode loops (shared `decode_loop.rs` + per-arch bitnet/laguna/qwen2 copies) caught the forward error, `warn!`+`break`, and returned `Ok(short steps)`; the server saw a non-EOS last token and called it `length`. (The very next line already did `reshape(...)?`.)

**A failure that reports as a success defeats every automated gate in the repo.** This is why #217 shipped a live breakage, and why the #233 class silently corrupted `iso3` output for a release.

## The gate was laundering crashes into data
`scripts/perf_canary.sh`, same forced failure (decode dies at step 140/300):

| | result |
|---|---|
| **before** | `EXIT=0` + `baseline: decode_tps=138.312 prefill_tps=841.4` — a plausible number, recorded into `runs.db` as legitimate |
| **after** | `EXIT=1`, no summary line, real error surfaced → `set -euo pipefail` → canary red |

Log forensics found this already happened: a 2026-07-15 Bonsai-27B `k8v4` run died at decode step 243 and its fabricated TPS informed a published matrix cell (filed as **#241**).

## Design — propagate, don't invent a finish_reason
`finish_reason:"error"` was **deliberately rejected**: it isn't in the OpenAI enum, and `map_stop_reason`'s `anything else → "end_turn"` catch-all would launder it into a *success* on `/v1/messages` — recreating the bug on another surface (filed as **#240**). The error channel + retry envelope already exist to classify/surface exactly this fault; the swallow was defeating them.

Each surface reports in its native shape — blocking → existing envelope (HTTP 503); OpenAI SSE → error event; Anthropic SSE → native `event: error`, skipping success-only bookkeeping. Also fixes a latent **double `[DONE]`** (unreachable before, so never seen).

| `/v1/messages` | before | after |
|---|---|---|
| blocking | `service_unavailable_error` | `service_unavailable_error` |
| streaming | **`service_unavailable`** ❌ | **`service_unavailable_error`** ✅ |

Anthropic SSE was emitting **OpenAI** type strings. Each surface now owns its mirror, with drift tests on **both** (all arms + all 3 `OomPhase`s) plus one pinning the intentional divergence.

## Also fixed: the same swallow one function up
Chunked text prefill in bitnet/laguna/qwen2 (6 sites) had `prefill_ok=false`/`break` → `Ok(steps)` with `steps` empty → the engine backstop turned a Metal fault into *"generation produced zero tokens"*, naming nothing — and `Error::Other` classifies **`Migratable`**, so the envelope replayed a deterministically-doomed prefill twice more. Now propagates.

## New CI gate
`make check-no-decode-swallow` — every `decode step failed` site must `return Err` within 8 lines. Wired into `make ci`. Verified by reintroducing the swallow into one arch copy → exit 1.

## Behavior consequence (owning it)
Propagating decode errors makes the **retry envelope newly reachable mid-decode**: `Error::Mlx → Migratable` means a mid-stream Metal fault now transparently replays from `prompt ++ delivered` at temp=0 — what `retry.rs` was built for, dead code while the loop swallowed. A win, but **untested here** (the repro uses `KvCeilingExceeded → Fatal` by design, to keep replay noise out of the proof).

## Testing
`cargo test -p rmlx-server -p rmlx-models` **1264 passed** · `make lint` clean · `make check-no-decode-swallow` OK. Both new gates proven non-vacuous by injecting the exact bugs. No-regression on **2 archs × 3 surfaces** (Bonsai-8B/Qwen3 + gemma-4-e2b/Gemma4; OpenAI blocking + SSE + Anthropic): natural EOS → `stop`/`end_turn`, `max_tokens` → `length`, 1 `[DONE]`, 0 errors.

## Follow-ups filed
#242 (image prefill — same class, `steps` not always empty so the backstop won't catch it), #243 (shared `chunked_prefill`'s `Ok(None)` contract), #239 (`KvCeilingExceeded` says "prefill" but now fires on decode — this PR makes that string user-visible), #240, #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)