### PR TITLE
chore(mlx): pin the validated MLX/mlx-c pair + detect the missing nax GEMM kernels (#216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,20 @@ baseline and has been retracted after a direct measurement.)
 brew install mlx-c          # provides the MLX + mlx-c libraries
 ```
 
-If your MLX install is not on the default homebrew cellar path, point the build
-at it:
+The build finds MLX via `brew --prefix` (or `/opt/homebrew/opt/…`) on its own.
+Point it elsewhere only if your install is somewhere else:
 
 ```sh
 export MLX_C_PREFIX="$(brew --prefix mlx-c)"   # dir containing lib/libmlxc.dylib + include/
+export MLX_PREFIX="$(brew --prefix mlx)"
 ```
+
+rMLX is validated against one MLX / mlx-c pair, declared in
+`crates/rmlx-mlx/mlx-pin.txt`. If your installed MLX differs, or if it is
+missing the fast GEMM kernels that some Homebrew bottles omit (a known bottle
+regression that costs ~3.8× GPU matmul throughput), the build prints a warning
+naming the fix. It is a warning, not an error — the build still succeeds. See
+[`docs/FFI.md`](docs/FFI.md#pinned-mlx--mlx-c-pair).
 
 ## Install
 

--- a/crates/rmlx-mlx/README.md
+++ b/crates/rmlx-mlx/README.md
@@ -10,13 +10,23 @@ FFI bindings to the brew-prebuilt `mlx-c` C ABI, plus a minimal safe Rust layer
 brew install mlx mlx-c
 ```
 
-Tested against `mlx-c 0.6.0_2` and `mlx 0.31.2`. Apple Silicon only.
+Apple Silicon only. The validated MLX / mlx-c pair is declared in
+[`mlx-pin.txt`](mlx-pin.txt) — that file is the single source of truth, so the
+versions are deliberately not repeated here. `build.rs` warns (never fails) when
+the resolved stack differs from it, or when the resolved `mlx.metallib` is
+missing the fast GEMM kernels. Rationale and the un-pin procedure:
+[`docs/FFI.md`](../../docs/FFI.md#pinned-mlx--mlx-c-pair).
 
 ## Environment variables
 
-| Variable | Default | Description |
-|---|---|---|
-| `MLX_C_PREFIX` | `/opt/homebrew/Cellar/mlx-c/0.6.0_2` | Root of the mlx-c cellar entry |
-| `MLX_PREFIX` | `/opt/homebrew/Cellar/mlx/0.31.2` | Root of the mlx cellar entry |
+Both are optional overrides. Unset, `build.rs` resolves each prefix via
+`brew --prefix <formula>`, falling back to `/opt/homebrew/opt/<formula>` — the
+`opt` symlink the dylibs' install names already point at, which is what keeps
+the library compiled against and the library loaded on the same file.
 
-Set these if you have a non-default Homebrew prefix or a different version pinned.
+| Variable | Description |
+|---|---|
+| `MLX_C_PREFIX` | Root of the mlx-c install (contains `lib/libmlxc.dylib`, `include/`) |
+| `MLX_PREFIX` | Root of the mlx install (contains `lib/libmlx.dylib`, `include/`) |
+
+Set these only for a non-Homebrew layout or a non-default Homebrew prefix.

--- a/crates/rmlx-mlx/build.rs
+++ b/crates/rmlx-mlx/build.rs
@@ -18,6 +18,32 @@
 use std::env;
 use std::path::PathBuf;
 
+/// Parse `MLX_VERSION_{MAJOR,MINOR,PATCH}` out of MLX's `version.h`.
+///
+/// The header is the authoritative source for the version of the tree we
+/// compile against — the Cellar directory name is only a Homebrew convention.
+/// Returns `"unknown"` when the header cannot be read or parsed; the runtime
+/// check treats that as "cannot verify" and stays quiet rather than crying
+/// wolf on a non-Homebrew layout.
+fn read_mlx_version(header: &str) -> String {
+    let Ok(src) = std::fs::read_to_string(header) else {
+        return "unknown".to_owned();
+    };
+    let field = |name: &str| -> Option<String> {
+        src.lines()
+            .find_map(|l| l.strip_prefix(&format!("#define {name} ")))
+            .map(|v| v.trim().to_owned())
+    };
+    match (
+        field("MLX_VERSION_MAJOR"),
+        field("MLX_VERSION_MINOR"),
+        field("MLX_VERSION_PATCH"),
+    ) {
+        (Some(a), Some(b), Some(c)) => format!("{a}.{b}.{c}"),
+        _ => "unknown".to_owned(),
+    }
+}
+
 fn main() {
     // Rebuild triggers.
     println!("cargo:rerun-if-env-changed=MLX_C_PREFIX");
@@ -55,6 +81,21 @@ fn main() {
          Install with: brew install mlx. \
          Or set MLX_PREFIX to the correct cellar path."
     );
+
+    // Record the MLX version we compile against, so the runtime can detect a
+    // build-vs-runtime skew.
+    //
+    // This matters because the linked dylib's install name is the Homebrew
+    // `opt` symlink (`/opt/homebrew/opt/mlx/lib/libmlx.dylib`), not the Cellar
+    // path resolved above. The symlink follows whatever version Homebrew has
+    // linked *now*, so upgrading MLX silently swaps the library this binary
+    // loads — a different dylib and a different `mlx.metallib` — with no
+    // rebuild and no error. The two versions can differ in ABI and in kernel
+    // throughput, so the skew must not pass unnoticed.
+    let version_header = format!("{mlx_prefix}/include/mlx/version.h");
+    println!("cargo:rerun-if-changed={version_header}");
+    let build_version = read_mlx_version(&version_header);
+    println!("cargo:rustc-env=RMLX_MLX_BUILD_VERSION={build_version}");
 
     // Link search paths.
     println!("cargo:rustc-link-search=native={mlx_c_prefix}/lib");

--- a/crates/rmlx-mlx/build.rs
+++ b/crates/rmlx-mlx/build.rs
@@ -18,37 +18,144 @@
 use std::env;
 use std::path::PathBuf;
 
-/// Parse `MLX_VERSION_{MAJOR,MINOR,PATCH}` out of MLX's `version.h`.
+// Pure resolution/parsing logic, shared with `tests/mlx_pin.rs`.
+include!("build_support.rs");
+
+/// Declares the MLX / mlx-c pair this build is validated against.
+const PIN_FILE: &str = "mlx-pin.txt";
+
+/// The GEMM kernel family whose presence in `mlx.metallib` is the capability
+/// the pin exists to guarantee. Missing entirely in some bottles.
+const NAX_GEMM_KERNEL: &str = "steel_gemm_fused_nax";
+
+/// Read size for the metallib scan.
+const SCAN_CHUNK: usize = 1 << 20;
+
+/// Resolve the install prefix of a Homebrew formula.
 ///
-/// The header is the authoritative source for the version of the tree we
-/// compile against — the Cellar directory name is only a Homebrew convention.
-/// Returns `"unknown"` when the header cannot be read or parsed; the runtime
-/// check treats that as "cannot verify" and stays quiet rather than crying
-/// wolf on a non-Homebrew layout.
-fn read_mlx_version(header: &str) -> String {
-    let Ok(src) = std::fs::read_to_string(header) else {
-        return "unknown".to_owned();
-    };
-    let field = |name: &str| -> Option<String> {
-        src.lines()
-            .find_map(|l| l.strip_prefix(&format!("#define {name} ")))
-            .map(|v| v.trim().to_owned())
-    };
-    match (
-        field("MLX_VERSION_MAJOR"),
-        field("MLX_VERSION_MINOR"),
-        field("MLX_VERSION_PATCH"),
-    ) {
-        (Some(a), Some(b), Some(c)) => format!("{a}.{b}.{c}"),
-        _ => "unknown".to_owned(),
+/// Order: explicit env override -> `brew --prefix <formula>` -> the
+/// conventional `opt` symlink.
+///
+/// Resolving to the `opt` path rather than a Cellar path is deliberate: the
+/// linked dylibs' install names *are* `opt` paths, so that is what gets loaded
+/// at run time no matter what this build points at. Compiling against the same
+/// path the loader will use is what keeps build and runtime the same file; a
+/// hard-coded Cellar path silently drifts from it on every upgrade.
+fn resolve_prefix(env_key: &str, formula: &str) -> String {
+    println!("cargo:rerun-if-env-changed={env_key}");
+    if let Ok(prefix) = env::var(env_key) {
+        return prefix;
+    }
+    if let Some(prefix) = brew_prefix(formula) {
+        return prefix;
+    }
+    format!("/opt/homebrew/opt/{formula}")
+}
+
+/// Ask Homebrew where a formula lives. `None` when brew is absent, the formula
+/// is not installed, or the answer does not exist on disk.
+fn brew_prefix(formula: &str) -> Option<String> {
+    let out = std::process::Command::new("brew")
+        .args(["--prefix", formula])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let prefix = String::from_utf8(out.stdout).ok()?.trim().to_owned();
+    (!prefix.is_empty() && std::path::Path::new(&prefix).exists()).then_some(prefix)
+}
+
+/// Compare the resolved MLX / mlx-c against the pinned pair, and check that the
+/// metallib actually carries the fast GEMM kernels.
+///
+/// Warn, never fail. The pin records what was validated here; it is not a
+/// statement that anything else is broken. A correct non-bottle build of
+/// another version must still build, so a hard error would be wrong.
+fn check_mlx_pin(mlx_prefix: &str, mlx_c_prefix: &str, mlx_version: &str) {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let pin_path = format!("{manifest_dir}/{PIN_FILE}");
+    println!("cargo:rerun-if-changed={pin_path}");
+
+    let pin_src = std::fs::read_to_string(&pin_path)
+        .unwrap_or_else(|e| panic!("rmlx-mlx: cannot read the MLX pin at {pin_path}: {e}"));
+    let pin = parse_pin(&pin_src).unwrap_or_else(|| {
+        panic!(
+            "rmlx-mlx: {pin_path} must declare one `mlx <version>` line and one \
+             `mlx-c <version>` line (plus `#` comments). The two are pinned as a \
+             pair — see docs/FFI.md."
+        )
+    });
+    let (pin_mlx, pin_mlx_c) = (pin.mlx.as_str(), pin.mlx_c.as_str());
+
+    // mlx-c ships no version header, so its identity is the keg directory name
+    // — which is also the only place the Homebrew revision suffix appears, and
+    // that suffix is the whole point (0.6.0_2 and 0.6.0_3 are the same upstream
+    // release built against different mlx).
+    let mlx_c_version = std::fs::canonicalize(mlx_c_prefix)
+        .ok()
+        .and_then(|real| keg_version_from(&real, "mlx-c"))
+        .unwrap_or_else(|| "unknown".to_owned());
+
+    // The capability itself, read off the library that will be loaded. This is
+    // the ground truth the version pin only proxies for, and it keeps passing
+    // on its own once a fixed bottle ships. `None` = no metallib to inspect.
+    let metallib = format!("{mlx_prefix}/lib/mlx.metallib");
+    println!("cargo:rerun-if-changed={metallib}");
+    let fast_gemm = std::fs::File::open(&metallib)
+        .ok()
+        .and_then(|f| contains_needle(f, NAX_GEMM_KERNEL.as_bytes(), SCAN_CHUNK).ok());
+
+    let drift = (mlx_version != "unknown" && mlx_version != pin_mlx)
+        || (mlx_c_version != "unknown" && mlx_c_version != pin_mlx_c);
+
+    if fast_gemm == Some(false) {
+        println!(
+            "cargo:warning=MLX at {mlx_prefix} (mlx {mlx_version}, mlx-c {mlx_c_version}) ships \
+             no {NAX_GEMM_KERNEL} kernels in lib/mlx.metallib."
+        );
+        println!(
+            "cargo:warning=  Those are the Neural-Accelerator GEMM path. Without them GPU matmul \
+             throughput measured ~3.8x lower and prefill 2.2-3.3x slower on \
+             Neural-Accelerator-class hardware. Decode is bandwidth-bound and looks normal, so \
+             the symptom mimics a model-code defect."
+        );
+        println!(
+            "cargo:warning=  rMLX pins the validated pair mlx {pin_mlx} + mlx-c {pin_mlx_c}, \
+             whose metallib ships 360 of them. Some Homebrew bottles omit the family entirely; a \
+             non-bottle build of the same version can be fine."
+        );
+        println!(
+            "cargo:warning=  Fix (Homebrew; both kegs must already be in the Cellar — check with \
+             `ls /opt/homebrew/Cellar/mlx`):"
+        );
+        println!(
+            "cargo:warning=    ln -sfn ../Cellar/mlx/{pin_mlx} /opt/homebrew/opt/mlx && ln -sfn \
+             ../Cellar/mlx-c/{pin_mlx_c} /opt/homebrew/opt/mlx-c && brew pin mlx mlx-c"
+        );
+        println!(
+            "cargo:warning=  Repoint both: mlx and mlx-c are ABI-coupled and a mismatched pair \
+             aborts at load. Then rebuild. Pin: crates/rmlx-mlx/{PIN_FILE}; rationale and un-pin \
+             steps: docs/FFI.md."
+        );
+    } else if drift {
+        println!(
+            "cargo:warning=MLX pin drift: resolved mlx {mlx_version} + mlx-c {mlx_c_version}, but \
+             rMLX pins mlx {pin_mlx} + mlx-c {pin_mlx_c} (crates/rmlx-mlx/{PIN_FILE})."
+        );
+        println!(
+            "cargo:warning=  The {NAX_GEMM_KERNEL} kernels the pin exists for are present, so GEMM \
+             throughput should be unaffected. mlx and mlx-c are ABI-coupled though: an unvalidated \
+             pair can abort at load with a dyld \"Symbol not found\". If this pair checks out, bump \
+             both pin lines together. See docs/FFI.md."
+        );
     }
 }
 
 fn main() {
-    // Rebuild triggers.
-    println!("cargo:rerun-if-env-changed=MLX_C_PREFIX");
-    println!("cargo:rerun-if-env-changed=MLX_PREFIX");
+    // Rebuild triggers. (The prefix env vars are declared by resolve_prefix.)
     println!("cargo:rerun-if-changed=wrapper.h");
+    println!("cargo:rerun-if-changed=build_support.rs");
 
     // Target guard: Apple Silicon only.
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
@@ -60,11 +167,9 @@ fn main() {
          MLX runs only on Apple Silicon Metal."
     );
 
-    // Prefix resolution: env var → brew canonical path.
-    let mlx_c_prefix = env::var("MLX_C_PREFIX")
-        .unwrap_or_else(|_| "/opt/homebrew/Cellar/mlx-c/0.6.0_2".to_owned());
-    let mlx_prefix =
-        env::var("MLX_PREFIX").unwrap_or_else(|_| "/opt/homebrew/Cellar/mlx/0.31.2".to_owned());
+    // Prefix resolution: env var → brew → the `opt` symlink the loader uses.
+    let mlx_c_prefix = resolve_prefix("MLX_C_PREFIX", "mlx-c");
+    let mlx_prefix = resolve_prefix("MLX_PREFIX", "mlx");
 
     // Verify the dylibs exist, give a helpful message if not.
     let mlxc_lib = format!("{mlx_c_prefix}/lib/libmlxc.dylib");
@@ -94,8 +199,13 @@ fn main() {
     // throughput, so the skew must not pass unnoticed.
     let version_header = format!("{mlx_prefix}/include/mlx/version.h");
     println!("cargo:rerun-if-changed={version_header}");
-    let build_version = read_mlx_version(&version_header);
+    let build_version =
+        read_mlx_version(&std::fs::read_to_string(&version_header).unwrap_or_default());
     println!("cargo:rustc-env=RMLX_MLX_BUILD_VERSION={build_version}");
+
+    // Report a resolved stack that is not the validated one, or that cannot
+    // reach the fast GEMM path at all.
+    check_mlx_pin(&mlx_prefix, &mlx_c_prefix, &build_version);
 
     // Link search paths.
     println!("cargo:rustc-link-search=native={mlx_c_prefix}/lib");

--- a/crates/rmlx-mlx/build.rs
+++ b/crates/rmlx-mlx/build.rs
@@ -52,6 +52,25 @@ fn resolve_prefix(env_key: &str, formula: &str) -> String {
     format!("/opt/homebrew/opt/{formula}")
 }
 
+/// Declare a rebuild trigger for a path, but only if it exists.
+///
+/// Cargo treats a listed path that is absent as permanently dirty, which would
+/// re-run this script — and bindgen — on every single build for anyone whose
+/// MLX is not laid out like a Homebrew keg. The probes already tolerate a
+/// missing file by going quiet, so the trigger must tolerate it too.
+///
+/// Note what this can and cannot catch: cargo compares mtimes and re-runs only
+/// for a *newer* one, and it stats through symlinks. Repointing `opt/mlx` at an
+/// older keg therefore moves the observed mtime backwards and does **not**
+/// trigger a re-run — recovering from a bad stack needs an explicit
+/// `cargo clean -p rmlx-mlx`, and the runtime version-skew warning is the
+/// backstop for a binary that was never rebuilt.
+fn rerun_if_present(path: &str) {
+    if std::path::Path::new(path).exists() {
+        println!("cargo:rerun-if-changed={path}");
+    }
+}
+
 /// Ask Homebrew where a formula lives. `None` when brew is absent, the formula
 /// is not installed, or the answer does not exist on disk.
 fn brew_prefix(formula: &str) -> Option<String> {
@@ -101,13 +120,12 @@ fn check_mlx_pin(mlx_prefix: &str, mlx_c_prefix: &str, mlx_version: &str) {
     // the ground truth the version pin only proxies for, and it keeps passing
     // on its own once a fixed bottle ships. `None` = no metallib to inspect.
     let metallib = format!("{mlx_prefix}/lib/mlx.metallib");
-    println!("cargo:rerun-if-changed={metallib}");
+    rerun_if_present(&metallib);
     let fast_gemm = std::fs::File::open(&metallib)
         .ok()
         .and_then(|f| contains_needle(f, NAX_GEMM_KERNEL.as_bytes(), SCAN_CHUNK).ok());
 
-    let drift = (mlx_version != "unknown" && mlx_version != pin_mlx)
-        || (mlx_c_version != "unknown" && mlx_c_version != pin_mlx_c);
+    let drift = pin_drift(mlx_version, &mlx_c_version, &pin);
 
     if fast_gemm == Some(false) {
         println!(
@@ -116,13 +134,13 @@ fn check_mlx_pin(mlx_prefix: &str, mlx_c_prefix: &str, mlx_version: &str) {
         );
         println!(
             "cargo:warning=  Those are the Neural-Accelerator GEMM path. Without them GPU matmul \
-             throughput measured ~3.8x lower and prefill 2.2-3.3x slower on \
+             throughput measured ~3.8x lower and prefill 2.2-3.7x slower on \
              Neural-Accelerator-class hardware. Decode is bandwidth-bound and looks normal, so \
              the symptom mimics a model-code defect."
         );
         println!(
             "cargo:warning=  rMLX pins the validated pair mlx {pin_mlx} + mlx-c {pin_mlx_c}, \
-             whose metallib ships 360 of them. Some Homebrew bottles omit the family entirely; a \
+             whose metallib ships them. Some Homebrew bottles omit the family entirely; a \
              non-bottle build of the same version can be fine."
         );
         println!(
@@ -131,12 +149,15 @@ fn check_mlx_pin(mlx_prefix: &str, mlx_c_prefix: &str, mlx_version: &str) {
         );
         println!(
             "cargo:warning=    ln -sfn ../Cellar/mlx/{pin_mlx} /opt/homebrew/opt/mlx && ln -sfn \
-             ../Cellar/mlx-c/{pin_mlx_c} /opt/homebrew/opt/mlx-c && brew pin mlx mlx-c"
+             ../Cellar/mlx-c/{pin_mlx_c} /opt/homebrew/opt/mlx-c && brew pin mlx mlx-c && cargo \
+             clean -p rmlx-mlx"
         );
         println!(
             "cargo:warning=  Repoint both: mlx and mlx-c are ABI-coupled and a mismatched pair \
-             aborts at load. Then rebuild. Pin: crates/rmlx-mlx/{PIN_FILE}; rationale and un-pin \
-             steps: docs/FFI.md."
+             aborts at load. The `cargo clean` is required, not tidiness: repointing to an older \
+             keg moves file times backwards, and cargo only re-runs a build script for a *newer* \
+             one — so a plain rebuild would silently keep these stale bindings. Pin: \
+             crates/rmlx-mlx/{PIN_FILE}; rationale and un-pin steps: docs/FFI.md."
         );
     } else if drift {
         println!(
@@ -198,7 +219,7 @@ fn main() {
     // rebuild and no error. The two versions can differ in ABI and in kernel
     // throughput, so the skew must not pass unnoticed.
     let version_header = format!("{mlx_prefix}/include/mlx/version.h");
-    println!("cargo:rerun-if-changed={version_header}");
+    rerun_if_present(&version_header);
     let build_version =
         read_mlx_version(&std::fs::read_to_string(&version_header).unwrap_or_default());
     println!("cargo:rustc-env=RMLX_MLX_BUILD_VERSION={build_version}");

--- a/crates/rmlx-mlx/build_support.rs
+++ b/crates/rmlx-mlx/build_support.rs
@@ -1,0 +1,108 @@
+// Pure helpers behind `build.rs`'s MLX prefix/version resolution.
+//
+// `include!`d by `build.rs` and by `tests/mlx_pin.rs` rather than imported: a
+// build script cannot depend on the crate it builds, and this logic decides
+// whether a known perf cliff gets reported, so it needs coverage that
+// `cargo test` actually runs. Everything here is pure — all I/O and all
+// `cargo:` directives stay in `build.rs`.
+//
+// Paths and traits are fully qualified: an `include!`d file cannot own imports
+// without colliding with whichever file pulled it in.
+
+/// The MLX / mlx-c pair declared by `mlx-pin.txt`.
+#[derive(Debug, PartialEq, Eq)]
+struct MlxPin {
+    mlx: String,
+    mlx_c: String,
+}
+
+/// Parse the pinned pair out of `mlx-pin.txt`.
+///
+/// Format: one `<formula> <version>` per line, `#` comments and blank lines
+/// ignored. Both formulas are mandatory and any other line is an error: the
+/// pair is the unit that was validated, so a half-declared or typo'd pin would
+/// quietly stop checking the very coupling it exists to enforce.
+fn parse_pin(src: &str) -> Option<MlxPin> {
+    let mut mlx = None;
+    let mut mlx_c = None;
+    for line in src.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut fields = line.split_whitespace();
+        match (fields.next(), fields.next(), fields.next()) {
+            (Some("mlx"), Some(v), None) => mlx = Some(v.to_owned()),
+            (Some("mlx-c"), Some(v), None) => mlx_c = Some(v.to_owned()),
+            _ => return None,
+        }
+    }
+    Some(MlxPin {
+        mlx: mlx?,
+        mlx_c: mlx_c?,
+    })
+}
+
+/// The Homebrew keg version an already-canonicalized prefix points at, e.g.
+/// `/opt/homebrew/Cellar/mlx-c/0.6.0_2` -> `0.6.0_2`.
+///
+/// This is the only version identity mlx-c has: it ships no version header, and
+/// the part that matters is precisely the Homebrew revision suffix (`_2` vs
+/// `_3`) — same upstream 0.6.0, different build, different mlx ABI. A layout
+/// that is not a keg (a wheel, a hand-built tree) yields `None`: the pin has
+/// nothing to say there and must stay quiet rather than guess.
+fn keg_version_from(real: &std::path::Path, formula: &str) -> Option<String> {
+    let version = real.file_name()?.to_str()?;
+    let parent = real.parent()?.file_name()?.to_str()?;
+    (parent == formula).then(|| version.to_owned())
+}
+
+/// Parse `MLX_VERSION_{MAJOR,MINOR,PATCH}` out of the text of MLX's `version.h`.
+///
+/// The header is authoritative for the tree we compile against — a Cellar
+/// directory name is only a Homebrew convention, and MLX is also installed
+/// other ways. Returns `"unknown"` when the header cannot be parsed; callers
+/// treat that as "cannot verify" and stay quiet rather than crying wolf.
+fn read_mlx_version(src: &str) -> String {
+    let field = |name: &str| -> Option<String> {
+        src.lines()
+            .find_map(|l| l.trim().strip_prefix(&format!("#define {name} ")))
+            .map(|v| v.trim().to_owned())
+    };
+    match (
+        field("MLX_VERSION_MAJOR"),
+        field("MLX_VERSION_MINOR"),
+        field("MLX_VERSION_PATCH"),
+    ) {
+        (Some(a), Some(b), Some(c)) => format!("{a}.{b}.{c}"),
+        _ => "unknown".to_owned(),
+    }
+}
+
+/// Whether `reader` yields `needle` anywhere, scanning in `chunk`-sized reads.
+///
+/// The metallib this scans is ~150 MB, which a build script has no business
+/// holding in memory. `chunk` is a parameter so the carry path — a needle that
+/// straddles two reads — is testable without a 150 MB fixture.
+fn contains_needle<R: std::io::Read>(
+    mut reader: R,
+    needle: &[u8],
+    chunk: usize,
+) -> std::io::Result<bool> {
+    let mut buf = vec![0_u8; chunk];
+    let mut window: Vec<u8> = Vec::new();
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            return Ok(false);
+        }
+        window.extend(buf.iter().take(n).copied());
+        if window.windows(needle.len()).any(|w| w == needle) {
+            return Ok(true);
+        }
+        // Keep the last needle-1 bytes: a match straddling this read and the
+        // next one lives entirely inside that tail plus what comes after.
+        let consumed = window.len().saturating_sub(needle.len().saturating_sub(1));
+        window.drain(..consumed);
+    }
+}

--- a/crates/rmlx-mlx/build_support.rs
+++ b/crates/rmlx-mlx/build_support.rs
@@ -57,6 +57,16 @@ fn keg_version_from(real: &std::path::Path, formula: &str) -> Option<String> {
     (parent == formula).then(|| version.to_owned())
 }
 
+/// Whether the resolved pair differs from the pinned one.
+///
+/// `"unknown"` means the version could not be established (a non-keg layout, an
+/// unreadable header) — that is "cannot verify", not "mismatch", so it never
+/// reports drift. Guessing there would warn at people whose install is simply
+/// shaped differently.
+fn pin_drift(mlx: &str, mlx_c: &str, pin: &MlxPin) -> bool {
+    (mlx != "unknown" && mlx != pin.mlx) || (mlx_c != "unknown" && mlx_c != pin.mlx_c)
+}
+
 /// Parse `MLX_VERSION_{MAJOR,MINOR,PATCH}` out of the text of MLX's `version.h`.
 ///
 /// The header is authoritative for the tree we compile against — a Cellar
@@ -92,11 +102,23 @@ fn contains_needle<R: std::io::Read>(
     let mut buf = vec![0_u8; chunk];
     let mut window: Vec<u8> = Vec::new();
     loop {
-        let n = reader.read(&mut buf)?;
-        if n == 0 {
-            return Ok(false);
-        }
-        window.extend(buf.iter().take(n).copied());
+        let n = match reader.read(&mut buf) {
+            Ok(0) => return Ok(false),
+            Ok(n) => n,
+            // A signal must not be mistaken for a failed probe: the caller reads
+            // an error as "cannot inspect" and goes quiet, which is precisely
+            // the outcome this scan exists to prevent.
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        };
+        // `Read` guarantees n <= buf.len(); `get` states that without a panic
+        // path, and keeps the copy a memcpy rather than a byte-at-a-time loop.
+        let Some(filled) = buf.get(..n) else {
+            return Err(std::io::Error::other(
+                "reader reported more bytes than the buffer holds",
+            ));
+        };
+        window.extend_from_slice(filled);
         if window.windows(needle.len()).any(|w| w == needle) {
             return Ok(true);
         }

--- a/crates/rmlx-mlx/mlx-pin.txt
+++ b/crates/rmlx-mlx/mlx-pin.txt
@@ -1,0 +1,14 @@
+# The MLX / mlx-c pair rMLX is validated against. Single source of truth:
+# build.rs reads this file, and nothing else declares these versions.
+#
+# Bump BOTH lines together, never one alone. mlx-c is compiled against a
+# specific mlx and both resolve the moving `opt` symlink at run time, so a
+# mismatched pair aborts at load with a dyld "Symbol not found".
+#
+# Why these versions, and how to un-pin once Homebrew's bottle is fixed:
+# docs/FFI.md -> "Pinned MLX / mlx-c pair".
+#
+# Format: <formula> <version>. The mlx-c version carries the Homebrew revision
+# suffix (`_2`), which is load-bearing: same upstream 0.6.0, different build.
+mlx    0.31.2
+mlx-c  0.6.0_2

--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -83,7 +83,80 @@ pub(crate) fn install_error_handler() {
         unsafe {
             sys::mlx_set_error_handler(Some(handler), ptr::null_mut(), None);
         }
+        warn_on_mlx_version_skew();
     });
+}
+
+/// The MLX version `rmlx-mlx` was compiled against (from `mlx/version.h`,
+/// captured by `build.rs`). `"unknown"` when the header was unreadable.
+const MLX_BUILD_VERSION: &str = env!("RMLX_MLX_BUILD_VERSION");
+
+/// Read the MLX version of the dylib actually loaded into this process.
+///
+/// Returns `None` if mlx-c reports an error or hands back a null string.
+fn runtime_mlx_version() -> Option<String> {
+    // SAFETY: mlx_version writes an owned mlx_string on success (status 0).
+    // mlx_string_data borrows its NUL-terminated buffer, which stays valid
+    // until mlx_string_free; the value is copied out before freeing.
+    unsafe {
+        let mut s = sys::mlx_string_new();
+        if sys::mlx_version(&raw mut s) != 0 {
+            let _ = sys::mlx_string_free(s);
+            return None;
+        }
+        let data = sys::mlx_string_data(s);
+        let out = if data.is_null() {
+            None
+        } else {
+            Some(
+                std::ffi::CStr::from_ptr(data)
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        };
+        let _ = sys::mlx_string_free(s);
+        out
+    }
+}
+
+/// Warn when the loaded MLX differs from the one this binary was built against.
+///
+/// The linked dylib's install name is a Homebrew `opt` symlink, so upgrading
+/// MLX silently redirects this binary to a different library and metallib with
+/// no rebuild. That skew is an ABI hazard and has been observed to cost a large
+/// factor of GPU matmul throughput, which shows up only as slow prefill — an
+/// easy defect to misattribute to model code. Surface it instead of letting it
+/// pass silently.
+///
+/// Warn (not fail): a skew is usually benign-but-slow, and a hard error here
+/// would brick every run on a host whose package manager moved ahead.
+fn warn_on_mlx_version_skew() {
+    if MLX_BUILD_VERSION == "unknown" {
+        return;
+    }
+    let Some(runtime) = runtime_mlx_version() else {
+        return;
+    };
+    // The runtime string carries a ".devYYYYMMDD+hash" suffix on dev builds;
+    // compare only the leading "major.minor.patch".
+    let runtime_core = runtime.split(['-', '+']).next().unwrap_or(&runtime);
+    let runtime_core = runtime_core
+        .split('.')
+        .take(3)
+        .collect::<Vec<_>>()
+        .join(".");
+    if runtime_core != MLX_BUILD_VERSION {
+        tracing::warn!(
+            build_version = MLX_BUILD_VERSION,
+            runtime_version = %runtime,
+            "MLX build/runtime version skew: this binary was compiled against \
+             MLX {MLX_BUILD_VERSION} but loaded MLX {runtime}. The linked dylib \
+             resolves through a package-manager symlink, so an upgrade swaps it \
+             without a rebuild. Expect ABI risk and possible large GPU-throughput \
+             differences (prefill). Rebuild against the loaded version, or pin \
+             the package back to {MLX_BUILD_VERSION}."
+        );
+    }
 }
 
 /// Check the return code of a mlx-c function call.

--- a/crates/rmlx-mlx/tests/mlx_pin.rs
+++ b/crates/rmlx-mlx/tests/mlx_pin.rs
@@ -50,6 +50,40 @@ fn parse_pin_rejects_unknown_or_malformed_lines() {
     assert_eq!(parse_pin("mlx 0.31.2 extra\nmlx-c 0.6.0_2\n"), None);
 }
 
+/// The pinned pair the drift cases are stated against.
+fn pin_fixture() -> MlxPin {
+    MlxPin {
+        mlx: "0.31.2".to_owned(),
+        mlx_c: "0.6.0_2".to_owned(),
+    }
+}
+
+#[test]
+fn no_drift_when_both_halves_match() {
+    assert!(!pin_drift("0.31.2", "0.6.0_2", &pin_fixture()));
+}
+
+#[test]
+fn drift_when_either_half_differs() {
+    // Either half alone is drift: the pair is the validated unit.
+    assert!(pin_drift("0.32.0", "0.6.0_2", &pin_fixture()));
+    assert!(pin_drift("0.31.2", "0.6.0_3", &pin_fixture()));
+    assert!(pin_drift("0.32.0", "0.6.0_3", &pin_fixture()));
+}
+
+#[test]
+fn unknown_never_reports_drift() {
+    // "unknown" is "cannot verify", not "mismatch" — a non-keg layout or an
+    // unreadable header must not warn at someone whose install is merely
+    // shaped differently.
+    assert!(!pin_drift("unknown", "unknown", &pin_fixture()));
+    assert!(!pin_drift("unknown", "0.6.0_2", &pin_fixture()));
+    assert!(!pin_drift("0.31.2", "unknown", &pin_fixture()));
+    // ...but a known-bad half still drifts even when the other is unknown.
+    assert!(pin_drift("unknown", "0.6.0_3", &pin_fixture()));
+    assert!(pin_drift("0.32.0", "unknown", &pin_fixture()));
+}
+
 #[test]
 fn keg_version_reads_the_homebrew_revision_suffix() {
     // The `_2` suffix is the load-bearing part: same upstream 0.6.0, built

--- a/crates/rmlx-mlx/tests/mlx_pin.rs
+++ b/crates/rmlx-mlx/tests/mlx_pin.rs
@@ -1,0 +1,139 @@
+//! Coverage for `build.rs`'s pin parsing and version/capability resolution.
+//!
+//! The helpers are `include!`d from the same file the build script includes: a
+//! build script cannot be imported, and this logic decides whether a known
+//! 3.8x GPU-matmul cliff gets reported. Silent breakage here would turn the
+//! pin into decoration, so it is tested against the real checked-in pin file.
+
+include!("../build_support.rs");
+
+/// The pin file as shipped. Bumping it is expected; breaking its shape is not.
+const PIN_SRC: &str = include_str!("../mlx-pin.txt");
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "the checked-in pin file must parse; a None here is the failure under test"
+)]
+fn checked_in_pin_declares_both_formulas() {
+    let pin = parse_pin(PIN_SRC).unwrap();
+    assert!(
+        !pin.mlx.is_empty() && !pin.mlx_c.is_empty(),
+        "both halves of the pair must be declared, got {pin:?}"
+    );
+}
+
+#[test]
+fn parse_pin_ignores_comments_and_blank_lines() {
+    let src = "# a comment\n\n  mlx    0.31.2  \n# another\nmlx-c  0.6.0_2\n";
+    assert_eq!(
+        parse_pin(src),
+        Some(MlxPin {
+            mlx: "0.31.2".to_owned(),
+            mlx_c: "0.6.0_2".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_pin_rejects_a_half_declared_pair() {
+    // Pinning one half is the exact mistake the pair exists to prevent, so it
+    // must fail the build rather than silently check only mlx.
+    assert_eq!(parse_pin("mlx 0.31.2\n"), None);
+    assert_eq!(parse_pin("mlx-c 0.6.0_2\n"), None);
+}
+
+#[test]
+fn parse_pin_rejects_unknown_or_malformed_lines() {
+    assert_eq!(parse_pin("mlx 0.31.2\nmlx-c 0.6.0_2\nmlx-rs 1.0\n"), None);
+    assert_eq!(parse_pin("mlx\nmlx-c 0.6.0_2\n"), None);
+    assert_eq!(parse_pin("mlx 0.31.2 extra\nmlx-c 0.6.0_2\n"), None);
+}
+
+#[test]
+fn keg_version_reads_the_homebrew_revision_suffix() {
+    // The `_2` suffix is the load-bearing part: same upstream 0.6.0, built
+    // against a different mlx.
+    assert_eq!(
+        keg_version_from(
+            std::path::Path::new("/opt/homebrew/Cellar/mlx-c/0.6.0_2"),
+            "mlx-c"
+        ),
+        Some("0.6.0_2".to_owned())
+    );
+    assert_eq!(
+        keg_version_from(
+            std::path::Path::new("/opt/homebrew/Cellar/mlx/0.31.2"),
+            "mlx"
+        ),
+        Some("0.31.2".to_owned())
+    );
+}
+
+#[test]
+fn keg_version_declines_non_keg_layouts() {
+    // A wheel or hand-built tree has no keg version; the pin must stay quiet
+    // instead of reading a directory name as a version.
+    assert_eq!(
+        keg_version_from(std::path::Path::new("/usr/local/mlx-c"), "mlx-c"),
+        None
+    );
+    assert_eq!(keg_version_from(std::path::Path::new("/"), "mlx"), None);
+    // Right leaf, wrong formula.
+    assert_eq!(
+        keg_version_from(
+            std::path::Path::new("/opt/homebrew/Cellar/mlx/0.31.2"),
+            "mlx-c"
+        ),
+        None
+    );
+}
+
+#[test]
+fn mlx_version_comes_from_the_header_macros() {
+    let header = "#pragma once\n\
+                  #define MLX_VERSION_MAJOR 0\n\
+                  #define MLX_VERSION_MINOR 31\n\
+                  #define MLX_VERSION_PATCH 2\n";
+    assert_eq!(read_mlx_version(header), "0.31.2");
+}
+
+#[test]
+fn mlx_version_degrades_to_unknown() {
+    // An unreadable header means "cannot verify", not "mismatch" — callers key
+    // off this string to stay quiet rather than warn wrongly.
+    assert_eq!(read_mlx_version(""), "unknown");
+    assert_eq!(read_mlx_version("#define MLX_VERSION_MAJOR 0\n"), "unknown");
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "reads from an in-memory slice, which cannot fail"
+)]
+fn needle_is_found_across_a_chunk_boundary() {
+    let needle = b"steel_gemm_fused_nax";
+    // Straddle a read boundary: the match exists only if the tail is carried.
+    let mut haystack = vec![b'.'; 7];
+    haystack.extend_from_slice(needle);
+    haystack.extend_from_slice(&[b'.'; 7]);
+    for chunk in [1, 3, 8, 4096] {
+        assert!(
+            contains_needle(haystack.as_slice(), needle, chunk).unwrap(),
+            "missed a boundary-straddling match at chunk={chunk}"
+        );
+    }
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "reads from an in-memory slice, which cannot fail"
+)]
+fn needle_absent_reports_false() {
+    let needle = b"steel_gemm_fused_nax";
+    assert!(!contains_needle(b"".as_slice(), needle, 8).unwrap());
+    assert!(!contains_needle(b"steel_gemm_fused_na".as_slice(), needle, 8).unwrap());
+    // A near-miss must not count: this is the 0-vs-360 distinction itself.
+    assert!(!contains_needle(b"steel_gemm_fused_max".as_slice(), needle, 8).unwrap());
+}

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -85,19 +85,25 @@ why the pin carries it.)
 
 #### Why the pin exists
 
-Homebrew's `mlx` 0.32.0 bottle ships **zero** of the ~360
-`steel_gemm_fused_nax_*` kernels — the M5 Neural-Accelerator GEMM path:
+Homebrew's `mlx` 0.32.0 bottle ships **zero** `steel_gemm_fused_nax_*` kernels
+— the M5 Neural-Accelerator GEMM path. The pinned 0.31.2 bottle ships 145 of
+them:
 
 ```sh
 strings "$(brew --prefix mlx)/lib/mlx.metallib" | grep -c steel_gemm_fused_nax
-# 0.31.2 -> 360      0.32.0 -> 0
+# 0.31.2 -> 288      0.32.0 -> 0
 ```
 
-Measured cost: ~3.8× lower GPU matmul throughput, 2.2–3.3× slower prefill on
+(`grep -c` counts matching *lines*, not kernels: 145 distinct kernel functions
+appear on 288 lines. Only the zero is load-bearing — the build's probe is
+boolean and never counts.)
+
+Measured cost: ~3.8× lower GPU matmul throughput, 2.2–3.7× slower prefill on
 Neural-Accelerator-class hardware. Decode is bandwidth-bound and barely moves
-(gemma-4-e2b @4k: prefill 7,080 → 15,592 t/s, decode 126.2 → 121.5), so the
-symptom looks like a model-code defect rather than a toolchain one — it cost
-one investigation days of misattribution before the metallib was inspected.
+(gemma-4-e2b @4k, median of 3, same binary: prefill 6,916 → 15,352 t/s, decode
+124.5 → 119.9), so the symptom looks like a model-code defect rather than a
+toolchain one — it cost one investigation days of misattribution before the
+metallib was inspected.
 
 This is a **Homebrew bottle regression, not an MLX regression**: the upstream
 0.32.0 PyPI wheel ships the kernels and is fine. Tracked in
@@ -135,11 +141,21 @@ Both kegs must already be in the Cellar (`ls /opt/homebrew/Cellar/mlx`):
 ```sh
 ln -sfn ../Cellar/mlx/0.31.2 /opt/homebrew/opt/mlx && \
 ln -sfn ../Cellar/mlx-c/0.6.0_2 /opt/homebrew/opt/mlx-c && \
-brew pin mlx mlx-c
+brew pin mlx mlx-c && \
+cargo clean -p rmlx-mlx        # required — see below
 ```
 
-Then rebuild. `brew pin` stops a later `brew upgrade` from repointing the
-symlinks back.
+`brew pin` stops a later `brew upgrade` from repointing the symlinks back.
+
+**The `cargo clean` is required, not hygiene.** Cargo re-runs a build script
+only when a `rerun-if-changed` path is *newer* than the last run, and it stats
+**through** the symlink. Repointing `opt/mlx` at the older validated keg moves
+the observed mtime **backwards** (0.31.2's metallib predates 0.32.0's), so a
+plain rebuild does not re-run `build.rs` at all: the crate keeps bindings
+generated against the wrong headers and a stale baked-in
+`RMLX_MLX_BUILD_VERSION`, while the loader picks up the newly-linked pair. That
+combination is the ABI abort this section exists to avoid. Touching
+`crates/rmlx-mlx/mlx-pin.txt` forces the same re-run if you prefer.
 
 #### Un-pinning when the bottle is fixed
 
@@ -147,12 +163,20 @@ symlinks back.
 2. Verify the capability actually returned — this is the whole point:
    ```sh
    strings "$(brew --prefix mlx)/lib/mlx.metallib" | grep -c steel_gemm_fused_nax
-   # must be ~360, not 0
+   # must be non-zero (288 on the 0.31.2 bottle); zero means the bottle is still broken
    ```
+   Assert non-zero, not a particular count: the number is a `strings` line count
+   that tracks kernel-name spelling, and the build's probe only asks present/absent.
 3. Bump **both** lines in `crates/rmlx-mlx/mlx-pin.txt` to the new pair
    (`brew list --versions mlx mlx-c` gives the keg names, revision suffix
-   included).
-4. Rebuild and confirm the build emits no MLX warning.
+   included). Editing the pin file is itself a rebuild trigger, which is what
+   makes step 4 mean something.
+4. Rebuild and confirm the build emits no MLX warning — but only after
+   `cargo clean -p rmlx-mlx`. Upgrading normally moves mtimes forward, so the
+   re-run usually happens on its own; a *downgrade* does not, and then "no
+   warning" would merely mean the check never ran. Force it and the step is
+   real. Confirm `build.rs` actually ran with `cargo build -p rmlx-mlx -vv`
+   (its output appears only on a real run).
 5. Re-verify on a real prefill cell, not just the kernel count:
    ```sh
    rmlx baseline --model <gemma-4-e2b> --kv-quant none --max-ctx 8192 --prompt-tokens 4096
@@ -189,9 +213,17 @@ catches a stack that changed underneath a built binary.
    resolved `mlx.metallib` is scanned for the fast GEMM kernels. Both warn,
    neither fails — see "Pinned MLX / mlx-c pair" above.
 5. Rebuild is triggered on `MLX_C_PREFIX`, `MLX_PREFIX`, `wrapper.h`,
-   `build_support.rs`, `mlx-pin.txt`, or a change to the resolved
-   `version.h` / `mlx.metallib` — so repointing the `opt` symlink re-runs the
-   checks.
+   `build_support.rs`, `mlx-pin.txt`, or a *newer* resolved
+   `version.h` / `mlx.metallib` (each registered only when it exists — cargo
+   treats a missing trigger path as permanently dirty, which would re-run
+   bindgen on every build of a non-keg layout).
+
+   **Repointing the `opt` symlink does not reliably re-run these checks.** Cargo
+   compares mtimes through the symlink and re-runs only for a newer one, so
+   moving to an *older* keg — the recovery direction — looks like nothing
+   changed. Use `cargo clean -p rmlx-mlx` when repointing; the runtime
+   version-skew warning below is the backstop for a binary that was never
+   rebuilt.
 6. rpath entries are emitted so the binary finds both dylibs at runtime
    without `DYLD_LIBRARY_PATH`.
 

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -28,16 +28,152 @@ drives mlx-c directly to control every detail of the FFI contract.
 
 ### Versioned ABI
 
-mlx-c pins a specific MLX version. The build links against:
+mlx-c pins a specific MLX version. The build links `libmlxc.dylib` and
+`libmlx.dylib`, resolving each prefix in this order:
 
-- `libmlxc.dylib` — mlx-c 0.6.0, default prefix
-  `/opt/homebrew/Cellar/mlx-c/0.6.0_2/lib`.
-- `libmlx.dylib` — MLX 0.31.2, default prefix
-  `/opt/homebrew/Cellar/mlx/0.31.2/lib`.
+1. `MLX_C_PREFIX` / `MLX_PREFIX` — explicit override.
+2. `brew --prefix mlx-c` / `brew --prefix mlx`.
+3. `/opt/homebrew/opt/mlx-c` / `/opt/homebrew/opt/mlx` — the conventional
+   Homebrew `opt` symlink.
 
-Both prefixes are overridable via `MLX_C_PREFIX` / `MLX_PREFIX` env vars.
 `build.rs` asserts the dylibs exist and aborts the build with an actionable
 message if they are absent.
+
+Resolving to the `opt` path rather than a Cellar path is deliberate. Both
+dylibs' install names **are** `opt` paths:
+
+```
+$ otool -D /opt/homebrew/opt/mlx/lib/libmlx.dylib
+/opt/homebrew/opt/mlx/lib/libmlx.dylib
+```
+
+so that symlink decides what gets loaded at run time regardless of what the
+build pointed at. An upgrade repoints it and silently retargets an
+already-built binary — no rebuild, no relink, no diagnostic. Building against
+the same path the loader uses is what keeps compile-time and run-time on the
+same file; a hard-coded Cellar path drifts from it on the next upgrade.
+
+### Pinned MLX / mlx-c pair
+
+rMLX declares the MLX stack it is validated against in **one** place:
+
+```
+crates/rmlx-mlx/mlx-pin.txt
+```
+
+```
+mlx    0.31.2
+mlx-c  0.6.0_2
+```
+
+Nothing else in the tree declares these versions — `build.rs` reads that file,
+and bumping a line there is the whole change.
+
+**They bump together.** mlx-c is compiled against a specific mlx, and both
+resolve the moving `opt` symlink at run time, so a mismatched pair aborts at
+load:
+
+```
+dyld: Symbol not found: __ZN3mlx4core4fast12metal_kernelE...
+  Referenced from: .../mlx-c/0.6.0_3/lib/libmlxc.dylib
+  Expected in:     .../mlx/0.31.2/lib/libmlx.dylib
+```
+
+(mlx-c 0.6.0_3 is built against mlx 0.32.0. Same upstream 0.6.0 as `_2` — the
+Homebrew revision suffix is the only thing that distinguishes them, which is
+why the pin carries it.)
+
+#### Why the pin exists
+
+Homebrew's `mlx` 0.32.0 bottle ships **zero** of the ~360
+`steel_gemm_fused_nax_*` kernels — the M5 Neural-Accelerator GEMM path:
+
+```sh
+strings "$(brew --prefix mlx)/lib/mlx.metallib" | grep -c steel_gemm_fused_nax
+# 0.31.2 -> 360      0.32.0 -> 0
+```
+
+Measured cost: ~3.8× lower GPU matmul throughput, 2.2–3.3× slower prefill on
+Neural-Accelerator-class hardware. Decode is bandwidth-bound and barely moves
+(gemma-4-e2b @4k: prefill 7,080 → 15,592 t/s, decode 126.2 → 121.5), so the
+symptom looks like a model-code defect rather than a toolchain one — it cost
+one investigation days of misattribution before the metallib was inspected.
+
+This is a **Homebrew bottle regression, not an MLX regression**: the upstream
+0.32.0 PyPI wheel ships the kernels and is fine. Tracked in
+[#216](https://github.com/Pushkinist/rMLX/issues/216).
+
+#### What the build checks
+
+`build.rs` warns — never fails — on two independent things:
+
+| Check | Fires when | Meaning |
+|---|---|---|
+| **Capability** | the resolved `mlx.metallib` contains no `steel_gemm_fused_nax` | the real defect; names both versions and the fix command |
+| **Pin drift** | resolved mlx/mlx-c ≠ the pinned pair, but the kernels are present | informational; the pair is unvalidated, and bumping the pin may be due |
+
+Warning rather than failing is deliberate: the pin records what *was validated
+here*, not a claim that everything else is broken. A correct non-bottle build
+of another version must still compile.
+
+The capability probe is the ground truth; the version pin only proxies for it.
+The probe is what keeps this from nagging forever once a fixed bottle ships —
+it simply passes. Neither check can be verified from a version number alone,
+which is why both exist.
+
+Version identity comes from different places per formula, of necessity: mlx
+ships `include/mlx/version.h` (authoritative, and works on non-Homebrew
+layouts), while mlx-c ships no version header at all — its identity is the keg
+directory name, which is also the only place the load-bearing revision suffix
+appears. A non-keg layout (a wheel, a hand-built tree) yields no version and
+the pin stays quiet rather than guessing.
+
+#### Fixing a machine that drifted
+
+Both kegs must already be in the Cellar (`ls /opt/homebrew/Cellar/mlx`):
+
+```sh
+ln -sfn ../Cellar/mlx/0.31.2 /opt/homebrew/opt/mlx && \
+ln -sfn ../Cellar/mlx-c/0.6.0_2 /opt/homebrew/opt/mlx-c && \
+brew pin mlx mlx-c
+```
+
+Then rebuild. `brew pin` stops a later `brew upgrade` from repointing the
+symlinks back.
+
+#### Un-pinning when the bottle is fixed
+
+1. `brew unpin mlx mlx-c && brew upgrade mlx mlx-c`
+2. Verify the capability actually returned — this is the whole point:
+   ```sh
+   strings "$(brew --prefix mlx)/lib/mlx.metallib" | grep -c steel_gemm_fused_nax
+   # must be ~360, not 0
+   ```
+3. Bump **both** lines in `crates/rmlx-mlx/mlx-pin.txt` to the new pair
+   (`brew list --versions mlx mlx-c` gives the keg names, revision suffix
+   included).
+4. Rebuild and confirm the build emits no MLX warning.
+5. Re-verify on a real prefill cell, not just the kernel count:
+   ```sh
+   rmlx baseline --model <gemma-4-e2b> --kv-quant none --max-ctx 8192 --prompt-tokens 4096
+   ```
+   Expect ~15k t/s prefill. A regression to ~7k means the kernels are present
+   but unused — reopen [#216](https://github.com/Pushkinist/rMLX/issues/216)
+   rather than re-pinning silently.
+
+Note that fixture lengths are nominal: `--prompt-tokens 4096` tokenizes to
+~4410 on Gemma, so pass `--max-ctx` deliberately or the prompt is rejected and
+the cell reports `prefill_tps=0`.
+
+### Runtime version skew
+
+The build-time pin cannot see a symlink that moves *after* the build. The FFI
+layer therefore also compares the version it was compiled against
+(`RMLX_MLX_BUILD_VERSION`, baked by `build.rs` from the resolved prefix's
+`version.h`) against `mlx_version()` of the library actually loaded, on the
+existing one-shot init, and warns on mismatch. Together the two checks cover
+both halves: the pin catches a bad stack at compile time, the skew warning
+catches a stack that changed underneath a built binary.
 
 ### Build pipeline (`build.rs`)
 
@@ -49,10 +185,21 @@ message if they are absent.
 3. `build.rs` post-processes `bindings.rs` to strip any `#![...]` inner
    attributes bindgen 0.71 emits at the file head — these are illegal inside
    the `include!()` call site in `sys.rs`.
-4. Rebuild is triggered on `MLX_C_PREFIX`, `MLX_PREFIX`, or `wrapper.h`
-   changes.
-5. rpath entries are emitted so the binary finds both dylibs at runtime
+4. The resolved MLX / mlx-c pair is checked against `mlx-pin.txt`, and the
+   resolved `mlx.metallib` is scanned for the fast GEMM kernels. Both warn,
+   neither fails — see "Pinned MLX / mlx-c pair" above.
+5. Rebuild is triggered on `MLX_C_PREFIX`, `MLX_PREFIX`, `wrapper.h`,
+   `build_support.rs`, `mlx-pin.txt`, or a change to the resolved
+   `version.h` / `mlx.metallib` — so repointing the `opt` symlink re-runs the
+   checks.
+6. rpath entries are emitted so the binary finds both dylibs at runtime
    without `DYLD_LIBRARY_PATH`.
+
+`build.rs`'s pure logic (pin parsing, keg-version and header-version
+resolution, the metallib scan) lives in `build_support.rs`, `include!`d by both
+the build script and `tests/mlx_pin.rs`. A build script cannot be imported by
+the crate it builds, and this logic decides whether a known 3.8× perf cliff is
+reported at all — so it is covered by tests `cargo test` actually runs.
 
 ### `sys.rs` — raw bindings
 


### PR DESCRIPTION
## Summary
Addresses #216 — whose **original analysis was wrong on every count**. No GDN kernel was built; a profile was run first and killed the premise.

**Homebrew's `mlx` 0.32.0 bottle ships ZERO `steel_gemm_fused_nax_*` kernels** (the Neural-Accelerator GEMM path) → **~3.8× GPU matmul loss** → 2.2–3.7× slower prefill on M5. rMLX loaded it silently: libmlx's install_name resolves through brew's **moving `opt/mlx` symlink**, which brew repointed 0.31.2 → 0.32.0 on **Jul 13** — two days before the Bonsai-27B campaign.

**The PyPI wheel of the same 0.32.0 measures identical to brew 0.31.2** (145 distinct kernels) while the brew bottle has 0. *Same version, different packaging* → a **bottling** regression, not an MLX one.

## Why the GDN theory was wrong (profile, Bonsai-27B @4k)
| layer type | time | share |
|---|---|---|
| MLP (dense 2-bit) | 10,689 ms | **66.5%** |
| GDN total | 3,928 ms | 24.4% |
| └ **recurrence kernel** | **326 ms** | **2.1%** |
| full-attn SDPA | 1,461 ms | 9.1% |

The "48×256 vs 30×128 = 3.2× ≈ the gap" arithmetic conflated **full-attn** `head_dim:256` with GDN's `linear_key_head_dim`, which is **128 on both** models — real ratio 1.6×. mlx-lm runs the *identical* sequential kernel, so it can't explain a gap *between* backends. An infinitely fast GDN kernel moves 4k TTFT 14.8s → 14.5s. The issue's own discriminator was cross-version: the "8B prefills fast ~3150 t/s" figure predated the upgrade.

## What ships
- **Single-source pin** — `crates/rmlx-mlx/mlx-pin.txt`, one line per formula. **mlx and mlx-c are ABI-coupled** (mlx-c 0.6.0_3 aborts against 0.31.2: `dyld: Symbol not found: mlx::core::fast::metal_kernel`), so they bump together; a half-declared pin fails the build. Validated pair: **mlx 0.31.2 + mlx-c 0.6.0_2**.
- **Real prefix resolution** (env → `brew --prefix` → `opt/<formula>`), replacing a hardcoded Cellar path. This caught a **live latent skew**: the build was compiling against mlx-c `0.6.0_2` headers while `opt/mlx-c` pointed at `0.6.0_3` — build and loader were different files.
- **Build-time capability probe** for the nax kernels, and it **gates the loud warning on missing kernels, not version drift** — so a correct wheel-based 0.32.0 gets only a mild "bump the pin" note. **The pin retires itself once Homebrew fixes the bottle.**
- **Runtime build-vs-loaded skew warning.** Everything warns; nothing hard-fails (public users on valid non-brew layouts must build).

## The recovery procedure was broken — fixed
`rerun-if-changed` only fires on a **newer** mtime and stats **through** the symlink. Repointing to the validated *older* keg moves mtimes **backwards** (0.31.2 metallib: Apr 22; 0.32.0: Jul 7), so the build script **doesn't re-run**. Proven, using a private symlink so the pinned machine was untouched:

| step | baked version | script last ran | crates compiled |
|---|---|---|---|
| built on 0.32.0 | `0.32.0` | 11:37:29 | — |
| repoint → 0.31.2, **plain rebuild** | **`0.32.0` STALE** | **unchanged** | **0** |
| `cargo clean -p rmlx-mlx` + rebuild | **`0.31.2`** | fresh | 1 |

Un-pin step 4 ("rebuild, confirm no warning") was **vacuous** — it read as success because nothing ran. Now every fix command includes `cargo clean -p rmlx-mlx`, and the docs state the newer-mtime-only semantics honestly.

## Verification
- Matched → **0** warnings. Mismatch → loud warning naming both versions + a fix command that works. Drift-with-kernels-present → mild note. Runtime skew fires and is silent when matched.
- Prefill, forced-clean rebuild so it's right by construction: gemma-4-e2b `--kv-quant none --max-ctx 8192` → **15,913 t/s median** (0.31.2) vs **6,916** (0.32.0) = **2.22×**; decode 0.96×. Binary sha reproduced bit-identically.
- `cargo test -p rmlx-mlx -p rmlx-models` **745 passed**; `make lint` / `check-metal-format` / `check-no-decode-swallow` clean.

## Corrections to earlier claims (mine)
"360 kernels" was a substring-*occurrence* count — each name is stored twice. **145 distinct** / 288 `grep -c` lines / 360 occurrences. The probe is boolean; the only load-bearing fact is **0.32.0 → zero**. Docs now pair the command with the number it actually prints and gate on **non-zero**.

## Follow-ups
#248 (27B matrix prefill numbers are a brew artifact; **all post-Jul-13 prefill benches suspect — decode unaffected**). Upstream Homebrew report drafted (uncommitted). A chunkwise GDN kernel is **not** worth building: ~2% ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)