### PR TITLE
fix(models): run mandatory exit_prefill sweep in speculative prefill_chunked on failure

### DIFF
--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -1344,9 +1344,6 @@ pub fn prefill_chunked(
     mut lin_caches: Option<&mut [LinearAttnCache]>,
     device: Device,
 ) -> Result<()> {
-    if tokens.is_empty() {
-        return Ok(());
-    }
     // Dispatch the chunk size off the actual arch family: Gemma4 and the
     // Qwen3.5MoE hybrid use their own per-arch prefill chunk size.
     let prefill_chunk = if arch.needs_lin_caches() {
@@ -1354,33 +1351,79 @@ pub fn prefill_chunked(
     } else {
         crate::prefill_chunk::prefill_chunk_for("gemma4")
     };
+    prefill_chunked_with(tokens, caches, prefill_chunk, device, |chunk, caches| {
+        // Single-position last_k=1 forward — we only need cache update, not
+        // logits. The lazy graph drops the lm_head matmul on non-final chunks;
+        // on the final chunk we discard the returned Array. For GDN-bearing
+        // archs the recurrent lin_caches advance alongside kv_caches; Gemma4
+        // passes None. `as_deref_mut` reborrows per chunk.
+        arch.forward_seq_last_k_with_cache(chunk, 1, caches, lin_caches.as_deref_mut(), device)
+            .map(|_| ())
+    })
+}
+
+/// Bracket-and-sweep engine behind [`prefill_chunked`]: `enter_prefill` on every
+/// cache, run `forward` per chunk, then `exit_prefill` on every cache.
+///
+/// The `exit_prefill` sweep is **mandatory** and runs on the failure path too.
+/// On a chunk forward / eval failure this captures the first cause, breaks the
+/// chunk loop, then sweeps `exit_prefill` over **all** caches unconditionally
+/// (no early `?`, no `break` that skips a cache) before returning that first
+/// cause. A cache left mid-prefill keeps un-finalized state (no decode seed /
+/// un-quantized storage), and the next decode on it errors or corrupts KV — so
+/// stranding even one cache poisons any later reuse of this slice.
+///
+/// The forward is injected so the invariant is unit-testable without a live
+/// model: a test drives a failing forward and asserts no cache is left
+/// `in_prefill`.
+fn prefill_chunked_with(
+    tokens: &[u32],
+    caches: &mut [KvCache],
+    prefill_chunk: usize,
+    device: Device,
+    mut forward: impl FnMut(&[u32], &mut [KvCache]) -> Result<()>,
+) -> Result<()> {
+    if tokens.is_empty() {
+        return Ok(());
+    }
     for c in caches.iter_mut() {
         c.enter_prefill();
     }
+    let mut first_err: Option<Error> = None;
     let n_chunks = tokens.len().div_ceil(prefill_chunk);
-    for (chunk_idx, chunk) in tokens.chunks(prefill_chunk).enumerate() {
+    'chunks: for (chunk_idx, chunk) in tokens.chunks(prefill_chunk).enumerate() {
         let is_last = chunk_idx + 1 == n_chunks;
-        // Single-position last_k=1 forward — we only need cache update,
-        // not logits. The lazy graph drops the lm_head matmul on
-        // non-final chunks; on final chunk we discard the returned Array.
-        // For GDN-bearing archs the recurrent lin_caches advance alongside
-        // kv_caches; Gemma4 passes None. `as_deref_mut` reborrows per chunk.
-        let _ = arch.forward_seq_last_k_with_cache(
-            chunk,
-            1,
-            caches,
-            lin_caches.as_deref_mut(),
-            device,
-        )?;
+        if let Err(e) = forward(chunk, caches) {
+            tracing::error!(error = %e, "spec prefill chunk forward failed, aborting generation");
+            first_err = Some(e);
+            break 'chunks;
+        }
         // Flush command buffer between chunks via cache eval.
         if !is_last {
             for c in caches.iter() {
-                c.eval_prefill_state()?;
+                if let Err(e) = c.eval_prefill_state() {
+                    tracing::error!(error = %e, "spec prefill chunk cache eval failed, aborting generation");
+                    first_err = Some(e);
+                    break 'chunks;
+                }
             }
         }
     }
+    // Mandatory cleanup: every cache entered prefill above and must run
+    // exit_prefill, even after a failure — no break, no early `?`. Skipping it
+    // strands the remaining caches with un-finalized prefill state that
+    // corrupts any later reuse of this slice. The first cause wins; a secondary
+    // exit failure is logged (so it does not vanish) but does not overwrite it.
     for c in caches.iter_mut() {
-        c.exit_prefill(device)?;
+        if let Err(e) = c.exit_prefill(device) {
+            tracing::error!(error = %e, "spec prefill: exit_prefill failed during cleanup sweep");
+            if first_err.is_none() {
+                first_err = Some(e);
+            }
+        }
+    }
+    if let Some(e) = first_err {
+        return Err(e);
     }
     Ok(())
 }

--- a/crates/rmlx-models/src/speculative/tests.rs
+++ b/crates/rmlx-models/src/speculative/tests.rs
@@ -82,3 +82,79 @@ fn spec_forward_k4_returns_correct_shape() {
     assert_eq!(shape[1] as usize, k);
     assert_eq!(shape[2] as usize, disp.vocab_size());
 }
+
+// ---------------------------------------------------------------------------
+// prefill_chunked exit-sweep invariant
+// ---------------------------------------------------------------------------
+
+/// Every cache that entered prefill must run `exit_prefill` before the spec
+/// `prefill_chunked` engine returns — on the failure path too.
+///
+/// This pins the inverse of the shared-helper invariant: an early `?` at the
+/// per-chunk forward would strand `caches[i..]` with `in_prefill = true` and no
+/// decode seed, so the next decode on a reused cache errors or corrupts KV. The
+/// forward is injected here (no live model) and fails on the FIRST chunk, so
+/// every cache is one an inline `return Err` would have stranded. Uses
+/// `KvQuant::None` caches: no Metal allocation happens because the forward never
+/// writes K/V.
+#[test]
+fn spec_prefill_chunked_runs_exit_sweep_on_failure() {
+    let mut caches: Vec<KvCache> = (0..3)
+        .map(|_| KvCache::with_quant_max_seq(KvQuant::None, 8))
+        .collect();
+    let tokens: Vec<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8];
+    // The closure also proves the assertion below is not vacuous: enter_prefill
+    // really set the flag on every cache before the forward runs.
+    let forward = |_chunk: &[u32], caches: &mut [KvCache]| -> Result<()> {
+        assert!(
+            caches.iter().all(KvCache::in_prefill),
+            "precondition: prefill_chunked_with must enter prefill on every cache"
+        );
+        Err(Error::Other(
+            "simulated spec first-chunk failure".to_owned(),
+        ))
+    };
+    let _ = prefill_chunked_with(&tokens, &mut caches, 4, Device::Cpu, forward);
+    for (i, c) in caches.iter_mut().enumerate() {
+        assert!(
+            !c.in_prefill(),
+            "cache {i} was left in prefill after a failed chunk — the exit_prefill \
+             sweep was skipped, so its state is un-finalized for the next decode"
+        );
+        // Consistent + reusable: a fresh enter/exit cycle succeeds and leaves
+        // the cache out of prefill. A stranded (double-swept or un-finalized)
+        // cache would not accept a clean re-bracket here.
+        c.enter_prefill();
+        assert!(
+            c.exit_prefill(Device::Cpu).is_ok(),
+            "cache {i} must be reusable after a failed prefill sweep"
+        );
+        assert!(!c.in_prefill(), "cache {i} must exit prefill on reuse");
+    }
+}
+
+/// The spec prefill engine reports the **first** cause, not a later cascade.
+///
+/// The forward fails on the first chunk with a distinctive message; the
+/// `exit_prefill` sweep for `KvQuant::None` caches is a no-op, so the only error
+/// in flight is the forward's. It must reach the caller verbatim.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: expect_err IS the assertion — an Ok here is the regression under test, and its panic names it"
+)]
+fn spec_prefill_chunked_reports_first_cause() {
+    let mut caches: Vec<KvCache> = (0..2)
+        .map(|_| KvCache::with_quant_max_seq(KvQuant::None, 8))
+        .collect();
+    let tokens: Vec<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8];
+    let forward = |_chunk: &[u32], _caches: &mut [KvCache]| -> Result<()> {
+        Err(Error::Other("simulated spec prefill cause".to_owned()))
+    };
+    let err = prefill_chunked_with(&tokens, &mut caches, 4, Device::Cpu, forward)
+        .expect_err("a rejected spec prefill must surface as Err, not a silent Ok");
+    assert!(
+        err.to_string().contains("simulated spec prefill cause"),
+        "the underlying cause must reach the caller verbatim, got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #251 — the inverse of the invariant #243 codified.

`speculative::prefill_chunked` called `enter_prefill` on every cache, then `?`-returned on a per-chunk forward / eval failure, stranding **every** cache with `in_prefill = true` and no `exit_prefill`. The cause propagated correctly (this was never a swallow); the defect was the opposite — the mandatory cleanup sweep never ran. Latent today (caches are dropped when spec generate aborts) but live the moment a caller retains the `Vec<KvCache>` across a failed spec prefill: the next decode runs on un-finalized caches (no decode seed / un-quantized storage) and errors or corrupts KV.

## Fix

Extract a `prefill_chunked_with` engine that mirrors the shared `chunked_prefill` bracket (`decode_loop.rs`): capture the **first** error, run `exit_prefill` over **all** caches unconditionally (no `break`, no early `?`), then return the first cause. Secondary `exit_prefill` errors are logged so they do not vanish but never overwrite the first cause. `prefill_chunked` becomes a thin wrapper that injects the arch forward — the forward seam makes the invariant unit-testable without a live model.

## Test — the real deliverable

The sweep was guarded by a comment, not a test. Now pinned on the spec path with two tests (the shared-helper `#243` path already had `chunked_prefill_runs_exit_sweep_on_failure`):

- `spec_prefill_chunked_runs_exit_sweep_on_failure` — after a failed chunked prefill **no** cache is left `in_prefill`, and each cache is reusable (clean re-enter/exit).
- `spec_prefill_chunked_reports_first_cause` — the first cause propagates verbatim.

**Observable choice:** used the existing **non-cfg-gated** `pub fn KvCache::in_prefill(&self) -> bool` (a real state query). A `#[cfg(test)] pub fn` in rmlx-kv-quant would be invisible to rmlx-models' test target (rmlx-models compiles rmlx-kv-quant without `cfg(test)`), so the assertion would silently not compile.

**Mutation evidence:** removing the sweep turns the invariant test red:
```
thread '...spec_prefill_chunked_runs_exit_sweep_on_failure' panicked at crates/rmlx-models/src/speculative/tests.rs:119:9:
cache 0 was left in prefill after a failed chunk — the exit_prefill sweep was skipped, so its state is un-finalized for the next decode
```
Reverted after capture.

## Scope

The spec path had exactly one enter/exit bracket site (now fixed). The per-arch `generate.rs` bracket sites are mainline decode, already governed by the deferred-sweep pattern from #235/#243 — out of scope here, no bound in-place fix.

`make ci` green end-to-end (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)