### PR TITLE
fix(error-contract): phase-neutral KV ceiling message + exhaustive stop/retry mapping (#239, #240)

### DIFF
--- a/crates/rmlx-core/src/error.rs
+++ b/crates/rmlx-core/src/error.rs
@@ -104,12 +104,14 @@ pub enum Error {
     #[error("unimplemented: {0}")]
     Unimplemented(&'static str),
 
-    /// Prefill requested a sequence length above the configured KV
+    /// A KV request needs a sequence length above the configured KV
     /// hard cap. The cap is opt-in via `RMLX_KV_MAX_SEQ_HARD_CAP` (no cap
     /// when unset). Raised before any large allocation so the caller can
     /// reject the request cleanly instead of triggering a broadcast-shape
-    /// error deep inside the prefill loop.
-    #[error("kv prefill request exceeds hard cap: requested={requested}, cap={cap}")]
+    /// error deep inside the cache path. Fires on either phase: prefill (the
+    /// prompt itself is too long) or decode (generation crosses the cap), so
+    /// the message names neither.
+    #[error("kv request exceeds hard cap: requested={requested}, cap={cap}")]
     KvHardCapExceeded {
         /// The needed sequence length (in tokens) that triggered the guard.
         requested: i32,
@@ -117,14 +119,14 @@ pub enum Error {
         cap: i32,
     },
 
-    /// Prefill requested a sequence length above the per-cache virtual
+    /// A KV request needs a sequence length above the per-cache virtual
     /// ceiling. The ceiling is the resolved `--max-ctx` (a virtual cap, not an
     /// eager allocation): the KV ring grows lazily up to it. Raised before any
-    /// allocation past the ceiling so an over-long prompt is rejected cleanly
-    /// instead of growing the ring beyond the operator-declared context bound.
-    #[error(
-        "kv prefill request exceeds max-ctx ceiling: requested={requested}, ceiling={ceiling}"
-    )]
+    /// allocation past the ceiling so a request is rejected cleanly instead of
+    /// growing the ring beyond the operator-declared context bound. Fires on
+    /// either phase: prefill (the prompt itself is over the ceiling) or decode
+    /// (generation crosses it mid-stream), so the message names neither.
+    #[error("kv request exceeds max-ctx ceiling: requested={requested}, ceiling={ceiling}")]
     KvCeilingExceeded {
         /// The needed sequence length (in tokens) that triggered the guard.
         requested: i32,
@@ -146,6 +148,50 @@ pub enum Error {
         /// correct alternative (e.g. the required assistant snapshot).
         reason: String,
     },
+}
+
+impl Error {
+    /// Whether this error is transient enough to justify a transparent retry
+    /// (e.g. token-replay of an interrupted stream).
+    ///
+    /// `true` — the failure is transient: a Metal-level fault (watchdog kill,
+    /// GPU-queue overflow, transient dispatch error) or a recovered engine
+    /// panic. Re-issuing the request may succeed.
+    ///
+    /// `false` — the failure is permanent, structural, or a policy rejection;
+    /// replaying would reproduce it. This includes the KV ceiling / hard-cap
+    /// rejections: the bound is identical on every attempt, whichever phase
+    /// (prefill or decode) crossed it, so a retry is futile.
+    ///
+    /// The match is exhaustive on purpose — **no wildcard arm**. This enum is
+    /// `#[non_exhaustive]`, which only relaxes exhaustiveness for *downstream*
+    /// crates; inside this crate the compiler still requires every variant to
+    /// be named. Adding a variant therefore fails the build here until it is
+    /// explicitly assigned a transient/permanent class, instead of a catch-all
+    /// silently laundering an unclassified error into one bucket.
+    #[must_use]
+    pub fn is_migratable(&self) -> bool {
+        match self {
+            // Transient Metal / engine failures — replay may succeed.
+            Error::Mlx(_) | Error::Other(_) => true,
+
+            // Permanent, structural, or policy failures — replay is futile.
+            Error::Io(_)
+            | Error::Config(_)
+            | Error::Loader(_)
+            | Error::Quant(_)
+            | Error::Model(_)
+            | Error::SmokeProbe(_)
+            | Error::Oom { .. }
+            | Error::ArchUnsupported { .. }
+            | Error::KvStorageMismatch { .. }
+            | Error::SsdTierAlreadyInstalled
+            | Error::Unimplemented(_)
+            | Error::KvHardCapExceeded { .. }
+            | Error::KvCeilingExceeded { .. }
+            | Error::SpeculativePairing { .. } => false,
+        }
+    }
 }
 
 /// The allocation phase in which an [`Error::Oom`] was raised.

--- a/crates/rmlx-core/src/error_tests.rs
+++ b/crates/rmlx-core/src/error_tests.rs
@@ -41,3 +41,61 @@ fn unimplemented_display() {
     );
     assert!(matches!(e, Error::Unimplemented(_)));
 }
+
+/// The ceiling error fires on both prefill and decode, so its message must not
+/// bake in a phase name. A decode-path violation reported as "prefill" is the
+/// user-visible mislabel this test guards against.
+#[test]
+fn kv_ceiling_exceeded_display_is_phase_neutral() {
+    let e = Error::KvCeilingExceeded {
+        requested: 641,
+        ceiling: 640,
+    };
+    assert_eq!(
+        e.to_string(),
+        "kv request exceeds max-ctx ceiling: requested=641, ceiling=640"
+    );
+    assert!(
+        !e.to_string().contains("prefill"),
+        "ceiling message must not name a phase — it fires on decode too"
+    );
+}
+
+/// The hard-cap error likewise fires on both phases; its message stays
+/// phase-neutral.
+#[test]
+fn kv_hard_cap_exceeded_display_is_phase_neutral() {
+    let e = Error::KvHardCapExceeded {
+        requested: 4097,
+        cap: 4096,
+    };
+    assert_eq!(
+        e.to_string(),
+        "kv request exceeds hard cap: requested=4097, cap=4096"
+    );
+    assert!(
+        !e.to_string().contains("prefill"),
+        "hard-cap message must not name a phase — it fires on decode too"
+    );
+}
+
+/// Only genuinely transient failures are migratable; a ceiling/hard-cap
+/// rejection (same bound on every attempt) and other structural errors are not.
+#[test]
+fn is_migratable_classifies_transient_and_permanent() {
+    assert!(Error::Mlx("watchdog".to_owned()).is_migratable());
+    assert!(Error::Other("recovered panic".to_owned()).is_migratable());
+
+    assert!(!Error::KvCeilingExceeded {
+        requested: 641,
+        ceiling: 640,
+    }
+    .is_migratable());
+    assert!(!Error::KvHardCapExceeded {
+        requested: 4097,
+        cap: 4096,
+    }
+    .is_migratable());
+    assert!(!Error::SmokeProbe("NaN".to_owned()).is_migratable());
+    assert!(!Error::Config("bad".to_owned()).is_migratable());
+}

--- a/crates/rmlx-server/src/anthropic/route.rs
+++ b/crates/rmlx-server/src/anthropic/route.rs
@@ -75,7 +75,15 @@ pub(super) fn record_metric(
 ///
 /// - `"length"` (token cap hit) → `"max_tokens"`
 /// - `"tool_calls"` (engine tool-call finish) → `"tool_use"`
-/// - `"stop"` (EOS / natural end) and everything else → `"end_turn"`
+/// - `"stop"` (explicit EOS) and `None` (unmarked clean terminal) → `"end_turn"`
+/// - any other / unrecognised finish reason → `"error"`
+///
+/// The unrecognised branch must **never** collapse to `"end_turn"`: an unknown
+/// or future finish reason (e.g. an engine-emitted `"error"` terminal) reported
+/// as a normal successful completion is a masked failure. Only reasons this
+/// mapper has an explicit success contract for become a successful stop; every
+/// other terminal surfaces as an explicit `"error"` stop reason a client or
+/// harness can detect.
 ///
 /// Note: `"stop_sequence"` is NOT produced here. A real stop-string match
 /// is detected by the stop-matcher path in `blocking.rs` / `streaming.rs`, which
@@ -85,8 +93,20 @@ pub(crate) fn map_stop_reason(finish_reason: Option<&str>) -> String {
     match finish_reason {
         Some("length") => "max_tokens".to_owned(),
         Some("tool_calls") => "tool_use".to_owned(),
-        // "stop" (natural EOS) and all unknown reasons → end_turn.
-        _ => "end_turn".to_owned(),
+        // Natural end of turn: an explicit EOS ("stop") or an unmarked clean
+        // terminal (None) are both legitimate successful completions.
+        Some("stop") | None => "end_turn".to_owned(),
+        // A finish reason this mapper has no success contract for. Do not
+        // launder it into "end_turn"; surface it as an explicit error stop
+        // reason so a failed/unexpected terminal is distinguishable from a
+        // genuine completion.
+        Some(other) => {
+            tracing::error!(
+                finish_reason = other,
+                "map_stop_reason: unrecognised finish reason; reporting error stop reason"
+            );
+            "error".to_owned()
+        }
     }
 }
 

--- a/crates/rmlx-server/src/anthropic/tests.rs
+++ b/crates/rmlx-server/src/anthropic/tests.rs
@@ -372,10 +372,28 @@ fn stop_reason_none_is_end_turn() {
     assert_eq!(map_stop_reason(None), "end_turn");
 }
 
-/// Unknown reason falls back to "end_turn".
+/// An unrecognised finish reason must NOT be laundered into the successful
+/// "end_turn"; it surfaces as an explicit "error" stop reason.
 #[test]
-fn stop_reason_unknown_is_end_turn() {
-    assert_eq!(map_stop_reason(Some("whatever")), "end_turn");
+fn stop_reason_unknown_is_error_not_success() {
+    let mapped = map_stop_reason(Some("whatever"));
+    assert_ne!(
+        mapped, "end_turn",
+        "unknown finish reason must never map to the successful end_turn"
+    );
+    assert_eq!(mapped, "error");
+}
+
+/// A finish reason of "error" (e.g. an engine-emitted error terminal) maps to
+/// an explicit "error" stop reason — the masked-failure case that motivated
+/// making this mapping non-laundering. It must not become a successful stop.
+#[test]
+fn stop_reason_error_terminal_is_not_success() {
+    let mapped = map_stop_reason(Some("error"));
+    assert_ne!(mapped, "end_turn");
+    assert_ne!(mapped, "max_tokens");
+    assert_ne!(mapped, "tool_use");
+    assert_eq!(mapped, "error");
 }
 
 /// Compose blocking path — EOS finish → stop_reason:"end_turn",

--- a/crates/rmlx-server/src/retry.rs
+++ b/crates/rmlx-server/src/retry.rs
@@ -104,56 +104,23 @@ pub enum RetryClass {
 /// Classify an [`RmlxError`] as [`RetryClass::Migratable`] or
 /// [`RetryClass::Fatal`].
 ///
-/// ### Migratable
-/// - [`RmlxError::Mlx`] — Metal-level failure (watchdog kill, GPU-queue
-///   overflow, transient dispatch error). The string may contain `"watchdog"`,
-///   `"gpu_queue"`, `"device_memory"`, etc.; we treat **all** `Mlx` variants as
-///   migratable rather than pattern-matching on the opaque string, since any
-///   unexpected Metal failure is better retried than surfaced as a permanent 503.
-/// - [`RmlxError::Other`] — catch-all for transient engine panics that the
-///   blocking-thread harness recovers and wraps in `Other`.
+/// Delegates to [`RmlxError::is_migratable`]. The transient/permanent decision
+/// lives on the error type itself, where the match over the variants is
+/// exhaustive (no wildcard) in the crate that defines them — so a newly added
+/// error variant fails the build until it is explicitly classified, rather than
+/// a catch-all here silently defaulting an unclassified error to `Fatal`.
 ///
-/// ### Fatal
-/// - [`RmlxError::SmokeProbe`] — NaN logits → broken snapshot; retrying would
-///   reproduce the same NaN and consume budget pointlessly.
-/// - [`RmlxError::Oom`] — KV-cache or weight OOM. A retry would OOM again
-///   immediately; let J3's evict-and-retry path handle this separately.
-/// - [`RmlxError::Config`] / [`RmlxError::Loader`] / [`RmlxError::Quant`] /
-///   [`RmlxError::Model`] / [`RmlxError::Io`] — structural / configuration
-///   errors. A retry would produce the same error.
+/// - Migratable: [`RmlxError::Mlx`] (any Metal-level fault) and
+///   [`RmlxError::Other`] (a recovered engine panic). Both may succeed on a
+///   fresh attempt.
+/// - Fatal: every other variant — structural, configuration, OOM, smoke-probe,
+///   and the KV ceiling / hard-cap rejections (the bound is the same on every
+///   attempt, whichever phase crossed it).
 pub fn classify(err: &RmlxError) -> RetryClass {
-    match err {
-        // Transient Metal / engine errors — replay permitted.
-        RmlxError::Mlx(_) => RetryClass::Migratable,
-        RmlxError::Other(_) => RetryClass::Migratable,
-
-        // Permanent or policy errors — never replay.
-        RmlxError::SmokeProbe(_) => RetryClass::Fatal,
-        RmlxError::Oom { .. } => RetryClass::Fatal,
-        RmlxError::Config(_) => RetryClass::Fatal,
-        RmlxError::Loader(_) => RetryClass::Fatal,
-        RmlxError::Quant(_) => RetryClass::Fatal,
-        RmlxError::Model(_) => RetryClass::Fatal,
-        RmlxError::Io(_) => RetryClass::Fatal,
-        // Structured error variants — all Fatal.
-        RmlxError::ArchUnsupported { .. } => RetryClass::Fatal,
-        RmlxError::KvStorageMismatch { .. } => RetryClass::Fatal,
-        RmlxError::SsdTierAlreadyInstalled => RetryClass::Fatal,
-        RmlxError::Unimplemented(_) => RetryClass::Fatal,
-        // KV prefill request above the configured hard cap. The
-        // request is structurally too large for the current process limits;
-        // replaying would hit the same cap. Fatal.
-        RmlxError::KvHardCapExceeded { .. } => RetryClass::Fatal,
-        // KV prefill request above the resolved `--max-ctx` virtual ceiling.
-        // The prompt exceeds the operator-declared context bound; replaying
-        // would hit the same ceiling. Fatal (same class as the hard cap).
-        RmlxError::KvCeilingExceeded { .. } => RetryClass::Fatal,
-        // Unsupported `--draft-model` + `--draft-kind` pairing. Structural
-        // misconfiguration detected at load; replaying would hit the same
-        // rejection. Fatal.
-        RmlxError::SpeculativePairing { .. } => RetryClass::Fatal,
-        // Non-exhaustive catch-all: future variants default to Fatal.
-        _ => RetryClass::Fatal,
+    if err.is_migratable() {
+        RetryClass::Migratable
+    } else {
+        RetryClass::Fatal
     }
 }
 

--- a/crates/rmlx-server/src/retry_tests.rs
+++ b/crates/rmlx-server/src/retry_tests.rs
@@ -109,6 +109,27 @@ fn classify_speculative_pairing_is_fatal() {
     assert_eq!(classify(&err), RetryClass::Fatal);
 }
 
+#[test]
+fn classify_kv_ceiling_exceeded_is_fatal() {
+    // A request that overruns the `--max-ctx` ceiling hits the same ceiling on
+    // every attempt — whichever phase (prefill or decode) crossed it — so a
+    // replay is futile. Must be Fatal, never Migratable.
+    let err = E::KvCeilingExceeded {
+        requested: 641,
+        ceiling: 640,
+    };
+    assert_eq!(classify(&err), RetryClass::Fatal);
+}
+
+#[test]
+fn classify_kv_hard_cap_exceeded_is_fatal() {
+    let err = E::KvHardCapExceeded {
+        requested: 4097,
+        cap: 4096,
+    };
+    assert_eq!(classify(&err), RetryClass::Fatal);
+}
+
 // ── is_replayable() ──────────────────────────────────────────────────────
 
 fn req_with_temp(temperature: f32) -> GenerationRequest {

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -384,9 +384,11 @@ data: [DONE]
 
 A stream that carries no `finish_reason` chunk did **not** complete. Clients and
 harnesses must treat the absence of a terminal `finish_reason` — or the presence
-of an `error` key — as a failure, never as a short answer. `finish_reason` is
-never `"error"`: that value is not in the OpenAI enum, and the Anthropic mapping
-below would launder it into a successful `stop_reason`.
+of an `error` key — as a failure, never as a short answer. The engine does not
+currently emit `finish_reason:"error"` (it is not in the OpenAI enum); if it
+ever did, the Anthropic mapping below surfaces an unrecognised reason as an
+explicit `"error"` stop reason rather than laundering it into a successful
+`stop_reason`.
 
 ### Stop-sequence truncation
 
@@ -427,15 +429,17 @@ Anthropic `stop_reason` field via `map_stop_reason` in
 
 | Engine `finish_reason` | Anthropic `stop_reason` |
 |---|---|
-| `"stop"` (natural EOS) | `"end_turn"` |
+| `"stop"` (natural EOS) / `None` (unmarked clean terminal) | `"end_turn"` |
 | `"length"` (token cap) | `"max_tokens"` |
 | `"tool_calls"` | `"tool_use"` |
-| anything else / `None` | `"end_turn"` |
+| anything else (unrecognised) | `"error"` |
 
-The `anything else / None → "end_turn"` row is why a failed generation must
-never reach this mapping: it resolves every unknown reason to a *successful*
-stop. A stream that dies mid-flight instead terminates with Anthropic's native
-`error` event and emits no `message_delta` / `message_stop`:
+Only reasons with an explicit success contract map to a successful stop. An
+unrecognised or future reason maps to an explicit `"error"` stop reason — never
+laundered into `"end_turn"` — so a masked failure cannot be reported as a normal
+completion on `/v1/messages`. A stream that dies mid-flight does not reach this
+mapping at all: it terminates with Anthropic's native `error` event and emits no
+`message_delta` / `message_stop`:
 
 ```
 event: error
@@ -939,7 +943,14 @@ Errors are classified as `RetryClass::Migratable` or `RetryClass::Fatal`:
 | Class | Conditions | Action |
 |---|---|---|
 | `Migratable` | `RmlxError::Mlx` (any Metal error), `RmlxError::Other` (engine panic) | Replay permitted. |
-| `Fatal` | `SmokeProbe` (NaN logits), `Oom`, `Config`, `Loader`, `Quant`, `Model`, `Io` | No retry; surface error. |
+| `Fatal` | every other variant — `SmokeProbe` (NaN logits), `Oom`, `Config`, `Loader`, `Quant`, `Model`, `Io`, `ArchUnsupported`, `KvStorageMismatch`, `SsdTierAlreadyInstalled`, `Unimplemented`, `KvHardCapExceeded`, `KvCeilingExceeded`, `SpeculativePairing` | No retry; surface error. |
+
+`classify` delegates to `RmlxError::is_migratable`, whose match over the error
+enum is **exhaustive with no wildcard arm**. `RmlxError` is `#[non_exhaustive]`,
+so that match must live in the crate that defines the variants (`rmlx-core`);
+there, adding a variant fails the build until it is explicitly classified as
+transient or permanent — a new error can never silently default into a retry
+bucket.
 
 ### Skip conditions
 


### PR DESCRIPTION
Fixes #239 and #240 — two logically-bound response/retry-contract defects surfaced by #235, on one branch. Both key off the contract/enum, not an arch.

## #239 — KvCeilingExceeded (and KvHardCapExceeded) mislabelled decode as prefill

Since #233 added `ensure_decode_capacity`, `KvCeilingExceeded` fires on the **decode** path too, but its message/docstring said *"prefill"*. #235 propagates the message into the **response payload**, so a user whose prompt fit comfortably was told their *prefill request* exceeded the ceiling when generation crossed it.

- Message is now phase-neutral: `kv request exceeds max-ctx ceiling: requested=N, ceiling=M`.
- Folded in the **same-shape bound defect**: `KvHardCapExceeded` had the identical "prefill" wording and also fires from `ensure_decode_capacity` → `kv request exceeds hard cap: requested=N, cap=M`.
- Docstrings for both now note they fire on either phase.

**Real-model payload proof** (bonsai-8b, `--max-ctx 640`, `--kv-quant none`, prompt 615 tokens, `max_tokens:300`), decode crosses the ceiling:

```
# /v1/chat/completions  → 503
{"error":{"message":"kv request exceeds max-ctx ceiling: requested=641, ceiling=640","type":"service_unavailable"}}
# /v1/messages          → 503
{"error":{"message":"kv request exceeds max-ctx ceiling: requested=641, ceiling=640","type":"service_unavailable_error"}}
```

Message no longer says "prefill"; the prompt was 615, well under 640. A prompt actually over the ceiling is caught earlier by the route guard with an accurate `context_length_exceeded` ("prompt has 853 tokens, max_ctx is 640").

## #240 — catch-all arms laundering unknowns into success

1. **`map_stop_reason`** (Anthropic `/v1/messages`): unknown/`_ => "end_turn"` reported an unknown finish reason as a normal successful completion. Now: `"stop"`/`None` → `"end_turn"` (clean terminal); `"length"` → `"max_tokens"`; `"tool_calls"` → `"tool_use"`; **any unrecognised reason → explicit `"error"`** (logged), never a success. This makes an engine-emitted `"error"` terminal reachable on the wire honestly.
2. **retry classification**: `classify()` now delegates to a new `rmlx_core::Error::is_migratable()`, whose match over the error enum is **exhaustive with no `_ =>` wildcard**. `Error` is `#[non_exhaustive]`, so the exhaustive match must live in the defining crate — there, adding a variant fails the build until it is explicitly classified.

### Compile-time guard (load-bearing evidence for #240)

Adding a throwaway variant to `Error` and building `rmlx-core`:

```
error[E0004]: non-exhaustive patterns: `&error::Error::TempCompileGuardProbe` not covered
   --> crates/rmlx-core/src/error.rs:178:15
    |
178 |         match self {
    |               ^^^^ pattern `&error::Error::TempCompileGuardProbe` not covered
```

Reverted after demonstrating.

## Mutation checks (both fixes)

- Revert #239 string (`kv prefill request exceeds…`) → `kv_ceiling_exceeded_display_is_phase_neutral` red (`left: "kv prefill request…"`).
- Flip `KvCeilingExceeded` to migratable → `is_migratable_classifies_transient_and_permanent` red.
- Restore `map_stop_reason` laundering `_ => "end_turn"` → `stop_reason_unknown_is_error_not_success` + `stop_reason_error_terminal_is_not_success` red (`left: "end_turn"`).

## Docs

`docs/SERVER.md`: stop_reason mapping table + the stale "would launder" note updated; retry-classification section now documents the compiler-forced exhaustiveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
