### PR TITLE
fix(kv): derive KV byte totals from real allocations — count the GPU ring (#246)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ Development runs at **info level** by default. Logs accumulate as a runtime-beha
 
 - **Log dir**: `<RMLX_HOME>/logs/` (resolved via `rmlx_core::paths::logs_dir()`).
 - **Verbosity flag**: `--log {info|debug|verbose}` (CLI-wide). `info` is the default; `debug` enables per-step phase events; `verbose` enables per-token / per-FFI / per-layer trace events.
-- **Per-token / per-layer trace events (e.g. `kv_bytes`) default OFF**; opt in with `--log verbose` or `RUST_LOG=...=trace`. This keeps `tracing` overhead out of steady-state decode.
+- **Per-token / per-layer trace events (e.g. per-token `token_id`, per-FFI dispatch) default OFF**; opt in with `--log verbose` or `RUST_LOG=...=trace`. This keeps `tracing` overhead out of steady-state decode. Level gating hides the *emission* cost, not the cost of *computing* a field: an event whose field is an O(seq) call still makes decode quadratic once the level is enabled. Compute such fields at request boundaries and emit them there (`kv_bytes` is one — it is a per-request `debug!`, not a per-layer `trace!`).
 - **EnvFilter precedence**: `RUST_LOG` (if set) > `--log` preset. `RUST_LOG=debug,rmlx=trace` remains the explicit escape hatch.
 - **Run-id**: `YYYYMMDD-HHMMSS-<version>`. One file per run: `<run-id>.jsonl`. (The binary does no git of any kind — see `docs/METRICS_DB.md` §8.5.1 — so the discriminator is the backend semver, not a commit SHA.)
 - **Total-size rotation**: at startup, oldest files are deleted until the directory total is ≤ `RMLX_LOG_CAP_MB` (default 100 MB). The in-flight log file is never a deletion candidate (rotation runs before the appender opens).

--- a/crates/rmlx-kv-quant/src/bytes.rs
+++ b/crates/rmlx-kv-quant/src/bytes.rs
@@ -1,0 +1,50 @@
+//! Byte-accounting primitives shared by every KV store's `byte_size`.
+//!
+//! # Why these exist
+//!
+//! KV byte totals are the number the quantized codecs are accepted or rejected
+//! on. The only way that number stays true as stores gain buffers is if it is
+//! *derived* from the allocations themselves — never restated as a per-codec
+//! formula that a reader has to remember to update.
+//!
+//! So each store's `byte_size` is built from these two primitives only:
+//!
+//! - [`array_bytes`] / [`opt_array_bytes`] — an `Array`'s real shape × dtype
+//!   item size. Picks up a dtype or capacity change for free.
+//! - [`vec_bytes`] / [`opt_vec_bytes`] — a `Vec`'s real length × element size.
+//!
+//! # The drift guard
+//!
+//! Every `byte_size` opens with an exhaustive `let Self { .. } = self`
+//! destructure that names **all** fields and binds non-payload ones to `_`.
+//! Adding a buffer to a store is then a hard compile error (E0027, "pattern
+//! does not mention field") until the author classifies it as payload or
+//! metadata. That is deliberate: the alternative — a `..` rest-pattern — is
+//! what let a GPU ring live in these stores while the byte total stayed
+//! silently blind to it.
+
+use rmlx_mlx::Array;
+
+/// Bytes an `Array` occupies: element count × dtype item size.
+///
+/// Reads the live shape, so a buffer that grew (or changed dtype) reports its
+/// new size with no formula to update. No FFI eval — safe to call anywhere.
+pub(crate) fn array_bytes(a: &Array) -> u64 {
+    let n: u64 = a.shape().iter().map(|&d| d as u64).product();
+    n * a.dtype().itemsize() as u64
+}
+
+/// [`array_bytes`] for an optional buffer; unallocated (`None`) is 0 bytes.
+pub(crate) fn opt_array_bytes(a: Option<&Array>) -> u64 {
+    a.map_or(0, array_bytes)
+}
+
+/// Bytes a slice occupies: length × element size.
+pub(crate) fn vec_bytes<T>(v: &[T]) -> u64 {
+    v.len() as u64 * size_of::<T>() as u64
+}
+
+/// [`vec_bytes`] for an optional payload; absent (`None`) is 0 bytes.
+pub(crate) fn opt_vec_bytes<T>(v: Option<&Vec<T>>) -> u64 {
+    v.map_or(0, |v| vec_bytes(v))
+}

--- a/crates/rmlx-kv-quant/src/bytes.rs
+++ b/crates/rmlx-kv-quant/src/bytes.rs
@@ -48,3 +48,33 @@ pub(crate) fn vec_bytes<T>(v: &[T]) -> u64 {
 pub(crate) fn opt_vec_bytes<T>(v: Option<&Vec<T>>) -> u64 {
     v.map_or(0, |v| vec_bytes(v))
 }
+
+/// Bytes of the *filled* prefix of a `[B, kv_h, seq, D]` per-position buffer.
+///
+/// The bf16 decode mirrors and the SWA ring are pre-allocated to a ceiling and
+/// only compacted later, so the same configuration would report different
+/// totals depending on when the metric is read. Only `filled` positions ever
+/// hold live K/V. Scaling by the filled length — using the buffer's own
+/// per-position size, so per-layer head_dim and dtype are picked up — keeps the
+/// figure comparable across contexts.
+///
+/// A buffer that is not the 4-D per-position shape is counted whole: it has no
+/// sequence axis to take a prefix of.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "indices 0..=3 are bounds-checked by the `s.len() != 4` early return above"
+)]
+pub(crate) fn filled_seq_bytes(a: &Array, filled: u64) -> u64 {
+    let s = a.shape();
+    if s.len() != 4 {
+        return array_bytes(a);
+    }
+    let per_pos = s[0] as u64 * s[1] as u64 * s[3] as u64 * a.dtype().itemsize() as u64;
+    let cap = s[2] as u64;
+    per_pos * filled.min(cap)
+}
+
+/// [`filled_seq_bytes`] for an optional buffer; unallocated (`None`) is 0 bytes.
+pub(crate) fn opt_filled_seq_bytes(a: Option<&Array>, filled: u64) -> u64 {
+    a.map_or(0, |a| filled_seq_bytes(a, filled))
+}

--- a/crates/rmlx-kv-quant/src/kvcache/fused_qk_shadow.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/fused_qk_shadow.rs
@@ -239,6 +239,30 @@ pub(crate) struct FusedQkShadow {
 }
 
 impl FusedQkShadow {
+    /// Resident bytes of the shadow's head-major K buffers and sidebands.
+    ///
+    /// Counted at full allocation — the shadow is sized to `max_seq` up front.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
+    pub(crate) fn byte_size(&self) -> u64 {
+        let Self {
+            k_codes,
+            k_scales,
+            sideband_norms,
+            sideband_rotor_table,
+            // Geometry / tags, not allocations.
+            max_seq: _,
+            filled: _,
+            codec: _,
+            layout: _,
+        } = self;
+        crate::bytes::array_bytes(k_codes)
+            + crate::bytes::array_bytes(k_scales)
+            + crate::bytes::opt_array_bytes(sideband_norms.as_ref())
+            + crate::bytes::opt_array_bytes(sideband_rotor_table.as_ref())
+    }
+
     /// Allocate a zero-init shadow for `[B, kv_h, max_seq, *]` plus any
     /// codec-specific sidebands. The rotor table sideband is allocated
     /// **zero-init** here; the dispatch layer seeds it from

--- a/crates/rmlx-kv-quant/src/kvcache/mod.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/mod.rs
@@ -27,7 +27,7 @@
 //!   [`KvCache::update_and_sdpa_k8v4_flash`], [`KvCache::update`].
 //! - Lifecycle: [`KvCache::enter_prefill`], [`KvCache::exit_prefill`],
 //!   [`KvCache::reset`], [`KvCache::truncate_to`].
-//! - Diagnostics: [`KvCache::approx_bytes`], [`KvCache::resident_bytes`],
+//! - Diagnostics: [`KvCache::resident_bytes`],
 //!   [`KvCache::offset`], [`KvCache::seq_len`].
 //!
 //! # See also
@@ -52,6 +52,11 @@ mod helpers;
 mod sdpa;
 mod shared_kv;
 mod update;
+
+// The GPU ring of the ring-backed K codecs is counted in resident_bytes.
+#[cfg(test)]
+#[path = "resident_ring_tests.rs"]
+mod resident_ring_tests;
 
 // Warm-TTFT shortcut regression for PlanarK.
 #[cfg(test)]

--- a/crates/rmlx-kv-quant/src/kvcache/resident_ring_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/resident_ring_tests.rs
@@ -10,10 +10,22 @@
 //! are accepted or rejected on, so an invisible allocation silently invalidates
 //! the comparison.
 //!
-//! These tests pin the ring into the total. They assert against the ring's
-//! **own measured size**, never against a restatement of the accounting — a
-//! test that recomputes the formula under test proves only that arithmetic is
-//! deterministic.
+//! # What these prove, and what they do not
+//!
+//! These pin the ring into the total: standing one up must move
+//! `resident_bytes` by at least the ring's own reported size, across both
+//! ring-backed codecs and two contexts. That is the bug that was shipped — a
+//! delta of exactly zero.
+//!
+//! They do **not** validate the ring's *magnitude*. The anchor
+//! (`QuantKGpuRing::byte_size`, via `live_ring_bytes`) is part of the
+//! accounting under test — `QuantIsoK3::byte_size` is literally
+//! `blocks + gpu.byte_size()` — so a ring size that was uniformly wrong by a
+//! constant factor would still pass here. Magnitude is anchored elsewhere, by
+//! independent literals: `kv_cache/tests.rs`
+//! (`resident_bytes_none_quant_is_the_two_bf16_mirrors`,
+//! `ring_bytes_match_independent_geometry` below) and, at the whole-process
+//! level, the RSS cross-check recorded in `docs/KV_QUANT.md`.
 
 use super::KvCache;
 use crate::clifford::make_rotor_table;
@@ -62,6 +74,9 @@ fn ring_backed_cache(quant: KvQuant) -> KvCache {
 }
 
 /// The ring's own byte size, read from the store. `None` when no ring is live.
+///
+/// This is the accounting under test, not an independent oracle — see the
+/// module docs. `ring_bytes_match_independent_geometry` is the oracle.
 #[allow(
     clippy::wildcard_enum_match_arm,
     reason = "only the ring-backed K-only variants carry a ring; every other storage variant correctly reports no live ring"
@@ -75,14 +90,24 @@ fn live_ring_bytes(cache: &KvCache) -> Option<u64> {
     allocated.then_some(bytes)
 }
 
-/// Prefill, then decode until the flash path stands the ring up.
-///
-/// Returns `(bytes_before_ring, bytes_after_ring, ring_bytes)`.
+/// The ring's live capacity, read from its bookkeeping (not from its buffers).
+#[allow(
+    clippy::wildcard_enum_match_arm,
+    reason = "only the ring-backed K-only variants carry a ring; every other storage variant has no capacity to report"
+)]
+fn live_ring_capacity(cache: &KvCache) -> Option<i32> {
+    match cache.storage() {
+        KvStorage::IsoKOnly3 { k: Some(ks), .. } if ks.gpu.is_allocated() => Some(ks.gpu.capacity),
+        _ => None,
+    }
+}
+
+/// Prefill `prefill` positions, then take one decode step — which is what
+/// stands the ring up. Returns `resident_bytes` from just before that step.
 #[allow(clippy::expect_used, reason = "test helper: invariants documented")]
-fn bytes_across_ring_allocation(quant: KvQuant, prefill: i32) -> (u64, u64, u64) {
+fn drive_to_ring(cache: &mut KvCache, prefill: i32) -> u64 {
     let device = Device::Gpu;
     let scale = 1.0_f32 / (HEAD_DIM as f32).sqrt();
-    let mut cache = ring_backed_cache(quant);
 
     // Prefill goes through the legacy path: CPU blocks accumulate, no ring yet.
     let pf = (prefill * KV_H * HEAD_DIM) as usize;
@@ -98,8 +123,8 @@ fn bytes_across_ring_allocation(quant: KvQuant, prefill: i32) -> (u64, u64, u64)
     cache.exit_prefill(device).expect("exit_prefill");
 
     assert!(
-        live_ring_bytes(&cache).is_none(),
-        "{quant}: no ring should exist before the first decode dispatch"
+        live_ring_bytes(cache).is_none(),
+        "no ring should exist before the first decode dispatch"
     );
     let before = cache.resident_bytes();
 
@@ -115,7 +140,15 @@ fn bytes_across_ring_allocation(quant: KvQuant, prefill: i32) -> (u64, u64, u64)
         .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
         .expect("decode update_and_sdpa");
     out.eval().expect("decode out eval");
+    before
+}
 
+/// Prefill, then decode until the flash path stands the ring up.
+///
+/// Returns `(bytes_before_ring, bytes_after_ring, ring_bytes)`.
+fn bytes_across_ring_allocation(quant: KvQuant, prefill: i32) -> (u64, u64, u64) {
+    let mut cache = ring_backed_cache(quant);
+    let before = drive_to_ring(&mut cache, prefill);
     let ring = live_ring_bytes(&cache).unwrap_or_else(|| {
         panic!("{quant}: decode must stand up the GPU ring — the flash path cannot run without it")
     });
@@ -140,6 +173,44 @@ fn assert_ring_is_counted(quant: KvQuant, prefill: i32) {
         delta >= ring,
         "{quant} @ prefill={prefill}: resident_bytes grew by {delta} B but the ring alone \
          allocated {ring} B — the ring is not being counted (before={before}, after={after})"
+    );
+}
+
+/// The ring's reported size matches its documented layout, derived independently.
+///
+/// This is the magnitude oracle the delta tests deliberately are not. It does
+/// not call `byte_size`'s arithmetic: it rebuilds the total from the layout
+/// `QuantKGpuRing` documents for its three buffers —
+/// `codes: u32[cap * kv_h * n_groups]`, `scales: f32[cap * kv_h * n_groups]`,
+/// `norms: f32[cap * kv_h]`, with iso's `n_groups = head_dim / 4` — and
+/// compares. A dtype or element-count error in the accounting (the 4-vs-8 byte
+/// class) fails here; the delta tests would sail through it.
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test resident_ring -- --ignored --test-threads=1"]
+fn ring_bytes_match_independent_geometry() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let (_, _, reported) = bytes_across_ring_allocation(KvQuant::IsoKOnly3, 256);
+
+    // Rebuild the cache the same way to read its live capacity; the ring is
+    // page-rounded, so the capacity is the one value that must come from it.
+    let mut cache = ring_backed_cache(KvQuant::IsoKOnly3);
+    drive_to_ring(&mut cache, 256);
+    let cap = live_ring_capacity(&cache).expect("iso3 ring must be live after decode") as u64;
+
+    let kv_h = KV_H as u64;
+    let n_groups = HEAD_DIM as u64 / 4; // ISO_QUAT_BLOCK_SIZE
+    let codes = cap * kv_h * n_groups * 4; // u32
+    let scales = cap * kv_h * n_groups * 4; // f32
+    let norms = cap * kv_h * 4; // f32
+    let expected = codes + scales + norms;
+
+    assert_eq!(
+        reported, expected,
+        "iso3 ring reports {reported} B but its documented layout at capacity={cap} \
+         (kv_h={kv_h}, n_groups={n_groups}) is {expected} B \
+         (codes={codes} + scales={scales} + norms={norms})"
     );
 }
 

--- a/crates/rmlx-kv-quant/src/kvcache/resident_ring_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/resident_ring_tests.rs
@@ -1,0 +1,181 @@
+//! `resident_bytes` sees the GPU ring that the ring-backed K codecs allocate.
+//!
+//! # Why this exists
+//!
+//! `k_iso3` / `k_rotor3` keep their CPU blocks *and* stand up a GPU-resident
+//! ring on the first flash-decode dispatch. The ring is real memory — tens of
+//! MB per layer at long context — but for a while the byte total counted the
+//! CPU blocks alone, so allocating it moved the reported KV bytes by exactly
+//! zero. That is worse than a wrong number: KV bytes is the axis these codecs
+//! are accepted or rejected on, so an invisible allocation silently invalidates
+//! the comparison.
+//!
+//! These tests pin the ring into the total. They assert against the ring's
+//! **own measured size**, never against a restatement of the accounting — a
+//! test that recomputes the formula under test proves only that arithmetic is
+//! deterministic.
+
+use super::KvCache;
+use crate::clifford::make_rotor_table;
+use crate::quant::KvQuant;
+use crate::rotorquant::n_groups_for;
+use crate::storage::{KvStorage, QuantIsoK3, QuantRotorK3};
+use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
+use rmlx_mlx::{Array, Device, Dtype};
+
+const MAX_SEQ: i32 = 1024;
+const KV_H: i32 = 8;
+const N_Q_HEADS: i32 = 32;
+const HEAD_DIM: i32 = 128;
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn f32_array(data: &[f32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::F32).expect("f32_array")
+}
+
+/// Build an empty K-only cache for a ring-backed codec.
+#[allow(
+    clippy::wildcard_enum_match_arm,
+    reason = "test helper covers exactly the two ring-backed K-only codecs it is called with; any other variant is a caller bug the unreachable! surfaces immediately"
+)]
+fn ring_backed_cache(quant: KvQuant) -> KvCache {
+    let shape = vec![1, KV_H, 0, HEAD_DIM];
+    let storage = match quant {
+        KvQuant::IsoKOnly3 => KvStorage::IsoKOnly3 {
+            k: Some(QuantIsoK3::from_cpu_blocks(Vec::new(), shape, MAX_SEQ)),
+            max_seq: MAX_SEQ,
+        },
+        KvQuant::RotorKOnly3 => KvStorage::RotorKOnly3 {
+            k: Some(QuantRotorK3::from_cpu_blocks(
+                make_rotor_table(0, 0, n_groups_for(HEAD_DIM as usize)),
+                None,
+                Vec::new(),
+                shape,
+                0,
+            )),
+            max_seq: MAX_SEQ,
+        },
+        _ => unreachable!("ring_backed_cache covers the K-only ring codecs only"),
+    };
+    KvCache::from_storage(storage, quant, 0, 0)
+}
+
+/// The ring's own byte size, read from the store. `None` when no ring is live.
+#[allow(
+    clippy::wildcard_enum_match_arm,
+    reason = "only the ring-backed K-only variants carry a ring; every other storage variant correctly reports no live ring"
+)]
+fn live_ring_bytes(cache: &KvCache) -> Option<u64> {
+    let (allocated, bytes) = match cache.storage() {
+        KvStorage::IsoKOnly3 { k: Some(ks), .. } => (ks.gpu.is_allocated(), ks.gpu.byte_size()),
+        KvStorage::RotorKOnly3 { k: Some(ks), .. } => (ks.gpu.is_allocated(), ks.gpu.byte_size()),
+        _ => (false, 0),
+    };
+    allocated.then_some(bytes)
+}
+
+/// Prefill, then decode until the flash path stands the ring up.
+///
+/// Returns `(bytes_before_ring, bytes_after_ring, ring_bytes)`.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn bytes_across_ring_allocation(quant: KvQuant, prefill: i32) -> (u64, u64, u64) {
+    let device = Device::Gpu;
+    let scale = 1.0_f32 / (HEAD_DIM as f32).sqrt();
+    let mut cache = ring_backed_cache(quant);
+
+    // Prefill goes through the legacy path: CPU blocks accumulate, no ring yet.
+    let pf = (prefill * KV_H * HEAD_DIM) as usize;
+    let k = f32_array(&lcg_data(pf, 1), &[1, KV_H, prefill, HEAD_DIM]);
+    let v = f32_array(&lcg_data(pf, 2), &[1, KV_H, prefill, HEAD_DIM]);
+    let q = f32_array(
+        &lcg_data((prefill * N_Q_HEADS * HEAD_DIM) as usize, 3),
+        &[1, N_Q_HEADS, prefill, HEAD_DIM],
+    );
+    cache
+        .update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+        .expect("prefill update_and_sdpa");
+    cache.exit_prefill(device).expect("exit_prefill");
+
+    assert!(
+        live_ring_bytes(&cache).is_none(),
+        "{quant}: no ring should exist before the first decode dispatch"
+    );
+    let before = cache.resident_bytes();
+
+    // First decode step seeds the ring from the accumulated CPU prefix.
+    let one = (KV_H * HEAD_DIM) as usize;
+    let k1 = f32_array(&lcg_data(one, 10), &[1, KV_H, 1, HEAD_DIM]);
+    let v1 = f32_array(&lcg_data(one, 20), &[1, KV_H, 1, HEAD_DIM]);
+    let q1 = f32_array(
+        &lcg_data((N_Q_HEADS * HEAD_DIM) as usize, 30),
+        &[1, N_Q_HEADS, 1, HEAD_DIM],
+    );
+    let out = cache
+        .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+        .expect("decode update_and_sdpa");
+    out.eval().expect("decode out eval");
+
+    let ring = live_ring_bytes(&cache).unwrap_or_else(|| {
+        panic!("{quant}: decode must stand up the GPU ring — the flash path cannot run without it")
+    });
+    (before, cache.resident_bytes(), ring)
+}
+
+/// Standing up the ring must move the reported total by at least the ring's
+/// own size.
+///
+/// `>=` not `==`: the same decode step also appends one position of K to the
+/// CPU blocks and advances the bf16 V mirror's filled prefix, so the total
+/// legitimately grows by a little more than the ring alone. What must never
+/// happen again is a delta of zero.
+fn assert_ring_is_counted(quant: KvQuant, prefill: i32) {
+    let (before, after, ring) = bytes_across_ring_allocation(quant, prefill);
+    assert!(
+        ring > 0,
+        "{quant}: a live ring must have non-zero size (prefill={prefill})"
+    );
+    let delta = after.saturating_sub(before);
+    assert!(
+        delta >= ring,
+        "{quant} @ prefill={prefill}: resident_bytes grew by {delta} B but the ring alone \
+         allocated {ring} B — the ring is not being counted (before={before}, after={after})"
+    );
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test resident_ring -- --ignored --test-threads=1"]
+fn iso_k_only3_ring_is_counted_in_resident_bytes() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    assert_ring_is_counted(KvQuant::IsoKOnly3, 256);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test resident_ring -- --ignored --test-threads=1"]
+fn rotor_k_only3_ring_is_counted_in_resident_bytes() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    assert_ring_is_counted(KvQuant::RotorKOnly3, 256);
+}
+
+/// The ring stays counted as it grows with context.
+///
+/// A single context is not enough: the ring is allocated in pages and re-seeded
+/// as the prefix grows, so an accounting that happened to be right at one size
+/// can still be wrong at another. Sweeps both ring-backed codecs across two
+/// contexts.
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test resident_ring -- --ignored --test-threads=1"]
+fn ring_stays_counted_across_contexts() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    for quant in [KvQuant::IsoKOnly3, KvQuant::RotorKOnly3] {
+        for prefill in [128, 512] {
+            assert_ring_is_counted(quant, prefill);
+        }
+    }
+}

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -542,7 +542,7 @@ impl KvCache {
                 device,
             )?;
             tracing::trace!(
-                kv_bytes = self.approx_bytes(),
+                kv_bytes = self.resident_bytes(),
                 offset = self.offset,
                 "kv cache bytes"
             );
@@ -561,7 +561,7 @@ impl KvCache {
                 device,
             )?;
             tracing::trace!(
-                kv_bytes = self.approx_bytes(),
+                kv_bytes = self.resident_bytes(),
                 offset = self.offset,
                 "kv cache bytes"
             );
@@ -576,7 +576,7 @@ impl KvCache {
             // Emit kv_bytes event for multi-turn growth tracking.
             // Demoted to trace! (per-layer per-step; opt in via --log verbose).
             tracing::trace!(
-                kv_bytes = self.approx_bytes(),
+                kv_bytes = self.resident_bytes(),
                 offset = self.offset,
                 "kv cache bytes"
             );
@@ -642,7 +642,7 @@ impl KvCache {
             )? {
                 tracing::Span::current().record("path", "planar_k_fused");
                 tracing::trace!(
-                    kv_bytes = self.approx_bytes(),
+                    kv_bytes = self.resident_bytes(),
                     offset = self.offset,
                     "kv cache bytes"
                 );
@@ -684,7 +684,7 @@ impl KvCache {
                 device,
             )? {
                 tracing::trace!(
-                    kv_bytes = self.approx_bytes(),
+                    kv_bytes = self.resident_bytes(),
                     offset = self.offset,
                     "kv cache bytes"
                 );
@@ -720,7 +720,7 @@ impl KvCache {
                 device,
             )? {
                 tracing::trace!(
-                    kv_bytes = self.approx_bytes(),
+                    kv_bytes = self.resident_bytes(),
                     offset = self.offset,
                     "kv cache bytes"
                 );
@@ -735,7 +735,7 @@ impl KvCache {
             tracing::Span::current().record("path", "flash");
             // Demoted to trace! (per-layer per-step; opt in via --log verbose).
             tracing::trace!(
-                kv_bytes = self.approx_bytes(),
+                kv_bytes = self.resident_bytes(),
                 offset = self.offset,
                 "kv cache bytes"
             );
@@ -752,7 +752,7 @@ impl KvCache {
         {
             tracing::Span::current().record("path", "fused_qk");
             tracing::trace!(
-                kv_bytes = self.approx_bytes(),
+                kv_bytes = self.resident_bytes(),
                 offset = self.offset,
                 "kv cache bytes"
             );
@@ -776,7 +776,7 @@ impl KvCache {
         )?;
         // Demoted to trace! (per-layer per-step; opt in via --log verbose).
         tracing::trace!(
-            kv_bytes = self.approx_bytes(),
+            kv_bytes = self.resident_bytes(),
             offset = self.offset,
             "kv cache bytes"
         );

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -541,11 +541,6 @@ impl KvCache {
                 additive_mask,
                 device,
             )?;
-            tracing::trace!(
-                kv_bytes = self.resident_bytes(),
-                offset = self.offset,
-                "kv cache bytes"
-            );
             return Ok(out);
         }
 
@@ -560,11 +555,6 @@ impl KvCache {
                 additive_mask,
                 device,
             )?;
-            tracing::trace!(
-                kv_bytes = self.resident_bytes(),
-                offset = self.offset,
-                "kv cache bytes"
-            );
             return Ok(out);
         }
 
@@ -573,13 +563,6 @@ impl KvCache {
             tracing::Span::current().record("path", "mixed");
             let out =
                 self.update_and_sdpa_mixed(queries, new_k, new_v, scale, additive_mask, device)?;
-            // Emit kv_bytes event for multi-turn growth tracking.
-            // Demoted to trace! (per-layer per-step; opt in via --log verbose).
-            tracing::trace!(
-                kv_bytes = self.resident_bytes(),
-                offset = self.offset,
-                "kv cache bytes"
-            );
             return Ok(out);
         }
 
@@ -641,11 +624,6 @@ impl KvCache {
                 device,
             )? {
                 tracing::Span::current().record("path", "planar_k_fused");
-                tracing::trace!(
-                    kv_bytes = self.resident_bytes(),
-                    offset = self.offset,
-                    "kv cache bytes"
-                );
                 return Ok(out);
                 // Falls through to legacy when fused path is not yet eligible
                 // (e.g. prefill chunk before any GPU buffer exists, or CPU device).
@@ -683,11 +661,6 @@ impl KvCache {
                 additive_mask,
                 device,
             )? {
-                tracing::trace!(
-                    kv_bytes = self.resident_bytes(),
-                    offset = self.offset,
-                    "kv cache bytes"
-                );
                 return Ok(out);
             }
         }
@@ -719,11 +692,6 @@ impl KvCache {
                 additive_mask,
                 device,
             )? {
-                tracing::trace!(
-                    kv_bytes = self.resident_bytes(),
-                    offset = self.offset,
-                    "kv cache bytes"
-                );
                 return Ok(out);
             }
         }
@@ -733,12 +701,6 @@ impl KvCache {
             self.sdpa_dispatch(queries, new_k, new_v, scale, additive_mask, device)?
         {
             tracing::Span::current().record("path", "flash");
-            // Demoted to trace! (per-layer per-step; opt in via --log verbose).
-            tracing::trace!(
-                kv_bytes = self.resident_bytes(),
-                offset = self.offset,
-                "kv cache bytes"
-            );
             return Ok(out);
         }
 
@@ -751,11 +713,6 @@ impl KvCache {
             self.try_fused_qk_dispatch(queries, new_k, new_v, scale, additive_mask, device)?
         {
             tracing::Span::current().record("path", "fused_qk");
-            tracing::trace!(
-                kv_bytes = self.resident_bytes(),
-                offset = self.offset,
-                "kv cache bytes"
-            );
             return Ok(out);
         }
 
@@ -774,12 +731,6 @@ impl KvCache {
             additive_mask,
             device,
         )?;
-        // Demoted to trace! (per-layer per-step; opt in via --log verbose).
-        tracing::trace!(
-            kv_bytes = self.resident_bytes(),
-            offset = self.offset,
-            "kv cache bytes"
-        );
         Ok(out)
     }
 

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -2932,6 +2932,14 @@ impl KvCache {
     /// bytes are whatever its store actually allocated, which only the store
     /// can answer.
     ///
+    /// **Cost: O(blocks).** Asking the store is not free — the block-based
+    /// codecs walk a `Vec` that grows by one entry per decode step. Call this
+    /// at request boundaries (as the `kv_bytes` event does), not per-layer
+    /// per-decode-step: that would make a generation quadratic in context.
+    /// Do not "fix" the cost with a cached running counter — a byte total kept
+    /// alongside the buffers instead of read from them is the drifting mirror
+    /// this accounting exists to avoid.
+    ///
     /// Returns 0 when the cache has never been used (`offset == 0` and no
     /// buffers are allocated). Safe to call at any point — no FFI eval, no
     /// data read, no mutation.
@@ -2939,39 +2947,7 @@ impl KvCache {
     /// The exhaustive destructure below is the drift guard: a new buffer cannot
     /// be added to `KvCache` without this failing to compile.
     pub fn resident_bytes(&self) -> u64 {
-        // Helper: bytes of a single Array without FFI eval.
-        #[inline]
-        fn ab(a: &Array) -> u64 {
-            let n: u64 = a.shape().iter().map(|&d| d as u64).product();
-            n * a.dtype().itemsize() as u64
-        }
-
-        // Helper: bytes of the *filled* prefix of a `[B, kv_h, seq, D]` decode
-        // buffer. These per-position mirrors are pre-allocated to the
-        // max-context ceiling (full `max_seq`) and compacted to the filled
-        // length only after `exit_prefill`/decode reclaim — so the same config
-        // reports different totals depending on when the metric is read. Only
-        // `offset` positions ever hold live K/V that decode reads. Counting the
-        // whole ceiling-sized buffer inflates the live-inference KV total and
-        // makes bytes-per-KV-token incomparable across contexts (a run with a
-        // high ceiling reports far more than its active cache). Scale by the
-        // filled length, using each buffer's real per-position size (shape ×
-        // dtype, so per-layer head_dim and dtype are picked up), so the figure
-        // is the KV that serves decode regardless of read timing.
-        #[inline]
-        #[allow(
-            clippy::indexing_slicing,
-            reason = "indices 0..=3 are bounds-checked by the `s.len() != 4` early return above"
-        )]
-        fn filled_seq_bytes(a: &Array, filled: u64) -> u64 {
-            let s = a.shape();
-            if s.len() != 4 {
-                return ab(a);
-            }
-            let per_pos = s[0] as u64 * s[1] as u64 * s[3] as u64 * a.dtype().itemsize() as u64;
-            let cap = s[2] as u64;
-            per_pos * filled.min(cap)
-        }
+        use crate::bytes::{array_bytes, filled_seq_bytes};
 
         // Naming every field is what makes this total drift-proof: a buffer
         // added to `KvCache` cannot slip past the accounting unnoticed, because
@@ -3016,29 +2992,24 @@ impl KvCache {
         }
 
         // 3. Rotating SWA ring buffer (bf16, sized to the sliding window). The
-        //    ring holds at most `window` live positions; early in a sequence
-        //    only `offset` are filled. Both are already ≤ the window allocation.
+        //    ring owns its own byte total: reaching its buffers by field access
+        //    from here would let a buffer added to it go uncounted.
         if let Some(rot) = rotating {
-            if let Some(ref k) = rot.keys {
-                total += filled_seq_bytes(k, offset);
-            }
-            if let Some(ref v) = rot.values {
-                total += filled_seq_bytes(v, offset);
-            }
+            total += rot.byte_size(offset);
         }
 
         // 4. TurboFlash head-major K/V buffers (lazy; only for K8V4 path).
         if let Some(c) = flash_k_codes {
-            total += ab(c);
+            total += array_bytes(c);
         }
         if let Some(s) = flash_k_scales {
-            total += ab(s);
+            total += array_bytes(s);
         }
         if let Some(c) = flash_v_codes {
-            total += ab(c);
+            total += array_bytes(c);
         }
         if let Some(s) = flash_v_scales {
-            total += ab(s);
+            total += array_bytes(s);
         }
 
         // 5. Fused-QK shadow (head-major K shadow for fused-QK MSL kernels).

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -2898,151 +2898,6 @@ impl KvCache {
         Ok(())
     }
 
-    /// Approximate RAM held by this cache slot, in bytes.
-    ///
-    /// Uses `self.offset` as the filled sequence length (not the pre-allocated
-    /// `max_seq`). Bits-per-element: 8 for K8V8/K8V4-K / Planar-K (q8_0),
-    /// 4 for K8V4-V / Planar-V / Mixed-V (4-bit codebook), 8 for Mixed-K,
-    /// 16 for None (bf16). Adds one factor-of-2 for the warm-TTFT fp16 seed
-    /// buffers (decode_fp16_k/v) when present.
-    ///
-    /// This is a best-effort estimate for the `/metrics/cache` endpoint —
-    /// not guaranteed to match Metal allocator accounting byte-for-byte.
-    ///
-    /// **Intentionally excludes paged-pool overhead**: paged KV storage
-    /// (`--paged-kv`) is default-OFF, so paged-pool overhead is always 0
-    /// on normal paths. If/when `paged_kv_enabled()` is flipped default-ON,
-    /// add a `paged_overhead_bytes()` method to `PagedKvArena` and sum it
-    /// alongside this estimate. See K15 in `docs/tasks/groups/group-K-backlog.md`.
-    #[allow(
-        clippy::indexing_slicing,
-        reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-    )]
-    pub fn approx_bytes(&self) -> u64 {
-        let seq = self.offset as u64;
-        if seq == 0 {
-            return 0;
-        }
-        // Derive B * kv_h * head_dim from a decode_fp16 buffer shape when
-        // available (most reliable post-prefill source), or from the rotating
-        // ring buffer. Fall back to zero if shape is unknown (cache never used).
-        //
-        // The K-only family no longer populates `decode_fp16_k` (it was dead
-        // memory), so fall through to `decode_fp16_v`, which is the same
-        // B·kv_h·head_dim shape and is still populated for those
-        // variants. Without this the K-only `approx_bytes` would read 0.
-        let bhd: u64 = if let Some(k) = self.decode_fp16_k.as_ref().or(self.decode_fp16_v.as_ref())
-        {
-            let s = k.shape();
-            if s.len() == 4 {
-                s[0] as u64 * s[1] as u64 * s[3] as u64
-            } else {
-                0
-            }
-        } else if let Some(ref rot) = self.rotating {
-            if let Some(k) = &rot.keys {
-                let s = k.shape();
-                if s.len() == 4 {
-                    s[0] as u64 * s[1] as u64 * s[3] as u64
-                } else {
-                    0
-                }
-            } else {
-                0
-            }
-        } else {
-            0
-        };
-        if bhd == 0 {
-            return 0;
-        }
-        // bits per element for K and V respectively.
-        let (k_bits, v_bits): (u64, u64) = match self.quant {
-            KvQuant::None => (16, 16),
-            KvQuant::K8V8 => (8, 8),
-            KvQuant::K8V4 => (8, 4),
-            KvQuant::Planar => (8, 4),
-            // Planar3 — K is affine q8_0; V is PlanarQuant 3-bit (3.25-bit effective).
-            KvQuant::Planar3 => (8, 3),
-            KvQuant::Mixed { k_bits, v_bits, .. } => (u64::from(k_bits), u64::from(v_bits)),
-            // RotK: K is 8-bit affine in the rotated basis; V is v_bits.
-            KvQuant::RotK { v_bits, .. } => (8, u64::from(v_bits)),
-            // RotKTq4V: K is 8-bit rotated affine; V is TurboQuant 4-bit.
-            KvQuant::RotKTq4V => (8, 4),
-            // K8VTurbo3: K is affine q8_0; V is TurboQuant 3-bit.
-            KvQuant::K8VTurbo3 => (8, 3),
-            // TurboSym3 — both K and V are TurboQuant 3-bit.
-            KvQuant::TurboSym3 => (3, 3),
-            // TurboSym4 — both K and V are TurboQuant 4-bit.
-            KvQuant::TurboSym4 => (4, 4),
-            // PlanarK — K is PlanarQuant 4-bit; V is bf16.
-            KvQuant::PlanarK => (4, 16),
-            // K8VTurbo2 — K is affine q8_0; V is TurboQuant 2-bit.
-            KvQuant::K8VTurbo2 => (8, 2),
-            // Iso3 — K is affine q8_0; V is IsoQuant 3-bit (~3.25
-            // bits effective with the per-group quaternion / scale overhead).
-            KvQuant::Iso3 => (8, 3),
-            // Iso4 — K is affine q8_0; V is IsoQuant 4-bit (~4.25
-            // bits effective with the per-group quaternion / scale overhead).
-            KvQuant::Iso4 => (8, 4),
-            // Rotor3 — K is affine q8_0; V is rotor3 (~3.25 bits
-            // effective with the per-group scale + per-token norm overhead;
-            // rotor table is static per layer so amortises across tokens).
-            KvQuant::Rotor3 => (8, 3),
-            // Rotor4 — K is affine q8_0; V is rotor4 (~4.25 bits
-            // effective; same amortised rotor table as rotor3).
-            KvQuant::Rotor4 => (8, 4),
-            // K8VTurbo3Tcq — K affine q8_0; V is TurboQuant 3-bit
-            // (Viterbi assignment, same pack as K8VTurbo3 — encode-side change only).
-            KvQuant::K8VTurbo3Tcq => (8, 3),
-            // K8VTurbo2Tcq — K affine q8_0; V is TurboQuant 2-bit
-            // (Viterbi assignment, same pack as K8VTurbo2 — encode-side change only).
-            KvQuant::K8VTurbo2Tcq => (8, 2),
-            // Iso3Sym — both K and V are iso 3-bit (~3.25 bits per
-            // axis effective with per-group quaternion + scale overhead).
-            KvQuant::Iso3Sym => (3, 3),
-            // Iso4Sym — both K and V are iso 4-bit.
-            KvQuant::Iso4Sym => (4, 4),
-            // IsoKOnly3 — K iso 3-bit; V stays bf16.
-            KvQuant::IsoKOnly3 => (3, 16),
-            // IsoKOnly4 — K iso 4-bit; V stays bf16.
-            KvQuant::IsoKOnly4 => (4, 16),
-            // Rotor3Sym — both K and V are rotor3 (~3.25 bits per axis effective;
-            // rotor table + optional QJL projection are layer-static so amortise
-            // across tokens, not counted in seq-scaled bytes).
-            KvQuant::Rotor3Sym => (3, 3),
-            // Rotor4Sym — both K and V are rotor4.
-            KvQuant::Rotor4Sym => (4, 4),
-            // RotorKOnly3 — K rotor3; V stays bf16.
-            KvQuant::RotorKOnly3 => (3, 16),
-            // RotorKOnly4 — K rotor4; V stays bf16.
-            KvQuant::RotorKOnly4 => (4, 16),
-            // RotorK3Asym — K rotor3 (3-bit effective); V affine
-            // at v_bits. Same as RotorKOnly3 K side, with affine V replacing bf16.
-            KvQuant::RotorK3Asym { v_bits, .. } => (3, u64::from(v_bits)),
-            // RotorK4Asym — K rotor4 (4-bit effective); V affine at v_bits.
-            KvQuant::RotorK4Asym { v_bits, .. } => (4, u64::from(v_bits)),
-        };
-        let kv_bytes = seq * bhd * (k_bits + v_bits) / 8;
-        // Add warm-TTFT fp16 seed buffers when they exist (present for
-        // quantised paths after exit_prefill; decode_fp16 uses max_seq not
-        // offset, but the memory impact is modest so we count offset).
-        //
-        // Count the K and V seeds independently (each = seq × bhd × 2 bytes /
-        // bf16). The K-only family drops the K seed but keeps the V seed, so
-        // `approx_bytes` reflects a single 2-byte mirror, not 4.
-        // `KvQuant::None` carries no quantised storage and is not a warm-TTFT
-        // seed path, so it is excluded from the seed bytes.
-        let seed_bytes: u64 = if matches!(self.quant, KvQuant::None) {
-            0
-        } else {
-            let k_seed = u64::from(self.decode_fp16_k.is_some());
-            let v_seed = u64::from(self.decode_fp16_v.is_some());
-            seq * bhd * 2 * (k_seed + v_seed)
-        };
-        kv_bytes + seed_bytes
-    }
-
     /// Live-inference KV resident bytes held by this cache at the call-site.
     ///
     /// Reports the bytes of the K/V that actually serves decode — the *filled*
@@ -3070,14 +2925,19 @@ impl KvCache {
     /// - **Fused-QK shadow** (`fused_qk_shadow`): head-major K shadow used by
     ///   fused-QK dispatch (q8, turbo3/4-sym, iso3/4-sym, rotor3/4-sym, …).
     ///
-    /// Unlike [`approx_bytes`], the per-position size comes from the actual
-    /// `Array` shape × dtype of each live buffer (picking up per-layer head_dim
-    /// differences, e.g. windowed vs full-attention layers), scaled by the
-    /// filled length rather than a quant-bit formula.
+    /// The per-position size comes from the actual `Array` shape × dtype of
+    /// each live buffer (picking up per-layer head_dim differences, e.g.
+    /// windowed vs full-attention layers), scaled by the filled length. There
+    /// is deliberately no quant-bit formula anywhere in this total: a codec's
+    /// bytes are whatever its store actually allocated, which only the store
+    /// can answer.
     ///
     /// Returns 0 when the cache has never been used (`offset == 0` and no
     /// buffers are allocated). Safe to call at any point — no FFI eval, no
     /// data read, no mutation.
+    ///
+    /// The exhaustive destructure below is the drift guard: a new buffer cannot
+    /// be added to `KvCache` without this failing to compile.
     pub fn resident_bytes(&self) -> u64 {
         // Helper: bytes of a single Array without FFI eval.
         #[inline]
@@ -3113,25 +2973,52 @@ impl KvCache {
             per_pos * filled.min(cap)
         }
 
-        let offset = self.offset.max(0) as u64;
+        // Naming every field is what makes this total drift-proof: a buffer
+        // added to `KvCache` cannot slip past the accounting unnoticed, because
+        // the pattern stops compiling until it is classified here.
+        let Self {
+            storage,
+            offset,
+            decode_fp16_k,
+            decode_fp16_v,
+            rotating,
+            flash_k_codes,
+            flash_k_scales,
+            flash_v_codes,
+            flash_v_scales,
+            fused_qk_shadow,
+            // Transient prefill staging: borrowed views handed straight to the
+            // encoder and dropped at `exit_prefill`, not cache residency.
+            prefill_raw_k: _,
+            prefill_raw_v: _,
+            // Configuration / bookkeeping, not allocations.
+            quant: _,
+            layer_idx: _,
+            in_prefill: _,
+            flash_max_seq: _,
+            flash_filled: _,
+            max_seq_ceiling: _,
+        } = self;
 
-        // 1. Quantized storage (codec-specific buffers; None → 0). Already
-        //    compacted to the filled length at `exit_prefill`.
-        let mut total = self.storage.resident_bytes();
+        let offset = (*offset).max(0) as u64;
+
+        // 1. Quantized storage (codec-specific buffers; None → 0). The store
+        //    owns its own byte total, GPU rings and mirrors included.
+        let mut total = storage.resident_bytes();
 
         // 2. fp16 decode seeds (KvQuant::None bf16 storage lives here too).
         //    Count only the filled prefix, not the ceiling-sized allocation.
-        if let Some(ref k) = self.decode_fp16_k {
+        if let Some(k) = decode_fp16_k {
             total += filled_seq_bytes(k, offset);
         }
-        if let Some(ref v) = self.decode_fp16_v {
+        if let Some(v) = decode_fp16_v {
             total += filled_seq_bytes(v, offset);
         }
 
         // 3. Rotating SWA ring buffer (bf16, sized to the sliding window). The
         //    ring holds at most `window` live positions; early in a sequence
         //    only `offset` are filled. Both are already ≤ the window allocation.
-        if let Some(ref rot) = self.rotating {
+        if let Some(rot) = rotating {
             if let Some(ref k) = rot.keys {
                 total += filled_seq_bytes(k, offset);
             }
@@ -3141,29 +3028,22 @@ impl KvCache {
         }
 
         // 4. TurboFlash head-major K/V buffers (lazy; only for K8V4 path).
-        if let Some(ref c) = self.flash_k_codes {
+        if let Some(c) = flash_k_codes {
             total += ab(c);
         }
-        if let Some(ref s) = self.flash_k_scales {
+        if let Some(s) = flash_k_scales {
             total += ab(s);
         }
-        if let Some(ref c) = self.flash_v_codes {
+        if let Some(c) = flash_v_codes {
             total += ab(c);
         }
-        if let Some(ref s) = self.flash_v_scales {
+        if let Some(s) = flash_v_scales {
             total += ab(s);
         }
 
         // 5. Fused-QK shadow (head-major K shadow for fused-QK MSL kernels).
-        if let Some(ref shadow) = self.fused_qk_shadow {
-            total += ab(&shadow.k_codes);
-            total += ab(&shadow.k_scales);
-            if let Some(ref norms) = shadow.sideband_norms {
-                total += ab(norms);
-            }
-            if let Some(ref table) = shadow.sideband_rotor_table {
-                total += ab(table);
-            }
+        if let Some(shadow) = fused_qk_shadow {
+            total += shadow.byte_size();
         }
 
         total

--- a/crates/rmlx-kv-quant/src/kvcache/warm_ttft_cross_codec_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/warm_ttft_cross_codec_tests.rs
@@ -76,6 +76,12 @@ struct DecodeOutcome {
 /// below anchor to the buffers the cache actually holds rather than to a
 /// per-codec bit-width formula, which is precisely the thing that reported a
 /// confident number for memory it was not measuring.
+///
+/// Scope: this pins **which buffers are counted** — that the dead K seed is
+/// not, and the live V seed is. The K store's own total is taken from
+/// `KvStorage::resident_bytes`, i.e. from the accounting, so these do not
+/// independently validate the store's magnitude. `resident_ring_tests`
+/// (`ring_bytes_match_independent_geometry`) is where that is checked.
 #[allow(
     clippy::indexing_slicing,
     reason = "test helper: decode mirrors are always the 4-D [B, kv_h, seq, D] shape asserted below"

--- a/crates/rmlx-kv-quant/src/kvcache/warm_ttft_cross_codec_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/warm_ttft_cross_codec_tests.rs
@@ -65,8 +65,26 @@ struct DecodeOutcome {
     v_seed_live: bool,
     /// Cache offset after one decode step.
     offset: i32,
-    /// `approx_bytes()` residency estimate after one decode step.
-    approx_bytes: u64,
+    /// `resident_bytes()` residency total after one decode step.
+    resident_bytes: u64,
+}
+
+/// Bytes of the *filled* prefix of a `[B, kv_h, seq, D]` bf16 mirror, computed
+/// straight from the array's own shape and dtype.
+///
+/// The independent restatement is deliberate: it lets the residency asserts
+/// below anchor to the buffers the cache actually holds rather than to a
+/// per-codec bit-width formula, which is precisely the thing that reported a
+/// confident number for memory it was not measuring.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "test helper: decode mirrors are always the 4-D [B, kv_h, seq, D] shape asserted below"
+)]
+fn filled_mirror_bytes(a: &Array, filled: i32) -> u64 {
+    let s = a.shape();
+    assert_eq!(s.len(), 4, "decode mirror must be 4-D [B, kv_h, seq, D]");
+    let per_pos = s[0] as u64 * s[1] as u64 * s[3] as u64 * a.dtype().itemsize() as u64;
+    per_pos * (filled.max(0) as u64).min(s[2] as u64)
 }
 
 /// Drive a cache through prefill (one chunk) → exit_prefill → one decode step.
@@ -94,7 +112,7 @@ fn drive_one_decode(cache: &mut KvCache, device: Device) -> DecodeOutcome {
         k_seed_live: cache.decode_fp16_k_for_test().is_some(),
         v_seed_live: cache.decode_fp16_v_for_test().is_some(),
         offset: cache.offset(),
-        approx_bytes: cache.approx_bytes(),
+        resident_bytes: cache.resident_bytes(),
     }
 }
 
@@ -218,7 +236,7 @@ fn iso_sym3_warm_ttft_freezes_codec() {
 /// never reads the bf16 K seed. The K-seed materialisation is gated on
 /// `KvQuant::feeds_bf16_k_at_decode()`, which is `false` for the K-only family:
 /// the K seed is ABSENT while the V seed stays live, the K codec still
-/// advances one position per decode step, and `approx_bytes` drops by the
+/// advances one position per decode step, and the reported residency drops by the
 /// bf16 K-seed cost. Output is byte-unchanged.
 #[test]
 fn iso_k_only3_quant_at_decode() {
@@ -251,24 +269,21 @@ fn iso_k_only3_quant_at_decode() {
         TEST_PREFILL_SEQ + 1,
         "IsoKOnly3 offset after one decode step"
     );
-    // Residency: exact post-reclaim expectation.
-    //
-    // Formula: kv_bytes + seed_bytes
-    //   seq = TEST_PREFILL_SEQ + 1 = 257
-    //   bhd = 1 * TEST_KV_H * TEST_HEAD_DIM = 8 * 128 = 1024
-    //   k_bits = 3 (IsoKOnly3 K is IsoQuant 3-bit), v_bits = 16 (bf16 V)
-    //   kv_bytes = 257 * 1024 * (3 + 16) / 8 = 625_024
-    //   seed_bytes: k_seed absent, v_seed present →
-    //     257 * 1024 * 2 * 1 = 526_336
-    //   total = 625_024 + 526_336 = 1_151_360
-    //
-    // This assert FAILS if the K seed is still counted (pre-fix total was
-    // 1_151_360 + 526_336 = 1_677_696 — not equal to 1_151_360).
+    // Residency: the total must be exactly the two things this cache really
+    // holds — whatever the iso3 K store allocated, plus the filled prefix of
+    // the surviving bf16 V seed. Anchored to the live buffers, not to a
+    // nominal bit-width: iso3 blocks also carry per-group quaternions, scales
+    // and norms, so a "3 bits per element" figure would not be this cache's
+    // memory. Fails if the absent K seed is counted anyway, if the V seed is
+    // missed, or if either is double-counted.
+    let v_seed = cache
+        .decode_fp16_v_for_test()
+        .expect("V seed is live (asserted above)");
+    let expected = cache.storage().resident_bytes() + filled_mirror_bytes(v_seed, out.offset);
     assert_eq!(
-        out.approx_bytes, 1_151_360,
-        "IsoKOnly3: approx_bytes must equal quantised-K (3-bit) + bf16-V-seed; \
-         got {}",
-        out.approx_bytes,
+        out.resident_bytes, expected,
+        "IsoKOnly3: resident_bytes must equal the iso3 K store plus the bf16 V seed's \
+         filled prefix and nothing else",
     );
 }
 
@@ -301,23 +316,19 @@ fn rotor_k_only3_quant_at_decode() {
         TEST_PREFILL_SEQ + 1,
         "RotorKOnly3 offset after one decode step"
     );
-    // Residency: exact post-reclaim expectation.
-    //
-    // Formula: kv_bytes + seed_bytes
-    //   seq = TEST_PREFILL_SEQ + 1 = 257
-    //   bhd = 1 * TEST_KV_H * TEST_HEAD_DIM = 8 * 128 = 1024
-    //   k_bits = 3 (RotorKOnly3 K is rotor3, 3-bit effective), v_bits = 16 (bf16 V)
-    //   kv_bytes = 257 * 1024 * (3 + 16) / 8 = 625_024
-    //   seed_bytes: k_seed absent, v_seed present →
-    //     257 * 1024 * 2 * 1 = 526_336
-    //   total = 625_024 + 526_336 = 1_151_360
-    //
-    // This assert FAILS if the K seed is still counted (pre-fix total was
-    // 1_151_360 + 526_336 = 1_677_696 — not equal to 1_151_360).
+    // Residency: the total must be exactly the two things this cache really
+    // holds — whatever the rotor3 K store allocated (blocks plus the static
+    // rotor table, and the GPU ring once one is live), plus the filled prefix
+    // of the surviving bf16 V seed. Anchored to the live buffers, not to a
+    // nominal bit-width. Fails if the absent K seed is counted anyway, if the
+    // V seed is missed, or if either is double-counted.
+    let v_seed = cache
+        .decode_fp16_v_for_test()
+        .expect("V seed is live (asserted above)");
+    let expected = cache.storage().resident_bytes() + filled_mirror_bytes(v_seed, out.offset);
     assert_eq!(
-        out.approx_bytes, 1_151_360,
-        "RotorKOnly3: approx_bytes must equal quantised-K (3-bit) + bf16-V-seed; \
-         got {}",
-        out.approx_bytes,
+        out.resident_bytes, expected,
+        "RotorKOnly3: resident_bytes must equal the rotor3 K store plus the bf16 V seed's \
+         filled prefix and nothing else",
     );
 }

--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -40,6 +40,7 @@
 #[cfg(test)]
 pub(crate) mod test_utils;
 
+pub(crate) mod bytes;
 pub mod clifford;
 pub(crate) mod fused_qk_common;
 pub mod iso_flash_decode_msl;

--- a/crates/rmlx-kv-quant/src/linear_attn.rs
+++ b/crates/rmlx-kv-quant/src/linear_attn.rs
@@ -111,22 +111,26 @@ impl LinearAttnCache {
         );
     }
 
-    /// Approximate RAM held by this recurrent state, in bytes.
+    /// Resident RAM held by this recurrent state, in bytes.
     ///
     /// Both `conv_state` and `delta_state` are fixed-shape tensors (independent
-    /// of sequence length). Assumes bf16 (2 bytes per element). Returns 0 if
-    /// neither field has been populated yet.
-    pub fn approx_bytes(&self) -> u64 {
-        let mut total: u64 = 0;
-        if let Some(a) = &self.conv_state {
-            let n: u64 = a.shape().iter().map(|&d| d as u64).product();
-            total += n * 2; // bf16
-        }
-        if let Some(a) = &self.delta_state {
-            let n: u64 = a.shape().iter().map(|&d| d as u64).product();
-            total += n * 4; // f32 (delta_state is always f32)
-        }
-        total
+    /// of sequence length). Each buffer's size comes from its own shape ×
+    /// dtype, so a state that is promoted to a wider dtype reports the truth
+    /// with nothing to update here — this total feeds the same `kv_bytes` sum
+    /// as the attention caches, and a hard-coded item size is how such a sum
+    /// silently drifts away from the memory it claims to measure.
+    ///
+    /// Returns 0 if neither field has been populated yet.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
+    pub fn resident_bytes(&self) -> u64 {
+        let Self {
+            conv_state,
+            delta_state,
+        } = self;
+        crate::bytes::opt_array_bytes(conv_state.as_ref())
+            + crate::bytes::opt_array_bytes(delta_state.as_ref())
     }
 
     /// Snapshot the recurrent state at the start of a speculative round.

--- a/crates/rmlx-kv-quant/src/mixed_quant/state.rs
+++ b/crates/rmlx-kv-quant/src/mixed_quant/state.rs
@@ -33,6 +33,22 @@ pub struct MixedTuple {
 }
 
 impl MixedTuple {
+    /// Resident bytes of this quantized 3-tuple.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            codes,
+            scales,
+            biases,
+        } = self;
+        crate::bytes::array_bytes(codes)
+            + crate::bytes::array_bytes(scales)
+            + crate::bytes::array_bytes(biases)
+    }
+
     /// Slice each of the three arrays along axis=2 to `[..., :off, :]`.
     #[allow(
         clippy::indexing_slicing,
@@ -155,6 +171,30 @@ pub struct MixedKvState {
 }
 
 impl MixedKvState {
+    /// Resident bytes held by this state: both quantized 3-tuples plus the
+    /// optional per-layer Hadamard rotation matrix.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            keys,
+            values,
+            k_rotation,
+            // Codec parameters / bookkeeping, not allocations.
+            k_bits: _,
+            v_bits: _,
+            k_group_size: _,
+            v_group_size: _,
+            offset: _,
+            rotate_k: _,
+        } = self;
+        keys.as_ref().map_or(0, MixedTuple::byte_size)
+            + values.as_ref().map_or(0, MixedTuple::byte_size)
+            + k_rotation.as_ref().map_or(0, crate::bytes::array_bytes)
+    }
+
     pub fn new(k_bits: i32, v_bits: i32, k_group_size: i32, v_group_size: i32) -> Self {
         Self {
             k_bits,

--- a/crates/rmlx-kv-quant/src/paged/alloc.rs
+++ b/crates/rmlx-kv-quant/src/paged/alloc.rs
@@ -57,22 +57,25 @@ impl PageSlab {
 
     /// Actual on-device bytes across all allocated pages in this slab.
     ///
-    /// Counts only allocated (initialised) pages — `pool[i].is_some()` up to
-    /// `next_free`. Each page holds `page_tokens * elems_per_token` elements at
-    /// `dtype.itemsize()` bytes each. Pages that are allocated but not yet fully
-    /// written count their full allocation.
+    /// Read from each live page's own shape × dtype rather than recomputed as
+    /// `pages × page_tokens × elems_per_token × itemsize`: the pages are the
+    /// allocation, the geometry fields are only bookkeeping about it. An
+    /// unallocated page contributes nothing. Pages that are allocated but not
+    /// yet fully written count their full allocation.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
     pub(super) fn resident_bytes(&self) -> u64 {
-        #[allow(
-            clippy::indexing_slicing,
-            reason = "next_free is monotonically bounded by pool.len() by construction"
-        )]
-        let allocated_pages = self.pool[..self.next_free]
-            .iter()
-            .filter(|p| p.is_some())
-            .count() as u64;
-        let elems_per_page = self.page_elems() as u64;
-        let item_bytes = self.dtype.itemsize() as u64;
-        allocated_pages * elems_per_page * item_bytes
+        let Self {
+            pool,
+            // Geometry / bookkeeping about the pages above, not allocations.
+            elems_per_token: _,
+            page_tokens: _,
+            next_free: _,
+            free_list: _,
+            dtype: _,
+        } = self;
+        pool.iter().flatten().map(crate::bytes::array_bytes).sum()
     }
 
     /// Allocate the next free physical page, initialize it to zeros on `device`.

--- a/crates/rmlx-kv-quant/src/paged/ops.rs
+++ b/crates/rmlx-kv-quant/src/paged/ops.rs
@@ -194,8 +194,24 @@ impl PagedKStorage {
     }
 
     /// Actual on-device bytes across all allocated pages (codes + scales slabs).
+    ///
+    /// The exhaustive destructure is the drift guard: a new slab cannot be
+    /// added to this struct without this failing to compile.
     pub fn resident_bytes(&self) -> u64 {
-        self.codes.resident_bytes() + self.scales.resident_bytes()
+        let Self {
+            codes,
+            scales,
+            // Block table / geometry, not page allocations.
+            block_table: _,
+            total_tokens: _,
+            page_tokens: _,
+            tokens_in_last_page: _,
+            words_per_token: _,
+            scales_per_token: _,
+            shape: _,
+            max_seq: _,
+        } = self;
+        codes.resident_bytes() + scales.resident_bytes()
     }
 
     #[allow(
@@ -390,8 +406,25 @@ impl PagedVStorage {
     }
 
     /// Actual on-device bytes across all allocated pages (codes + scales slabs).
+    ///
+    /// The exhaustive destructure is the drift guard: a new slab cannot be
+    /// added to this struct without this failing to compile.
     pub fn resident_bytes(&self) -> u64 {
-        self.codes.resident_bytes() + self.scales.resident_bytes()
+        let Self {
+            codes,
+            scales,
+            // Block table / geometry, not page allocations.
+            block_table: _,
+            total_tokens: _,
+            page_tokens: _,
+            tokens_in_last_page: _,
+            words_per_token: _,
+            scales_per_token: _,
+            shape: _,
+            max_seq: _,
+            bits: _,
+        } = self;
+        codes.resident_bytes() + scales.resident_bytes()
     }
 
     #[allow(
@@ -617,8 +650,26 @@ impl PagedPlanarVStorage {
     }
 
     /// Actual on-device bytes across all allocated pages (codes + scales + rotations slabs).
+    ///
+    /// The exhaustive destructure is the drift guard: a new slab cannot be
+    /// added to this struct without this failing to compile.
     pub fn resident_bytes(&self) -> u64 {
-        self.codes.resident_bytes() + self.scales.resident_bytes() + self.rotations.resident_bytes()
+        let Self {
+            codes,
+            scales,
+            rotations,
+            // Block table / geometry, not page allocations.
+            block_table: _,
+            total_tokens: _,
+            page_tokens: _,
+            tokens_in_last_page: _,
+            codes_words_per_token: _,
+            scales_per_token: _,
+            rotations_words_per_token: _,
+            shape: _,
+            max_seq: _,
+        } = self;
+        codes.resident_bytes() + scales.resident_bytes() + rotations.resident_bytes()
     }
 
     #[allow(

--- a/crates/rmlx-kv-quant/src/planarquant.rs
+++ b/crates/rmlx-kv-quant/src/planarquant.rs
@@ -153,6 +153,27 @@ pub struct PlanarBlocks {
     pub bits: u8,
 }
 
+impl PlanarBlocks {
+    /// Heap bytes this block holds.
+    ///
+    /// The exhaustive destructure is the drift guard: a new payload field
+    /// cannot be added without this failing to compile. See [`crate::bytes`].
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            codes,
+            scales,
+            rotations,
+            // Inline metadata (no heap payload).
+            original_shape: _,
+            bits: _,
+        } = self;
+        crate::bytes::vec_bytes(codes)
+            + crate::bytes::vec_bytes(scales)
+            + crate::bytes::vec_bytes(rotations)
+    }
+}
+
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 /// Pairs per block: `GROUP_SIZE / 2`.

--- a/crates/rmlx-kv-quant/src/rotating.rs
+++ b/crates/rmlx-kv-quant/src/rotating.rs
@@ -64,6 +64,30 @@ pub(super) struct RotatingState {
 }
 
 impl RotatingState {
+    /// Resident bytes of the SWA ring, counting the filled prefix of each
+    /// buffer.
+    ///
+    /// The ring holds at most `max_size` live positions and is allocated to
+    /// that window; early in a sequence only `filled` of them carry K/V.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile. Reaching the ring's
+    /// buffers by field access from the caller would leave a third buffer
+    /// silently uncounted, which is the whole class this accounting closes.
+    pub(super) fn byte_size(&self, filled: u64) -> u64 {
+        let Self {
+            keys,
+            values,
+            // Ring bookkeeping, not allocations.
+            offset: _,
+            max_size: _,
+            keep: _,
+            idx: _,
+        } = self;
+        crate::bytes::opt_filled_seq_bytes(keys.as_ref(), filled)
+            + crate::bytes::opt_filled_seq_bytes(values.as_ref(), filled)
+    }
+
     pub(super) fn new(max_size: i32) -> Self {
         Self {
             keys: None,

--- a/crates/rmlx-kv-quant/src/storage/kv_storage.rs
+++ b/crates/rmlx-kv-quant/src/storage/kv_storage.rs
@@ -14,7 +14,6 @@
 #![allow(clippy::match_same_arms, clippy::too_many_lines)]
 
 use rmlx_core::error::Result;
-use rmlx_mlx::Array;
 
 use super::{
     QuantIsoK3, QuantIsoK4, QuantIsoV3, QuantIsoV4, QuantK, QuantKTurbo3, QuantKTurbo4,
@@ -22,18 +21,6 @@ use super::{
 };
 use crate::paged::{PagedKStorage, PagedPlanarVStorage, PagedVStorage};
 use crate::KvQuant;
-
-// ── Byte-accounting helper ────────────────────────────────────────────────────
-
-/// Actual on-device bytes for a single `Array` — shape product × dtype item size.
-///
-/// Works entirely from array metadata (no FFI eval, no data read). Returns 0
-/// for zero-dimensional or empty arrays. Used by [`KvStorage::resident_bytes`].
-#[inline]
-fn array_nbytes(a: &Array) -> u64 {
-    let n: u64 = a.shape().iter().map(|&d| d as u64).product();
-    n * a.dtype().itemsize() as u64
-}
 
 /// Layout tag for symmetric TurboQuant 3-bit K + turbo3 V.
 ///
@@ -1559,117 +1546,163 @@ impl KvStorage {
         })
     }
 
-    /// Actual on-device byte footprint of the quantized storage buffers.
+    /// Resident byte footprint of this variant's quantized storage.
     ///
-    /// Sums the bytes of every allocated buffer in the storage variant:
-    /// - For GPU-backed variants (`QuantK`, `QuantV`, `QuantPlanarV`, …):
-    ///   actual `Array` shape × dtype item-size (allocated at `gpu_capacity`,
-    ///   not just filled tokens — the allocator uses power-of-two pages).
-    /// - For CPU-backed variants (`IsoBlocks`, `RotorBlocks`, …):
-    ///   sum of all `Vec` element sizes in bytes.
-    /// - `KvStorage::None` returns **0**: its buffers live on the parent
-    ///   `KvCache::decode_fp16_k/v` and are counted by `KvCache::resident_bytes`.
+    /// Every arm delegates to the owning store's own `byte_size`, which derives
+    /// the total from that store's real allocations — CPU blocks, GPU mirrors
+    /// and GPU rings alike. There is deliberately **no** per-codec byte formula
+    /// here: a second, hand-maintained restatement of what each store holds is
+    /// what let a store grow a GPU ring while this total stayed blind to it.
+    /// The store owns its own size; this function only routes.
     ///
-    /// Does **not** count the warm-TTFT fp16 decode-seed buffers
-    /// (`KvCache::decode_fp16_k/v`) — those are tallied separately in
-    /// [`KvCache::resident_bytes`] for all quantized variants.
+    /// GPU buffers count their full allocation (rings and mirrors are sized to
+    /// capacity, not to the filled prefix) — that is the memory actually held.
+    ///
+    /// `KvStorage::None` returns **0**: its buffers live on the parent
+    /// `KvCache::decode_fp16_k/v` and are counted by `KvCache::resident_bytes`,
+    /// which also adds the warm-TTFT fp16 decode seeds for quantized variants.
+    ///
+    /// The arms bind every field explicitly (no `..` rest-patterns): adding a
+    /// buffer to a variant is then a compile error here until it is accounted.
     #[allow(
         clippy::too_many_lines,
-        reason = "exhaustive match over all KvStorage variants — LOC-exempt: KvStorage has 30 variants; each arm is a one-to-three line byte summation that cannot be factored further without losing explicitness"
+        reason = "exhaustive match over all KvStorage variants — LOC-exempt: KvStorage has 30 variants; each arm is a one-to-three line delegation that cannot be factored further without losing explicitness"
     )]
     pub fn resident_bytes(&self) -> u64 {
         match self {
             // ── Unquantised (bf16) ─────────────────────────────────────────────
             // Buffers live on KvCache::decode_fp16_k/v; nothing extra here.
-            KvStorage::None { .. } => 0,
+            KvStorage::None { max_seq: _ } => 0,
 
             // ── K8V8 (K = q8_0, V = q8_0; V uses QuantK not QuantV) ─────────
-            KvStorage::K8V8 { k, v, .. } => quant_k_bytes(k.as_ref()) + quant_k_bytes(v.as_ref()),
+            KvStorage::K8V8 { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantK::byte_size) + opt_bytes(v.as_ref(), QuantK::byte_size)
+            }
 
             // ── K8V4 / K8VTurbo* (K = q8_0, V = TurboQuant) ─────────────────
-            KvStorage::K8V4 { k, v, .. }
-            | KvStorage::K8VTurbo3 { k, v, .. }
-            | KvStorage::K8VTurbo3Tcq { k, v, .. }
-            | KvStorage::K8VTurbo2 { k, v, .. }
-            | KvStorage::K8VTurbo2Tcq { k, v, .. } => {
-                quant_k_bytes(k.as_ref()) + quant_v_bytes(v.as_ref())
+            KvStorage::K8V4 { k, v, max_seq: _ }
+            | KvStorage::K8VTurbo3 { k, v, max_seq: _ }
+            | KvStorage::K8VTurbo3Tcq { k, v, max_seq: _ }
+            | KvStorage::K8VTurbo2 { k, v, max_seq: _ }
+            | KvStorage::K8VTurbo2Tcq { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantK::byte_size) + opt_bytes(v.as_ref(), QuantV::byte_size)
             }
 
             // ── Planar (K=q8, V=PlanarQuant) ─────────────────────────────────
-            KvStorage::Planar { k, v, .. } => {
-                quant_k_bytes(k.as_ref()) + quant_planar_v_bytes(v.as_ref())
+            KvStorage::Planar {
+                k,
+                v,
+                max_seq: _,
+                bits: _,
+            } => {
+                opt_bytes(k.as_ref(), QuantK::byte_size)
+                    + opt_bytes(v.as_ref(), QuantPlanarV::byte_size)
             }
 
             // ── PlanarK (K=PlanarQuant, V=bf16 on KvCache) ───────────────────
-            KvStorage::PlanarK { k, .. } => quant_planar_k_bytes(k.as_ref()),
+            KvStorage::PlanarK { k, max_seq: _ } => opt_bytes(k.as_ref(), QuantPlanarK::byte_size),
 
             // ── Mixed (MLX mx.quantize 3-tuples, opt. RotK) ───────────────────
-            KvStorage::Mixed { state, .. } => mixed_kv_state_bytes(state),
+            KvStorage::Mixed { state, max_seq: _ } => state.byte_size(),
 
             // ── RotKTq4V (rotated-K 3-tuple + TurboQuant V4) ─────────────────
-            KvStorage::RotKTq4V { k_state, v, .. } => {
-                mixed_kv_state_bytes(k_state) + quant_v_bytes(v.as_ref())
-            }
+            KvStorage::RotKTq4V {
+                k_state,
+                v,
+                max_seq: _,
+            } => k_state.byte_size() + opt_bytes(v.as_ref(), QuantV::byte_size),
 
             // ── Symmetric Turbo (K=TurboK3/4, V=TurboV) ─────────────────────
-            KvStorage::TurboSym3 { k, v, .. } => {
-                quant_k_turbo3_bytes(k.as_ref()) + quant_v_bytes(v.as_ref())
+            KvStorage::TurboSym3 { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantKTurbo3::byte_size)
+                    + opt_bytes(v.as_ref(), QuantV::byte_size)
             }
-            KvStorage::TurboSym4 { k, v, .. } => {
-                quant_k_turbo4_bytes(k.as_ref()) + quant_v_bytes(v.as_ref())
+            KvStorage::TurboSym4 { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantKTurbo4::byte_size)
+                    + opt_bytes(v.as_ref(), QuantV::byte_size)
             }
 
             // ── IsoQuant V (K=q8, V=Iso3/4) ──────────────────────────────────
-            KvStorage::IsoV3 { k, v, .. } => {
-                quant_k_bytes(k.as_ref()) + quant_iso_v3_bytes(v.as_ref())
+            KvStorage::IsoV3 { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantK::byte_size)
+                    + opt_bytes(v.as_ref(), QuantIsoV3::byte_size)
             }
-            KvStorage::IsoV4 { k, v, .. } => {
-                quant_k_bytes(k.as_ref()) + quant_iso_v4_bytes(v.as_ref())
+            KvStorage::IsoV4 { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantK::byte_size)
+                    + opt_bytes(v.as_ref(), QuantIsoV4::byte_size)
             }
 
             // ── IsoQuant Sym (K=IsoK3/4, V=IsoV3/4) ─────────────────────────
-            KvStorage::IsoSym3 { k, v, .. } => {
-                quant_iso_k3_bytes(k.as_ref()) + quant_iso_v3_bytes(v.as_ref())
+            KvStorage::IsoSym3 { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantIsoK3::byte_size)
+                    + opt_bytes(v.as_ref(), QuantIsoV3::byte_size)
             }
-            KvStorage::IsoSym4 { k, v, .. } => {
-                quant_iso_k4_bytes(k.as_ref()) + quant_iso_v4_bytes(v.as_ref())
+            KvStorage::IsoSym4 { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantIsoK4::byte_size)
+                    + opt_bytes(v.as_ref(), QuantIsoV4::byte_size)
             }
 
             // ── IsoKOnly (K=Iso3/4, V=bf16 on KvCache) ───────────────────────
-            KvStorage::IsoKOnly3 { k, .. } => quant_iso_k3_bytes(k.as_ref()),
-            KvStorage::IsoKOnly4 { k, .. } => quant_iso_k4_bytes(k.as_ref()),
+            KvStorage::IsoKOnly3 { k, max_seq: _ } => opt_bytes(k.as_ref(), QuantIsoK3::byte_size),
+            KvStorage::IsoKOnly4 { k, max_seq: _ } => opt_bytes(k.as_ref(), QuantIsoK4::byte_size),
 
             // ── RotorV (K=q8, V=Rotor3/4) ────────────────────────────────────
-            KvStorage::RotorV3 { k, v, .. } => {
-                quant_k_bytes(k.as_ref()) + quant_rotor_v3_bytes(v.as_ref())
+            KvStorage::RotorV3 { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantK::byte_size)
+                    + opt_bytes(v.as_ref(), QuantRotorV3::byte_size)
             }
-            KvStorage::RotorV4 { k, v, .. } => {
-                quant_k_bytes(k.as_ref()) + quant_rotor_v4_bytes(v.as_ref())
+            KvStorage::RotorV4 { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantK::byte_size)
+                    + opt_bytes(v.as_ref(), QuantRotorV4::byte_size)
             }
 
             // ── RotorSym (K=RotorK3/4, V=RotorV3/4) ─────────────────────────
-            KvStorage::RotorSym3 { k, v, .. } => {
-                quant_rotor_k3_bytes(k.as_ref()) + quant_rotor_v3_bytes(v.as_ref())
+            KvStorage::RotorSym3 { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantRotorK3::byte_size)
+                    + opt_bytes(v.as_ref(), QuantRotorV3::byte_size)
             }
-            KvStorage::RotorSym4 { k, v, .. } => {
-                quant_rotor_k4_bytes(k.as_ref()) + quant_rotor_v4_bytes(v.as_ref())
+            KvStorage::RotorSym4 { k, v, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantRotorK4::byte_size)
+                    + opt_bytes(v.as_ref(), QuantRotorV4::byte_size)
             }
 
             // ── RotorKOnly (K=RotorK3/4, V=bf16 on KvCache) ─────────────────
-            KvStorage::RotorKOnly3 { k, .. } => quant_rotor_k3_bytes(k.as_ref()),
-            KvStorage::RotorKOnly4 { k, .. } => quant_rotor_k4_bytes(k.as_ref()),
+            KvStorage::RotorKOnly3 { k, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantRotorK3::byte_size)
+            }
+            KvStorage::RotorKOnly4 { k, max_seq: _ } => {
+                opt_bytes(k.as_ref(), QuantRotorK4::byte_size)
+            }
 
             // ── RotorKAsym (K=RotorK3/4, V=affine QuantV) ────────────────────
-            KvStorage::RotorKAsym3 { k, v, .. } => {
-                quant_rotor_k3_bytes(k.as_ref()) + quant_v_bytes(v.as_ref())
+            KvStorage::RotorKAsym3 {
+                k,
+                v,
+                max_seq: _,
+                v_bits: _,
+                v_group_size: _,
+            } => {
+                opt_bytes(k.as_ref(), QuantRotorK3::byte_size)
+                    + opt_bytes(v.as_ref(), QuantV::byte_size)
             }
-            KvStorage::RotorKAsym4 { k, v, .. } => {
-                quant_rotor_k4_bytes(k.as_ref()) + quant_v_bytes(v.as_ref())
+            KvStorage::RotorKAsym4 {
+                k,
+                v,
+                max_seq: _,
+                v_bits: _,
+                v_group_size: _,
+            } => {
+                opt_bytes(k.as_ref(), QuantRotorK4::byte_size)
+                    + opt_bytes(v.as_ref(), QuantV::byte_size)
             }
 
             // ── Paged (block-table KV, --paged-kv path) ───────────────────────
             KvStorage::Paged {
-                k, v_k8, v_planar, ..
+                k,
+                v_k8,
+                v_planar,
+                quant: _,
+                max_seq: _,
             } => {
                 let k_bytes = k.as_ref().map_or(0, PagedKStorage::resident_bytes);
                 // v_k8 / v_planar are Box-wrapped; closure used to deref through Box.
@@ -1681,369 +1714,7 @@ impl KvStorage {
     }
 }
 
-// ── Per-type byte-counting helpers ────────────────────────────────────────────
-//
-// Each function accepts an `Option<&T>` (None = storage not yet populated →
-// returns 0) and sums the actual buffer bytes for that codec type.
-
-/// Affine q8_0 K buffer (`QuantK`).
-///
-/// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32) — sized to
-/// `gpu_capacity`, not just `offset`. CPU path: `codes` (u8) + `scales` (f32).
-///
-/// NOTE: After an SSD-hydrate init the GPU mirror is live (`gpu_codes_buf =
-/// Some`) *and* the pre-hydration CPU `codes`/`scales` are still resident in
-/// RAM (the hydrate upload path never clears them). Both allocations are
-/// counted.
-fn quant_k_bytes(qk: Option<&QuantK>) -> u64 {
-    let Some(qk) = qk else {
-        return 0;
-    };
-    if let Some(ref codes) = qk.gpu_codes_buf {
-        let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
-        // Add any coexisting CPU residual (pre-hydration data not cleared on
-        // GPU-mirror init; see `QuantK::append_inner` hydrated-init block).
-        let cpu_residual = qk.codes.len() as u64 + qk.scales.len() as u64 * 4;
-        array_nbytes(codes) + scales_bytes + cpu_residual
-    } else {
-        // CPU path: codes = Vec<u8>, scales = Vec<f32>
-        qk.codes.len() as u64 + qk.scales.len() as u64 * 4
-    }
-}
-
-/// TurboQuant V buffer (`QuantV`), used for K8V4 / K8V8 / K8VTurbo* / RotorKAsym.
-///
-/// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32). CPU path: sum of
-/// `TurboBlocks` — each block has `codes: Vec<u8>` (1 B/elem) and
-/// `scales: Vec<f32>` (4 B/elem).
-///
-/// NOTE: After an SSD-hydrate init the GPU mirror is live and the pre-hydration
-/// CPU `blocks` are still resident in RAM. Both are counted.
-fn quant_v_bytes(qv: Option<&QuantV>) -> u64 {
-    let Some(qv) = qv else {
-        return 0;
-    };
-    if let Some(ref codes) = qv.gpu_codes_buf {
-        let scales_bytes = qv.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
-        // Add any coexisting CPU residual (pre-hydration blocks not cleared on
-        // GPU-mirror init; see `QuantV::append_inner` hydrated-init block).
-        let cpu_residual: u64 = qv
-            .blocks
-            .iter()
-            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
-            .sum();
-        array_nbytes(codes) + scales_bytes + cpu_residual
-    } else {
-        // CPU path: TurboBlocks — codes: Vec<u8>, scales: Vec<f32>
-        qv.blocks
-            .iter()
-            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
-            .sum()
-    }
-}
-
-/// PlanarQuant V buffer (`QuantPlanarV`), used for `Planar` variant.
-///
-/// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32) +
-/// `gpu_rotations_buf` (u32). CPU path: sum of `PlanarBlocks` — each has
-/// `codes: Vec<u8>` (1 B), `scales: Vec<f32>` (4 B), `rotations: Vec<u8>` (1 B).
-///
-/// NOTE: After an SSD-hydrate init the GPU mirror is live and the pre-hydration
-/// CPU `blocks` are still resident in RAM. Both are counted.
-fn quant_planar_v_bytes(qv: Option<&QuantPlanarV>) -> u64 {
-    let Some(qv) = qv else {
-        return 0;
-    };
-    if let Some(ref codes) = qv.gpu_codes_buf {
-        let scales_bytes = qv.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
-        let rot_bytes = qv.gpu_rotations_buf.as_ref().map_or(0, array_nbytes);
-        // Add any coexisting CPU residual (pre-hydration blocks not cleared on
-        // GPU-mirror init; see `QuantPlanarV::append` hydrated-init block).
-        let cpu_residual: u64 = qv
-            .blocks
-            .iter()
-            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4 + b.rotations.len() as u64)
-            .sum();
-        array_nbytes(codes) + scales_bytes + rot_bytes + cpu_residual
-    } else {
-        qv.blocks
-            .iter()
-            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4 + b.rotations.len() as u64)
-            .sum()
-    }
-}
-
-/// PlanarQuant K buffer (`QuantPlanarK`), used for `PlanarK` variant.
-///
-/// Same buffer layout as `QuantPlanarV` — GPU or CPU with codes/scales/rotations.
-///
-/// NOTE: After an SSD-hydrate init the GPU mirror is live and the pre-hydration
-/// CPU `blocks` are still resident in RAM. Both are counted.
-fn quant_planar_k_bytes(qk: Option<&QuantPlanarK>) -> u64 {
-    let Some(qk) = qk else {
-        return 0;
-    };
-    if let Some(ref codes) = qk.gpu_codes_buf {
-        let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
-        let rot_bytes = qk.gpu_rotations_buf.as_ref().map_or(0, array_nbytes);
-        // Add any coexisting CPU residual (pre-hydration blocks not cleared on
-        // GPU-mirror init; see `QuantPlanarK::append` hydrated-init block).
-        let cpu_residual: u64 = qk
-            .blocks
-            .iter()
-            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4 + b.rotations.len() as u64)
-            .sum();
-        array_nbytes(codes) + scales_bytes + rot_bytes + cpu_residual
-    } else {
-        qk.blocks
-            .iter()
-            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4 + b.rotations.len() as u64)
-            .sum()
-    }
-}
-
-/// MLX mx.quantize 3-tuple state (`MixedKvState`).
-///
-/// Each `MixedTuple` has three `Array`s: codes (u32), scales (bf16/f32), biases
-/// (bf16/f32). Also includes the optional per-layer Hadamard rotation matrix
-/// (`k_rotation`: `Array`).
-fn mixed_kv_state_bytes(state: &crate::mixed_quant::MixedKvState) -> u64 {
-    fn tuple_bytes(t: &crate::mixed_quant::MixedTuple) -> u64 {
-        array_nbytes(&t.codes) + array_nbytes(&t.scales) + array_nbytes(&t.biases)
-    }
-    let k_bytes = state.keys.as_ref().map_or(0, tuple_bytes);
-    let v_bytes = state.values.as_ref().map_or(0, tuple_bytes);
-    let rot_bytes = state.k_rotation.as_ref().map_or(0, array_nbytes);
-    k_bytes + v_bytes + rot_bytes
-}
-
-/// TurboQuant 3-bit K buffer (`QuantKTurbo3`).
-///
-/// GPU path: `gpu_codes_buf` (u32) + `gpu_scales_buf` (f32).
-/// CPU path: sum of `TurboBlocks`.
-///
-/// NOTE: After an SSD-hydrate init the GPU mirror is live and the pre-hydration
-/// CPU `blocks` are still resident in RAM. Both are counted.
-fn quant_k_turbo3_bytes(qk: Option<&QuantKTurbo3>) -> u64 {
-    let Some(qk) = qk else {
-        return 0;
-    };
-    if let Some(ref codes) = qk.gpu_codes_buf {
-        let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
-        // Add any coexisting CPU residual (pre-hydration blocks not cleared on
-        // GPU-mirror init; see `QuantKTurbo3::append` hydrated-init block).
-        let cpu_residual: u64 = qk
-            .blocks
-            .iter()
-            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
-            .sum();
-        array_nbytes(codes) + scales_bytes + cpu_residual
-    } else {
-        qk.blocks
-            .iter()
-            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
-            .sum()
-    }
-}
-
-/// TurboQuant 4-bit K buffer (`QuantKTurbo4`).
-///
-/// Same buffer layout as `QuantKTurbo3` — GPU codes/scales or CPU TurboBlocks.
-///
-/// NOTE: After an SSD-hydrate init the GPU mirror is live and the pre-hydration
-/// CPU `blocks` are still resident in RAM. Both are counted.
-fn quant_k_turbo4_bytes(qk: Option<&QuantKTurbo4>) -> u64 {
-    let Some(qk) = qk else {
-        return 0;
-    };
-    if let Some(ref codes) = qk.gpu_codes_buf {
-        let scales_bytes = qk.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
-        // Add any coexisting CPU residual (pre-hydration blocks not cleared on
-        // GPU-mirror init; see `QuantKTurbo4::append` hydrated-init block).
-        let cpu_residual: u64 = qk
-            .blocks
-            .iter()
-            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
-            .sum();
-        array_nbytes(codes) + scales_bytes + cpu_residual
-    } else {
-        qk.blocks
-            .iter()
-            .map(|b| b.codes.len() as u64 + b.scales.len() as u64 * 4)
-            .sum()
-    }
-}
-
-/// IsoQuant 3-bit V buffer (`QuantIsoV3`).
-///
-/// GPU path (when `gpu_resident_iso` gate enabled): `gpu_codes_buf` (u32) +
-/// `gpu_scales_buf` (f32) + `gpu_norms_buf` (f32). CPU path: sum of
-/// `IsoBlocks` — each has `codes: Vec<u32>` (4 B), `scales: Vec<f32>` (4 B),
-/// `quaternions: Vec<f32>` (4 B), `norms: Vec<f32>` (4 B).
-///
-/// NOTE: `QuantIsoV3::gpu_offset` advances independently from `blocks` when
-/// CPU-only blocks are also appended, e.g. after an SSD-hydrate fallback
-/// (see `quant_iso_v.rs` field doc on `gpu_offset`). Both GPU-mirror and any
-/// coexisting CPU `blocks` are resident simultaneously, so both are counted.
-fn quant_iso_v3_bytes(qv: Option<&QuantIsoV3>) -> u64 {
-    let Some(qv) = qv else {
-        return 0;
-    };
-    // GPU path (crate-private fields accessed from within the same crate).
-    if let Some(ref codes) = qv.gpu_codes_buf {
-        let scales_bytes = qv.gpu_scales_buf.as_ref().map_or(0, array_nbytes);
-        let norms_bytes = qv.gpu_norms_buf.as_ref().map_or(0, array_nbytes);
-        // Add any coexisting CPU residual (blocks can be non-empty under a live
-        // GPU mirror after an SSD-hydrate fallback — gpu_offset advances
-        // independently; CPU blocks remain resident).
-        let cpu_residual: u64 = qv
-            .blocks
-            .iter()
-            .map(|b| {
-                b.codes.len() as u64 * 4
-                    + b.scales.len() as u64 * 4
-                    + b.quaternions.len() as u64 * 4
-                    + b.norms.len() as u64 * 4
-            })
-            .sum();
-        return array_nbytes(codes) + scales_bytes + norms_bytes + cpu_residual;
-    }
-    // CPU path.
-    qv.blocks
-        .iter()
-        .map(|b| {
-            b.codes.len() as u64 * 4
-                + b.scales.len() as u64 * 4
-                + b.quaternions.len() as u64 * 4
-                + b.norms.len() as u64 * 4
-        })
-        .sum()
-}
-
-/// IsoQuant 4-bit V buffer (`QuantIsoV4`, CPU-only).
-fn quant_iso_v4_bytes(qv: Option<&QuantIsoV4>) -> u64 {
-    qv.map_or(0, |q| {
-        q.blocks
-            .iter()
-            .map(|b| {
-                b.codes.len() as u64 * 4
-                    + b.scales.len() as u64 * 4
-                    + b.quaternions.len() as u64 * 4
-                    + b.norms.len() as u64 * 4
-            })
-            .sum()
-    })
-}
-
-/// IsoQuant 3-bit K buffer (`QuantIsoK3`, CPU-only). Same layout as IsoV3 blocks.
-fn quant_iso_k3_bytes(qk: Option<&QuantIsoK3>) -> u64 {
-    qk.map_or(0, |q| {
-        q.blocks
-            .iter()
-            .map(|b| {
-                b.codes.len() as u64 * 4
-                    + b.scales.len() as u64 * 4
-                    + b.quaternions.len() as u64 * 4
-                    + b.norms.len() as u64 * 4
-            })
-            .sum()
-    })
-}
-
-/// IsoQuant 4-bit K buffer (`QuantIsoK4`, CPU-only). Same block layout.
-fn quant_iso_k4_bytes(qk: Option<&QuantIsoK4>) -> u64 {
-    qk.map_or(0, |q| {
-        q.blocks
-            .iter()
-            .map(|b| {
-                b.codes.len() as u64 * 4
-                    + b.scales.len() as u64 * 4
-                    + b.quaternions.len() as u64 * 4
-                    + b.norms.len() as u64 * 4
-            })
-            .sum()
-    })
-}
-
-/// Rotor3 V buffer (`QuantRotorV3`, CPU-only).
-///
-/// Includes the static per-layer rotor table (`rotors: Vec<f32>`, 4 B each)
-/// and the per-token `RotorBlocks` payload: `codes: Vec<u32>` (4 B),
-/// `scales: Vec<f32>` (4 B), `norms: Vec<f32>` (4 B).
-fn quant_rotor_v3_bytes(qv: Option<&QuantRotorV3>) -> u64 {
-    qv.map_or(0, |q| {
-        let rotor_bytes = q.rotors.len() as u64 * 4;
-        let block_bytes: u64 = q
-            .blocks
-            .iter()
-            .map(|b| {
-                b.codes.len() as u64 * 4 + b.scales.len() as u64 * 4 + b.norms.len() as u64 * 4
-            })
-            .sum();
-        rotor_bytes + block_bytes
-    })
-}
-
-/// Rotor4 V buffer (`QuantRotorV4`, CPU-only). Same layout as RotorV3.
-fn quant_rotor_v4_bytes(qv: Option<&QuantRotorV4>) -> u64 {
-    qv.map_or(0, |q| {
-        let rotor_bytes = q.rotors.len() as u64 * 4;
-        let block_bytes: u64 = q
-            .blocks
-            .iter()
-            .map(|b| {
-                b.codes.len() as u64 * 4 + b.scales.len() as u64 * 4 + b.norms.len() as u64 * 4
-            })
-            .sum();
-        rotor_bytes + block_bytes
-    })
-}
-
-/// Rotor3 K buffer (`QuantRotorK3`).
-///
-/// Counts the CPU blocks only. The GPU-resident ring (`QuantKGpuRing`) that backs
-/// the rotor flash-decode is accounted by `QuantRotorK3::byte_size`.
-///
-/// Includes: static `rotors: Vec<f32>` (4 B), optional QJL projection matrix
-/// `qjl_s_matrix: Vec<f32>` (4 B), and per-token `RotorKBlocks`:
-/// `codes: Vec<u32>` (4 B), `scales: Vec<f32>` (4 B), `norms: Vec<f32>` (4 B),
-/// `qjl_codes: Vec<u8>` (1 B), `qjl_norms: Vec<f32>` (4 B).
-fn quant_rotor_k3_bytes(qk: Option<&QuantRotorK3>) -> u64 {
-    qk.map_or(0, |q| {
-        let rotor_bytes = q.rotors.len() as u64 * 4;
-        let qjl_mat_bytes = q.qjl_s_matrix.as_ref().map_or(0, |m| m.len() as u64 * 4);
-        let block_bytes: u64 = q
-            .blocks
-            .iter()
-            .map(|b| {
-                b.codes.len() as u64 * 4
-                    + b.scales.len() as u64 * 4
-                    + b.norms.len() as u64 * 4
-                    + b.qjl_codes.len() as u64
-                    + b.qjl_norms.len() as u64 * 4
-            })
-            .sum();
-        rotor_bytes + qjl_mat_bytes + block_bytes
-    })
-}
-
-/// Rotor4 K buffer (`QuantRotorK4`). Same layout as RotorK3; same GPU-ring
-/// accounting note.
-fn quant_rotor_k4_bytes(qk: Option<&QuantRotorK4>) -> u64 {
-    qk.map_or(0, |q| {
-        let rotor_bytes = q.rotors.len() as u64 * 4;
-        let qjl_mat_bytes = q.qjl_s_matrix.as_ref().map_or(0, |m| m.len() as u64 * 4);
-        let block_bytes: u64 = q
-            .blocks
-            .iter()
-            .map(|b| {
-                b.codes.len() as u64 * 4
-                    + b.scales.len() as u64 * 4
-                    + b.norms.len() as u64 * 4
-                    + b.qjl_codes.len() as u64
-                    + b.qjl_norms.len() as u64 * 4
-            })
-            .sum();
-        rotor_bytes + qjl_mat_bytes + block_bytes
-    })
+/// Bytes of an optional store slot; an unpopulated slot (`None`) holds nothing.
+fn opt_bytes<T>(slot: Option<&T>, byte_size: impl Fn(&T) -> u64) -> u64 {
+    slot.map_or(0, byte_size)
 }

--- a/crates/rmlx-kv-quant/src/storage/kv_storage.rs
+++ b/crates/rmlx-kv-quant/src/storage/kv_storage.rs
@@ -1558,6 +1558,12 @@ impl KvStorage {
     /// GPU buffers count their full allocation (rings and mirrors are sized to
     /// capacity, not to the filled prefix) — that is the memory actually held.
     ///
+    /// **Excludes paged-pool overhead.** The `Paged` arm counts the pages the
+    /// slabs hold, not the arena bookkeeping around them. Paged KV
+    /// (`--paged-kv`) is default-OFF, so that overhead is 0 on every normal
+    /// path; if it is ever flipped default-ON, give `PagedKvArena` its own
+    /// `byte_size` and sum it in the `Paged` arm rather than estimating it here.
+    ///
     /// `KvStorage::None` returns **0**: its buffers live on the parent
     /// `KvCache::decode_fp16_k/v` and are counted by `KvCache::resident_bytes`,
     /// which also adds the warm-TTFT fp16 decode seeds for quantized variants.

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -348,20 +348,25 @@ impl QuantIsoK3 {
         self.gpu.packed_view(kv_seq, device)
     }
 
-    /// Approximate byte footprint of the accumulated payload.
+    /// Resident bytes held by this store: CPU blocks plus the GPU ring.
     ///
-    /// Includes the GPU ring when live — it is real resident memory, so
-    /// omitting it would under-report this cache's KV bytes.
+    /// The ring is real resident memory and is counted at its full allocation
+    /// — omitting it under-reports this cache's KV bytes, which is the number
+    /// the codec is judged on.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
     #[must_use]
-    pub fn byte_size(&self) -> usize {
-        let mut total = 0usize;
-        for blk in &self.blocks {
-            total += blk.codes.len() * size_of::<u32>();
-            total += blk.scales.len() * size_of::<f32>();
-            total += blk.quaternions.len() * size_of::<f32>();
-            total += blk.norms.len() * size_of::<f32>();
-        }
-        total + self.gpu.byte_size()
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            blocks,
+            gpu,
+            // Geometry / tags, not allocations.
+            shape: _,
+            max_seq: _,
+            bits: _,
+        } = self;
+        blocks.iter().map(IsoBlocks::byte_size).sum::<u64>() + gpu.byte_size()
     }
 
     /// Dequantize all accumulated K slices into one flat f32 vector of length

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
@@ -264,18 +264,23 @@ impl QuantIsoK4 {
         self.gpu.packed_view(kv_seq, device)
     }
 
-    /// Approximate byte footprint. Includes the GPU ring when live — it is
-    /// real resident memory.
+    /// Resident bytes held by this store: CPU blocks plus the GPU ring.
+    ///
+    /// The ring is real resident memory and is counted at its full allocation.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
     #[must_use]
-    pub fn byte_size(&self) -> usize {
-        let mut total = 0usize;
-        for blk in &self.blocks {
-            total += blk.codes.len() * size_of::<u32>();
-            total += blk.scales.len() * size_of::<f32>();
-            total += blk.quaternions.len() * size_of::<f32>();
-            total += blk.norms.len() * size_of::<f32>();
-        }
-        total + self.gpu.byte_size()
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            blocks,
+            gpu,
+            // Geometry / tags, not allocations.
+            shape: _,
+            max_seq: _,
+            bits: _,
+        } = self;
+        blocks.iter().map(IsoBlocks::byte_size).sum::<u64>() + gpu.byte_size()
     }
 
     /// Dequantize all accumulated K slices into one flat f32 vector.

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -53,6 +53,28 @@ pub struct IsoBlocks {
     pub n_tokens: usize,
 }
 
+impl IsoBlocks {
+    /// Heap bytes this block holds.
+    ///
+    /// The exhaustive destructure is the drift guard: a new payload field
+    /// cannot be added without this failing to compile. See [`crate::bytes`].
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            codes,
+            scales,
+            quaternions,
+            norms,
+            // Inline metadata (no heap payload).
+            n_tokens: _,
+        } = self;
+        crate::bytes::vec_bytes(codes)
+            + crate::bytes::vec_bytes(scales)
+            + crate::bytes::vec_bytes(quaternions)
+            + crate::bytes::vec_bytes(norms)
+    }
+}
+
 /// Accumulated IsoQuant V cache (3-bit, quaternion SO(4) fast mode).
 ///
 /// Storage parallels [`crate::storage::QuantPlanarV`] but the per-group
@@ -329,27 +351,34 @@ impl QuantIsoV3 {
         })
     }
 
-    /// Approximate byte footprint of the accumulated payload.
+    /// Resident bytes held by this store: CPU blocks plus the GPU mirror.
+    ///
+    /// Both are summed unconditionally. `gpu_offset` advances independently of
+    /// `blocks`, so after an SSD-hydrate fallback the mirror and the CPU blocks
+    /// are resident at the same time; an either/or branch would drop one of
+    /// them. Unallocated buffers contribute 0 on their own.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
     #[must_use]
-    pub fn byte_size(&self) -> usize {
-        let mut total = 0usize;
-        for blk in &self.blocks {
-            total += blk.codes.len() * size_of::<u32>();
-            total += blk.scales.len() * size_of::<f32>();
-            total += blk.quaternions.len() * size_of::<f32>();
-            total += blk.norms.len() * size_of::<f32>();
-        }
-        // Include the GPU-resident mirror buffers when allocated. Size is
-        // derived from the per-step shape × current capacity (not blocks),
-        // because the buffers are pre-allocated.
-        if self.gpu_codes_buf.is_some() {
-            let cap = self.gpu_capacity.max(0) as usize;
-            total += cap * (self.gpu_words_per_step.max(0) as usize) * size_of::<u32>();
-            total += cap * (self.gpu_groups_per_step.max(0) as usize) * size_of::<f32>();
-            // norms mirror same per-group layout as scales.
-            total += cap * (self.gpu_groups_per_step.max(0) as usize) * size_of::<f32>();
-        }
-        total
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            blocks,
+            gpu_codes_buf,
+            gpu_scales_buf,
+            gpu_norms_buf,
+            // Geometry / bookkeeping about the buffers above, not allocations.
+            shape: _,
+            bits: _,
+            gpu_words_per_step: _,
+            gpu_groups_per_step: _,
+            gpu_capacity: _,
+            gpu_offset: _,
+        } = self;
+        blocks.iter().map(IsoBlocks::byte_size).sum::<u64>()
+            + crate::bytes::opt_array_bytes(gpu_codes_buf.as_ref())
+            + crate::bytes::opt_array_bytes(gpu_scales_buf.as_ref())
+            + crate::bytes::opt_array_bytes(gpu_norms_buf.as_ref())
     }
 
     /// Dequantize all accumulated V slices into one flat f32 vector

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
@@ -177,17 +177,21 @@ impl QuantIsoV4 {
         })
     }
 
-    /// Approximate byte footprint of the accumulated payload.
+    /// Resident bytes held by this store (CPU blocks; this codec has no GPU
+    /// mirror).
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
     #[must_use]
-    pub fn byte_size(&self) -> usize {
-        let mut total = 0usize;
-        for blk in &self.blocks {
-            total += blk.codes.len() * size_of::<u32>();
-            total += blk.scales.len() * size_of::<f32>();
-            total += blk.quaternions.len() * size_of::<f32>();
-            total += blk.norms.len() * size_of::<f32>();
-        }
-        total
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            blocks,
+            // Geometry / tags, not allocations.
+            shape: _,
+            max_seq: _,
+            bits: _,
+        } = self;
+        blocks.iter().map(IsoBlocks::byte_size).sum()
     }
 
     /// Dequantize all accumulated V slices into one flat f32 vector of length

--- a/crates/rmlx-kv-quant/src/storage/quant_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k.rs
@@ -67,6 +67,35 @@ pub struct QuantK {
 use super::seq_layout::{transpose_heads_seq, transpose_seq_heads};
 
 impl QuantK {
+    /// Resident bytes held by this store: CPU codes/scales plus the GPU mirror.
+    ///
+    /// Both are summed unconditionally — an SSD-hydrate init leaves the
+    /// pre-hydration CPU `codes`/`scales` resident under a live GPU mirror (the
+    /// hydrate upload path never clears them), so both are real memory at once.
+    /// Unallocated buffers contribute 0 on their own.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            codes,
+            scales,
+            gpu_codes_buf,
+            gpu_scales_buf,
+            // Geometry / bookkeeping about the buffers above, not allocations.
+            gpu_words_per_step: _,
+            gpu_scales_per_step: _,
+            gpu_capacity: _,
+            shape: _,
+            max_seq: _,
+        } = self;
+        crate::bytes::vec_bytes(codes)
+            + crate::bytes::vec_bytes(scales)
+            + crate::bytes::opt_array_bytes(gpu_codes_buf.as_ref())
+            + crate::bytes::opt_array_bytes(gpu_scales_buf.as_ref())
+    }
+
     /// Append a new K slice. Picks CPU or GPU path from `device`.
     #[allow(
         clippy::indexing_slicing,

--- a/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring.rs
@@ -85,17 +85,29 @@ impl QuantKGpuRing {
         self.capacity = 0;
     }
 
-    /// Approximate resident byte footprint.
+    /// Resident byte footprint of the ring's GPU buffers.
+    ///
+    /// Read from each buffer's real shape × dtype rather than recomputed from
+    /// `capacity × *_per_step`: the buffers are the allocation, the step
+    /// counts are only bookkeeping about it. A ring that grew — or one whose
+    /// codes dtype changed — reports the truth here with nothing to update.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
     #[must_use]
-    pub fn byte_size(&self) -> usize {
-        if !self.is_allocated() {
-            return 0;
-        }
-        let cap = self.capacity.max(0) as usize;
-        let cps = self.codes_per_step.max(0) as usize;
-        let nps = self.norms_per_step.max(0) as usize;
-        // codes (u32) + scales (f32) + norms (f32).
-        cap * cps * 4 + cap * cps * 4 + cap * nps * 4
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            codes,
+            scales,
+            norms,
+            // Bookkeeping about the buffers above, not allocations of their own.
+            codes_per_step: _,
+            norms_per_step: _,
+            capacity: _,
+        } = self;
+        crate::bytes::opt_array_bytes(codes.as_ref())
+            + crate::bytes::opt_array_bytes(scales.as_ref())
+            + crate::bytes::opt_array_bytes(norms.as_ref())
     }
 
     /// Append one already-encoded chunk into the ring at `prev_seq`.

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo3.rs
@@ -133,16 +133,31 @@ impl QuantKTurbo3 {
         }
     }
 
-    /// Approximate byte footprint of the accumulated payload (CPU path only;
-    /// GPU buffer size is `gpu_capacity * gpu_words_per_step * 4` bytes).
+    /// Resident bytes held by this store: CPU blocks plus the GPU mirror.
+    ///
+    /// Both are summed unconditionally — an SSD-hydrate init leaves the
+    /// pre-hydration CPU blocks resident under a live GPU mirror, so both are
+    /// real memory at once. Unallocated buffers contribute 0 on their own.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
     #[must_use]
-    pub fn byte_size(&self) -> usize {
-        let mut total = 0usize;
-        for blk in &self.blocks {
-            total += blk.codes.len();
-            total += blk.scales.len() * size_of::<f32>();
-        }
-        total
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            blocks,
+            gpu_codes_buf,
+            gpu_scales_buf,
+            // Geometry / bookkeeping about the buffers above, not allocations.
+            gpu_words_per_step: _,
+            gpu_scales_per_step: _,
+            gpu_capacity: _,
+            shape: _,
+            bits: _,
+            max_seq: _,
+        } = self;
+        blocks.iter().map(TurboBlocks::byte_size).sum::<u64>()
+            + crate::bytes::opt_array_bytes(gpu_codes_buf.as_ref())
+            + crate::bytes::opt_array_bytes(gpu_scales_buf.as_ref())
     }
 
     /// Dequantize all accumulated K slices to a flat f32 vec (CPU path).

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo4.rs
@@ -79,6 +79,33 @@ pub struct QuantKTurbo4 {
 }
 
 impl QuantKTurbo4 {
+    /// Resident bytes held by this store: CPU blocks plus the GPU mirror.
+    ///
+    /// Both are summed unconditionally — an SSD-hydrate init leaves the
+    /// pre-hydration CPU blocks resident under a live GPU mirror, so both are
+    /// real memory at once. Unallocated buffers contribute 0 on their own.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            blocks,
+            gpu_codes_buf,
+            gpu_scales_buf,
+            // Geometry / bookkeeping about the buffers above, not allocations.
+            gpu_words_per_step: _,
+            gpu_scales_per_step: _,
+            gpu_capacity: _,
+            shape: _,
+            bits: _,
+            max_seq: _,
+        } = self;
+        blocks.iter().map(TurboBlocks::byte_size).sum::<u64>()
+            + crate::bytes::opt_array_bytes(gpu_codes_buf.as_ref())
+            + crate::bytes::opt_array_bytes(gpu_scales_buf.as_ref())
+    }
+
     /// Append a new K slice. CPU path uses scalar Rust; GPU path uses MSL kernel
     /// + pre-allocated 1D buffer with `slice_update`.
     #[allow(

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_k.rs
@@ -55,6 +55,35 @@ pub struct QuantPlanarK {
 }
 
 impl QuantPlanarK {
+    /// Resident bytes held by this store: CPU blocks plus the GPU mirror.
+    ///
+    /// Both are summed unconditionally — an SSD-hydrate init leaves the
+    /// pre-hydration CPU blocks resident under a live GPU mirror, so both are
+    /// real memory at once. Unallocated buffers contribute 0 on their own.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            blocks,
+            gpu_codes_buf,
+            gpu_scales_buf,
+            gpu_rotations_buf,
+            // Geometry / bookkeeping about the buffers above, not allocations.
+            gpu_codes_words_per_step: _,
+            gpu_scales_per_step: _,
+            gpu_rotations_words_per_step: _,
+            gpu_capacity: _,
+            shape: _,
+            max_seq: _,
+        } = self;
+        blocks.iter().map(PlanarBlocks::byte_size).sum::<u64>()
+            + crate::bytes::opt_array_bytes(gpu_codes_buf.as_ref())
+            + crate::bytes::opt_array_bytes(gpu_scales_buf.as_ref())
+            + crate::bytes::opt_array_bytes(gpu_rotations_buf.as_ref())
+    }
+
     /// Create an empty `QuantPlanarK` with the accumulated shape initialised
     /// to `init_shape` (seq dimension = 0) and GPU buffers unallocated.
     /// Mirrors the `from_cpu_blocks` pattern but sets `max_seq` for later

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_v.rs
@@ -76,6 +76,36 @@ pub struct QuantPlanarV {
 }
 
 impl QuantPlanarV {
+    /// Resident bytes held by this store: CPU blocks plus the GPU mirror.
+    ///
+    /// Both are summed unconditionally — an SSD-hydrate init leaves the
+    /// pre-hydration CPU blocks resident under a live GPU mirror, so both are
+    /// real memory at once. Unallocated buffers contribute 0 on their own.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            blocks,
+            gpu_codes_buf,
+            gpu_scales_buf,
+            gpu_rotations_buf,
+            // Geometry / bookkeeping about the buffers above, not allocations.
+            gpu_codes_words_per_step: _,
+            gpu_scales_per_step: _,
+            gpu_rotations_words_per_step: _,
+            gpu_capacity: _,
+            shape: _,
+            max_seq: _,
+            bits: _,
+        } = self;
+        blocks.iter().map(PlanarBlocks::byte_size).sum::<u64>()
+            + crate::bytes::opt_array_bytes(gpu_codes_buf.as_ref())
+            + crate::bytes::opt_array_bytes(gpu_scales_buf.as_ref())
+            + crate::bytes::opt_array_bytes(gpu_rotations_buf.as_ref())
+    }
+
     /// Append a new V slice. CPU path uses scalar Rust; GPU path uses MSL kernel
     /// + pre-allocated 1D buffers with `slice_update`.
     #[allow(

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
@@ -54,6 +54,30 @@ pub struct RotorKBlocks {
     pub n_tokens: usize,
 }
 
+impl RotorKBlocks {
+    /// Heap bytes this block holds.
+    ///
+    /// The exhaustive destructure is the drift guard: a new payload field
+    /// cannot be added without this failing to compile. See [`crate::bytes`].
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            codes,
+            scales,
+            norms,
+            qjl_codes,
+            qjl_norms,
+            // Inline metadata (no heap payload).
+            n_tokens: _,
+        } = self;
+        crate::bytes::vec_bytes(codes)
+            + crate::bytes::vec_bytes(scales)
+            + crate::bytes::vec_bytes(norms)
+            + crate::bytes::vec_bytes(qjl_codes)
+            + crate::bytes::vec_bytes(qjl_norms)
+    }
+}
+
 /// Accumulated rotor3 K cache.
 ///
 /// Holds:
@@ -392,21 +416,30 @@ impl QuantRotorK3 {
         })
     }
 
-    /// Approximate byte footprint of the accumulated payload.
+    /// Resident bytes held by this store: CPU blocks, the static rotor table
+    /// and QJL projection, plus the GPU ring.
+    ///
+    /// The ring is real resident memory and is counted at its full allocation.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
     #[must_use]
-    pub fn byte_size(&self) -> usize {
-        let mut total = self.rotors.len() * size_of::<f32>();
-        if let Some(s) = &self.qjl_s_matrix {
-            total += s.len() * size_of::<f32>();
-        }
-        for blk in &self.blocks {
-            total += blk.codes.len() * size_of::<u32>();
-            total += blk.scales.len() * size_of::<f32>();
-            total += blk.norms.len() * size_of::<f32>();
-            total += blk.qjl_codes.len();
-            total += blk.qjl_norms.len() * size_of::<f32>();
-        }
-        total + self.gpu.byte_size()
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            rotors,
+            gpu,
+            qjl_s_matrix,
+            blocks,
+            // Geometry / tags, not allocations.
+            shape: _,
+            layer_idx: _,
+            head_idx: _,
+            bits: _,
+        } = self;
+        crate::bytes::vec_bytes(rotors)
+            + crate::bytes::opt_vec_bytes(qjl_s_matrix.as_ref())
+            + blocks.iter().map(RotorKBlocks::byte_size).sum::<u64>()
+            + gpu.byte_size()
     }
 
     /// True when the QJL sideband is active on this cache.

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
@@ -315,21 +315,30 @@ impl QuantRotorK4 {
         })
     }
 
-    /// Approximate byte footprint.
+    /// Resident bytes held by this store: CPU blocks, the static rotor table
+    /// and QJL projection, plus the GPU ring.
+    ///
+    /// The ring is real resident memory and is counted at its full allocation.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
     #[must_use]
-    pub fn byte_size(&self) -> usize {
-        let mut total = self.rotors.len() * size_of::<f32>();
-        if let Some(s) = &self.qjl_s_matrix {
-            total += s.len() * size_of::<f32>();
-        }
-        for blk in &self.blocks {
-            total += blk.codes.len() * size_of::<u32>();
-            total += blk.scales.len() * size_of::<f32>();
-            total += blk.norms.len() * size_of::<f32>();
-            total += blk.qjl_codes.len();
-            total += blk.qjl_norms.len() * size_of::<f32>();
-        }
-        total + self.gpu.byte_size()
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            rotors,
+            gpu,
+            qjl_s_matrix,
+            blocks,
+            // Geometry / tags, not allocations.
+            shape: _,
+            layer_idx: _,
+            head_idx: _,
+            bits: _,
+        } = self;
+        crate::bytes::vec_bytes(rotors)
+            + crate::bytes::opt_vec_bytes(qjl_s_matrix.as_ref())
+            + blocks.iter().map(RotorKBlocks::byte_size).sum::<u64>()
+            + gpu.byte_size()
     }
 
     /// True when the QJL sideband is active.

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
@@ -43,6 +43,26 @@ pub struct RotorBlocks {
     pub n_tokens: usize,
 }
 
+impl RotorBlocks {
+    /// Heap bytes this block holds.
+    ///
+    /// The exhaustive destructure is the drift guard: a new payload field
+    /// cannot be added without this failing to compile. See [`crate::bytes`].
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            codes,
+            scales,
+            norms,
+            // Inline metadata (no heap payload).
+            n_tokens: _,
+        } = self;
+        crate::bytes::vec_bytes(codes)
+            + crate::bytes::vec_bytes(scales)
+            + crate::bytes::vec_bytes(norms)
+    }
+}
+
 /// Accumulated rotor3 V cache.
 ///
 /// Holds:
@@ -259,19 +279,26 @@ impl QuantRotorV3 {
         })
     }
 
-    /// Approximate byte footprint of the accumulated payload.
+    /// Resident bytes held by this store.
     ///
     /// Counts the rotor table **once** (it is layer-static) plus all
     /// accumulated per-token block buffers.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
     #[must_use]
-    pub fn byte_size(&self) -> usize {
-        let mut total = self.rotors.len() * size_of::<f32>();
-        for blk in &self.blocks {
-            total += blk.codes.len() * size_of::<u32>();
-            total += blk.scales.len() * size_of::<f32>();
-            total += blk.norms.len() * size_of::<f32>();
-        }
-        total
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            rotors,
+            blocks,
+            // Geometry / tags, not allocations.
+            shape: _,
+            max_seq: _,
+            layer_idx: _,
+            head_idx: _,
+            bits: _,
+        } = self;
+        crate::bytes::vec_bytes(rotors) + blocks.iter().map(RotorBlocks::byte_size).sum::<u64>()
     }
 
     /// Dequantize all accumulated V slices into one flat f32 vector of length

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3_tests.rs
@@ -82,12 +82,12 @@ fn quant_rotor_v3_byte_size_counts_rotors_once() {
     let data = vec![0.5_f32; 1 * 1 * 4 * head_dim];
     qv.append(&data, &new_shape).unwrap();
 
-    let rotors_bytes = qv.rotors.len() * size_of::<f32>();
+    let rotors_bytes = (qv.rotors.len() * size_of::<f32>()) as u64;
     let blocks_bytes = qv
         .blocks
         .iter()
-        .map(|b| b.codes.len() * 4 + b.scales.len() * 4 + b.norms.len() * 4)
-        .sum::<usize>();
+        .map(|b| (b.codes.len() * 4 + b.scales.len() * 4 + b.norms.len() * 4) as u64)
+        .sum::<u64>();
     assert_eq!(qv.byte_size(), rotors_bytes + blocks_bytes);
 
     // Appending a second block must not double-count rotors.
@@ -95,8 +95,8 @@ fn quant_rotor_v3_byte_size_counts_rotors_once() {
     let new_blocks_bytes = qv
         .blocks
         .iter()
-        .map(|b| b.codes.len() * 4 + b.scales.len() * 4 + b.norms.len() * 4)
-        .sum::<usize>();
+        .map(|b| (b.codes.len() * 4 + b.scales.len() * 4 + b.norms.len() * 4) as u64)
+        .sum::<u64>();
     assert_eq!(qv.byte_size(), rotors_bytes + new_blocks_bytes);
 }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
@@ -245,19 +245,26 @@ impl QuantRotorV4 {
         })
     }
 
-    /// Approximate byte footprint of the accumulated payload.
+    /// Resident bytes held by this store.
     ///
     /// Counts the rotor table **once** (it is layer-static) plus all
     /// accumulated per-token block buffers.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
     #[must_use]
-    pub fn byte_size(&self) -> usize {
-        let mut total = self.rotors.len() * size_of::<f32>();
-        for blk in &self.blocks {
-            total += blk.codes.len() * size_of::<u32>();
-            total += blk.scales.len() * size_of::<f32>();
-            total += blk.norms.len() * size_of::<f32>();
-        }
-        total
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            rotors,
+            blocks,
+            // Geometry / tags, not allocations.
+            shape: _,
+            max_seq: _,
+            layer_idx: _,
+            head_idx: _,
+            bits: _,
+        } = self;
+        crate::bytes::vec_bytes(rotors) + blocks.iter().map(RotorBlocks::byte_size).sum::<u64>()
     }
 
     /// Dequantize all accumulated V slices into one flat f32 vector of length

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v4_tests.rs
@@ -82,12 +82,12 @@ fn quant_rotor_v4_byte_size_counts_rotors_once() {
     let data = vec![0.5_f32; 1 * 1 * 4 * head_dim];
     qv.append(&data, &new_shape).unwrap();
 
-    let rotors_bytes = qv.rotors.len() * size_of::<f32>();
+    let rotors_bytes = (qv.rotors.len() * size_of::<f32>()) as u64;
     let blocks_bytes = qv
         .blocks
         .iter()
-        .map(|b| b.codes.len() * 4 + b.scales.len() * 4 + b.norms.len() * 4)
-        .sum::<usize>();
+        .map(|b| (b.codes.len() * 4 + b.scales.len() * 4 + b.norms.len() * 4) as u64)
+        .sum::<u64>();
     assert_eq!(qv.byte_size(), rotors_bytes + blocks_bytes);
 
     // Appending a second block must not double-count rotors.
@@ -95,8 +95,8 @@ fn quant_rotor_v4_byte_size_counts_rotors_once() {
     let new_blocks_bytes = qv
         .blocks
         .iter()
-        .map(|b| b.codes.len() * 4 + b.scales.len() * 4 + b.norms.len() * 4)
-        .sum::<usize>();
+        .map(|b| (b.codes.len() * 4 + b.scales.len() * 4 + b.norms.len() * 4) as u64)
+        .sum::<u64>();
     assert_eq!(qv.byte_size(), rotors_bytes + new_blocks_bytes);
 }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_v.rs
@@ -151,7 +151,7 @@ impl QuantV {
             max_seq: _,
             use_tcq: _,
         } = self;
-        // `high_precision_indices` is a Vec of per-block Vecs: sum the inner
+        // `high_precision_indices` is a Vec of per-KV-head Vecs: sum the inner
         // payloads, not just the outer Vec's headers.
         let hpi: u64 = high_precision_indices.as_ref().map_or(0, |v| {
             v.iter().map(|inner| crate::bytes::vec_bytes(inner)).sum()

--- a/crates/rmlx-kv-quant/src/storage/quant_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_v.rs
@@ -124,6 +124,46 @@ pub struct QuantV {
 }
 
 impl QuantV {
+    /// Resident bytes held by this store: CPU blocks, the GPU mirror, and the
+    /// TCQ sidebands (high-precision indices, value codebook and its GPU copy).
+    ///
+    /// All are summed unconditionally — an SSD-hydrate init leaves the
+    /// pre-hydration CPU blocks resident under a live GPU mirror, so both are
+    /// real memory at once. Unallocated buffers contribute 0 on their own.
+    ///
+    /// The exhaustive destructure is the drift guard: a new buffer cannot be
+    /// added to this struct without this failing to compile.
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            blocks,
+            gpu_codes_buf,
+            gpu_scales_buf,
+            high_precision_indices,
+            value_codebook,
+            value_codebook_gpu,
+            // Geometry / bookkeeping about the buffers above, not allocations.
+            gpu_words_per_step: _,
+            gpu_scales_per_step: _,
+            gpu_capacity: _,
+            shape: _,
+            bits: _,
+            max_seq: _,
+            use_tcq: _,
+        } = self;
+        // `high_precision_indices` is a Vec of per-block Vecs: sum the inner
+        // payloads, not just the outer Vec's headers.
+        let hpi: u64 = high_precision_indices.as_ref().map_or(0, |v| {
+            v.iter().map(|inner| crate::bytes::vec_bytes(inner)).sum()
+        });
+        blocks.iter().map(TurboBlocks::byte_size).sum::<u64>()
+            + crate::bytes::opt_array_bytes(gpu_codes_buf.as_ref())
+            + crate::bytes::opt_array_bytes(gpu_scales_buf.as_ref())
+            + hpi
+            + crate::bytes::opt_vec_bytes(value_codebook.as_ref())
+            + crate::bytes::opt_array_bytes(value_codebook_gpu.as_ref())
+    }
+
     /// Zero-state decode-init helper. Returns a fresh `QuantV` with cleared
     /// CPU/GPU buffers, the supplied `shape` / `bits` / `max_seq`, and all
     /// calibration / TCQ fields set to their default-off values.

--- a/crates/rmlx-kv-quant/src/turboquant.rs
+++ b/crates/rmlx-kv-quant/src/turboquant.rs
@@ -147,6 +147,24 @@ pub struct TurboBlocks {
     pub bits: u8,
 }
 
+impl TurboBlocks {
+    /// Heap bytes this block holds.
+    ///
+    /// The exhaustive destructure is the drift guard: a new payload field
+    /// cannot be added without this failing to compile. See [`crate::bytes`].
+    #[must_use]
+    pub fn byte_size(&self) -> u64 {
+        let Self {
+            codes,
+            scales,
+            // Inline metadata (no heap payload).
+            original_shape: _,
+            bits: _,
+        } = self;
+        crate::bytes::vec_bytes(codes) + crate::bytes::vec_bytes(scales)
+    }
+}
+
 /// Cold helper: "bits=8 not supported — use affine q8_0" error.
 ///
 /// This arm fires at validation time only (loader or parameter-check call),

--- a/crates/rmlx-models/src/kv_cache/tests.rs
+++ b/crates/rmlx-models/src/kv_cache/tests.rs
@@ -605,32 +605,39 @@ mod tests {
         );
     }
 
-    // ── N16: approx_bytes unit tests ──────────────────────────────────────────
+    // ── resident_bytes unit tests ─────────────────────────────────────────────
+    //
+    // These assert against the buffers each cache really allocated, never
+    // against a per-codec bits-per-element figure. A nominal bit-width is not a
+    // cache's memory: q8_0 also carries per-group scales, and the quantized
+    // paths carry warm-TTFT bf16 seeds on top of the codes. Restating a formula
+    // here would only re-derive the accounting from itself and would go blind
+    // the moment a store grows a buffer.
 
     /// Zero offset → zero bytes regardless of quant mode.
     #[test]
-    fn approx_bytes_empty_cache_is_zero() {
+    fn resident_bytes_empty_cache_is_zero() {
         for quant in [KvQuant::K8V8, KvQuant::K8V4, KvQuant::None, KvQuant::Planar] {
             let cache = KvCache::with_quant(quant);
             assert_eq!(
-                cache.approx_bytes(),
+                cache.resident_bytes(),
                 0,
                 "empty {quant:?} cache must be 0 bytes"
             );
         }
     }
 
-    /// After a single update on `KvQuant::None` (bf16, 16-bit K + 16-bit V),
-    /// approx_bytes should equal: seq × B × kv_h × head_dim × (16+16)/8 bytes.
+    /// `KvQuant::None` holds nothing but the two bf16 mirrors, so its residency
+    /// is exactly their filled prefix — and its storage contributes nothing.
     ///
-    /// Shape: B=1, kv_h=4, seq=256, head_dim=128.
-    /// Expected = 256 × 1 × 4 × 128 × 4 = 524_288 bytes (512 KiB).
+    /// Shape: B=1, kv_h=4, seq=256, head_dim=128 → 256 × 4 × 128 × 2 B per
+    /// mirror, two mirrors.
     #[test]
     #[allow(
         clippy::expect_used,
         reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
     )]
-    fn approx_bytes_none_quant_matches_formula() {
+    fn resident_bytes_none_quant_is_the_two_bf16_mirrors() {
         let device = Device::Cpu;
         // Use a large max_seq so the cache isn't truncated.
         let mut cache = KvCache::with_quant_max_seq(KvQuant::None, 4096);
@@ -643,31 +650,29 @@ mod tests {
             .exit_prefill(device)
             .expect("exit_prefill must not fail");
 
-        // seq=256, B=1, kv_h=4, head_dim=128, bf16 (2 bytes each for K and V)
-        // Formula: seq × kv_h × head_dim × (k_bits + v_bits) / 8
-        let expected: u64 = 256 * 4 * 128 * 4; // (16+16)/8 = 4 bytes per element pair
         assert_eq!(
-            cache.approx_bytes(),
-            expected,
-            "None (bf16) cache: expected {expected} bytes, got {}",
-            cache.approx_bytes()
+            cache.storage().resident_bytes(),
+            0,
+            "KvStorage::None is geometry-only — the bf16 K/V live on the cache's mirrors"
+        );
+        // Two bf16 mirrors at the filled length: 256 × 4 × 128 × 2 B each.
+        let one_mirror: u64 = 256 * 4 * 128 * 2;
+        assert_eq!(
+            cache.resident_bytes(),
+            2 * one_mirror,
+            "None (bf16) cache must report exactly its two bf16 mirrors"
         );
     }
 
-    /// After a single update on `KvQuant::K8V8` (8-bit K + 8-bit V),
-    /// approx_bytes should equal:
-    /// seq × B × kv_h × head_dim × (8+8)/8 + warm-seed bytes
-    /// = 256 × 1 × 4 × 128 × 2 + 256 × 1 × 4 × 128 × 4
-    /// = 262_144 + 524_288 = 786_432 bytes.
-    ///
-    /// The warm-TTFT fp16 seed (decode_fp16_k/v) adds one 2-byte buffer per K
-    /// and V element at the filled sequence length.
+    /// `KvQuant::K8V8` residency is the q8_0 store plus **both** warm-TTFT bf16
+    /// seeds — and the store's real cost (codes *and* per-group scales) exceeds
+    /// the 8-bits-per-element the codec is named for.
     #[test]
     #[allow(
         clippy::expect_used,
         reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
     )]
-    fn approx_bytes_k8v8_matches_formula() {
+    fn resident_bytes_k8v8_counts_store_plus_both_seeds() {
         let device = Device::Cpu;
         let mut cache = KvCache::with_quant_max_seq(KvQuant::K8V8, 4096);
         cache.enter_prefill();
@@ -678,18 +683,23 @@ mod tests {
             .exit_prefill(device)
             .expect("exit_prefill must not fail");
 
-        // quant: K8V8 → (8+8)/8 = 2 bytes per elem pair × seq × bhd
-        // seed: fp16 seed = 4 bytes per elem pair (K+V both fp16) × seq × bhd
-        let bhd: u64 = 4 * 128; // kv_h=4, head_dim=128 (B=1 implicit)
         let seq: u64 = 256;
-        let quant_bytes = seq * bhd * 2; // (8+8)/8 = 2 bytes per (K,V) element
-        let seed_bytes = seq * bhd * 4; // decode_fp16 K+V combined (2+2 bytes)
-        let expected = quant_bytes + seed_bytes;
+        let bhd: u64 = 4 * 128; // kv_h=4, head_dim=128 (B=1 implicit)
+        let store = cache.storage().resident_bytes();
+        // Both seeds are live on K8V8 and both are bf16 at the filled length.
+        let seeds = seq * bhd * 2 * 2;
         assert_eq!(
-            cache.approx_bytes(),
-            expected,
-            "K8V8 cache: expected {expected} bytes, got {}",
-            cache.approx_bytes()
+            cache.resident_bytes(),
+            store + seeds,
+            "K8V8 must report its q8_0 store plus both bf16 seeds"
+        );
+        // The store is the codes *and* their per-group scales: strictly more
+        // than the codec's nominal 8 bits per element for K and V.
+        assert!(
+            store > seq * bhd * 2,
+            "q8_0 store ({store} B) must exceed the nominal 8-bit-per-element figure \
+             ({} B) — the per-group scales are real memory too",
+            seq * bhd * 2
         );
     }
 
@@ -1052,7 +1062,7 @@ mod tests {
     /// drops non-leading kv heads on any axis-2 sub-slice write into a larger
     /// pre-allocated buffer (a pre-existing primitive quirk, unrelated to —
     /// it corrupts K8V8/K8V4/None `decode_fp16` and `prefill_raw` accumulators on
-    /// CPU identically, which is why the existing `approx_bytes_*` CPU tests only
+    /// CPU identically, which is why the existing `resident_bytes_*` CPU tests only
     /// assert byte counts, never values). Therefore this test asserts shape,
     /// finiteness and offset progression on CPU; value-level coherence of the
     /// dequant-before-share K/V is validated by the Gemma4 e4b/26b Mixed baseline
@@ -1375,14 +1385,19 @@ mod tests {
     // each KvQuant variant stays within documented tolerance bands.
     //
     // DESIGN: uses codes-only bytes (seq * bhd * (k_bits + v_bits) / 8),
-    // NOT approx_bytes(), because:
-    // 1. The warm-TTFT fp16 seed included in approx_bytes is a transient
-    // buffer, not steady-state KV compression — including it in a ratio
-    // produces values < 1.0 (quantized "uses more" than bf16), which is
-    // misleading and not what the reference table (mlx-vlm / docs §4) cites.
-    // 2. The (k_bits, v_bits) mapping in approx_bytes IS the regression target:
-    // if any variant's bits change, the codes formula changes → ratio changes
-    // → this test fails.
+    // NOT resident_bytes(), because:
+    // 1. This table pins each codec's **nominal** bit-width ratio — the number
+    // the reference table (mlx-vlm / docs §4) cites. Real residency also
+    // carries per-group scales, warm-TTFT bf16 seeds and (for the ring-backed
+    // codecs) a GPU ring; folding those in produces ratios < 1.0 (quantized
+    // "uses more" than bf16), which is not what this table is about.
+    // 2. The (k_bits, v_bits) mapping below IS the regression target: if any
+    // variant's bits change, the codes formula changes → ratio changes → this
+    // test fails.
+    //
+    // This is the ONE place a bits-per-element figure is legitimate: it is the
+    // codec's advertised ratio, explicitly not a claim about resident memory.
+    // For memory, ask the store — see `KvCache::resident_bytes`.
     //
     // FIXED SHAPE: B=1, kv_h=8, head_dim=128, seq=1024
     // bhd = B * kv_h * head_dim = 1 * 8 * 128 = 1024
@@ -1408,11 +1423,11 @@ mod tests {
     // rMLX's q2_g64 is V-side only (k=8-bit, v=2-bit): (16+16)/(8+2) = 3.2×.
     // The V-only compression is 16/2 = 8× (codes) / ~6.4× effective (at g=64, scale overhead
     // adds ~1 byte per 64 elements). Both figures are correct for their context; the test
-    // uses the K+V combined ratio (3.2×), which is what approx_bytes computes.
+    // uses the K+V combined ratio (3.2×), which is the codecs nominal figure.
     // See docs/KV_CACHE.md §4 (q2_g64 row) and §5.10 (pure-2-bit-K gated).
 
     /// Pure-formula helper: codes-only KV bytes for a given shape and bit widths.
-    /// No GPU, no MLX operations. Mirrors the `kv_bytes` formula in `approx_bytes`.
+    /// No GPU, no MLX operations. Pure arithmetic over the codec bit-widths.
     fn codes_bytes(seq: u64, bhd: u64, k_bits: u64, v_bits: u64) -> u64 {
         seq * bhd * (k_bits + v_bits) / 8
     }

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -1373,7 +1373,15 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
 
     /// Store the KV-cache bytes for the just-finished request. Called by
     /// `generate_greedy` at request boundary.
+    ///
+    /// Also emits the `kv_bytes` event. This is the one place it is emitted:
+    /// `n` is already summed over every cache by the caller, so the event costs
+    /// nothing extra. Emitting it per-layer per-decode-step instead would call
+    /// `KvCache::resident_bytes` — which walks a block list that grows by one
+    /// entry per decode step — making a generation quadratic in context for the
+    /// sake of a diagnostic.
     pub(crate) fn store_kv_cache_bytes(&self, n: u64) {
+        tracing::debug!(kv_bytes = n, "kv cache bytes");
         self.last_kv_bytes
             .store(n, std::sync::atomic::Ordering::Relaxed);
     }

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -305,7 +305,7 @@ pub(crate) trait PromptCacheEntry: Sized {
 
     /// Approximate RAM held by this entry's KV/recurrent state, in bytes.
     ///
-    /// Default body sums KV `resident_bytes` plus linear-attn `approx_bytes`
+    /// Default body sums KV `resident_bytes` plus linear-attn `resident_bytes`
     /// (the latter is empty for pure-attention archs). Used by
     /// `PromptCache::stats()` to populate `CacheStats::bytes` and by the
     /// RAM-cap eviction policy in `push`. Best-effort estimate — does not
@@ -318,7 +318,7 @@ pub(crate) trait PromptCacheEntry: Sized {
             + self
                 .lin_caches()
                 .iter()
-                .map(LinearAttnCache::approx_bytes)
+                .map(LinearAttnCache::resident_bytes)
                 .sum::<u64>()
     }
 

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -424,7 +424,7 @@ fn default_truncate_and_kv_bytes_over_real_caches() {
 }
 
 /// Default `kv_bytes` sums BOTH KV `resident_bytes` and linear-attn
-/// `approx_bytes`. Before this refactor only the qwen3.5-moe override summed
+/// `resident_bytes`. Before this refactor only the qwen3.5-moe override summed
 /// the lin half; the default body now makes that structural for every arch
 /// that returns a non-empty `lin_caches()`.
 #[test]
@@ -432,7 +432,7 @@ fn default_kv_bytes_sums_lin_caches() {
     let seq = (2 * BLOCK_TOKENS) as i32;
     let ids = make_ids(2 * BLOCK_TOKENS);
     // 1 real KvCache + 1 LinearAttnCache. Populate the lin state with real
-    // arrays so `approx_bytes() > 0` — an empty lin cache reports 0, which would
+    // arrays so `resident_bytes() > 0` — an empty lin cache reports 0, which would
     // make this test vacuous (it would pass even if the default body dropped the
     // `+ lin_caches()` term).
     let mut e = RealEntry::new(ids, seq, 1, 1);
@@ -446,7 +446,7 @@ fn default_kv_bytes_sums_lin_caches() {
     let lin_only: u64 = e
         .lin_caches()
         .iter()
-        .map(LinearAttnCache::approx_bytes)
+        .map(LinearAttnCache::resident_bytes)
         .sum();
     assert!(kv_only > 0, "the real KV cache contributes bytes");
     assert!(
@@ -456,7 +456,7 @@ fn default_kv_bytes_sums_lin_caches() {
     assert_eq!(
         e.kv_bytes(),
         kv_only + lin_only,
-        "default kv_bytes must equal KV resident_bytes + lin approx_bytes"
+        "default kv_bytes must equal KV resident_bytes + lin resident_bytes"
     );
 }
 

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -223,7 +223,7 @@ pub fn generate_greedy<'a>(
         }
         // N16: store KV-cache bytes (KV + linear-attn state) for /metrics/cache.
         let kv_bytes: u64 = kv_caches.iter().map(|c| c.resident_bytes()).sum::<u64>()
-            + lin_caches.iter().map(|c| c.approx_bytes()).sum::<u64>();
+            + lin_caches.iter().map(|c| c.resident_bytes()).sum::<u64>();
         store_kv_cache_bytes(kv_bytes);
         return Ok(steps);
     }
@@ -434,7 +434,7 @@ pub fn generate_greedy<'a>(
         })?;
 
         let kv_bytes: u64 = kv_caches.iter().map(|c| c.resident_bytes()).sum::<u64>()
-            + lin_caches.iter().map(|c| c.approx_bytes()).sum::<u64>();
+            + lin_caches.iter().map(|c| c.resident_bytes()).sum::<u64>();
         store_kv_cache_bytes(kv_bytes);
         return Ok(steps);
     }
@@ -657,7 +657,7 @@ pub fn generate_greedy<'a>(
 
     // N16: store KV-cache bytes (KV + linear-attn state) for /metrics/cache.
     let kv_bytes: u64 = kv_caches.iter().map(|c| c.resident_bytes()).sum::<u64>()
-        + lin_caches.iter().map(|c| c.approx_bytes()).sum::<u64>();
+        + lin_caches.iter().map(|c| c.resident_bytes()).sum::<u64>();
     store_kv_cache_bytes(kv_bytes);
 
     Ok(steps)

--- a/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
@@ -115,7 +115,7 @@ impl PromptCacheEntry for Qwen35MoeEntry {
 
     // Hybrid GDN arch: real recurrent caches. The default `truncate_kv_to`
     // deliberately cannot reach these (recurrent state is re-run on the tail,
-    // never sliced), and the default `kv_bytes` sums their `approx_bytes`.
+    // never sliced), and the default `kv_bytes` sums their `resident_bytes`.
     fn lin_caches(&self) -> &[LinearAttnCache] {
         &self.lin_caches
     }

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -1088,14 +1088,14 @@ shortcut codec. The `KvStorage::None` bf16-fallback path always forces the K see
 unconditional — the K-only decode path consumes it via
 `update_decode_fp16_v_only`. Pure RAM reclaim: decode behaviour and output are
 **byte-unchanged** (verified on Bonsai-8B-2bit `k_iso3`, base vs branch decoded
-string identical, 2026-06-03). `approx_bytes` now counts the K and V seeds
+string identical, 2026-06-03). `resident_bytes` counts the K and V seeds
 independently and so reflects the dropped buffer. Residency reclaimed for Bonsai
 (`num_kv_heads=8`, `head_dim=128`, 36 layers): 288 MiB @ 4k ctx, 576 MiB @ 8k,
 1152 MiB @ 16k (= `seq × kv_h × head_dim × 2 B × n_layers`). Pinned by
-`warm_ttft_cross_codec_tests::iso_k_only3_quant_at_decode` (asserts
-the seed is **absent** and `approx_bytes` drops). `resident_bytes` is the
-preferred diagnostic in metrics paths — it reads actual buffer sizes rather
-than re-deriving from shape fields.
+`warm_ttft_cross_codec_tests::iso_k_only3_quant_at_decode`, which asserts the
+seed is **absent** and that the reported total is the K store plus the surviving
+V seed and nothing else. `resident_bytes` is the **only** byte diagnostic: it
+reads actual buffer sizes rather than re-deriving from shape fields.
 
 ### Decision: keep warm-TTFT universal
 

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -255,16 +255,23 @@ cache-store boundary as **bf16 (400+/400+ prefill+decode store calls, zero f32)*
 and `bf16_param_casts_fp16_to_bf16` (helper-contract gate — RED if `bf16_param`
 stops casting fp16→bf16; loader call sites verified by real-model load proof).
 
-**Byte accounting.** Two methods report KV-cache size:
+**Byte accounting.** One method reports KV-cache size:
 
-- `KvCache::approx_bytes()` — formula-based estimate using stored shape fields.
-  Used for SWA ring sizing and internal shape guards. Can return 0 when shape
-  fields are absent (e.g. before the first prefill).
 - `KvCache::resident_bytes()` — actual on-device allocation: reads the real
   `Array` shape × `dtype.itemsize()` for every GPU buffer, and `Vec.len()`
-  for CPU codec blocks. Covers packed codes, scales, zero-points, and optional
-  rotation/residual buffers. This is the value recorded in `kv_cache_bytes`
-  metrics observations and returned by `rmlx baseline`.
+  for CPU codec blocks. Covers packed codes, scales, zero-points, optional
+  rotation/residual buffers, the GPU rings behind the ring-backed K codecs,
+  and the warm-TTFT bf16 mirrors. This is the value recorded in
+  `kv_cache_bytes` metrics observations, emitted as the `kv_bytes` trace
+  event, used for prompt-cache eviction, and returned by `rmlx baseline`.
+
+Each figure is delegated to the store that owns the buffers
+(`KvStorage::resident_bytes` → per-codec `byte_size`), so it is derived from
+the allocations themselves. There is deliberately **no** second, per-codec
+bits-per-element formula: one existed (`approx_bytes`) and drifted, reporting
+byte-identical totals for `k_iso3` and `k_rotor3` — two codecs with entirely
+different storage — while missing their GPU rings outright. A nominal
+bit-width is not a cache's memory.
 
 ### Per-request hot-swap
 
@@ -2769,10 +2776,16 @@ below `none` (bf16 ≈ 110 TPS). The residual 3.40 µs/KV-token is the flash-dec
 idle. That is shared with `rotor_flash_decode` and is where further work belongs.
 
 **Memory.** The GPU ring is additional resident memory on top of the CPU blocks
-(~8.1 MB/layer vs 23.9 MB of blocks at Bonsai 4k — ~34%). Note the `kv_bytes`
-trace event does **not** show it: `approx_bytes` routes through
-`quant_iso_k3_bytes`, which counts CPU blocks only. Same gap as rotor — the
-ring is only counted by `QuantIsoK3::byte_size`.
+(~8.1 MB/layer vs 23.9 MB of blocks at Bonsai 4k — ~34% on top of the blocks).
+It **is** counted: `KvStorage::resident_bytes` delegates to
+`QuantIsoK3::byte_size`, which sums the CPU blocks and the ring. Same for rotor.
+
+This was not always so. The byte total used to route through a per-codec
+bits-per-element formula that never read the store, so the ring was invisible
+and `k_iso3` and `k_rotor3` reported byte-identical KV. Measured on Bonsai-8B at
+4k, the decode-time `kv_bytes` for `k_iso3` went from 25.3 MB/layer to
+42.9 MB/layer once the total was derived from the allocations — the old figure
+accounted for only 60% of the process's RSS growth, the new one for 99%.
 
 ---
 

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -261,9 +261,9 @@ stops casting fp16→bf16; loader call sites verified by real-model load proof).
   `Array` shape × `dtype.itemsize()` for every GPU buffer, and `Vec.len()`
   for CPU codec blocks. Covers packed codes, scales, zero-points, optional
   rotation/residual buffers, the GPU rings behind the ring-backed K codecs,
-  and the warm-TTFT bf16 mirrors. This is the value recorded in
-  `kv_cache_bytes` metrics observations, emitted as the `kv_bytes` trace
-  event, used for prompt-cache eviction, and returned by `rmlx baseline`.
+  and the warm-TTFT bf16 mirrors. It backs `kv_cache_bytes` observations, the
+  `kv_bytes` event, prompt-cache eviction, and `rmlx baseline`. **Cost is
+  O(blocks)** — call it at request boundaries, not per-layer per-decode-step.
 
 Each figure is delegated to the store that owns the buffers
 (`KvStorage::resident_bytes` → per-codec `byte_size`), so it is derived from
@@ -272,6 +272,22 @@ bits-per-element formula: one existed (`approx_bytes`) and drifted, reporting
 byte-identical totals for `k_iso3` and `k_rotor3` — two codecs with entirely
 different storage — while missing their GPU rings outright. A nominal
 bit-width is not a cache's memory.
+
+**Sample point differs per arch — read `kv_cache_bytes` accordingly.** The
+function is right everywhere; *when* each arch calls it is not yet uniform, so
+the recorded figure does not mean the same thing across the matrix:
+
+| Arch | Sampled | Sees the decode-time GPU ring? |
+|---|---|---|
+| gemma4, qwen3.5-moe | after the decode loop | yes |
+| qwen3 (exact-hit path) | after the decode loop | yes |
+| qwen3 (miss path), qwen2, laguna | at the prefill snapshot, before decode | **no** — no ring exists yet |
+
+So a single-request bench of a ring-backed codec on a pre-decode arch reports
+post-prefill KV, not steady-state decode KV — and `qwen3` reports both,
+depending on which path the request took. Unifying the sample point is tracked
+separately; until then, the ring-backed cells of a pre-decode arch are a lower
+bound.
 
 ### Per-request hot-swap
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -2029,7 +2029,7 @@ re-quantises K every decode step and routes V through
 clone+eval+store on the new predicate `KvQuant::feeds_bf16_k_at_decode()`
 (`false` for the K-only family, `true` for every shortcut codec). The bf16 V
 seed stays unconditional; the `KvStorage::None` bf16-fallback path still forces
-the K seed. `approx_bytes` now counts K and V seeds independently.
+the K seed. `resident_bytes` counts K and V seeds independently.
 
 **Pure RAM reclaim — output byte-unchanged.** Verified on Bonsai-8B-2bit
 (`Qwen3ForCausalLM`), GPU, `release-perf`, 2026-06-03:
@@ -2056,6 +2056,6 @@ Bonsai: `num_kv_heads=8`, `head_dim=128`, `n_layers=36`):
 
 (Whole-process RSS at 4k is dominated by ~2.5 GB model weights + Metal buffers,
 so the per-cache K-seed delta is below RSS noise there; the deterministic
-`approx_bytes` accounting is the authoritative measure and is regression-locked
-by the warm-TTFT K-only tests, which assert the seed is absent and
-`approx_bytes` drops.)
+`resident_bytes` accounting is the authoritative measure and is regression-locked
+by the warm-TTFT K-only tests, which assert the seed is absent and that the
+reported total is the K store plus the surviving V seed and nothing else.)

--- a/docs/models/bonsai/27B/rMLX.md
+++ b/docs/models/bonsai/27B/rMLX.md
@@ -112,6 +112,19 @@ prompt-token cap and silently truncates, so the 131k fixture would read as a
 is 1.97× the 64k reading (4507 MB), matching the ~2× token ratio — confirming a
 genuine full-length prefill.
 
+> ⚠️ **KV-MB is SUSPECT (under-reported) for the `k_iso3` / `k_iso4` /
+> `k_rotor3` / `k_rotor4` rows.** These four codecs are the ring-backed K-only
+> family: their flash-decode path stands up a GPU ring during decode that the
+> byte accounting did not count when this matrix was captured, so the published
+> figure is CPU blocks only. The ring is roughly **+34% on top of the blocks**;
+> measured on the 8B sibling at 4k the decode-time total for `k_iso3` moved
+> 25.3 → 42.9 MB/layer once the ring was counted. The accounting is fixed, but
+> **these cells have not been re-measured** — treat them as a lower bound, not a
+> reading. Re-capture is tracked separately. Decode-TPS and TTFT in those rows
+> are unaffected (the ring was always allocated; only the metric was blind).
+> All other codecs' KV-MB is unaffected: they allocate no ring, and their bytes
+> were already read from their real buffers.
+
 ---
 
 ## 1. rMLX snapshot benched

--- a/docs/models/bonsai/27B/rMLX.md
+++ b/docs/models/bonsai/27B/rMLX.md
@@ -122,8 +122,11 @@ genuine full-length prefill.
 > **these cells have not been re-measured** — treat them as a lower bound, not a
 > reading. Re-capture is tracked separately. Decode-TPS and TTFT in those rows
 > are unaffected (the ring was always allocated; only the metric was blind).
-> All other codecs' KV-MB is unaffected: they allocate no ring, and their bytes
-> were already read from their real buffers.
+> All other codecs' KV-MB is unaffected within this column's reading precision:
+> they allocate no ring, and their bytes already came from their real buffers.
+> The one exception is immaterial — the TurboQuant V store's optional TCQ
+> codebook and calibration indices are now counted too, which is O(100 B)
+> against an MB column.
 
 ---
 


### PR DESCRIPTION
Fixes #246.

## Was the issue's ~34% right?

**Yes, on its own terms — but it understates the bug.**

The 34% traces to `docs/KV_QUANT.md`: *"~8.1 MB/layer vs 23.9 MB of blocks at
Bonsai 4k"*. That is **ring ÷ CPU blocks**, and it checks out (I measure a
~8.6 MB/layer ring against ~25 MB of blocks). But the ring is not the whole
defect, and the under-count is not one number:

| denominator | figure |
|---|---|
| ring ÷ CPU blocks (the issue's) | ~34% ✅ |
| ring ÷ true total (isolated on gemma) | 19.1–19.8% |
| ring ÷ true total (unit tests, 2 codecs × 2 ctx) | 18.5–37.4% |
| **what the trace metric actually under-reported** | **12.8–41.1%**, codec- and context-dependent |

The last row is the real headline, and it is bigger than the ring: the metric
was a per-codec **bits-per-element formula that never read the store**. On
Bonsai-8B it reported **byte-identical KV for `k_iso3`, `k_rotor3` and `k8v4`**
— three codecs, three storage layouts, one number (25,288,704 @4k;
100,786,176 @16k). Identical distributions, verified by hash. So even the two
codecs with **no ring at all** were misreported (+14.8% / +30.2%).

## Root cause: two mirrors, one of them dead

- `KvStorage::resident_bytes` → `quant_*_bytes` free functions → **CPU blocks only**.
- Each store *also* had `byte_size`, which **did** count the ring — but nothing
  in production called it. Reachable only from tests, so the two were free to
  disagree, and did.
- `KvCache::approx_bytes` (the `kv_bytes` trace source) → pure bit formula.

## Fix: the store owns its own size

```
KvCache::resident_bytes → KvStorage::resident_bytes → <Store>::byte_size
```

`approx_bytes` and the whole `quant_*_bytes` mirror are **deleted** (−366 lines
of formula). Every `byte_size` is built from two primitives in the new
`rmlx-kv-quant::bytes`: `Array` shape × dtype, and `Vec` len × elem size. No
formula to update when a store grows a buffer.

This also catches buffers the old mirror never counted: `QuantV`'s TCQ codebook
+ high-precision indices, and the rings behind `QuantIsoK3/K4` /
`QuantRotorK3/K4`. `LinearAttnCache` loses its hard-coded 2 B/4 B item sizes.

## Anti-drift guard — compiler-enforced, and mutation-checked

Every accounting fn opens with an exhaustive `let Self { .. }` destructure
naming all fields; `KvStorage::resident_bytes` binds every variant field with
no `..`. Adding a buffer is **E0027** until it is classified.

Mutation-checked at three levels — probe added, guard went red, probe reverted:

```
error[E0027]: pattern does not mention field `mutation_probe_buf`
  --> storage/quant_iso_k.rs:363:13   (QuantIsoK3::byte_size)
  --> storage/quant_v.rs:140:13       (QuantV::byte_size)
  --> kvcache/update.rs:2979:13       (KvCache::resident_bytes)
```

The tests were mutation-checked too (ring dropped from `byte_size` → red):

```
k_iso3 @ prefill=256: resident_bytes grew by 10272 B but the ring alone
allocated 1064960 B — the ring is not being counted
```

A first draft of one test (`ring is >10% of the total`) **passed** under that
mutation — omitting the ring makes the share go *up*. It was a fake guard and
was replaced with a real one (delta across two contexts).

## Proof — anchored to reality, not to the new formula

**RSS anchor** (Bonsai-8B `k_iso3` @4k, 36 layers):

| | reported KV total | process RSS delta | ratio |
|---|---|---|---|
| before | 0.85 GiB | 1.42 GiB | **0.60** |
| after | 1.44 GiB | 1.45 GiB | **0.99** |

Before, the metric left 0.57 GiB of the process's growth unexplained. After, KV
accounts for 99% of it and sits just under it — which is the physically
necessary direction.

**Bonsai-8B** (`Qwen3ForCausalLM`) — decode-time `kv_bytes` trace, bytes/layer:

| ctx | codec | rings | before | after | Δ |
|---|---|---|---|---|---|
| 4k | k_iso3 | 26 | 25,288,704 | 42,902,144 | +69.6% |
| 4k | k_rotor3 | 0 | 25,288,704 | 29,042,864 | +14.8% |
| 4k | k8v4 | 0 | 25,288,704 | 32,923,648 | +30.2% |
| 16k | k_iso3 | 26 | 100,786,176 | 169,517,696 | +68.2% |
| 16k | k_rotor3 | 0 | 100,786,176 | 115,550,384 | +14.6% |
| 16k | k8v4 | 0 | 100,786,176 | 124,936,192 | +24.0% |

**Gemma-4-e2b** (`Gemma4`) — `/metrics/cache`, total. This model **isolates the
ring**: its metric already used `resident_bytes` on both sides, so the only
delta is the ring.

| ctx | codec | rings | before | after | Δ |
|---|---|---|---|---|---|
| 4k | k_iso3 | 3 | 56,869,056 | 70,290,624 | +23.6% |
| 4k | k_rotor3 | 0 | 48,262,672 | 48,262,672 | **+0.0%** |
| 4k | k8v4 | 0 | 42,627,072 | 42,627,072 | **+0.0%** |
| 16k | k_iso3 | 3 | 208,011,456 | 259,329,216 | +24.7% |
| 16k | k_rotor3 | 0 | 164,261,392 | 164,261,392 | **+0.0%** |
| 16k | k8v4 | 0 | 149,385,216 | 149,385,216 | **+0.0%** |

The exact 0.0% rows are the control: no ring, no change.

Both binaries were snapshotted and hash-verified distinct before any A/B. An
earlier matrix run was **discarded**: a stale server held the shared port and
answered for the wrong model, producing plausible-but-wrong numbers. The
harness now asserts the served model identity and aborts otherwise.

`make ci`: **exit 0** — 73 suites, 2492 passed, 0 failed (identical to the
pre-change baseline).

## Bonsai-27B KV-MB column (#248)

Its arch (`Qwen3_5`) samples `kv_cache_bytes` **after** the decode loop, so its
column *does* see the ring — and therefore under-reports it. **Affected cells:
`k_iso3`, `k_iso4`, `k_rotor3`, `k_rotor4`** (only `IsoKOnly3/4` and
`RotorKOnly3/4` stand up a ring), by roughly **+20–25% of the true total**
(ring ≈ +34% on top of blocks). Every other codec is unaffected — no ring, and
their bytes already came from real buffers. Not re-measured here (a long bench,
out of scope); the doc now marks those four rows **SUSPECT / lower bound**
rather than presenting a known-wrong number as fact.

## Follow-up found on the way (not fixed here)

The **Qwen3 / Gemma3 / Qwen2 / Laguna** generate paths sample
`store_kv_cache_bytes` at the **prefill snapshot on the cache-miss path — i.e.
before the decode loop that creates the ring**. So for a single-request bench
those archs' recorded `kv_cache_bytes` cannot contain the ring regardless of
this fix (Bonsai's `endpoint_kv_total` is unchanged above for exactly this
reason). Gemma4 and Qwen3.5 sample after decode and are fine. Worth a separate
issue: the same metric name means "post-prefill KV" on some archs and
"post-decode KV" on others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
