### PR TITLE
fix(test): workspace-wide GPU-ignore gate + ignore 3 SIGSEGV qwen tests (#267)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,9 +207,10 @@ Hard rules:
   `make check-gpu-tests-ignored` enforces this across **every workspace member
   crate** (from `Cargo.toml`), scanning `src/**/{*_tests.rs,tests.rs}` and
   `tests/*.rs`; it keys on shape (does the test reach `Device::Gpu`?), never on
-  the ignore reason's text. A pure device-*policy* test file (passes
-  `Device::Gpu` as a plain value, never dispatches Metal) opts out with a
-  `// gpu-test-gate: exempt — <reason>` marker. See `docs/TESTING.md`.
+  the ignore reason's text. A pure device-*policy* test (passes `Device::Gpu`
+  as a plain value, never dispatches Metal) opts out **per fn** with a
+  line-leading `// gpu-test-gate: exempt` marker in its own attribute block —
+  scoped to that one `#[test]`, not the whole file. See `docs/TESTING.md`.
 - **Advisory: `make file-size-report`** prints files >1000 LOC. Non-failing.
   Also runs at the end of `make ci` (advisory, non-blocking).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,9 +204,12 @@ Hard rules:
   that only exercises a check the dispatcher rejects **before** touching a
   device-parameterized op is not a GPU test: pass `Device::Cpu` and leave it
   un-ignored — ignoring a CPU test silently stops running it. The CI gate
-  `make check-gpu-tests-ignored` enforces this for `rmlx-kv-quant`; it keys on
-  shape (does the test reach `Device::Gpu`?), never on the ignore reason's text.
-  See `docs/TESTING.md`.
+  `make check-gpu-tests-ignored` enforces this across **every workspace member
+  crate** (from `Cargo.toml`), scanning `src/**/{*_tests.rs,tests.rs}` and
+  `tests/*.rs`; it keys on shape (does the test reach `Device::Gpu`?), never on
+  the ignore reason's text. A pure device-*policy* test file (passes
+  `Device::Gpu` as a plain value, never dispatches Metal) opts out with a
+  `// gpu-test-gate: exempt — <reason>` marker. See `docs/TESTING.md`.
 - **Advisory: `make file-size-report`** prints files >1000 LOC. Non-failing.
   Also runs at the end of `make ci` (advisory, non-blocking).
 

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ check-no-scalar-f32-leak: ## CI gate: fail if arch-layer code has unguarded scal
 check-no-decode-swallow: ## CI gate: fail if a decode-step failure breaks instead of propagating (would report as finish_reason="length")
 	@bash scripts/check_no_decode_swallow.sh
 
-check-gpu-tests-ignored: ## CI gate: fail if a GPU-touching rmlx-kv-quant test lacks #[ignore] (would abort the whole test binary under parallel cargo test)
+check-gpu-tests-ignored: ## CI gate: fail if a GPU-touching test in ANY workspace member lacks #[ignore] (would abort the whole test binary under parallel cargo test)
 	@bash scripts/check_gpu_tests_ignored.sh
 
 # METAL_STRICT=--strict turns a missing toolchain into a hard failure instead of

--- a/crates/rmlx-audio/src/vad_tests.rs
+++ b/crates/rmlx-audio/src/vad_tests.rs
@@ -6,6 +6,7 @@ use super::{voiced_segments, SileroVad, VadState, HOP_LENGTH};
 
 /// Verify the VAD model loads successfully from the embedded asset.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test vad -- --ignored --test-threads=1"]
 fn test_vad_loads() {
     let vad = SileroVad::load(Device::Gpu);
     assert!(vad.is_ok(), "VAD load failed: {:?}", vad.err());
@@ -13,6 +14,7 @@ fn test_vad_loads() {
 
 /// Silence (all-zeros) should produce low voice probability.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test vad -- --ignored --test-threads=1"]
 fn test_silence_gives_low_prob() {
     let vad = SileroVad::load(Device::Gpu).expect("VAD load");
     // 0.5 s of silence at 16kHz = 8000 samples
@@ -32,6 +34,7 @@ fn test_silence_gives_low_prob() {
 /// (The VAD is designed to detect speech, not pure tones, but this at least
 /// verifies the signal propagates through the model rather than being suppressed.)
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test vad -- --ignored --test-threads=1"]
 fn test_sine_vs_silence() {
     let vad = SileroVad::load(Device::Gpu).expect("VAD load");
 
@@ -65,6 +68,7 @@ fn test_sine_vs_silence() {
 /// Integration test: concatenate a 5s clip 7 times to get >30s audio and
 /// verify the VAD runs without errors.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test vad -- --ignored --test-threads=1"]
 fn test_long_audio_no_panic() {
     let vad = SileroVad::load(Device::Gpu).expect("VAD load");
 

--- a/crates/rmlx-audio/tests/transcribe.rs
+++ b/crates/rmlx-audio/tests/transcribe.rs
@@ -216,6 +216,7 @@ fn transcribe_file(
 /// Portable smoke: a known `say` sentence transcribes correctly and is
 /// deterministic across two runs at temp=0.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test say_clip -- --ignored --test-threads=1"]
 fn say_clip_deterministic() {
     let Some(t) = load_transcriber() else {
         eprintln!("skip say_clip_deterministic: whisper snapshot not present");
@@ -256,6 +257,7 @@ fn say_clip_deterministic() {
 /// Long-form regression: transcribe every fixture audio with a sibling VTT and
 /// assert normalized WER ≤ threshold on the FULL file.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test long_form_regression -- --ignored --test-threads=1"]
 fn long_form_regression() {
     let fixtures = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     if !fixtures.exists() {

--- a/crates/rmlx-cli/src/commands/baseline_tests.rs
+++ b/crates/rmlx-cli/src/commands/baseline_tests.rs
@@ -1,3 +1,6 @@
+// gpu-test-gate: exempt — `Device::Gpu` here is a CLI policy/parse value passed
+// to pure functions (`resolve_prompt_truncation`, device-arg parsing); no test
+// in this file constructs or evaluates an mlx array. Must stay Metal-free.
 use super::*;
 use rmlx_mlx::Device;
 

--- a/crates/rmlx-cli/src/commands/baseline_tests.rs
+++ b/crates/rmlx-cli/src/commands/baseline_tests.rs
@@ -1,9 +1,12 @@
-// gpu-test-gate: exempt — `Device::Gpu` here is a CLI policy/parse value passed
-// to pure functions (`resolve_prompt_truncation`, device-arg parsing); no test
-// in this file constructs or evaluates an mlx array. Must stay Metal-free.
+// Device-policy tests: `Device::Gpu` here is a selector value passed to pure
+// functions (`resolve_prompt_truncation`, device-arg parsing), never a Metal
+// dispatch. Each such test carries a per-fn `gpu-test-gate: exempt` marker so
+// the shape gate does not treat the value as a GPU test — while any genuinely
+// Metal-driving test added to this file still trips the gate.
 use super::*;
 use rmlx_mlx::Device;
 
+// gpu-test-gate: exempt
 #[test]
 fn device_arg_accepts_cpu_and_gpu() {
     // Valid devices must not return Err.
@@ -25,6 +28,7 @@ fn device_arg_accepts_cpu_and_gpu() {
     ));
 }
 
+// gpu-test-gate: exempt
 #[test]
 fn device_arg_rejects_tpu() {
     let result: anyhow::Result<Device> = match "tpu" {
@@ -255,6 +259,7 @@ fn build_record_git_sha_blank_string_is_null() {
 // Model-agnostic: pure function over (prompt_len, cap, device, flags), no
 // model load / GPU context involved.
 
+// gpu-test-gate: exempt
 #[test]
 fn resolve_prompt_truncation_under_cap_is_a_noop_on_gpu() {
     let len =
@@ -271,6 +276,7 @@ fn resolve_prompt_truncation_under_cap_is_a_noop_on_cpu() {
 
 /// Equality boundary on the GPU-default (no opt-in) path: a prompt exactly
 /// at the cap must not error -- pins the `<=` guard against a `<` mutation.
+// gpu-test-gate: exempt
 #[test]
 fn resolve_prompt_truncation_gpu_at_cap_exactly_is_a_noop() {
     let len = resolve_prompt_truncation(65_536, 65_536, Device::Gpu, false, false)
@@ -281,6 +287,7 @@ fn resolve_prompt_truncation_gpu_at_cap_exactly_is_a_noop() {
 /// The bug this fixes: a >65536-token prompt on `--device gpu` with the
 /// default cap and no opt-in must fail loudly, not silently truncate down to
 /// a shorter measurement that looks like a full-length one.
+// gpu-test-gate: exempt
 #[test]
 fn resolve_prompt_truncation_gpu_default_cap_over_limit_errors_loudly() {
     let err = resolve_prompt_truncation(131_072, 65_536, Device::Gpu, false, false)
@@ -292,6 +299,7 @@ fn resolve_prompt_truncation_gpu_default_cap_over_limit_errors_loudly() {
     assert!(msg.contains("--allow-truncate"), "{msg}");
 }
 
+// gpu-test-gate: exempt
 #[test]
 fn resolve_prompt_truncation_gpu_explicit_cap_over_limit_truncates() {
     // An explicit `--max-prompt-tokens` is itself the opt-in.
@@ -300,6 +308,7 @@ fn resolve_prompt_truncation_gpu_explicit_cap_over_limit_truncates() {
     assert_eq!(len, 65_536);
 }
 
+// gpu-test-gate: exempt
 #[test]
 fn resolve_prompt_truncation_gpu_allow_truncate_over_limit_truncates() {
     let len = resolve_prompt_truncation(131_072, 65_536, Device::Gpu, false, true)
@@ -309,6 +318,7 @@ fn resolve_prompt_truncation_gpu_allow_truncate_over_limit_truncates() {
 
 /// `--device gpu` measuring the full length requires raising the cap; when
 /// the caller does that, the full prompt is measured (not truncated).
+// gpu-test-gate: exempt
 #[test]
 fn resolve_prompt_truncation_gpu_full_length_when_cap_raised() {
     let len = resolve_prompt_truncation(131_072, 131_072, Device::Gpu, true, false)

--- a/crates/rmlx-mlx/src/compile_tests.rs
+++ b/crates/rmlx-mlx/src/compile_tests.rs
@@ -35,6 +35,7 @@ fn raw_closure_apply_works() {
 /// - Same shape invoked twice uses the compiled cache (no panic, correct output).
 /// - Closure correctly transforms inputs on both the trace call and the cache hit.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test compile_shapeless -- --ignored --test-threads=1"]
 fn compile_shapeless_cache_hit() {
     // Simple element-wise double: arr + arr = 2 * arr
     let cls = Closure::from_fn(|inputs| {

--- a/crates/rmlx-mlx/src/metal_kernel_tests.rs
+++ b/crates/rmlx-mlx/src/metal_kernel_tests.rs
@@ -24,6 +24,7 @@ fn array_to_f32(a: &Array) -> Vec<f32> {
 ///
 /// Runs unconditionally — the CI/dev host has a GPU (Apple Silicon M-series).
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test metal_kernel -- --ignored --test-threads=1"]
 fn metal_kernel_add_one_gpu() {
     let kernel = MetalKernel::new(
         "rmlx_add_one",
@@ -76,6 +77,7 @@ fn new_rejects_nul_in_output_name() {
 /// in `apply` rather than `new`. Both outcomes are acceptable; what must
 /// NOT happen is a panic or UB.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test metal_kernel -- --ignored --test-threads=1"]
 fn metal_kernel_bad_source_does_not_panic() {
     let result = MetalKernel::new(
         "rmlx_bad_kernel_test",

--- a/crates/rmlx-models/src/qwen3_5_moe/tests.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/tests.rs
@@ -334,6 +334,7 @@ fn prompt_cache_identical_prompt_is_exact_not_partial() {
 ///
 /// MLX requires group_size ∈ {32, 64, 128} — smaller values have no kernel.
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test paro_weight_conversion_matmul -- --ignored --test-threads=1"]
 #[allow(
     clippy::expect_used,
     reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
@@ -479,6 +480,7 @@ fn paro_weight_conversion_matmul() {
 /// - returns dtype BF16 (the `astype Bf16` else-arm fires because dequantize
 ///   returns the scales dtype = F16 ≠ BF16).
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test embed_lookup -- --ignored --test-threads=1"]
 #[allow(
     clippy::expect_used,
     reason = "values established by construction; .expect() message documents the invariant"
@@ -594,6 +596,7 @@ fn embed_lookup_f16_scales_selects_correct_row_and_casts_to_bf16() {
 /// - ids=[2] selects the CORRECT row (all output values ≈ 2.0),
 /// - output dtype is BF16 (the direct `Ok(dq)` passthrough arm fires).
 #[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test embed_lookup -- --ignored --test-threads=1"]
 #[allow(
     clippy::expect_used,
     reason = "values established by construction; .expect() message documents the invariant"

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -138,10 +138,20 @@ rejects before it touches a device-parameterized op is **not** a GPU test —
 pass it `Device::Cpu` and leave it un-ignored, so it keeps running in the
 default gate. Ignoring a CPU test is how a test silently stops running.
 
-`make check-gpu-tests-ignored` enforces this for `rmlx-kv-quant` and runs in
-`make ci` and in the hosted `source gates` job. It keys on the shape (does the
-test reach `Device::Gpu`?), never on the ignore reason's wording, which varies
-across the crate.
+`make check-gpu-tests-ignored` enforces this across **every workspace member
+crate** (read from `Cargo.toml`, never hard-coded), scanning both unit-test
+roots — `src/**/*_tests.rs` *and* bare `src/**/tests.rs` — and the integration
+binaries under `tests/*.rs`. It runs in `make ci` and in the hosted `source
+gates` job. It keys on the shape (does the test reach `Device::Gpu`, directly,
+through a same-file helper, or via a module-scope `const … = Device::Gpu`?),
+never on the ignore reason's wording, which varies across the tree.
+
+Two known edges: (1) a file of pure device-*policy* tests — ones that pass
+`Device::Gpu` to a non-mlx function as a plain selector value, never a Metal
+dispatch — opts out with a `// gpu-test-gate: exempt — <reason>` marker and
+must stay free of Metal-driving tests; (2) the reachability seed is file-local,
+so a test that reaches Metal only through a helper defined in another module can
+draw a non-fatal false-positive warning — verify before acting on it.
 
 ### `#[ignore]` is not a place to park a broken test
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -146,12 +146,14 @@ gates` job. It keys on the shape (does the test reach `Device::Gpu`, directly,
 through a same-file helper, or via a module-scope `const … = Device::Gpu`?),
 never on the ignore reason's wording, which varies across the tree.
 
-Two known edges: (1) a file of pure device-*policy* tests — ones that pass
-`Device::Gpu` to a non-mlx function as a plain selector value, never a Metal
-dispatch — opts out with a `// gpu-test-gate: exempt — <reason>` marker and
-must stay free of Metal-driving tests; (2) the reachability seed is file-local,
-so a test that reaches Metal only through a helper defined in another module can
-draw a non-fatal false-positive warning — verify before acting on it.
+Two known edges: (1) a pure device-*policy* test — one that passes `Device::Gpu`
+to a non-mlx function as a plain selector value, never a Metal dispatch — opts
+out **per fn** with a line-leading `// gpu-test-gate: exempt` marker in its own
+attribute block (scoped to that one `#[test]`, so a Metal-driving test added to
+the same file still trips the gate; a copy of the marker inside a fn body does
+not exempt); (2) the reachability seed is file-local, so a test that reaches
+Metal only through a helper defined in another module can draw a non-fatal
+false-positive warning — verify before acting on it.
 
 ### `#[ignore]` is not a place to park a broken test
 

--- a/scripts/check_gpu_tests_ignored.sh
+++ b/scripts/check_gpu_tests_ignored.sh
@@ -53,19 +53,21 @@
 # that has silently stopped running. It is a warning, not a failure: some
 # ignores are legitimately non-GPU (e.g. "requires mlx runtime").
 #
-# FILE EXEMPTION (device-as-value false positives)
+# PER-TEST EXEMPTION (device-as-value false positives)
 #   Detection is by shape: naming `Device::Gpu`. In compute crates that always
 #   means a Metal dispatch. In higher crates `Device` is a plain config enum —
 #   a test may pass `Device::Gpu` to a PURE function that only branches on it
 #   (e.g. a CLI truncation-policy resolver) and never touches Metal. No local
 #   shape separates `pure_fn(.., Device::Gpu, ..)` from `mlx_op(.., Device::Gpu)`,
 #   and the seed must stay broad (the real GPU tests bind `let d = Device::Gpu;`,
-#   so any narrower match would miss them). Such a file opts out with a marker
-#   on its own line:
-#       // gpu-test-gate: exempt — <reason>
-#   The file is then skipped entirely. Use it ONLY for files that contain no
-#   Metal-driving test; a reviewer audits each marker, and the file must stay
-#   free of GPU-dispatching tests (a new one there would be silently uncaught).
+#   so any narrower match would miss them). Such a test opts out with a
+#   line-leading marker inside its OWN attribute/comment block:
+#       // gpu-test-gate: exempt
+#   The exemption is scoped to that one `#[test]` fn — NOT the whole file — so a
+#   Metal-driving test added to the same file still trips the gate. The marker
+#   must lead its line and sit in the fn's attribute block; a copy inside a fn
+#   body does not exempt. A reviewer audits each marker; use it ONLY for a test
+#   that passes `Device::Gpu` as a value and never dispatches Metal.
 #
 # PARSING
 #   Relies on rustfmt layout (already enforced by `make fmt-check`): a `fn`
@@ -89,6 +91,12 @@ fi
 # Read `[workspace] members = [ ... ]` — the single source of the crate list.
 # Never hard-code a crate root: a moved/renamed crate must surface as a
 # fail-closed error below, not as a silently narrowed scan.
+#
+# NOTE: this parser assumes the one-member-per-line array layout. `make
+# fmt-check` (rustfmt) does NOT format `Cargo.toml`, so that layout is a
+# convention, not an enforced invariant — a reformat to a single-line array or
+# an inline comment could silently narrow the scan. The plausibility floor
+# below (parsed members vs. crate dirs on disk) guards against exactly that.
 members=()
 while IFS= read -r m; do
     [ -n "$m" ] && members+=("$m")
@@ -108,6 +116,23 @@ done < <(awk '
 if [ ${#members[@]} -eq 0 ]; then
     echo "ERROR: parsed 0 workspace members from ${CARGO_TOML}." >&2
     echo "A gate that scans nothing passes everything; refusing to report OK." >&2
+    exit 1
+fi
+
+# Plausibility floor: every crate under crates/ (a dir with its own Cargo.toml)
+# must be a parsed member. If the parse yields fewer, the members array layout
+# changed and the scan silently narrowed — the exact scope-loss class this gate
+# guards against. Fail closed. (A crate deliberately excluded from the workspace
+# would trip this; that is a reviewable event, not a silent narrowing.)
+disk_crates=0
+if [ -d "${REPO_ROOT}/crates" ]; then
+    disk_crates=$(find "${REPO_ROOT}/crates" -mindepth 2 -maxdepth 2 \
+        -name Cargo.toml -not -path "*/target/*" | wc -l | tr -d ' ')
+fi
+if [ "${#members[@]}" -lt "${disk_crates}" ]; then
+    echo "ERROR: parsed ${#members[@]} workspace members but ${disk_crates} crate dirs exist under crates/." >&2
+    echo "The members array in ${CARGO_TOML} likely changed layout and narrowed the scan." >&2
+    echo "Restore the one-member-per-line layout, or reconcile the members list." >&2
     exit 1
 fi
 
@@ -155,11 +180,6 @@ violations=""
 warnings=""
 
 for f in "${scan_files[@]}"; do
-    # A file may opt out of the GPU-dispatch check with an explicit marker
-    # (see FILE EXEMPTION in the header). Skip it entirely.
-    if grep -q "gpu-test-gate: exempt" "$f"; then
-        continue
-    fi
     out=$(awk -v fname="$f" '
         # ── Multi-line attribute continuation ────────────────────────────────
         in_attr {
@@ -171,6 +191,13 @@ for f in "${scan_files[@]}"; do
         /^[[:space:]]*#\[/ {
             attrs = attrs " " $0
             if ($0 !~ /\][[:space:]]*$/) { in_attr = 1 }
+            next
+        }
+        # ── Per-test exemption marker (line-leading, in the attr block) ─────
+        # Folds into the pending attribute block so it attaches to the NEXT fn
+        # only. Guarded by !in_fn so a copy inside a body cannot exempt.
+        !in_fn && /^[[:space:]]*\/\/[[:space:]]*gpu-test-gate:[[:space:]]*exempt([[:space:]]|$)/ {
+            attrs = attrs " GATE_EXEMPT"
             next
         }
         # ── Comments / doc comments keep the pending attribute block ────────
@@ -262,7 +289,9 @@ for f in "${scan_files[@]}"; do
                 f_ = order[i]
                 if (fn_attrs[f_] !~ /#\[test\]/) { continue }
                 has_ignore = (fn_attrs[f_] ~ /#\[ignore/)
-                if (gpu[f_] && !has_ignore) {
+                # Per-test opt-out for a device-as-value false positive.
+                exempt = (fn_attrs[f_] ~ /GATE_EXEMPT/)
+                if (gpu[f_] && !has_ignore && !exempt) {
                     printf "V  %s: %s\n", fname, f_
                 }
                 # Converse: an ignore claiming a Metal context on a test that

--- a/scripts/check_gpu_tests_ignored.sh
+++ b/scripts/check_gpu_tests_ignored.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # scripts/check_gpu_tests_ignored.sh — CI gate: fail if a GPU-touching test in
-# rmlx-kv-quant is missing the `#[ignore]` Metal-context attribute.
+# ANY workspace member crate is missing the `#[ignore]` Metal-context attribute.
 #
 # WHY
 #   A shared Metal context cannot be driven from parallel test threads. A GPU
@@ -13,17 +13,32 @@
 #   is not evidence of compliance. That is why this is a static gate.
 #
 # SCOPE
-#   Both test roots of the crate: unit tests (`src/**/*_tests.rs`) and the
-#   integration binaries (`tests/*.rs`). `cargo test -p rmlx-kv-quant --lib`
-#   does not build `tests/` at all, so a check scoped to `src/` alone would
-#   mirror exactly the blind spot it exists to catch.
+#   Every member crate of the workspace (read from `Cargo.toml [workspace]
+#   members`, never hard-coded), across both of its test roots:
+#     * unit tests under `src/` — files named `<name>_tests.rs` OR bare
+#       `tests.rs` (the file-size convention in CLAUDE.md allows both; a glob
+#       of `*_tests.rs` alone silently misses every `tests.rs`).
+#     * integration binaries under `tests/*.rs`.
+#   `cargo test -p <crate> --lib` does not build `tests/` at all, so a check
+#   scoped to `src/` alone would mirror exactly the blind spot it exists to
+#   catch.
 #
 # WHAT COUNTS AS GPU-TOUCHING (shape, not message)
 #   A `#[test]` fn that reaches `Device::Gpu`, directly in its own body or
 #   transitively through a helper it calls (including generic helpers called
-#   with a turbofish, and methods on an inherent impl). The check keys on that
-#   shape alone — never on the ignore *reason* text, which varies across the
-#   crate and would make the gate green while the class stayed live.
+#   with a turbofish, and methods on an inherent impl). `Device::Gpu` bound to
+#   a module-scope `const NAME: Device = Device::Gpu;` counts too — a body that
+#   uses NAME is GPU-touching. The check keys on that shape alone — never on
+#   the ignore *reason* text, which varies across the tree and would make the
+#   gate green while the class stayed live.
+#
+# KNOWN LIMITATION (file-local fixed point)
+#   The reachability fixed point runs per file. A `#[test]` that reaches Metal
+#   ONLY through a helper defined in another file (e.g. a `tests/common/mod.rs`
+#   `run_golden_test`) is not seen. Those helpers' callers are `#[ignore]`d
+#   today, so nothing is un-caught now, but a new un-ignored cross-file caller
+#   would slip through. Closing this needs a whole-tree (not per-file) pass and
+#   is tracked as a separate follow-up.
 #
 # THE FIX FOR A VIOLATION — pick the one that is true:
 #   * The test really drives the GPU -> add the attribute:
@@ -38,6 +53,20 @@
 # that has silently stopped running. It is a warning, not a failure: some
 # ignores are legitimately non-GPU (e.g. "requires mlx runtime").
 #
+# FILE EXEMPTION (device-as-value false positives)
+#   Detection is by shape: naming `Device::Gpu`. In compute crates that always
+#   means a Metal dispatch. In higher crates `Device` is a plain config enum —
+#   a test may pass `Device::Gpu` to a PURE function that only branches on it
+#   (e.g. a CLI truncation-policy resolver) and never touches Metal. No local
+#   shape separates `pure_fn(.., Device::Gpu, ..)` from `mlx_op(.., Device::Gpu)`,
+#   and the seed must stay broad (the real GPU tests bind `let d = Device::Gpu;`,
+#   so any narrower match would miss them). Such a file opts out with a marker
+#   on its own line:
+#       // gpu-test-gate: exempt — <reason>
+#   The file is then skipped entirely. Use it ONLY for files that contain no
+#   Metal-driving test; a reviewer audits each marker, and the file must stay
+#   free of GPU-dispatching tests (a new one there would be silently uncaught).
+#
 # PARSING
 #   Relies on rustfmt layout (already enforced by `make fmt-check`): a `fn`
 #   item's closing brace sits at the same indent as its `fn` keyword. That
@@ -48,30 +77,76 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-CRATE_SRC="${REPO_ROOT}/crates/rmlx-kv-quant/src"
-CRATE_TESTS="${REPO_ROOT}/crates/rmlx-kv-quant/tests"
+CARGO_TOML="${REPO_ROOT}/Cargo.toml"
 
-# Fail closed. A moved or renamed crate must break this gate loudly rather than
-# let it report OK over an empty scan — this crate has been extracted once
-# already (see the workspace dep graph in CLAUDE.md).
-for root in "${CRATE_SRC}" "${CRATE_TESTS}"; do
-    if [ ! -d "${root}" ]; then
-        echo "ERROR: ${root} does not exist — this gate is scanning nothing." >&2
-        echo "The crate moved or was renamed; update the roots in check_gpu_tests_ignored.sh." >&2
+# Fail closed: the workspace manifest is the source of the member list. If it
+# is gone the gate is scanning nothing.
+if [ ! -f "${CARGO_TOML}" ]; then
+    echo "ERROR: ${CARGO_TOML} not found — cannot resolve workspace members." >&2
+    exit 1
+fi
+
+# Read `[workspace] members = [ ... ]` — the single source of the crate list.
+# Never hard-code a crate root: a moved/renamed crate must surface as a
+# fail-closed error below, not as a silently narrowed scan.
+members=()
+while IFS= read -r m; do
+    [ -n "$m" ] && members+=("$m")
+done < <(awk '
+    /^[[:space:]]*members[[:space:]]*=[[:space:]]*\[/ { inm = 1; next }
+    inm {
+        line = $0
+        if (line ~ /\]/) { inm = 0 }
+        gsub(/[",]/, "", line)
+        gsub(/[[:space:]]/, "", line)
+        gsub(/\[/, "", line)
+        gsub(/\]/, "", line)
+        if (line != "" && line !~ /^#/) { print line }
+    }
+' "${CARGO_TOML}")
+
+if [ ${#members[@]} -eq 0 ]; then
+    echo "ERROR: parsed 0 workspace members from ${CARGO_TOML}." >&2
+    echo "A gate that scans nothing passes everything; refusing to report OK." >&2
+    exit 1
+fi
+
+# Fail closed per member. A member listed in Cargo.toml whose dir or `src/` is
+# missing means the crate moved or was renamed — break loudly rather than let
+# the gate report OK over a narrowed scan (this workspace has extracted crates
+# before; see the dep graph in CLAUDE.md).
+scan_files=()
+for crate in "${members[@]}"; do
+    crate_dir="${REPO_ROOT}/${crate}"
+    src_dir="${crate_dir}/src"
+    tests_dir="${crate_dir}/tests"
+
+    if [ ! -d "${crate_dir}" ]; then
+        echo "ERROR: member crate '${crate}' from Cargo.toml has no directory at ${crate_dir}." >&2
+        echo "The crate moved or was renamed; fix the members list or the path." >&2
         exit 1
+    fi
+    if [ ! -d "${src_dir}" ]; then
+        echo "ERROR: ${src_dir} does not exist — this gate is scanning nothing for '${crate}'." >&2
+        echo "The crate moved or was renamed; update Cargo.toml members." >&2
+        exit 1
+    fi
+
+    # Unit tests: match both `<name>_tests.rs` and bare `tests.rs`.
+    while IFS= read -r -d '' f; do scan_files+=("$f"); done < <(
+        find "${src_dir}" \( -name "*_tests.rs" -o -name "tests.rs" \) \
+            -not -path "*/target/*" -print0
+    )
+    # Integration binaries (optional per crate).
+    if [ -d "${tests_dir}" ]; then
+        while IFS= read -r -d '' f; do scan_files+=("$f"); done < <(
+            find "${tests_dir}" -name "*.rs" -not -path "*/target/*" -print0
+        )
     fi
 done
 
-scan_files=()
-while IFS= read -r -d '' f; do scan_files+=("$f"); done < <(
-    find "${CRATE_SRC}" -name "*_tests.rs" -not -path "*/target/*" -print0
-)
-while IFS= read -r -d '' f; do scan_files+=("$f"); done < <(
-    find "${CRATE_TESTS}" -name "*.rs" -not -path "*/target/*" -print0
-)
-
 if [ ${#scan_files[@]} -eq 0 ]; then
-    echo "ERROR: matched 0 test files under ${CRATE_SRC} and ${CRATE_TESTS}." >&2
+    echo "ERROR: matched 0 test files across ${#members[@]} workspace members." >&2
     echo "A gate that scans nothing passes everything; refusing to report OK." >&2
     exit 1
 fi
@@ -80,6 +155,11 @@ violations=""
 warnings=""
 
 for f in "${scan_files[@]}"; do
+    # A file may opt out of the GPU-dispatch check with an explicit marker
+    # (see FILE EXEMPTION in the header). Skip it entirely.
+    if grep -q "gpu-test-gate: exempt" "$f"; then
+        continue
+    fi
     out=$(awk -v fname="$f" '
         # ── Multi-line attribute continuation ────────────────────────────────
         in_attr {
@@ -95,6 +175,18 @@ for f in "${scan_files[@]}"; do
         }
         # ── Comments / doc comments keep the pending attribute block ────────
         /^[[:space:]]*\/\// { next }
+
+        # ── Module-scope `const NAME: Device = Device::Gpu;` ────────────────
+        # A test that uses NAME (rather than the Device::Gpu literal) is still
+        # GPU-touching; record the alias so the seed below can see it.
+        !in_fn && /^[[:space:]]*const[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*Device[[:space:]]*=[[:space:]]*Device::Gpu/ {
+            cname = $0
+            sub(/^[[:space:]]*const[[:space:]]+/, "", cname)
+            sub(/[^A-Za-z0-9_].*$/, "", cname)
+            gpu_const[cname] = 1
+            attrs = ""
+            next
+        }
 
         # ── fn item at any indent (top-level or inside an inherent impl) ────
         !in_fn && /^[[:space:]]*(pub[^ ]* )?(async )?fn [a-zA-Z0-9_]+/ {
@@ -132,9 +224,19 @@ for f in "${scan_files[@]}"; do
         /^[[:space:]]*[^[:space:]]/ { attrs = "" }
 
         END {
-            # Seed: fns that name Device::Gpu in their own body.
+            # Seed: fns that name Device::Gpu (literal) or a module-scope
+            # `const … = Device::Gpu` alias in their own body.
             for (f_ in body) {
-                gpu[f_] = (body[f_] ~ /Device::Gpu/) ? 1 : 0
+                is_gpu = (body[f_] ~ /Device::Gpu/) ? 1 : 0
+                if (!is_gpu) {
+                    for (c in gpu_const) {
+                        if (body[f_] ~ ("(^|[^A-Za-z0-9_])" c "([^A-Za-z0-9_]|$)")) {
+                            is_gpu = 1
+                            break
+                        }
+                    }
+                }
+                gpu[f_] = is_gpu
             }
             # Fixed point: a fn that *calls* a GPU-reaching fn is GPU-reaching.
             # Match a call site — `name(` or `name::<T>(` (turbofish) — not a
@@ -181,15 +283,18 @@ for f in "${scan_files[@]}"; do
 done
 
 if [ -n "$warnings" ]; then
-    echo "WARNING: tests whose #[ignore] claims a Metal context but that never reach Device::Gpu:" >&2
+    echo "WARNING (non-fatal): #[ignore] claims a Metal context but no Device::Gpu is visible in-file:" >&2
     printf '%s' "$warnings" >&2
-    echo "  -> an ignored CPU test is a test that silently stopped running." >&2
-    echo "     Drop the #[ignore] (and pass Device::Cpu) if it does not touch the GPU." >&2
+    echo "  -> If the test truly does not touch the GPU, drop the #[ignore] (and pass" >&2
+    echo "     Device::Cpu) — an ignored CPU test is a test that silently stopped running." >&2
+    echo "  -> But the seed is file-local: a test reaching Metal ONLY through a helper" >&2
+    echo "     defined in another module (e.g. a kernel-builder in the parent) is a false" >&2
+    echo "     positive here and the #[ignore] is correct. Verify before removing it." >&2
     echo >&2
 fi
 
 if [ -n "$violations" ]; then
-    echo "ERROR: GPU-touching tests in rmlx-kv-quant missing the #[ignore] Metal-context attribute:" >&2
+    echo "ERROR: GPU-touching tests missing the #[ignore] Metal-context attribute:" >&2
     printf '%s' "$violations" >&2
     echo >&2
     echo "A shared Metal context cannot be driven from parallel test threads: an" >&2
@@ -204,4 +309,4 @@ if [ -n "$violations" ]; then
     exit 1
 fi
 
-echo "OK: every GPU-touching test in rmlx-kv-quant carries #[ignore] (${#scan_files[@]} files scanned)."
+echo "OK: every GPU-touching test carries #[ignore] (${#scan_files[@]} files across ${#members[@]} workspace members)."


### PR DESCRIPTION
Closes #267.

## Root cause (the SIGSEGV)
Three GPU-reaching `#[test]` fns in `crates/rmlx-models/src/qwen3_5_moe/tests.rs` ran **un-ignored** — each binds `let device = Device::Gpu;` and dispatches real Metal (`quantized_matmul(...).eval()`, on-device `embed_lookup` take+dequant):

- `paro_weight_conversion_matmul`
- `embed_lookup_f16_scales_selects_correct_row_and_casts_to_bf16`
- `embed_lookup_bf16_scales_passthrough_arm`

Under parallel `cargo test --workspace` they drive the shared Metal context concurrently and can abort `rmlx-models --lib` ("Rust cannot catch foreign exceptions"). All three now carry `#[ignore = "GPU Metal context — run in isolation: …"]` and **pass in isolation** (`cargo test -p rmlx-models --lib -- --ignored --test-threads=1`: `3 passed; 0 failed`).

## Why the #252 gate missed them — two holes, both closed
1. **Crate scope**: roots were hard-coded to `rmlx-kv-quant`. The gate now iterates **every** `Cargo.toml` `[workspace] members` crate (never hard-coded).
2. **Filename glob**: src scan was `*_tests.rs`, which does **not** match bare `tests.rs` (`case tests.rs in *_tests.rs → no match`). The three violations live in `qwen3_5_moe/tests.rs`. The scan now matches `*_tests.rs` **and** `tests.rs`.

Fail-closed preserved: a listed member with a missing dir/`src`, or an empty scan, errors loudly. The seed also now recognises module-scope `const _: Device = Device::Gpu;` aliases.

## Mutation evidence (the gate is provably real)
- **red→green**: with the three ignores removed and the `tests.rs` glob active, the gate goes **RED** and names exactly `qwen3_5_moe/tests.rs: paro_weight_conversion_matmul / embed_lookup_f16… / embed_lookup_bf16…`.
- **glob-revert → blind**: reverting the glob to `*_tests.rs`-only, ignores still removed → gate goes **GREEN**, names none of the three (file count 292→269).
- **root-revert → fail-closed**: injecting a bogus member → `ERROR: member crate 'crates/rmlx-does-not-exist' … has no directory …`, exit 1.

## Other-crate sweep (newly covered by the widened gate)
Genuine un-ignored GPU tests found and `#[ignore]`d:
- `rmlx-mlx`: `metal_kernel_add_one_gpu`, `metal_kernel_bad_source_does_not_panic`, `compile_shapeless_cache_hit`
- `rmlx-audio`: `test_vad_loads`, `test_silence_gives_low_prob`, `test_sine_vs_silence`, `test_long_audio_no_panic`, `say_clip_deterministic`, `long_form_regression`

Verified clean (no action): `rmlx-kv-ssd` block_io GPU tests already ignored; `rmlx-server/runtime/loader/quant/metrics/core` have no `Device::Gpu` in test files.

**False positives — `rmlx-cli` `baseline_tests`**: `device_arg_*` and `resolve_prompt_truncation_gpu_*` pass `Device::Gpu` as a **policy value** to a pure function — never a Metal dispatch, and must keep running as fast CPU guards. No local shape separates `pure_fn(.., Device::Gpu, ..)` from `mlx_op(.., Device::Gpu)`, and the seed must stay broad (the real GPU tests bind `let d = Device::Gpu;`, so any narrower match would miss them). The file opts out with an explicit, auditable `// gpu-test-gate: exempt — <reason>` marker; it contains no Metal-driving test.

## Two awk detection gaps
- **(b) module-scope const** — **closed**: the seed now treats `const _: Device = Device::Gpu;` aliases as GPU-reaching.
- **(a) cross-file helper** — **deferred** (scoped follow-up): a test reaching Metal only via a helper in another module (e.g. `paro_kernel_construction_* → kernel_rpt1()`) isn't seen by the file-local seed. Closing it needs a whole-tree (not per-file) pass with fn-name-collision handling — out of proportion for this PR. It surfaces only as a **non-fatal** warning (reworded to flag the blind spot honestly); it does not fail CI. No live miss today (those callers are ignored).

## Verification
- `make ci` green end-to-end (`ci ok`, exit 0); gate reports "every GPU-touching test carries #[ignore] (292 files across 12 workspace members)".
- The SIGSEGV is load-dependent, so a single green run is weak evidence. The deterministic proof is (gate red→green) + (three tests now ignored) + (they pass in isolation) — not a claim that one green `cargo test` proves the crash gone.

Docs updated (`docs/TESTING.md`, `CLAUDE.md`, `Makefile`) to state the gate is workspace-wide, not kv-quant-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)