### PR TITLE
fix(deps): move spin off yanked 0.9.8 to unyanked 0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spm_precompiled"


### PR DESCRIPTION
## Summary
- `cargo deny check advisories` was RED on `main`: `spin 0.9.8` (transitive via `multer 3.1.0 -> axum 0.8.9 -> rmlx-server -> rmlx-cli`) was yanked from crates.io.
- Research: spin's entire pre-existing `0.9.x` line was mass-yanked on 2026-07-13, alongside a fresh `0.9.9` patch release published the same day that remains unyanked (verified live against crates.io: `yanked: false`). `multer 3.1.0` pins `spin = "^0.9"`, so `0.9.9` satisfies its own semver requirement — no `Cargo.toml` edit needed anywhere in the tree.
- Fix is `cargo update -p spin`, a lockfile-only move. Diffed `Cargo.lock`: only the `spin` entry changed (`version` 0.9.8 -> 0.9.9, `checksum`); no other package moved.

## Test plan
- [x] `make deny` -> `advisories ok, bans ok, licenses ok, sources ok`
- [x] `make audit` -> exit 0, "Scanning Cargo.lock for vulnerabilities (355 crate dependencies)", no findings
- [x] `cargo build --workspace --release` -> `Finished release profile [optimized + debuginfo] target(s) in 3m 00s`
- [x] `cargo tree -i spin` -> single resolved entry, `spin v0.9.9`
- [x] `cargo test --workspace` -> 333 passed; one pre-existing SIGSEGV in `rmlx-kv-quant --lib` (GPU Metal test parallelism, tracked separately in PR #254) reproduces identically on unmodified `main` with this change stashed out — confirmed not caused by this bump.

Fixes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)