### PR TITLE
fix(models): propagate prefill failures instead of fabricating zeros (#243)

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -1620,6 +1620,18 @@ impl KvCache {
         Ok((k_full, v_full))
     }
 
+    /// True while the cache sits between `enter_prefill` and `exit_prefill`.
+    ///
+    /// Observable for the sweep invariant: every cache that entered prefill must
+    /// run `exit_prefill` before its prefill helper returns, on the failure path
+    /// as well as the success path. A cache left in prefill keeps un-finalized
+    /// state (no decode seed / un-quantized storage), and the next decode on it
+    /// errors or corrupts KV. Rotating caches never enter prefill (the ring is
+    /// the authority), so this stays false for them throughout.
+    pub fn in_prefill(&self) -> bool {
+        self.in_prefill
+    }
+
     /// Switch the cache into prefill mode (accumulates raw K/V before quantizing).
     pub fn enter_prefill(&mut self) {
         // Rotating cache handles prefill via update_concat directly.

--- a/crates/rmlx-models/src/decode_loop.rs
+++ b/crates/rmlx-models/src/decode_loop.rs
@@ -596,8 +596,11 @@ pub(crate) fn chunked_prefill(
     if let Some(e) = first_err {
         return Err(e);
     }
+    // Model, not Other: an empty prompt is deterministic, so the retry envelope
+    // must not replay it. Other classifies Migratable and would re-run a request
+    // that reproduces the same failure every time.
     last_logits.ok_or_else(|| {
-        Error::Other(format!(
+        Error::Model(format!(
             "prefill produced no logits (empty prompt), arch={arch}"
         ))
     })

--- a/crates/rmlx-models/src/decode_loop.rs
+++ b/crates/rmlx-models/src/decode_loop.rs
@@ -25,7 +25,7 @@ use std::time::Instant;
 use rmlx_mlx::{argmax, Array, Device, Dtype};
 use tracing::info_span;
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 
 use crate::constraint::ConstraintEngine;
 use crate::sampler::{
@@ -505,22 +505,29 @@ fn resolve_piece(ctx: &DecodeCtx<'_>, id: u32) -> Box<str> {
 }
 
 /// Fresh chunked prefill: `enter_prefill` → per-chunk forward + `eval_prefill_state`
-/// → `exit_prefill`. Returns the final-position logits, or `None` when prefill was
-/// rejected (caller returns `Ok(steps)` as today, unchanged).
+/// → `exit_prefill`. Returns the final-position logits, or the cause of the
+/// failure that prevented them.
+///
+/// A prefill that does not produce logits is a **failure, not an outcome**: the
+/// caller has no logits to sample from, so every path out of here that is not a
+/// final-position `Array` carries an `Err` naming why. Returning the cause is
+/// what keeps a rejected prefill from surfacing as a successful run reporting
+/// zeros — a bench harness reads throughput fields, not the log.
 ///
 /// `caches` is borrowed `&mut` by this fn (it brackets enter/exit and evals
 /// non-final chunk state) AND re-borrowed into `forward_chunk` per chunk — the
 /// closure takes `&mut Vec<KvCache>` so the arch's forward writes into the same
 /// caches this fn brackets.
 ///
+/// Failure ordering: the **first** cause wins. A failed chunk forward leaves the
+/// caches mid-prefill, so the `exit_prefill` sweep below it may fail too — but
+/// that second error is a consequence, not the diagnosis. Reporting the root
+/// cause is the whole point of propagating.
+///
 /// Deliberately Fresh-only. gemma4's prefix-append flush (`eval_gpu_state`, no
 /// enter/exit) and qwen3_5_moe's HydratedTail append (`eval_prefill_state`, no
 /// enter/exit) are two different flush protocols and stay per-arch — there is no
 /// `PrefillKind` enum.
-#[allow(
-    clippy::unnecessary_wraps,
-    reason = "Result is the documented contract: callers `?`-chain it, and the per-chunk forward / exit_prefill failures it folds into Ok(None) are genuinely fallible — the wrapper keeps the rejection path uniform with the loop call site"
-)]
 pub(crate) fn chunked_prefill(
     caches: &mut Vec<KvCache>,
     ids: &[u32],
@@ -528,14 +535,14 @@ pub(crate) fn chunked_prefill(
     device: Device,
     arch: &'static str,
     mut forward_chunk: impl FnMut(&[u32], &mut Vec<KvCache>) -> Result<Array>,
-) -> Result<Option<Array>> {
+) -> Result<Array> {
     for c in caches.iter_mut() {
         c.enter_prefill();
     }
     let mut last_logits: Option<Array> = None;
-    let mut prefill_ok = true;
+    let mut first_err: Option<Error> = None;
     let n_chunks = ids.len().div_ceil(chunk_size.max(1));
-    'prefill: for (chunk_idx, chunk) in ids.chunks(chunk_size.max(1)).enumerate() {
+    for (chunk_idx, chunk) in ids.chunks(chunk_size.max(1)).enumerate() {
         let is_last = chunk_idx + 1 == n_chunks;
         match forward_chunk(chunk, caches) {
             Ok(logits) => {
@@ -543,48 +550,57 @@ pub(crate) fn chunked_prefill(
                     last_logits = Some(logits);
                 } else {
                     // Eval only the cache prefill state, skip the lm_head matmul
-                    // for non-final chunks via lazy-graph pruning.
-                    for c in caches.iter() {
-                        if let Err(e) = c.eval_prefill_state() {
-                            tracing::warn!(
-                                arch,
-                                error = %e,
-                                chunk_len = chunk.len(),
-                                "prefill chunk cache eval failed"
-                            );
-                            prefill_ok = false;
-                            break 'prefill;
-                        }
+                    // for non-final chunks via lazy-graph pruning. Stops at the
+                    // first failing cache.
+                    if let Some(e) = caches.iter().find_map(|c| c.eval_prefill_state().err()) {
+                        tracing::error!(
+                            arch,
+                            error = %e,
+                            chunk_len = chunk.len(),
+                            "prefill chunk cache eval failed, aborting generation"
+                        );
+                        // Cause captured, not returned: the exit_prefill sweep
+                        // below is mandatory for every cache that entered
+                        // prefill. It runs, then this error propagates.
+                        first_err = Some(e);
+                        break;
                     }
                 }
             }
             Err(e) => {
-                tracing::warn!(
+                tracing::error!(
                     arch,
                     error = %e,
                     prompt_len = ids.len(),
-                    "prefill chunk failed, returning empty"
+                    "prefill chunk failed, aborting generation"
                 );
-                prefill_ok = false;
+                // Cause captured, not returned — see above.
+                first_err = Some(e);
                 break;
             }
         }
     }
     for c in caches.iter_mut() {
         if let Err(e) = c.exit_prefill(device) {
-            tracing::warn!(arch, error = %e, "prefill: exit_prefill quantization failed");
-            prefill_ok = false;
+            tracing::error!(arch, error = %e, "prefill: exit_prefill quantization failed, aborting generation");
             // No break: every cache entered prefill above and must run
             // exit_prefill, even after a failure — skipping it leaves the
             // remaining caches with un-finalized prefill state (no decode
             // seed / un-quantized storage) that corrupts any later reuse of
             // this Vec.
+            if first_err.is_none() {
+                first_err = Some(e);
+            }
         }
     }
-    if !prefill_ok || last_logits.is_none() {
-        return Ok(None);
+    if let Some(e) = first_err {
+        return Err(e);
     }
-    Ok(last_logits)
+    last_logits.ok_or_else(|| {
+        Error::Other(format!(
+            "prefill produced no logits (empty prompt), arch={arch}"
+        ))
+    })
 }
 
 #[cfg(test)]

--- a/crates/rmlx-models/src/decode_loop_tests.rs
+++ b/crates/rmlx-models/src/decode_loop_tests.rs
@@ -730,6 +730,41 @@ fn chunked_prefill_propagates_chunk_failure() {
     );
 }
 
+/// Every cache that entered prefill must run `exit_prefill` before
+/// `chunked_prefill` returns — on the failure path too.
+///
+/// This is why the failure sites capture the cause instead of returning it
+/// inline: an early `return Err` skips the sweep for the remaining caches,
+/// stranding them mid-prefill with un-finalized state, and the next decode on a
+/// stuck cache errors or corrupts KV. The capture-then-sweep ordering is load
+/// bearing, so it is pinned here rather than left to a comment.
+#[test]
+fn chunked_prefill_runs_exit_sweep_on_failure() {
+    let _g = mlx_guard();
+    let mut caches: Vec<KvCache> = (0..3)
+        .map(|_| KvCache::with_quant_max_seq(KvQuant::None, 8))
+        .collect();
+    let ids: Vec<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8];
+    // Fail on the FIRST chunk, so caches[1..] are the ones an inline `return
+    // Err` at the log site would strand. The closure also proves the assertion
+    // below is not vacuous: enter_prefill really did set the flag.
+    let forward_chunk = |_chunk: &[u32], caches: &mut Vec<KvCache>| -> Result<Array> {
+        assert!(
+            caches.iter().all(KvCache::in_prefill),
+            "precondition: chunked_prefill must have entered prefill on every cache"
+        );
+        Err(Error::Other("simulated first-chunk failure".to_owned()))
+    };
+    let _ = chunked_prefill(&mut caches, &ids, 4, Device::Cpu, "test", forward_chunk);
+    for (i, c) in caches.iter().enumerate() {
+        assert!(
+            !c.in_prefill(),
+            "cache {i} was left in prefill after a failed chunk — the exit_prefill \
+             sweep was skipped, so its state is un-finalized for the next decode"
+        );
+    }
+}
+
 #[test]
 #[allow(
     clippy::expect_used,
@@ -751,5 +786,12 @@ fn chunked_prefill_rejects_empty_prompt() {
     assert!(
         err.to_string().contains("prefill produced no logits"),
         "the empty-prompt cause must name itself, got: {err}"
+    );
+    // An empty prompt is deterministic: replaying it reproduces the failure.
+    // Model classifies Fatal; Other would classify Migratable and be replayed.
+    assert!(
+        matches!(err, Error::Model(_)),
+        "the empty-prompt cause must use a variant the retry envelope treats as \
+         fatal, or a doomed request is replayed; got: {err:?}"
     );
 }

--- a/crates/rmlx-models/src/decode_loop_tests.rs
+++ b/crates/rmlx-models/src/decode_loop_tests.rs
@@ -698,14 +698,20 @@ fn pipelined_decode_propagates_step_failure() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[allow(clippy::unwrap_used)]
-fn chunked_prefill_rejects_over_ceiling() {
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: expect_err IS the assertion — an Ok here is the regression under test, and its panic names it"
+)]
+fn chunked_prefill_propagates_chunk_failure() {
     let _g = mlx_guard();
     // An over-ceiling prefill manifests as the per-chunk forward returning Err
     // (the arch's forward rejects an over-long sequence). chunked_prefill must
-    // funnel that into `Ok(None)` — never a panic — so the caller returns its
-    // empty step list as today. Uses KvQuant::None caches (no Metal allocation
-    // until a forward actually writes K/V, which here never happens).
+    // hand that cause back to the caller verbatim — never a panic, and never a
+    // success. A prefill that produced no logits is a failure: swallowing it
+    // lets the caller report an empty generation as a completed run, which
+    // every bench gate reads as a valid zero. Uses KvQuant::None caches (no
+    // Metal allocation until a forward actually writes K/V, which here never
+    // happens).
     let mut caches: Vec<KvCache> = (0..2)
         .map(|_| KvCache::with_quant_max_seq(KvQuant::None, 8))
         .collect();
@@ -715,6 +721,35 @@ fn chunked_prefill_rejects_over_ceiling() {
             "simulated over-ceiling prefill rejection".to_owned(),
         ))
     };
-    let out = chunked_prefill(&mut caches, &ids, 4, Device::Cpu, "test", forward_chunk).unwrap();
-    assert!(out.is_none(), "rejected prefill returns Ok(None)");
+    let err = chunked_prefill(&mut caches, &ids, 4, Device::Cpu, "test", forward_chunk)
+        .expect_err("a rejected prefill must surface as Err, not a zero-token Ok run");
+    assert!(
+        err.to_string()
+            .contains("simulated over-ceiling prefill rejection"),
+        "the underlying cause must reach the caller verbatim, got: {err}"
+    );
+}
+
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: expect_err IS the assertion — an Ok here is the regression under test, and its panic names it"
+)]
+fn chunked_prefill_rejects_empty_prompt() {
+    let _g = mlx_guard();
+    // No chunks run, so no logits exist. There is nothing for the caller to
+    // sample from — that is an error, not an empty success.
+    let mut caches: Vec<KvCache> = (0..2)
+        .map(|_| KvCache::with_quant_max_seq(KvQuant::None, 8))
+        .collect();
+    let ids: Vec<u32> = vec![];
+    let forward_chunk = |_chunk: &[u32], _caches: &mut Vec<KvCache>| -> Result<Array> {
+        Err(Error::Other("forward must not be called".to_owned()))
+    };
+    let err = chunked_prefill(&mut caches, &ids, 4, Device::Cpu, "test", forward_chunk)
+        .expect_err("an empty prompt must surface as Err, not a zero-token Ok run");
+    assert!(
+        err.to_string().contains("prefill produced no logits"),
+        "the empty-prompt cause must name itself, got: {err}"
+    );
 }

--- a/crates/rmlx-models/src/gemma3/generate.rs
+++ b/crates/rmlx-models/src/gemma3/generate.rs
@@ -19,7 +19,7 @@
 use std::path::Path;
 use std::time::Instant;
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{argmax, max_axis, Array, Device, Dtype};
 use rmlx_runtime::{count_nan_in_bytes, max_abs_from_bytes};
 use tracing::{info, warn};
@@ -270,23 +270,32 @@ pub fn generate_greedy<'a>(
             c.enter_prefill();
         }
         let seq_i32 = prompt_ids.len() as i32;
-        let logits = match model.forward_arr_embeds(embeds, seq_i32, Some(&mut caches), device) {
-            Ok(l) => l,
+        // Every cache entered prefill above, so the exit_prefill sweep below is
+        // mandatory even when the forward fails: the cause is captured, the
+        // sweep runs, then the first cause propagates.
+        let mut first_err: Option<Error> = None;
+        let forward = match model.forward_arr_embeds(embeds, seq_i32, Some(&mut caches), device) {
+            Ok(l) => Some(l),
             Err(e) => {
-                tracing::warn!(error = %e, prompt_len = prompt_ids.len(), "gemma3 generate_greedy: image prefill failed, returning empty");
-                for c in &mut caches {
-                    let _ = c.exit_prefill(device);
-                }
-                return Ok(steps);
+                tracing::error!(error = %e, prompt_len = prompt_ids.len(), "gemma3 generate_greedy: image prefill failed, aborting generation");
+                first_err = Some(e);
+                None
             }
         };
         for c in &mut caches {
             if let Err(e) = c.exit_prefill(device) {
-                tracing::warn!(error = %e, "gemma3 generate_greedy: image exit_prefill quantization failed");
-                return Ok(steps);
+                tracing::error!(error = %e, "gemma3 generate_greedy: image exit_prefill quantization failed, aborting generation");
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
             }
         }
-        logits
+        if let Some(e) = first_err {
+            return Err(e);
+        }
+        forward.ok_or_else(|| {
+            Error::Model("gemma3 generate_greedy: image prefill produced no logits".to_owned())
+        })?
     } else {
         chunked_prefill(
             &mut caches,

--- a/crates/rmlx-models/src/gemma3/generate.rs
+++ b/crates/rmlx-models/src/gemma3/generate.rs
@@ -288,7 +288,7 @@ pub fn generate_greedy<'a>(
         }
         logits
     } else {
-        let Some(logits) = chunked_prefill(
+        chunked_prefill(
             &mut caches,
             prompt_ids,
             prefill_chunk,
@@ -296,10 +296,6 @@ pub fn generate_greedy<'a>(
             "Gemma3ForConditionalGeneration",
             |chunk, caches| model.forward_seq_with_cache(chunk, Some(caches), device),
         )?
-        else {
-            return Ok(steps);
-        };
-        logits
     };
 
     let logits_flat = prefill_logits.reshape(&[1, vocab], device)?;

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -523,8 +523,9 @@ pub fn generate_greedy<'a>(
     } else {
         // Miss: Fresh full re-prefill via the shared chunked_prefill helper. It
         // brackets the loop with enter_prefill() / exit_prefill(), evals only
-        // the cache state on non-final chunks, and returns None on rejection.
-        let Some(logits) = chunked_prefill(
+        // the cache state on non-final chunks, and propagates the cause when a
+        // chunk is rejected.
+        chunked_prefill(
             &mut caches,
             prompt_ids,
             prefill_chunk,
@@ -532,10 +533,6 @@ pub fn generate_greedy<'a>(
             "Gemma4ForConditionalGeneration",
             |chunk, caches| model.forward_seq_with_cache(chunk, Some(caches), device),
         )?
-        else {
-            return Ok(steps);
-        };
-        logits
     };
 
     let logits_flat = prefill_logits.reshape(&[1, vocab], device)?;

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -454,22 +454,40 @@ pub fn generate_greedy<'a>(
             c.enter_prefill();
         }
         let seq_i32 = prompt_ids.len() as i32;
-        let logits =
-            match model.forward_arr_embeds(embeds, &masked_ids, seq_i32, Some(&mut caches), device)
-            {
-                Ok(l) => l,
-                Err(e) => {
-                    tracing::warn!(error = %e, "generate_greedy: image prefill forward failed");
-                    return Ok(steps);
-                }
-            };
+        // Every cache entered prefill above, so the exit_prefill sweep below is
+        // mandatory even when the forward fails: the cause is captured, the
+        // sweep runs, then the first cause propagates.
+        let mut first_err: Option<rmlx_core::error::Error> = None;
+        let forward = match model.forward_arr_embeds(
+            embeds,
+            &masked_ids,
+            seq_i32,
+            Some(&mut caches),
+            device,
+        ) {
+            Ok(l) => Some(l),
+            Err(e) => {
+                tracing::error!(error = %e, "generate_greedy: image prefill forward failed, aborting generation");
+                first_err = Some(e);
+                None
+            }
+        };
         for c in &mut caches {
             if let Err(e) = c.exit_prefill(device) {
-                tracing::warn!(error = %e, "generate_greedy: image exit_prefill failed");
-                return Ok(steps);
+                tracing::error!(error = %e, "generate_greedy: image exit_prefill failed, aborting generation");
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
             }
         }
-        logits
+        if let Some(e) = first_err {
+            return Err(e);
+        }
+        forward.ok_or_else(|| {
+            rmlx_core::error::Error::Model(
+                "generate_greedy: image prefill produced no logits".to_owned(),
+            )
+        })?
     } else if is_prefix {
         // Prefix (B1): per-arch tail re-prefill. The cloned snapshot is already
         // post-prefill quantized (offset == prefix_len), so the tail appends
@@ -478,10 +496,13 @@ pub fn generate_greedy<'a>(
         // buffer and exit_prefill would re-quantize only the tail). Non-final
         // chunks flush the quantized/decode_fp16 buffers via `eval_gpu_state`
         // (NOT `eval_prefill_state`); there is nothing to quantize on exit.
+        //
+        // No enter_prefill above means no exit_prefill sweep is owed here, so a
+        // failure returns its cause immediately (unlike the shared helper, which
+        // must capture and sweep first).
         let mut last_logits: Option<Array> = None;
-        let mut prefill_ok = true;
         let n_chunks = prefill_ids.len().div_ceil(prefill_chunk);
-        'prefill: for (chunk_idx, chunk) in prefill_ids.chunks(prefill_chunk).enumerate() {
+        for (chunk_idx, chunk) in prefill_ids.chunks(prefill_chunk).enumerate() {
             let is_last = chunk_idx + 1 == n_chunks;
             match model.forward_seq_with_cache(chunk, Some(&mut caches), device) {
                 Ok(logits) => {
@@ -492,34 +513,32 @@ pub fn generate_greedy<'a>(
                     } else {
                         // Non-final chunk: discard logits (lazy graph drops
                         // lm_head matmul) and flush only the decode-mode state.
-                        for c in &caches {
-                            if let Err(e) = c.eval_gpu_state() {
-                                tracing::warn!(
-                                    error = %e,
-                                    chunk_len = chunk.len(),
-                                    "generate_greedy: prefix tail chunk cache eval failed"
-                                );
-                                prefill_ok = false;
-                                break 'prefill;
-                            }
+                        // Stops at the first failing cache.
+                        if let Some(e) = caches.iter().find_map(|c| c.eval_gpu_state().err()) {
+                            tracing::error!(
+                                error = %e,
+                                chunk_len = chunk.len(),
+                                "generate_greedy: prefix tail chunk cache eval failed, aborting generation"
+                            );
+                            return Err(e);
                         }
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(
+                    tracing::error!(
                         error = %e,
                         prompt_len = prompt_ids.len(),
-                        "generate_greedy: prefix tail chunk failed, returning empty"
+                        "generate_greedy: prefix tail chunk failed, aborting generation"
                     );
-                    prefill_ok = false;
-                    break;
+                    return Err(e);
                 }
             }
         }
-        if !prefill_ok || last_logits.is_none() {
-            return Ok(steps);
-        }
-        last_logits.unwrap()
+        last_logits.ok_or_else(|| {
+            rmlx_core::error::Error::Model(
+                "generate_greedy: prefix tail produced no logits (empty tail)".to_owned(),
+            )
+        })?
     } else {
         // Miss: Fresh full re-prefill via the shared chunked_prefill helper. It
         // brackets the loop with enter_prefill() / exit_prefill(), evals only

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -2010,17 +2010,14 @@ pub fn generate_greedy<'a>(
     // Chunk size is per-arch; default 256 for qwen3, override via
     // `RMLX_PREFILL_CHUNK` (global) or `RMLX_PREFILL_CHUNK_QWEN3` (per-arch).
     let prefill_chunk = crate::prefill_chunk::prefill_chunk_for("qwen3");
-    let Some(prefill_logits) = chunked_prefill(
+    let prefill_logits = chunked_prefill(
         &mut caches,
         prompt_ids,
         prefill_chunk,
         device,
         "Qwen3ForCausalLM",
         |chunk, caches| model.forward_seq_with_cache(chunk, Some(caches), device),
-    )?
-    else {
-        return Ok(steps);
-    };
+    )?;
 
     let logits_flat = prefill_logits.reshape(&[1, vocab], device)?;
     logits_flat.eval()?;

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -18,7 +18,7 @@
 )]
 use std::time::Instant;
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{Array, Device};
 
 use crate::constraint::ConstraintEngine;
@@ -267,9 +267,12 @@ pub fn generate_greedy<'a>(
 
         let prefill_chunk = crate::prefill_chunk::prefill_chunk_for("qwen3_5_moe");
 
+        // No enter_prefill above (see the note on resumed caches) means no
+        // exit_prefill sweep is owed here, so a failure returns its cause
+        // immediately (unlike the shared helper, which must capture and sweep
+        // first).
         let prefill_logits = {
             let mut last_logits: Option<Array> = None;
-            let mut prefill_ok = true;
             let tail = &prompt_ids[prefix_len..];
             let n_chunks = tail.len().div_ceil(prefill_chunk);
             for (chunk_idx, chunk) in tail.chunks(prefill_chunk).enumerate() {
@@ -286,39 +289,37 @@ pub fn generate_greedy<'a>(
                         } else {
                             // Force-evaluate the KV cache state between chunks
                             // (avoids lazy-graph explosion, mirrors Path C).
-                            for c in &kv_caches {
-                                if let Err(e) = c.eval_prefill_state() {
-                                    tracing::warn!(
-                                        error = %e,
-                                        chunk_len = chunk.len(),
-                                        "qwen3_5moe generate_greedy (hydrated-tail): tail chunk eval failed"
-                                    );
-                                    prefill_ok = false;
-                                    break;
-                                }
+                            // Stops at the first failing cache.
+                            if let Some(e) =
+                                kv_caches.iter().find_map(|c| c.eval_prefill_state().err())
+                            {
+                                tracing::error!(
+                                    error = %e,
+                                    chunk_len = chunk.len(),
+                                    "qwen3_5moe generate_greedy (hydrated-tail): tail chunk eval failed, aborting generation"
+                                );
+                                return Err(e);
                             }
                         }
                     }
                     Err(e) => {
-                        tracing::warn!(
+                        tracing::error!(
                             error = %e,
                             prefix_len,
                             tail_len,
-                            "qwen3_5moe generate_greedy (hydrated-tail): tail chunk failed, returning empty"
+                            "qwen3_5moe generate_greedy (hydrated-tail): tail chunk failed, aborting generation"
                         );
-                        prefill_ok = false;
-                        break;
+                        return Err(e);
                     }
-                }
-                if !prefill_ok {
-                    break;
                 }
             }
 
-            if !prefill_ok || last_logits.is_none() {
-                return Ok(steps);
-            }
-            last_logits.unwrap()
+            last_logits.ok_or_else(|| {
+                Error::Model(
+                    "qwen3_5moe generate_greedy (hydrated-tail): tail produced no logits"
+                        .to_owned(),
+                )
+            })?
         };
 
         let logits_flat = prefill_logits.reshape(&[1, vocab], device)?;

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -480,19 +480,16 @@ pub fn generate_greedy<'a>(
 
     // Fresh chunked prefill via the shared helper. It brackets the loop with
     // enter_prefill() / exit_prefill(), evals only the cache state on non-final
-    // chunks, and returns None on rejection. The GDN `lin_caches` are
+    // chunks, and propagates the cause on rejection. The GDN `lin_caches` are
     // closure-captured — the helper only owns `kv_caches`.
-    let Some(prefill_logits) = chunked_prefill(
+    let prefill_logits = chunked_prefill(
         &mut kv_caches,
         prompt_ids,
         prefill_chunk,
         device,
         "Qwen3_5MoeForConditionalGeneration",
         |chunk, kv| model.forward_seq_with_cache(chunk, Some(kv), Some(&mut lin_caches), device),
-    )?
-    else {
-        return Ok(steps);
-    };
+    )?;
 
     let logits_flat = prefill_logits.reshape(&[1, vocab], device)?;
     // top-k logprob capture (0 = disabled, hot-loop zero-overhead).

--- a/crates/rmlx-models/src/qwen3_vl_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_vl_moe/generate.rs
@@ -250,17 +250,14 @@ pub fn generate_greedy(
         .collect();
 
     let prefill_chunk = crate::prefill_chunk::prefill_chunk_for("qwen3_vl_moe");
-    let Some(logits) = crate::decode_loop::chunked_prefill(
+    let logits = crate::decode_loop::chunked_prefill(
         &mut kv,
         prompt_ids,
         prefill_chunk,
         device,
         "Qwen3VLMoeForConditionalGeneration",
         |chunk, kv| model.forward_seq_with_cache(chunk, Some(kv), device),
-    )?
-    else {
-        return Ok(steps);
-    };
+    )?;
     let first = pick_token(
         &logits,
         vocab,

--- a/scripts/check_no_decode_swallow.sh
+++ b/scripts/check_no_decode_swallow.sh
@@ -1,27 +1,54 @@
 #!/usr/bin/env bash
-# scripts/check_no_decode_swallow.sh — CI gate: a failed decode step must
-# propagate, never be swallowed into a short-but-successful generation.
+# scripts/check_no_decode_swallow.sh — CI gate: a failed decode step or a failed
+# prefill chunk must propagate, never be swallowed into a successful-looking run.
 #
 # THE BUG THIS PINS
-#   A decode step that errored used to log a warning and `break`, handing the
-#   caller the tokens produced so far. The server then saw a non-EOS last token
-#   and reported `finish_reason="length"` — byte-identical to hitting the token
-#   cap. Every automated gate in this repo (bench harness, perf canary,
-#   regression gate, smoke probes) reads exactly `finish_reason` + token counts,
-#   so a stream that died mid-flight passed all of them.
+#   Decode: a decode step that errored used to log a warning and `break`, handing
+#   the caller the tokens produced so far. The server then saw a non-EOS last
+#   token and reported `finish_reason="length"` — byte-identical to hitting the
+#   token cap.
+#
+#   Prefill: a prefill chunk that errored used to log a warning and hand the
+#   caller "no logits" with no cause. The caller returned its empty step list and
+#   the run completed successfully, reporting `ttft_ms=0 decode_tps=0.000
+#   prefill_tps=0.0` — a fabricated zero, emitted as a measurement, with exit 0.
+#
+#   Both shapes defeat the same thing. Every automated gate in this repo (bench
+#   harness, perf canary, regression gate, smoke probes) reads `finish_reason`,
+#   token counts, and throughput fields — never the log. A failure that reports
+#   as an ordinary outcome passes all of them, and a zero is as dangerous as a
+#   plausible number: any harness that averages, medians, or records without
+#   refusing zeros silently absorbs it.
 #
 # WHY A GREP GATE
-#   The decode loop is copied per-arch (the shared pipelined loop plus the
-#   bitnet / laguna / qwen2 hand-written ones). A unit test needs a concrete
-#   `&Model` per arch, so the per-arch copies are effectively untestable at unit
-#   scope — and a fix hand-applied to some copies but not others is precisely
-#   the "looks complete, isn't" failure this rule exists to prevent. The shared
-#   loop carries a real unit test (`pipelined_decode_propagates_step_failure`);
-#   this gate covers every copy of the shape.
+#   The decode loop and the chunked prefill are copied per-arch (the shared
+#   pipelined loop and shared `chunked_prefill`, plus the bitnet / laguna /
+#   qwen2 hand-written ones). A unit test needs a concrete `&Model` per arch, so
+#   the per-arch copies are effectively untestable at unit scope — and a fix
+#   hand-applied to some copies but not others is precisely the "looks complete,
+#   isn't" failure this rule exists to prevent. The shared loops carry real unit
+#   tests (`pipelined_decode_propagates_step_failure`,
+#   `chunked_prefill_propagates_chunk_failure`); this gate covers every copy of
+#   the shape.
 #
 # THE RULE
-#   Every `decode step failed` log site must `return Err` within the next few
-#   lines. A `break` there is the swallow.
+#   Every failure log site listed below must propagate the cause, either by
+#   returning it directly (`return Err`) or — where a mandatory cleanup sweep
+#   must run first — by capturing it (`= Some(e)`) for return after the sweep.
+#   A `break` with no capture is the swallow, and a `return Ok(` on a failure
+#   path is the fabricated success this gate exists to kill.
+#
+#   The deferred-capture form is not a loophole: the shared `chunked_prefill`
+#   cannot `return Err` at the log site because every cache that entered prefill
+#   must run `exit_prefill` before the function leaves, or the remaining caches
+#   keep un-finalized prefill state that corrupts any later reuse. The cause is
+#   captured, the sweep runs, the cause propagates.
+#
+# NOT YET COVERED
+#   The image-prefill failure sites (`image prefill failed`, and the image-path
+#   `exit_prefill quantization failed` in gemma3) still `return Ok(steps)`.
+#   Adding those anchors to PREFILL_ANCHORS below is a one-line change that goes
+#   red on exactly those sites — do it with the fix, not before.
 #
 # Exit 0 = clean. Exit 1 = violation found.
 
@@ -30,7 +57,17 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
-ANCHOR='decode step failed'
+# Sites that must propagate at the log site itself — no cleanup is owed.
+DECODE_ANCHORS=(
+    'decode step failed'
+)
+
+# Sites that may defer propagation until after a mandatory cleanup sweep.
+PREFILL_ANCHORS=(
+    'prefill chunk failed'
+    'prefill chunk cache eval failed'
+)
+
 # Lines of context after the anchor in which the verdict must appear. The log
 # macro spans several lines (fields, message, closing paren) before the control
 # flow; 8 covers the widest current site with room to spare.
@@ -38,27 +75,67 @@ CONTEXT=8
 
 violations=0
 
-# Every site that logs the anchor, as "file:line".
-while IFS= read -r site; do
-    [ -z "${site}" ] && continue
-    f="${site%%:*}"
-    ln="${site##*:}"
-    end=$((ln + CONTEXT))
-    window="$(sed -n "${ln},${end}p" "${f}")"
-    if ! printf '%s' "${window}" | grep -q 'return Err'; then
-        echo "VIOLATION: ${f}:${ln} — 'decode step failed' is not followed by 'return Err' within ${CONTEXT} lines."
+# Emit "file:line" for every non-test site logging $1.
+anchor_sites() {
+    grep -rn --include='*.rs' -F "$1" crates/ 2>/dev/null \
+        | grep -v '_tests\.rs:' | cut -d: -f1,2 || true
+}
+
+# $1 = anchor, $2 = "direct" (return Err only) or "deferred" (capture allowed).
+check_anchor() {
+    local anchor="$1" mode="$2" site f ln end window
+    while IFS= read -r site; do
+        [ -z "${site}" ] && continue
+        f="${site%%:*}"
+        ln="${site##*:}"
+        end=$((ln + CONTEXT))
+        window="$(sed -n "${ln},${end}p" "${f}")"
+
+        # A fabricated success on a failure path — never allowed, either mode.
+        if printf '%s' "${window}" | grep -q 'return Ok('; then
+            echo "VIOLATION: ${f}:${ln} — '${anchor}' returns Ok on the failure path."
+            echo "    A failure reported as a successful run is the bug this gate pins."
+            printf '%s\n' "${window}" | sed 's/^/    | /'
+            violations=$((violations + 1))
+            continue
+        fi
+
+        if printf '%s' "${window}" | grep -q 'return Err'; then
+            continue
+        fi
+        # Deferred propagation: cause captured now, returned after the sweep.
+        if [ "${mode}" = "deferred" ] && printf '%s' "${window}" | grep -q '= Some(e)'; then
+            continue
+        fi
+
+        if [ "${mode}" = "deferred" ]; then
+            echo "VIOLATION: ${f}:${ln} — '${anchor}' neither returns the cause ('return Err')"
+            echo "    nor captures it for propagation after the cleanup sweep ('= Some(e)')"
+            echo "    within ${CONTEXT} lines."
+        else
+            echo "VIOLATION: ${f}:${ln} — '${anchor}' is not followed by 'return Err' within ${CONTEXT} lines."
+        fi
         printf '%s\n' "${window}" | sed 's/^/    | /'
         violations=$((violations + 1))
-    fi
-done < <(grep -rn --include='*.rs' -F "${ANCHOR}" crates/ | grep -v '_tests\.rs:' | cut -d: -f1,2 || true)
+    done < <(anchor_sites "${anchor}")
+}
+
+for anchor in "${DECODE_ANCHORS[@]}"; do
+    check_anchor "${anchor}" direct
+done
+for anchor in "${PREFILL_ANCHORS[@]}"; do
+    check_anchor "${anchor}" deferred
+done
 
 if [ "${violations}" -gt 0 ]; then
     echo
-    echo "FAIL: ${violations} decode-step failure site(s) swallow the error."
+    echo "FAIL: ${violations} failure site(s) swallow the error."
     echo "A decode step that fails must abort the request — returning the tokens"
     echo "produced so far is reported as finish_reason=\"length\", indistinguishable"
-    echo "from a clean token-cap stop, and every automated gate reads that field."
+    echo "from a clean token-cap stop. A prefill chunk that fails must abort too —"
+    echo "returning no logits without a cause completes the run and reports zeros"
+    echo "as a measurement. Every automated gate reads those fields, not the log."
     exit 1
 fi
 
-echo "OK: every decode-step failure site propagates (no swallow)."
+echo "OK: every decode-step and prefill-chunk failure site propagates (no swallow)."

--- a/scripts/check_no_decode_swallow.sh
+++ b/scripts/check_no_decode_swallow.sh
@@ -21,34 +21,35 @@
 #   refusing zeros silently absorbs it.
 #
 # WHY A GREP GATE
-#   The decode loop and the chunked prefill are copied per-arch (the shared
-#   pipelined loop and shared `chunked_prefill`, plus the bitnet / laguna /
-#   qwen2 hand-written ones). A unit test needs a concrete `&Model` per arch, so
-#   the per-arch copies are effectively untestable at unit scope — and a fix
-#   hand-applied to some copies but not others is precisely the "looks complete,
-#   isn't" failure this rule exists to prevent. The shared loops carry real unit
-#   tests (`pipelined_decode_propagates_step_failure`,
-#   `chunked_prefill_propagates_chunk_failure`); this gate covers every copy of
-#   the shape.
+#   The decode loop and the chunked prefill are copied per-arch. A unit test
+#   needs a concrete `&Model` per arch, so the per-arch copies are effectively
+#   untestable at unit scope — and a fix hand-applied to some copies but not
+#   others is precisely the "looks complete, isn't" failure this rule exists to
+#   prevent. The shared loops carry real unit tests
+#   (`pipelined_decode_propagates_step_failure`,
+#   `chunked_prefill_propagates_chunk_failure`); this gate covers the copies.
 #
-# THE RULE
-#   Every failure log site listed below must propagate the cause, either by
-#   returning it directly (`return Err`) or — where a mandatory cleanup sweep
-#   must run first — by capturing it (`= Some(e)`) for return after the sweep.
-#   A `break` with no capture is the swallow, and a `return Ok(` on a failure
-#   path is the fabricated success this gate exists to kill.
+# WHY THE SWALLOW RULE IS KEYED ON SHAPE, NOT ON MESSAGE TEXT
+#   An earlier revision anchored on log message text ("prefill chunk failed").
+#   Two live swallows evaded it purely by wording ("prefix tail chunk failed",
+#   "tail chunk failed") and the gate reported OK with the pinned bug present.
+#   Message-keyed anchors are whack-a-mole. RULE 1 therefore anchors on the
+#   structural marker every failure-log site in the arch layer shares —
+#   `error = %e` — and looks for the swallow itself.
 #
-#   The deferred-capture form is not a loophole: the shared `chunked_prefill`
-#   cannot `return Err` at the log site because every cache that entered prefill
-#   must run `exit_prefill` before the function leaves, or the remaining caches
-#   keep un-finalized prefill state that corrupts any later reuse. The cause is
-#   captured, the sweep runs, the cause propagates.
+# THE RULES
+#   1. SWALLOW (shape-keyed, arch layer): no failure-log site may return Ok or
+#      set a `*_ok = false` swallow flag from inside its own failure arm.
+#   2. DECODE (message-keyed): every `decode step failed` site must `return Err`.
+#   3. SWEEP (message-keyed): the shared chunked_prefill must CAPTURE its cause
+#      (`= Some(e)`), not `return Err` inline — see RULE 3 below.
 #
-# NOT YET COVERED
-#   The image-prefill failure sites (`image prefill failed`, and the image-path
-#   `exit_prefill quantization failed` in gemma3) still `return Ok(steps)`.
-#   Adding those anchors to PREFILL_ANCHORS below is a one-line change that goes
-#   red on exactly those sites — do it with the fix, not before.
+# SCOPE (what this does NOT cover)
+#   RULE 1 scans crates/rmlx-models/src only — the arch generate/prefill paths
+#   where this class lives. Failure sites in other crates are not covered.
+#   RULE 1 keys on `error = %e`; a failure-log site that does not carry the
+#   error as a structured field is invisible to it (and is a traceability bug
+#   in its own right — see the tracing rules in CLAUDE.md).
 #
 # Exit 0 = clean. Exit 1 = violation found.
 
@@ -57,79 +58,129 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
-# Sites that must propagate at the log site itself — no cleanup is owed.
-DECODE_ANCHORS=(
-    'decode step failed'
-)
-
-# Sites that may defer propagation until after a mandatory cleanup sweep.
-PREFILL_ANCHORS=(
-    'prefill chunk failed'
-    'prefill chunk cache eval failed'
-)
-
-# Lines of context after the anchor in which the verdict must appear. The log
+# Lines of context after an anchor in which the verdict must appear. The log
 # macro spans several lines (fields, message, closing paren) before the control
 # flow; 8 covers the widest current site with room to spare.
 CONTEXT=8
 
 violations=0
 
-# Emit "file:line" for every non-test site logging $1.
-anchor_sites() {
-    grep -rn --include='*.rs' -F "$1" crates/ 2>/dev/null \
-        | grep -v '_tests\.rs:' | cut -d: -f1,2 || true
-}
+# Indent (leading spaces) of a line. rustfmt guarantees consistent indentation,
+# which is what makes the nesting test below meaningful.
+indent_of() { printf '%s' "$1" | awk '{ match($0, /[^ ]/); print RSTART - 1 }'; }
 
-# $1 = anchor, $2 = "direct" (return Err only) or "deferred" (capture allowed).
-check_anchor() {
-    local anchor="$1" mode="$2" site f ln end window
+# ── RULE 1: no swallow at any arch-layer failure-log site ────────────────────
+#
+# Anchor: `error = %e`, the structural marker shared by every failure-log site
+# in the arch layer.
+#
+# Verdict: a `return Ok(` or `*_ok = false` inside the anchor's own failure arm
+# is the swallow. The discriminator is NESTING, not distance: a swallow is
+# nested at or below the log statement, whereas a correct degrade-and-continue
+# site (`warn!` + fall through, e.g. "skipping prompt cache store") is followed
+# only by later SIBLING blocks, which are dedented relative to it.
+#
+# The `- 4` slack is one macro-continuation level: the anchor is often an
+# argument line of a multi-line `tracing::error!(...)`, one level deeper than
+# the statement it belongs to.
+check_swallow() {
+    local site f ln anchor_line a_ind limit win l l_ind
     while IFS= read -r site; do
         [ -z "${site}" ] && continue
         f="${site%%:*}"
         ln="${site##*:}"
-        end=$((ln + CONTEXT))
-        window="$(sed -n "${ln},${end}p" "${f}")"
-
-        # A fabricated success on a failure path — never allowed, either mode.
-        if printf '%s' "${window}" | grep -q 'return Ok('; then
-            echo "VIOLATION: ${f}:${ln} — '${anchor}' returns Ok on the failure path."
-            echo "    A failure reported as a successful run is the bug this gate pins."
-            printf '%s\n' "${window}" | sed 's/^/    | /'
+        anchor_line="$(sed -n "${ln}p" "${f}")"
+        a_ind="$(indent_of "${anchor_line}")"
+        limit=$((a_ind - 4))
+        win="$(sed -n "${ln},$((ln + CONTEXT))p" "${f}")"
+        while IFS= read -r l; do
+            printf '%s' "${l}" | grep -q 'return Ok(\|_ok = false' || continue
+            l_ind="$(indent_of "${l}")"
+            [ "${l_ind}" -ge "${limit}" ] || continue
+            echo "VIOLATION: ${f}:${ln} — failure-log site swallows the cause."
+            echo "    A 'return Ok(' / '*_ok = false' inside the failure arm reports a failed"
+            echo "    prefill or decode as a successful run. Propagate the cause instead."
+            printf '%s\n' "${win}" | sed 's/^/    | /'
             violations=$((violations + 1))
-            continue
-        fi
-
-        if printf '%s' "${window}" | grep -q 'return Err'; then
-            continue
-        fi
-        # Deferred propagation: cause captured now, returned after the sweep.
-        if [ "${mode}" = "deferred" ] && printf '%s' "${window}" | grep -q '= Some(e)'; then
-            continue
-        fi
-
-        if [ "${mode}" = "deferred" ]; then
-            echo "VIOLATION: ${f}:${ln} — '${anchor}' neither returns the cause ('return Err')"
-            echo "    nor captures it for propagation after the cleanup sweep ('= Some(e)')"
-            echo "    within ${CONTEXT} lines."
-        else
-            echo "VIOLATION: ${f}:${ln} — '${anchor}' is not followed by 'return Err' within ${CONTEXT} lines."
-        fi
-        printf '%s\n' "${window}" | sed 's/^/    | /'
-        violations=$((violations + 1))
-    done < <(anchor_sites "${anchor}")
+            break
+        done <<< "${win}"
+    done < <(grep -rn --include='*.rs' -F 'error = %e' crates/rmlx-models/src/ \
+        | grep -v '_tests\.rs:' | cut -d: -f1,2 || true)
 }
 
-for anchor in "${DECODE_ANCHORS[@]}"; do
-    check_anchor "${anchor}" direct
-done
-for anchor in "${PREFILL_ANCHORS[@]}"; do
-    check_anchor "${anchor}" deferred
+# ── RULE 2: a failed decode step must return Err at the site ─────────────────
+check_decode() {
+    local site f ln win
+    while IFS= read -r site; do
+        [ -z "${site}" ] && continue
+        f="${site%%:*}"
+        ln="${site##*:}"
+        win="$(sed -n "${ln},$((ln + CONTEXT))p" "${f}")"
+        if ! printf '%s' "${win}" | grep -q 'return Err'; then
+            echo "VIOLATION: ${f}:${ln} — 'decode step failed' is not followed by 'return Err' within ${CONTEXT} lines."
+            printf '%s\n' "${win}" | sed 's/^/    | /'
+            violations=$((violations + 1))
+        fi
+    done < <(grep -rn --include='*.rs' -F 'decode step failed' crates/ \
+        | grep -v '_tests\.rs:' | cut -d: -f1,2 || true)
+}
+
+# ── RULE 3: the shared chunked_prefill must capture, not return inline ───────
+#
+# These two sites are the ONLY ones that owe a cleanup sweep: chunked_prefill
+# calls `enter_prefill` on every cache up front, so it must run `exit_prefill`
+# on every cache before it leaves. A `return Err` at the log site skips the
+# sweep for the remaining caches, stranding them `in_prefill = true` — the next
+# decode on a stuck cache errors or corrupts KV. So here, and only here, the
+# correct form is to capture the cause and let the post-loop sweep run first.
+#
+# Message-keyed on purpose: "owes a sweep" is a property of this one function,
+# not a shape visible to grep. RULE 1 still covers these sites against the
+# swallow itself, and `chunked_prefill_runs_exit_sweep_on_failure` pins the
+# ordering invariant with a real test — this rule is the cheap early warning.
+SWEEP_ANCHORS=(
+    'prefill chunk failed'
+    'prefill chunk cache eval failed'
+)
+
+check_sweep() {
+    local anchor="$1" site f ln win
+    while IFS= read -r site; do
+        [ -z "${site}" ] && continue
+        f="${site%%:*}"
+        ln="${site##*:}"
+        # Only the shared helper owes a sweep; the per-arch copies that never
+        # call enter_prefill correctly return inline and are covered by RULE 1.
+        case "${f}" in
+        *decode_loop.rs) ;;
+        *) continue ;;
+        esac
+        win="$(sed -n "${ln},$((ln + CONTEXT))p" "${f}")"
+        if printf '%s' "${win}" | grep -q 'return Err'; then
+            echo "VIOLATION: ${f}:${ln} — '${anchor}' returns Err inline, skipping the exit_prefill sweep."
+            echo "    Every cache that entered prefill must run exit_prefill before this"
+            echo "    function leaves. Capture the cause ('= Some(e)') and let the sweep run."
+            printf '%s\n' "${win}" | sed 's/^/    | /'
+            violations=$((violations + 1))
+        elif ! printf '%s' "${win}" | grep -q '= Some(e)'; then
+            echo "VIOLATION: ${f}:${ln} — '${anchor}' neither captures the cause ('= Some(e)')"
+            echo "    for propagation after the exit_prefill sweep, nor propagates it at all."
+            printf '%s\n' "${win}" | sed 's/^/    | /'
+            violations=$((violations + 1))
+        fi
+    done < <(grep -rn --include='*.rs' -F "${anchor}" crates/ \
+        | grep -v '_tests\.rs:' | cut -d: -f1,2 || true)
+}
+
+check_swallow
+check_decode
+for anchor in "${SWEEP_ANCHORS[@]}"; do
+    check_sweep "${anchor}"
 done
 
 if [ "${violations}" -gt 0 ]; then
     echo
-    echo "FAIL: ${violations} failure site(s) swallow the error."
+    echo "FAIL: ${violations} failure site(s) swallow the error or skip the prefill sweep."
     echo "A decode step that fails must abort the request — returning the tokens"
     echo "produced so far is reported as finish_reason=\"length\", indistinguishable"
     echo "from a clean token-cap stop. A prefill chunk that fails must abort too —"
@@ -138,4 +189,4 @@ if [ "${violations}" -gt 0 ]; then
     exit 1
 fi
 
-echo "OK: every decode-step and prefill-chunk failure site propagates (no swallow)."
+echo "OK: no swallow at any arch-layer failure-log site; decode + prefill propagate."


### PR DESCRIPTION
## Summary
Closes #243. The shared `chunked_prefill` returned **`Ok(None)`** on a failed prefill chunk, so `rmlx baseline` on **Gemma4** exited **0** and printed `prefill_tps=0.0` as a measurement. #235 fixed the decode loops and the bitnet/laguna/qwen2 copies but deferred this one — `Ok(None)` was a documented, tested contract with 5 arch callers, so #235's grep gate had to **exclude** it.

**Caller audit settled the design:** all 5 callers (gemma3, gemma4, qwen3_5_moe, qwen3, qwen3_vl_moe) answered `None` *identically* — `else { return Ok(steps); }`. **Nobody used it as control flow.** The test asserting the contract even documented the bug as intended behaviour. So the contract was simply wrong → `Result<Array>`, propagate the cause.

## The canary was laundering failures into the source-of-truth DB
| | result |
|---|---|
| **before** | `CANARY_EXIT=0` — printed `decode_tps=0.00 ± 0.00`, appended 2 zero rows to `perf_canary.csv`, **and wrote 6 rows into `runs.db` ("runs.db: ok")** |
| **after** | `CANARY_EXIT=1` — aborts, writes nothing |

Its only guard was `[[ -z "${val}" ]]` — *"did we parse a value"*, never *"is it real"*. `"0.000"` sailed through. This is #241's twin wearing a `0` instead of a plausible `138.312`. (Ingest-level fix proposed on #241: the DB **already** records `early_stop=true n_generated=0` — nothing reads it.)

## Review found two survivors — and the gate was green anyway
The first gate anchored on log **message text**, so two verbatim copies of the same swallow evaded it **purely by wording** (`"prefix tail chunk failed"` ≠ `"prefill chunk failed"`):
- **`gemma4/generate/mod.rs`** — the prompt-cache **prefix-hit** branch, 15 lines above the fixed call site, same arch as the repro. **A gemma4 warm-cache hit still fabricated a zero.**
- **`qwen3_5_moe/generate.rs`** — the SSD-**hydrated-tail** path.

Both fixed (neither calls `enter_prefill`, so inline `return Err` is correct — no sweep owed).

**The gate is now keyed on shape, not prose:** anchor on `error = %e` + flag `return Ok(` / `*_ok = false` **inside the failure arm**, discriminated by **nesting** (a swallow sits within its arm; a correct degrade is followed only by dedented siblings). Red-first proof on the tree the old gate called OK:
```
GATE_EXIT=1 — 8 violations:
  gemma4:498,510   qwen3_5_moe:292,304   gemma3:276,285   gemma4:462,468
```

## Also
- **`exit_prefill` sweep pinned by a real test** (new `pub fn in_prefill()`): the shared helper *must* defer-capture — an inline `return Err` strands `caches[1..]` `in_prefill`, the regression on record at `deep-analysis-remediation.md:174`. Mutation: inline `return Err` → test *"cache 0 was left in prefill…"* **and** gate RULE 3 both fire. Nothing pinned this before; the design rested on a comment.
- Empty-prompt fallback reclassified `Error::Other` → **`Error::Model`** (Fatal). `Other` is `Migratable`, so a deterministic empty prompt was being replayed — the same doomed-replay degradation this PR set out to kill.
- **Scope note:** the shape-keyed gate flags **#242's 4 image sites** by design. Fixing them was the only alternative to a carve-out (the exact defect above), so they're fixed here using the snippet #242 prescribes — error-arm-only, cannot touch the happy path. **#242 stays open**: its vision-model proof is not discharged here.

## Proof
Repro: `exit=1`, real error, **0 summary lines**. Warm path **proven, not assumed** — a first attempt logged `cache_path="miss"` (chat template appends a suffix; `BLOCK_TOKENS=256`), so a real multi-turn >256-token case was built: `cache_path=prefix hits=1/2`.

| | evidence |
|---|---|
| gemma4 warm non-streaming | `cache_path=prefix hits=1` → coherent |
| gemma4 warm **streaming** | `cache_path=prefix hits=2` → `stop` |
| gemma4 warm + cap | `length` |
| Bonsai stream + non-stream | `stop`/`length`, coherent |

Paired TPS: Bonsai 124.2→125.7, Gemma4 122.4→125.8. Scratch `RMLX_HOME` used — real `runs.db` untouched. `make lint` clean; `cargo test -p rmlx-models -p rmlx-server` exit 0 (28 suites).

> ⚠️ `make ci` is currently red on `main` for an unrelated pre-existing reason — **#252** (46 GPU flash tests from #217/#218 missing the Metal-context `#[ignore]`). Not touched here; this branch's own crates are green.

Follow-up filed: **#251** (speculative `prefill_chunked` strands caches `in_prefill` — the inverse violation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)