### PR TITLE
fix(mlx): gate the loud nax-kernel warning on Neural-Accelerator-class hosts

### DIFF
--- a/crates/rmlx-mlx/build.rs
+++ b/crates/rmlx-mlx/build.rs
@@ -85,13 +85,36 @@ fn brew_prefix(formula: &str) -> Option<String> {
     (!prefix.is_empty() && std::path::Path::new(&prefix).exists()).then_some(prefix)
 }
 
+/// Ask `sysctl` for this Mac's chip marketing name, e.g. `"Apple M5 Max"`.
+///
+/// `None` when the command is unavailable or its output is empty/not valid
+/// UTF-8 — anything that means the chip cannot be identified, which
+/// `is_na_class_host` (in `build_support.rs`) treats the same as "not
+/// NA-class": a probe that cannot look must stay quiet, not guess.
+fn brand_string() -> Option<String> {
+    let out = std::process::Command::new("sysctl")
+        .args(["-n", "machdep.cpu.brand_string"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let brand = String::from_utf8(out.stdout).ok()?.trim().to_owned();
+    (!brand.is_empty()).then_some(brand)
+}
+
 /// Compare the resolved MLX / mlx-c against the pinned pair, and check that the
 /// metallib actually carries the fast GEMM kernels.
 ///
 /// Warn, never fail. The pin records what was validated here; it is not a
 /// statement that anything else is broken. A correct non-bottle build of
 /// another version must still build, so a hard error would be wrong.
-fn check_mlx_pin(mlx_prefix: &str, mlx_c_prefix: &str, mlx_version: &str) {
+///
+/// `na_class_host` gates how loudly a missing-kernel finding is reported: the
+/// kernels only matter on Neural-Accelerator-class hardware (M5-family and
+/// later), so their absence on anything else — including every GitHub
+/// `macos-14` (M1) runner — is expected and silent.
+fn check_mlx_pin(mlx_prefix: &str, mlx_c_prefix: &str, mlx_version: &str, na_class_host: bool) {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let pin_path = format!("{manifest_dir}/{PIN_FILE}");
     println!("cargo:rerun-if-changed={pin_path}");
@@ -126,50 +149,38 @@ fn check_mlx_pin(mlx_prefix: &str, mlx_c_prefix: &str, mlx_version: &str) {
         .and_then(|f| contains_needle(f, NAX_GEMM_KERNEL.as_bytes(), SCAN_CHUNK).ok());
 
     let drift = pin_drift(mlx_version, &mlx_c_version, &pin);
+    // `fast_gemm == None` (metallib unreadable) has nothing concrete to
+    // report either way, so it is folded into "kernels present" here: this
+    // gate's only job is to catch a *confirmed* absence.
+    let level = nax_warning_level(na_class_host, fast_gemm != Some(false));
 
-    if fast_gemm == Some(false) {
-        println!(
-            "cargo:warning=MLX at {mlx_prefix} (mlx {mlx_version}, mlx-c {mlx_c_version}) ships \
-             no {NAX_GEMM_KERNEL} kernels in lib/mlx.metallib."
-        );
-        println!(
-            "cargo:warning=  Those are the Neural-Accelerator GEMM path. Without them GPU matmul \
-             throughput measured ~3.8x lower and prefill 2.2-3.7x slower on \
-             Neural-Accelerator-class hardware. Decode is bandwidth-bound and looks normal, so \
-             the symptom mimics a model-code defect."
-        );
-        println!(
-            "cargo:warning=  rMLX pins the validated pair mlx {pin_mlx} + mlx-c {pin_mlx_c}, \
-             whose metallib ships them. Some Homebrew bottles omit the family entirely; a \
-             non-bottle build of the same version can be fine."
-        );
-        println!(
-            "cargo:warning=  Fix (Homebrew; both kegs must already be in the Cellar — check with \
-             `ls /opt/homebrew/Cellar/mlx`):"
-        );
-        println!(
-            "cargo:warning=    ln -sfn ../Cellar/mlx/{pin_mlx} /opt/homebrew/opt/mlx && ln -sfn \
-             ../Cellar/mlx-c/{pin_mlx_c} /opt/homebrew/opt/mlx-c && brew pin mlx mlx-c && cargo \
-             clean -p rmlx-mlx"
-        );
-        println!(
-            "cargo:warning=  Repoint both: mlx and mlx-c are ABI-coupled and a mismatched pair \
-             aborts at load. The `cargo clean` is required, not tidiness: repointing to an older \
-             keg moves file times backwards, and cargo only re-runs a build script for a *newer* \
-             one — so a plain rebuild would silently keep these stale bindings. Pin: \
-             crates/rmlx-mlx/{PIN_FILE}; rationale and un-pin steps: docs/FFI.md."
-        );
-    } else if drift {
-        println!(
-            "cargo:warning=MLX pin drift: resolved mlx {mlx_version} + mlx-c {mlx_c_version}, but \
-             rMLX pins mlx {pin_mlx} + mlx-c {pin_mlx_c} (crates/rmlx-mlx/{PIN_FILE})."
-        );
-        println!(
-            "cargo:warning=  The {NAX_GEMM_KERNEL} kernels the pin exists for are present, so GEMM \
-             throughput should be unaffected. mlx and mlx-c are ABI-coupled though: an unvalidated \
-             pair can abort at load with a dyld \"Symbol not found\". If this pair checks out, bump \
-             both pin lines together. See docs/FFI.md."
-        );
+    match level {
+        NaxWarningLevel::Loud => {
+            let pin_file_display = format!("crates/rmlx-mlx/{PIN_FILE}");
+            for line in nax_missing_kernel_lines(
+                mlx_prefix,
+                mlx_version,
+                &mlx_c_version,
+                &pin,
+                NAX_GEMM_KERNEL,
+                &pin_file_display,
+            ) {
+                println!("cargo:warning={line}");
+            }
+        }
+        NaxWarningLevel::Silent if drift => {
+            println!(
+                "cargo:warning=MLX pin drift: resolved mlx {mlx_version} + mlx-c {mlx_c_version}, but \
+                 rMLX pins mlx {pin_mlx} + mlx-c {pin_mlx_c} (crates/rmlx-mlx/{PIN_FILE})."
+            );
+            println!(
+                "cargo:warning=  The {NAX_GEMM_KERNEL} kernels the pin exists for are present, so GEMM \
+                 throughput should be unaffected. mlx and mlx-c are ABI-coupled though: an unvalidated \
+                 pair can abort at load with a dyld \"Symbol not found\". If this pair checks out, bump \
+                 both pin lines together. See docs/FFI.md."
+            );
+        }
+        NaxWarningLevel::Silent => {}
     }
 }
 
@@ -224,9 +235,15 @@ fn main() {
         read_mlx_version(&std::fs::read_to_string(&version_header).unwrap_or_default());
     println!("cargo:rustc-env=RMLX_MLX_BUILD_VERSION={build_version}");
 
+    // Whether this Mac is Neural-Accelerator-class hardware (M5-family and
+    // later) — the audience the missing-kernel warning exists for. Every
+    // GitHub `macos-14` runner is M1 and answers false here, which is why
+    // the kernels' absence there is expected rather than alarming.
+    let na_class_host = brand_string().as_deref().is_some_and(is_na_class_host);
+
     // Report a resolved stack that is not the validated one, or that cannot
     // reach the fast GEMM path at all.
-    check_mlx_pin(&mlx_prefix, &mlx_c_prefix, &build_version);
+    check_mlx_pin(&mlx_prefix, &mlx_c_prefix, &build_version, na_class_host);
 
     // Link search paths.
     println!("cargo:rustc-link-search=native={mlx_c_prefix}/lib");

--- a/crates/rmlx-mlx/build.rs
+++ b/crates/rmlx-mlx/build.rs
@@ -149,10 +149,11 @@ fn check_mlx_pin(mlx_prefix: &str, mlx_c_prefix: &str, mlx_version: &str, na_cla
         .and_then(|f| contains_needle(f, NAX_GEMM_KERNEL.as_bytes(), SCAN_CHUNK).ok());
 
     let drift = pin_drift(mlx_version, &mlx_c_version, &pin);
-    // `fast_gemm == None` (metallib unreadable) has nothing concrete to
-    // report either way, so it is folded into "kernels present" here: this
-    // gate's only job is to catch a *confirmed* absence.
-    let level = nax_warning_level(na_class_host, fast_gemm != Some(false));
+    // A confirmed absence (not `None` — an unreadable metallib has nothing
+    // concrete to report) is the only thing that gates both the nax report
+    // and, via `should_report_drift`, the separate pin-drift note.
+    let kernels_missing = fast_gemm == Some(false);
+    let level = nax_warning_level(na_class_host, !kernels_missing);
 
     match level {
         NaxWarningLevel::Loud => {
@@ -168,19 +169,20 @@ fn check_mlx_pin(mlx_prefix: &str, mlx_c_prefix: &str, mlx_version: &str, na_cla
                 println!("cargo:warning={line}");
             }
         }
-        NaxWarningLevel::Silent if drift => {
-            println!(
-                "cargo:warning=MLX pin drift: resolved mlx {mlx_version} + mlx-c {mlx_c_version}, but \
-                 rMLX pins mlx {pin_mlx} + mlx-c {pin_mlx_c} (crates/rmlx-mlx/{PIN_FILE})."
-            );
-            println!(
-                "cargo:warning=  The {NAX_GEMM_KERNEL} kernels the pin exists for are present, so GEMM \
-                 throughput should be unaffected. mlx and mlx-c are ABI-coupled though: an unvalidated \
-                 pair can abort at load with a dyld \"Symbol not found\". If this pair checks out, bump \
-                 both pin lines together. See docs/FFI.md."
-            );
+        NaxWarningLevel::Silent => {
+            if should_report_drift(kernels_missing, drift) {
+                println!(
+                    "cargo:warning=MLX pin drift: resolved mlx {mlx_version} + mlx-c {mlx_c_version}, but \
+                     rMLX pins mlx {pin_mlx} + mlx-c {pin_mlx_c} (crates/rmlx-mlx/{PIN_FILE})."
+                );
+                println!(
+                    "cargo:warning=  The {NAX_GEMM_KERNEL} kernels the pin exists for are present, so GEMM \
+                     throughput should be unaffected. mlx and mlx-c are ABI-coupled though: an unvalidated \
+                     pair can abort at load with a dyld \"Symbol not found\". If this pair checks out, bump \
+                     both pin lines together. See docs/FFI.md."
+                );
+            }
         }
-        NaxWarningLevel::Silent => {}
     }
 }
 

--- a/crates/rmlx-mlx/build_support.rs
+++ b/crates/rmlx-mlx/build_support.rs
@@ -89,11 +89,6 @@ fn read_mlx_version(src: &str) -> String {
     }
 }
 
-/// Whether `reader` yields `needle` anywhere, scanning in `chunk`-sized reads.
-///
-/// The metallib this scans is ~150 MB, which a build script has no business
-/// holding in memory. `chunk` is a parameter so the carry path — a needle that
-/// straddles two reads — is testable without a 150 MB fixture.
 /// Parse the Apple chip generation number out of a `machdep.cpu.brand_string`
 /// value, e.g. `"Apple M5 Max"` -> `Some(5)`.
 ///
@@ -152,6 +147,23 @@ fn nax_warning_level(na_class_host: bool, kernels_present: bool) -> NaxWarningLe
     }
 }
 
+/// Whether the separate "MLX pin drift" note should print, alongside — not
+/// instead of — the nax-missing-kernel report above.
+///
+/// A confirmed kernel absence takes over the report entirely, on any host:
+/// this mirrors the pre-existing `if kernels_missing { <nax report> } else if
+/// drift { <drift note> }` exclusivity exactly. Without this, gating the
+/// drift note on `NaxWarningLevel` alone would let it fire on a non-NA host
+/// whose kernels are missing — a state that was structurally unreachable
+/// before this file started distinguishing NA-class hosts, and a regression
+/// on the very audience (`macos-14` / M1 CI) this distinguishing exists for:
+/// that build would go from "loud" to "a different warning" instead of
+/// silent. `drift` alone is also stale prose once kernels are confirmed
+/// missing — its text asserts the kernels "are present".
+fn should_report_drift(kernels_missing: bool, drift: bool) -> bool {
+    drift && !kernels_missing
+}
+
 /// Build the loud missing-nax-kernel report lines (each printed by the
 /// caller as its own `cargo:warning=`).
 ///
@@ -207,6 +219,11 @@ fn nax_missing_kernel_lines(
     ]
 }
 
+/// Whether `reader` yields `needle` anywhere, scanning in `chunk`-sized reads.
+///
+/// The metallib this scans is ~150 MB, which a build script has no business
+/// holding in memory. `chunk` is a parameter so the carry path — a needle that
+/// straddles two reads — is testable without a 150 MB fixture.
 fn contains_needle<R: std::io::Read>(
     mut reader: R,
     needle: &[u8],

--- a/crates/rmlx-mlx/build_support.rs
+++ b/crates/rmlx-mlx/build_support.rs
@@ -94,6 +94,119 @@ fn read_mlx_version(src: &str) -> String {
 /// The metallib this scans is ~150 MB, which a build script has no business
 /// holding in memory. `chunk` is a parameter so the carry path — a needle that
 /// straddles two reads — is testable without a 150 MB fixture.
+/// Parse the Apple chip generation number out of a `machdep.cpu.brand_string`
+/// value, e.g. `"Apple M5 Max"` -> `Some(5)`.
+///
+/// `None` covers anything that is not the `"Apple M<n>[ variant]"` shape
+/// Apple Silicon brand strings have used since M1 — an Intel brand string, an
+/// empty one, or a malformed reading. `is_na_class_host` treats that the same
+/// as "not NA-class": a probe that cannot identify the chip has nothing to
+/// assert and must stay quiet rather than guess.
+fn chip_generation(brand_string: &str) -> Option<u32> {
+    let after_m = brand_string.trim().strip_prefix("Apple M")?;
+    let digits: String = after_m.chars().take_while(char::is_ascii_digit).collect();
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+/// Whether this host is Neural-Accelerator-class hardware — the GPU matmul
+/// path the `steel_gemm_fused_nax*` kernels exist for.
+///
+/// NA arrived with the M5 generation (macOS; A19 Pro on iOS, out of scope
+/// here since this crate targets macOS only). Do not confuse this with the
+/// Neural *Engine* (ANE): every Mac since M1 has an ANE, and it is unrelated
+/// to this GEMM path — gating on it would make every Mac "NA-class" and
+/// bring back the exact false positive this check exists to remove.
+fn is_na_class_host(brand_string: &str) -> bool {
+    chip_generation(brand_string).is_some_and(|gen| gen >= 5)
+}
+
+/// The two outcomes for the missing-nax-kernel report: shout only where the
+/// absence actually costs the host something.
+#[derive(Debug, PartialEq, Eq)]
+enum NaxWarningLevel {
+    /// Missing kernels cost this host nothing (no Neural Accelerator to feed,
+    /// or they are simply present) — say nothing about it.
+    Silent,
+    /// A Neural-Accelerator-class host is missing the kernels it needs.
+    Loud,
+}
+
+/// Decide whether the missing-nax-kernel report should be loud, given
+/// whether this host would benefit from the kernels and whether the metallib
+/// scan found them.
+///
+/// Pure so the full host x kernel-presence matrix is unit-testable without a
+/// metallib to scan or a real Mac model to probe: kernels present is silent
+/// regardless of host, and a non-NA (or unidentifiable) host is silent even
+/// when kernels are absent — only "NA-class host, confirmed absent" is loud.
+/// This is precisely the case GitHub's `macos-14` (M1) runners hit: kernels
+/// absent, but not NA-class, so silent.
+fn nax_warning_level(na_class_host: bool, kernels_present: bool) -> NaxWarningLevel {
+    if na_class_host && !kernels_present {
+        NaxWarningLevel::Loud
+    } else {
+        NaxWarningLevel::Silent
+    }
+}
+
+/// Build the loud missing-nax-kernel report lines (each printed by the
+/// caller as its own `cargo:warning=`).
+///
+/// Pure: takes everything it needs to render, so the exact text — including
+/// that it never asserts a property of a bottle it did not inspect — is
+/// covered by tests without a real metallib or Homebrew install. Every claim
+/// here is scoped to `mlx_prefix`'s own metallib, the one the scan just
+/// read; it must never assert what the pinned pair's bottle contains in the
+/// abstract, since that bottle was not the one inspected.
+fn nax_missing_kernel_lines(
+    mlx_prefix: &str,
+    mlx_version: &str,
+    mlx_c_version: &str,
+    pin: &MlxPin,
+    kernel: &str,
+    pin_file_display: &str,
+) -> Vec<String> {
+    vec![
+        format!(
+            "MLX at {mlx_prefix} (mlx {mlx_version}, mlx-c {mlx_c_version}) ships no {kernel} \
+             kernels in lib/mlx.metallib."
+        ),
+        format!(
+            "  Those are the Neural-Accelerator GEMM path, and this is Neural-Accelerator-class \
+             hardware: without them GPU matmul throughput measured ~3.8x lower and prefill \
+             2.2-3.7x slower. Decode is bandwidth-bound and looks normal, so the symptom mimics \
+             a model-code defect."
+        ),
+        format!(
+            "  rMLX validates against mlx {} + mlx-c {}: on the bottle that pair was checked \
+             against, the kernels were present, but bottle contents vary by build runner — the \
+             version pin alone does not guarantee this or any other bottle carries them. Only \
+             the metallib scan above does. Some Homebrew bottles omit the family entirely; a \
+             non-bottle build of the same version can be fine.",
+            pin.mlx, pin.mlx_c
+        ),
+        "  Fix (Homebrew; both kegs must already be in the Cellar — check with \
+         `ls /opt/homebrew/Cellar/mlx`):"
+            .to_owned(),
+        format!(
+            "    ln -sfn ../Cellar/mlx/{} /opt/homebrew/opt/mlx && ln -sfn \
+             ../Cellar/mlx-c/{} /opt/homebrew/opt/mlx-c && brew pin mlx mlx-c && cargo \
+             clean -p rmlx-mlx",
+            pin.mlx, pin.mlx_c
+        ),
+        format!(
+            "  Repoint both: mlx and mlx-c are ABI-coupled and a mismatched pair aborts at load. \
+             The `cargo clean` is required, not tidiness: repointing to an older keg moves file \
+             times backwards, and cargo only re-runs a build script for a *newer* one — so a \
+             plain rebuild would silently keep these stale bindings. Pin: {pin_file_display}; \
+             rationale and un-pin steps: docs/FFI.md."
+        ),
+    ]
+}
+
 fn contains_needle<R: std::io::Read>(
     mut reader: R,
     needle: &[u8],

--- a/crates/rmlx-mlx/tests/mlx_pin.rs
+++ b/crates/rmlx-mlx/tests/mlx_pin.rs
@@ -171,3 +171,133 @@ fn needle_absent_reports_false() {
     // A near-miss must not count: this is the 0-vs-360 distinction itself.
     assert!(!contains_needle(b"steel_gemm_fused_max".as_slice(), needle, 8).unwrap());
 }
+
+#[test]
+fn chip_generation_reads_the_marketing_number() {
+    assert_eq!(chip_generation("Apple M5 Max"), Some(5));
+    assert_eq!(chip_generation("Apple M5"), Some(5));
+    assert_eq!(chip_generation("Apple M1"), Some(1));
+    assert_eq!(chip_generation("Apple M2 Pro"), Some(2));
+    assert_eq!(chip_generation("Apple M4 Max"), Some(4));
+    assert_eq!(chip_generation("  Apple M3 Ultra  "), Some(3));
+}
+
+#[test]
+fn chip_generation_declines_non_apple_silicon_strings() {
+    assert_eq!(chip_generation(""), None);
+    assert_eq!(
+        chip_generation("Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz"),
+        None
+    );
+    // Right prefix, no digits after it.
+    assert_eq!(chip_generation("Apple M"), None);
+}
+
+#[test]
+fn is_na_class_host_is_true_only_from_m5_onward() {
+    // The exact boundary this whole gate exists to draw: M1-M4 never had a
+    // Neural Accelerator, M5 and later do.
+    assert!(!is_na_class_host("Apple M1"));
+    assert!(!is_na_class_host("Apple M2 Pro"));
+    assert!(!is_na_class_host("Apple M3 Max"));
+    assert!(!is_na_class_host("Apple M4"));
+    assert!(is_na_class_host("Apple M5"));
+    assert!(is_na_class_host("Apple M5 Max"));
+    // Unidentifiable input must not be guessed as NA-class.
+    assert!(!is_na_class_host(""));
+    assert!(!is_na_class_host(
+        "Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz"
+    ));
+}
+
+#[test]
+fn nax_warning_level_matrix() {
+    // NA-class host, kernels confirmed missing -> loud (today's behaviour).
+    assert_eq!(nax_warning_level(true, false), NaxWarningLevel::Loud);
+    // Non-NA host, kernels missing -> silent: exactly the macos-14 CI case.
+    assert_eq!(nax_warning_level(false, false), NaxWarningLevel::Silent);
+    // Kernels present -> silent regardless of host.
+    assert_eq!(nax_warning_level(true, true), NaxWarningLevel::Silent);
+    assert_eq!(nax_warning_level(false, true), NaxWarningLevel::Silent);
+}
+
+#[test]
+fn ci_m1_runner_with_missing_kernels_stays_silent() {
+    // The exact scenario the bug report describes: GitHub's macos-14 runners
+    // are M1, which never had a Neural Accelerator, so the metallib
+    // legitimately ships no nax kernels there and that must not be alarming.
+    // This cannot be run against real CI from this dev machine (it is an M5
+    // and cannot reproduce the missing-kernel finding), so the M1 brand
+    // string is asserted directly through the same pure decision the real
+    // build uses.
+    let ci_host = is_na_class_host("Apple M1");
+    assert!(!ci_host);
+    assert_eq!(nax_warning_level(ci_host, false), NaxWarningLevel::Silent);
+}
+
+#[test]
+fn dev_m5_host_with_kernels_present_stays_silent() {
+    // This machine, run for real: M5, and its Homebrew mlx 0.31.2 ships the
+    // nax kernels. The one cell of the matrix actually exercised on this box.
+    let dev_host = is_na_class_host("Apple M5 Max");
+    assert!(dev_host);
+    assert_eq!(nax_warning_level(dev_host, true), NaxWarningLevel::Silent);
+}
+
+/// The pin fixture with an mlx-c value distinct from the resolved one, so
+/// tests can tell "the pin's pair" from "the pair currently in scope" apart
+/// in assertions.
+fn nax_message_fixture_pin() -> MlxPin {
+    MlxPin {
+        mlx: "0.31.2".to_owned(),
+        mlx_c: "0.6.0_2".to_owned(),
+    }
+}
+
+#[test]
+fn loud_message_reports_the_absence_without_the_ships_them_contradiction() {
+    let pin = nax_message_fixture_pin();
+    let lines = nax_missing_kernel_lines(
+        "/opt/homebrew/opt/mlx",
+        "0.32.0",
+        "0.6.0_3",
+        &pin,
+        "steel_gemm_fused_nax",
+        "crates/rmlx-mlx/mlx-pin.txt",
+    );
+    let joined = lines.join("\n");
+
+    // States the finding plainly.
+    assert!(joined.contains("ships no steel_gemm_fused_nax kernels"));
+
+    // Must not restate the fixed self-contradiction: claiming, in the same
+    // breath as reporting an absence, that the pinned pair's metallib ships
+    // the very kernels just found missing.
+    assert!(
+        !joined.contains("whose metallib ships them"),
+        "must not assert what an uninspected bottle contains: {joined}"
+    );
+    // Must instead hedge: the pin records what one bottle had, not a promise
+    // about this or any other bottle.
+    assert!(
+        joined.contains("does not guarantee"),
+        "must hedge that the version pin alone promises nothing about kernel presence: {joined}"
+    );
+}
+
+#[test]
+fn loud_message_never_hard_fails() {
+    // The report is pure string-building with no I/O and no panics: whatever
+    // the inputs, it always yields lines to print with `cargo:warning=`,
+    // never a build abort. A public user on any layout must still build.
+    let pin = nax_message_fixture_pin();
+    let lines = nax_missing_kernel_lines(
+        "",
+        "unknown",
+        "unknown",
+        &pin,
+        "steel_gemm_fused_nax",
+        "crates/rmlx-mlx/mlx-pin.txt",
+    );
+    assert!(!lines.is_empty());
+}

--- a/crates/rmlx-mlx/tests/mlx_pin.rs
+++ b/crates/rmlx-mlx/tests/mlx_pin.rs
@@ -222,6 +222,22 @@ fn nax_warning_level_matrix() {
 }
 
 #[test]
+fn should_report_drift_matrix() {
+    // No drift -> never report, regardless of kernel presence.
+    assert!(!should_report_drift(false, false));
+    assert!(!should_report_drift(true, false));
+    // Drift, kernels present -> report (the original, untouched drift note).
+    assert!(should_report_drift(false, true));
+    // Drift, kernels confirmed missing -> stays suppressed on ANY host: this
+    // is the exact regression case. Before NA-class gating existed, a
+    // confirmed absence always took the loud branch and the drift branch was
+    // structurally unreachable underneath it. A non-NA host (macos-14 / M1)
+    // with both a confirmed absence and a version drift must still end up
+    // fully silent, not fall through to a different warning.
+    assert!(!should_report_drift(true, true));
+}
+
+#[test]
 fn ci_m1_runner_with_missing_kernels_stays_silent() {
     // The exact scenario the bug report describes: GitHub's macos-14 runners
     // are M1, which never had a Neural Accelerator, so the metallib


### PR DESCRIPTION
## Summary
- The missing-`steel_gemm_fused_nax`-kernel warning fired loudly on every build regardless of hardware, including GitHub's `macos-14` (M1) runners, which never had a Neural Accelerator and legitimately ship none of these kernels.
- The message also asserted the pinned pair's metallib "ships them" in the same breath as reporting a confirmed absence — self-contradictory on exactly that runner (the runner is on the pinned 0.31.2 pair).
- Detects NA-class hardware (M5-family and later, the generation this GPU matmul path exists for — distinct from the Neural Engine/ANE every Mac has had since M1) via `sysctl machdep.cpu.brand_string`, parsed for the `Apple M<n>` marketing generation number. `>= 5` is NA-class; unidentifiable readings default to non-NA-class (quiet, not a guess).
- Factored the warn/silent decision into a pure `nax_warning_level(na_class_host, kernels_present)` function over the full 2x2 matrix, plus a pure `nax_missing_kernel_lines(...)` message builder — both `include!`d into `build.rs` and unit-tested from `tests/mlx_pin.rs` (the crate's existing pattern for testing build-script logic). The self-contradictory clause is rewritten to only claim what this scan actually inspected.
- Warn-not-fail is unchanged: no new panics/asserts, build never hard-errors on missing kernels.

## Decision matrix
| na_class_host | kernels_present | Result |
|---|---|---|
| true (M5+) | false | **Loud** (today's behaviour, kept) |
| false (M1-M4 / unknown) | false | **Silent** — the exact `macos-14` CI case |
| true | true | Silent |
| false | true | Silent |

## Test plan
- [x] `cargo test -p rmlx-mlx --test mlx_pin` — 21 passed, including the new chip-generation, host-class, decision-matrix, and message-contradiction assertions.
- [x] Verified on this dev machine (M5 Max, brew mlx 0.31.2 ships the kernels): a forced rebuild of `rmlx-mlx` emits zero `cargo:warning` output — the one cell of the matrix this box can actually exercise.
- [x] Verified the CI-equivalent case cannot be reproduced here (M5 has the kernels) but is proven via the same pure function with an `"Apple M1"` brand string, matching what GitHub's `macos-14` runners report.
- [x] `make ci` green end-to-end (fmt, clippy -D warnings, full workspace test suite, deny, audit, doctor/advisory checks).

Fixes #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)