### PR TITLE
fix(test): ignore GPU-touching kv-quant tests so parallel Metal stops aborting the suite (#252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
     # is a `cargo test --workspace` that this workflow never runs. The check is
     # static (bash + awk over the checked-in sources), needs neither a Rust
     # toolchain, mlx-c, nor a GPU, so it stays seconds-long and reports as its
-    # own named check.
-    runs-on: macos-latest
+    # own named check — and runs on Linux, which bills at a tenth of macOS.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: GPU-touching tests carry the Metal-context #[ignore]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,21 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  gates:
+    name: source gates
+    # This job runs no tests — nothing here does. That is precisely why the
+    # gate below exists: a GPU test left without the Metal-context `#[ignore]`
+    # aborts the whole test binary, and the only thing that would have caught it
+    # is a `cargo test --workspace` that this workflow never runs. The check is
+    # static (bash + awk over the checked-in sources), needs neither a Rust
+    # toolchain, mlx-c, nor a GPU, so it stays seconds-long and reports as its
+    # own named check.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: GPU-touching tests carry the Metal-context #[ignore]
+        run: make check-gpu-tests-ignored
+
   msl:
     name: msl kernels (compile + format)
     # macos-14 ships full Xcode, so the Metal compiler is available here (see the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,17 @@ Hard rules:
   ```
   The CI gate `make check-no-inline-tests` enforces this as a hard-fail step
   in `make ci`. All workspace violations have been migrated.
+- **Hard rule: a test that reaches `Device::Gpu` carries `#[ignore]`.** A shared
+  Metal context driven from parallel `cargo test` threads aborts the whole test
+  binary ("Rust cannot catch foreign exceptions"), taking every other test in
+  the crate with it. Run them as
+  `cargo test -p <crate> --lib -- --ignored <filter> --test-threads=1`. A guard
+  that only exercises a check the dispatcher rejects **before** touching a
+  device-parameterized op is not a GPU test: pass `Device::Cpu` and leave it
+  un-ignored — ignoring a CPU test silently stops running it. The CI gate
+  `make check-gpu-tests-ignored` enforces this for `rmlx-kv-quant`; it keys on
+  shape (does the test reach `Device::Gpu`?), never on the ignore reason's text.
+  See `docs/TESTING.md`.
 - **Advisory: `make file-size-report`** prints files >1000 LOC. Non-failing.
   Also runs at the end of `make ci` (advisory, non-blocking).
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         smoke-codec-matrix \
         e2e \
         file-size-report check-no-inline-tests check-no-scalar-f32-leak \
-        check-no-decode-swallow \
+        check-no-decode-swallow check-gpu-tests-ignored \
         check-metal-compiles check-metal-format
 
 help:
@@ -170,6 +170,9 @@ check-no-scalar-f32-leak: ## CI gate: fail if arch-layer code has unguarded scal
 check-no-decode-swallow: ## CI gate: fail if a decode-step failure breaks instead of propagating (would report as finish_reason="length")
 	@bash scripts/check_no_decode_swallow.sh
 
+check-gpu-tests-ignored: ## CI gate: fail if a GPU-touching rmlx-kv-quant test lacks #[ignore] (would abort the whole test binary under parallel cargo test)
+	@bash scripts/check_gpu_tests_ignored.sh
+
 # METAL_STRICT=--strict turns a missing toolchain into a hard failure instead of
 # a skip. CI sets it (the macOS runner ships the toolchain, so a skip there would
 # mean the gate protected nothing); local runs leave it empty and skip.
@@ -186,6 +189,7 @@ ci: fmt-check lint test deny audit ci-metrics ## full pre-merge gate: fmt + clip
 	@bash scripts/check_no_inline_tests.sh
 	@bash scripts/check_no_scalar_f32_leak.sh
 	@bash scripts/check_no_decode_swallow.sh
+	@bash scripts/check_gpu_tests_ignored.sh
 	@bash scripts/check_metal_format.sh
 	@bash scripts/check_metal_compiles.sh
 	@bash scripts/file_size_report.sh || true

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
@@ -269,20 +269,20 @@ fn run_oracle_masked(
 // ── Oracle: kernel == CPU dequant reference ───────────────────────────────────
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso3_flash_decode_matches_cpu_dequant_reference() {
     // Bonsai / Qwen3 shape: head_dim 128, GQA 4:1.
     run_oracle(3, 2, 4, 40, 128);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso4_flash_decode_matches_cpu_dequant_reference() {
     run_oracle(4, 2, 4, 40, 128);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_across_tiles() {
     // kv_seq is set above TILE_SIZE so the P2 log-sum-exp merge runs over
     // several tiles rather than a single one.
@@ -290,33 +290,33 @@ fn iso3_flash_decode_matches_reference_across_tiles() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_across_tiles() {
     run_oracle(4, 1, 8, (TILE_SIZE as usize) * 2 + 22, 128);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_head_dim_512() {
     // Gemma4 e2b/e4b global layers run head_dim = 512 with a single KV head.
     run_oracle(3, 1, 8, 70, 512);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_head_dim_512() {
     run_oracle(4, 1, 8, 70, 512);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_head_dim_256() {
     // medgemma / Gemma3 shape.
     run_oracle(3, 1, 4, 70, 256);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_head_dim_256() {
     run_oracle(4, 1, 4, 70, 256);
 }
@@ -329,7 +329,7 @@ fn iso4_flash_decode_matches_reference_head_dim_256() {
 // or mis-strided mask index would pass the whole suite.
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_with_additive_mask() {
     // kv_h=2, heads_per_kv=4 also pins the GQA (q_head -> kv_head) mapping: the
     // mask is indexed by q_head while K is indexed by kv_head, so conflating the
@@ -338,13 +338,13 @@ fn iso3_flash_decode_matches_reference_with_additive_mask() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_with_additive_mask() {
     run_oracle_masked(4, 2, 4, 40, 128, true);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_with_mask_across_tiles() {
     // Mask + multi-tile: the per-tile online softmax and the P2 merge both have
     // to see the masked scores.
@@ -352,7 +352,7 @@ fn iso3_flash_decode_matches_reference_with_mask_across_tiles() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_with_mask_across_tiles() {
     run_oracle_masked(4, 2, 4, (TILE_SIZE as usize) * 2 + 22, 128, true);
 }
@@ -360,7 +360,7 @@ fn iso4_flash_decode_matches_reference_with_mask_across_tiles() {
 // ── GQA ───────────────────────────────────────────────────────────────────────
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_multi_kv_head_gqa() {
     // kv_h=4 with heads_per_kv=2: several KV heads AND a GQA fan-out, so a
     // kv_h_idx derived with the wrong divisor reads another head's K.
@@ -368,20 +368,20 @@ fn iso3_flash_decode_matches_reference_multi_kv_head_gqa() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_multi_kv_head_gqa() {
     run_oracle(4, 4, 2, 40, 128);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_mha_no_gqa() {
     // heads_per_kv=1 (plain MHA): kv_h_idx == hq, the degenerate GQA case.
     run_oracle(3, 4, 1, 40, 128);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_mha_no_gqa() {
     run_oracle(4, 4, 1, 40, 128);
 }

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
@@ -269,17 +269,20 @@ fn run_oracle_masked(
 // ── Oracle: kernel == CPU dequant reference ───────────────────────────────────
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso3_flash_decode_matches_cpu_dequant_reference() {
     // Bonsai / Qwen3 shape: head_dim 128, GQA 4:1.
     run_oracle(3, 2, 4, 40, 128);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso4_flash_decode_matches_cpu_dequant_reference() {
     run_oracle(4, 2, 4, 40, 128);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_across_tiles() {
     // kv_seq is set above TILE_SIZE so the P2 log-sum-exp merge runs over
     // several tiles rather than a single one.
@@ -287,28 +290,33 @@ fn iso3_flash_decode_matches_reference_across_tiles() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_across_tiles() {
     run_oracle(4, 1, 8, (TILE_SIZE as usize) * 2 + 22, 128);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_head_dim_512() {
     // Gemma4 e2b/e4b global layers run head_dim = 512 with a single KV head.
     run_oracle(3, 1, 8, 70, 512);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_head_dim_512() {
     run_oracle(4, 1, 8, 70, 512);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_head_dim_256() {
     // medgemma / Gemma3 shape.
     run_oracle(3, 1, 4, 70, 256);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_head_dim_256() {
     run_oracle(4, 1, 4, 70, 256);
 }
@@ -321,6 +329,7 @@ fn iso4_flash_decode_matches_reference_head_dim_256() {
 // or mis-strided mask index would pass the whole suite.
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_with_additive_mask() {
     // kv_h=2, heads_per_kv=4 also pins the GQA (q_head -> kv_head) mapping: the
     // mask is indexed by q_head while K is indexed by kv_head, so conflating the
@@ -329,11 +338,13 @@ fn iso3_flash_decode_matches_reference_with_additive_mask() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_with_additive_mask() {
     run_oracle_masked(4, 2, 4, 40, 128, true);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_with_mask_across_tiles() {
     // Mask + multi-tile: the per-tile online softmax and the P2 merge both have
     // to see the masked scores.
@@ -341,6 +352,7 @@ fn iso3_flash_decode_matches_reference_with_mask_across_tiles() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_with_mask_across_tiles() {
     run_oracle_masked(4, 2, 4, (TILE_SIZE as usize) * 2 + 22, 128, true);
 }
@@ -348,6 +360,7 @@ fn iso4_flash_decode_matches_reference_with_mask_across_tiles() {
 // ── GQA ───────────────────────────────────────────────────────────────────────
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_multi_kv_head_gqa() {
     // kv_h=4 with heads_per_kv=2: several KV heads AND a GQA fan-out, so a
     // kv_h_idx derived with the wrong divisor reads another head's K.
@@ -355,28 +368,34 @@ fn iso3_flash_decode_matches_reference_multi_kv_head_gqa() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_multi_kv_head_gqa() {
     run_oracle(4, 4, 2, 40, 128);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso3_flash_decode_matches_reference_mha_no_gqa() {
     // heads_per_kv=1 (plain MHA): kv_h_idx == hq, the degenerate GQA case.
     run_oracle(3, 4, 1, 40, 128);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --include-ignored --test-threads=1"]
 fn iso4_flash_decode_matches_reference_mha_no_gqa() {
     run_oracle(4, 4, 1, 40, 128);
 }
 
 // ── Gates ─────────────────────────────────────────────────────────────────────
+//
+// Every gate below is rejected by a scalar shape check that runs before the
+// dispatcher touches a device-parameterized op, so these pass `Device::Cpu` and
+// stay un-ignored — they are the cheap always-on half of the suite. Handing them
+// `Device::Gpu` would claim a Metal context they never reach and force them
+// behind `--ignored` with the real parity tests.
 
 #[test]
 fn iso_flash_decode_rejects_non_pow2_head_dim() {
-    if skip_if_no_gpu_env() {
-        return;
-    }
     let dummy = make_f32_array(&[0.0], &[1]);
     let codes = make_u32_array(&[0], &[1]);
     // head_dim=96 is a multiple of the quaternion block size but not a power of
@@ -394,7 +413,7 @@ fn iso_flash_decode_rejects_non_pow2_head_dim() {
         96,
         1,
         1.0,
-        Device::Gpu,
+        Device::Cpu,
     );
     assert!(
         err.is_err(),
@@ -404,9 +423,6 @@ fn iso_flash_decode_rejects_non_pow2_head_dim() {
 
 #[test]
 fn iso_flash_decode_rejects_head_dim_above_max() {
-    if skip_if_no_gpu_env() {
-        return;
-    }
     let dummy = make_f32_array(&[0.0], &[1]);
     let codes = make_u32_array(&[0], &[1]);
     let err = iso_flash_decode_sdpa::<3>(
@@ -422,7 +438,7 @@ fn iso_flash_decode_rejects_head_dim_above_max() {
         ISO_FLASH_HEAD_DIM_MAX * 2,
         1,
         1.0,
-        Device::Gpu,
+        Device::Cpu,
     );
     assert!(
         err.is_err(),
@@ -433,9 +449,6 @@ fn iso_flash_decode_rejects_head_dim_above_max() {
 
 #[test]
 fn iso_flash_decode_rejects_unsupported_bits() {
-    if skip_if_no_gpu_env() {
-        return;
-    }
     let dummy = make_f32_array(&[0.0], &[1]);
     let codes = make_u32_array(&[0], &[1]);
     // BITS=5 must not silently decode as 3-bit or 4-bit.
@@ -452,7 +465,7 @@ fn iso_flash_decode_rejects_unsupported_bits() {
         128,
         1,
         1.0,
-        Device::Gpu,
+        Device::Cpu,
     );
     assert!(
         err.is_err(),

--- a/crates/rmlx-kv-quant/src/kvcache/decode_grow_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/decode_grow_tests.rs
@@ -252,7 +252,7 @@ fn saturated_prompt_decodes(quant: KvQuant, label: &str) {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --ignored --test-threads=1"]
 fn rotor3_decode_grows_past_a_saturated_max_seq() {
     if skip_if_no_gpu_env() {
         return;
@@ -261,7 +261,7 @@ fn rotor3_decode_grows_past_a_saturated_max_seq() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --ignored --test-threads=1"]
 fn rotor4_decode_grows_past_a_saturated_max_seq() {
     if skip_if_no_gpu_env() {
         return;
@@ -274,7 +274,7 @@ fn rotor4_decode_grows_past_a_saturated_max_seq() {
 /// The incidental headroom (here 6 tokens) is what made this look healthy on a
 /// short generation: the bound only bites once generation outruns it.
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --ignored --test-threads=1"]
 fn rotor3_decode_grows_across_the_boundary_from_just_under() {
     if skip_if_no_gpu_env() {
         return;
@@ -295,7 +295,7 @@ fn rotor3_decode_grows_across_the_boundary_from_just_under() {
 /// The backstop matters as much as the growth: a request that genuinely cannot
 /// fit the configured context must be rejected, never quietly truncated.
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --ignored --test-threads=1"]
 fn decode_past_the_ceiling_errors_loudly() {
     if skip_if_no_gpu_env() {
         return;
@@ -326,7 +326,7 @@ fn decode_past_the_ceiling_errors_loudly() {
 /// (`sqrt(sum(x^2))`, un-quantised), so it is the one checked here: a dropped
 /// append reads back as `0.0` against a re-encode that never is.
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --ignored --test-threads=1"]
 fn decode_past_max_seq_lands_every_append_in_the_ring() {
     if skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/src/kvcache/decode_grow_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/decode_grow_tests.rs
@@ -252,6 +252,7 @@ fn saturated_prompt_decodes(quant: KvQuant, label: &str) {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --include-ignored --test-threads=1"]
 fn rotor3_decode_grows_past_a_saturated_max_seq() {
     if skip_if_no_gpu_env() {
         return;
@@ -260,6 +261,7 @@ fn rotor3_decode_grows_past_a_saturated_max_seq() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --include-ignored --test-threads=1"]
 fn rotor4_decode_grows_past_a_saturated_max_seq() {
     if skip_if_no_gpu_env() {
         return;
@@ -272,6 +274,7 @@ fn rotor4_decode_grows_past_a_saturated_max_seq() {
 /// The incidental headroom (here 6 tokens) is what made this look healthy on a
 /// short generation: the bound only bites once generation outruns it.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --include-ignored --test-threads=1"]
 fn rotor3_decode_grows_across_the_boundary_from_just_under() {
     if skip_if_no_gpu_env() {
         return;
@@ -292,6 +295,7 @@ fn rotor3_decode_grows_across_the_boundary_from_just_under() {
 /// The backstop matters as much as the growth: a request that genuinely cannot
 /// fit the configured context must be rejected, never quietly truncated.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --include-ignored --test-threads=1"]
 fn decode_past_the_ceiling_errors_loudly() {
     if skip_if_no_gpu_env() {
         return;
@@ -322,6 +326,7 @@ fn decode_past_the_ceiling_errors_loudly() {
 /// (`sqrt(sum(x^2))`, un-quantised), so it is the one checked here: a dropped
 /// append reads back as `0.0` against a re-encode that never is.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test decode_grow -- --include-ignored --test-threads=1"]
 fn decode_past_max_seq_lands_every_append_in_the_ring() {
     if skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/src/kvcache/iso_flash_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/iso_flash_dispatch_tests.rs
@@ -139,7 +139,7 @@ fn run_decode_steps(
 // ── The kernel is reached from the production entry point ─────────────────────
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --ignored --test-threads=1"]
 fn iso_k_only_3_decode_dispatches_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -155,7 +155,7 @@ fn iso_k_only_3_decode_dispatches_flash_kernel() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --ignored --test-threads=1"]
 fn iso_k_only_4_decode_dispatches_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -170,7 +170,7 @@ fn iso_k_only_4_decode_dispatches_flash_kernel() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --ignored --test-threads=1"]
 fn iso_k_only_decode_dispatches_across_a_tile_boundary() {
     if skip_if_no_gpu_env() {
         return;
@@ -186,7 +186,7 @@ fn iso_k_only_decode_dispatches_across_a_tile_boundary() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --ignored --test-threads=1"]
 fn iso_k_only_decode_dispatches_at_head_dim_256() {
     if skip_if_no_gpu_env() {
         return;
@@ -235,7 +235,7 @@ fn batched_ring_feed_is_skipped(quant: KvQuant, bits_label: &str) {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --ignored --test-threads=1"]
 fn iso3_batched_gpu_append_skips_the_ring_instead_of_erroring() {
     if skip_if_no_gpu_env() {
         return;
@@ -244,7 +244,7 @@ fn iso3_batched_gpu_append_skips_the_ring_instead_of_erroring() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --ignored --test-threads=1"]
 fn iso4_batched_gpu_append_skips_the_ring_instead_of_erroring() {
     if skip_if_no_gpu_env() {
         return;
@@ -313,7 +313,7 @@ fn cpu_append_drops_a_live_ring(quant: KvQuant, bits_label: &str) {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --ignored --test-threads=1"]
 fn iso3_cpu_append_drops_a_live_gpu_ring() {
     if skip_if_no_gpu_env() {
         return;
@@ -322,7 +322,7 @@ fn iso3_cpu_append_drops_a_live_gpu_ring() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --ignored --test-threads=1"]
 fn iso4_cpu_append_drops_a_live_gpu_ring() {
     if skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/src/kvcache/iso_flash_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/iso_flash_dispatch_tests.rs
@@ -139,6 +139,7 @@ fn run_decode_steps(
 // ── The kernel is reached from the production entry point ─────────────────────
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
 fn iso_k_only_3_decode_dispatches_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -154,6 +155,7 @@ fn iso_k_only_3_decode_dispatches_flash_kernel() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
 fn iso_k_only_4_decode_dispatches_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -168,6 +170,7 @@ fn iso_k_only_4_decode_dispatches_flash_kernel() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
 fn iso_k_only_decode_dispatches_across_a_tile_boundary() {
     if skip_if_no_gpu_env() {
         return;
@@ -183,6 +186,7 @@ fn iso_k_only_decode_dispatches_across_a_tile_boundary() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
 fn iso_k_only_decode_dispatches_at_head_dim_256() {
     if skip_if_no_gpu_env() {
         return;
@@ -231,6 +235,7 @@ fn batched_ring_feed_is_skipped(quant: KvQuant, bits_label: &str) {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
 fn iso3_batched_gpu_append_skips_the_ring_instead_of_erroring() {
     if skip_if_no_gpu_env() {
         return;
@@ -239,6 +244,7 @@ fn iso3_batched_gpu_append_skips_the_ring_instead_of_erroring() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
 fn iso4_batched_gpu_append_skips_the_ring_instead_of_erroring() {
     if skip_if_no_gpu_env() {
         return;
@@ -307,6 +313,7 @@ fn cpu_append_drops_a_live_ring(quant: KvQuant, bits_label: &str) {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
 fn iso3_cpu_append_drops_a_live_gpu_ring() {
     if skip_if_no_gpu_env() {
         return;
@@ -315,6 +322,7 @@ fn iso3_cpu_append_drops_a_live_gpu_ring() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_dispatch -- --include-ignored --test-threads=1"]
 fn iso4_cpu_append_drops_a_live_gpu_ring() {
     if skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
@@ -155,7 +155,7 @@ fn run_decode_steps(
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --ignored --test-threads=1"]
 fn rotor_k_only_3_decode_dispatches_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -172,7 +172,7 @@ fn rotor_k_only_3_decode_dispatches_flash_kernel() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --ignored --test-threads=1"]
 fn rotor_k_only_4_decode_dispatches_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -187,7 +187,7 @@ fn rotor_k_only_4_decode_dispatches_flash_kernel() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --ignored --test-threads=1"]
 fn rotor_k_only_decode_dispatches_across_a_tile_boundary() {
     if skip_if_no_gpu_env() {
         return;
@@ -203,7 +203,7 @@ fn rotor_k_only_decode_dispatches_across_a_tile_boundary() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --ignored --test-threads=1"]
 fn rotor_k_only_decode_dispatches_at_head_dim_256() {
     if skip_if_no_gpu_env() {
         return;
@@ -263,7 +263,7 @@ fn batched_ring_feed_is_skipped(quant: KvQuant, bits_label: &str) {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --ignored --test-threads=1"]
 fn rotor3_batched_gpu_append_skips_the_ring_instead_of_erroring() {
     if skip_if_no_gpu_env() {
         return;
@@ -272,7 +272,7 @@ fn rotor3_batched_gpu_append_skips_the_ring_instead_of_erroring() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --ignored --test-threads=1"]
 fn rotor4_batched_gpu_append_skips_the_ring_instead_of_erroring() {
     if skip_if_no_gpu_env() {
         return;
@@ -281,7 +281,7 @@ fn rotor4_batched_gpu_append_skips_the_ring_instead_of_erroring() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --ignored --test-threads=1"]
 fn rotor_k_only_decode_stays_cpu_when_store_carries_qjl() {
     if skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
@@ -155,6 +155,7 @@ fn run_decode_steps(
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
 fn rotor_k_only_3_decode_dispatches_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -171,6 +172,7 @@ fn rotor_k_only_3_decode_dispatches_flash_kernel() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
 fn rotor_k_only_4_decode_dispatches_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -185,6 +187,7 @@ fn rotor_k_only_4_decode_dispatches_flash_kernel() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
 fn rotor_k_only_decode_dispatches_across_a_tile_boundary() {
     if skip_if_no_gpu_env() {
         return;
@@ -200,6 +203,7 @@ fn rotor_k_only_decode_dispatches_across_a_tile_boundary() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
 fn rotor_k_only_decode_dispatches_at_head_dim_256() {
     if skip_if_no_gpu_env() {
         return;
@@ -259,6 +263,7 @@ fn batched_ring_feed_is_skipped(quant: KvQuant, bits_label: &str) {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
 fn rotor3_batched_gpu_append_skips_the_ring_instead_of_erroring() {
     if skip_if_no_gpu_env() {
         return;
@@ -267,6 +272,7 @@ fn rotor3_batched_gpu_append_skips_the_ring_instead_of_erroring() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
 fn rotor4_batched_gpu_append_skips_the_ring_instead_of_erroring() {
     if skip_if_no_gpu_env() {
         return;
@@ -275,6 +281,7 @@ fn rotor4_batched_gpu_append_skips_the_ring_instead_of_erroring() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --include-ignored --test-threads=1"]
 fn rotor_k_only_decode_stays_cpu_when_store_carries_qjl() {
     if skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/src/kvcache/shared_kv_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/shared_kv_tests.rs
@@ -106,6 +106,7 @@ fn producer_decode_step(cache: &mut KvCache, step: u64) -> SharedKv {
 /// and every step fell through to `update()`'s O(seq) CPU dequant, so the
 /// dispatch delta was 0 no matter what the codec supported.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
 fn shared_source_producer_dispatches_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -131,6 +132,7 @@ fn shared_source_producer_dispatches_flash_kernel() {
 /// A consumer attends the producer's store through the same kernel — the
 /// producer never materialises bf16 K/V on its behalf.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
 fn shared_consumer_attends_store_through_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -166,6 +168,7 @@ fn shared_consumer_attends_store_through_flash_kernel() {
 /// The consumer's mask is sized from the **producer's** K length. A store-backed
 /// share must report exactly what a bf16 share's `k.shape()[2]` would have.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
 fn store_share_kv_len_tracks_producer_offset() {
     if skip_if_no_gpu_env() {
         return;
@@ -194,6 +197,7 @@ fn store_share_kv_len_tracks_producer_offset() {
 /// production shape — the other tests here push F32 K/V, which would hide the
 /// bug (F32 K matches an F32 V by accident).
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
 #[allow(
     clippy::indexing_slicing,
     reason = "test asserts on a known rank-4 shape"
@@ -267,6 +271,7 @@ fn materialise_casts_k_to_the_stream_dtype() {
 /// directions against a live store — stubbing the guard to `Ok(())` must turn
 /// this red.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
 fn store_share_refuses_length_desync_against_live_store() {
     if skip_if_no_gpu_env() {
         return;
@@ -304,7 +309,11 @@ fn store_share_refuses_length_desync_against_live_store() {
 /// not hold it: no producer supplied, or a codec with no fused-over-store path.
 #[test]
 fn store_share_refuses_missing_producer_and_wrong_codec() {
-    let device = Device::Gpu;
+    // Every refusal below is decided before the device is consulted — a missing
+    // producer and a codec with no fused-over-store path are both rejected up
+    // front. `Device::Cpu` keeps this guard in the default gate instead of
+    // parking it behind `--ignored` for a Metal context it never reaches.
+    let device = Device::Cpu;
     let share = SharedKv::Store { kv_len: 8 };
     let q = f32_array(
         &lcg_data((N_Q_HEADS * HEAD_DIM) as usize, 7),
@@ -331,6 +340,7 @@ fn store_share_refuses_missing_producer_and_wrong_codec() {
 /// `KvQuant::None` keeps the bf16 contract: the share is the stored tensors and
 /// consumers read them exactly as before.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
 fn none_quant_shares_bf16_unchanged() {
     if skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/src/kvcache/shared_kv_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/shared_kv_tests.rs
@@ -106,7 +106,7 @@ fn producer_decode_step(cache: &mut KvCache, step: u64) -> SharedKv {
 /// and every step fell through to `update()`'s O(seq) CPU dequant, so the
 /// dispatch delta was 0 no matter what the codec supported.
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --ignored --test-threads=1"]
 fn shared_source_producer_dispatches_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -132,7 +132,7 @@ fn shared_source_producer_dispatches_flash_kernel() {
 /// A consumer attends the producer's store through the same kernel — the
 /// producer never materialises bf16 K/V on its behalf.
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --ignored --test-threads=1"]
 fn shared_consumer_attends_store_through_flash_kernel() {
     if skip_if_no_gpu_env() {
         return;
@@ -168,7 +168,7 @@ fn shared_consumer_attends_store_through_flash_kernel() {
 /// The consumer's mask is sized from the **producer's** K length. A store-backed
 /// share must report exactly what a bf16 share's `k.shape()[2]` would have.
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --ignored --test-threads=1"]
 fn store_share_kv_len_tracks_producer_offset() {
     if skip_if_no_gpu_env() {
         return;
@@ -197,7 +197,7 @@ fn store_share_kv_len_tracks_producer_offset() {
 /// production shape — the other tests here push F32 K/V, which would hide the
 /// bug (F32 K matches an F32 V by accident).
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --ignored --test-threads=1"]
 #[allow(
     clippy::indexing_slicing,
     reason = "test asserts on a known rank-4 shape"
@@ -271,7 +271,7 @@ fn materialise_casts_k_to_the_stream_dtype() {
 /// directions against a live store — stubbing the guard to `Ok(())` must turn
 /// this red.
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --ignored --test-threads=1"]
 fn store_share_refuses_length_desync_against_live_store() {
     if skip_if_no_gpu_env() {
         return;
@@ -340,7 +340,7 @@ fn store_share_refuses_missing_producer_and_wrong_codec() {
 /// `KvQuant::None` keeps the bf16 contract: the share is the stored tensors and
 /// consumers read them exactly as before.
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test shared_kv -- --ignored --test-threads=1"]
 fn none_quant_shares_bf16_unchanged() {
     if skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_msl_tests.rs
@@ -267,20 +267,20 @@ fn run_oracle_masked(
 // ── Oracle: kernel == CPU dequant reference ───────────────────────────────────
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_cpu_dequant_reference() {
     // Bonsai / Qwen3 shape: head_dim 128, GQA 4:1.
     run_oracle(3, 2, 4, 40, 128);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --ignored --test-threads=1"]
 fn rotor4_flash_decode_matches_cpu_dequant_reference() {
     run_oracle(4, 2, 4, 40, 128);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_reference_across_tiles() {
     // kv_seq is set above TILE_SIZE so the P2 log-sum-exp merge runs over
     // several tiles rather than a single one.
@@ -288,13 +288,13 @@ fn rotor3_flash_decode_matches_reference_across_tiles() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --ignored --test-threads=1"]
 fn rotor4_flash_decode_matches_reference_across_tiles() {
     run_oracle(4, 1, 8, (TILE_SIZE as usize) * 2 + 22, 128);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_reference_head_dim_512() {
     // Gemma4 e2b/e4b global layers run head_dim = 512 with a single KV head.
     // head_dim % 3 != 0, so the last rotor group is tail-padded.
@@ -302,13 +302,13 @@ fn rotor3_flash_decode_matches_reference_head_dim_512() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --ignored --test-threads=1"]
 fn rotor4_flash_decode_matches_reference_head_dim_512() {
     run_oracle(4, 1, 8, 70, 512);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_reference_head_dim_256() {
     run_oracle(3, 1, 4, 70, 256);
 }
@@ -321,7 +321,7 @@ fn rotor3_flash_decode_matches_reference_head_dim_256() {
 // or mis-strided mask index would pass the whole suite.
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_reference_with_additive_mask() {
     // kv_h=2, heads_per_kv=4 also pins the GQA (q_head -> kv_head) mapping: the
     // mask is indexed by q_head while K is indexed by kv_head, so conflating the
@@ -330,13 +330,13 @@ fn rotor3_flash_decode_matches_reference_with_additive_mask() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --ignored --test-threads=1"]
 fn rotor4_flash_decode_matches_reference_with_additive_mask() {
     run_oracle_masked(4, 2, 4, 40, 128, true);
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_reference_with_mask_across_tiles() {
     // Mask + multi-tile: the per-tile online softmax and the P2 merge both have
     // to see the masked scores.
@@ -488,7 +488,7 @@ fn rotor_flash_header_exposes_reusable_decode_fn() {
 // fire") is asserted on cache-local state in
 // `kvcache::rotor_flash_dispatch_tests` instead.
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --ignored --test-threads=1"]
 fn rotor_flash_decode_dispatch_count_increments_on_gpu() {
     if skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_msl_tests.rs
@@ -267,17 +267,20 @@ fn run_oracle_masked(
 // ── Oracle: kernel == CPU dequant reference ───────────────────────────────────
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_cpu_dequant_reference() {
     // Bonsai / Qwen3 shape: head_dim 128, GQA 4:1.
     run_oracle(3, 2, 4, 40, 128);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
 fn rotor4_flash_decode_matches_cpu_dequant_reference() {
     run_oracle(4, 2, 4, 40, 128);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_reference_across_tiles() {
     // kv_seq is set above TILE_SIZE so the P2 log-sum-exp merge runs over
     // several tiles rather than a single one.
@@ -285,11 +288,13 @@ fn rotor3_flash_decode_matches_reference_across_tiles() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
 fn rotor4_flash_decode_matches_reference_across_tiles() {
     run_oracle(4, 1, 8, (TILE_SIZE as usize) * 2 + 22, 128);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_reference_head_dim_512() {
     // Gemma4 e2b/e4b global layers run head_dim = 512 with a single KV head.
     // head_dim % 3 != 0, so the last rotor group is tail-padded.
@@ -297,11 +302,13 @@ fn rotor3_flash_decode_matches_reference_head_dim_512() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
 fn rotor4_flash_decode_matches_reference_head_dim_512() {
     run_oracle(4, 1, 8, 70, 512);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_reference_head_dim_256() {
     run_oracle(3, 1, 4, 70, 256);
 }
@@ -314,6 +321,7 @@ fn rotor3_flash_decode_matches_reference_head_dim_256() {
 // or mis-strided mask index would pass the whole suite.
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_reference_with_additive_mask() {
     // kv_h=2, heads_per_kv=4 also pins the GQA (q_head -> kv_head) mapping: the
     // mask is indexed by q_head while K is indexed by kv_head, so conflating the
@@ -322,11 +330,13 @@ fn rotor3_flash_decode_matches_reference_with_additive_mask() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
 fn rotor4_flash_decode_matches_reference_with_additive_mask() {
     run_oracle_masked(4, 2, 4, 40, 128, true);
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
 fn rotor3_flash_decode_matches_reference_with_mask_across_tiles() {
     // Mask + multi-tile: the per-tile online softmax and the P2 merge both have
     // to see the masked scores.
@@ -334,12 +344,15 @@ fn rotor3_flash_decode_matches_reference_with_mask_across_tiles() {
 }
 
 // ── Gates ─────────────────────────────────────────────────────────────────────
+//
+// Every gate below is rejected by a scalar shape check that runs before the
+// dispatcher touches a device-parameterized op, so these pass `Device::Cpu` and
+// stay un-ignored — they are the cheap always-on half of the suite. Handing them
+// `Device::Gpu` would claim a Metal context they never reach and force them
+// behind `--ignored` with the real parity tests.
 
 #[test]
 fn rotor_flash_decode_rejects_non_pow2_head_dim() {
-    if skip_if_no_gpu_env() {
-        return;
-    }
     let dummy = make_f32_array(&[0.0], &[1]);
     let codes = make_u32_array(&[0], &[1]);
     let err = rotor_flash_decode_sdpa::<3>(
@@ -356,7 +369,7 @@ fn rotor_flash_decode_rejects_non_pow2_head_dim() {
         96,
         1,
         1.0,
-        Device::Gpu,
+        Device::Cpu,
     );
     assert!(
         err.is_err(),
@@ -366,9 +379,6 @@ fn rotor_flash_decode_rejects_non_pow2_head_dim() {
 
 #[test]
 fn rotor_flash_decode_rejects_head_dim_above_max() {
-    if skip_if_no_gpu_env() {
-        return;
-    }
     let dummy = make_f32_array(&[0.0], &[1]);
     let codes = make_u32_array(&[0], &[1]);
     let over = ROTOR_FLASH_HEAD_DIM_MAX * 2;
@@ -386,7 +396,7 @@ fn rotor_flash_decode_rejects_head_dim_above_max() {
         over,
         1,
         1.0,
-        Device::Gpu,
+        Device::Cpu,
     );
     assert!(
         err.is_err(),
@@ -396,9 +406,6 @@ fn rotor_flash_decode_rejects_head_dim_above_max() {
 
 #[test]
 fn rotor_flash_decode_rejects_unsupported_bits() {
-    if skip_if_no_gpu_env() {
-        return;
-    }
     let dummy = make_f32_array(&[0.0], &[1]);
     let codes = make_u32_array(&[0], &[1]);
     // An unknown bit width must be an explicit error, never a silent fallback
@@ -417,7 +424,7 @@ fn rotor_flash_decode_rejects_unsupported_bits() {
         128,
         1,
         1.0,
-        Device::Gpu,
+        Device::Cpu,
     );
     assert!(err.is_err(), "BITS=5 must be rejected");
 }
@@ -481,6 +488,7 @@ fn rotor_flash_header_exposes_reusable_decode_fn() {
 // fire") is asserted on cache-local state in
 // `kvcache::rotor_flash_dispatch_tests` instead.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode -- --include-ignored --test-threads=1"]
 fn rotor_flash_decode_dispatch_count_increments_on_gpu() {
     if skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/src/sparse_v_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/sparse_v_msl_tests.rs
@@ -85,7 +85,7 @@ fn ref_weighted_sum(
 /// Two sparse token positions per head: prob=0.5 and prob=0.5.
 /// All other probs = 0 (skipped). Expected acc = 0.5 * 0.5 + 0.5 * 0.5 = 0.5.
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test sparse_v_msl -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test sparse_v_msl -- --ignored --test-threads=1"]
 #[allow(
     clippy::expect_used,
     reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
@@ -162,7 +162,7 @@ fn test_sparse_v_basic_8bit() {
 
 /// Test: 4-bit, compare GPU kernel against reference CPU for 2 KV heads.
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test sparse_v_msl -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test sparse_v_msl -- --ignored --test-threads=1"]
 #[allow(
     clippy::expect_used,
     reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"

--- a/crates/rmlx-kv-quant/src/sparse_v_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/sparse_v_msl_tests.rs
@@ -85,6 +85,7 @@ fn ref_weighted_sum(
 /// Two sparse token positions per head: prob=0.5 and prob=0.5.
 /// All other probs = 0 (skipped). Expected acc = 0.5 * 0.5 + 0.5 * 0.5 = 0.5.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test sparse_v_msl -- --include-ignored --test-threads=1"]
 #[allow(
     clippy::expect_used,
     reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
@@ -161,6 +162,7 @@ fn test_sparse_v_basic_8bit() {
 
 /// Test: 4-bit, compare GPU kernel against reference CPU for 2 KV heads.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test sparse_v_msl -- --include-ignored --test-threads=1"]
 #[allow(
     clippy::expect_used,
     reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"

--- a/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring_tests.rs
@@ -60,6 +60,7 @@ const CODES_PER_STEP: usize = 4; // kv_h * n_groups = 2 * 2
 const NORMS_PER_STEP: usize = 2; // kv_h
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
 fn new_ring_is_unallocated_and_views_none() {
     if skip_if_no_gpu_env() {
         return;
@@ -75,6 +76,7 @@ fn new_ring_is_unallocated_and_views_none() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
 fn append_then_view_round_trips_payload() {
     if skip_if_no_gpu_env() {
         return;
@@ -107,6 +109,7 @@ fn append_then_view_round_trips_payload() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
 fn sequential_appends_land_at_increasing_offsets() {
     if skip_if_no_gpu_env() {
         return;
@@ -150,6 +153,7 @@ fn sequential_appends_land_at_increasing_offsets() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
 fn seed_from_cpu_then_append_preserves_prefix() {
     if skip_if_no_gpu_env() {
         return;
@@ -211,6 +215,7 @@ fn seed_from_cpu_then_append_preserves_prefix() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
 fn seed_is_a_no_op_once_allocated() {
     if skip_if_no_gpu_env() {
         return;
@@ -254,6 +259,7 @@ fn seed_is_a_no_op_once_allocated() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
 fn growth_across_a_page_boundary_preserves_prefix() {
     if skip_if_no_gpu_env() {
         return;
@@ -310,6 +316,7 @@ fn growth_across_a_page_boundary_preserves_prefix() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
 fn clear_drops_the_ring() {
     if skip_if_no_gpu_env() {
         return;
@@ -337,11 +344,16 @@ fn clear_drops_the_ring() {
         .is_none());
 }
 
+// ── Shape guards ─────────────────────────────────────────────────────────────
+//
+// Every guard below is rejected by a scalar shape check that runs before the
+// ring allocates or writes, so these pass `Device::Cpu` and stay un-ignored —
+// they are the cheap always-on half of the suite. Handing them `Device::Gpu`
+// would claim a Metal context they never reach and force them behind
+// `--ignored` with the tests that do.
+
 #[test]
 fn append_on_unallocated_ring_with_existing_prefix_errors() {
-    if skip_if_no_gpu_env() {
-        return;
-    }
     // The zeroed-prefix footgun: allocating here and writing only
     // [prev_seq, needed) would leave [0, prev_seq) as zeros — silently wrong
     // attention. Must be rejected rather than "helpfully" allocated.
@@ -355,7 +367,7 @@ fn append_on_unallocated_ring_with_existing_prefix_errors() {
         5, // prev_seq > 0 on an unallocated ring
         1,
         64,
-        Device::Gpu,
+        Device::Cpu,
     );
     assert!(
         err.is_err(),
@@ -370,9 +382,6 @@ fn append_on_unallocated_ring_with_existing_prefix_errors() {
 
 #[test]
 fn append_beyond_max_seq_errors() {
-    if skip_if_no_gpu_env() {
-        return;
-    }
     let mut ring = QuantKGpuRing::default();
     let err = ring.append_encoded(
         &u32_arr(&[1, 2, 3, 4]),
@@ -383,7 +392,7 @@ fn append_beyond_max_seq_errors() {
         8,
         1,
         8, // max_seq — prev_seq + new_seq = 9 > 8
-        Device::Gpu,
+        Device::Cpu,
     );
     assert!(
         err.is_err(),
@@ -393,9 +402,6 @@ fn append_beyond_max_seq_errors() {
 
 #[test]
 fn chunk_length_mismatch_errors() {
-    if skip_if_no_gpu_env() {
-        return;
-    }
     let mut ring = QuantKGpuRing::default();
     // Two positions' worth of codes declared as new_seq = 1.
     let err = ring.append_encoded(
@@ -407,7 +413,7 @@ fn chunk_length_mismatch_errors() {
         0,
         1,
         64,
-        Device::Gpu,
+        Device::Cpu,
     );
     assert!(
         err.is_err(),
@@ -417,9 +423,6 @@ fn chunk_length_mismatch_errors() {
 
 #[test]
 fn seed_length_mismatch_errors() {
-    if skip_if_no_gpu_env() {
-        return;
-    }
     let mut ring = QuantKGpuRing::default();
     let err = ring.seed_from_cpu(
         &[1, 2, 3], // not filled_seq * kv_h * n_groups
@@ -429,7 +432,7 @@ fn seed_length_mismatch_errors() {
         N_GROUPS,
         1,
         64,
-        Device::Gpu,
+        Device::Cpu,
     );
     assert!(
         err.is_err(),

--- a/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring_tests.rs
@@ -60,7 +60,7 @@ const CODES_PER_STEP: usize = 4; // kv_h * n_groups = 2 * 2
 const NORMS_PER_STEP: usize = 2; // kv_h
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --ignored --test-threads=1"]
 fn new_ring_is_unallocated_and_views_none() {
     if skip_if_no_gpu_env() {
         return;
@@ -76,7 +76,7 @@ fn new_ring_is_unallocated_and_views_none() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --ignored --test-threads=1"]
 fn append_then_view_round_trips_payload() {
     if skip_if_no_gpu_env() {
         return;
@@ -109,7 +109,7 @@ fn append_then_view_round_trips_payload() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --ignored --test-threads=1"]
 fn sequential_appends_land_at_increasing_offsets() {
     if skip_if_no_gpu_env() {
         return;
@@ -153,7 +153,7 @@ fn sequential_appends_land_at_increasing_offsets() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --ignored --test-threads=1"]
 fn seed_from_cpu_then_append_preserves_prefix() {
     if skip_if_no_gpu_env() {
         return;
@@ -215,7 +215,7 @@ fn seed_from_cpu_then_append_preserves_prefix() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --ignored --test-threads=1"]
 fn seed_is_a_no_op_once_allocated() {
     if skip_if_no_gpu_env() {
         return;
@@ -259,7 +259,7 @@ fn seed_is_a_no_op_once_allocated() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --ignored --test-threads=1"]
 fn growth_across_a_page_boundary_preserves_prefix() {
     if skip_if_no_gpu_env() {
         return;
@@ -316,7 +316,7 @@ fn growth_across_a_page_boundary_preserves_prefix() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_k_gpu_ring -- --ignored --test-threads=1"]
 fn clear_drops_the_ring() {
     if skip_if_no_gpu_env() {
         return;
@@ -346,11 +346,18 @@ fn clear_drops_the_ring() {
 
 // ── Shape guards ─────────────────────────────────────────────────────────────
 //
-// Every guard below is rejected by a scalar shape check that runs before the
-// ring allocates or writes, so these pass `Device::Cpu` and stay un-ignored —
-// they are the cheap always-on half of the suite. Handing them `Device::Gpu`
-// would claim a Metal context they never reach and force them behind
-// `--ignored` with the tests that do.
+// These assert that a malformed append / seed is rejected. None of them needs a
+// Metal context, so they pass `Device::Cpu` and stay un-ignored — the cheap
+// always-on half of the suite.
+//
+// The device argument is **load-bearing in `chunk_length_mismatch_errors`**,
+// not incidental: `prev_seq = 0` on an unallocated ring clears every
+// pre-allocation check, so the ring really does allocate (`alloc` -> `zeros`)
+// and only then does `write_range` catch the length mismatch. Passing
+// `Device::Gpu` there would make that a live Metal allocation and drag the test
+// behind `--ignored`. The other three are rejected before the ring allocates at
+// all: `prev_seq > 0` on an unallocated ring, `prev_seq + new_seq > max_seq`,
+// and the `seed_from_cpu` stride check all return first.
 
 #[test]
 fn append_on_unallocated_ring_with_existing_prefix_errors() {

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
@@ -247,7 +247,7 @@ fn seed_ring_via_gpu_append(
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test quant_rotor_k3 -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_rotor_k3 -- --ignored --test-threads=1"]
 fn quant_rotor_k3_reset_drops_the_gpu_ring() {
     if crate::test_utils::skip_if_no_gpu_env() {
         return;
@@ -267,7 +267,7 @@ fn quant_rotor_k3_reset_drops_the_gpu_ring() {
 }
 
 #[test]
-#[ignore = "GPU Metal context — run in isolation: cargo test quant_rotor_k3 -- --include-ignored --test-threads=1"]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_rotor_k3 -- --ignored --test-threads=1"]
 fn quant_rotor_k3_truncate_to_drops_the_gpu_ring() {
     if crate::test_utils::skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
@@ -247,6 +247,7 @@ fn seed_ring_via_gpu_append(
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_rotor_k3 -- --include-ignored --test-threads=1"]
 fn quant_rotor_k3_reset_drops_the_gpu_ring() {
     if crate::test_utils::skip_if_no_gpu_env() {
         return;
@@ -266,6 +267,7 @@ fn quant_rotor_k3_reset_drops_the_gpu_ring() {
 }
 
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test quant_rotor_k3 -- --include-ignored --test-threads=1"]
 fn quant_rotor_k3_truncate_to_drops_the_gpu_ring() {
     if crate::test_utils::skip_if_no_gpu_env() {
         return;

--- a/crates/rmlx-kv-quant/tests/rotor_decode_grow_legacy.rs
+++ b/crates/rmlx-kv-quant/tests/rotor_decode_grow_legacy.rs
@@ -123,11 +123,13 @@ fn legacy_path_grows(quant: KvQuant, label: &str) {
 }
 
 #[test]
+#[ignore = "GPU Metal context: cargo test -p rmlx-kv-quant --test rotor_decode_grow_legacy -- --ignored --test-threads=1"]
 fn rotor3_legacy_path_decode_grows_past_a_saturated_max_seq() {
     legacy_path_grows(KvQuant::RotorKOnly3, "rotor3");
 }
 
 #[test]
+#[ignore = "GPU Metal context: cargo test -p rmlx-kv-quant --test rotor_decode_grow_legacy -- --ignored --test-threads=1"]
 fn rotor4_legacy_path_decode_grows_past_a_saturated_max_seq() {
     legacy_path_grows(KvQuant::RotorKOnly4, "rotor4");
 }
@@ -136,6 +138,7 @@ fn rotor4_legacy_path_decode_grows_past_a_saturated_max_seq() {
 /// pins that the growth is shape-independent rather than traded from one shape
 /// to another.
 #[test]
+#[ignore = "GPU Metal context: cargo test -p rmlx-kv-quant --test rotor_decode_grow_legacy -- --ignored --test-threads=1"]
 fn rotor3_fused_path_still_grows_at_power_of_two_head_dim() {
     if skip_gpu() {
         return;

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -107,11 +107,49 @@ When env vars are unset, all snapshot-gated tests **skip** with an `[SKIP]` or
 `tracing::warn!` message and report success. The test suite is always green on
 machines without model snapshots (including CI).
 
-GPU-intensive tests are additionally marked `#[ignore]` and must be run
-explicitly:
+---
+
+## Metal-context `#[ignore]` convention (enforced)
+
+A test that drives the GPU is marked `#[ignore]` and run explicitly:
 
 ```bash
 cargo test --test embeddings_smoke -- --ignored --test-threads=1
+cargo test -p rmlx-kv-quant --lib -- --ignored <filter> --test-threads=1
+```
+
+This is a correctness requirement, not a runtime-saving convenience. `cargo
+test` runs a binary's tests on parallel threads, and a shared Metal context
+driven from several of them aborts the **whole process**:
+
+```
+fatal runtime error: Rust cannot catch foreign exceptions, aborting
+```
+
+Every other test in the crate dies with it. The failure is load-dependent — a
+couple of parallel GPU tests can pass for a long time before enough of them
+tip the binary over — and each one still passes when run alone, so a PR's own
+targeted run looks green. That is why the rule is mechanical rather than
+judgement-based.
+
+**Which tests get the attribute:** those that reach `Device::Gpu`, directly or
+through a helper. A guard that only exercises a shape check the dispatcher
+rejects before it touches a device-parameterized op is **not** a GPU test —
+pass it `Device::Cpu` and leave it un-ignored, so it keeps running in the
+default gate. Ignoring a CPU test is how a test silently stops running.
+
+`make check-gpu-tests-ignored` enforces this for `rmlx-kv-quant` and runs in
+`make ci` and in the hosted `source gates` job. It keys on the shape (does the
+test reach `Device::Gpu`?), never on the ignore reason's wording, which varies
+across the crate.
+
+### `#[ignore]` is not a place to park a broken test
+
+An ignored test runs only when someone asks for it, so a real failure can sit
+in the tree indefinitely. Run the ignored suites when touching a codec:
+
+```bash
+cargo test -p rmlx-kv-quant --lib -- --ignored --test-threads=1
 ```
 
 ---

--- a/scripts/check_gpu_tests_ignored.sh
+++ b/scripts/check_gpu_tests_ignored.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# scripts/check_gpu_tests_ignored.sh — CI gate: fail if a GPU-touching test in
+# rmlx-kv-quant is missing the `#[ignore]` Metal-context attribute.
+#
+# WHY
+#   A shared Metal context cannot be driven from parallel test threads. A GPU
+#   test left un-ignored runs under the default `cargo test` alongside its
+#   siblings and aborts the whole binary ("Rust cannot catch foreign
+#   exceptions"), taking every other test in the crate down with it. Such tests
+#   pass when run in isolation, so a PR's own targeted run looks green — the
+#   drift only surfaces on a full `cargo test --workspace`.
+#
+# WHAT COUNTS AS GPU-TOUCHING (shape, not message)
+#   A `#[test]` fn that reaches `Device::Gpu`, directly in its own body or
+#   transitively through a file-local helper it calls. The check keys on that
+#   shape alone — it never matches on the ignore *reason* text, which varies
+#   across the crate and would make the gate green while the class stayed live.
+#
+# THE FIX FOR A VIOLATION — pick the one that is true:
+#   * The test really drives the GPU -> add the attribute:
+#       #[ignore = "GPU Metal context — run in isolation: \
+#                   cargo test <filter> -- --include-ignored --test-threads=1"]
+#   * The test only exercises a CPU-side guard that returns before any
+#     device-parameterized op -> pass `Device::Cpu`, and leave it un-ignored so
+#     it keeps running in the default gate.
+#
+# PARSING
+#   Relies on rustfmt layout (already enforced by `make fmt-check`): top-level
+#   `fn` items start at column 0 and close with `}` at column 0. That makes
+#   brace/string depth tracking unnecessary.
+#
+# Exit 0 = clean. Exit 1 = violation found.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CRATE_SRC="${REPO_ROOT}/crates/rmlx-kv-quant/src"
+
+violations=""
+
+while IFS= read -r -d '' f; do
+    out=$(awk -v fname="$f" '
+        # ── Multi-line attribute continuation ────────────────────────────────
+        in_attr {
+            attrs = attrs " " $0
+            if ($0 ~ /^\)\]/) { in_attr = 0 }
+            next
+        }
+        # ── Attribute at column 0 ───────────────────────────────────────────
+        /^#\[/ {
+            attrs = attrs " " $0
+            if ($0 !~ /\]$/) { in_attr = 1 }
+            next
+        }
+        # ── Comments / doc comments keep the pending attribute block ────────
+        /^\/\// { next }
+        # ── Top-level fn item ───────────────────────────────────────────────
+        /^(pub[^ ]* )?(async )?fn [a-zA-Z0-9_]+/ {
+            name = $0
+            sub(/^(pub[^ ]* )?(async )?fn /, "", name)
+            sub(/[^a-zA-Z0-9_].*$/, "", name)
+            order[++n] = name
+            fn_attrs[name] = attrs
+            body[name] = $0
+            cur = name
+            in_fn = 1
+            attrs = ""
+            next
+        }
+        # ── Close of a top-level item ───────────────────────────────────────
+        /^\}/ {
+            in_fn = 0
+            cur = ""
+            attrs = ""
+            next
+        }
+        # Body lines, with line comments stripped: prose that names a GPU
+        # helper or Device::Gpu must not make the fn look GPU-touching.
+        in_fn {
+            line = $0
+            sub(/\/\/.*$/, "", line)
+            body[cur] = body[cur] " " line
+            next
+        }
+        # Any other column-0 line drops a dangling attribute block.
+        /^[^[:space:]]/ { attrs = "" }
+
+        END {
+            # Seed: fns that name Device::Gpu in their own body.
+            for (f_ in body) {
+                gpu[f_] = (body[f_] ~ /Device::Gpu/) ? 1 : 0
+            }
+            # Fixed point: a fn that *calls* a GPU-reaching fn is GPU-reaching.
+            # Match a call site (`name(`), not a bare mention, so a name in a
+            # doc reference or a string does not propagate.
+            changed = 1
+            while (changed) {
+                changed = 0
+                for (caller in body) {
+                    if (gpu[caller]) { continue }
+                    for (callee in body) {
+                        if (caller == callee || !gpu[callee]) { continue }
+                        if (body[caller] ~ ("(^|[^a-zA-Z0-9_])" callee "[[:space:]]*\\(")) {
+                            gpu[caller] = 1
+                            changed = 1
+                            break
+                        }
+                    }
+                }
+            }
+            for (i = 1; i <= n; i++) {
+                f_ = order[i]
+                if (fn_attrs[f_] !~ /#\[test\]/) { continue }
+                if (!gpu[f_]) { continue }
+                if (fn_attrs[f_] ~ /#\[ignore/) { continue }
+                printf "  %s: %s\n", fname, f_
+            }
+        }
+    ' "$f")
+    if [ -n "$out" ]; then
+        violations="${violations}${out}"$'\n'
+    fi
+done < <(find "${CRATE_SRC}" -name "*_tests.rs" -not -path "*/target/*" -print0)
+
+if [ -n "$violations" ]; then
+    echo "ERROR: GPU-touching tests in rmlx-kv-quant missing the #[ignore] Metal-context attribute:" >&2
+    printf '%s' "$violations" >&2
+    echo >&2
+    echo "A shared Metal context cannot be driven from parallel test threads: an" >&2
+    echo "un-ignored GPU test aborts the whole test binary under a plain" >&2
+    echo "\`cargo test\`, killing every other test in the crate." >&2
+    echo >&2
+    echo "Add to each test that really drives the GPU:" >&2
+    echo "  #[ignore = \"GPU Metal context — run in isolation: cargo test <filter> -- --include-ignored --test-threads=1\"]" >&2
+    echo >&2
+    echo "If the test only exercises a CPU-side guard that returns before any" >&2
+    echo "device-parameterized op, pass Device::Cpu instead and leave it un-ignored." >&2
+    exit 1
+fi
+
+echo "OK: every GPU-touching test in rmlx-kv-quant carries #[ignore]."

--- a/scripts/check_gpu_tests_ignored.sh
+++ b/scripts/check_gpu_tests_ignored.sh
@@ -6,69 +6,115 @@
 #   A shared Metal context cannot be driven from parallel test threads. A GPU
 #   test left un-ignored runs under the default `cargo test` alongside its
 #   siblings and aborts the whole binary ("Rust cannot catch foreign
-#   exceptions"), taking every other test in the crate down with it. Such tests
-#   pass when run in isolation, so a PR's own targeted run looks green — the
-#   drift only surfaces on a full `cargo test --workspace`.
+#   exceptions"), taking every other test in that binary down with it. Such
+#   tests pass when run in isolation, so a PR's own targeted run looks green.
+#   The abort is load-dependent — a couple of parallel GPU tests can pass for a
+#   long time before enough of them tip the binary over — so "it passes today"
+#   is not evidence of compliance. That is why this is a static gate.
+#
+# SCOPE
+#   Both test roots of the crate: unit tests (`src/**/*_tests.rs`) and the
+#   integration binaries (`tests/*.rs`). `cargo test -p rmlx-kv-quant --lib`
+#   does not build `tests/` at all, so a check scoped to `src/` alone would
+#   mirror exactly the blind spot it exists to catch.
 #
 # WHAT COUNTS AS GPU-TOUCHING (shape, not message)
 #   A `#[test]` fn that reaches `Device::Gpu`, directly in its own body or
-#   transitively through a file-local helper it calls. The check keys on that
-#   shape alone — it never matches on the ignore *reason* text, which varies
-#   across the crate and would make the gate green while the class stayed live.
+#   transitively through a helper it calls (including generic helpers called
+#   with a turbofish, and methods on an inherent impl). The check keys on that
+#   shape alone — never on the ignore *reason* text, which varies across the
+#   crate and would make the gate green while the class stayed live.
 #
 # THE FIX FOR A VIOLATION — pick the one that is true:
 #   * The test really drives the GPU -> add the attribute:
 #       #[ignore = "GPU Metal context — run in isolation: \
-#                   cargo test <filter> -- --include-ignored --test-threads=1"]
-#   * The test only exercises a CPU-side guard that returns before any
-#     device-parameterized op -> pass `Device::Cpu`, and leave it un-ignored so
-#     it keeps running in the default gate.
+#                   cargo test <filter> -- --ignored --test-threads=1"]
+#   * The test only exercises a guard that returns before any GPU work ->
+#     pass `Device::Cpu`, and leave it un-ignored so it keeps running in the
+#     default gate.
+#
+# Also emits a non-fatal WARNING for the converse — a test whose `#[ignore]`
+# claims a Metal context but which never reaches `Device::Gpu`. That is a test
+# that has silently stopped running. It is a warning, not a failure: some
+# ignores are legitimately non-GPU (e.g. "requires mlx runtime").
 #
 # PARSING
-#   Relies on rustfmt layout (already enforced by `make fmt-check`): top-level
-#   `fn` items start at column 0 and close with `}` at column 0. That makes
-#   brace/string depth tracking unnecessary.
+#   Relies on rustfmt layout (already enforced by `make fmt-check`): a `fn`
+#   item's closing brace sits at the same indent as its `fn` keyword. That
+#   makes brace/string depth tracking unnecessary.
 #
-# Exit 0 = clean. Exit 1 = violation found.
+# Exit 0 = clean. Exit 1 = violation (or a scan that found nothing to check).
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CRATE_SRC="${REPO_ROOT}/crates/rmlx-kv-quant/src"
+CRATE_TESTS="${REPO_ROOT}/crates/rmlx-kv-quant/tests"
+
+# Fail closed. A moved or renamed crate must break this gate loudly rather than
+# let it report OK over an empty scan — this crate has been extracted once
+# already (see the workspace dep graph in CLAUDE.md).
+for root in "${CRATE_SRC}" "${CRATE_TESTS}"; do
+    if [ ! -d "${root}" ]; then
+        echo "ERROR: ${root} does not exist — this gate is scanning nothing." >&2
+        echo "The crate moved or was renamed; update the roots in check_gpu_tests_ignored.sh." >&2
+        exit 1
+    fi
+done
+
+scan_files=()
+while IFS= read -r -d '' f; do scan_files+=("$f"); done < <(
+    find "${CRATE_SRC}" -name "*_tests.rs" -not -path "*/target/*" -print0
+)
+while IFS= read -r -d '' f; do scan_files+=("$f"); done < <(
+    find "${CRATE_TESTS}" -name "*.rs" -not -path "*/target/*" -print0
+)
+
+if [ ${#scan_files[@]} -eq 0 ]; then
+    echo "ERROR: matched 0 test files under ${CRATE_SRC} and ${CRATE_TESTS}." >&2
+    echo "A gate that scans nothing passes everything; refusing to report OK." >&2
+    exit 1
+fi
 
 violations=""
+warnings=""
 
-while IFS= read -r -d '' f; do
+for f in "${scan_files[@]}"; do
     out=$(awk -v fname="$f" '
         # ── Multi-line attribute continuation ────────────────────────────────
         in_attr {
             attrs = attrs " " $0
-            if ($0 ~ /^\)\]/) { in_attr = 0 }
+            if ($0 ~ /^[[:space:]]*\)\]/) { in_attr = 0 }
             next
         }
-        # ── Attribute at column 0 ───────────────────────────────────────────
-        /^#\[/ {
+        # ── Attribute (any indent) ──────────────────────────────────────────
+        /^[[:space:]]*#\[/ {
             attrs = attrs " " $0
-            if ($0 !~ /\]$/) { in_attr = 1 }
+            if ($0 !~ /\][[:space:]]*$/) { in_attr = 1 }
             next
         }
         # ── Comments / doc comments keep the pending attribute block ────────
-        /^\/\// { next }
-        # ── Top-level fn item ───────────────────────────────────────────────
-        /^(pub[^ ]* )?(async )?fn [a-zA-Z0-9_]+/ {
-            name = $0
-            sub(/^(pub[^ ]* )?(async )?fn /, "", name)
+        /^[[:space:]]*\/\// { next }
+
+        # ── fn item at any indent (top-level or inside an inherent impl) ────
+        !in_fn && /^[[:space:]]*(pub[^ ]* )?(async )?fn [a-zA-Z0-9_]+/ {
+            line = $0
+            indent = line
+            sub(/[^[:space:]].*$/, "", indent)   # leading whitespace only
+            name = line
+            sub(/^[[:space:]]*(pub[^ ]* )?(async )?fn /, "", name)
             sub(/[^a-zA-Z0-9_].*$/, "", name)
             order[++n] = name
             fn_attrs[name] = attrs
-            body[name] = $0
+            body[name] = line
             cur = name
             in_fn = 1
+            close_marker = indent "}"
             attrs = ""
             next
         }
-        # ── Close of a top-level item ───────────────────────────────────────
-        /^\}/ {
+        # ── Close of the captured fn: `}` at the fn keyword indent ──────────
+        in_fn && $0 == close_marker {
             in_fn = 0
             cur = ""
             attrs = ""
@@ -82,8 +128,8 @@ while IFS= read -r -d '' f; do
             body[cur] = body[cur] " " line
             next
         }
-        # Any other column-0 line drops a dangling attribute block.
-        /^[^[:space:]]/ { attrs = "" }
+        # Any other line drops a dangling attribute block.
+        /^[[:space:]]*[^[:space:]]/ { attrs = "" }
 
         END {
             # Seed: fns that name Device::Gpu in their own body.
@@ -91,8 +137,9 @@ while IFS= read -r -d '' f; do
                 gpu[f_] = (body[f_] ~ /Device::Gpu/) ? 1 : 0
             }
             # Fixed point: a fn that *calls* a GPU-reaching fn is GPU-reaching.
-            # Match a call site (`name(`), not a bare mention, so a name in a
-            # doc reference or a string does not propagate.
+            # Match a call site — `name(` or `name::<T>(` (turbofish) — not a
+            # bare mention, so a name in a doc reference or a string does not
+            # propagate. A leading `.` is admitted so method calls count.
             changed = 1
             while (changed) {
                 changed = 0
@@ -100,7 +147,8 @@ while IFS= read -r -d '' f; do
                     if (gpu[caller]) { continue }
                     for (callee in body) {
                         if (caller == callee || !gpu[callee]) { continue }
-                        if (body[caller] ~ ("(^|[^a-zA-Z0-9_])" callee "[[:space:]]*\\(")) {
+                        if (body[caller] ~ ("(^|[^a-zA-Z0-9_])" callee \
+                                            "([[:space:]]*::[[:space:]]*<[^;{]*>)?[[:space:]]*\\(")) {
                             gpu[caller] = 1
                             changed = 1
                             break
@@ -111,16 +159,34 @@ while IFS= read -r -d '' f; do
             for (i = 1; i <= n; i++) {
                 f_ = order[i]
                 if (fn_attrs[f_] !~ /#\[test\]/) { continue }
-                if (!gpu[f_]) { continue }
-                if (fn_attrs[f_] ~ /#\[ignore/) { continue }
-                printf "  %s: %s\n", fname, f_
+                has_ignore = (fn_attrs[f_] ~ /#\[ignore/)
+                if (gpu[f_] && !has_ignore) {
+                    printf "V  %s: %s\n", fname, f_
+                }
+                # Converse: an ignore claiming a Metal context on a test that
+                # never reaches one. Warn — the test has stopped running.
+                if (!gpu[f_] && has_ignore && fn_attrs[f_] ~ /#\[ignore[^]]*([Mm]etal|GPU)/) {
+                    printf "W  %s: %s\n", fname, f_
+                }
             }
         }
     ' "$f")
-    if [ -n "$out" ]; then
-        violations="${violations}${out}"$'\n'
-    fi
-done < <(find "${CRATE_SRC}" -name "*_tests.rs" -not -path "*/target/*" -print0)
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        case "$line" in
+            "V  "*) violations="${violations}  ${line#V  }"$'\n' ;;
+            "W  "*) warnings="${warnings}  ${line#W  }"$'\n' ;;
+        esac
+    done <<< "$out"
+done
+
+if [ -n "$warnings" ]; then
+    echo "WARNING: tests whose #[ignore] claims a Metal context but that never reach Device::Gpu:" >&2
+    printf '%s' "$warnings" >&2
+    echo "  -> an ignored CPU test is a test that silently stopped running." >&2
+    echo "     Drop the #[ignore] (and pass Device::Cpu) if it does not touch the GPU." >&2
+    echo >&2
+fi
 
 if [ -n "$violations" ]; then
     echo "ERROR: GPU-touching tests in rmlx-kv-quant missing the #[ignore] Metal-context attribute:" >&2
@@ -128,14 +194,14 @@ if [ -n "$violations" ]; then
     echo >&2
     echo "A shared Metal context cannot be driven from parallel test threads: an" >&2
     echo "un-ignored GPU test aborts the whole test binary under a plain" >&2
-    echo "\`cargo test\`, killing every other test in the crate." >&2
+    echo "\`cargo test\`, killing every other test in it." >&2
     echo >&2
     echo "Add to each test that really drives the GPU:" >&2
-    echo "  #[ignore = \"GPU Metal context — run in isolation: cargo test <filter> -- --include-ignored --test-threads=1\"]" >&2
+    echo "  #[ignore = \"GPU Metal context — run in isolation: cargo test <filter> -- --ignored --test-threads=1\"]" >&2
     echo >&2
-    echo "If the test only exercises a CPU-side guard that returns before any" >&2
-    echo "device-parameterized op, pass Device::Cpu instead and leave it un-ignored." >&2
+    echo "If the test only exercises a guard that returns before any GPU work," >&2
+    echo "pass Device::Cpu instead and leave it un-ignored." >&2
     exit 1
 fi
 
-echo "OK: every GPU-touching test in rmlx-kv-quant carries #[ignore]."
+echo "OK: every GPU-touching test in rmlx-kv-quant carries #[ignore] (${#scan_files[@]} files scanned)."


### PR DESCRIPTION
Fixes #252.

## What was wrong

`cargo test -p rmlx-kv-quant` aborted the whole test binary — a shared Metal context cannot be driven from parallel test threads:

```
fatal runtime error: Rust cannot catch foreign exceptions, aborting
process didn't exit successfully: ... (signal: 6, SIGABRT)
```

## The issue's diagnosis was directionally right, but its inventory was not

The issue scoped this to **46 tests in 2 files** from #217/#218. Measured, the class is **78 GPU-touching tests across 10 files**, and fixing only the two named files still aborts (verified). Contributors: #217, #218, #228, #233, plus **5 that predate all of them**.

The failure is also **load-dependent**, not all-or-nothing: those pre-existing un-ignored GPU tests pass in parallel today. Enough new ones landed together to tip the binary over — which is why this looked like a clean two-PR regression. "It passes today" is not evidence of compliance, which is why the gate is static.

## Classification — by shape, not by file

Per the issue's constraint (*"a pure-CPU test that gets ignored is a test that silently stops running"*), each test was classified by whether it actually reaches Metal:

| Class | Count | Treatment |
|---|---|---|
| Reaches `Device::Gpu` (directly, via helper, turbofish, or method) | 67 | `#[ignore]` |
| Guard that returns before any GPU work | 11 | `Device::Cpu`, left un-ignored |
| Pure CPU (header builders, probe snapshots, algebra) | — | untouched |

The 11 were handed `Device::Gpu` but do not need it. Ignoring them would have silently retired live guards. This matches the `planar_flash_decode_msl_tests.rs` precedent.

## Verification

- `cargo test -p rmlx-kv-quant` (no `--lib`) → all binaries ok, **0 FAILED**
- `make ci` → **green end-to-end** (`ci ok`, `advisories ok` since #255): workspace **2492 passed, 0 failed**, all 5 static gates OK
- All 67 newly-ignored tests pass in isolation.

**Mutation-checked that the guards still bite** (each reverted after):

| Mutation | Result |
|---|---|
| seq-major → head-major K index | 10 of 16 iso parity tests FAIL (the 6 that pass are `kv_h=1`, where the layouts are identical) |
| transposed additive-mask index | exactly the 4 mask tests FAIL |
| `bits=4` dispatched through a 3-bit unpack header | exactly the 8 iso4 tests FAIL — **while the default non-ignored run stays green** |

That last one is the point: these tests are the only thing between that defect class and a release.

## Gate

`make check-gpu-tests-ignored` — same shape as `check-no-inline-tests` / `check-no-decode-swallow`. Keys on **shape** (does the test reach `Device::Gpu`, transitively?), never on the ignore reason's prose — a message-keyed gate has previously been green here while its class was live.

Scans **both** test roots (`src/**/*_tests.rs` and `tests/*.rs`). A gate scoped to `src/` alone would mirror exactly the blind spot it exists to catch — see below.

Mutation-checked, each proven to fail:

| Gate mutation | Result |
|---|---|
| Remove one `#[ignore]` | red, names the exact test |
| GPU test reaching Metal only via a helper | caught |
| `#[ignore = "banana"]` | green — keys on the attribute, not its wording |
| Root points at a nonexistent dir | red (was: silent `OK`) |
| Roots exist but match zero files | red (was: silent `OK`) |
| Turbofish call `helper::<3>(x)` | caught (old gate: silent) |
| Method on an inherent impl | caught (old gate: silent) |
| Metal-claiming `#[ignore]` parked on a CPU test | warns, does not fail; legitimate `requires mlx runtime` ignores not flagged |

Wired into `make ci` **and** a hosted `source gates` job (ubuntu, 7s — bash+awk, no toolchain/mlx-c/GPU). `make ci` runs the gate after `test`, so it never fires there; the drift is only visible where no tests run, which is the hosted CI.

## Review follow-up: the instrument had the same blind spot as the bug

The first round verified with `cargo test -p rmlx-kv-quant **--lib**`, which excludes `tests/` **by construction**. Three un-ignored GPU tests were live in `tests/rotor_decode_grow_legacy.rs` and the instrument could not see them. Both the gate and the verification command are corrected; re-running the full inventory against the corrected scope found exactly those 3 and nothing further.

Also corrected a comment that claimed a stronger property than the code has: `chunk_length_mismatch_errors` passes `prev_seq = 0` on an unallocated ring, clears every pre-allocation check, and *does* allocate (`alloc` → `zeros`) before `write_range` catches the mismatch. `Device::Cpu` is **load-bearing** there, not incidental. The outcome was right; the stated reason was not — and that comment is the rule the next contributor applies to the next test.

## Pre-existing problem found, deliberately not fixed here

**`tcq_v2_msl` is broken on `main`** (#256) — 2 tests fail with `Unable to load kernel custom_kernel_rmlx_tcq2_quantize`. Reproduced on clean `main`; that module is untouched here. Already `#[ignore]`d, so nobody was running it — exactly the rot that ignoring invites, and the reason this PR adds the converse warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)