### PR TITLE
feat(kv): iso_flash_decode_msl — fused flash-decode over iso-quant K (#218)

### DIFF
--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
@@ -111,7 +111,7 @@ use rmlx_mlx::metal_kernel::{MetalKernel, MetalKernelInvoke};
 use rmlx_mlx::{Array, Device, Dtype};
 
 use crate::isoquant::FIXED_QUAT;
-use crate::storage::{iso_n_groups_for, ISO_K3_GROUP_SIZE};
+use crate::storage::{iso_n_groups_for, ISO_QUAT_BLOCK_SIZE};
 use crate::turboquant::lloyd_gaussian_codebook;
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -139,19 +139,28 @@ static ISO4_FLASH_DECODE_DISPATCHES: AtomicU64 = AtomicU64::new(0);
 
 /// Process-lifetime count of iso3 flash-decode P1 dispatches.
 ///
-/// Tests assert `delta > 0` to prove the MSL kernel actually fired rather than
-/// the caller silently falling back to the CPU dequant path. Production code
-/// does not consult this counter.
+/// The per-width breakdown of [`iso_flash_decode_dispatch_count`], for a caller
+/// that needs to tell the two apart. Production code does not consult it.
 pub fn iso3_flash_decode_dispatch_count() -> u64 {
     ISO3_FLASH_DECODE_DISPATCHES.load(Ordering::Relaxed)
 }
 
-/// Process-lifetime count of iso4 flash-decode P1 dispatches.
+/// Process-lifetime count of iso4 flash-decode P1 dispatches. See
+/// [`iso3_flash_decode_dispatch_count`].
 pub fn iso4_flash_decode_dispatch_count() -> u64 {
     ISO4_FLASH_DECODE_DISPATCHES.load(Ordering::Relaxed)
 }
 
 /// Combined process-lifetime count (3-bit + 4-bit).
+///
+/// `kvcache::iso_flash_dispatch_tests` asserts a positive delta across decode
+/// steps to prove the MSL kernel actually fired, rather than the caller silently
+/// falling back to the CPU dequant path this kernel exists to remove.
+///
+/// The counter is process-global, so a concurrent test can only ever *inflate* a
+/// delta: `>=` assertions on it are race-free, `== 0` ones are not. For the
+/// negative case assert on the cache's own ring instead (the flash path cannot
+/// run without it). Production code does not consult this counter.
 pub fn iso_flash_decode_dispatch_count() -> u64 {
     iso3_flash_decode_dispatch_count() + iso4_flash_decode_dispatch_count()
 }
@@ -175,7 +184,7 @@ pub fn iso_flash_decode_dispatch_count() -> u64 {
 /// codec's `R̃ * mv * R` sandwich is a different algebra; do not cross the two.)
 fn render_decode_fn() -> String {
     // Bound to a local so the group size is an inline `{gs}` capture below.
-    let gs = ISO_K3_GROUP_SIZE;
+    let gs = ISO_QUAT_BLOCK_SIZE;
     let mut s = String::new();
     let _ = write!(
         s,
@@ -504,10 +513,10 @@ pub fn iso_flash_decode_sdpa<const BITS: u8>(
              to support it"
         )));
     }
-    if !(head_dim as usize).is_multiple_of(ISO_K3_GROUP_SIZE) {
+    if !(head_dim as usize).is_multiple_of(ISO_QUAT_BLOCK_SIZE) {
         return Err(Error::Quant(format!(
             "iso_flash_decode: head_dim={head_dim} must be a multiple of the quaternion \
-             block size {ISO_K3_GROUP_SIZE}"
+             block size {ISO_QUAT_BLOCK_SIZE}"
         )));
     }
     if heads_per_kv <= 0 {

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
@@ -1,0 +1,727 @@
+// unsafe_code: Metal kernel byte cast — slice::from_raw_parts over kernel
+// input data (dims arrays) for MSL dispatch.
+#![allow(unsafe_code)]
+
+//! iso_flash_decode: fused QK over iso-quant K + online softmax + bf16-V SV
+//! in a single MSL pass per (B, H, tile).
+//!
+//! # What this is
+//!
+//! A FlashAttention-style decode over the IsoQuant K store. Pre-softmax
+//! scores, online softmax, and the SV product all run in one threadgroup pass
+//! per (batch, head, tile). K is read directly from the
+//! [`crate::storage::QuantIsoK3`] / [`crate::storage::QuantIsoK4`] packed GPU
+//! ring (codes + per-group scales + per-token L2 norms) — no bf16 / f32 K is
+//! ever materialised, and nothing restages through the host.
+//!
+//! Without this kernel the iso K-only decode path calls
+//! `QuantIsoK{3,4}::dequant()` — a full-prefix **CPU** dequant plus re-upload
+//! on every decode step, i.e. O(seq) host work per token with the GPU idle.
+//!
+//! Two Metal dispatches per call:
+//! * **Pass 1** (`rmlx_iso_flash_decode_p1_b{3,4}`): per-tile threadgroups
+//!   compute partial outputs + per-tile LSE state `(tile_max, tile_sum_exp)`.
+//!   Each threadgroup runs `head_dim` threads over `TILE_SIZE` tokens.
+//! * **Pass 2** (`rmlx_iso_flash_decode_p2`): one threadgroup per `(B, head)`
+//!   merges the per-tile partials via log-sum-exp into the final output. The
+//!   body is the codec-agnostic `metal/flash_decode_merge_p2.metal`, shared
+//!   with `rotor_flash_decode_msl` / `planar_flash_decode_msl`.
+//!
+//! # Bit-width parameterisation
+//!
+//! `bits ∈ {3, 4}` is a template parameter carried by the **header**, not by a
+//! second kernel body: [`build_iso_flash_header`] emits `IF_BITS` / `IF_MASK`
+//! alongside the matching Lloyd-Max codebook, so one
+//! `metal/iso_flash_decode_p1.metal` serves both variants. Selection is
+//! explicit — any other `bits` is an `Err`, never a silent fallback to the
+//! wrong unpack width.
+//!
+//! # Reusable K-decode half
+//!
+//! The per-lane iso decode lives in the header as the MSL function
+//! `if_decode_k_lane(...)` rather than inline in the body — the same split
+//! `rotor_flash_decode_msl` uses. A future quantized-V flash kernel needs the
+//! identical quaternion decode against the V store's `(codes, scales, norms)`
+//! triple; emitting it as a header function lets that kernel call it directly
+//! instead of copying the Hamilton product. (MSL bodies in this repo are
+//! statement sequences spliced inside a generated kernel signature, so a body
+//! cannot define functions — the header is the only place a shared function
+//! can live.)
+//!
+//! Unlike the fused-QK kernel's phrasing of the same math, this one is
+//! **self-contained per lane**: it unpacks all four of its group's codes from
+//! the group's single u32 and applies the Hamilton product in registers. The
+//! fused-QK kernel instead stages the group's rotated centroids through
+//! threadgroup memory and reads its neighbours' lanes after a barrier. A
+//! barrier per token inside a flash inner loop would serialise the tile, and
+//! the redundant work it saves is 3 extra codebook lookups — so the register
+//! form is both faster here and callable from any kernel without imposing a
+//! threadgroup layout on it.
+//!
+//! # Codec contract
+//!
+//! Bit-exact with [`crate::isoquant::iso_decode_fast`]:
+//!
+//! * `codes`  u32 `[B * S_kv * kv_h * n_groups]` — 1 u32 per group of 4
+//!   quaternion components. Element `e ∈ 0..4` occupies bits
+//!   `[e*BITS, e*BITS + BITS)` LSB-first (`mask = 0x7` for 3-bit, `0xF` for
+//!   4-bit). Both widths fit one group in one word
+//!   (`words_per_group = ceil(4 / (32 / BITS)) = 1`).
+//! * `scales` f32 `[B * S_kv * kv_h * n_groups]` — one f32 per group of 4.
+//! * `norms`  f32 `[B * S_kv * kv_h]` — per-token L2 norm.
+//!
+//! Buffers are **sequence-major** (`[B, S, kv_h, ...]`) — the canonical flat-KV
+//! layout in this crate, matching the codec's chunk-append order.
+//!
+//! # Fixed quaternion
+//!
+//! The iso codec rotates every group by the same golden-ratio unit quaternion
+//! ([`crate::isoquant::FIXED_QUAT`]); `iso_encode_fast` writes that constant
+//! into every slot of its per-group `quaternions` array. The header therefore
+//! bakes `q̄` in as a constant and the ring does not carry the quaternion
+//! table at all — storing `n_tokens * n_groups * 4` copies of one constant per
+//! decode step would be pure bandwidth. [`crate::isoquant_msl`] does the same.
+//!
+//! This is a real coupling, not an assumption: if the codec ever emits
+//! per-group quaternions (the encoder's own docs float that as future work),
+//! this kernel becomes silently wrong rather than merely stale. The
+//! dispatcher's [`assert_fixed_quat_blocks`] rejects a store whose quaternions
+//! are not `FIXED_QUAT`, so that change fails loudly here instead of decoding
+//! K against the wrong rotation.
+//!
+//! # Single-MLX claim
+//!
+//! Per CLAUDE.md "Single MLX process per Mac", callers must hold the
+//! `/tmp/rmlx.<port>.claim` lock before dispatching GPU kernels.
+//!
+//! # Pattern reference
+//!
+//! * [`crate::rotor_flash_decode_msl`] — the two-pass flash-decode shell this
+//!   is a sibling of (grid / tile / online-softmax broadcast / P2 merge).
+//! * [`crate::iso_fused_qk_msl`] — iso quaternion K-decode in MSL, and the
+//!   codebook / fixed-quaternion header-rendering pattern.
+//! * [`crate::isoquant::iso_decode_fast`] — CPU reference (Rust).
+
+use std::fmt::Write as _;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+use rmlx_core::error::{Error, Result};
+use rmlx_mlx::metal_kernel::{MetalKernel, MetalKernelInvoke};
+use rmlx_mlx::{Array, Device, Dtype};
+
+use crate::isoquant::FIXED_QUAT;
+use crate::storage::{iso_n_groups_for, ISO_K3_GROUP_SIZE};
+use crate::turboquant::lloyd_gaussian_codebook;
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Tokens per pass-1 tile. Matches `rotor_flash_decode_msl::TILE_SIZE` so the
+/// flash kernels share one tuning surface.
+pub(crate) const TILE_SIZE: i32 = 64;
+
+/// Maximum supported `head_dim`.
+///
+/// Sized to the largest production head_dim reached by an iso-quantized
+/// growing layer: Gemma4 e2b/e4b global layers run `head_dim = 512` (their
+/// `global_head_dim`), while Bonsai / Qwen3 run 128. The kernel uses
+/// static-sized threadgroup arrays of this length; raising it widens SMEM and
+/// lowers occupancy.
+pub(crate) const ISO_FLASH_HEAD_DIM_MAX: i32 = 512;
+
+// ── Dispatch counters ─────────────────────────────────────────────────────────
+
+/// Incremented once per `iso_flash_decode_sdpa::<3>` P1 enqueue.
+static ISO3_FLASH_DECODE_DISPATCHES: AtomicU64 = AtomicU64::new(0);
+
+/// Incremented once per `iso_flash_decode_sdpa::<4>` P1 enqueue.
+static ISO4_FLASH_DECODE_DISPATCHES: AtomicU64 = AtomicU64::new(0);
+
+/// Process-lifetime count of iso3 flash-decode P1 dispatches.
+///
+/// Tests assert `delta > 0` to prove the MSL kernel actually fired rather than
+/// the caller silently falling back to the CPU dequant path. Production code
+/// does not consult this counter.
+pub fn iso3_flash_decode_dispatch_count() -> u64 {
+    ISO3_FLASH_DECODE_DISPATCHES.load(Ordering::Relaxed)
+}
+
+/// Process-lifetime count of iso4 flash-decode P1 dispatches.
+pub fn iso4_flash_decode_dispatch_count() -> u64 {
+    ISO4_FLASH_DECODE_DISPATCHES.load(Ordering::Relaxed)
+}
+
+/// Combined process-lifetime count (3-bit + 4-bit).
+pub fn iso_flash_decode_dispatch_count() -> u64 {
+    iso3_flash_decode_dispatch_count() + iso4_flash_decode_dispatch_count()
+}
+
+// ── MSL header builder ────────────────────────────────────────────────────────
+
+/// Emit the reusable per-lane iso K-decode as an MSL function.
+///
+/// This is the half a quantized-V flash kernel reuses verbatim: it consumes a
+/// packed iso store (codes / scales / norms) plus a token index and a head-dim
+/// lane, and returns that lane's dequantised value. Keeping it a header
+/// function (rather than inlining it into the pass-1 body) is what makes it
+/// callable from another kernel body.
+///
+/// Mirrors [`crate::isoquant::iso_decode_fast`] step for step: unpack the
+/// group's 4 `IF_BITS`-bit codes from its single u32, centroid lookup × the
+/// per-group scale, inverse Hamilton product `q̄ * r`, × the per-token L2 norm.
+///
+/// Note this is a single **left** Hamilton product, not a sandwich — iso
+/// encodes with `r = q * v_unit`, so the inverse is `q̄ * r` alone. (The rotor
+/// codec's `R̃ * mv * R` sandwich is a different algebra; do not cross the two.)
+fn render_decode_fn() -> String {
+    // Bound to a local so the group size is an inline `{gs}` capture below.
+    let gs = ISO_K3_GROUP_SIZE;
+    let mut s = String::new();
+    let _ = write!(
+        s,
+        "\n// Decode one head-dim lane of an iso-quantized token.\n\
+         //\n\
+         // `tok_idx` indexes the flat sequence-major token stream\n\
+         // (`(b * kv_seq + t) * kv_h + kv_h_idx`); `lane` is the head-dim slot\n\
+         // in [0, head_dim). Bit-exact with the CPU iso_decode_fast.\n\
+         //\n\
+         // Self-contained per lane: the group's four codes all live in one u32,\n\
+         // so the Hamilton product runs in registers with no threadgroup\n\
+         // staging and no barrier — callable from any kernel body.\n\
+         //\n\
+         // Shared surface: a quantized-V flash kernel calls this unchanged,\n\
+         // passing the V store's (codes, scales, norms) instead of K's.\n\
+         inline float if_decode_k_lane(\n\
+         \x20   device const uint*  codes,\n\
+         \x20   device const float* scales,\n\
+         \x20   device const float* norms,\n\
+         \x20   uint                tok_idx,\n\
+         \x20   uint                n_groups,\n\
+         \x20   uint                lane) {{\n\
+         \x20   // Each group of 4 head-dim slots is one quaternion block.\n\
+         \x20   uint group_id_in_head = lane / {gs}u;\n\
+         \x20   uint lane_in_group    = lane - group_id_in_head * {gs}u;\n\
+         \n\
+         \x20   uint  word    = codes[tok_idx * n_groups + group_id_in_head];\n\
+         \x20   float k_scale = scales[tok_idx * n_groups + group_id_in_head];\n\
+         \n\
+         \x20   // Unpack the group's 4 IF_BITS-bit codes -> centroid x scale.\n\
+         \x20   float rw = ISO_CB[(word >> (0u * IF_BITS)) & IF_MASK] * k_scale;\n\
+         \x20   float rx = ISO_CB[(word >> (1u * IF_BITS)) & IF_MASK] * k_scale;\n\
+         \x20   float ry = ISO_CB[(word >> (2u * IF_BITS)) & IF_MASK] * k_scale;\n\
+         \x20   float rz = ISO_CB[(word >> (3u * IF_BITS)) & IF_MASK] * k_scale;\n\
+         \n\
+         \x20   // Inverse rotation: r' = qbar * r, Hamilton product in the\n\
+         \x20   // [w, x, y, z] convention. qbar = (ISO_QW, ISO_QCX, ISO_QCY,\n\
+         \x20   // ISO_QCZ) is already conjugated by the header.\n\
+         \x20   float v_for_lane;\n\
+         \x20   if (lane_in_group == 0u) {{\n\
+         \x20       v_for_lane = ISO_QW * rw - ISO_QCX * rx - ISO_QCY * ry - ISO_QCZ * rz;\n\
+         \x20   }} else if (lane_in_group == 1u) {{\n\
+         \x20       v_for_lane = ISO_QW * rx + ISO_QCX * rw + ISO_QCY * rz - ISO_QCZ * ry;\n\
+         \x20   }} else if (lane_in_group == 2u) {{\n\
+         \x20       v_for_lane = ISO_QW * ry - ISO_QCX * rz + ISO_QCY * rw + ISO_QCZ * rx;\n\
+         \x20   }} else {{\n\
+         \x20       v_for_lane = ISO_QW * rz + ISO_QCX * ry - ISO_QCY * rx + ISO_QCZ * rw;\n\
+         \x20   }}\n\
+         \n\
+         \x20   return v_for_lane * norms[tok_idx];\n\
+         }}\n",
+    );
+    s
+}
+
+/// Build the MSL header for the iso flash-decode pass-1 kernel.
+///
+/// Emits, in order: the `IF_BITS` / `IF_MASK` unpack parameters, the conjugated
+/// fixed quaternion, the Lloyd-Max N(0,1) codebook for `bits`, the shared
+/// `if_decode_k_lane` function, and the tile / head-dim sizing macros.
+///
+/// # Errors
+///
+/// Returns [`Error::Quant`] for any `bits` outside `{3, 4}` and for a codebook
+/// whose length disagrees with `2^bits`.
+pub(crate) fn build_iso_flash_header(bits: u8) -> Result<String> {
+    let (mask, n_entries) = match bits {
+        3 => (0x7_u32, 8_usize),
+        4 => (0xF_u32, 16_usize),
+        _ => {
+            return Err(Error::Quant(format!(
+                "iso_flash_decode: bits must be 3 or 4, got {bits}"
+            )))
+        }
+    };
+    let cb = lloyd_gaussian_codebook(bits)?;
+    if cb.len() != n_entries {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode: codebook length {got} != 2^{bits} = {n_entries}",
+            got = cb.len(),
+        )));
+    }
+
+    // q̄ = (w, -x, -y, -z) — the inverse of the encode-side rotation.
+    let [qw, qx, qy, qz] = FIXED_QUAT;
+    let qw_bits = f32::to_bits(qw);
+    let qcx_bits = f32::to_bits(-qx);
+    let qcy_bits = f32::to_bits(-qy);
+    let qcz_bits = f32::to_bits(-qz);
+
+    let cb_hex: Vec<String> = cb
+        .iter()
+        .map(|&v| format!("    as_type<float>(0x{:08X}u)", f32::to_bits(v)))
+        .collect();
+
+    let mut s = String::new();
+    let _ = write!(
+        s,
+        "\n// Iso flash-decode header — unpack params + conjugated golden-ratio\n\
+         // fixed quaternion + Lloyd-Max N(0,1) codebook + the shared per-lane\n\
+         // K decode.\n\
+         // BITS = {bits} (codebook = {n_entries} entries, mask = 0x{mask:X}).\n\
+         // Bit-exact with crate::isoquant::FIXED_QUAT + \
+         lloyd_gaussian_codebook({bits}).\n"
+    );
+    let _ = write!(
+        s,
+        "\n#define IF_BITS {bits}u\n#define IF_MASK 0x{mask:X}u\n"
+    );
+    let _ = write!(
+        s,
+        "\nconstant float ISO_QW  = as_type<float>(0x{qw_bits:08X}u);\n\
+         constant float ISO_QCX = as_type<float>(0x{qcx_bits:08X}u);\n\
+         constant float ISO_QCY = as_type<float>(0x{qcy_bits:08X}u);\n\
+         constant float ISO_QCZ = as_type<float>(0x{qcz_bits:08X}u);\n"
+    );
+    let _ = write!(
+        s,
+        "\nconstant float ISO_CB[{n_entries}] = {{\n{cb_join}\n}};\n",
+        cb_join = cb_hex.join(",\n")
+    );
+    s.push_str(&render_decode_fn());
+    let _ = write!(
+        s,
+        "\n#define IF_TILE_SIZE {TILE_SIZE}u\n#define IF_HEAD_DIM_MAX {ISO_FLASH_HEAD_DIM_MAX}\n"
+    );
+    Ok(s)
+}
+
+/// Reject a store whose per-group quaternions are not [`FIXED_QUAT`].
+///
+/// The kernel bakes `q̄` into its header instead of reading the store's
+/// quaternion table (see the module docs). That is correct only while the
+/// encoder writes the one constant into every slot. This check is what turns a
+/// future per-group-quaternion encoder from "silently decodes K against the
+/// wrong rotation" into a loud error at the dispatch boundary.
+///
+/// `quaternions` is the CPU-side per-group table (`n * 4` f32, `[w, x, y, z]`
+/// per group) carried by [`crate::storage::quant_iso_v::IsoBlocks`].
+///
+/// # Errors
+///
+/// Returns [`Error::Quant`] when the length is not a multiple of 4 or any group
+/// differs from [`FIXED_QUAT`].
+pub fn assert_fixed_quat_blocks(quaternions: &[f32], what: &str) -> Result<()> {
+    if !quaternions.len().is_multiple_of(4) {
+        return Err(Error::Quant(format!(
+            "{what}: quaternion table length {} is not a multiple of 4",
+            quaternions.len()
+        )));
+    }
+    for (g, quat) in quaternions.chunks_exact(4).enumerate() {
+        // Bit-equality: the encoder copies FIXED_QUAT verbatim, so anything
+        // else means a different rotation, not a rounding difference.
+        if quat != FIXED_QUAT.as_slice() {
+            return Err(Error::Quant(format!(
+                "{what}: group {g} carries quaternion {quat:?}, expected the fixed \
+                 golden-ratio quaternion {FIXED_QUAT:?}. The iso flash-decode kernel bakes \
+                 the fixed quaternion into its header and does not read a per-group table; \
+                 a per-group-quaternion store must not decode through it."
+            )));
+        }
+    }
+    Ok(())
+}
+
+// ── MSL sources ───────────────────────────────────────────────────────────────
+//
+// Grid: (n_tiles * head_dim, B * n_q_heads, 1).  Threadgroup: (head_dim, 1, 1).
+//
+// P1 buffer layout (must match `add_input` order in `iso_flash_decode_sdpa`):
+// K buffers are SEQUENCE-major (`[B, S, kv_h, ...]`); V stays head-major.
+// 0. query     : f32  [B * n_q_heads * head_dim]
+// 1. codes     : u32  [B * kv_seq * kv_h * n_groups]
+// 2. scales    : f32  [B * kv_seq * kv_h * n_groups]
+// 3. norms     : f32  [B * kv_seq * kv_h]
+// 4. v_flat    : bf16 / f16 / f32 [B * kv_h * kv_seq * head_dim] (native dtype)
+// 5. mask_flat : f32  [B * n_q_heads * kv_seq] or [1] dummy when no mask
+// 6. scale_arr : f32  [1]
+// 7. dims      : u32  [8] — {head_dim, kv_seq, n_bh, kv_h, heads_per_kv,
+//                            n_tiles, has_mask, n_groups}
+//
+// P1 outputs:
+// 0. partial_o     : f32 [n_tiles * n_bh * head_dim]
+// 1. tile_max      : f32 [n_tiles * n_bh]
+// 2. tile_sum_exp  : f32 [n_tiles * n_bh]
+//
+// One body serves both bit widths — the unpack width arrives via the header's
+// IF_BITS / IF_MASK.
+const P1_SOURCE: &str = include_str!("metal/iso_flash_decode_p1.metal");
+
+// P2 buffer layout:
+// 0. partial_o    : f32 [n_tiles * n_bh * head_dim]
+// 1. tile_max     : f32 [n_tiles * n_bh]
+// 2. tile_sum_exp : f32 [n_tiles * n_bh]
+// 3. dims_p2      : u32 [3] — {head_dim, n_tiles, n_bh}
+// Output:
+// 0. dst          : f32 [n_bh * head_dim]
+//
+// Codec-agnostic; shared with `rotor_flash_decode_msl` / `planar_flash_decode_msl`.
+const P2_SOURCE: &str = include_str!("metal/flash_decode_merge_p2.metal");
+
+// ── Kernel singletons (one P1 per BITS variant) ───────────────────────────────
+
+static P1_KERNEL_B3: OnceLock<std::result::Result<MetalKernel, String>> = OnceLock::new();
+static P1_KERNEL_B4: OnceLock<std::result::Result<MetalKernel, String>> = OnceLock::new();
+static P2_KERNEL: OnceLock<std::result::Result<MetalKernel, String>> = OnceLock::new();
+
+fn p1_kernel(bits: u8) -> Result<&'static MetalKernel> {
+    let (cell, name) = match bits {
+        3 => (&P1_KERNEL_B3, "rmlx_iso_flash_decode_p1_b3"),
+        4 => (&P1_KERNEL_B4, "rmlx_iso_flash_decode_p1_b4"),
+        _ => {
+            return Err(Error::Quant(format!(
+                "iso_flash_decode: bits must be 3 or 4, got {bits}"
+            )))
+        }
+    };
+    cell.get_or_init(|| {
+        let header = build_iso_flash_header(bits).map_err(|e| format!("{e}"))?;
+        MetalKernel::new(
+            name,
+            &header,
+            P1_SOURCE,
+            &[
+                "query",
+                "codes",
+                "scales",
+                "norms",
+                "v_flat",
+                "mask_flat",
+                "scale_arr",
+                "dims",
+            ],
+            &["partial_o", "tile_max", "tile_sum_exp"],
+        )
+        .map_err(|e| format!("{e}"))
+    })
+    .as_ref()
+    .map_err(|e| Error::Mlx(format!("iso_flash_decode P1(bits={bits}) kernel init: {e}")))
+}
+
+fn p2_kernel() -> Result<&'static MetalKernel> {
+    P2_KERNEL
+        .get_or_init(|| {
+            MetalKernel::new(
+                "rmlx_iso_flash_decode_p2",
+                "", // No header — P2 is generic over (head_dim, n_tiles, n_bh).
+                P2_SOURCE,
+                &["partial_o", "tile_max", "tile_sum_exp", "dims_p2"],
+                &["dst"],
+            )
+            .map_err(|e| format!("{e}"))
+        })
+        .as_ref()
+        .map_err(|e| Error::Mlx(format!("iso_flash_decode P2 kernel init: {e}")))
+}
+
+// ── Public dispatcher ─────────────────────────────────────────────────────────
+
+/// Run the iso flash-decode kernel (fused QK over iso-quant K + online softmax
+/// + bf16-V SV).
+///
+/// # Inputs
+///
+/// * `query`     — Q for the new token, shape `[B, n_q_heads, 1, head_dim]`.
+/// * `k_codes`   — packed iso codes, flat `u32 [B * kv_seq * kv_h * n_groups]`
+///   (sequence-major).
+/// * `k_scales`  — per-group f32 scales, same flat length as `k_codes`.
+/// * `k_norms`   — per-token f32 L2 norms, flat `[B * kv_seq * kv_h]`.
+/// * `v`         — bf16 / f16 / f32 V, shape `[B, kv_h, kv_seq, head_dim]`.
+///   Read in its native dtype; the dispatcher does NOT astype-upcast.
+/// * `additive_mask` — optional `f32 [B, n_q_heads, 1, kv_seq]`.
+/// * `b`, `kv_h`, `kv_seq`, `head_dim`, `heads_per_kv` — shape metadata.
+/// * `scale`     — softmax pre-scale (typically `1/sqrt(head_dim)`).
+/// * `device`    — MLX device (must be GPU).
+///
+/// # Output
+///
+/// `f32` array of shape `[B, n_q_heads, 1, head_dim]`.
+///
+/// # Errors
+///
+/// * [`Error::Quant`] for `BITS` outside `{3, 4}`, shape-contract violations
+///   (`head_dim` not a power of two, not a multiple of the quaternion block
+///   size, above [`ISO_FLASH_HEAD_DIM_MAX`], non-positive shapes), an
+///   unsupported V dtype, or grid overflow.
+/// * [`Error::Mlx`] for kernel build / dispatch failures.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub fn iso_flash_decode_sdpa<const BITS: u8>(
+    query: &Array,
+    k_codes: &Array,
+    k_scales: &Array,
+    k_norms: &Array,
+    v: &Array,
+    additive_mask: Option<&Array>,
+    b: i32,
+    kv_h: i32,
+    kv_seq: i32,
+    head_dim: i32,
+    heads_per_kv: i32,
+    scale: f32,
+    device: Device,
+) -> Result<Array> {
+    if BITS != 3 && BITS != 4 {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode: unsupported BITS={BITS} (only 3 and 4)"
+        )));
+    }
+    if head_dim <= 0 {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode: head_dim={head_dim} must be positive"
+        )));
+    }
+    if !(head_dim as u32).is_power_of_two() {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode: head_dim={head_dim} must be a power of two for the \
+             tree reduction; caller falls back to the CPU dequant path"
+        )));
+    }
+    if head_dim > ISO_FLASH_HEAD_DIM_MAX {
+        let max = ISO_FLASH_HEAD_DIM_MAX;
+        return Err(Error::Quant(format!(
+            "iso_flash_decode: head_dim={head_dim} exceeds ISO_FLASH_HEAD_DIM_MAX={max}; \
+             raise the static threadgroup-array sizes in metal/iso_flash_decode_p1.metal \
+             to support it"
+        )));
+    }
+    if !(head_dim as usize).is_multiple_of(ISO_K3_GROUP_SIZE) {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode: head_dim={head_dim} must be a multiple of the quaternion \
+             block size {ISO_K3_GROUP_SIZE}"
+        )));
+    }
+    if heads_per_kv <= 0 {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode: heads_per_kv must be > 0, got {heads_per_kv}"
+        )));
+    }
+    if b <= 0 || kv_seq <= 0 || kv_h <= 0 {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode: b={b}, kv_h={kv_h}, kv_seq={kv_seq} must all be > 0"
+        )));
+    }
+
+    let n_q_heads = kv_h * heads_per_kv;
+    let n_bh = b * n_q_heads;
+    let n_tiles = (kv_seq + TILE_SIZE - 1) / TILE_SIZE;
+    let n_groups = iso_n_groups_for(head_dim as usize);
+    let n_groups_i64 = n_groups as i64;
+
+    // ── Flatten Q to [n_bh * head_dim] f32 ────────────────────────────────
+    let q_total: i64 = i64::from(n_bh) * i64::from(head_dim);
+    let q_flat = query.reshape(&[q_total as i32], device)?;
+    let q_f32 = if q_flat.dtype() == Dtype::F32 {
+        q_flat
+    } else {
+        q_flat.astype(Dtype::F32, device)?
+    };
+
+    // ── Flatten K buffers ─────────────────────────────────────────────────
+    let tok_count: i64 = i64::from(b) * i64::from(kv_h) * i64::from(kv_seq);
+    let codes_total: i64 = tok_count * n_groups_i64;
+
+    let codes_flat = k_codes.reshape(&[codes_total as i32], device)?;
+    let scales_flat = k_scales.reshape(&[codes_total as i32], device)?;
+    let norms_flat = k_norms.reshape(&[tok_count as i32], device)?;
+
+    // ── V flat — keep native dtype (bf16 / f16 / f32) ─────────────────────
+    let v_total: i64 = tok_count * i64::from(head_dim);
+    let v_flat = match v.dtype() {
+        Dtype::F32 | Dtype::Bf16 | Dtype::F16 => v.reshape(&[v_total as i32], device)?,
+        Dtype::U8 | Dtype::U32 | Dtype::I32 => {
+            let dt = v.dtype();
+            return Err(Error::Quant(format!(
+                "iso_flash_decode: V dtype must be F32 / Bf16 / F16, got {dt:?}"
+            )));
+        }
+    };
+
+    // ── Mask ──────────────────────────────────────────────────────────────
+    let (mask_flat, has_mask) = if let Some(m) = additive_mask {
+        let flat_len: i64 = i64::from(n_bh) * i64::from(kv_seq);
+        let m_f = if m.dtype() == Dtype::F32 {
+            m.reshape(&[flat_len as i32], device)?
+        } else {
+            m.astype(Dtype::F32, device)?
+                .reshape(&[flat_len as i32], device)?
+        };
+        (m_f, 1u32)
+    } else {
+        let zero_bytes = [0u8; 4];
+        Array::from_bytes(&zero_bytes, &[1], Dtype::F32)
+            .map(|a| (a, 0u32))
+            .map_err(|e| Error::Mlx(format!("iso_flash_decode dummy mask: {e}")))?
+    };
+
+    // ── scale_arr ─────────────────────────────────────────────────────────
+    let scale_arr = {
+        let bytes = scale.to_le_bytes();
+        Array::from_bytes(&bytes, &[1], Dtype::F32)?
+    };
+
+    // ── dims (8 u32) ──────────────────────────────────────────────────────
+    // `bits` is not carried — the dispatcher selects the per-BITS kernel and
+    // its header supplies IF_BITS / IF_MASK.
+    let dims_arr = {
+        let dims: [u32; 8] = [
+            head_dim as u32,
+            kv_seq as u32,
+            n_bh as u32,
+            kv_h as u32,
+            heads_per_kv as u32,
+            n_tiles as u32,
+            has_mask,
+            n_groups as u32,
+        ];
+        // SAFETY:
+        // * `dims` is a stack-local `[u32; 8]` fully initialised above.
+        // * `u32` has stricter alignment than `u8`, so the cast is sound.
+        // * The byte length `8 * 4` equals `size_of::<[u32; 8]>()`.
+        // * The borrow is bounded by the enclosing block; `Array::from_bytes`
+        //   copies into mlx storage before this scope ends.
+        let bytes: &[u8] = unsafe { std::slice::from_raw_parts(dims.as_ptr().cast::<u8>(), 8 * 4) };
+        Array::from_bytes(bytes, &[8], Dtype::U32)
+            .map_err(|e| Error::Mlx(format!("iso_flash_decode dims: {e}")))?
+    };
+
+    // Materialise inputs to flush any pending lazy ops before kernel dispatch.
+    // The MSL kernels read by raw linear offset and ignore MLX lazy-transpose
+    // strides, so a pending permutation must be resolved here.
+    q_f32.eval()?;
+    codes_flat.eval()?;
+    scales_flat.eval()?;
+    norms_flat.eval()?;
+    v_flat.eval()?;
+    if has_mask == 1 {
+        mask_flat.eval()?;
+    }
+    scale_arr.eval()?;
+    dims_arr.eval()?;
+
+    // ── P1 dispatch ───────────────────────────────────────────────────────
+    let kern_p1 = p1_kernel(BITS)?;
+    let mut inv_p1 = MetalKernelInvoke::new();
+    inv_p1.add_input(&q_f32)?;
+    inv_p1.add_input(&codes_flat)?;
+    inv_p1.add_input(&scales_flat)?;
+    inv_p1.add_input(&norms_flat)?;
+    inv_p1.add_input(&v_flat)?;
+    inv_p1.add_input(&mask_flat)?;
+    inv_p1.add_input(&scale_arr)?;
+    inv_p1.add_input(&dims_arr)?;
+
+    let partial_o_len: i64 = i64::from(n_tiles) * i64::from(n_bh) * i64::from(head_dim);
+    let tile_meta_len: i64 = i64::from(n_tiles) * i64::from(n_bh);
+    if partial_o_len > i64::from(i32::MAX) {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode: partial_o length {partial_o_len} exceeds i32::MAX"
+        )));
+    }
+    inv_p1.add_output_shape(&[partial_o_len as i32], Dtype::F32)?;
+    inv_p1.add_output_shape(&[tile_meta_len as i32], Dtype::F32)?;
+    inv_p1.add_output_shape(&[tile_meta_len as i32], Dtype::F32)?;
+
+    // Grid X: n_tiles threadgroups × head_dim threads each.
+    let grid_x: i64 = i64::from(n_tiles) * i64::from(head_dim);
+    let grid_y: i64 = i64::from(n_bh);
+    if grid_x > i64::from(i32::MAX) || grid_y > i64::from(i32::MAX) {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode: grid dimensions exceed i32::MAX (x={grid_x}, y={grid_y})"
+        )));
+    }
+    inv_p1.set_grid(grid_x as i32, grid_y as i32, 1)?;
+    inv_p1.set_thread_group(head_dim, 1, 1)?;
+
+    // Counter increment at the actual P1 enqueue point — after every
+    // validation gate, immediately before `.apply()`.
+    if BITS == 3 {
+        ISO3_FLASH_DECODE_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+    } else {
+        ISO4_FLASH_DECODE_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+    }
+    tracing::trace!(
+        bits = BITS,
+        b,
+        n_q_heads,
+        kv_h,
+        kv_seq,
+        head_dim,
+        has_mask,
+        n_groups,
+        n_tiles,
+        "iso_flash_decode_sdpa: dispatch"
+    );
+
+    let mut p1_outs = kern_p1.apply(inv_p1, device)?;
+    if p1_outs.len() < 3 {
+        return Err(Error::Mlx("iso_flash_decode P1: expected 3 outputs".into()));
+    }
+    let partial_o = p1_outs.remove(0);
+    let tile_max = p1_outs.remove(0);
+    let tile_sum_exp = p1_outs.remove(0);
+
+    // ── P2 dispatch ───────────────────────────────────────────────────────
+    let dims_p2_arr = {
+        let dims_p2: [u32; 3] = [head_dim as u32, n_tiles as u32, n_bh as u32];
+        // SAFETY: same reasoning as the `dims` cast above — stack-local
+        // `[u32; 3]`, `u32` alignment ≥ `u8`, byte length `3 * 4` equals
+        // `size_of::<[u32; 3]>()`, and `Array::from_bytes` copies before the
+        // borrow ends.
+        let bytes: &[u8] =
+            unsafe { std::slice::from_raw_parts(dims_p2.as_ptr().cast::<u8>(), 3 * 4) };
+        Array::from_bytes(bytes, &[3], Dtype::U32)
+            .map_err(|e| Error::Mlx(format!("iso_flash_decode dims_p2: {e}")))?
+    };
+
+    let kern_p2 = p2_kernel()?;
+    let mut inv_p2 = MetalKernelInvoke::new();
+    inv_p2.add_input(&partial_o)?;
+    inv_p2.add_input(&tile_max)?;
+    inv_p2.add_input(&tile_sum_exp)?;
+    inv_p2.add_input(&dims_p2_arr)?;
+
+    let dst_len: i64 = i64::from(n_bh) * i64::from(head_dim);
+    inv_p2.add_output_shape(&[dst_len as i32], Dtype::F32)?;
+
+    let p2_grid_x: i64 = i64::from(n_bh) * i64::from(head_dim);
+    if p2_grid_x > i64::from(i32::MAX) {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode P2: grid x {p2_grid_x} exceeds i32::MAX"
+        )));
+    }
+    inv_p2.set_grid(p2_grid_x as i32, 1, 1)?;
+    inv_p2.set_thread_group(head_dim, 1, 1)?;
+
+    let mut p2_outs = kern_p2.apply(inv_p2, device)?;
+    if p2_outs.is_empty() {
+        return Err(Error::Mlx("iso_flash_decode P2: expected 1 output".into()));
+    }
+    let dst_flat = p2_outs.remove(0);
+
+    // Reshape to canonical SDPA output.
+    dst_flat.reshape(&[b, n_q_heads, 1, head_dim], device)
+}
+
+#[cfg(test)]
+#[path = "iso_flash_decode_msl_tests.rs"]
+mod iso_flash_decode_msl_tests;

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
@@ -1,0 +1,561 @@
+//! GPU parity tests for the iso flash-decode kernel (BITS in {3, 4}).
+//!
+//! The oracle is the codec's own CPU dequant
+//! ([`crate::isoquant::iso_decode_fast`]) fed through a scalar reference
+//! attention chain. That is exactly what the production path did before this
+//! kernel existed, so a match proves the kernel reproduces the path it
+//! replaces — not merely that it is self-consistent.
+
+use super::*;
+use crate::isoquant::{iso_decode_fast, iso_encode_fast};
+use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
+use rmlx_mlx::{Array, Device, Dtype};
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn make_f32_array(data: &[f32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::F32).expect("make_f32_array")
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn make_u32_array(data: &[u32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|w| w.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::U32).expect("make_u32_array")
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: chunks_exact(4) guarantees length"
+)]
+fn array_to_f32(a: &Array) -> Vec<f32> {
+    a.eval().expect("array eval");
+    let bytes = a.to_bytes().expect("to_bytes");
+    bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
+        .collect()
+}
+
+/// Scalar reference attention over an already-dequantized K.
+///
+/// `k_deq` is sequence-major (`[(s * kv_h + h), head_dim]`) — the layout the
+/// iso ring accumulates and the kernel reads. `v` is head-major
+/// (`[b, kv_h, kv_seq, head_dim]`) — the bf16 mirror's layout.
+#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "test reference: all indices derived from the shape params under test"
+)]
+fn ref_attention(
+    q: &[f32],
+    k_deq: &[f32],
+    v: &[f32],
+    mask: Option<&[f32]>,
+    n_q_heads: usize,
+    kv_h: usize,
+    kv_seq: usize,
+    head_dim: usize,
+    scale: f32,
+) -> Vec<f32> {
+    let heads_per_kv = n_q_heads / kv_h;
+    let mut out = vec![0.0_f32; n_q_heads * head_dim];
+    for hq in 0..n_q_heads {
+        let h = hq / heads_per_kv;
+
+        // Scores over the whole prefix.
+        let mut scores = vec![0.0_f32; kv_seq];
+        for (s, score) in scores.iter_mut().enumerate() {
+            let k_row = (s * kv_h + h) * head_dim;
+            let mut acc = 0.0_f32;
+            for d in 0..head_dim {
+                acc += q[hq * head_dim + d] * k_deq[k_row + d];
+            }
+            *score = acc * scale;
+        }
+        if let Some(m) = mask {
+            // Additive mask, laid out [b, n_q_heads, 1, kv_seq] with b == 1.
+            for (s, score) in scores.iter_mut().enumerate() {
+                *score += m[hq * kv_seq + s];
+            }
+        }
+
+        // Softmax (max-subtracted, matching the kernel's online form).
+        let mut m = f32::NEG_INFINITY;
+        for &s in &scores {
+            if s > m {
+                m = s;
+            }
+        }
+        let mut denom = 0.0_f32;
+        for s in &mut scores {
+            *s = (*s - m).exp();
+            denom += *s;
+        }
+
+        // Weighted V sum.
+        for d in 0..head_dim {
+            let mut acc = 0.0_f32;
+            for (s, &p) in scores.iter().enumerate() {
+                acc += p * v[(h * kv_seq + s) * head_dim + d];
+            }
+            out[hq * head_dim + d] = acc / denom;
+        }
+    }
+    out
+}
+
+/// Encode `k_seq_major` with the iso codec on CPU and return the GPU-resident
+/// packed buffers plus the CPU dequant oracle.
+///
+/// `norms` is deduplicated to per-token here: `iso_encode_fast` already emits
+/// one norm per token, which is exactly what the ring and the kernel want.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn iso_encode_for_test(
+    k_seq_major: &[f32],
+    head_dim: usize,
+    bits: u8,
+) -> (Array, Array, Array, Vec<f32>) {
+    let (codes, scales, quaternions, norms) =
+        iso_encode_fast(k_seq_major, head_dim, ISO_K3_GROUP_SIZE, bits).expect("iso_encode_fast");
+    let dequant = iso_decode_fast(
+        &codes,
+        &scales,
+        &quaternions,
+        &norms,
+        head_dim,
+        ISO_K3_GROUP_SIZE,
+        bits,
+    )
+    .expect("iso_decode_fast");
+
+    (
+        make_u32_array(&codes, &[codes.len() as i32]),
+        make_f32_array(&scales, &[scales.len() as i32]),
+        make_f32_array(&norms, &[norms.len() as i32]),
+        dequant,
+    )
+}
+
+/// Run the kernel against the CPU-dequant oracle for one shape, with no mask.
+fn run_oracle(bits: u8, kv_h: usize, heads_per_kv: usize, kv_seq: usize, head_dim: usize) -> bool {
+    run_oracle_masked(bits, kv_h, heads_per_kv, kv_seq, head_dim, false)
+}
+
+/// Run the kernel against the CPU-dequant oracle for one shape.
+///
+/// When `with_mask`, feeds a per-(q_head, key) additive mask with a distinct
+/// value in every cell, so a transposed or mis-strided mask index in either the
+/// kernel or the dispatcher changes the result instead of cancelling out.
+///
+/// Returns `false` when the GPU is unavailable so the caller can skip.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+#[allow(clippy::too_many_arguments)]
+fn run_oracle_masked(
+    bits: u8,
+    kv_h: usize,
+    heads_per_kv: usize,
+    kv_seq: usize,
+    head_dim: usize,
+    with_mask: bool,
+) -> bool {
+    if skip_if_no_gpu_env() {
+        return false;
+    }
+    let b = 1_usize;
+    let n_q_heads = kv_h * heads_per_kv;
+    let n_tokens = kv_seq * kv_h;
+
+    let q = lcg_data(n_q_heads * head_dim, 0xA11CE);
+    // K is generated in the store's sequence-major order: token (s, h) at row
+    // (s * kv_h + h).
+    let k = lcg_data(n_tokens * head_dim, 0xB0B);
+    let v = lcg_data(n_tokens * head_dim, 0xC0FFEE);
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    let (codes, scales, norms, k_deq) = iso_encode_for_test(&k, head_dim, bits);
+    let q_arr = make_f32_array(&q, &[b as i32, n_q_heads as i32, 1, head_dim as i32]);
+    let v_arr = make_f32_array(&v, &[b as i32, kv_h as i32, kv_seq as i32, head_dim as i32]);
+
+    // Asymmetric in both axes and never zero, so a (hq, s) index swap or a wrong
+    // stride shifts the scores rather than landing on an equal value. Includes a
+    // -inf-ish cell to exercise full suppression through the online softmax.
+    let mask_vec: Option<Vec<f32>> = with_mask.then(|| {
+        (0..n_q_heads * kv_seq)
+            .map(|i| {
+                let hq = i / kv_seq;
+                let s = i % kv_seq;
+                if hq == 0 && s == kv_seq / 2 {
+                    -1.0e30
+                } else {
+                    (hq as f32) * 0.25 - (s as f32) * 0.03125
+                }
+            })
+            .collect()
+    });
+    let mask_arr = mask_vec
+        .as_ref()
+        .map(|m| make_f32_array(m, &[b as i32, n_q_heads as i32, 1, kv_seq as i32]));
+
+    let out = match bits {
+        3 => iso_flash_decode_sdpa::<3>(
+            &q_arr,
+            &codes,
+            &scales,
+            &norms,
+            &v_arr,
+            mask_arr.as_ref(),
+            b as i32,
+            kv_h as i32,
+            kv_seq as i32,
+            head_dim as i32,
+            heads_per_kv as i32,
+            scale,
+            Device::Gpu,
+        ),
+        _ => iso_flash_decode_sdpa::<4>(
+            &q_arr,
+            &codes,
+            &scales,
+            &norms,
+            &v_arr,
+            mask_arr.as_ref(),
+            b as i32,
+            kv_h as i32,
+            kv_seq as i32,
+            head_dim as i32,
+            heads_per_kv as i32,
+            scale,
+            Device::Gpu,
+        ),
+    }
+    .expect("iso_flash_decode_sdpa");
+
+    let got = array_to_f32(&out);
+    let want = ref_attention(
+        &q,
+        &k_deq,
+        &v,
+        mask_vec.as_deref(),
+        n_q_heads,
+        kv_h,
+        kv_seq,
+        head_dim,
+        scale,
+    );
+
+    assert_eq!(got.len(), want.len(), "bits={bits}: output length");
+    let mut max_err = 0.0_f32;
+    for (g, w) in got.iter().zip(want.iter()) {
+        max_err = max_err.max((g - w).abs());
+    }
+    // bf16 has ~8 mantissa bits (~3e-3 relative). The kernel accumulates in
+    // f32 but is fed the same quantized codes as the oracle, so the only
+    // divergence is summation order; this bound is well inside bf16 tolerance.
+    assert!(
+        max_err < 2e-3,
+        "bits={bits} kv_h={kv_h} hpk={heads_per_kv} S={kv_seq} D={head_dim}: \
+         max_err={max_err} exceeds bf16 tolerance"
+    );
+    true
+}
+
+// ── Oracle: kernel == CPU dequant reference ───────────────────────────────────
+
+#[test]
+fn iso3_flash_decode_matches_cpu_dequant_reference() {
+    // Bonsai / Qwen3 shape: head_dim 128, GQA 4:1.
+    run_oracle(3, 2, 4, 40, 128);
+}
+
+#[test]
+fn iso4_flash_decode_matches_cpu_dequant_reference() {
+    run_oracle(4, 2, 4, 40, 128);
+}
+
+#[test]
+fn iso3_flash_decode_matches_reference_across_tiles() {
+    // kv_seq is set above TILE_SIZE so the P2 log-sum-exp merge runs over
+    // several tiles rather than a single one.
+    run_oracle(3, 1, 8, (TILE_SIZE as usize) * 2 + 22, 128);
+}
+
+#[test]
+fn iso4_flash_decode_matches_reference_across_tiles() {
+    run_oracle(4, 1, 8, (TILE_SIZE as usize) * 2 + 22, 128);
+}
+
+#[test]
+fn iso3_flash_decode_matches_reference_head_dim_512() {
+    // Gemma4 e2b/e4b global layers run head_dim = 512 with a single KV head.
+    run_oracle(3, 1, 8, 70, 512);
+}
+
+#[test]
+fn iso4_flash_decode_matches_reference_head_dim_512() {
+    run_oracle(4, 1, 8, 70, 512);
+}
+
+#[test]
+fn iso3_flash_decode_matches_reference_head_dim_256() {
+    // medgemma / Gemma3 shape.
+    run_oracle(3, 1, 4, 70, 256);
+}
+
+#[test]
+fn iso4_flash_decode_matches_reference_head_dim_256() {
+    run_oracle(4, 1, 4, 70, 256);
+}
+
+// ── Additive mask ─────────────────────────────────────────────────────────────
+//
+// Without these the kernel's mask read
+// (`mask_flat[(b * n_q_heads + hq) * kv_seq + t]`) and the dispatcher's mask
+// flatten are never executed — every other test passes `None`, so a transposed
+// or mis-strided mask index would pass the whole suite.
+
+#[test]
+fn iso3_flash_decode_matches_reference_with_additive_mask() {
+    // kv_h=2, heads_per_kv=4 also pins the GQA (q_head -> kv_head) mapping: the
+    // mask is indexed by q_head while K is indexed by kv_head, so conflating the
+    // two shows up here.
+    run_oracle_masked(3, 2, 4, 40, 128, true);
+}
+
+#[test]
+fn iso4_flash_decode_matches_reference_with_additive_mask() {
+    run_oracle_masked(4, 2, 4, 40, 128, true);
+}
+
+#[test]
+fn iso3_flash_decode_matches_reference_with_mask_across_tiles() {
+    // Mask + multi-tile: the per-tile online softmax and the P2 merge both have
+    // to see the masked scores.
+    run_oracle_masked(3, 2, 4, (TILE_SIZE as usize) * 2 + 22, 128, true);
+}
+
+#[test]
+fn iso4_flash_decode_matches_reference_with_mask_across_tiles() {
+    run_oracle_masked(4, 2, 4, (TILE_SIZE as usize) * 2 + 22, 128, true);
+}
+
+// ── GQA ───────────────────────────────────────────────────────────────────────
+
+#[test]
+fn iso3_flash_decode_matches_reference_multi_kv_head_gqa() {
+    // kv_h=4 with heads_per_kv=2: several KV heads AND a GQA fan-out, so a
+    // kv_h_idx derived with the wrong divisor reads another head's K.
+    run_oracle(3, 4, 2, 40, 128);
+}
+
+#[test]
+fn iso3_flash_decode_matches_reference_mha_no_gqa() {
+    // heads_per_kv=1 (plain MHA): kv_h_idx == hq, the degenerate GQA case.
+    run_oracle(3, 4, 1, 40, 128);
+}
+
+// ── Gates ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn iso_flash_decode_rejects_non_pow2_head_dim() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    // head_dim=96 is a multiple of the quaternion block size but not a power of
+    // two, so it isolates the tree-reduction gate from the group-size gate.
+    let err = iso_flash_decode_sdpa::<3>(
+        &dummy,
+        &codes,
+        &dummy,
+        &dummy,
+        &dummy,
+        None,
+        1,
+        1,
+        8,
+        96,
+        1,
+        1.0,
+        Device::Gpu,
+    );
+    assert!(
+        err.is_err(),
+        "head_dim=96 is not a power of two — the tree reduction requires one"
+    );
+}
+
+#[test]
+fn iso_flash_decode_rejects_head_dim_above_max() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    let err = iso_flash_decode_sdpa::<3>(
+        &dummy,
+        &codes,
+        &dummy,
+        &dummy,
+        &dummy,
+        None,
+        1,
+        1,
+        8,
+        ISO_FLASH_HEAD_DIM_MAX * 2,
+        1,
+        1.0,
+        Device::Gpu,
+    );
+    assert!(
+        err.is_err(),
+        "head_dim above ISO_FLASH_HEAD_DIM_MAX must error — the threadgroup arrays are \
+         statically sized to it"
+    );
+}
+
+#[test]
+fn iso_flash_decode_rejects_unsupported_bits() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    // BITS=5 must not silently decode as 3-bit or 4-bit.
+    let err = iso_flash_decode_sdpa::<5>(
+        &dummy,
+        &codes,
+        &dummy,
+        &dummy,
+        &dummy,
+        None,
+        1,
+        1,
+        8,
+        128,
+        1,
+        1.0,
+        Device::Gpu,
+    );
+    assert!(
+        err.is_err(),
+        "BITS=5 has no codebook — it must error, never fall back to another width"
+    );
+}
+
+#[test]
+fn iso_flash_header_rejects_unsupported_bits() {
+    // Header build is the other place a bad width could silently pick a
+    // codebook. No GPU needed.
+    assert!(build_iso_flash_header(3).is_ok(), "bits=3 is supported");
+    assert!(build_iso_flash_header(4).is_ok(), "bits=4 is supported");
+    for bits in [0_u8, 1, 2, 5, 8] {
+        assert!(
+            build_iso_flash_header(bits).is_err(),
+            "bits={bits} must be rejected, not rendered with a wrong-width codebook"
+        );
+    }
+}
+
+#[test]
+fn iso_flash_header_carries_the_matching_codebook_width() {
+    #[allow(
+        clippy::expect_used,
+        reason = "test: bits 3/4 are supported, asserted directly above"
+    )]
+    let h3 = build_iso_flash_header(3).expect("header bits=3");
+    #[allow(
+        clippy::expect_used,
+        reason = "test: bits 3/4 are supported, asserted directly above"
+    )]
+    let h4 = build_iso_flash_header(4).expect("header bits=4");
+    assert!(h3.contains("#define IF_BITS 3u"), "bits=3 unpack width");
+    assert!(h3.contains("#define IF_MASK 0x7u"), "bits=3 unpack mask");
+    assert!(h3.contains("constant float ISO_CB[8]"), "bits=3 codebook");
+    assert!(h4.contains("#define IF_BITS 4u"), "bits=4 unpack width");
+    assert!(h4.contains("#define IF_MASK 0xFu"), "bits=4 unpack mask");
+    assert!(h4.contains("constant float ISO_CB[16]"), "bits=4 codebook");
+    // The shared K-decode is what a quantized-V flash kernel calls; it has to
+    // be a header function, not inlined into the body.
+    assert!(
+        h3.contains("inline float if_decode_k_lane("),
+        "the reusable per-lane decode must live in the header"
+    );
+}
+
+// ── Fixed-quaternion coupling ─────────────────────────────────────────────────
+
+#[test]
+fn assert_fixed_quat_accepts_the_encoder_table() {
+    // What `iso_encode_fast` actually writes must pass — otherwise the guard
+    // would reject every real store.
+    let k = lcg_data(4 * 128, 0xD00D);
+    #[allow(clippy::expect_used, reason = "test: fixed shape known-valid")]
+    let (_c, _s, quaternions, _n) =
+        iso_encode_fast(&k, 128, ISO_K3_GROUP_SIZE, 3).expect("iso_encode_fast");
+    assert!(
+        assert_fixed_quat_blocks(&quaternions, "test").is_ok(),
+        "the encoder's own quaternion table must satisfy the kernel's fixed-quat contract"
+    );
+}
+
+#[test]
+fn assert_fixed_quat_rejects_a_per_group_table() {
+    // The failure this guard exists for: a store whose groups carry their own
+    // quaternions decodes to garbage through a header that baked in a constant.
+    let mut quats: Vec<f32> = FIXED_QUAT.to_vec();
+    quats.extend_from_slice(&[0.5, 0.5, 0.5, 0.5]);
+    let err = assert_fixed_quat_blocks(&quats, "test");
+    assert!(
+        err.is_err(),
+        "a group with a non-fixed quaternion must be rejected, not decoded against the \
+         header's constant"
+    );
+}
+
+#[test]
+fn assert_fixed_quat_rejects_a_ragged_table() {
+    let err = assert_fixed_quat_blocks(&[1.0, 0.0, 0.0], "test");
+    assert!(
+        err.is_err(),
+        "a quaternion table that is not a multiple of 4 is malformed"
+    );
+}
+
+// ── Probe-snapshot drift guards ───────────────────────────────────────────────
+//
+// The `metal/probes/*.hdr.metal` files are captured output of the builder
+// below, compiled by `make check-metal-compiles`. Without these the snapshot
+// could drift from what production actually dispatches, and the compile gate
+// would happily keep verifying the stale copy.
+
+#[test]
+fn hdr_probe_snapshot_b3_matches_builder() {
+    #[allow(
+        clippy::unwrap_used,
+        reason = "bits 3 is a supported width; a failure here is the assertion"
+    )]
+    let built = build_iso_flash_header(3).unwrap();
+    assert_eq!(
+        built,
+        include_str!("metal/probes/iso_flash_decode_p1_b3.hdr.metal"),
+        "stale snapshot: refresh metal/probes/iso_flash_decode_p1_b3.hdr.metal"
+    );
+}
+
+#[test]
+fn hdr_probe_snapshot_b4_matches_builder() {
+    #[allow(
+        clippy::unwrap_used,
+        reason = "bits 4 is a supported width; a failure here is the assertion"
+    )]
+    let built = build_iso_flash_header(4).unwrap();
+    assert_eq!(
+        built,
+        include_str!("metal/probes/iso_flash_decode_p1_b4.hdr.metal"),
+        "stale snapshot: refresh metal/probes/iso_flash_decode_p1_b4.hdr.metal"
+    );
+}

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
@@ -119,14 +119,14 @@ fn iso_encode_for_test(
     bits: u8,
 ) -> (Array, Array, Array, Vec<f32>) {
     let (codes, scales, quaternions, norms) =
-        iso_encode_fast(k_seq_major, head_dim, ISO_K3_GROUP_SIZE, bits).expect("iso_encode_fast");
+        iso_encode_fast(k_seq_major, head_dim, ISO_QUAT_BLOCK_SIZE, bits).expect("iso_encode_fast");
     let dequant = iso_decode_fast(
         &codes,
         &scales,
         &quaternions,
         &norms,
         head_dim,
-        ISO_K3_GROUP_SIZE,
+        ISO_QUAT_BLOCK_SIZE,
         bits,
     )
     .expect("iso_decode_fast");
@@ -215,7 +215,7 @@ fn run_oracle_masked(
             scale,
             Device::Gpu,
         ),
-        _ => iso_flash_decode_sdpa::<4>(
+        4 => iso_flash_decode_sdpa::<4>(
             &q_arr,
             &codes,
             &scales,
@@ -230,6 +230,10 @@ fn run_oracle_masked(
             scale,
             Device::Gpu,
         ),
+        // Not a `_` arm: a wildcard would silently run some other width's
+        // kernel under a test name asserting this one, and the assertion below
+        // would pass. Production rejects an unknown width here too.
+        other => panic!("run_oracle: unsupported bits={other} (only 3 and 4)"),
     }
     .expect("iso_flash_decode_sdpa");
 
@@ -351,9 +355,19 @@ fn iso3_flash_decode_matches_reference_multi_kv_head_gqa() {
 }
 
 #[test]
+fn iso4_flash_decode_matches_reference_multi_kv_head_gqa() {
+    run_oracle(4, 4, 2, 40, 128);
+}
+
+#[test]
 fn iso3_flash_decode_matches_reference_mha_no_gqa() {
     // heads_per_kv=1 (plain MHA): kv_h_idx == hq, the degenerate GQA case.
     run_oracle(3, 4, 1, 40, 128);
+}
+
+#[test]
+fn iso4_flash_decode_matches_reference_mha_no_gqa() {
+    run_oracle(4, 4, 1, 40, 128);
 }
 
 // ── Gates ─────────────────────────────────────────────────────────────────────
@@ -495,7 +509,7 @@ fn assert_fixed_quat_accepts_the_encoder_table() {
     let k = lcg_data(4 * 128, 0xD00D);
     #[allow(clippy::expect_used, reason = "test: fixed shape known-valid")]
     let (_c, _s, quaternions, _n) =
-        iso_encode_fast(&k, 128, ISO_K3_GROUP_SIZE, 3).expect("iso_encode_fast");
+        iso_encode_fast(&k, 128, ISO_QUAT_BLOCK_SIZE, 3).expect("iso_encode_fast");
     assert!(
         assert_fixed_quat_blocks(&quaternions, "test").is_ok(),
         "the encoder's own quaternion table must satisfy the kernel's fixed-quat contract"
@@ -523,6 +537,32 @@ fn assert_fixed_quat_rejects_a_ragged_table() {
         err.is_err(),
         "a quaternion table that is not a multiple of 4 is malformed"
     );
+}
+
+// ── Group-size aliases ────────────────────────────────────────────────────────
+
+#[test]
+fn both_iso_widths_share_the_quaternion_block_size() {
+    use crate::storage::{ISO_K3_GROUP_SIZE, ISO_K4_GROUP_SIZE};
+    // Every iso4 GPU path derives its ring stride through `iso_n_groups_for`
+    // (which uses ISO_QUAT_BLOCK_SIZE) while `QuantIsoK4::append` uses the K4
+    // alias. If those ever disagreed, the iso4 ring and the iso4 CPU blocks
+    // would silently describe different layouts.
+    assert_eq!(
+        ISO_K3_GROUP_SIZE, ISO_QUAT_BLOCK_SIZE,
+        "the iso3 alias must track the quaternion block size"
+    );
+    assert_eq!(
+        ISO_K4_GROUP_SIZE, ISO_QUAT_BLOCK_SIZE,
+        "the iso4 alias must track the quaternion block size"
+    );
+    assert_eq!(
+        ISO_QUAT_BLOCK_SIZE, 4,
+        "a quaternion has 4 components — this is algebra, not a tunable"
+    );
+    // The rule the whole ring stride rests on.
+    assert_eq!(iso_n_groups_for(128), 32, "D=128 -> 32 quaternion blocks");
+    assert_eq!(iso_n_groups_for(256), 64, "D=256 -> 64 quaternion blocks");
 }
 
 // ── Probe-snapshot drift guards ───────────────────────────────────────────────

--- a/crates/rmlx-kv-quant/src/kvcache/decode_grow_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/decode_grow_tests.rs
@@ -15,7 +15,7 @@
 //!
 //! # Why the rotor K-only codec
 //!
-//! It is the codec whose ring reports the overflow **loudly** (`RotorGpuK::
+//! It is the codec whose ring reports the overflow **loudly** (`QuantKGpuRing::
 //! append_encoded` errors), so a regression here is unambiguous rather than a
 //! silently short attention prefix. The growth itself is model-agnostic and
 //! lives on the shared storage `max_seq`, not in this codec.

--- a/crates/rmlx-kv-quant/src/kvcache/fused_qk_dispatch.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/fused_qk_dispatch.rs
@@ -1,9 +1,11 @@
 // Production fused-QK dispatch using the head-major persistent K shadow.
 //
 // Enables the 6 rotor variants (Rotor3Sym, Rotor4Sym, RotorKOnly3,
-// RotorKOnly4, RotorKAsym{3,4}) on the fused-QK fast path via the
-// per-token + sideband-table array split. Iso variants remain held until
-// their K-side GPU encoder ships.
+// RotorKOnly4, RotorKAsym{3,4}) and the 4 iso variants (Iso3Sym, Iso4Sym,
+// IsoKOnly3, IsoKOnly4) on the fused-QK fast path via the per-token +
+// sideband-table array split. Iso carries the per-token norm sideband but no
+// rotor table — its rotation is one fixed quaternion baked into the kernel
+// header.
 //
 // Wires the fused-QK MSL kernel families (q8 = K8V*, TurboSym3, TurboSym4,
 // Rotor3Sym, Rotor4Sym, …) into the production decode path.
@@ -48,6 +50,7 @@ use crate::q8_msl::q8_quantize_gpu;
 use crate::rotor_fused_qk_msl::{rotor3_fused_qk_sdpa, rotor4_fused_qk_sdpa};
 use crate::rotorquant::{n_groups_for, ROTOR3_BITS, ROTOR4_BITS};
 use crate::rotorquant_msl::{rotor_quantize_v3_gpu, rotor_quantize_v4_gpu, rotor_table_to_array};
+use crate::storage::{iso_n_groups_for, ISO_K3_BITS, ISO_K3_GROUP_SIZE, ISO_K4_BITS};
 use crate::turbo_k3_fused_qk_msl::turbo_k3_fused_qk_sdpa;
 use crate::turbo_k4_fused_qk_msl::turbo_k4_fused_qk_sdpa;
 use crate::turboquant_msl::turbo_quantize_v4_gpu;
@@ -695,8 +698,12 @@ fn codec_is_rotor(codec: KvQuant) -> bool {
     )
 }
 
-/// Whether the codec has a GPU encoder wired in for the fused-QK shadow
-/// path. Iso variants remain HOLD until their K-side GPU encoders ship.
+/// Whether the codec has a GPU encoder wired in for the fused-QK shadow path.
+///
+/// Every codec listed here must have a matching arm in
+/// [`encode_chunk_to_head_major`] — the two lists are the same fact stated
+/// twice, and a codec in one but not the other either errors at encode or
+/// silently sits on the legacy path.
 fn codec_has_gpu_encoder(codec: KvQuant) -> bool {
     matches!(
         codec,
@@ -704,6 +711,10 @@ fn codec_has_gpu_encoder(codec: KvQuant) -> bool {
             | KvQuant::K8V8
             | KvQuant::TurboSym3
             | KvQuant::TurboSym4
+            | KvQuant::Iso3Sym
+            | KvQuant::Iso4Sym
+            | KvQuant::IsoKOnly3
+            | KvQuant::IsoKOnly4
             | KvQuant::Rotor3Sym
             | KvQuant::Rotor4Sym
             | KvQuant::RotorKOnly3
@@ -843,6 +854,12 @@ fn encode_chunk_to_head_major(
                 norms: None,
             })
         }
+        KvQuant::Iso3Sym | KvQuant::IsoKOnly3 => {
+            encode_chunk_iso(k_f32, b, kv_h, n, d, layout, ISO_K3_BITS, device)
+        }
+        KvQuant::Iso4Sym | KvQuant::IsoKOnly4 => {
+            encode_chunk_iso(k_f32, b, kv_h, n, d, layout, ISO_K4_BITS, device)
+        }
         KvQuant::Rotor3Sym | KvQuant::RotorKOnly3 | KvQuant::RotorK3Asym { .. } => {
             encode_chunk_rotor(
                 k_f32,
@@ -873,6 +890,70 @@ fn encode_chunk_to_head_major(
             "fused_qk encode: codec {codec:?} HOLD — GPU encoder not yet wired"
         ))),
     }
+}
+
+/// Iso chunk encode. Calls the K-side GPU quantize kernel and reshapes the flat
+/// `[n_tokens * n_groups]` outputs into the per-token head-major slabs the
+/// shadow stores. The per-token norm is extracted as the first group's norm
+/// slot, the same convention [`encode_chunk_rotor`] uses.
+///
+/// No rotor-table sideband: iso rotates every group by the same fixed
+/// golden-ratio quaternion, which the kernel header bakes in.
+///
+/// `bits` is selected explicitly by the caller; there is no default arm, so a
+/// width with no kernel errors rather than encoding through the other's.
+#[allow(clippy::too_many_arguments)]
+fn encode_chunk_iso(
+    k_f32: &Array,
+    b: i32,
+    kv_h: i32,
+    n: i32,
+    d: i32,
+    layout: crate::kvcache::fused_qk_shadow::FusedQkLayout,
+    bits: u8,
+    device: Device,
+) -> Result<ChunkEncoded> {
+    let d_usize = usize::try_from(d)
+        .map_err(|_| Error::Mlx(format!("fused_qk iso encode: negative head_dim={d}")))?;
+    if !d_usize.is_multiple_of(ISO_K3_GROUP_SIZE) {
+        return Err(Error::Mlx(format!(
+            "fused_qk iso encode: head_dim={d} must be a multiple of the quaternion block \
+             size {ISO_K3_GROUP_SIZE}"
+        )));
+    }
+    let n_groups = iso_n_groups_for(d_usize);
+    let n_groups_i32 = i32::try_from(n_groups).map_err(|_| {
+        Error::Mlx(format!(
+            "fused_qk iso encode: n_groups {n_groups} overflows"
+        ))
+    })?;
+
+    let (codes_flat, scales_flat, _quats, norms_flat) = match bits {
+        ISO_K3_BITS => crate::isoquant_msl::iso_quantize_v3_gpu(k_f32, d_usize, device)?,
+        ISO_K4_BITS => crate::isoquant_msl_v4::iso_quantize_v4_gpu(k_f32, d_usize, device)?,
+        other => {
+            return Err(Error::Mlx(format!(
+                "fused_qk iso encode: unsupported bits={other} (only 3 and 4); refusing to \
+                 encode with another width's kernel"
+            )))
+        }
+    };
+
+    // codes_flat / scales_flat shape: [n_tokens * n_groups]. Reshape to
+    // head-major — one u32 word per quaternion block at both bit widths.
+    let codes_4d = codes_flat.reshape(&[b, kv_h, n, n_groups_i32], device)?;
+    let scales_4d = scales_flat.reshape(&[b, kv_h, n, n_groups_i32], device)?;
+    // norms_flat is per-group; deduplicate to per-token by slicing the first
+    // slot of each token's group-tuple.
+    let norms_per_group = norms_flat.reshape(&[b, kv_h, n, n_groups_i32], device)?;
+    let norms_4d =
+        norms_per_group.slice(&[0_i32, 0, 0, 0], &[b, kv_h, n, 1], &[1_i32; 4], device)?;
+    assert_layout(layout, n_groups_i32, n_groups_i32)?;
+    Ok(ChunkEncoded {
+        codes: codes_4d,
+        scales: scales_4d,
+        norms: Some(norms_4d),
+    })
 }
 
 /// Rotor chunk encode. Calls the K-side GPU quantize kernel and reshapes

--- a/crates/rmlx-kv-quant/src/kvcache/fused_qk_dispatch.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/fused_qk_dispatch.rs
@@ -50,7 +50,7 @@ use crate::q8_msl::q8_quantize_gpu;
 use crate::rotor_fused_qk_msl::{rotor3_fused_qk_sdpa, rotor4_fused_qk_sdpa};
 use crate::rotorquant::{n_groups_for, ROTOR3_BITS, ROTOR4_BITS};
 use crate::rotorquant_msl::{rotor_quantize_v3_gpu, rotor_quantize_v4_gpu, rotor_table_to_array};
-use crate::storage::{iso_n_groups_for, ISO_K3_BITS, ISO_K3_GROUP_SIZE, ISO_K4_BITS};
+use crate::storage::{iso_n_groups_for, ISO_K3_BITS, ISO_K4_BITS, ISO_QUAT_BLOCK_SIZE};
 use crate::turbo_k3_fused_qk_msl::turbo_k3_fused_qk_sdpa;
 use crate::turbo_k4_fused_qk_msl::turbo_k4_fused_qk_sdpa;
 use crate::turboquant_msl::turbo_quantize_v4_gpu;
@@ -915,10 +915,10 @@ fn encode_chunk_iso(
 ) -> Result<ChunkEncoded> {
     let d_usize = usize::try_from(d)
         .map_err(|_| Error::Mlx(format!("fused_qk iso encode: negative head_dim={d}")))?;
-    if !d_usize.is_multiple_of(ISO_K3_GROUP_SIZE) {
+    if !d_usize.is_multiple_of(ISO_QUAT_BLOCK_SIZE) {
         return Err(Error::Mlx(format!(
             "fused_qk iso encode: head_dim={d} must be a multiple of the quaternion block \
-             size {ISO_K3_GROUP_SIZE}"
+             size {ISO_QUAT_BLOCK_SIZE}"
         )));
     }
     let n_groups = iso_n_groups_for(d_usize);

--- a/crates/rmlx-kv-quant/src/kvcache/fused_qk_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/fused_qk_dispatch_tests.rs
@@ -10,6 +10,7 @@
     clippy::float_cmp
 )]
 
+use super::{codec_has_gpu_encoder, lookup_fused_qk_kernel};
 use crate::kvcache::fused_qk_shadow::FusedQkLayout;
 use crate::kvcache::fused_qk_total_dispatch_count;
 use crate::KvQuant;
@@ -69,21 +70,73 @@ fn fused_qk_layout_turbo_sym4_head_dim_128() {
 }
 
 #[test]
-fn fused_qk_layout_returns_none_for_iso_codecs() {
-    // Iso codecs remain held until their K-side GPU encoder ships.
-    // The shadow supports the layout (sideband norms) but the dispatch
-    // site has no encoder to populate them. `for_codec` returns `Ok(None)`
-    // for iso; dispatch falls through to the legacy bf16 SDPA path.
+fn fused_qk_layout_iso_codecs_head_dim_128() {
+    // All four iso variants share one K-side layout: one u32 word and one f32
+    // scale per quaternion block (head_dim / 4 = 32 at D=128), plus the
+    // per-token L2 norm sideband. No rotor table — iso's rotation is a single
+    // fixed quaternion baked into the kernel header, so `n_groups` (which sizes
+    // that table) stays 0.
     for codec in [
         KvQuant::Iso3Sym,
         KvQuant::IsoKOnly3,
         KvQuant::Iso4Sym,
         KvQuant::IsoKOnly4,
     ] {
-        let r = FusedQkLayout::for_codec(codec, 128).expect("Ok result");
+        let l = FusedQkLayout::for_codec(codec, 128)
+            .expect("layout result")
+            .unwrap_or_else(|| panic!("{codec:?} has a fused-QK entry"));
+        assert_eq!(l.codes_per_token, 32, "{codec:?}: codes = head_dim / 4");
+        assert_eq!(l.scales_per_token, 32, "{codec:?}: scales = head_dim / 4");
+        assert!(l.has_norm, "{codec:?}: iso carries a per-token L2 norm");
         assert!(
-            r.is_none(),
-            "FusedQkLayout::for_codec({codec:?}) must return None — iso encoder followup"
+            !l.has_rotor_table,
+            "{codec:?}: iso has no rotor table — its quaternion is fixed"
+        );
+        assert_eq!(
+            l.n_groups, 0,
+            "{codec:?}: n_groups sizes the rotor table only"
+        );
+    }
+}
+
+#[test]
+fn fused_qk_layout_iso_rejects_head_dim_off_the_quaternion_block() {
+    // A head_dim that is not a multiple of 4 would drop a partial trailing
+    // quaternion block. That must error rather than silently round down.
+    for codec in [KvQuant::Iso3Sym, KvQuant::IsoKOnly4] {
+        assert!(
+            FusedQkLayout::for_codec(codec, 130).is_err(),
+            "{codec:?}: head_dim=130 is not a whole number of quaternion blocks"
+        );
+    }
+}
+
+#[test]
+fn fused_qk_encoder_coverage_matches_the_kernel_table() {
+    // `codec_has_gpu_encoder` and `lookup_fused_qk_kernel` are the same fact
+    // stated twice. A codec with a kernel but no encoder silently sits on the
+    // legacy path; one with an encoder but no kernel errors at dispatch.
+    for codec in [
+        KvQuant::K8V4,
+        KvQuant::K8V8,
+        KvQuant::TurboSym3,
+        KvQuant::TurboSym4,
+        KvQuant::Iso3Sym,
+        KvQuant::Iso4Sym,
+        KvQuant::IsoKOnly3,
+        KvQuant::IsoKOnly4,
+        KvQuant::Rotor3Sym,
+        KvQuant::Rotor4Sym,
+        KvQuant::RotorKOnly3,
+        KvQuant::RotorKOnly4,
+    ] {
+        assert!(
+            codec_has_gpu_encoder(codec),
+            "{codec:?} has a fused-QK kernel, so it must have a GPU encoder too"
+        );
+        assert!(
+            lookup_fused_qk_kernel(codec).is_some(),
+            "{codec:?} has a GPU encoder, so it must have a fused-QK kernel too"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/kvcache/fused_qk_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/fused_qk_dispatch_tests.rs
@@ -111,32 +111,127 @@ fn fused_qk_layout_iso_rejects_head_dim_off_the_quaternion_block() {
     }
 }
 
+/// Every [`KvQuant`] variant, with representative parameters for the
+/// parameterised ones.
+///
+/// Pinned to the enum by [`assert_kv_quant_exhaustive`] below — a new variant
+/// fails to compile until it is added here, which is what makes the coverage
+/// test below able to catch an **omission**. A hand-maintained list on its own
+/// cannot: the drift it exists to catch is a codec nobody remembered to list.
+const ALL_KV_QUANTS: &[KvQuant] = &[
+    KvQuant::K8V4,
+    KvQuant::K8V8,
+    KvQuant::Planar,
+    KvQuant::None,
+    KvQuant::Mixed {
+        k_bits: 8,
+        v_bits: 4,
+        k_group_size: 64,
+        v_group_size: 64,
+    },
+    KvQuant::RotK {
+        v_bits: 4,
+        v_group_size: 64,
+    },
+    KvQuant::RotKTq4V,
+    KvQuant::K8VTurbo3,
+    KvQuant::TurboSym3,
+    KvQuant::TurboSym4,
+    KvQuant::Planar3,
+    KvQuant::PlanarK,
+    KvQuant::K8VTurbo2,
+    KvQuant::Iso3,
+    KvQuant::Iso4,
+    KvQuant::Iso3Sym,
+    KvQuant::Iso4Sym,
+    KvQuant::IsoKOnly3,
+    KvQuant::IsoKOnly4,
+    KvQuant::Rotor3,
+    KvQuant::Rotor4,
+    KvQuant::K8VTurbo3Tcq,
+    KvQuant::Rotor3Sym,
+    KvQuant::Rotor4Sym,
+    KvQuant::RotorKOnly3,
+    KvQuant::RotorKOnly4,
+    KvQuant::RotorK3Asym {
+        v_bits: 4,
+        v_group_size: 64,
+    },
+    KvQuant::RotorK4Asym {
+        v_bits: 4,
+        v_group_size: 64,
+    },
+    KvQuant::K8VTurbo2Tcq,
+];
+
+/// Compile-time pin: this match is exhaustive, so adding a [`KvQuant`] variant
+/// breaks the build here until the author also adds it to [`ALL_KV_QUANTS`].
+/// Never called — the type check is the whole point.
+#[allow(dead_code, reason = "compile-time exhaustiveness pin, never invoked")]
+fn assert_kv_quant_exhaustive(q: KvQuant) {
+    match q {
+        KvQuant::K8V4
+        | KvQuant::K8V8
+        | KvQuant::Planar
+        | KvQuant::None
+        | KvQuant::Mixed { .. }
+        | KvQuant::RotK { .. }
+        | KvQuant::RotKTq4V
+        | KvQuant::K8VTurbo3
+        | KvQuant::TurboSym3
+        | KvQuant::TurboSym4
+        | KvQuant::Planar3
+        | KvQuant::PlanarK
+        | KvQuant::K8VTurbo2
+        | KvQuant::Iso3
+        | KvQuant::Iso4
+        | KvQuant::Iso3Sym
+        | KvQuant::Iso4Sym
+        | KvQuant::IsoKOnly3
+        | KvQuant::IsoKOnly4
+        | KvQuant::Rotor3
+        | KvQuant::Rotor4
+        | KvQuant::K8VTurbo3Tcq
+        | KvQuant::Rotor3Sym
+        | KvQuant::Rotor4Sym
+        | KvQuant::RotorKOnly3
+        | KvQuant::RotorKOnly4
+        | KvQuant::RotorK3Asym { .. }
+        | KvQuant::RotorK4Asym { .. }
+        | KvQuant::K8VTurbo2Tcq => (),
+    }
+}
+
+#[test]
+fn all_kv_quants_list_covers_every_variant() {
+    // Guards the guard: the exhaustive match above forces an author to touch
+    // this file, but only a count check notices if they touch the match and
+    // forget the list.
+    assert_eq!(
+        ALL_KV_QUANTS.len(),
+        29,
+        "ALL_KV_QUANTS must list every KvQuant variant — update it (and this count) \
+         when a variant is added or removed"
+    );
+}
+
 #[test]
 fn fused_qk_encoder_coverage_matches_the_kernel_table() {
     // `codec_has_gpu_encoder` and `lookup_fused_qk_kernel` are the same fact
     // stated twice. A codec with a kernel but no encoder silently sits on the
     // legacy path; one with an encoder but no kernel errors at dispatch.
-    for codec in [
-        KvQuant::K8V4,
-        KvQuant::K8V8,
-        KvQuant::TurboSym3,
-        KvQuant::TurboSym4,
-        KvQuant::Iso3Sym,
-        KvQuant::Iso4Sym,
-        KvQuant::IsoKOnly3,
-        KvQuant::IsoKOnly4,
-        KvQuant::Rotor3Sym,
-        KvQuant::Rotor4Sym,
-        KvQuant::RotorKOnly3,
-        KvQuant::RotorKOnly4,
-    ] {
-        assert!(
+    //
+    // Asserted as a **biconditional over every variant**, not over a list of
+    // the codecs already known to agree: the failure this exists to catch is a
+    // codec present in one table and absent from the other, and a hand-picked
+    // list would simply not mention it. (Iso was in exactly that state before
+    // the flash-decode kernel landed.)
+    for &codec in ALL_KV_QUANTS {
+        assert_eq!(
             codec_has_gpu_encoder(codec),
-            "{codec:?} has a fused-QK kernel, so it must have a GPU encoder too"
-        );
-        assert!(
             lookup_fused_qk_kernel(codec).is_some(),
-            "{codec:?} has a GPU encoder, so it must have a fused-QK kernel too"
+            "{codec:?}: encoder coverage and kernel table disagree — a codec must be in \
+             both or neither"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/kvcache/fused_qk_shadow.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/fused_qk_shadow.rs
@@ -45,7 +45,7 @@ use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{zeros, Array, Device, Dtype};
 
 use crate::q8_msl::Q8_GROUP_SIZE;
-use crate::storage::ISO_K3_GROUP_SIZE;
+use crate::storage::ISO_QUAT_BLOCK_SIZE;
 use crate::turboquant::GROUP_SIZE as TURBO_GROUP_SIZE;
 use crate::KvQuant;
 
@@ -148,13 +148,13 @@ impl FusedQkLayout {
             // per token. No rotor table — iso rotates every group by the same
             // fixed golden-ratio quaternion, which the kernel header bakes in.
             KvQuant::Iso3Sym | KvQuant::IsoKOnly3 | KvQuant::Iso4Sym | KvQuant::IsoKOnly4 => {
-                if !hd.is_multiple_of(ISO_K3_GROUP_SIZE) {
+                if !hd.is_multiple_of(ISO_QUAT_BLOCK_SIZE) {
                     return Err(Error::Quant(format!(
                         "FusedQkLayout(iso): head_dim={head_dim} must be a multiple of \
-                         ISO_K3_GROUP_SIZE={ISO_K3_GROUP_SIZE}"
+                         ISO_QUAT_BLOCK_SIZE={ISO_QUAT_BLOCK_SIZE}"
                     )));
                 }
-                let n_groups = head_dim / ISO_K3_GROUP_SIZE as i32;
+                let n_groups = head_dim / ISO_QUAT_BLOCK_SIZE as i32;
                 Self {
                     codes_per_token: n_groups,
                     scales_per_token: n_groups,

--- a/crates/rmlx-kv-quant/src/kvcache/fused_qk_shadow.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/fused_qk_shadow.rs
@@ -45,6 +45,7 @@ use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{zeros, Array, Device, Dtype};
 
 use crate::q8_msl::Q8_GROUP_SIZE;
+use crate::storage::ISO_K3_GROUP_SIZE;
 use crate::turboquant::GROUP_SIZE as TURBO_GROUP_SIZE;
 use crate::KvQuant;
 
@@ -142,19 +143,25 @@ impl FusedQkLayout {
                     n_groups: 0,
                 }
             }
-            // Iso3 / Iso4: codes = head_dim/4 u32, scales = head_dim/4 f32,
-            // plus 1 norm per token. The kernel shim expects
-            // `[scales_all | norms_all]` flat — the dispatch layer
-            // assembles that by concatenating the per-token scales
-            // (sliced to `kv_seq`) with the per-token norms.
-            //
-            // Iso variants are still gated off at `for_codec` until iso's
-            // K-side GPU encoder lands. The shadow can hold the layout but
-            // the dispatch site does not have a populated encoder for iso
-            // yet. Only the rotor variants below are enabled.
+            // Iso3 / Iso4: codes = head_dim/4 u32 (one word per quaternion
+            // block, both bit widths), scales = head_dim/4 f32, plus 1 norm
+            // per token. No rotor table — iso rotates every group by the same
+            // fixed golden-ratio quaternion, which the kernel header bakes in.
             KvQuant::Iso3Sym | KvQuant::IsoKOnly3 | KvQuant::Iso4Sym | KvQuant::IsoKOnly4 => {
-                warn_iso_hold_once(codec);
-                return Ok(None);
+                if !hd.is_multiple_of(ISO_K3_GROUP_SIZE) {
+                    return Err(Error::Quant(format!(
+                        "FusedQkLayout(iso): head_dim={head_dim} must be a multiple of \
+                         ISO_K3_GROUP_SIZE={ISO_K3_GROUP_SIZE}"
+                    )));
+                }
+                let n_groups = head_dim / ISO_K3_GROUP_SIZE as i32;
+                Self {
+                    codes_per_token: n_groups,
+                    scales_per_token: n_groups,
+                    has_norm: true,
+                    has_rotor_table: false,
+                    n_groups: 0,
+                }
             }
             // Rotor3 / Rotor4 (Sym + K-only + Asym): codes = ceil(head_dim/3)
             // u32, scales = ceil(head_dim/3) f32, 1 norm per token,
@@ -195,20 +202,6 @@ impl FusedQkLayout {
         };
         Ok(Some(layout))
     }
-}
-
-/// Emit a one-shot `tracing::warn!` when an iso codec hits the fused-QK
-/// shadow path. Iso remains held until its K-side GPU encoder ships.
-fn warn_iso_hold_once(codec: KvQuant) {
-    use std::sync::OnceLock;
-    static WARNED: OnceLock<()> = OnceLock::new();
-    WARNED.get_or_init(|| {
-        tracing::warn!(
-            ?codec,
-            "fused-QK: iso codec not yet enabled in the per-token shadow path \
-             (iso K-side GPU encoder followup); falling back to legacy bf16 SDPA"
-        );
-    });
 }
 
 /// Head-major persistent fused-QK K-side shadow buffer.

--- a/crates/rmlx-kv-quant/src/kvcache/iso_flash_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/iso_flash_dispatch_tests.rs
@@ -1,0 +1,323 @@
+//! Production-path dispatch tests for the iso flash-decode kernel.
+//!
+//! The oracle tests in `iso_flash_decode_msl_tests.rs` prove the kernel is
+//! numerically right when called **directly**, with hand-built arrays. These
+//! prove the thing that actually matters in production: that
+//! `KvCache::update_and_sdpa` **reaches** it on an iso K-only cache, instead of
+//! silently falling through to the O(seq) CPU dequant path the kernel exists to
+//! remove — and that the ring bookkeeping around it (seed / grow / feed / skip)
+//! holds. That growth-and-seed logic is exactly what carried the rotor ring's
+//! frozen-`max_seq` defect, and a direct-call oracle cannot see any of it.
+//!
+//! Sibling of `rotor_flash_dispatch_tests.rs`.
+//!
+//! # No env dependence
+//!
+//! Iso has no QJL sideband and no CLI/env gate, so unlike the rotor siblings
+//! these tests need no toggle-pinning: the path is on whenever it is applicable.
+
+use super::KvCache;
+use crate::iso_flash_decode_msl::iso_flash_decode_dispatch_count;
+use crate::quant::KvQuant;
+use crate::storage::{KvStorage, QuantIsoK3, QuantIsoK4};
+use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
+use rmlx_mlx::{Array, Device, Dtype};
+
+const MAX_SEQ: i32 = 512;
+
+/// What one `run_decode_steps` call observed.
+struct DecodeProbe {
+    /// Dispatch-count delta across the decode steps.
+    ///
+    /// The counter is process-global, so a concurrent test can only ever
+    /// *inflate* this — `>=` assertions on it are race-free, `== 0` ones are
+    /// not. Use `gpu_ring_live` for the negative case.
+    delta: u64,
+    /// Whether the iso store's GPU ring is live at the end of the run.
+    ///
+    /// Local to this cache, so unlike `delta` it is immune to other tests. The
+    /// flash path cannot run without the ring, so `!gpu_ring_live` is a
+    /// race-free proof that decode stayed on the CPU dequant path.
+    gpu_ring_live: bool,
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn f32_array(data: &[f32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::F32).expect("f32_array")
+}
+
+/// Build an empty iso K-only cache.
+fn iso_cache(quant: KvQuant, kv_h: i32, head_dim: i32) -> KvCache {
+    iso_cache_b(quant, 1, kv_h, head_dim)
+}
+
+/// [`iso_cache`] with an explicit batch dimension.
+fn iso_cache_b(quant: KvQuant, b: i32, kv_h: i32, head_dim: i32) -> KvCache {
+    let shape = vec![b, kv_h, 0, head_dim];
+    let storage = if quant == KvQuant::IsoKOnly4 {
+        KvStorage::IsoKOnly4 {
+            k: Some(QuantIsoK4::from_cpu_blocks(Vec::new(), shape, MAX_SEQ)),
+            max_seq: MAX_SEQ,
+        }
+    } else {
+        KvStorage::IsoKOnly3 {
+            k: Some(QuantIsoK3::from_cpu_blocks(Vec::new(), shape, MAX_SEQ)),
+            max_seq: MAX_SEQ,
+        }
+    };
+    KvCache::from_storage(storage, quant, 0, 0)
+}
+
+/// Whether the cache's iso store currently holds a live GPU ring.
+fn ring_live(cache: &KvCache) -> bool {
+    if let KvStorage::IsoKOnly3 { k: Some(ks), .. } = cache.storage() {
+        ks.gpu.is_allocated()
+    } else if let KvStorage::IsoKOnly4 { k: Some(ks), .. } = cache.storage() {
+        ks.gpu.is_allocated()
+    } else {
+        false
+    }
+}
+
+/// Drive one prefill chunk + 4 decode steps through the production
+/// `update_and_sdpa` entry point.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn run_decode_steps(
+    quant: KvQuant,
+    kv_h: i32,
+    n_q_heads: i32,
+    head_dim: i32,
+    prefill: i32,
+) -> DecodeProbe {
+    let device = Device::Gpu;
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+    let mut cache = iso_cache(quant, kv_h, head_dim);
+
+    // Prefill chunk (q_seq > 1): the flash path is decode-only, so this goes
+    // through the legacy path and leaves an accumulated prefix behind —
+    // exactly the state the first decode step must seed the GPU ring from.
+    let pf = (prefill * kv_h * head_dim) as usize;
+    let k = f32_array(&lcg_data(pf, 1), &[1, kv_h, prefill, head_dim]);
+    let v = f32_array(&lcg_data(pf, 2), &[1, kv_h, prefill, head_dim]);
+    let q = f32_array(
+        &lcg_data((prefill * n_q_heads * head_dim) as usize, 3),
+        &[1, n_q_heads, prefill, head_dim],
+    );
+    cache
+        .update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+        .expect("prefill update_and_sdpa");
+    cache.exit_prefill(device).expect("exit_prefill");
+
+    let before = iso_flash_decode_dispatch_count();
+    for step in 0..4_u64 {
+        let one = (kv_h * head_dim) as usize;
+        let k1 = f32_array(&lcg_data(one, 10 + step), &[1, kv_h, 1, head_dim]);
+        let v1 = f32_array(&lcg_data(one, 20 + step), &[1, kv_h, 1, head_dim]);
+        let q1 = f32_array(
+            &lcg_data((n_q_heads * head_dim) as usize, 30 + step),
+            &[1, n_q_heads, 1, head_dim],
+        );
+        let out = cache
+            .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .expect("decode update_and_sdpa");
+        out.eval().expect("decode out eval");
+        assert_eq!(
+            out.shape(),
+            vec![1, n_q_heads, 1, head_dim],
+            "decode output shape"
+        );
+    }
+    let delta = iso_flash_decode_dispatch_count() - before;
+    let gpu_ring_live = ring_live(&cache);
+    DecodeProbe {
+        delta,
+        gpu_ring_live,
+    }
+}
+
+// ── The kernel is reached from the production entry point ─────────────────────
+
+#[test]
+fn iso_k_only_3_decode_dispatches_flash_kernel() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let probe = run_decode_steps(KvQuant::IsoKOnly3, 2, 8, 128, 24);
+    assert!(
+        probe.delta >= 4,
+        "iso3 decode did not dispatch the flash kernel (delta={}) — it fell through \
+         to the CPU dequant path",
+        probe.delta
+    );
+    assert!(probe.gpu_ring_live, "iso3: the GPU ring must be live");
+}
+
+#[test]
+fn iso_k_only_4_decode_dispatches_flash_kernel() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let probe = run_decode_steps(KvQuant::IsoKOnly4, 2, 8, 128, 24);
+    assert!(
+        probe.delta >= 4,
+        "iso4 decode did not dispatch the flash kernel (delta={})",
+        probe.delta
+    );
+    assert!(probe.gpu_ring_live, "iso4: the GPU ring must be live");
+}
+
+#[test]
+fn iso_k_only_decode_dispatches_across_a_tile_boundary() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    // Prefill 62 + 4 decode steps crosses TILE_SIZE (64), so the ring grows and
+    // the P2 log-sum-exp merge runs over more than one tile.
+    let probe = run_decode_steps(KvQuant::IsoKOnly3, 2, 8, 128, 62);
+    assert!(
+        probe.delta >= 4,
+        "tile-boundary decode did not dispatch (delta={})",
+        probe.delta
+    );
+}
+
+#[test]
+fn iso_k_only_decode_dispatches_at_head_dim_256() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    // Gemma3-class shape. The kernel keys off shape, not arch.
+    let probe = run_decode_steps(KvQuant::IsoKOnly3, 4, 8, 256, 24);
+    assert!(
+        probe.delta >= 4,
+        "head_dim=256 decode did not dispatch (delta={})",
+        probe.delta
+    );
+}
+
+// ── Ring feed: b > 1 skips rather than errors ─────────────────────────────────
+
+/// `b > 1` must skip the ring feed, not attempt (and fail) it.
+///
+/// `QuantKGpuRing`'s per-step stride is `kv_h * n_groups` and does not interleave
+/// batch, so a batched chunk cannot be laid into it: the encode arrays carry
+/// `b * kv_h * new_seq * n_groups` entries against a `new_seq * kv_h * n_groups`
+/// span. Attempting it returns `Err` and kills the request, where the CPU blocks
+/// (which handle `b > 1`) would have served it fine.
+fn batched_ring_feed_is_skipped(quant: KvQuant, bits_label: &str) {
+    let device = Device::Gpu;
+    let (b, kv_h, head_dim, new_seq) = (2_i32, 2_i32, 128_i32, 4_i32);
+    let mut cache = iso_cache_b(quant, b, kv_h, head_dim);
+    let shape = [b, kv_h, new_seq, head_dim];
+    let k = f32_array(
+        &lcg_data((b * kv_h * new_seq * head_dim) as usize, 7),
+        &shape,
+    );
+
+    let res = if quant == KvQuant::IsoKOnly4 {
+        super::update::iso4_k_only_gpu_append(&mut cache, &k, &shape, device)
+    } else {
+        super::update::iso3_k_only_gpu_append(&mut cache, &k, &shape, device)
+    };
+    res.unwrap_or_else(|e| {
+        panic!("{bits_label}: batched GPU append must not error, got: {e}");
+    });
+
+    assert!(
+        !ring_live(&cache),
+        "{bits_label}: a b>1 cache must not carry a ring — the stride cannot represent it"
+    );
+}
+
+#[test]
+fn iso3_batched_gpu_append_skips_the_ring_instead_of_erroring() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    batched_ring_feed_is_skipped(KvQuant::IsoKOnly3, "iso3");
+}
+
+#[test]
+fn iso4_batched_gpu_append_skips_the_ring_instead_of_erroring() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    batched_ring_feed_is_skipped(KvQuant::IsoKOnly4, "iso4");
+}
+
+// ── Ring invariant: a CPU append must drop a live ring ────────────────────────
+
+/// A CPU `append` after a GPU append must **drop** the ring, not leave it short.
+///
+/// The invariant (see `RingFeed`): the ring either tracks `blocks` exactly, or
+/// it does not exist. A CPU append grows `blocks` and `shape[2]` without
+/// touching the ring, so leaving the ring live is the dangerous state — the next
+/// `gpu_append` takes `prev_seq` from the longer `shape` and writes past the
+/// ring's filled region, leaving `[ring_filled, prev_seq)` zeroed. The kernel
+/// then attends a zero-filled hole with **no error**.
+///
+/// Reachable in production: `update_iso_k_only_{3,4}` / `update_iso{3,4}_sym`
+/// take `ks.append(..)` on the `device != Gpu` branch while the fused decode
+/// entry feeds with `RingFeed::Maintain`, so a Gpu→Cpu→Gpu sequence on one cache
+/// hits it. The field is `pub`, so the store cannot rely on its callers either.
+fn cpu_append_drops_a_live_ring(quant: KvQuant, bits_label: &str) {
+    let device = Device::Gpu;
+    let (kv_h, head_dim, new_seq) = (2_i32, 128_i32, 4_i32);
+    let mut cache = iso_cache(quant, kv_h, head_dim);
+    let shape = [1_i32, kv_h, new_seq, head_dim];
+    let n = (kv_h * new_seq * head_dim) as usize;
+    let k = f32_array(&lcg_data(n, 11), &shape);
+
+    // 1. GPU append -> ring live.
+    if quant == KvQuant::IsoKOnly4 {
+        super::update::iso4_k_only_gpu_append(&mut cache, &k, &shape, device)
+    } else {
+        super::update::iso3_k_only_gpu_append(&mut cache, &k, &shape, device)
+    }
+    .unwrap_or_else(|e| panic!("{bits_label}: gpu_append: {e}"));
+    assert!(
+        ring_live(&cache),
+        "{bits_label}: precondition — the GPU append must leave a live ring, else this \
+         test proves nothing"
+    );
+
+    // 2. CPU append on the same store.
+    let cpu_data = lcg_data(n, 12);
+    #[allow(
+        clippy::wildcard_enum_match_arm,
+        reason = "the wildcard arm panics — it never selects another codec's store, and \
+                  `iso_cache` built this one, so reaching it is a broken test invariant \
+                  rather than a variant that needs handling"
+    )]
+    match &mut cache.storage {
+        KvStorage::IsoKOnly3 { k: Some(ks), .. } => ks.append(&cpu_data, &shape),
+        KvStorage::IsoKOnly4 { k: Some(ks), .. } => ks.append(&cpu_data, &shape),
+        _ => panic!("{bits_label}: store vanished"),
+    }
+    .unwrap_or_else(|e| panic!("{bits_label}: cpu append: {e}"));
+
+    // 3. The ring must be gone — it no longer tracks `blocks`.
+    assert!(
+        !ring_live(&cache),
+        "{bits_label}: a CPU append left a live GPU ring behind. `blocks` and `shape[2]` \
+         grew but the ring did not, so the next gpu_append writes past its filled region \
+         and the kernel silently attends a zero-filled hole."
+    );
+}
+
+#[test]
+fn iso3_cpu_append_drops_a_live_gpu_ring() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    cpu_append_drops_a_live_ring(KvQuant::IsoKOnly3, "iso3");
+}
+
+#[test]
+fn iso4_cpu_append_drops_a_live_gpu_ring() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    cpu_append_drops_a_live_ring(KvQuant::IsoKOnly4, "iso4");
+}

--- a/crates/rmlx-kv-quant/src/kvcache/mod.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/mod.rs
@@ -104,6 +104,12 @@ mod windowed_ring_sizing_tests;
 #[path = "rotor_flash_dispatch_tests.rs"]
 mod rotor_flash_dispatch_tests;
 
+// Iso K-only flash-decode reaches the kernel from the production
+// `update_and_sdpa` entry point, and its ring bookkeeping holds.
+#[cfg(test)]
+#[path = "iso_flash_dispatch_tests.rs"]
+mod iso_flash_dispatch_tests;
+
 pub use core::KvCache;
 pub use fused_qk_dispatch::fused_qk_total_dispatch_count;
 pub use shared_kv::SharedKv;

--- a/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
@@ -215,7 +215,7 @@ fn rotor_k_only_decode_dispatches_at_head_dim_256() {
 
 /// `b > 1` must skip the ring feed, not attempt (and fail) it.
 ///
-/// `RotorGpuK`'s per-step stride is `kv_h * n_groups` and does not interleave
+/// `QuantKGpuRing`'s per-step stride is `kv_h * n_groups` and does not interleave
 /// batch, so a batched chunk cannot be laid into it: the encode arrays carry
 /// `b * kv_h * new_seq * n_groups` entries against a `new_seq * kv_h * n_groups`
 /// span. Attempting it returns `Err` and kills the request, where the CPU blocks

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -18,7 +18,7 @@ use crate::planar_flash_decode_msl::{planar_flash_decode_enabled, planar_flash_d
 use crate::planar_fused_qk::planar_fused_qk_enabled;
 use crate::planar_fused_qk_msl::planar_fused_qk;
 use crate::rotor_flash_decode_msl::{rotor_flash_decode_sdpa, ROTOR_FLASH_HEAD_DIM_MAX};
-use crate::storage::{KvStorage, ISO_K3_GROUP_SIZE};
+use crate::storage::{KvStorage, ISO_QUAT_BLOCK_SIZE};
 
 use super::helpers::{f32_vec_to_array, storage_variant_name};
 use super::shared_kv::SharedKv;
@@ -2213,7 +2213,7 @@ impl KvCache {
         }
         // One quaternion block per group — a partial trailing group has no
         // defined decode.
-        if !(head_dim as usize).is_multiple_of(ISO_K3_GROUP_SIZE) {
+        if !(head_dim as usize).is_multiple_of(ISO_QUAT_BLOCK_SIZE) {
             return false;
         }
         // Tree reduction over `head_dim` threads.

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -12,12 +12,13 @@ use rmlx_mlx::{
     add, dequantize, matmul, scaled_dot_product_attention, softmax_precise, Array, Device, Dtype,
 };
 
+use crate::iso_flash_decode_msl::{iso_flash_decode_sdpa, ISO_FLASH_HEAD_DIM_MAX};
 use crate::mixed_quant::{mixed_quantized_sdpa, rot_k_tq4v_sdpa};
 use crate::planar_flash_decode_msl::{planar_flash_decode_enabled, planar_flash_decode_sdpa};
 use crate::planar_fused_qk::planar_fused_qk_enabled;
 use crate::planar_fused_qk_msl::planar_fused_qk;
 use crate::rotor_flash_decode_msl::{rotor_flash_decode_sdpa, ROTOR_FLASH_HEAD_DIM_MAX};
-use crate::storage::KvStorage;
+use crate::storage::{KvStorage, ISO_K3_GROUP_SIZE};
 
 use super::helpers::{f32_vec_to_array, storage_variant_name};
 use super::shared_kv::SharedKv;
@@ -691,6 +692,42 @@ impl KvCache {
             }
         }
 
+        // 1d. Iso K-only flash-decode fast path. Same shape as the rotor arm
+        // above and for the same reason: without it this codec CPU-dequants the
+        // entire K prefix on every decode step (`QuantIsoK{3,4}::dequant()` →
+        // `Vec<f32>` → re-upload), which is O(seq) host work per token with the
+        // GPU idle. The kernel reads the packed iso ring directly instead.
+        //
+        // Iso has no QJL sideband — that is a rotor-only residual — so there is
+        // no equivalent gate here.
+        //
+        // The decode-only gate (q_seq == 1) is checked HERE, not in the helper:
+        // the helper mutates cache state (store append, bf16 V accumulate)
+        // before it knows whether it can complete the SDPA, so a late fallback
+        // would double-append.
+        if matches!(
+            self.storage,
+            KvStorage::IsoKOnly3 { .. } | KvStorage::IsoKOnly4 { .. }
+        ) && device == Device::Gpu
+            && queries.shape().get(2).copied().unwrap_or(0) == 1
+        {
+            if let Some(out) = self.update_and_sdpa_iso_k_fused(
+                queries,
+                new_k,
+                new_v,
+                scale,
+                additive_mask,
+                device,
+            )? {
+                tracing::trace!(
+                    kv_bytes = self.approx_bytes(),
+                    offset = self.offset,
+                    "kv cache bytes"
+                );
+                return Ok(out);
+            }
+        }
+
         // 2. K8V4 TurboFlash path (returns None when not eligible).
         if let Some(out) =
             self.sdpa_dispatch(queries, new_k, new_v, scale, additive_mask, device)?
@@ -705,11 +742,10 @@ impl KvCache {
             return Ok(out);
         }
 
-        // 2b. Head-major fused-QK shadow path (q8/turbo3/turbo4 today;
-        // iso/rotor are HOLD until GPU encoders ship). Decode-only,
-        // gated by `RMLX_FUSED_QK=1`. Returns `None` to fall through to the
-        // legacy bf16 SDPA path when any gate is off, when the codec has
-        // no GPU encoder yet, or when the bf16 mirror is not yet seeded
+        // 2b. Head-major fused-QK shadow path (q8/turbo3/turbo4/iso/rotor).
+        // Decode-only, gated by `RMLX_FUSED_QK=1`. Returns `None` to fall
+        // through to the legacy bf16 SDPA path when any gate is off, when the
+        // codec has no GPU encoder, or when the bf16 mirror is not yet seeded
         // (cold-prefill window).
         if let Some(out) =
             self.try_fused_qk_dispatch(queries, new_k, new_v, scale, additive_mask, device)?
@@ -998,6 +1034,35 @@ impl KvCache {
             }
         }
 
+        // Iso K-only flash-decode. Mirrors arm 1d of `update_and_sdpa`; without
+        // it a shared-KV model (Gemma4) would push this codec onto the legacy
+        // bf16 path and the kernel would be silently dead there.
+        if matches!(
+            self.storage,
+            KvStorage::IsoKOnly3 { .. } | KvStorage::IsoKOnly4 { .. }
+        ) && device == Device::Gpu
+            && q_seq_is_decode
+        {
+            if let Some(out) = self.update_and_sdpa_iso_k_fused(
+                queries,
+                new_k,
+                new_v,
+                scale,
+                additive_mask,
+                device,
+            )? {
+                tracing::debug!(
+                    target: "rmlx_kv_quant::shared_kv",
+                    kernel = "iso_flash",
+                    offset = self.offset,
+                    "fused kernel dispatched on the shared-KV producer path — \
+                     consumers attend the quant store"
+                );
+                let kv_len = iso_k_accumulated_seq(&self.storage)?;
+                return Ok(Some((out, kv_len)));
+            }
+        }
+
         Ok(None)
     }
 
@@ -1050,8 +1115,7 @@ impl KvCache {
             return Ok(Some((out, k_full, v_full)));
         }
 
-        // Head-major fused-QK shadow (q8/turbo3/turbo4 codecs today;
-        // iso/rotor HOLD pending GPU encoders).
+        // Head-major fused-QK shadow (q8/turbo3/turbo4/iso/rotor codecs).
         if let Some(out) =
             self.try_fused_qk_dispatch(queries, new_k, new_v, scale, additive_mask, device)?
         {
@@ -1111,6 +1175,12 @@ impl KvCache {
                     device,
                 )
             }
+            KvStorage::IsoKOnly3 { .. } | KvStorage::IsoKOnly4 { .. } => {
+                let kv_seq = iso_k_accumulated_seq(&self.storage)?;
+                Self::check_shared_kv_len(kv_len, kv_seq)?;
+                let v_full = self.slice_decode_fp16_v(kv_seq, device)?;
+                self.iso_k_flash_over_store(queries, &v_full, scale, additive_mask, kv_seq, device)
+            }
             KvStorage::PlanarK { .. } => {
                 let kv_seq = planar_k_accumulated_seq(&self.storage)?;
                 Self::check_shared_kv_len(kv_len, kv_seq)?;
@@ -1168,6 +1238,14 @@ impl KvCache {
             }
             KvStorage::RotorKOnly4 { k: Some(ks), .. } => {
                 Self::check_shared_kv_len(kv_len, rotor_k_accumulated_seq(&self.storage)?)?;
+                f32_vec_to_array(&ks.dequant()?, &ks.shape)?
+            }
+            KvStorage::IsoKOnly3 { k: Some(ks), .. } => {
+                Self::check_shared_kv_len(kv_len, iso_k_accumulated_seq(&self.storage)?)?;
+                f32_vec_to_array(&ks.dequant()?, &ks.shape)?
+            }
+            KvStorage::IsoKOnly4 { k: Some(ks), .. } => {
+                Self::check_shared_kv_len(kv_len, iso_k_accumulated_seq(&self.storage)?)?;
                 f32_vec_to_array(&ks.dequant()?, &ks.shape)?
             }
             KvStorage::PlanarK { k: Some(ks), .. } => {
@@ -1905,6 +1983,272 @@ impl KvCache {
         let rotors_arr = crate::rotorquant_msl::rotor_table_to_array(rotors)?;
         Ok(Some((codes, scales, norms, rotors_arr)))
     }
+
+    /// Flash-decode dispatch for the iso K-only storage variants
+    /// (`IsoKOnly3` / `IsoKOnly4`).
+    ///
+    /// Sibling of [`Self::update_and_sdpa_rotor_k_fused`] — see it for the full
+    /// rationale. Same shape, same ordering constraints:
+    ///
+    ///   1. Append `new_k` into the iso store — GPU encode into the packed ring,
+    ///      no dequant.
+    ///   2. Append `new_v` into the bf16 accumulator (V is bf16 for this codec).
+    ///   3. Run [`iso_flash_decode_sdpa`] over the ring's packed view.
+    ///
+    /// The full-prefix `QuantIsoK{3,4}::dequant()` is skipped — that is the
+    /// entire point: it is O(seq) CPU work per decode step.
+    ///
+    /// Caller must have already gated `q_seq == 1` and `device == Gpu` BEFORE
+    /// any cache mutation.
+    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "all index uses validated by the shape contracts at function entry"
+    )]
+    fn update_and_sdpa_iso_k_fused(
+        &mut self,
+        queries: &Array,
+        new_k: &Array,
+        new_v: &Array,
+        scale: f32,
+        additive_mask: Option<&Array>,
+        device: Device,
+    ) -> Result<Option<Array>> {
+        let new_shape = new_k.shape();
+        if new_shape.len() != 4 {
+            return Err(Error::Mlx(format!(
+                "iso_k_fused: new_k rank != 4, got {new_shape:?}"
+            )));
+        }
+        let new_seq = new_shape[2];
+
+        // Shape gates — checked BEFORE any mutation so a reject is a clean
+        // fall-through to the legacy path.
+        if !Self::iso_flash_shape_ok(&new_shape) {
+            return Ok(None);
+        }
+
+        let prev_seq = self.offset;
+        // Not an iso K-only cache: the caller's gate should have kept us out.
+        // Fall through rather than mutate.
+        if !matches!(
+            self.storage,
+            KvStorage::IsoKOnly3 { .. } | KvStorage::IsoKOnly4 { .. }
+        ) {
+            return Ok(None);
+        }
+        // Provision this step before the first mutation: both the packed ring
+        // below and the bf16 V mirror further down are capped by the storage
+        // `max_seq`, so it has to cover `prev_seq + new_seq` first.
+        self.ensure_decode_capacity(prev_seq + new_seq)?;
+        self.iso_k_gpu_append(new_k, &new_shape, device)?;
+
+        // CRITICAL: advance `self.offset` BEFORE `update_decode_fp16_v_only` —
+        // the V-only helper computes its write window as
+        // `[self.offset - new_seq, self.offset)`. Without the pre-increment
+        // every decode step overwrites the last V position instead of
+        // appending. Same ordering as `update_and_sdpa_rotor_k_fused`.
+        self.offset = prev_seq + new_seq;
+        let max_seq = iso_k_max_seq(&self.storage)?;
+        let v_full = self.update_decode_fp16_v_only(new_v, max_seq, device)?;
+
+        // Take `kv_seq` from the store the ring was written from, not from
+        // `self.offset` — one source of truth.
+        let kv_seq = iso_k_accumulated_seq(&self.storage)?;
+        debug_assert_eq!(
+            kv_seq, self.offset,
+            "iso_k_fused: store seq {kv_seq} != cache offset {} — the ring write \
+             and the attention length disagree",
+            self.offset
+        );
+        // Past this point the cache is already mutated, so `Ok(None)` is NOT
+        // available: it would send the caller into the legacy `update()` path,
+        // which appends K/V a second time and advances `offset` again. Every
+        // not-eligible condition is screened at the call-site gate and by
+        // `iso_flash_shape_ok` BEFORE any mutation.
+        let out =
+            self.iso_k_flash_over_store(queries, &v_full, scale, additive_mask, kv_seq, device)?;
+        Ok(Some(out))
+    }
+
+    /// Run the iso flash-decode kernel over the K already packed in this cache's
+    /// store — no append, no offset advance.
+    ///
+    /// Split out of [`Self::update_and_sdpa_iso_k_fused`] so a shared-KV
+    /// **consumer** layer can attend the producer's store through the exact same
+    /// kernel the producer used. Sibling of
+    /// [`Self::rotor_k_flash_over_store`].
+    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "all index uses validated by the shape contracts at function entry"
+    )]
+    fn iso_k_flash_over_store(
+        &self,
+        queries: &Array,
+        v_full: &Array,
+        scale: f32,
+        additive_mask: Option<&Array>,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Array> {
+        // Select the bit width from the live storage variant. No wildcard arm:
+        // an unexpected variant must not be decoded with another codec's kernel.
+        let bits: u8 = if matches!(self.storage, KvStorage::IsoKOnly3 { .. }) {
+            3
+        } else if matches!(self.storage, KvStorage::IsoKOnly4 { .. }) {
+            4
+        } else {
+            return Err(Error::KvStorageMismatch {
+                expected: "IsoKOnly3 | IsoKOnly4",
+                got: storage_variant_name(&self.storage),
+            });
+        };
+        let Some((codes, scales, norms)) = self.iso_k_packed_view(kv_seq, device)? else {
+            return Err(Error::Mlx(format!(
+                "iso_k_fused: GPU ring absent after a maintained append \
+                 (kv_seq={kv_seq}, bits={bits}) — internal invariant violated"
+            )));
+        };
+
+        let v_shape = v_full.shape();
+        if v_shape.len() != 4 {
+            return Err(Error::Mlx(format!(
+                "iso_k_fused: V rank != 4, got {v_shape:?}"
+            )));
+        }
+        let b = v_shape[0];
+        let kv_h = v_shape[1];
+        let head_dim = v_shape[3];
+
+        let q_shape = queries.shape();
+        if q_shape.len() != 4 {
+            return Err(Error::Mlx(format!(
+                "iso_k_fused: Q shape rank != 4, got {q_shape:?}"
+            )));
+        }
+        let q_seq = q_shape[2];
+        let n_q_heads = q_shape[1];
+        // Defence-in-depth: the call site already gates decode-only.
+        if q_seq != 1 {
+            return Err(Error::Mlx(format!(
+                "iso_k_fused: q_seq must be 1 (decode-only), got {q_seq}"
+            )));
+        }
+        if n_q_heads % kv_h != 0 {
+            return Err(Error::Mlx(format!(
+                "iso_k_fused: n_q_heads={n_q_heads} not divisible by kv_h={kv_h}"
+            )));
+        }
+        let heads_per_kv = n_q_heads / kv_h;
+
+        tracing::Span::current().record("path", "iso_flash_decode");
+        // Select the bit width explicitly. A wildcard arm here would map any
+        // unexpected `bits` onto one width's kernel and decode the other's codes
+        // at the wrong unpack stride — silently wrong K, no error. `bits` is a
+        // plain integer, so no exhaustiveness lint would catch that.
+        let flash_out = match bits {
+            3 => iso_flash_decode_sdpa::<3>(
+                queries,
+                &codes,
+                &scales,
+                &norms,
+                v_full,
+                additive_mask,
+                b,
+                kv_h,
+                kv_seq,
+                head_dim,
+                heads_per_kv,
+                scale,
+                device,
+            )?,
+            4 => iso_flash_decode_sdpa::<4>(
+                queries,
+                &codes,
+                &scales,
+                &norms,
+                v_full,
+                additive_mask,
+                b,
+                kv_h,
+                kv_seq,
+                head_dim,
+                heads_per_kv,
+                scale,
+                device,
+            )?,
+            other => {
+                return Err(Error::Quant(format!(
+                    "iso_k_fused: unsupported bits={other} (only 3 and 4); \
+                     refusing to decode with another width's kernel"
+                )))
+            }
+        };
+        if flash_out.dtype() == queries.dtype() {
+            Ok(flash_out)
+        } else {
+            flash_out.astype(queries.dtype(), device)
+        }
+    }
+
+    /// Shape gates for the iso flash-decode kernel, evaluated before any cache
+    /// mutation.
+    ///
+    /// Keyed off shape only — never an arch name. `b == 1` because the packed
+    /// ring's per-step stride does not interleave batch (one `KvCache` per
+    /// request); a batched cache falls back rather than read a layout the kernel
+    /// would misinterpret.
+    fn iso_flash_shape_ok(new_shape: &[i32]) -> bool {
+        let (Some(&b), Some(&kv_h), Some(&head_dim)) =
+            (new_shape.first(), new_shape.get(1), new_shape.get(3))
+        else {
+            return false;
+        };
+        if b != 1 || kv_h <= 0 {
+            return false;
+        }
+        if head_dim <= 0 || head_dim > ISO_FLASH_HEAD_DIM_MAX {
+            return false;
+        }
+        // One quaternion block per group — a partial trailing group has no
+        // defined decode.
+        if !(head_dim as usize).is_multiple_of(ISO_K3_GROUP_SIZE) {
+            return false;
+        }
+        // Tree reduction over `head_dim` threads.
+        (head_dim as u32).is_power_of_two()
+    }
+
+    /// GPU-append `new_k` into whichever iso K-only store is active.
+    fn iso_k_gpu_append(&mut self, new_k: &Array, new_shape: &[i32], device: Device) -> Result<()> {
+        if matches!(self.storage, KvStorage::IsoKOnly3 { .. }) {
+            super::update::iso3_k_only_gpu_append(self, new_k, new_shape, device)
+        } else if matches!(self.storage, KvStorage::IsoKOnly4 { .. }) {
+            super::update::iso4_k_only_gpu_append(self, new_k, new_shape, device)
+        } else {
+            Err(Error::KvStorageMismatch {
+                expected: "IsoKOnly3 | IsoKOnly4",
+                got: storage_variant_name(&self.storage),
+            })
+        }
+    }
+
+    /// `(codes, scales, norms)` GPU view of the active iso K store at `kv_seq`,
+    /// or `None` when the ring is not live.
+    fn iso_k_packed_view(
+        &self,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Option<(Array, Array, Array)>> {
+        if let KvStorage::IsoKOnly3 { k: Some(ks), .. } = &self.storage {
+            ks.gpu_packed_view(kv_seq, device)
+        } else if let KvStorage::IsoKOnly4 { k: Some(ks), .. } = &self.storage {
+            ks.gpu_packed_view(kv_seq, device)
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 /// Whether the active rotor K-only store carries the QJL residual sideband.
@@ -1966,6 +2310,46 @@ fn planar_k_accumulated_seq(storage: &KvStorage) -> Result<i32> {
             ks.shape
         ))
     })
+}
+
+/// Accumulated sequence length held by the active iso K-only store.
+///
+/// Sibling of [`rotor_k_accumulated_seq`]: the store's own `shape[2]` is the
+/// length the GPU ring was written against, so it — not [`KvCache::offset`] —
+/// is what the kernel attends and what a shared-KV consumer sizes its mask
+/// from.
+fn iso_k_accumulated_seq(storage: &KvStorage) -> Result<i32> {
+    let shape = if let KvStorage::IsoKOnly3 { k: Some(ks), .. } = storage {
+        &ks.shape
+    } else if let KvStorage::IsoKOnly4 { k: Some(ks), .. } = storage {
+        &ks.shape
+    } else {
+        return Err(Error::KvStorageMismatch {
+            expected: "IsoKOnly3 | IsoKOnly4 with a live K buffer",
+            got: storage_variant_name(storage),
+        });
+    };
+    shape.get(2).copied().ok_or_else(|| {
+        Error::Mlx(format!(
+            "iso_k_fused: iso K store shape {shape:?} has no seq axis"
+        ))
+    })
+}
+
+/// `max_seq` of the active iso K-only storage variant.
+///
+/// Read from the live `KvStorage` variant — which `ensure_decode_capacity` has
+/// just grown for this step — never from the store struct's own inert
+/// `max_seq` field, which is a prefill-time snapshot.
+fn iso_k_max_seq(storage: &KvStorage) -> Result<i32> {
+    if let KvStorage::IsoKOnly3 { max_seq, .. } | KvStorage::IsoKOnly4 { max_seq, .. } = storage {
+        Ok(*max_seq)
+    } else {
+        Err(Error::KvStorageMismatch {
+            expected: "IsoKOnly3 | IsoKOnly4",
+            got: storage_variant_name(storage),
+        })
+    }
 }
 
 /// `max_seq` of the active rotor K-only storage variant.

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -13,9 +13,9 @@ use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{zeros, Array, Device, Dtype};
 
 use crate::storage::{
-    IsoBlocks, KvStorage, QuantIsoK3, QuantIsoK4, QuantIsoV3, QuantIsoV4, QuantK, QuantKTurbo3,
-    QuantKTurbo4, QuantPlanarK, QuantPlanarV, QuantRotorV3, QuantRotorV4, QuantV, RotorBlocks,
-    RotorKBlocks, ISO3_GROUP_SIZE, ISO4_GROUP_SIZE,
+    iso_n_groups_for, IsoBlocks, KvStorage, QuantIsoK3, QuantIsoK4, QuantIsoV3, QuantIsoV4, QuantK,
+    QuantKTurbo3, QuantKTurbo4, QuantPlanarK, QuantPlanarV, QuantRotorV3, QuantRotorV4, QuantV,
+    RotorBlocks, RotorKBlocks, ISO4_GROUP_SIZE, ISO_K3_BITS, ISO_K4_BITS,
 };
 use crate::turbo_flash_msl::{turbo_flash_lock_enabled, turbo_flash_sdpa, turbo_flash_should_run};
 use crate::KvQuant;
@@ -172,86 +172,28 @@ fn iso4_gpu_append_into_blocks(
     Ok(())
 }
 
-/// Convenience wrapper for the K-side iso4 codec
-/// ([`KvCache::update_iso_k_only_4`] and the K-side of
-/// [`KvCache::update_iso4_sym`]).
+/// Mirror of [`iso3_gpu_append_into_k_blocks`] for the iso4 codec — see it for
+/// the `feed` contract and why the chunk is reordered to sequence-major.
 fn iso4_gpu_append_into_k_blocks(
     ks: &mut QuantIsoK4,
     new_k: &Array,
     new_shape: &[i32],
+    device: Device,
+    feed: RingFeed,
+    max_seq: i32,
 ) -> Result<()> {
-    let block = iso4_gpu_encode_block(new_k, new_shape)?;
+    let head_dim = head_dim_from_shape(new_shape, "iso4_gpu_append_into_k_blocks")?;
+    let seq_major = packed_k_chunk_seq_major(new_k, new_shape, device)?;
+    let (block, gpu) = iso_gpu_encode_block_retaining(&seq_major, new_shape, ISO_K4_BITS)?;
+    iso4_sync_ring(ks, &gpu, feed, new_shape, head_dim, max_seq, device)?;
     push_iso4_k_block(ks, block, new_shape);
     Ok(())
 }
 
 // ── Iso3 MSL helpers (mirror of iso4) ────────────────────────────────────────
-
-/// Encode a KV chunk (`new_kv`, shape `[B, kv_h, S, D]`) via the iso3
-/// MSL kernel and return the resulting CPU [`IsoBlocks`].
-///
-/// Mirrors the CPU codec ([`crate::isoquant::iso_encode_fast`] with
-/// `bits = 3`): the returned block's `n_tokens` equals `B * kv_h * S`, codes
-/// are bit-packed identically (10 vals/u32, Planar3 pack convention), and the
-/// per-token L2 norm is preserved (deduplicated from the per-group GPU norm
-/// slot).
-///
-/// The kernel is axis-agnostic, so the same helper drives both the V-side
-/// ([`QuantIsoV3`]) and K-side ([`QuantIsoK3`]) appenders.
-///
-/// # Errors
-///
-/// Forwards Metal kernel / shape errors as `Error::Mlx` / `Error::Quant`.
-#[allow(
-    clippy::indexing_slicing,
-    reason = "shape rank guarded to 4 immediately above each indexing site; new_shape[0..=3] are always in-bounds"
-)]
-fn iso3_gpu_encode_block(new_kv: &Array, new_shape: &[i32]) -> Result<IsoBlocks> {
-    if new_shape.len() != 4 {
-        return Err(Error::Mlx(format!(
-            "iso3_gpu_encode_block: expected 4D new_shape, got {new_shape:?}"
-        )));
-    }
-    let b = new_shape[0] as usize;
-    let kv_h = new_shape[1] as usize;
-    let s = new_shape[2] as usize;
-    let head_dim = new_shape[3] as usize;
-    let n_tokens_total = b * kv_h * s;
-    if !head_dim.is_multiple_of(ISO3_GROUP_SIZE) {
-        return Err(Error::Quant(format!(
-            "iso3_gpu_encode_block: head_dim={head_dim} must be a positive multiple of \
-             ISO3_GROUP_SIZE={ISO3_GROUP_SIZE}"
-        )));
-    }
-    let n_groups = head_dim / ISO3_GROUP_SIZE;
-
-    tracing::debug!(
-        target: "rmlx::kv_quant::iso3",
-        n_tokens = n_tokens_total,
-        n_groups,
-        head_dim,
-        "iso3 GPU encode block"
-    );
-
-    let (codes_arr, scales_arr, quats_arr, norms_arr) =
-        crate::isoquant_msl::iso_quantize_v3_gpu(new_kv, head_dim, Device::Gpu)?;
-    let (codes, scales, quaternions, norms) = crate::isoquant_msl::iso3_gpu_outputs_to_cpu(
-        &codes_arr,
-        &scales_arr,
-        &quats_arr,
-        &norms_arr,
-        n_tokens_total,
-        n_groups,
-    )?;
-
-    Ok(IsoBlocks {
-        codes,
-        scales,
-        quaternions,
-        norms,
-        n_tokens: n_tokens_total,
-    })
-}
+//
+// The iso3 K-side encode itself lives in `iso_gpu_encode_block_retaining`,
+// which serves both bit widths and hands back the GPU arrays the ring needs.
 
 // `push_iso3_v_block` was removed along with the V-side helper —
 // `QuantIsoV3::append_gpu` now owns shape bookkeeping for the V path. The
@@ -277,15 +219,32 @@ fn push_iso3_k_block(ks: &mut QuantIsoK3, block: IsoBlocks, new_shape: &[i32]) {
 // `QuantIsoV3::append_gpu` (which also writes the GPU-resident mirror). The
 // K-side wrapper below remains in use.
 
-/// Convenience wrapper for the K-side iso3 codec
-/// ([`KvCache::update_iso_k_only_3`] and the K-side of
-/// [`KvCache::update_iso3_sym`]).
+/// Append one iso3 K chunk: GPU encode → CPU blocks (+ the GPU ring when
+/// `feed` is [`RingFeed::Maintain`]).
+///
+/// Used by [`KvCache::update_iso_k_only_3`] and the K-side of
+/// [`KvCache::update_iso3_sym`] (both `RingFeed::Skip` — they dequant the whole
+/// prefix anyway), and by [`iso3_k_only_gpu_append`] on the flash-decode path
+/// (`RingFeed::Maintain`).
+///
+/// The chunk is reordered to sequence-major before encoding. That is not
+/// optional: `QuantIsoK3::append` (the CPU path) transposes, and
+/// `QuantIsoK3::dequant{,_gpu}` transpose *back* — so encoding head-major here
+/// would hand `dequant` head-major blocks it reads as sequence-major and
+/// scramble heads for any `kv_h > 1` chunk longer than one token. For the
+/// decode step (`S == 1`) the reorder is the identity.
 fn iso3_gpu_append_into_k_blocks(
     ks: &mut QuantIsoK3,
     new_k: &Array,
     new_shape: &[i32],
+    device: Device,
+    feed: RingFeed,
+    max_seq: i32,
 ) -> Result<()> {
-    let block = iso3_gpu_encode_block(new_k, new_shape)?;
+    let head_dim = head_dim_from_shape(new_shape, "iso3_gpu_append_into_k_blocks")?;
+    let seq_major = packed_k_chunk_seq_major(new_k, new_shape, device)?;
+    let (block, gpu) = iso_gpu_encode_block_retaining(&seq_major, new_shape, ISO_K3_BITS)?;
+    iso3_sync_ring(ks, &gpu, feed, new_shape, head_dim, max_seq, device)?;
     push_iso3_k_block(ks, block, new_shape);
     Ok(())
 }
@@ -318,10 +277,13 @@ fn rotor_gpu_encode_block(
     Ok(block)
 }
 
-/// The GPU-resident `(codes, scales, norms)` triple a rotor encode produced,
-/// retained so a caller can push it straight into a GPU ring instead of
-/// re-uploading the downloaded CPU copy.
-struct RotorEncodedGpu {
+/// The GPU-resident `(codes, scales, norms)` triple a packed-K encode produced
+/// (rotor or iso), retained so a caller can push it straight into a GPU ring
+/// instead of re-uploading the downloaded CPU copy.
+///
+/// `norms` is always the **per-token** form the decode kernels index
+/// (`norms[tok_idx]`), not the per-group form the encode kernels emit.
+struct PackedKEncodedGpu {
     codes: Array,
     scales: Array,
     norms: Array,
@@ -338,7 +300,7 @@ fn rotor_gpu_encode_block_retaining(
     new_shape: &[i32],
     rotors: &[f32],
     bits: u8,
-) -> Result<(RotorBlocks, RotorEncodedGpu)> {
+) -> Result<(RotorBlocks, PackedKEncodedGpu)> {
     if new_shape.len() != 4 {
         return Err(Error::Mlx(format!(
             "rotor_gpu_encode_block: expected 4D new_shape, got {new_shape:?}"
@@ -410,7 +372,7 @@ fn rotor_gpu_encode_block_retaining(
             norms,
             n_tokens: n_tokens_total,
         },
-        RotorEncodedGpu {
+        PackedKEncodedGpu {
             codes: codes_arr,
             scales: scales_arr,
             norms: norms_per_token,
@@ -418,20 +380,29 @@ fn rotor_gpu_encode_block_retaining(
     ))
 }
 
-/// Collapse the rotor encode kernel's per-group norms (`[n_tokens, n_groups]`,
+/// Collapse a packed-K encode kernel's per-group norms (`[n_tokens, n_groups]`,
 /// each row a repeat of that token's L2) to the per-token `[n_tokens]` form.
 ///
-/// GPU-side equivalent of the `norms_per_group[tok * n_groups]` pick in
-/// [`crate::rotorquant_msl::rotor_gpu_outputs_to_cpu`] — column 0 of each row.
+/// Shared by the rotor and iso encode paths — both kernels emit the per-group
+/// form and both rings store per-token. GPU-side equivalent of the
+/// `norms_per_group[tok * n_groups]` pick in
+/// [`crate::rotorquant_msl::rotor_gpu_outputs_to_cpu`] /
+/// [`crate::isoquant_msl::iso3_gpu_outputs_to_cpu`] — column 0 of each row.
 fn collapse_group_norms_to_token(
     norms_per_group: &Array,
     n_tokens: usize,
     n_groups: usize,
 ) -> Result<Array> {
-    let n_tokens_i32 = i32::try_from(n_tokens)
-        .map_err(|_| Error::Quant(format!("rotor norms: n_tokens={n_tokens} exceeds i32::MAX")))?;
-    let n_groups_i32 = i32::try_from(n_groups)
-        .map_err(|_| Error::Quant(format!("rotor norms: n_groups={n_groups} exceeds i32::MAX")))?;
+    let n_tokens_i32 = i32::try_from(n_tokens).map_err(|_| {
+        Error::Quant(format!(
+            "packed-K norms: n_tokens={n_tokens} exceeds i32::MAX"
+        ))
+    })?;
+    let n_groups_i32 = i32::try_from(n_groups).map_err(|_| {
+        Error::Quant(format!(
+            "packed-K norms: n_groups={n_groups} exceeds i32::MAX"
+        ))
+    })?;
     norms_per_group
         .reshape(&[n_tokens_i32, n_groups_i32], Device::Gpu)?
         .slice(&[0, 0], &[n_tokens_i32, 1], &[1, 1], Device::Gpu)?
@@ -649,13 +620,13 @@ enum RingFeed {
 /// cleared ring is re-seeded from `blocks` on the next maintained append, so
 /// this is self-healing rather than a one-way door.
 ///
-/// `b > 1` is a skip: [`crate::storage::RotorGpuK`]'s per-step stride is
+/// `b > 1` is a skip: [`crate::storage::QuantKGpuRing`]'s per-step stride is
 /// `kv_h * n_groups` and does not interleave batch, so a batched chunk cannot be
 /// laid into it. The CPU blocks (which do handle `b > 1`) stay the source of
 /// truth and the flash dispatcher's own `b == 1` gate keeps the kernel away.
 fn rotor3_sync_ring(
     ks: &mut crate::storage::QuantRotorK3,
-    gpu: &RotorEncodedGpu,
+    gpu: &PackedKEncodedGpu,
     feed: RingFeed,
     new_shape: &[i32],
     head_dim: usize,
@@ -686,7 +657,7 @@ fn rotor3_sync_ring(
 /// Mirror of [`rotor3_sync_ring`] for [`crate::storage::QuantRotorK4`].
 fn rotor4_sync_ring(
     ks: &mut crate::storage::QuantRotorK4,
-    gpu: &RotorEncodedGpu,
+    gpu: &PackedKEncodedGpu,
     feed: RingFeed,
     new_shape: &[i32],
     head_dim: usize,
@@ -735,7 +706,7 @@ fn rotor3_gpu_append_into_k_blocks(
     // is true (mid-run CPU fallback after a GPU first-chunk needs it). The GPU
     // encode itself ignores the JL projection — this path is QJL-off-only by
     // dispatcher contract.
-    let seq_major = rotor_k_chunk_seq_major(new_k, new_shape, device)?;
+    let seq_major = packed_k_chunk_seq_major(new_k, new_shape, device)?;
     let (block, gpu) = rotor_gpu_encode_block_retaining(
         &seq_major,
         new_shape,
@@ -758,7 +729,7 @@ fn rotor4_gpu_append_into_k_blocks(
 ) -> Result<()> {
     let head_dim = head_dim_from_shape(new_shape, "rotor4_gpu_append_into_k_blocks")?;
     ensure_k4_rotors(ks, head_dim);
-    let seq_major = rotor_k_chunk_seq_major(new_k, new_shape, device)?;
+    let seq_major = packed_k_chunk_seq_major(new_k, new_shape, device)?;
     let (block, gpu) = rotor_gpu_encode_block_retaining(
         &seq_major,
         new_shape,
@@ -862,22 +833,245 @@ fn b_kv_h_new_seq(new_shape: &[i32]) -> Result<(i32, i32, i32)> {
 }
 
 /// Reorder a head-major `[B, kv_h, S, D]` K chunk to the sequence-major
-/// `[B, S, kv_h, D]` element order the rotor store accumulates in.
+/// `[B, S, kv_h, D]` element order the packed K stores (rotor / iso)
+/// accumulate in.
 ///
-/// The CPU `QuantRotorK{3,4}::append` transposes before encoding, so the GPU
-/// encode must too or the two produce different block layouts for a multi-token
-/// chunk with `kv_h > 1`. For the decode step (`S == 1`) this is the identity.
+/// The CPU `QuantRotorK{3,4}::append` / `QuantIsoK{3,4}::append` transpose
+/// before encoding, so the GPU encode must too or the two produce different
+/// block layouts for a multi-token chunk with `kv_h > 1`. For the decode step
+/// (`S == 1`) this is the identity.
 ///
-/// `transpose` yields a strided view and the rotor MSL kernel reads by raw
-/// linear offset (it ignores MLX lazy-transpose strides), so the permutation is
+/// `transpose` yields a strided view and the MSL kernels read by raw linear
+/// offset (they ignore MLX lazy-transpose strides), so the permutation is
 /// materialised here.
-fn rotor_k_chunk_seq_major(new_k: &Array, new_shape: &[i32], device: Device) -> Result<Array> {
+fn packed_k_chunk_seq_major(new_k: &Array, new_shape: &[i32], device: Device) -> Result<Array> {
     let (_b, _kv_h, new_seq) = b_kv_h_new_seq(new_shape)?;
     if new_seq == 1 {
         // Identity permutation — skip the copy on the decode hot path.
         return new_k.try_clone();
     }
     new_k.transpose(&[0, 2, 1, 3], device)?.contiguous(device)
+}
+
+/// GPU-encode one iso K chunk, returning the CPU block **and** the GPU arrays
+/// the ring feed consumes.
+///
+/// Mirror of [`rotor_gpu_encode_block_retaining`] for the iso codec. The CPU
+/// download is kept for the same reason it is there: [`IsoBlocks`] is the
+/// source of truth for `dequant()` and the SSD spill, and `shape[2]` is bumped
+/// in lockstep with the block push, so skipping the block would leave `blocks`
+/// shorter than `shape[2]` — a gap `dequant()` silently zero-pads and a spill
+/// would persist as a truncated store.
+///
+/// `bits` selects the encode kernel explicitly; anything but 3 or 4 is an error
+/// rather than a silent fall-through to one width's kernel over the other's
+/// codes.
+fn iso_gpu_encode_block_retaining(
+    new_k: &Array,
+    new_shape: &[i32],
+    bits: u8,
+) -> Result<(IsoBlocks, PackedKEncodedGpu)> {
+    let head_dim = head_dim_from_shape(new_shape, "iso_gpu_encode_block_retaining")?;
+    let (b, kv_h, s) = b_kv_h_new_seq(new_shape)?;
+    let n_tokens_total = (b as usize) * (kv_h as usize) * (s as usize);
+    let n_groups = iso_n_groups_for(head_dim);
+    if n_groups == 0 {
+        return Err(Error::Quant(format!(
+            "iso_gpu_encode_block_retaining: head_dim={head_dim} yields no quaternion groups"
+        )));
+    }
+
+    let (codes_arr, scales_arr, quats_arr, norms_arr) = match bits {
+        ISO_K3_BITS => crate::isoquant_msl::iso_quantize_v3_gpu(new_k, head_dim, Device::Gpu)?,
+        ISO_K4_BITS => crate::isoquant_msl_v4::iso_quantize_v4_gpu(new_k, head_dim, Device::Gpu)?,
+        other => {
+            return Err(Error::Quant(format!(
+                "iso_gpu_encode_block_retaining: unsupported bits={other} (only 3 and 4); \
+                 refusing to encode with another width's kernel"
+            )))
+        }
+    };
+
+    // Select the readback by width explicitly. A `_` arm here would send a
+    // future width's codes through one of these two unpackers and silently
+    // produce a wrong CPU block — `bits` is a plain integer, so no
+    // exhaustiveness lint would catch it.
+    let (codes, scales, quats, norms) = match bits {
+        ISO_K3_BITS => crate::isoquant_msl::iso3_gpu_outputs_to_cpu(
+            &codes_arr,
+            &scales_arr,
+            &quats_arr,
+            &norms_arr,
+            n_tokens_total,
+            n_groups,
+        )?,
+        ISO_K4_BITS => crate::isoquant_msl_v4::iso4_gpu_outputs_to_cpu(
+            &codes_arr,
+            &scales_arr,
+            &quats_arr,
+            &norms_arr,
+            n_tokens_total,
+            n_groups,
+        )?,
+        other => {
+            return Err(Error::Quant(format!(
+                "iso_gpu_encode_block_retaining: unsupported bits={other} on readback \
+                 (only 3 and 4)"
+            )))
+        }
+    };
+
+    // The encode kernel emits norms **per group** (`[n_tokens * n_groups]`, the
+    // same per-token L2 replicated across a token's groups). The ring stores the
+    // per-token form the decode kernel indexes (`norms[tok_idx]`), so collapse
+    // it on the GPU to keep the ring feed off the host.
+    let norms_per_token = collapse_group_norms_to_token(&norms_arr, n_tokens_total, n_groups)?;
+
+    Ok((
+        IsoBlocks {
+            codes,
+            scales,
+            quaternions: quats,
+            norms,
+            n_tokens: n_tokens_total,
+        },
+        PackedKEncodedGpu {
+            codes: codes_arr,
+            scales: scales_arr,
+            norms: norms_per_token,
+        },
+    ))
+}
+
+/// Append `new_k` into a live `IsoKOnly3` store's GPU ring (+ CPU blocks),
+/// lazily creating the store on first use. No dequant — this is the entry point
+/// the iso flash-decode SDPA path uses.
+///
+/// # Errors
+///
+/// Returns [`Error::KvStorageMismatch`] when the active storage is not
+/// `IsoKOnly3`, and forwards encode / ring errors.
+pub(super) fn iso3_k_only_gpu_append(
+    cache: &mut KvCache,
+    new_k: &Array,
+    new_shape: &[i32],
+    device: Device,
+) -> Result<()> {
+    let KvStorage::IsoKOnly3 { k, max_seq } = &mut cache.storage else {
+        return Err(Error::KvStorageMismatch {
+            expected: "IsoKOnly3",
+            got: storage_variant_name(&cache.storage),
+        });
+    };
+    let max_seq = *max_seq;
+    if k.is_none() {
+        let mut init_shape = new_shape.to_vec();
+        if let Some(s) = init_shape.get_mut(2) {
+            *s = 0;
+        }
+        *k = Some(QuantIsoK3::new(init_shape, max_seq));
+    }
+    let Some(ks) = k.as_mut() else {
+        return Err(Error::Mlx("IsoKOnly3 K buffer absent after init".into()));
+    };
+    iso3_gpu_append_into_k_blocks(ks, new_k, new_shape, device, RingFeed::Maintain, max_seq)
+}
+
+/// Mirror of [`iso3_k_only_gpu_append`] for `IsoKOnly4`.
+///
+/// # Errors
+///
+/// Returns [`Error::KvStorageMismatch`] when the active storage is not
+/// `IsoKOnly4`, and forwards encode / ring errors.
+pub(super) fn iso4_k_only_gpu_append(
+    cache: &mut KvCache,
+    new_k: &Array,
+    new_shape: &[i32],
+    device: Device,
+) -> Result<()> {
+    let KvStorage::IsoKOnly4 { k, max_seq } = &mut cache.storage else {
+        return Err(Error::KvStorageMismatch {
+            expected: "IsoKOnly4",
+            got: storage_variant_name(&cache.storage),
+        });
+    };
+    let max_seq = *max_seq;
+    if k.is_none() {
+        let mut init_shape = new_shape.to_vec();
+        if let Some(s) = init_shape.get_mut(2) {
+            *s = 0;
+        }
+        *k = Some(QuantIsoK4::new(init_shape, max_seq));
+    }
+    let Some(ks) = k.as_mut() else {
+        return Err(Error::Mlx("IsoKOnly4 K buffer absent after init".into()));
+    };
+    iso4_gpu_append_into_k_blocks(ks, new_k, new_shape, device, RingFeed::Maintain, max_seq)
+}
+
+/// Feed one encoded iso3 chunk into the store's GPU ring.
+///
+/// `b > 1` is a skip for the same reason [`rotor3_sync_ring`] skips it:
+/// [`crate::storage::QuantKGpuRing`]'s per-step stride does not interleave
+/// batch. A skipped feed *clears* rather than leaving a stale ring — see the
+/// [`RingFeed`] invariant.
+fn iso3_sync_ring(
+    ks: &mut QuantIsoK3,
+    gpu: &PackedKEncodedGpu,
+    feed: RingFeed,
+    new_shape: &[i32],
+    head_dim: usize,
+    max_seq: i32,
+    device: Device,
+) -> Result<()> {
+    let (b, kv_h, new_seq) = b_kv_h_new_seq(new_shape)?;
+    if feed != RingFeed::Maintain || b != 1 {
+        ks.gpu.clear();
+        return Ok(());
+    }
+    // Feed BEFORE `push_iso3_k_block` — the push bumps `ks.shape[2]`, and the
+    // ring append needs `prev_seq`, the length before this chunk.
+    let prev_seq = accumulated_seq(&ks.shape);
+    ks.gpu_append(
+        &gpu.codes,
+        &gpu.scales,
+        &gpu.norms,
+        kv_h,
+        head_dim as i32,
+        prev_seq,
+        new_seq,
+        max_seq,
+        device,
+    )
+}
+
+/// Mirror of [`iso3_sync_ring`] for [`QuantIsoK4`].
+fn iso4_sync_ring(
+    ks: &mut QuantIsoK4,
+    gpu: &PackedKEncodedGpu,
+    feed: RingFeed,
+    new_shape: &[i32],
+    head_dim: usize,
+    max_seq: i32,
+    device: Device,
+) -> Result<()> {
+    let (b, kv_h, new_seq) = b_kv_h_new_seq(new_shape)?;
+    if feed != RingFeed::Maintain || b != 1 {
+        ks.gpu.clear();
+        return Ok(());
+    }
+    let prev_seq = accumulated_seq(&ks.shape);
+    ks.gpu_append(
+        &gpu.codes,
+        &gpu.scales,
+        &gpu.norms,
+        kv_h,
+        head_dim as i32,
+        prev_seq,
+        new_seq,
+        max_seq,
+        device,
+    )
 }
 
 impl KvCache {
@@ -5734,7 +5928,7 @@ impl KvCache {
             return Err(Error::Mlx("IsoSym3 K buffer absent after init".into()));
         };
         if device == Device::Gpu {
-            iso3_gpu_append_into_k_blocks(ks, new_k, &new_shape)?;
+            iso3_gpu_append_into_k_blocks(ks, new_k, &new_shape, device, RingFeed::Skip, max_seq)?;
         } else {
             ks.append(&k_f32, &new_shape)?;
         }
@@ -5863,7 +6057,7 @@ impl KvCache {
             return Err(Error::Mlx("IsoSym4 K buffer absent after init".into()));
         };
         if device == Device::Gpu {
-            iso4_gpu_append_into_k_blocks(ks, new_k, &new_shape)?;
+            iso4_gpu_append_into_k_blocks(ks, new_k, &new_shape, device, RingFeed::Skip, max_seq)?;
         } else {
             ks.append(&k_f32, &new_shape)?;
         }
@@ -5936,7 +6130,7 @@ impl KvCache {
         let head_dim = new_shape[3];
         let t_enc = std::time::Instant::now();
         if device == Device::Gpu {
-            iso3_gpu_append_into_k_blocks(ks, new_k, &new_shape)?;
+            iso3_gpu_append_into_k_blocks(ks, new_k, &new_shape, device, RingFeed::Skip, max_seq)?;
         } else {
             ks.append(&k_f32, &new_shape)?;
         }
@@ -6034,7 +6228,7 @@ impl KvCache {
             return Err(Error::Mlx("IsoKOnly4 K buffer absent after init".into()));
         };
         if device == Device::Gpu {
-            iso4_gpu_append_into_k_blocks(ks, new_k, &new_shape)?;
+            iso4_gpu_append_into_k_blocks(ks, new_k, &new_shape, device, RingFeed::Skip, max_seq)?;
         } else {
             ks.append(&k_f32, &new_shape)?;
         }

--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -42,6 +42,7 @@ pub(crate) mod test_utils;
 
 pub mod clifford;
 pub(crate) mod fused_qk_common;
+pub mod iso_flash_decode_msl;
 pub mod iso_fused_qk_msl;
 pub mod isoquant;
 pub mod isoquant_msl;

--- a/crates/rmlx-kv-quant/src/metal/iso_flash_decode_p1.metal
+++ b/crates/rmlx-kv-quant/src/metal/iso_flash_decode_p1.metal
@@ -1,0 +1,122 @@
+
+// ── Thread / threadgroup coordinates ──────────────────────────────────
+uint head_dim     = dims[0];
+uint kv_seq       = dims[1];
+uint n_bh         = dims[2];
+uint kv_h         = dims[3];
+uint heads_per_kv = dims[4];
+uint n_tiles      = dims[5];
+uint has_mask     = dims[6];
+uint n_groups     = dims[7];
+
+uint tile_idx = threadgroup_position_in_grid.x;
+uint bh       = threadgroup_position_in_grid.y;
+uint tid      = thread_position_in_threadgroup.x;
+
+if (bh >= n_bh)
+    return;
+if (tile_idx >= n_tiles)
+    return;
+
+uint n_q_heads = kv_h * heads_per_kv;
+uint b         = bh / n_q_heads;
+uint hq        = bh % n_q_heads;
+uint kv_h_idx  = hq / heads_per_kv;
+
+uint tile_start = tile_idx * IF_TILE_SIZE;
+uint tile_end   = tile_start + IF_TILE_SIZE;
+if (tile_end > kv_seq)
+    tile_end = kv_seq;
+
+// ── Load Q once into threadgroup memory ──────────────────────────────
+// SMEM ceiling: head_dim <= IF_HEAD_DIM_MAX (dispatcher-enforced). Two
+// float[IF_HEAD_DIM_MAX] arrays at the 512 ceiling = 4 KiB, well inside the
+// Apple GPU 32 KiB threadgroup-memory budget.
+threadgroup float q_shared[IF_HEAD_DIM_MAX];
+q_shared[tid] = query[bh * head_dim + tid];
+
+// ── Online softmax broadcast slots ───────────────────────────────────
+threadgroup float s_max[1];
+threadgroup float s_sum[1];
+threadgroup float s_corr[1];
+threadgroup float s_expsc[1];
+
+if (tid == 0u) {
+    s_max[0] = -INFINITY;
+    s_sum[0] = 0.0f;
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+// Per-thread V accumulator (registers — never spills to threadgroup mem).
+float acc_v = 0.0f;
+
+// Shared scratch for the QK dot reduction.
+threadgroup float dot_shared[IF_HEAD_DIM_MAX];
+
+for (uint t = tile_start; t < tile_end; t++) {
+    // ── Decode K[tid] for this (b, kv_h_idx, t) ──────────────────────
+    // The iso K ring is SEQUENCE-major (`[B, S, kv_h, n_groups]`): per token
+    // all heads are contiguous, matching the chunk-append layout.
+    // (V below stays head-major — it is the separate bf16 mirror, not an
+    // iso-packed buffer.)
+    uint kv_tok = (b * kv_seq + t) * kv_h + kv_h_idx;
+
+    float k_val = if_decode_k_lane(codes, scales, norms, kv_tok, n_groups, tid);
+
+    // ── QK dot product + tree reduction ─────────────────────────────
+    dot_shared[tid] = q_shared[tid] * k_val;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // REQUIRES head_dim to be a power of two (dispatcher rejects non-pow-2).
+    for (uint stride = head_dim >> 1; stride > 0u; stride >>= 1u) {
+        if (tid < stride) {
+            dot_shared[tid] += dot_shared[tid + stride];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // ── Thread 0: online softmax update + broadcast ──────────────────
+    if (tid == 0u) {
+        float raw = dot_shared[0] * scale_arr[0];
+        // Mask is per (b, q_head, t) — add inside thread 0.
+        float mask_val = 0.0f;
+        if (has_mask != 0u) {
+            mask_val = mask_flat[(b * n_q_heads + hq) * kv_seq + t];
+        }
+        float score = raw + mask_val;
+
+        float old_max = s_max[0];
+        float new_max = (score > old_max) ? score : old_max;
+        float corr    = exp(old_max - new_max);
+        float es      = exp(score - new_max);
+
+        s_max[0]   = new_max;
+        s_sum[0]   = s_sum[0] * corr + es;
+        s_corr[0]  = corr;
+        s_expsc[0] = es;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // ── V read + softmax-weighted accumulation ──────────────────────
+    // V layout: [B, kv_h, kv_seq, head_dim], flat. Read in V's native dtype
+    // (bf16 / f16 / f32) — the pointer is auto-typed by mlx-c from the array
+    // dtype and MSL promotes to float at the read site, halving V bandwidth
+    // vs. an f32 astype upcast.
+    float corr = s_corr[0];
+    float es   = s_expsc[0];
+
+    uint v_off  = ((b * kv_h + kv_h_idx) * kv_seq + t) * head_dim + tid;
+    float v_val = v_flat[v_off];
+
+    acc_v = acc_v * corr + es * v_val;
+}
+
+// ── Write per-tile partials ──────────────────────────────────────────
+uint out_base             = (tile_idx * n_bh + bh) * head_dim;
+partial_o[out_base + tid] = acc_v;
+
+if (tid == 0u) {
+    uint meta          = tile_idx * n_bh + bh;
+    tile_max[meta]     = s_max[0];
+    tile_sum_exp[meta] = s_sum[0];
+}

--- a/crates/rmlx-kv-quant/src/metal/probes/iso_flash_decode_p1_b3.hdr.metal
+++ b/crates/rmlx-kv-quant/src/metal/probes/iso_flash_decode_p1_b3.hdr.metal
@@ -1,0 +1,77 @@
+
+// Iso flash-decode header — unpack params + conjugated golden-ratio
+// fixed quaternion + Lloyd-Max N(0,1) codebook + the shared per-lane
+// K decode.
+// BITS = 3 (codebook = 8 entries, mask = 0x7).
+// Bit-exact with crate::isoquant::FIXED_QUAT + lloyd_gaussian_codebook(3).
+
+#define IF_BITS 3u
+#define IF_MASK 0x7u
+
+constant float ISO_QW  = as_type<float>(0x3EE4F930u);
+constant float ISO_QCX = as_type<float>(0xBF393E4Cu);
+constant float ISO_QCY = as_type<float>(0xBE8D8368u);
+constant float ISO_QCZ = as_type<float>(0xBEE4F930u);
+
+constant float ISO_CB[8] = {
+    as_type<float>(0xC009B977u),
+    as_type<float>(0xBFAC0532u),
+    as_type<float>(0xBF418987u),
+    as_type<float>(0xBE7AF9EBu),
+    as_type<float>(0x3E7AF9EBu),
+    as_type<float>(0x3F418987u),
+    as_type<float>(0x3FAC0532u),
+    as_type<float>(0x4009B977u)
+};
+
+// Decode one head-dim lane of an iso-quantized token.
+//
+// `tok_idx` indexes the flat sequence-major token stream
+// (`(b * kv_seq + t) * kv_h + kv_h_idx`); `lane` is the head-dim slot
+// in [0, head_dim). Bit-exact with the CPU iso_decode_fast.
+//
+// Self-contained per lane: the group's four codes all live in one u32,
+// so the Hamilton product runs in registers with no threadgroup
+// staging and no barrier — callable from any kernel body.
+//
+// Shared surface: a quantized-V flash kernel calls this unchanged,
+// passing the V store's (codes, scales, norms) instead of K's.
+inline float if_decode_k_lane(
+    device const uint*  codes,
+    device const float* scales,
+    device const float* norms,
+    uint                tok_idx,
+    uint                n_groups,
+    uint                lane) {
+    // Each group of 4 head-dim slots is one quaternion block.
+    uint group_id_in_head = lane / 4u;
+    uint lane_in_group    = lane - group_id_in_head * 4u;
+
+    uint  word    = codes[tok_idx * n_groups + group_id_in_head];
+    float k_scale = scales[tok_idx * n_groups + group_id_in_head];
+
+    // Unpack the group's 4 IF_BITS-bit codes -> centroid x scale.
+    float rw = ISO_CB[(word >> (0u * IF_BITS)) & IF_MASK] * k_scale;
+    float rx = ISO_CB[(word >> (1u * IF_BITS)) & IF_MASK] * k_scale;
+    float ry = ISO_CB[(word >> (2u * IF_BITS)) & IF_MASK] * k_scale;
+    float rz = ISO_CB[(word >> (3u * IF_BITS)) & IF_MASK] * k_scale;
+
+    // Inverse rotation: r' = qbar * r, Hamilton product in the
+    // [w, x, y, z] convention. qbar = (ISO_QW, ISO_QCX, ISO_QCY,
+    // ISO_QCZ) is already conjugated by the header.
+    float v_for_lane;
+    if (lane_in_group == 0u) {
+        v_for_lane = ISO_QW * rw - ISO_QCX * rx - ISO_QCY * ry - ISO_QCZ * rz;
+    } else if (lane_in_group == 1u) {
+        v_for_lane = ISO_QW * rx + ISO_QCX * rw + ISO_QCY * rz - ISO_QCZ * ry;
+    } else if (lane_in_group == 2u) {
+        v_for_lane = ISO_QW * ry - ISO_QCX * rz + ISO_QCY * rw + ISO_QCZ * rx;
+    } else {
+        v_for_lane = ISO_QW * rz + ISO_QCX * ry - ISO_QCY * rx + ISO_QCZ * rw;
+    }
+
+    return v_for_lane * norms[tok_idx];
+}
+
+#define IF_TILE_SIZE 64u
+#define IF_HEAD_DIM_MAX 512

--- a/crates/rmlx-kv-quant/src/metal/probes/iso_flash_decode_p1_b4.hdr.metal
+++ b/crates/rmlx-kv-quant/src/metal/probes/iso_flash_decode_p1_b4.hdr.metal
@@ -1,0 +1,85 @@
+
+// Iso flash-decode header — unpack params + conjugated golden-ratio
+// fixed quaternion + Lloyd-Max N(0,1) codebook + the shared per-lane
+// K decode.
+// BITS = 4 (codebook = 16 entries, mask = 0xF).
+// Bit-exact with crate::isoquant::FIXED_QUAT + lloyd_gaussian_codebook(4).
+
+#define IF_BITS 4u
+#define IF_MASK 0xFu
+
+constant float ISO_QW  = as_type<float>(0x3EE4F930u);
+constant float ISO_QCX = as_type<float>(0xBF393E4Cu);
+constant float ISO_QCY = as_type<float>(0xBE8D8368u);
+constant float ISO_QCZ = as_type<float>(0xBEE4F930u);
+
+constant float ISO_CB[16] = {
+    as_type<float>(0xC02DEE42u),
+    as_type<float>(0xC003563Bu),
+    as_type<float>(0xBFCCE718u),
+    as_type<float>(0xBF9EB6FAu),
+    as_type<float>(0xBF6DA172u),
+    as_type<float>(0xBF255816u),
+    as_type<float>(0xBEC329CBu),
+    as_type<float>(0xBE011273u),
+    as_type<float>(0x3E011273u),
+    as_type<float>(0x3EC329CBu),
+    as_type<float>(0x3F255816u),
+    as_type<float>(0x3F6DA172u),
+    as_type<float>(0x3F9EB6FAu),
+    as_type<float>(0x3FCCE718u),
+    as_type<float>(0x4003563Bu),
+    as_type<float>(0x402DEE42u)
+};
+
+// Decode one head-dim lane of an iso-quantized token.
+//
+// `tok_idx` indexes the flat sequence-major token stream
+// (`(b * kv_seq + t) * kv_h + kv_h_idx`); `lane` is the head-dim slot
+// in [0, head_dim). Bit-exact with the CPU iso_decode_fast.
+//
+// Self-contained per lane: the group's four codes all live in one u32,
+// so the Hamilton product runs in registers with no threadgroup
+// staging and no barrier — callable from any kernel body.
+//
+// Shared surface: a quantized-V flash kernel calls this unchanged,
+// passing the V store's (codes, scales, norms) instead of K's.
+inline float if_decode_k_lane(
+    device const uint*  codes,
+    device const float* scales,
+    device const float* norms,
+    uint                tok_idx,
+    uint                n_groups,
+    uint                lane) {
+    // Each group of 4 head-dim slots is one quaternion block.
+    uint group_id_in_head = lane / 4u;
+    uint lane_in_group    = lane - group_id_in_head * 4u;
+
+    uint  word    = codes[tok_idx * n_groups + group_id_in_head];
+    float k_scale = scales[tok_idx * n_groups + group_id_in_head];
+
+    // Unpack the group's 4 IF_BITS-bit codes -> centroid x scale.
+    float rw = ISO_CB[(word >> (0u * IF_BITS)) & IF_MASK] * k_scale;
+    float rx = ISO_CB[(word >> (1u * IF_BITS)) & IF_MASK] * k_scale;
+    float ry = ISO_CB[(word >> (2u * IF_BITS)) & IF_MASK] * k_scale;
+    float rz = ISO_CB[(word >> (3u * IF_BITS)) & IF_MASK] * k_scale;
+
+    // Inverse rotation: r' = qbar * r, Hamilton product in the
+    // [w, x, y, z] convention. qbar = (ISO_QW, ISO_QCX, ISO_QCY,
+    // ISO_QCZ) is already conjugated by the header.
+    float v_for_lane;
+    if (lane_in_group == 0u) {
+        v_for_lane = ISO_QW * rw - ISO_QCX * rx - ISO_QCY * ry - ISO_QCZ * rz;
+    } else if (lane_in_group == 1u) {
+        v_for_lane = ISO_QW * rx + ISO_QCX * rw + ISO_QCY * rz - ISO_QCZ * ry;
+    } else if (lane_in_group == 2u) {
+        v_for_lane = ISO_QW * ry - ISO_QCX * rz + ISO_QCY * rw + ISO_QCZ * rx;
+    } else {
+        v_for_lane = ISO_QW * rz + ISO_QCX * ry - ISO_QCY * rx + ISO_QCZ * rw;
+    }
+
+    return v_for_lane * norms[tok_idx];
+}
+
+#define IF_TILE_SIZE 64u
+#define IF_HEAD_DIM_MAX 512

--- a/crates/rmlx-kv-quant/src/metal/probes/kernels.manifest
+++ b/crates/rmlx-kv-quant/src/metal/probes/kernels.manifest
@@ -19,6 +19,11 @@
 # the probe only — production still builds them at dispatch. Regenerate them if
 # a header builder changes; see README.md here.
 
+# One flash-decode pass-1 body serves both iso bit widths — the unpack width
+# arrives via the header (IF_BITS / IF_MASK), so each header gets its own probe
+# line over the same body.
+iso_flash_decode_p1.metal | iso_flash_decode_p1_b3.hdr.metal | query:f,codes:u,scales:f,norms:f,v_flat:f,mask_flat:f,scale_arr:f,dims:u,partial_o:f,tile_max:f,tile_sum_exp:f
+iso_flash_decode_p1.metal | iso_flash_decode_p1_b4.hdr.metal | query:f,codes:u,scales:f,norms:f,v_flat:f,mask_flat:f,scale_arr:f,dims:u,partial_o:f,tile_max:f,tile_sum_exp:f
 iso_fused_qk_b3.metal | iso_fused_qk_b3.hdr.metal | query:f,codes:u,scales:f,norms:f,mask:f,scale_arr:f,dims:u,out:f
 iso_fused_qk_b4.metal | iso_fused_qk_b4.hdr.metal | query:f,codes:u,scales:f,norms:f,mask:f,scale_arr:f,dims:u,out:f
 isoquant_quantize_iso3.metal | isoquant_iso3.hdr.metal | inp:f,n_groups:u,codes_out:u,scales_out:f,norms_out:f
@@ -26,8 +31,9 @@ isoquant_dequantize_iso3.metal | isoquant_iso3.hdr.metal | codes_in:u,scales_in:
 k8vturbo3_quantize.metal | ../k8vturbo3_header.metal | inp:f,codes:u,scales:f
 k8vturbo3_dequantize.metal | ../k8vturbo3_header.metal | codes:u,scales:f,out:f
 planar_flash_decode_p1.metal | planar_flash_decode_p1.hdr.metal | query:f,k_codes:u,k_scales:f,k_rot32:u,v_flat:f,mask_flat:f,scale_arr:f,dims:u,partial_o:f,tile_max:f,tile_sum_exp:f
-# Codec-agnostic flash-decode pass-2 LSE merge; shared by the planar and rotor
-# flash-decode dispatchers (each registers its own kernel name over this body).
+# Codec-agnostic flash-decode pass-2 LSE merge; shared by the planar, rotor and
+# iso flash-decode dispatchers (each registers its own kernel name over this
+# body).
 flash_decode_merge_p2.metal | - | partial_o:f,tile_max:f,tile_sum_exp:f,dims_p2:u,dst:f
 planar_fused_qk_b3.metal | planar_fused_qk_b3.hdr.metal | query:f,codes:u,scales:f,rot32:u,scale_arr:f,dims:u,out:f
 planar_fused_qk_b4.metal | planar_fused_qk_b4.hdr.metal | query:f,codes:u,scales:f,rot32:u,scale_arr:f,dims:u,out:f

--- a/crates/rmlx-kv-quant/src/storage/kv_storage.rs
+++ b/crates/rmlx-kv-quant/src/storage/kv_storage.rs
@@ -2001,7 +2001,7 @@ fn quant_rotor_v4_bytes(qv: Option<&QuantRotorV4>) -> u64 {
 
 /// Rotor3 K buffer (`QuantRotorK3`).
 ///
-/// Counts the CPU blocks only. The GPU-resident ring (`RotorGpuK`) that backs
+/// Counts the CPU blocks only. The GPU-resident ring (`QuantKGpuRing`) that backs
 /// the rotor flash-decode is accounted by `QuantRotorK3::byte_size`.
 ///
 /// Includes: static `rotors: Vec<f32>` (4 B), optional QJL projection matrix

--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -59,7 +59,9 @@ pub use kv_storage::{
     ROTOR_SYM_3_QJL_LAYOUT_TAG, ROTOR_SYM_4_LAYOUT_TAG, ROTOR_SYM_4_QJL_LAYOUT_TAG,
     TURBOSYM3_LAYOUT_TAG, TURBOSYM4_LAYOUT_TAG,
 };
-pub use quant_iso_k::{iso_n_groups_for, QuantIsoK3, ISO_K3_BITS, ISO_K3_GROUP_SIZE};
+pub use quant_iso_k::{
+    iso_n_groups_for, QuantIsoK3, ISO_K3_BITS, ISO_K3_GROUP_SIZE, ISO_QUAT_BLOCK_SIZE,
+};
 pub use quant_iso_k4::{QuantIsoK4, ISO_K4_BITS, ISO_K4_GROUP_SIZE};
 pub use quant_iso_v::{IsoBlocks, QuantIsoV3, ISO3_BITS, ISO3_GROUP_SIZE};
 pub use quant_iso_v4::{QuantIsoV4, ISO4_BITS, ISO4_GROUP_SIZE};

--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -37,6 +37,7 @@ mod quant_iso_k4;
 mod quant_iso_v;
 mod quant_iso_v4;
 mod quant_k;
+mod quant_k_gpu_ring;
 mod quant_k_turbo3;
 mod quant_k_turbo4;
 mod quant_planar_k;
@@ -46,7 +47,6 @@ mod quant_rotor_k4;
 mod quant_rotor_v3;
 mod quant_rotor_v4;
 mod quant_v;
-mod rotor_gpu_k;
 mod seq_layout;
 
 pub use kv_storage::{
@@ -59,11 +59,12 @@ pub use kv_storage::{
     ROTOR_SYM_3_QJL_LAYOUT_TAG, ROTOR_SYM_4_LAYOUT_TAG, ROTOR_SYM_4_QJL_LAYOUT_TAG,
     TURBOSYM3_LAYOUT_TAG, TURBOSYM4_LAYOUT_TAG,
 };
-pub use quant_iso_k::{QuantIsoK3, ISO_K3_BITS, ISO_K3_GROUP_SIZE};
+pub use quant_iso_k::{iso_n_groups_for, QuantIsoK3, ISO_K3_BITS, ISO_K3_GROUP_SIZE};
 pub use quant_iso_k4::{QuantIsoK4, ISO_K4_BITS, ISO_K4_GROUP_SIZE};
 pub use quant_iso_v::{IsoBlocks, QuantIsoV3, ISO3_BITS, ISO3_GROUP_SIZE};
 pub use quant_iso_v4::{QuantIsoV4, ISO4_BITS, ISO4_GROUP_SIZE};
 pub use quant_k::QuantK;
+pub use quant_k_gpu_ring::QuantKGpuRing;
 pub use quant_k_turbo3::{QuantKTurbo3, TURBO3_K_BITS};
 pub use quant_k_turbo4::QuantKTurbo4;
 pub use quant_planar_k::QuantPlanarK;
@@ -73,7 +74,6 @@ pub use quant_rotor_k4::{QuantRotorK4, ROTOR4_K_BITS, ROTOR4_K_GROUP_SIZE};
 pub use quant_rotor_v3::{QuantRotorV3, RotorBlocks, ROTOR3_V_BITS, ROTOR3_V_GROUP_SIZE};
 pub use quant_rotor_v4::{QuantRotorV4, ROTOR4_V_BITS, ROTOR4_V_GROUP_SIZE};
 pub use quant_v::QuantV;
-pub use rotor_gpu_k::RotorGpuK;
 
 #[cfg(test)]
 #[path = "quant_rotor_k_qjl_tests.rs"]

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -16,11 +16,13 @@
 )]
 //! Quantized K buffer: `QuantIsoK3` (IsoQuant 3-bit K codec).
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{Array, Device, Dtype};
 
 use crate::isoquant::{iso_decode_fast, iso_encode_fast, IsoQuantError};
 use crate::storage::quant_iso_v::IsoBlocks;
+
+use super::QuantKGpuRing;
 
 /// Bit-width of the iso3 K codec (fixed at 3-bit — identical codebook to the
 /// V-side [`crate::storage::QuantIsoV3`]).
@@ -30,20 +32,71 @@ pub const ISO_K3_BITS: u8 = 3;
 /// group in fast mode).
 pub const ISO_K3_GROUP_SIZE: usize = 4;
 
+/// Per-token group count for an iso K row of `head_dim` elements.
+///
+/// One quaternion block per group, so `head_dim / 4`. This is iso's group rule
+/// and it lives here, in iso's own store — [`QuantKGpuRing`] is told the
+/// resulting integer and knows nothing about quaternions.
+#[must_use]
+pub fn iso_n_groups_for(head_dim: usize) -> usize {
+    head_dim / ISO_K3_GROUP_SIZE
+}
+
+/// [`iso_n_groups_for`] with the group-size invariant enforced, as `i32`.
+///
+/// A `head_dim` that is not a multiple of the quaternion block size would
+/// silently truncate the last partial group, so it is an error rather than a
+/// rounded-down group count.
+///
+/// # Errors
+///
+/// Returns [`Error::Quant`] when `head_dim` is not a positive multiple of
+/// [`ISO_K3_GROUP_SIZE`].
+pub(crate) fn iso_n_groups_i32(head_dim: i32, what: &str) -> Result<i32> {
+    let hd = usize::try_from(head_dim)
+        .map_err(|_| Error::Quant(format!("{what}: head_dim={head_dim} must be positive")))?;
+    if hd == 0 || !hd.is_multiple_of(ISO_K3_GROUP_SIZE) {
+        return Err(Error::Quant(format!(
+            "{what}: head_dim={head_dim} must be a positive multiple of \
+             ISO_K3_GROUP_SIZE={ISO_K3_GROUP_SIZE}"
+        )));
+    }
+    i32::try_from(iso_n_groups_for(hd)).map_err(|_| {
+        Error::Quant(format!(
+            "{what}: n_groups for head_dim={head_dim} exceeds i32::MAX"
+        ))
+    })
+}
+
 /// Accumulated IsoQuant K cache (3-bit, quaternion SO(4) fast mode).
 ///
-/// CPU-only — no MSL kernel for K-side iso3 (the V-side iso3 MSL kernel
-/// in `isoquant_msl.rs` is structurally K/V-agnostic but the K-side dispatch
-/// path falls through to the dequant-then-SDPA legacy fallback). Storage
-/// payload layout is identical to [`crate::storage::QuantIsoV3`] — the only
-/// distinction at the storage level is the role on the SDPA path.
+/// Carries both forms of the payload:
+///
+/// * `blocks` — CPU [`IsoBlocks`], the source of truth for `dequant()` and the
+///   SSD spill/hydrate round-trip.
+/// * `gpu` — the optional GPU-resident packed ring ([`QuantKGpuRing`]),
+///   populated by [`Self::gpu_append`]. When present it lets the iso
+///   flash-decode kernel read the quant store directly instead of paying a
+///   full-prefix CPU `dequant()` per decode step.
+///
+/// Storage payload layout is identical to [`crate::storage::QuantIsoV3`] — the
+/// only distinction at the storage level is the role on the SDPA path.
 pub struct QuantIsoK3 {
     /// Accumulated per-token blocks (one entry per append call; `dequant`
     /// flattens them).
     pub blocks: Vec<IsoBlocks>,
+    /// GPU-resident packed ring. Empty until the first [`Self::gpu_append`].
+    pub gpu: QuantKGpuRing,
     /// Accumulated shape `[B, kv_h, S_total, D]`.
     pub shape: Vec<i32>,
     /// Maximum sequence length the storage was provisioned for.
+    ///
+    /// Inert: nothing sizes a buffer from it. The provisioned window that the
+    /// GPU ring grows against is a **per-call** `max_seq` argument to
+    /// [`Self::gpu_append`], read from the live `KvStorage` variant by the
+    /// caller. A snapshot cached here would go stale the moment the window
+    /// grows during decode, which is exactly how the rotor ring came to reject
+    /// valid appends mid-stream — do not wire the ring to this field.
     pub max_seq: i32,
     /// Bit-width tag (always [`ISO_K3_BITS`]).
     pub bits: u8,
@@ -53,6 +106,7 @@ impl std::fmt::Debug for QuantIsoK3 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QuantIsoK3")
             .field("n_blocks", &self.blocks.len())
+            .field("gpu_resident", &self.gpu.is_allocated())
             .field("shape", &self.shape)
             .field("max_seq", &self.max_seq)
             .field("bits", &self.bits)
@@ -66,6 +120,7 @@ impl QuantIsoK3 {
     pub fn new(init_shape: Vec<i32>, max_seq: i32) -> Self {
         Self {
             blocks: Vec::new(),
+            gpu: QuantKGpuRing::default(),
             shape: init_shape,
             max_seq,
             bits: ISO_K3_BITS,
@@ -78,7 +133,7 @@ impl QuantIsoK3 {
     /// Forwards any [`IsoQuantError`] from [`iso_encode_fast`].
     pub fn append(&mut self, f32_data: &[f32], new_shape: &[i32]) -> Result<()> {
         if new_shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantIsoK3::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
@@ -97,9 +152,8 @@ impl QuantIsoK3 {
             super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
 
         let (codes, scales, quaternions, norms) =
-            iso_encode_fast(&seq_major, head_dim, ISO_K3_GROUP_SIZE, ISO_K3_BITS).map_err(
-                |e: IsoQuantError| rmlx_core::error::Error::Mlx(format!("iso_k3 encode: {e}")),
-            )?;
+            iso_encode_fast(&seq_major, head_dim, ISO_K3_GROUP_SIZE, ISO_K3_BITS)
+                .map_err(|e: IsoQuantError| Error::Mlx(format!("iso_k3 encode: {e}")))?;
 
         self.blocks.push(IsoBlocks {
             codes,
@@ -108,6 +162,10 @@ impl QuantIsoK3 {
             norms,
             n_tokens: n_tokens_total,
         });
+
+        // A CPU append does not touch the GPU ring, so any live ring is now a
+        // stale prefix. Drop it; the next `gpu_append` re-seeds from `blocks`.
+        self.gpu.clear();
 
         if self.shape.len() != 4 || self.shape[0] == 0 {
             self.shape = new_shape.to_vec();
@@ -132,6 +190,9 @@ impl QuantIsoK3 {
         );
         Self {
             blocks,
+            // Hydrated caches start CPU-only; the ring is rebuilt lazily from
+            // the next GPU append.
+            gpu: QuantKGpuRing::default(),
             shape,
             max_seq,
             bits: ISO_K3_BITS,
@@ -141,6 +202,9 @@ impl QuantIsoK3 {
     /// Reset the accumulated sequence length to zero.
     pub fn reset(&mut self) {
         self.blocks.clear();
+        // The ring would otherwise keep a prefix the CPU blocks no longer
+        // claim. Dropped here; the next `gpu_append` re-seeds from `blocks`.
+        self.gpu.clear();
         if self.shape.len() >= 4 {
             self.shape[2] = 0;
         }
@@ -160,6 +224,9 @@ impl QuantIsoK3 {
             }
         }
         self.blocks.truncate(keep);
+        // The ring's filled prefix no longer matches `blocks`; drop it rather
+        // than leave a longer-than-truncated prefix live.
+        self.gpu.clear();
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }
@@ -172,13 +239,105 @@ impl QuantIsoK3 {
     pub fn try_deep_clone(&self) -> Result<Self> {
         Ok(Self {
             blocks: self.blocks.clone(),
+            // The clone starts CPU-only: `blocks` carries the full payload, so
+            // the ring re-seeds from them on the clone's first GPU append.
+            // Sharing the source's Arrays would alias one ring across two
+            // independent caches.
+            gpu: QuantKGpuRing::default(),
             shape: self.shape.clone(),
             max_seq: self.max_seq,
             bits: self.bits,
         })
     }
 
+    /// Concatenate the accumulated CPU blocks into flat sequence-major
+    /// `(codes, scales, norms)` — the form [`QuantKGpuRing::seed_from_cpu`]
+    /// wants.
+    fn flatten_blocks(&self) -> (Vec<u32>, Vec<f32>, Vec<f32>) {
+        // Exact capacities — the prefill seed concatenates the whole prefix
+        // (millions of entries at long context), so growing from empty would
+        // realloc+memcpy repeatedly.
+        let (n_codes, n_scales, n_norms) = self.blocks.iter().fold((0, 0, 0), |(c, s, n), blk| {
+            (
+                c + blk.codes.len(),
+                s + blk.scales.len(),
+                n + blk.norms.len(),
+            )
+        });
+        let mut codes = Vec::with_capacity(n_codes);
+        let mut scales = Vec::with_capacity(n_scales);
+        let mut norms = Vec::with_capacity(n_norms);
+        for blk in &self.blocks {
+            codes.extend_from_slice(&blk.codes);
+            scales.extend_from_slice(&blk.scales);
+            norms.extend_from_slice(&blk.norms);
+        }
+        (codes, scales, norms)
+    }
+
+    /// Push one GPU-encoded chunk into the GPU ring, seeding the ring from the
+    /// accumulated CPU blocks first when it is not yet live.
+    ///
+    /// `codes` / `scales` / `norms` are the iso encode kernel's GPU outputs for
+    /// a **sequence-major** chunk; `norms` must already be per-token (the iso
+    /// quantize kernel emits a per-group norm slot — the caller deduplicates).
+    /// `prev_seq` is the accumulated sequence length **before** this chunk.
+    ///
+    /// This only maintains the ring — the caller still pushes the matching CPU
+    /// block, which stays the source of truth for `dequant()` and SSD spill.
+    ///
+    /// `max_seq` is the window the cache is provisioned for **right now**, read
+    /// from the active `KvStorage` variant by the caller. It is a parameter
+    /// rather than a field so it cannot go stale as the window grows during
+    /// decode — see the note on [`Self::max_seq`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Quant`] when `head_dim` violates the group-size
+    /// invariant, and forwards [`QuantKGpuRing::seed_from_cpu`] /
+    /// [`QuantKGpuRing::append_encoded`] errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gpu_append(
+        &mut self,
+        codes: &Array,
+        scales: &Array,
+        norms: &Array,
+        kv_h: i32,
+        head_dim: i32,
+        prev_seq: i32,
+        new_seq: i32,
+        max_seq: i32,
+        device: Device,
+    ) -> Result<()> {
+        let n_groups = iso_n_groups_i32(head_dim, "QuantIsoK3::gpu_append")?;
+        if !self.gpu.is_allocated() && prev_seq > 0 {
+            let (c, s, n) = self.flatten_blocks();
+            self.gpu
+                .seed_from_cpu(&c, &s, &n, kv_h, n_groups, prev_seq, max_seq, device)?;
+        }
+        self.gpu.append_encoded(
+            codes, scales, norms, kv_h, n_groups, prev_seq, new_seq, max_seq, device,
+        )
+    }
+
+    /// GPU packed view of the first `kv_seq` positions, or `None` when the ring
+    /// is not live (CPU path — caller falls back to `dequant`).
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`QuantKGpuRing::packed_view`] errors.
+    pub fn gpu_packed_view(
+        &self,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Option<(Array, Array, Array)>> {
+        self.gpu.packed_view(kv_seq, device)
+    }
+
     /// Approximate byte footprint of the accumulated payload.
+    ///
+    /// Includes the GPU ring when live — it is real resident memory, so
+    /// omitting it would under-report this cache's KV bytes.
     #[must_use]
     pub fn byte_size(&self) -> usize {
         let mut total = 0usize;
@@ -188,7 +347,7 @@ impl QuantIsoK3 {
             total += blk.quaternions.len() * size_of::<f32>();
             total += blk.norms.len() * size_of::<f32>();
         }
-        total
+        total + self.gpu.byte_size()
     }
 
     /// Dequantize all accumulated K slices into one flat f32 vector of length
@@ -198,7 +357,7 @@ impl QuantIsoK3 {
     /// Returns an `Error::Mlx` if the underlying [`iso_decode_fast`] fails.
     pub fn dequant(&self) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantIsoK3::dequant: malformed shape {:?}",
                 self.shape
             )));
@@ -216,9 +375,7 @@ impl QuantIsoK3 {
                 ISO_K3_GROUP_SIZE,
                 ISO_K3_BITS,
             )
-            .map_err(|e: IsoQuantError| {
-                rmlx_core::error::Error::Mlx(format!("iso_k3 decode: {e}"))
-            })?;
+            .map_err(|e: IsoQuantError| Error::Mlx(format!("iso_k3 decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
         if out.len() < total_elems {
@@ -248,14 +405,14 @@ impl QuantIsoK3 {
     ///   `ISO_K3_GROUP_SIZE` multiple constraint.
     pub fn dequant_gpu(&self, device: Device) -> Result<Array> {
         if self.shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantIsoK3::dequant_gpu: malformed shape {:?}",
                 self.shape
             )));
         }
         let head_dim = self.shape[3] as usize;
         if head_dim == 0 || !head_dim.is_multiple_of(ISO_K3_GROUP_SIZE) {
-            return Err(rmlx_core::error::Error::Quant(format!(
+            return Err(Error::Quant(format!(
                 "QuantIsoK3::dequant_gpu: head_dim={head_dim} must be a positive multiple of \
                  ISO_K3_GROUP_SIZE={ISO_K3_GROUP_SIZE}"
             )));
@@ -286,24 +443,20 @@ impl QuantIsoK3 {
             }
             // Checked arithmetic — see V-side mirror.
             let blk_groups = blk.n_tokens.checked_mul(n_groups).ok_or_else(|| {
-                rmlx_core::error::Error::Quant(
-                    "dequant_gpu: blk.n_tokens * n_groups overflow".to_owned(),
-                )
+                Error::Quant("dequant_gpu: blk.n_tokens * n_groups overflow".to_owned())
             })?;
-            total_groups = total_groups.checked_add(blk_groups).ok_or_else(|| {
-                rmlx_core::error::Error::Quant("dequant_gpu: total_groups overflow".to_owned())
-            })?;
+            total_groups = total_groups
+                .checked_add(blk_groups)
+                .ok_or_else(|| Error::Quant("dequant_gpu: total_groups overflow".to_owned()))?;
         }
 
         // Guard against silent shape divergence — see V-side mirror.
         let declared_total: usize = self.shape.iter().map(|&d| d as usize).product();
         let actual_total: usize = total_groups.checked_mul(ISO_K3_GROUP_SIZE).ok_or_else(|| {
-            rmlx_core::error::Error::Quant(
-                "dequant_gpu: total_groups * ISO_K3_GROUP_SIZE overflow".to_owned(),
-            )
+            Error::Quant("dequant_gpu: total_groups * ISO_K3_GROUP_SIZE overflow".to_owned())
         })?;
         if actual_total != declared_total {
-            return Err(rmlx_core::error::Error::Quant(format!(
+            return Err(Error::Quant(format!(
                 "dequant_gpu: actual_total={actual_total} (blocks×groups×group_size) != \
                  declared_total={declared_total} (prod(shape)={:?}); refusing to silently \
                  truncate/pad",

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -28,18 +28,32 @@ use super::QuantKGpuRing;
 /// V-side [`crate::storage::QuantIsoV3`]).
 pub const ISO_K3_BITS: u8 = 3;
 
-/// Quaternion-block size for the iso3 K codec (fixed at 4; one quaternion per
-/// group in fast mode).
-pub const ISO_K3_GROUP_SIZE: usize = 4;
+/// Elements per iso group: the component count of a quaternion.
+///
+/// **Codec-wide, and not a tunable.** The iso codec's group *is* one quaternion
+/// block (`iso_encode_fast` rotates `[w, x, y, z]` at a time), so this is fixed
+/// by the algebra rather than chosen per bit width — 3-bit and 4-bit iso differ
+/// in codebook and pack stride, never in this. The per-width aliases
+/// [`ISO_K3_GROUP_SIZE`] / [`crate::storage::ISO_K4_GROUP_SIZE`] are defined
+/// from it so they cannot drift apart: the iso4 GPU paths derive their ring
+/// stride through [`iso_n_groups_for`] while `QuantIsoK4::append` uses the K4
+/// alias, and a divergence would silently mismatch the iso4 ring against its
+/// own CPU blocks.
+pub const ISO_QUAT_BLOCK_SIZE: usize = 4;
 
-/// Per-token group count for an iso K row of `head_dim` elements.
+/// Quaternion-block size for the iso3 K codec. Alias of
+/// [`ISO_QUAT_BLOCK_SIZE`] — see it for why this is not independently tunable.
+pub const ISO_K3_GROUP_SIZE: usize = ISO_QUAT_BLOCK_SIZE;
+
+/// Per-token group count for an iso K row of `head_dim` elements — **both** bit
+/// widths.
 ///
 /// One quaternion block per group, so `head_dim / 4`. This is iso's group rule
 /// and it lives here, in iso's own store — [`QuantKGpuRing`] is told the
 /// resulting integer and knows nothing about quaternions.
 #[must_use]
 pub fn iso_n_groups_for(head_dim: usize) -> usize {
-    head_dim / ISO_K3_GROUP_SIZE
+    head_dim / ISO_QUAT_BLOCK_SIZE
 }
 
 /// [`iso_n_groups_for`] with the group-size invariant enforced, as `i32`.
@@ -51,14 +65,14 @@ pub fn iso_n_groups_for(head_dim: usize) -> usize {
 /// # Errors
 ///
 /// Returns [`Error::Quant`] when `head_dim` is not a positive multiple of
-/// [`ISO_K3_GROUP_SIZE`].
+/// [`ISO_QUAT_BLOCK_SIZE`].
 pub(crate) fn iso_n_groups_i32(head_dim: i32, what: &str) -> Result<i32> {
     let hd = usize::try_from(head_dim)
         .map_err(|_| Error::Quant(format!("{what}: head_dim={head_dim} must be positive")))?;
-    if hd == 0 || !hd.is_multiple_of(ISO_K3_GROUP_SIZE) {
+    if hd == 0 || !hd.is_multiple_of(ISO_QUAT_BLOCK_SIZE) {
         return Err(Error::Quant(format!(
-            "{what}: head_dim={head_dim} must be a positive multiple of \
-             ISO_K3_GROUP_SIZE={ISO_K3_GROUP_SIZE}"
+            "{what}: head_dim={head_dim} must be a positive multiple of the quaternion \
+             block size {ISO_QUAT_BLOCK_SIZE}"
         )));
     }
     i32::try_from(iso_n_groups_for(hd)).map_err(|_| {

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
@@ -12,9 +12,13 @@
 //! Quantized K buffer: `QuantIsoK4` (IsoQuant 4-bit K codec).
 
 use rmlx_core::error::Result;
+use rmlx_mlx::{Array, Device};
 
 use crate::isoquant::{iso_decode_fast, iso_encode_fast, IsoQuantError};
+use crate::storage::quant_iso_k::iso_n_groups_i32;
 use crate::storage::quant_iso_v::IsoBlocks;
+
+use super::QuantKGpuRing;
 
 /// Bit-width of the iso4 K codec (fixed at 4-bit).
 pub const ISO_K4_BITS: u8 = 4;
@@ -25,13 +29,19 @@ pub const ISO_K4_GROUP_SIZE: usize = 4;
 /// Accumulated IsoQuant K cache (4-bit, quaternion SO(4) fast mode).
 ///
 /// Same per-block payload as [`crate::storage::QuantIsoK3`] with `bits=4` and
-/// the dense 8-vals-per-u32 pack handled internally by `iso_encode_fast`.
+/// the dense 8-vals-per-u32 pack handled internally by `iso_encode_fast`, and
+/// the same optional GPU ring — see [`crate::storage::QuantIsoK3`] for the
+/// field semantics.
 pub struct QuantIsoK4 {
     /// Accumulated per-token blocks.
     pub blocks: Vec<IsoBlocks>,
+    /// GPU-resident packed ring. Empty until the first [`Self::gpu_append`].
+    pub gpu: QuantKGpuRing,
     /// Accumulated shape `[B, kv_h, S_total, D]`.
     pub shape: Vec<i32>,
-    /// Maximum sequence length provisioned.
+    /// Maximum sequence length provisioned. Inert — see
+    /// [`crate::storage::QuantIsoK3::max_seq`]; the ring grows against a
+    /// per-call `max_seq`, never this snapshot.
     pub max_seq: i32,
     /// Bit-width tag (always [`ISO_K4_BITS`]).
     pub bits: u8,
@@ -41,6 +51,7 @@ impl std::fmt::Debug for QuantIsoK4 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QuantIsoK4")
             .field("n_blocks", &self.blocks.len())
+            .field("gpu_resident", &self.gpu.is_allocated())
             .field("shape", &self.shape)
             .field("max_seq", &self.max_seq)
             .field("bits", &self.bits)
@@ -54,6 +65,7 @@ impl QuantIsoK4 {
     pub fn new(init_shape: Vec<i32>, max_seq: i32) -> Self {
         Self {
             blocks: Vec::new(),
+            gpu: QuantKGpuRing::default(),
             shape: init_shape,
             max_seq,
             bits: ISO_K4_BITS,
@@ -118,6 +130,9 @@ impl QuantIsoK4 {
         );
         Self {
             blocks,
+            // Hydrated caches start CPU-only; the ring is rebuilt lazily from
+            // the next GPU append.
+            gpu: QuantKGpuRing::default(),
             shape,
             max_seq,
             bits: ISO_K4_BITS,
@@ -127,6 +142,9 @@ impl QuantIsoK4 {
     /// Reset the accumulated sequence length to zero.
     pub fn reset(&mut self) {
         self.blocks.clear();
+        // The ring would otherwise keep a prefix the CPU blocks no longer
+        // claim. Dropped here; the next `gpu_append` re-seeds from `blocks`.
+        self.gpu.clear();
         if self.shape.len() >= 4 {
             self.shape[2] = 0;
         }
@@ -146,6 +164,9 @@ impl QuantIsoK4 {
             }
         }
         self.blocks.truncate(keep);
+        // The ring's filled prefix no longer matches `blocks`; drop it rather
+        // than leave a longer-than-truncated prefix live.
+        self.gpu.clear();
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }
@@ -158,13 +179,85 @@ impl QuantIsoK4 {
     pub fn try_deep_clone(&self) -> Result<Self> {
         Ok(Self {
             blocks: self.blocks.clone(),
+            // The clone starts CPU-only — see
+            // [`crate::storage::QuantIsoK3::try_deep_clone`].
+            gpu: QuantKGpuRing::default(),
             shape: self.shape.clone(),
             max_seq: self.max_seq,
             bits: self.bits,
         })
     }
 
-    /// Approximate byte footprint.
+    /// Concatenate the accumulated CPU blocks into flat sequence-major
+    /// `(codes, scales, norms)`. See
+    /// [`crate::storage::QuantIsoK3::flatten_blocks`].
+    fn flatten_blocks(&self) -> (Vec<u32>, Vec<f32>, Vec<f32>) {
+        let (n_codes, n_scales, n_norms) = self.blocks.iter().fold((0, 0, 0), |(c, s, n), blk| {
+            (
+                c + blk.codes.len(),
+                s + blk.scales.len(),
+                n + blk.norms.len(),
+            )
+        });
+        let mut codes = Vec::with_capacity(n_codes);
+        let mut scales = Vec::with_capacity(n_scales);
+        let mut norms = Vec::with_capacity(n_norms);
+        for blk in &self.blocks {
+            codes.extend_from_slice(&blk.codes);
+            scales.extend_from_slice(&blk.scales);
+            norms.extend_from_slice(&blk.norms);
+        }
+        (codes, scales, norms)
+    }
+
+    /// Push one GPU-encoded chunk into the GPU ring. Mirror of
+    /// [`crate::storage::QuantIsoK3::gpu_append`] — see it for the contract,
+    /// including why `max_seq` is a parameter and not a field.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`rmlx_core::error::Error::Quant`] when `head_dim` violates the
+    /// group-size invariant, and forwards ring errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gpu_append(
+        &mut self,
+        codes: &Array,
+        scales: &Array,
+        norms: &Array,
+        kv_h: i32,
+        head_dim: i32,
+        prev_seq: i32,
+        new_seq: i32,
+        max_seq: i32,
+        device: Device,
+    ) -> Result<()> {
+        let n_groups = iso_n_groups_i32(head_dim, "QuantIsoK4::gpu_append")?;
+        if !self.gpu.is_allocated() && prev_seq > 0 {
+            let (c, s, n) = self.flatten_blocks();
+            self.gpu
+                .seed_from_cpu(&c, &s, &n, kv_h, n_groups, prev_seq, max_seq, device)?;
+        }
+        self.gpu.append_encoded(
+            codes, scales, norms, kv_h, n_groups, prev_seq, new_seq, max_seq, device,
+        )
+    }
+
+    /// GPU packed view of the first `kv_seq` positions. Mirror of
+    /// [`crate::storage::QuantIsoK3::gpu_packed_view`].
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`QuantKGpuRing::packed_view`] errors.
+    pub fn gpu_packed_view(
+        &self,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Option<(Array, Array, Array)>> {
+        self.gpu.packed_view(kv_seq, device)
+    }
+
+    /// Approximate byte footprint. Includes the GPU ring when live — it is
+    /// real resident memory.
     #[must_use]
     pub fn byte_size(&self) -> usize {
         let mut total = 0usize;
@@ -174,7 +267,7 @@ impl QuantIsoK4 {
             total += blk.quaternions.len() * size_of::<f32>();
             total += blk.norms.len() * size_of::<f32>();
         }
-        total
+        total + self.gpu.byte_size()
     }
 
     /// Dequantize all accumulated K slices into one flat f32 vector.

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
@@ -23,8 +23,12 @@ use super::QuantKGpuRing;
 /// Bit-width of the iso4 K codec (fixed at 4-bit).
 pub const ISO_K4_BITS: u8 = 4;
 
-/// Quaternion-block size for the iso4 K codec (fixed at 4 elements/group).
-pub const ISO_K4_GROUP_SIZE: usize = 4;
+/// Quaternion-block size for the iso4 K codec. Alias of
+/// [`crate::storage::ISO_QUAT_BLOCK_SIZE`] — one quaternion per group is fixed
+/// by the algebra, not chosen per bit width, and defining it from the shared
+/// constant is what stops this store's CPU blocks drifting away from the ring
+/// stride its GPU paths derive via `iso_n_groups_for`.
+pub const ISO_K4_GROUP_SIZE: usize = crate::storage::ISO_QUAT_BLOCK_SIZE;
 
 /// Accumulated IsoQuant K cache (4-bit, quaternion SO(4) fast mode).
 ///
@@ -106,6 +110,10 @@ impl QuantIsoK4 {
             norms,
             n_tokens: n_tokens_total,
         });
+
+        // A CPU append does not touch the GPU ring, so any live ring is now a
+        // stale prefix. Drop it; the next `gpu_append` re-seeds from `blocks`.
+        self.gpu.clear();
 
         if self.shape.len() != 4 || self.shape[0] == 0 {
             self.shape = new_shape.to_vec();

--- a/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring.rs
@@ -1,17 +1,21 @@
-// Shared GPU-resident ring for the rotor K codecs (rotor3 / rotor4).
+// Shared GPU-resident ring for the packed K codecs that carry a
+// `(codes, per-group scales, per-token norm)` payload — rotor3 / rotor4 and
+// iso3 / iso4 today.
 //
-// `QuantRotorK3` and `QuantRotorK4` differ only in bit width and codebook, so
-// both embed this helper rather than each carrying its own copy of the buffer
-// bookkeeping.
+// Those stores differ in bit width, codebook, and rotation algebra, but their
+// ring bookkeeping is identical, so they embed this helper instead of each
+// carrying a copy. The ring is deliberately codec-agnostic: it is told
+// `n_groups` rather than deriving it, so no codec's group-size rule leaks in
+// here.
 #![allow(unreachable_pub, clippy::exhaustive_structs)]
-//! GPU packed ring for the rotor K store: `RotorGpuK`.
+//! GPU packed ring for a quantized K store: `QuantKGpuRing`.
 //!
 //! # Why this exists
 //!
-//! The rotor K codec's CPU form (`RotorKBlocks`) is a `Vec<u32>` per append.
-//! Decoding attention from it means `dequant()` — a full-prefix CPU decode plus
-//! re-upload on **every decode step**, which is O(seq) host work per token with
-//! the GPU idle.
+//! These K codecs' CPU form (`RotorKBlocks` / `IsoBlocks`) is a `Vec<u32>` per
+//! append. Decoding attention from it means `dequant()` — a full-prefix CPU
+//! decode plus re-upload on **every decode step**, which is O(seq) host work
+//! per token with the GPU idle.
 //!
 //! This ring keeps the same payload (codes / per-group scales / per-token L2
 //! norms) resident on the GPU, appended in place, so a flash-decode kernel can
@@ -23,8 +27,9 @@
 //! Buffers are flat and **sequence-major** — the canonical flat-KV layout in
 //! this crate. For a token at sequence position `s` and KV head `h`:
 //!
-//! * `codes[(s * kv_h + h) * n_groups + g]`  (1 u32 per group of 8 Cl(3,0)
-//!   multivector components)
+//! * `codes[(s * kv_h + h) * n_groups + g]`  (1 u32 per group; what a group
+//!   spans is the codec's business — 8 Cl(3,0) multivector components for
+//!   rotor, one 4-element quaternion block for iso)
 //! * `scales[(s * kv_h + h) * n_groups + g]` (1 f32 per group)
 //! * `norms[s * kv_h + h]`                   (1 f32 per token)
 //!
@@ -41,16 +46,14 @@
 use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{zeros, Array, Device, Dtype};
 
-use crate::rotorquant::n_groups_for;
-
 use super::KV_PAGE_SIZE;
 
-/// GPU-resident packed rotor K payload plus its growth bookkeeping.
+/// GPU-resident packed K payload plus its growth bookkeeping.
 ///
 /// `None` buffers mean "not yet allocated" — the ring is created lazily on the
 /// first GPU append, so a CPU-only cache never pays for it.
 #[derive(Debug, Default)]
-pub struct RotorGpuK {
+pub struct QuantKGpuRing {
     /// Packed codes, flat `u32 [capacity * kv_h * n_groups]`.
     pub codes: Option<Array>,
     /// Per-group scales, flat `f32 [capacity * kv_h * n_groups]`.
@@ -65,7 +68,7 @@ pub struct RotorGpuK {
     pub capacity: i32,
 }
 
-impl RotorGpuK {
+impl QuantKGpuRing {
     /// True once the ring has been allocated.
     #[must_use]
     pub fn is_allocated(&self) -> bool {
@@ -97,8 +100,12 @@ impl RotorGpuK {
 
     /// Append one already-encoded chunk into the ring at `prev_seq`.
     ///
-    /// `codes` / `scales` / `norms` are the GPU outputs of the rotor encode
+    /// `codes` / `scales` / `norms` are the GPU outputs of the codec's encode
     /// kernel for a **sequence-major** chunk of `new_seq` positions.
+    ///
+    /// `n_groups` is the codec's per-token group count — passed in rather than
+    /// derived, so the ring stays codec-agnostic (rotor's `ceil(head_dim / 3)`
+    /// and iso's `head_dim / 4` are both just an integer here).
     ///
     /// # Errors
     ///
@@ -110,19 +117,18 @@ impl RotorGpuK {
         scales: &Array,
         norms: &Array,
         kv_h: i32,
-        head_dim: i32,
+        n_groups: i32,
         prev_seq: i32,
         new_seq: i32,
         max_seq: i32,
         device: Device,
     ) -> Result<()> {
-        if kv_h <= 0 || head_dim <= 0 || new_seq <= 0 || prev_seq < 0 {
+        if kv_h <= 0 || n_groups <= 0 || new_seq <= 0 || prev_seq < 0 {
             return Err(Error::Quant(format!(
-                "RotorGpuK::append_encoded: bad shape kv_h={kv_h}, head_dim={head_dim}, \
+                "QuantKGpuRing::append_encoded: bad shape kv_h={kv_h}, n_groups={n_groups}, \
                  prev_seq={prev_seq}, new_seq={new_seq}"
             )));
         }
-        let n_groups = n_groups_for(head_dim as usize) as i32;
         let codes_per_step = kv_h * n_groups;
         let norms_per_step = kv_h;
 
@@ -130,7 +136,7 @@ impl RotorGpuK {
             && (self.codes_per_step != codes_per_step || self.norms_per_step != norms_per_step)
         {
             return Err(Error::Quant(format!(
-                "RotorGpuK::append_encoded: stride changed under a live ring \
+                "QuantKGpuRing::append_encoded: stride changed under a live ring \
                  (codes {} -> {codes_per_step}, norms {} -> {norms_per_step})",
                 self.codes_per_step, self.norms_per_step
             )));
@@ -140,10 +146,10 @@ impl RotorGpuK {
 
         let needed = prev_seq
             .checked_add(new_seq)
-            .ok_or_else(|| Error::Quant("RotorGpuK::append_encoded: seq overflow".into()))?;
+            .ok_or_else(|| Error::Quant("QuantKGpuRing::append_encoded: seq overflow".into()))?;
         if needed > max_seq {
             return Err(Error::Quant(format!(
-                "RotorGpuK::append_encoded: needed={needed} exceeds max_seq={max_seq}"
+                "QuantKGpuRing::append_encoded: needed={needed} exceeds max_seq={max_seq}"
             )));
         }
 
@@ -156,7 +162,7 @@ impl RotorGpuK {
             // re-exported.
             if prev_seq > 0 {
                 return Err(Error::Quant(format!(
-                    "RotorGpuK::append_encoded: ring is unallocated but prev_seq={prev_seq} \
+                    "QuantKGpuRing::append_encoded: ring is unallocated but prev_seq={prev_seq} \
                      tokens already exist — seed_from_cpu() must upload the prefix first, \
                      or [0, {prev_seq}) would silently read as zeros"
                 )));
@@ -204,7 +210,7 @@ impl RotorGpuK {
         scales: &[f32],
         norms: &[f32],
         kv_h: i32,
-        head_dim: i32,
+        n_groups: i32,
         filled_seq: i32,
         max_seq: i32,
         device: Device,
@@ -212,13 +218,12 @@ impl RotorGpuK {
         if self.is_allocated() {
             return Ok(());
         }
-        if kv_h <= 0 || head_dim <= 0 || filled_seq <= 0 {
+        if kv_h <= 0 || n_groups <= 0 || filled_seq <= 0 {
             return Err(Error::Quant(format!(
-                "RotorGpuK::seed_from_cpu: bad shape kv_h={kv_h}, head_dim={head_dim}, \
+                "QuantKGpuRing::seed_from_cpu: bad shape kv_h={kv_h}, n_groups={n_groups}, \
                  filled_seq={filled_seq}"
             )));
         }
-        let n_groups = n_groups_for(head_dim as usize) as i32;
         self.codes_per_step = kv_h * n_groups;
         self.norms_per_step = kv_h;
 
@@ -229,7 +234,7 @@ impl RotorGpuK {
             || norms.len() as i64 != want_norms
         {
             return Err(Error::Quant(format!(
-                "RotorGpuK::seed_from_cpu: CPU prefix length mismatch at filled_seq={filled_seq} \
+                "QuantKGpuRing::seed_from_cpu: CPU prefix length mismatch at filled_seq={filled_seq} \
                  (codes {} want {want_codes}, scales {} want {want_codes}, norms {} want \
                  {want_norms})",
                 codes.len(),
@@ -239,7 +244,7 @@ impl RotorGpuK {
         }
         if filled_seq > max_seq {
             return Err(Error::Quant(format!(
-                "RotorGpuK::seed_from_cpu: filled_seq={filled_seq} exceeds max_seq={max_seq}"
+                "QuantKGpuRing::seed_from_cpu: filled_seq={filled_seq} exceeds max_seq={max_seq}"
             )));
         }
 
@@ -257,7 +262,7 @@ impl RotorGpuK {
         tracing::debug!(
             filled_seq,
             cap,
-            "RotorGpuK: seeded ring from accumulated CPU blocks"
+            "QuantKGpuRing: seeded ring from accumulated CPU blocks"
         );
         Ok(())
     }
@@ -284,7 +289,7 @@ impl RotorGpuK {
         }
         if kv_seq > self.capacity {
             return Err(Error::Quant(format!(
-                "RotorGpuK::packed_view: kv_seq={kv_seq} exceeds capacity={}",
+                "QuantKGpuRing::packed_view: kv_seq={kv_seq} exceeds capacity={}",
                 self.capacity
             )));
         }
@@ -303,7 +308,7 @@ impl RotorGpuK {
         self.scales = Some(zeros(&[cap * cps], Dtype::F32, device)?);
         self.norms = Some(zeros(&[cap * nps], Dtype::F32, device)?);
         self.capacity = cap;
-        tracing::debug!(cap, cps, nps, "RotorGpuK: ring allocated");
+        tracing::debug!(cap, cps, nps, "QuantKGpuRing: ring allocated");
         Ok(())
     }
 
@@ -341,7 +346,7 @@ impl RotorGpuK {
             old_capacity,
             new_capacity = cap,
             prev_seq,
-            "RotorGpuK: ring grown"
+            "QuantKGpuRing: ring grown"
         );
         Ok(())
     }
@@ -369,7 +374,7 @@ fn regrow(
     }
     let old = old.ok_or_else(|| {
         Error::Mlx(format!(
-            "RotorGpuK::grow: {what} buffer vanished mid-grow (internal invariant)"
+            "QuantKGpuRing::grow: {what} buffer vanished mid-grow (internal invariant)"
         ))
     })?;
     let prefix = old.slice(&[0], &[filled], &[1], device)?;
@@ -384,14 +389,14 @@ fn write_range(
     stop: i32,
     device: Device,
 ) -> Result<()> {
-    let target = buf
-        .take()
-        .ok_or_else(|| Error::Mlx("RotorGpuK::append_encoded: buffer absent after alloc".into()))?;
+    let target = buf.take().ok_or_else(|| {
+        Error::Mlx("QuantKGpuRing::append_encoded: buffer absent after alloc".into())
+    })?;
     let span = stop - start;
     let src_len: i32 = src.shape().iter().product();
     if src_len != span {
         return Err(Error::Quant(format!(
-            "RotorGpuK::append_encoded: encoded chunk length {src_len} != target span {span}"
+            "QuantKGpuRing::append_encoded: encoded chunk length {src_len} != target span {span}"
         )));
     }
     let flat = src.reshape(&[span], device)?;
@@ -407,7 +412,7 @@ fn u32_slice_to_array(vals: &[u32]) -> Result<Array> {
     let bytes: &[u8] =
         unsafe { std::slice::from_raw_parts(vals.as_ptr().cast::<u8>(), vals.len() * 4) };
     let len = i32::try_from(vals.len())
-        .map_err(|_| Error::Quant("RotorGpuK: u32 prefix exceeds i32::MAX".into()))?;
+        .map_err(|_| Error::Quant("QuantKGpuRing: u32 prefix exceeds i32::MAX".into()))?;
     Array::from_bytes(bytes, &[len], Dtype::U32)
 }
 
@@ -418,19 +423,19 @@ fn f32_slice_to_array(vals: &[f32]) -> Result<Array> {
     let bytes: &[u8] =
         unsafe { std::slice::from_raw_parts(vals.as_ptr().cast::<u8>(), vals.len() * 4) };
     let len = i32::try_from(vals.len())
-        .map_err(|_| Error::Quant("RotorGpuK: f32 prefix exceeds i32::MAX".into()))?;
+        .map_err(|_| Error::Quant("QuantKGpuRing: f32 prefix exceeds i32::MAX".into()))?;
     Array::from_bytes(bytes, &[len], Dtype::F32)
 }
 
 fn slice_prefix(buf: Option<&Array>, len: i32, what: &str, device: Device) -> Result<Array> {
     let b = buf.ok_or_else(|| {
         Error::Mlx(format!(
-            "RotorGpuK::packed_view: {what} buffer absent (internal invariant)"
+            "QuantKGpuRing::packed_view: {what} buffer absent (internal invariant)"
         ))
     })?;
     b.slice(&[0], &[len], &[1], device)
 }
 
 #[cfg(test)]
-#[path = "rotor_gpu_k_tests.rs"]
-mod rotor_gpu_k_tests;
+#[path = "quant_k_gpu_ring_tests.rs"]
+mod quant_k_gpu_ring_tests;

--- a/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring_tests.rs
@@ -1,7 +1,7 @@
-//! Unit tests for the rotor K GPU ring ([`RotorGpuK`]).
+//! Unit tests for the packed K GPU ring ([`QuantKGpuRing`]).
 //!
-//! The ring is the thing that makes the rotor K store readable by a Metal
-//! kernel without a host round-trip, so its prefix bookkeeping is
+//! The ring is the thing that makes a packed K store (rotor / iso) readable by
+//! a Metal kernel without a host round-trip, so its prefix bookkeeping is
 //! correctness-critical: a mis-seeded or mis-strided ring is silently wrong
 //! attention, not a slow path.
 
@@ -48,9 +48,13 @@ fn read_f32(a: &Array) -> Vec<f32> {
         .collect()
 }
 
-/// head_dim 6 → n_groups 2, so one sequence position with kv_h=2 is 4 code
-/// words and 2 norms. Small enough to assert element-by-element.
-const HEAD_DIM: i32 = 6;
+/// n_groups 2, so one sequence position with kv_h=2 is 4 code words and 2
+/// norms. Small enough to assert element-by-element.
+///
+/// The ring takes `n_groups` directly — how a codec derives it from `head_dim`
+/// (rotor `ceil(D/3)`, iso `D/4`) is the codec's rule, not the ring's, so no
+/// head_dim appears here.
+const N_GROUPS: i32 = 2;
 const KV_H: i32 = 2;
 const CODES_PER_STEP: usize = 4; // kv_h * n_groups = 2 * 2
 const NORMS_PER_STEP: usize = 2; // kv_h
@@ -60,7 +64,7 @@ fn new_ring_is_unallocated_and_views_none() {
     if skip_if_no_gpu_env() {
         return;
     }
-    let ring = RotorGpuK::default();
+    let ring = QuantKGpuRing::default();
     assert!(!ring.is_allocated());
     assert_eq!(ring.byte_size(), 0);
     let view = ring.packed_view(4, Device::Gpu).expect("packed_view");
@@ -75,7 +79,7 @@ fn append_then_view_round_trips_payload() {
     if skip_if_no_gpu_env() {
         return;
     }
-    let mut ring = RotorGpuK::default();
+    let mut ring = QuantKGpuRing::default();
     let codes: Vec<u32> = (0..CODES_PER_STEP as u32).collect();
     let scales: Vec<f32> = vec![0.5, 1.5, 2.5, 3.5];
     let norms: Vec<f32> = vec![7.0, 8.0];
@@ -85,7 +89,7 @@ fn append_then_view_round_trips_payload() {
         &f32_arr(&scales),
         &f32_arr(&norms),
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         0,
         1,
         64,
@@ -107,7 +111,7 @@ fn sequential_appends_land_at_increasing_offsets() {
     if skip_if_no_gpu_env() {
         return;
     }
-    let mut ring = RotorGpuK::default();
+    let mut ring = QuantKGpuRing::default();
     // Three single-position appends; each step's payload is tagged by value so
     // a mis-strided write shows up as a wrong element, not just a wrong length.
     for step in 0..3_u32 {
@@ -123,7 +127,7 @@ fn sequential_appends_land_at_increasing_offsets() {
             &f32_arr(&scales),
             &f32_arr(&norms),
             KV_H,
-            HEAD_DIM,
+            N_GROUPS,
             step as i32,
             1,
             64,
@@ -163,13 +167,13 @@ fn seed_from_cpu_then_append_preserves_prefix() {
         .map(|i| i as f32 + 0.5)
         .collect();
 
-    let mut ring = RotorGpuK::default();
+    let mut ring = QuantKGpuRing::default();
     ring.seed_from_cpu(
         &cpu_codes,
         &cpu_scales,
         &cpu_norms,
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         filled,
         64,
         Device::Gpu,
@@ -183,7 +187,7 @@ fn seed_from_cpu_then_append_preserves_prefix() {
         &f32_arr(&[9.0, 9.1, 9.2, 9.3]),
         &f32_arr(&[99.0, 99.1]),
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         filled,
         1,
         64,
@@ -211,13 +215,13 @@ fn seed_is_a_no_op_once_allocated() {
     if skip_if_no_gpu_env() {
         return;
     }
-    let mut ring = RotorGpuK::default();
+    let mut ring = QuantKGpuRing::default();
     ring.append_encoded(
         &u32_arr(&[1, 2, 3, 4]),
         &f32_arr(&[1.0, 2.0, 3.0, 4.0]),
         &f32_arr(&[5.0, 6.0]),
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         0,
         1,
         64,
@@ -231,7 +235,7 @@ fn seed_is_a_no_op_once_allocated() {
         &[0.0; CODES_PER_STEP],
         &[0.0; NORMS_PER_STEP],
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         1,
         64,
         Device::Gpu,
@@ -256,7 +260,7 @@ fn growth_across_a_page_boundary_preserves_prefix() {
     }
     // KV_PAGE_SIZE positions fit in the first page; position KV_PAGE_SIZE
     // forces a realloc + prefix copy.
-    let mut ring = RotorGpuK::default();
+    let mut ring = QuantKGpuRing::default();
     let first = KV_PAGE_SIZE;
     let cpu_codes: Vec<u32> = (0..(first as usize * CODES_PER_STEP) as u32).collect();
     let cpu_scales: Vec<f32> = vec![1.0; first as usize * CODES_PER_STEP];
@@ -266,7 +270,7 @@ fn growth_across_a_page_boundary_preserves_prefix() {
         &cpu_scales,
         &cpu_norms,
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         first,
         4096,
         Device::Gpu,
@@ -279,7 +283,7 @@ fn growth_across_a_page_boundary_preserves_prefix() {
         &f32_arr(&[1.0, 1.0, 1.0, 1.0]),
         &f32_arr(&[3.0, 3.0]),
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         first,
         1,
         4096,
@@ -310,13 +314,13 @@ fn clear_drops_the_ring() {
     if skip_if_no_gpu_env() {
         return;
     }
-    let mut ring = RotorGpuK::default();
+    let mut ring = QuantKGpuRing::default();
     ring.append_encoded(
         &u32_arr(&[1, 2, 3, 4]),
         &f32_arr(&[1.0, 2.0, 3.0, 4.0]),
         &f32_arr(&[5.0, 6.0]),
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         0,
         1,
         64,
@@ -341,13 +345,13 @@ fn append_on_unallocated_ring_with_existing_prefix_errors() {
     // The zeroed-prefix footgun: allocating here and writing only
     // [prev_seq, needed) would leave [0, prev_seq) as zeros — silently wrong
     // attention. Must be rejected rather than "helpfully" allocated.
-    let mut ring = RotorGpuK::default();
+    let mut ring = QuantKGpuRing::default();
     let err = ring.append_encoded(
         &u32_arr(&[1, 2, 3, 4]),
         &f32_arr(&[1.0, 2.0, 3.0, 4.0]),
         &f32_arr(&[5.0, 6.0]),
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         5, // prev_seq > 0 on an unallocated ring
         1,
         64,
@@ -369,13 +373,13 @@ fn append_beyond_max_seq_errors() {
     if skip_if_no_gpu_env() {
         return;
     }
-    let mut ring = RotorGpuK::default();
+    let mut ring = QuantKGpuRing::default();
     let err = ring.append_encoded(
         &u32_arr(&[1, 2, 3, 4]),
         &f32_arr(&[1.0, 2.0, 3.0, 4.0]),
         &f32_arr(&[5.0, 6.0]),
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         8,
         1,
         8, // max_seq — prev_seq + new_seq = 9 > 8
@@ -392,14 +396,14 @@ fn chunk_length_mismatch_errors() {
     if skip_if_no_gpu_env() {
         return;
     }
-    let mut ring = RotorGpuK::default();
+    let mut ring = QuantKGpuRing::default();
     // Two positions' worth of codes declared as new_seq = 1.
     let err = ring.append_encoded(
         &u32_arr(&[1, 2, 3, 4, 5, 6, 7, 8]),
         &f32_arr(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
         &f32_arr(&[5.0, 6.0]),
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         0,
         1,
         64,
@@ -416,13 +420,13 @@ fn seed_length_mismatch_errors() {
     if skip_if_no_gpu_env() {
         return;
     }
-    let mut ring = RotorGpuK::default();
+    let mut ring = QuantKGpuRing::default();
     let err = ring.seed_from_cpu(
         &[1, 2, 3], // not filled_seq * kv_h * n_groups
         &[1.0, 2.0, 3.0],
         &[1.0, 2.0],
         KV_H,
-        HEAD_DIM,
+        N_GROUPS,
         1,
         64,
         Device::Gpu,

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
@@ -14,7 +14,7 @@
 )]
 //! Quantized K buffer: `QuantRotorK3` (rotor3 K codec).
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{Array, Device};
 
 use crate::clifford::make_rotor_table;
@@ -23,7 +23,7 @@ use crate::rotorquant::{
     ROTOR3_BITS, ROTOR3_GROUP_SIZE,
 };
 
-use super::RotorGpuK;
+use super::QuantKGpuRing;
 
 /// Bit-width of the rotor3 K codec.
 pub const ROTOR3_K_BITS: u8 = ROTOR3_BITS;
@@ -69,7 +69,7 @@ pub struct RotorKBlocks {
 ///
 /// * `blocks` — CPU `RotorKBlocks`, the source of truth for `dequant()`, the
 ///   SSD spill/hydrate round-trip, and the QJL path.
-/// * `gpu` — the optional GPU-resident packed ring ([`RotorGpuK`]), populated by
+/// * `gpu` — the optional GPU-resident packed ring ([`QuantKGpuRing`]), populated by
 ///   `gpu_append` on the QJL-off GPU encode path. When present it lets the
 ///   rotor flash-decode kernel read the quant store directly instead of paying a
 ///   full-prefix CPU `dequant()` per decode step.
@@ -77,7 +77,7 @@ pub struct QuantRotorK3 {
     /// Static rotor table for this layer/head, flat `[n_groups * 4]` f32.
     pub rotors: Vec<f32>,
     /// GPU-resident packed ring. Empty until the first `gpu_append`.
-    pub gpu: RotorGpuK,
+    pub gpu: QuantKGpuRing,
     /// Static QJL projection matrix, flat `[qjl_dim * head_dim]` f32. `None`
     /// when QJL is disabled — chosen at first `append` time from the global
     /// [`crate::rotor_qjl::rotor_qjl_enabled`] toggle.
@@ -123,7 +123,7 @@ impl QuantRotorK3 {
     pub fn new(init_shape: Vec<i32>, layer_idx: u32) -> Self {
         Self {
             rotors: Vec::new(),
-            gpu: RotorGpuK::default(),
+            gpu: QuantKGpuRing::default(),
             qjl_s_matrix: None,
             blocks: Vec::new(),
             shape: init_shape,
@@ -157,7 +157,7 @@ impl QuantRotorK3 {
             rotors,
             // Hydrated caches start CPU-only; the ring is rebuilt lazily from
             // the next GPU append.
-            gpu: RotorGpuK::default(),
+            gpu: QuantKGpuRing::default(),
             qjl_s_matrix,
             blocks,
             shape,
@@ -186,7 +186,7 @@ impl QuantRotorK3 {
     )]
     pub fn append(&mut self, f32_data: &[f32], new_shape: &[i32]) -> Result<()> {
         if new_shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantRotorK3::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
@@ -220,9 +220,7 @@ impl QuantRotorK3 {
             head_dim,
             self.qjl_s_matrix.as_deref(),
         )
-        .map_err(|e: RotorQuantError| {
-            rmlx_core::error::Error::Mlx(format!("rotor3_k encode: {e}"))
-        })?;
+        .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor3_k encode: {e}")))?;
 
         self.blocks.push(RotorKBlocks {
             codes,
@@ -246,7 +244,7 @@ impl QuantRotorK3 {
     }
 
     /// Concatenate the accumulated CPU blocks into flat sequence-major
-    /// `(codes, scales, norms)` — the form [`RotorGpuK::seed_from_cpu`] wants.
+    /// `(codes, scales, norms)` — the form [`QuantKGpuRing::seed_from_cpu`] wants.
     fn flatten_blocks(&self) -> (Vec<u32>, Vec<f32>, Vec<f32>) {
         // Exact capacities — the prefill seed concatenates the whole prefix
         // (millions of entries at long context), so growing from empty would
@@ -286,7 +284,7 @@ impl QuantRotorK3 {
     ///
     /// # Errors
     ///
-    /// Forwards [`RotorGpuK::seed_from_cpu`] / [`RotorGpuK::append_encoded`]
+    /// Forwards [`QuantKGpuRing::seed_from_cpu`] / [`QuantKGpuRing::append_encoded`]
     /// errors.
     #[allow(clippy::too_many_arguments)]
     pub fn gpu_append(
@@ -301,13 +299,21 @@ impl QuantRotorK3 {
         max_seq: i32,
         device: Device,
     ) -> Result<()> {
+        // The ring is codec-agnostic and takes `n_groups`; the rotor group rule
+        // stays here, in the codec's own store.
+        let n_groups = i32::try_from(n_groups_for(usize::try_from(head_dim.max(0)).unwrap_or(0)))
+            .map_err(|_| {
+            Error::Quant(format!(
+                "QuantRotorK3::gpu_append: n_groups for head_dim={head_dim} exceeds i32::MAX"
+            ))
+        })?;
         if !self.gpu.is_allocated() && prev_seq > 0 {
             let (c, s, n) = self.flatten_blocks();
             self.gpu
-                .seed_from_cpu(&c, &s, &n, kv_h, head_dim, prev_seq, max_seq, device)?;
+                .seed_from_cpu(&c, &s, &n, kv_h, n_groups, prev_seq, max_seq, device)?;
         }
         self.gpu.append_encoded(
-            codes, scales, norms, kv_h, head_dim, prev_seq, new_seq, max_seq, device,
+            codes, scales, norms, kv_h, n_groups, prev_seq, new_seq, max_seq, device,
         )
     }
 
@@ -316,7 +322,7 @@ impl QuantRotorK3 {
     ///
     /// # Errors
     ///
-    /// Forwards [`RotorGpuK::packed_view`] errors.
+    /// Forwards [`QuantKGpuRing::packed_view`] errors.
     pub fn gpu_packed_view(
         &self,
         kv_seq: i32,
@@ -376,7 +382,7 @@ impl QuantRotorK3 {
             // the ring re-seeds from them on the clone's first GPU append.
             // Sharing the source's Arrays would alias one ring across two
             // independent caches.
-            gpu: RotorGpuK::default(),
+            gpu: QuantKGpuRing::default(),
             qjl_s_matrix: self.qjl_s_matrix.clone(),
             blocks: self.blocks.clone(),
             shape: self.shape.clone(),
@@ -423,7 +429,7 @@ impl QuantRotorK3 {
     )]
     pub fn dequant(&self) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantRotorK3::dequant: malformed shape {:?}",
                 self.shape
             )));
@@ -438,7 +444,7 @@ impl QuantRotorK3 {
         }
 
         if self.rotors.is_empty() {
-            return Err(rmlx_core::error::Error::Mlx(
+            return Err(Error::Mlx(
                 "QuantRotorK3::dequant: rotor table is empty but blocks were appended".into(),
             ));
         }
@@ -454,9 +460,7 @@ impl QuantRotorK3 {
                 &blk.qjl_norms,
                 self.qjl_s_matrix.as_deref(),
             )
-            .map_err(|e: RotorQuantError| {
-                rmlx_core::error::Error::Mlx(format!("rotor3_k decode: {e}"))
-            })?;
+            .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor3_k decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
         if out.len() < total_elems {

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
@@ -11,7 +11,7 @@
 )]
 //! Quantized K buffer: `QuantRotorK4` (rotor4 K codec).
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{Array, Device};
 
 use crate::clifford::make_rotor_table;
@@ -21,7 +21,7 @@ use crate::rotorquant::{
 };
 use crate::storage::quant_rotor_k3::RotorKBlocks;
 
-use super::RotorGpuK;
+use super::QuantKGpuRing;
 
 /// Bit-width of the rotor4 K codec.
 pub const ROTOR4_K_BITS: u8 = ROTOR4_BITS;
@@ -35,7 +35,7 @@ pub struct QuantRotorK4 {
     /// Static rotor table for this layer/head.
     pub rotors: Vec<f32>,
     /// GPU-resident packed ring. Empty until the first `gpu_append`.
-    pub gpu: RotorGpuK,
+    pub gpu: QuantKGpuRing,
     /// Static QJL projection matrix (None when QJL is disabled at first append).
     pub qjl_s_matrix: Option<Vec<f32>>,
     /// Accumulated per-token blocks.
@@ -73,7 +73,7 @@ impl QuantRotorK4 {
     pub fn new(init_shape: Vec<i32>, layer_idx: u32) -> Self {
         Self {
             rotors: Vec::new(),
-            gpu: RotorGpuK::default(),
+            gpu: QuantKGpuRing::default(),
             qjl_s_matrix: None,
             blocks: Vec::new(),
             shape: init_shape,
@@ -102,7 +102,7 @@ impl QuantRotorK4 {
             rotors,
             // Hydrated caches start CPU-only; the ring is rebuilt lazily from
             // the next GPU append.
-            gpu: RotorGpuK::default(),
+            gpu: QuantKGpuRing::default(),
             qjl_s_matrix,
             blocks,
             shape,
@@ -123,7 +123,7 @@ impl QuantRotorK4 {
     )]
     pub fn append(&mut self, f32_data: &[f32], new_shape: &[i32]) -> Result<()> {
         if new_shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantRotorK4::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
@@ -154,9 +154,7 @@ impl QuantRotorK4 {
             head_dim,
             self.qjl_s_matrix.as_deref(),
         )
-        .map_err(|e: RotorQuantError| {
-            rmlx_core::error::Error::Mlx(format!("rotor4_k encode: {e}"))
-        })?;
+        .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor4_k encode: {e}")))?;
 
         self.blocks.push(RotorKBlocks {
             codes,
@@ -208,7 +206,7 @@ impl QuantRotorK4 {
     ///
     /// # Errors
     ///
-    /// Forwards [`RotorGpuK::seed_from_cpu`] / [`RotorGpuK::append_encoded`]
+    /// Forwards [`QuantKGpuRing::seed_from_cpu`] / [`QuantKGpuRing::append_encoded`]
     /// errors.
     ///
     /// `max_seq` is a parameter, not a field — see [`QuantRotorK3::gpu_append`].
@@ -225,13 +223,21 @@ impl QuantRotorK4 {
         max_seq: i32,
         device: Device,
     ) -> Result<()> {
+        // The ring is codec-agnostic and takes `n_groups`; the rotor group rule
+        // stays here, in the codec's own store.
+        let n_groups = i32::try_from(n_groups_for(usize::try_from(head_dim.max(0)).unwrap_or(0)))
+            .map_err(|_| {
+            Error::Quant(format!(
+                "QuantRotorK4::gpu_append: n_groups for head_dim={head_dim} exceeds i32::MAX"
+            ))
+        })?;
         if !self.gpu.is_allocated() && prev_seq > 0 {
             let (c, s, n) = self.flatten_blocks();
             self.gpu
-                .seed_from_cpu(&c, &s, &n, kv_h, head_dim, prev_seq, max_seq, device)?;
+                .seed_from_cpu(&c, &s, &n, kv_h, n_groups, prev_seq, max_seq, device)?;
         }
         self.gpu.append_encoded(
-            codes, scales, norms, kv_h, head_dim, prev_seq, new_seq, max_seq, device,
+            codes, scales, norms, kv_h, n_groups, prev_seq, new_seq, max_seq, device,
         )
     }
 
@@ -240,7 +246,7 @@ impl QuantRotorK4 {
     ///
     /// # Errors
     ///
-    /// Forwards [`RotorGpuK::packed_view`] errors.
+    /// Forwards [`QuantKGpuRing::packed_view`] errors.
     pub fn gpu_packed_view(
         &self,
         kv_seq: i32,
@@ -299,7 +305,7 @@ impl QuantRotorK4 {
             // the ring re-seeds from them on the clone's first GPU append.
             // Sharing the source's Arrays would alias one ring across two
             // independent caches.
-            gpu: RotorGpuK::default(),
+            gpu: QuantKGpuRing::default(),
             qjl_s_matrix: self.qjl_s_matrix.clone(),
             blocks: self.blocks.clone(),
             shape: self.shape.clone(),
@@ -342,7 +348,7 @@ impl QuantRotorK4 {
     )]
     pub fn dequant(&self) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantRotorK4::dequant: malformed shape {:?}",
                 self.shape
             )));
@@ -357,7 +363,7 @@ impl QuantRotorK4 {
         }
 
         if self.rotors.is_empty() {
-            return Err(rmlx_core::error::Error::Mlx(
+            return Err(Error::Mlx(
                 "QuantRotorK4::dequant: rotor table is empty but blocks were appended".into(),
             ));
         }
@@ -373,9 +379,7 @@ impl QuantRotorK4 {
                 &blk.qjl_norms,
                 self.qjl_s_matrix.as_deref(),
             )
-            .map_err(|e: RotorQuantError| {
-                rmlx_core::error::Error::Mlx(format!("rotor4_k decode: {e}"))
-            })?;
+            .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor4_k decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
         if out.len() < total_elems {

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2736,12 +2736,17 @@ sha256. Every `after` cell carries a positive dispatch witness
 
 | Model | Codec | ctx (real tok) | Before | After | Gain |
 |---|---|---|---|---|---|
-| Bonsai-8B (Qwen3, D=128) | `k_iso3` | 4k (4085) | 4.24 | **19.85** | 4.7× |
-| Bonsai-8B | `k_iso4` | 4k (4085) | 1.89 | **19.88** | 10.5× |
+| Bonsai-8B (Qwen3, D=128) | `k_iso3` | 4k (4085) | 4.24 | **18.9–19.9** | ~4.5× |
+| Bonsai-8B | `k_iso4` | 4k (4085) | 1.89 | **17.8–19.9** | ~9.9× |
 | Bonsai-8B | `k_iso3` | 16k (16913) | 0.96 | **10.59** | 11.0× |
 | Bonsai-8B | `k_iso3` | 32k (33612) | 0.59 | **6.63** | 11.2× |
 | gemma-4-e2b (Gemma4, D=256, shared-KV) | `k_iso3` | 4k | 44.65 | **64.80** | 1.45× |
 | medgemma-4B (Gemma3, D=256) | `k_iso3` | 4k | 21.96 | **51.96** | 2.4× |
+
+Bonsai at 4k is a noisy target (individual runs span 15.4–20.1 across repeats of
+the same binary), so its 4k cells are given as a range over two independent
+3-run medians; the 16k/32k cells and the other two models are stable to a few
+percent. Treat a single Bonsai 4k run as indicative only.
 
 The gain grows with context because the cost removed is O(seq) host work per
 token. Fitting `itl = a + b·kv_seq` over Bonsai `k_iso3` at 4k/16k/32k:

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -326,12 +326,12 @@ be classified or the build fails.
     prefill) is CPU. The rotor family's GPU fused-QK encoder is gated OFF by
     default (`RMLX_FUSED_QK`).
   * **K-only iso** (`k_iso3` / `k_iso4`) → **`None`** (Metal). No bf16
-    early-return: `update_iso_k_only_{3,4}` dispatches the `iso{3,4}` MSL encode
-    kernel every decode step on GPU (`k_iso3` also runs the iso3 MSL dequant
-    kernel). Hybrid — the dequant restages the growing prefix host-side and
-    re-uploads via `Array::from_bytes` each step (a real, growing CPU cost) — but
-    a Metal kernel demonstrably dispatches, so it is **not** "no Metal kernel",
-    and must not be hard-rejected by the CPU-path classifier.
+    early-return: `update_and_sdpa_iso_k_fused` GPU-encodes the step into the
+    packed ring and `iso_flash_decode` reads that ring directly, so **both**
+    sides are GPU-resident and nothing restages through the host. Before the
+    flash-decode kernel this was a hybrid — the per-step dequant restaged the
+    growing prefix host-side and re-uploaded it via `Array::from_bytes` — which
+    is what held these codecs at single-digit TPS.
   * **K-only rotor** (`k_rotor3` / `k_rotor4`) → **QJL-dependent**. No bf16
     early-return; `update_rotor_k_only_{3,4}` gates the GPU K encode on
     `device == Gpu && !rotor_qjl_enabled()`. QJL **on** (default) → CPU
@@ -354,7 +354,7 @@ be classified or the build fails.
 | `mixed_*` / `rot_k_v*` / `rot_k_tq4v` | **Metal** | MLX-affine `mx.quantize` K + tq4/affine V (compiled Metal ops) |
 | `k8vturbo3` / `k8vturbo2` / `*tcq` / `tsym3` / `tsym4` | **Metal K**, CPU V (bounded) | K=q8_0 GPU; V CPU-forced by the −1 %/−2 % TPS gate, cost small |
 | `iso3` / `iso4` / `iso3_sym` / `iso4_sym` | **CPU** | bf16 decode seed shadows the GPU iso branch; prefill V-encode on host |
-| `k_iso3` / `k_iso4` | **Metal (hybrid)** | iso K MSL encode every decode step (`k_iso3` also MSL dequant); dequant restages prefix host-side per step. `cpu_hot_path_reason() == None` |
+| `k_iso3` / `k_iso4` | **fully Metal** | iso K MSL encode into the packed ring + `iso_flash_decode` fused decode over that ring. No host restaging. `cpu_hot_path_reason() == None` |
 | `rotor3` / `rotor4` / `rotor*_sym` / `rotor_k_*_asym_*` | **CPU** | bf16 decode seed shadows the GPU branch; GPU fused-QK encoder is `RMLX_FUSED_QK`-only |
 | `k_rotor3` / `k_rotor4` | **QJL-dependent** | QJL on (default) → CPU; QJL off (`--rotor-qjl off`) → **fully Metal**: rotor K MSL encode + `rotor_flash_decode` fused decode. Verdict reads `rotor_qjl_enabled()` |
 
@@ -1995,20 +1995,20 @@ rejected for Qwen3.5/3.6 MoE."` (positive guard test).
 the K side and the V side is rebuilt transparently from the live request's
 bf16 buffer on first decode step.
 
-**Status.** CPU-only on the hot path. The iso3 MSL kernel could in principle
-be reused on the K axis (it is axis-agnostic), but on-disk and SDPA paths use
-the CPU dequant fallback; an MSL re-wiring is a deferred follow-up.
+**Status.** GPU-resident on the hot path. `QuantIsoK3` / `QuantIsoK4` each embed
+a `QuantKGpuRing`; the K encode writes the packed ring on-GPU and
+`iso_flash_decode` reads that ring directly — see § `iso_flash_decode` below.
 
-**Decode-cost caveat.** `QuantIsoK3`/`QuantIsoK4` have no GPU-resident code
-mirror on the live decode path: the CPU `dequant()` re-materializes every
-accumulated block each step and the reconstructed K prefix is re-uploaded to
-the GPU via `Array::from_bytes` — an O(kv_seq) per-step cost that grows
-monotonically with context. (A `dequant_gpu` mirror exists but is gated behind
-`gpu_resident_iso_enabled()`, hardcoded `false` in `rmlx-kv-quant/src/lib.rs`,
-so it does not run.) The short-prompt anchors elsewhere in this doc (warm-TTFT
-masks the cost after step 1) do not show it; long-prompt decode does (k_iso3
-Bonsai ~59 TPS vs iso3_sym ~142). The GPU mirror is deferred until a bench arm
-shows a win on a FusedQkShadow-incompatible path.
+**Decode-cost caveat (historical — fixed).** These stores used to have no
+GPU-resident mirror on the live decode path: the CPU `dequant()` re-materialised
+every accumulated block each step and re-uploaded the reconstructed K prefix via
+`Array::from_bytes` — an O(kv_seq) per-step cost that grew monotonically with
+context. Short-prompt anchors (warm-TTFT masks the cost after step 1) hid it;
+long-prompt decode showed it. Measured on Bonsai-8B `k_iso3`, that cost was
+~48.5 µs per KV token, taking decode to 0.96 TPS at 16k and 0.59 at 32k. The
+flash-decode kernel removes it (16k: 0.96 → 10.6; 32k: 0.59 → 6.6). Kept here
+because the shape of the bug — an O(seq) host restage hidden behind a warm bf16
+seed — recurs across codecs.
 
 **Cosine empirical floors.** Measured on the LCG fixture at
 `head_dim=128, n_rows=16, TEST_SEED` (see `quant_iso_k{,4}_tests.rs`):
@@ -2503,7 +2503,7 @@ host.
 decode into a `Vec<f32>` plus a re-upload. That is O(seq) host work per token
 with the GPU idle, and it is what pinned the K-only rotor family in the
 "Tier 3 — CPU-bound" bucket (0.05–8.8 TPS, see `docs/models/bonsai/27B/rMLX.md`).
-The store is now GPU-resident (`storage::RotorGpuK`) and the kernel reads it
+The store is now GPU-resident (`storage::QuantKGpuRing`) and the kernel reads it
 directly.
 
 ### Files
@@ -2514,9 +2514,10 @@ directly.
   (one body for **both** bit widths).
 * `crates/rmlx-kv-quant/src/metal/flash_decode_merge_p2.metal` — codec-agnostic
   pass-2 log-sum-exp merge, shared with `planar_flash_decode`.
-* `crates/rmlx-kv-quant/src/storage/rotor_gpu_k.rs` — `RotorGpuK`, the
+* `crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring.rs` — `QuantKGpuRing`, the
   GPU-resident packed ring (codes / per-group scales / per-token L2 norms) with
-  paged growth and CPU-prefix seeding.
+  paged growth and CPU-prefix seeding. Codec-agnostic: it is told `n_groups`
+  rather than deriving it, and is shared with the iso K stores.
 * `crates/rmlx-kv-quant/src/kvcache/sdpa.rs::update_and_sdpa_rotor_k_fused` —
   dispatch site.
 
@@ -2566,7 +2567,7 @@ must not change how existing bytes are read.
 
 ### Ring eligibility is passed down, not inferred
 
-`RotorGpuK` is only built for the codecs that can actually read it. The rotor K
+`QuantKGpuRing` is only built for the codecs that can actually read it. The rotor K
 GPU encode takes a `RingFeed` from its caller: `Maintain` from the two K-only
 paths (prefill `update_rotor_k_only_*` and the fused decode entry), `Skip` from
 the sym/asym mirrors. A ring for a non-eligible codec is not free —
@@ -2632,6 +2633,143 @@ below `none` (Bonsai bf16 ≈ 110 TPS). The rotor sandwich is ~64 FMAs per group
 per lane and each of a group's 3 lanes redoes it, so the inner loop is
 compute-bound, not KV-bandwidth-bound. Narrowing that gap (sparse geometric
 product, one decode per group instead of per lane) is future work.
+
+---
+
+## `iso_flash_decode` — fused MSL flash-decode over iso-quant K
+
+Sibling of `rotor_flash_decode` for `KvStorage::IsoKOnly3` / `IsoKOnly4`: QK over
+the packed iso K store + online softmax + bf16-V SV, in two Metal dispatches per
+decode step. Same two-pass shell, same shared
+`metal/flash_decode_merge_p2.metal`; only the K-decode differs.
+
+**What it replaced.** `update_iso_k_only_{3,4}` called `QuantIsoK{3,4}::dequant()`
+on every decode step — a full-prefix **CPU** iso decode into a `Vec<f32>` plus a
+re-upload. That is O(seq) host work per token with the GPU idle, and it is what
+pinned the K-only iso family in the "Tier 3 — CPU-bound" bucket. The store is now
+GPU-resident (`storage::QuantKGpuRing`, shared with rotor) and the kernel reads
+it directly.
+
+### Files
+
+* `crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs` — Rust dispatcher, header
+  builder, dispatch counters, `assert_fixed_quat_blocks`.
+* `crates/rmlx-kv-quant/src/metal/iso_flash_decode_p1.metal` — pass-1 body (one
+  body for **both** bit widths).
+* `crates/rmlx-kv-quant/src/metal/flash_decode_merge_p2.metal` — codec-agnostic
+  pass-2 log-sum-exp merge, shared with `rotor_flash_decode` / `planar_flash_decode`.
+* `crates/rmlx-kv-quant/src/storage/quant_iso_k.rs` / `quant_iso_k4.rs` — the iso
+  K stores, each embedding a `QuantKGpuRing`.
+* `crates/rmlx-kv-quant/src/kvcache/sdpa.rs::update_and_sdpa_iso_k_fused` —
+  dispatch site (plus `try_dispatch_shared_store` / `sdpa_shared` for shared-KV
+  models).
+
+### Decode: one left Hamilton product, not a sandwich
+
+The iso codec encodes `r = q * v_unit` with the single fixed golden-ratio unit
+quaternion `FIXED_QUAT`, so the decode is `q̄ * r` — **one** left Hamilton
+product. Do not carry the rotor codec's `R̃ * mv * R` sandwich across; they are
+different algebras. This is also why iso's inner loop is much cheaper than
+rotor's: ~16 FMAs per group, not ~64.
+
+The decode is **self-contained per lane** — a group's four codes all live in one
+u32, so `if_decode_k_lane` unpacks them and runs the Hamilton product in
+registers with no threadgroup staging and no barrier. (The older
+`iso_fused_qk_*` kernel phrases the same math through SMEM + a barrier; a
+barrier per token inside a flash inner loop would serialise the tile.)
+
+### Fixed quaternion is baked into the header
+
+`iso_encode_fast` writes the one `FIXED_QUAT` constant into every slot of its
+per-group `quaternions` array, so the kernel bakes `q̄` in and the ring does not
+carry the quaternion table at all — storing `n_tokens * n_groups * 4` copies of
+one constant would be pure bandwidth.
+
+That is a real coupling, not an assumption. If the encoder ever emits per-group
+quaternions (its own docs float that as future work) this kernel would be
+silently wrong rather than merely stale, so `assert_fixed_quat_blocks` rejects a
+store whose quaternions are not `FIXED_QUAT`.
+
+### Bit width is a header parameter
+
+`bits ∈ {3, 4}` arrives via the header (`IF_BITS` / `IF_MASK`) alongside the
+matching Lloyd-Max codebook, so one `.metal` body serves both variants. Both
+widths pack one group of 4 into a single u32
+(`words_per_group = ceil(4 / (32 / BITS)) = 1`); element `e` sits at
+`[e*BITS, e*BITS + BITS)`. Selection is explicit; any other `bits` is an `Err`,
+never a silent fallback to the wrong unpack width.
+
+### Reusable K-decode half
+
+The per-lane iso decode is emitted into the **header** as the MSL function
+`if_decode_k_lane(codes, scales, norms, tok_idx, n_groups, lane)` rather than
+inlined into the body. A quantized-V flash kernel (the `iso*_sym` follow-up)
+needs the identical decode against the V store's `(codes, scales, norms)` triple
+and can call it unchanged.
+
+### Gate
+
+No env var and no CLI flag: the path is on whenever it is applicable. Gates, in
+order — device is GPU, storage is an iso K-only variant, `q_seq == 1`, `b == 1`,
+`head_dim` is a power of two, a multiple of the quaternion block size (4), and
+`<= ISO_FLASH_HEAD_DIM_MAX` (512). Any miss falls through to the legacy CPU
+dequant path.
+
+**No QJL analogue.** The 1-bit QJL residual is rotor-only, so unlike
+`k_rotor*` — which needs `--rotor-qjl off` to reach its kernel at all — `k_iso3`
+/ `k_iso4` reach this kernel at **stock defaults**.
+
+### Storage applicability
+
+| Variant | Eligible? | Notes |
+|---|---|---|
+| `KvStorage::IsoKOnly3` / `IsoKOnly4`, `b == 1` | **YES** | GPU ring + `iso_flash_decode_sdpa`. |
+| `KvStorage::IsoKOnly{3,4}`, `b > 1` | NO | Ring stride does not interleave batch. |
+| `Iso{3,4}Sym` | NO | V side is also iso-quantized; this kernel takes bf16 V only. Shares the K-decode half when a quant-V kernel lands. |
+
+### Measured
+
+`release-perf`, M-series, decode TPS, 3 measured runs per cell, median. Both A/B
+binaries verified by kernel-name string (`main` = 0 hits, `fix` = 1) and distinct
+sha256. Every `after` cell carries a positive dispatch witness
+(`rmlx_iso_flash_decode_p1_b{3,4}` in the log); every `before` cell has none.
+
+| Model | Codec | ctx (real tok) | Before | After | Gain |
+|---|---|---|---|---|---|
+| Bonsai-8B (Qwen3, D=128) | `k_iso3` | 4k (4085) | 4.24 | **19.85** | 4.7× |
+| Bonsai-8B | `k_iso4` | 4k (4085) | 1.89 | **19.88** | 10.5× |
+| Bonsai-8B | `k_iso3` | 16k (16913) | 0.96 | **10.59** | 11.0× |
+| Bonsai-8B | `k_iso3` | 32k (33612) | 0.59 | **6.63** | 11.2× |
+| gemma-4-e2b (Gemma4, D=256, shared-KV) | `k_iso3` | 4k | 44.65 | **64.80** | 1.45× |
+| medgemma-4B (Gemma3, D=256) | `k_iso3` | 4k | 21.96 | **51.96** | 2.4× |
+
+The gain grows with context because the cost removed is O(seq) host work per
+token. Fitting `itl = a + b·kv_seq` over Bonsai `k_iso3` at 4k/16k/32k:
+
+| path | `a` (fixed) | `b` (per KV token) |
+|---|---|---|
+| before — CPU dequant | 101 ms | **48.5 µs** |
+| after — `iso_flash_decode` | 37 ms | **3.40 µs** |
+
+`b` is what decides whether a codec can win at long context, and it drops 14.3×.
+
+`gemma-4-e2b` gains least because only its global layers are iso-quantized (its
+SWA layers stay bf16), so the CPU dequant removed was a smaller share of the
+step. It dispatches via the shared-KV **store** path; without that wiring the
+kernel would be dead on every shared-KV model.
+
+This makes the K-only iso family **usable** rather than fast: Bonsai is still
+below `none` (bf16 ≈ 110 TPS). The residual 3.40 µs/KV-token is the flash-decode
+*shell*, not the iso decode — a barrier-tree reduction per token with most lanes
+idle. That is shared with `rotor_flash_decode` and is where further work belongs.
+
+**Memory.** The GPU ring is additional resident memory on top of the CPU blocks
+(~8.1 MB/layer vs 23.9 MB of blocks at Bonsai 4k — ~34%). Note the `kv_bytes`
+trace event does **not** show it: `approx_bytes` routes through
+`quant_iso_k3_bytes`, which counts CPU blocks only. Same gap as rotor — the
+ring is only counted by `QuantIsoK3::byte_size`.
+
+---
 
 ## `planar_flash_decode` — single-pass MSL flash-decode for PlanarK
 


### PR DESCRIPTION
## Summary
Closes #218. `k_iso3`/`k_iso4` were **CPU-bound** (0.1–8.8 TPS, GPU idle) — the K-encode was Metal but attention dequant restaged host-side. This adds `iso_flash_decode_msl` (QK over iso-quant K + online softmax + bf16-V SV) reading a GPU-resident ring, and **ships the previously-HELD iso K-side GPU encoder** (`warn_iso_hold_once` deleted).

Unlike #219 (held), the baseline here is a **CPU dequant path, not a bf16 mirror** — so even on the current shell (#234) this wins big.

## Results (medians of 3 paired runs; both binaries symbol-verified, positive dispatch witness `rmlx_iso_flash_decode_p1_b{3,4}` — `main` shows 0)
| model | codec | ctx | before | after | gain |
|---|---|---|---|---|---|
| Ternary-Bonsai-8B-2bit (Qwen3, D=128) | k_iso3 | 4k | 4.24 | **17.9–19.9** | ~4.5× |
| Bonsai-8B | k_iso4 | 4k | 1.89 | **17.8–19.9** | ~9.9× |
| Bonsai-8B | k_iso3 | 16k | 0.96 | **10.59** | 11.0× |
| Bonsai-8B | k_iso3 | 32k | 0.59 | **6.63** | 11.2× |
| medgemma-4B (Gemma3, D=256) | k_iso3 | 4k | 21.96 | **51.96** | 2.4× |
| gemma-4-e2b (Gemma4, D=256, shared-KV) | k_iso3 | 4k | 44.65 | **64.80** | 1.45× |

**Slope `b` (`itl = a + b·kv_seq`): 48.5 → 3.40 µs/KV-token — 14.3×.** That's the number that decides whether a codec can win (per #234); TPS at one ctx isn't. Bonsai's 4k cells are given as a range over two independent 3-run medians because single-binary runs genuinely span 15.4–20.1 here.

**Unlike `k_rotor*` (#245), `k_iso*` dispatches at stock defaults** — no QJL analogue gates it off.

## Design
Iso decode is **one left Hamilton product** (`q̄ * r`), not rotor's `R̃·mv·R` sandwich — ~16 FMA/group vs ~64. `if_decode_k_lane` is **self-contained per lane**: a group's 4 codes share one u32, so it unpacks + rotates in registers — no SMEM, no barrier (the existing `iso_fused_qk` stages through SMEM + a barrier, which would serialise the tile). Reusable verbatim for **#220** by passing the V store's buffers.

`RotorGpuK` generalised to `QuantKGpuRing` (`head_dim` → `n_groups`) rather than duplicating 437 lines of the growth/seed logic that carried #233 — reviewer verified behaviour-identical; its 12 ring tests caught a positional swap the type-checker couldn't.

## Licensing
**Did not copy the CUDA.** `isoquant` has **no LICENSE** → all-rights-reserved; `isoclinic_fused_kernel.cu` was deliberately not read or ported. Not needed — the quaternion decode already exists in-repo as landed rMLX code. Zero exposure.

## Fixed en route
A **latent head-scramble**: the existing iso GPU append encoded head-major while the CPU append transposes and `dequant()` transposes back, so GPU blocks were read as seq-major (#80/#105 class, reachable at `exit_prefill` with `kv_h>1`).

## Review findings (all fixed)
- **HIGH:** `QuantIsoK4::append` was the **only** packed-K store not clearing a live GPU ring on a CPU append — a Gpu→Cpu→Gpu sequence left a zero-filled hole the kernel attended **with no error**, violating the `RingFeed` invariant. Proven **red-first** (iso3 green / iso4 red), one line, now 8/8.
- **MEDIUM:** all 24 oracle tests called the kernel *directly* — none drove the production wiring, which is exactly how the HIGH got through. New `iso_flash_dispatch_tests.rs` (8 tests) mirrors the rotor sibling: counter-delta through `update_and_sdpa`, tile boundary, head_dim 256, `b>1` ring-skip (previously **unexecuted**), + the HIGH's regression.
- The encoder-coverage test was a hardcoded 12-codec list that couldn't catch an omission — now a biconditional over all 29 `KvQuant` variants, pinned by an exhaustive `match` so a new variant **fails to compile** until listed. Mutation-verified against the exact pre-PR drift.
- `ISO_K3/K4_GROUP_SIZE` are now aliases **defined from** one `ISO_QUAT_BLOCK_SIZE` (the block size is the quaternion component count — fixed by the algebra), so they cannot drift even in principle.

## Testing
24 oracle tests on real GPU (bits 3+4, D=128/256/512, multi-tile, additive-mask, GQA 4:1/2:1 + MHA) vs the CPU `iso_decode_fast` reference. **Mutations all red:** bits4→3-bit kernel (0.128), mask index transposed (0.213), seq-major→head-major (0.131/0.155), quat-block assert defanged. `cargo test -p rmlx-kv-quant -p rmlx-models --lib` **1111 passed** (+12); `--tests` 426. `make lint` / `check-metal-format` / `check-no-decode-swallow` clean.

## Known reporting gap (filed as #246)
`kv_bytes` reports **identical bytes before and after** — it counts CPU blocks only, so the ring's genuine **+8.1 MB/layer (~34%)** is invisible. Pre-existing; affects #217 too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)