### PR TITLE
fix(kv): grow the K8V4 TurboFlash decode window across the 2^k boundary (#261)

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -1444,12 +1444,15 @@ impl KvCache {
     /// reach: each tracks its own capacity and copies the filled prefix forward
     /// on realloc, so the scalar and the buffers cannot disagree.
     ///
-    /// **Exception.** The head-major flash buffers latch their window into
-    /// `flash_max_seq` at allocation and never revisit it, so growing `max_seq`
-    /// does not extend them. They are unreachable from here — the TurboFlash
-    /// path is opt-in and has its own dispatch — and their append now fails
-    /// loudly rather than dropping silently, but they are not covered by the
-    /// invariant above.
+    /// **Head-major flash buffers.** These latch their window into
+    /// `flash_max_seq` at allocation, so raising `max_seq` here does not, by
+    /// itself, extend them. The TurboFlash path is opt-in and has its own
+    /// dispatch (`update_and_sdpa_k8v4_flash_inner`), which bypasses
+    /// `KvCache::update` — so it calls this function directly before its append
+    /// and re-sizes the latched buffers via `grow_flash_buffers` when the window
+    /// grew past `flash_max_seq`. That keeps the one provisioning rule covering
+    /// the flash path too, instead of letting the append walk off the frozen
+    /// window at the next power-of-two boundary.
     ///
     /// The hard cap and the `--max-ctx` ceiling still bound the growth: a
     /// request that genuinely cannot fit is rejected loudly rather than
@@ -4508,6 +4511,16 @@ impl KvCache {
         if self.decode_fp16_k.is_none() {
             return Ok(None);
         }
+        // Grow the provisioned decode window before the head-major append, the
+        // same rule the legacy `update()` path applies via `ensure_decode_capacity`.
+        // This flash dispatch bypasses `update()`, so without growing here the
+        // storage `max_seq` (and the bf16 mirror + latched flash buffers sized
+        // off it) freeze at the prefill length; the append then walks off the
+        // end at the next power-of-two boundary and slices an empty tensor
+        // (surfacing downstream as a `reshape … size 0`). A request that
+        // genuinely cannot fit is rejected loudly here (ceiling / hard cap)
+        // rather than crashing mid-append.
+        self.ensure_decode_capacity(kv_seq_after_update)?;
         let max_seq = match &self.storage {
             KvStorage::K8V4 { max_seq, .. } => *max_seq,
             _ => return Ok(None),
@@ -4568,15 +4581,25 @@ impl KvCache {
             // First-dispatch new chunk still comes from decode_fp16_k/v
             // (the mirror was just updated above so it contains the new token).
             self.append_flash_buffers_from_fp16(prev_offset, new_seq, device)?;
-        } else if lock_on {
-            // Subsequent dispatch under lock-on: quantise `new_k`/`new_v`
-            // directly into the persistent flash buffers — no bf16 round-trip.
-            self.append_flash_buffers_from_new(new_k, new_v, prev_offset, new_seq, device)?;
         } else {
-            // Subsequent dispatch, lock OFF: read the new chunk back through
-            // `decode_fp16_k/v` (which was just updated above). Preserves the
-            // original P2.A.1 behaviour bit-for-bit when lock is not requested.
-            self.append_flash_buffers_from_fp16(prev_offset, new_seq, device)?;
+            // Grow the latched head-major buffers when the storage window has
+            // grown past what they were allocated for — a power-of-two boundary
+            // crossed mid-decode. The buffers latch their capacity into
+            // `flash_max_seq` at allocation, so without re-sizing them here the
+            // append below overflows the frozen window.
+            if self.flash_max_seq < max_seq {
+                self.grow_flash_buffers(b, kv_h, head_dim, max_seq, device)?;
+            }
+            if lock_on {
+                // Subsequent dispatch under lock-on: quantise `new_k`/`new_v`
+                // directly into the persistent flash buffers — no bf16 round-trip.
+                self.append_flash_buffers_from_new(new_k, new_v, prev_offset, new_seq, device)?;
+            } else {
+                // Subsequent dispatch, lock OFF: read the new chunk back through
+                // `decode_fp16_k/v` (which was just updated above). Preserves the
+                // original behaviour bit-for-bit when lock is not requested.
+                self.append_flash_buffers_from_fp16(prev_offset, new_seq, device)?;
+            }
         }
 
         // Pull the persistent buffers as 1-D flat views for the kernel
@@ -4672,6 +4695,104 @@ impl KvCache {
         self.flash_v_scales = Some(zeros(&v_scales_shape, Dtype::F32, device)?);
         self.flash_max_seq = max_seq;
         self.flash_filled = 0;
+        Ok(())
+    }
+
+    /// Grow the head-major persistent K8V4 buffers to a larger `max_seq`,
+    /// preserving every already-written slot.
+    ///
+    /// The flash buffers latch their capacity into `flash_max_seq` at
+    /// [`Self::alloc_flash_buffers`] and never revisit it. When decode crosses a
+    /// power-of-two boundary the storage window grows (via
+    /// [`Self::ensure_decode_capacity`]) but these buffers do not — so the next
+    /// head-major append would walk off the frozen window. This reallocates each
+    /// buffer at the new capacity and copies the existing `[.., 0..old_max_seq, .]`
+    /// content forward, matching the copy-prefix-forward contract every other
+    /// grow path uses. It is codec-general (keyed off buffer shape, never an
+    /// arch) and lock-state agnostic — under `RMLX_TURBO_FLASH_LOCK` the flash
+    /// buffers are the sole K/V store, so copying them (rather than re-seeding
+    /// from the frozen bf16 mirror) is what preserves the decode tail.
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+    )]
+    #[allow(
+        clippy::unwrap_used,
+        reason = "the four flash buffers are Some by the caller's is_none() guard; the grow path only runs after a first dispatch allocated them"
+    )]
+    fn grow_flash_buffers(
+        &mut self,
+        b: i32,
+        kv_h: i32,
+        head_dim: i32,
+        new_max_seq: i32,
+        device: Device,
+    ) -> Result<()> {
+        use crate::q8_msl::Q8_GROUP_SIZE;
+        use crate::turboquant::GROUP_SIZE as TQ4_GROUP;
+
+        let old_max_seq = self.flash_max_seq;
+        if new_max_seq <= old_max_seq {
+            return Ok(());
+        }
+
+        let k_codes_shape = [b, kv_h, new_max_seq, head_dim / 4];
+        let k_scales_shape = [b, kv_h, new_max_seq, head_dim / Q8_GROUP_SIZE as i32];
+        let v_codes_shape = [b, kv_h, new_max_seq, head_dim / 8];
+        let v_scales_shape = [b, kv_h, new_max_seq, head_dim / TQ4_GROUP as i32];
+
+        let sl_start = [0i32; 4];
+        let sl_strides = [1i32; 4];
+
+        let kc_old = self.flash_k_codes.take().unwrap();
+        let ks_old = self.flash_k_scales.take().unwrap();
+        let vc_old = self.flash_v_codes.take().unwrap();
+        let vs_old = self.flash_v_scales.take().unwrap();
+
+        let kc_stop = [b, kv_h, old_max_seq, head_dim / 4];
+        let ks_stop = [b, kv_h, old_max_seq, head_dim / Q8_GROUP_SIZE as i32];
+        let vc_stop = [b, kv_h, old_max_seq, head_dim / 8];
+        let vs_stop = [b, kv_h, old_max_seq, head_dim / TQ4_GROUP as i32];
+
+        let kc_new = zeros(&k_codes_shape, Dtype::U32, device)?.slice_update(
+            &kc_old,
+            &sl_start,
+            &kc_stop,
+            &sl_strides,
+            device,
+        )?;
+        let ks_new = zeros(&k_scales_shape, Dtype::F32, device)?.slice_update(
+            &ks_old,
+            &sl_start,
+            &ks_stop,
+            &sl_strides,
+            device,
+        )?;
+        let vc_new = zeros(&v_codes_shape, Dtype::U32, device)?.slice_update(
+            &vc_old,
+            &sl_start,
+            &vc_stop,
+            &sl_strides,
+            device,
+        )?;
+        let vs_new = zeros(&v_scales_shape, Dtype::F32, device)?.slice_update(
+            &vs_old,
+            &sl_start,
+            &vs_stop,
+            &sl_strides,
+            device,
+        )?;
+
+        self.flash_k_codes = Some(kc_new);
+        self.flash_k_scales = Some(ks_new);
+        self.flash_v_codes = Some(vc_new);
+        self.flash_v_scales = Some(vs_new);
+        self.flash_max_seq = new_max_seq;
+        tracing::info!(
+            from = old_max_seq,
+            to = new_max_seq,
+            "TurboFlash buffer grow"
+        );
         Ok(())
     }
 

--- a/crates/rmlx-kv-quant/tests/k8v4_flash_decode_grow.rs
+++ b/crates/rmlx-kv-quant/tests/k8v4_flash_decode_grow.rs
@@ -156,9 +156,9 @@ fn decode_inputs(head_dim: i32, step: u64, device: Device) -> (Array, Array, Arr
     (k, q, v)
 }
 
-/// Drive a K8V4 TurboFlash cache and a bf16 reference cache in lock-step across
-/// two power-of-two boundaries, asserting the flash decode neither crashes nor
-/// diverges from bf16.
+/// Drive a growing K8V4 TurboFlash cache and a pre-sized K8V4 reference cache in
+/// lock-step across two power-of-two boundaries, asserting the flash decode
+/// neither crashes nor diverges from the pre-sized K8V4 reference.
 fn boundary_run(head_dim: i32, label: &str) {
     let device = Device::Gpu;
     let scale = 1.0_f32 / (head_dim as f32).sqrt();
@@ -210,7 +210,7 @@ fn boundary_run(head_dim: i32, label: &str) {
         let offset = prefill_len as u64 + step + 1;
         assert!(
             cos >= CODEC_FLOOR,
-            "{label}: flash vs bf16 cosine {cos} < {CODEC_FLOOR} at offset {offset} — a frozen \
+            "{label}: flash vs pre-sized K8V4 cosine {cos} < {CODEC_FLOOR} at offset {offset} — a frozen \
              or truncated cache changes the attention output across the boundary"
         );
         if offset >= 129 {

--- a/crates/rmlx-kv-quant/tests/k8v4_flash_decode_grow.rs
+++ b/crates/rmlx-kv-quant/tests/k8v4_flash_decode_grow.rs
@@ -1,0 +1,258 @@
+// K8V4 TurboFlash: decode-time growth across a power-of-two KV boundary.
+//
+// The K8V4 head-major "flash" decode path (`update_and_sdpa` →
+// `sdpa_dispatch` → `update_and_sdpa_k8v4_flash_inner`) dispatches only once
+// `kv_seq > RMLX_TURBO_FLASH_MIN`. That dispatch bypasses the legacy
+// `update()` call, so it never ran `ensure_decode_capacity`: the storage
+// `max_seq`, the bf16 mirror, and the latched head-major flash buffers all
+// froze at the prefill window. The moment decode crossed the next power-of-two
+// boundary the head-major append sliced an empty tensor off the frozen mirror
+// and the step died with `reshape … size 0`.
+//
+// This is the same window-growth class as the rotor / planar / bf16 mirror
+// decode-grow fix, but on the K8V4 flash path, which that fix did not reach.
+// The growth is model-agnostic — keyed off codec + geometry (head_dim, kv_h),
+// never an arch — so both real head_dim geometries (128 = Qwen3 family,
+// 256 = Gemma4 family) are exercised here directly.
+//
+// These live in a dedicated test binary because `turbo_flash_enabled()` /
+// `turbo_flash_min_kv_seq()` latch their env reads into a `OnceLock` on first
+// call: the env must be set before any other code path in the process reads
+// the gate. Same reasoning as `tests/apple10_head_dim_256.rs`.
+//
+// Run:
+//   cargo test -p rmlx-kv-quant --test k8v4_flash_decode_grow -- \
+//       --ignored --test-threads=1 --nocapture
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::print_stderr,
+    clippy::indexing_slicing,
+    unsafe_code,
+    missing_docs
+)]
+
+use rmlx_kv_quant::turbo_flash_msl::turbo_flash_dispatch_count;
+use rmlx_kv_quant::{KvCache, KvQuant};
+use rmlx_mlx::{Array, Device, Dtype};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn make_f32_array(data: &[f32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::F32).expect("from_bytes")
+}
+
+fn collect_f32(a: &Array) -> Vec<f32> {
+    a.eval().expect("materialise array on device");
+    let bytes = a.to_bytes().expect("to_bytes");
+    bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().expect("chunk len 4")))
+        .collect()
+}
+
+/// LCG pseudo-random data (same constants as the sibling integration tests so
+/// reproducer seeds round-trip across reports).
+fn lcg_data(n: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed;
+    (0..n)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            let frac = (state >> 32) as u32 as f32 / u32::MAX as f32;
+            frac * 2.0 - 1.0
+        })
+        .collect()
+}
+
+/// Minimum per-row cosine between two flattened `[rows, row_len]` buffers.
+fn cosine_min(a: &[f32], b: &[f32], row_len: usize) -> f32 {
+    assert_eq!(a.len(), b.len(), "cosine: len mismatch");
+    assert!(row_len > 0);
+    let n_rows = a.len() / row_len;
+    let mut mn = f32::INFINITY;
+    for r in 0..n_rows {
+        let ra = &a[r * row_len..(r + 1) * row_len];
+        let rb = &b[r * row_len..(r + 1) * row_len];
+        let dot: f64 = ra
+            .iter()
+            .zip(rb.iter())
+            .map(|(x, y)| f64::from(*x) * f64::from(*y))
+            .sum();
+        let na: f64 = ra.iter().map(|x| f64::from(*x).powi(2)).sum::<f64>().sqrt();
+        let nb: f64 = rb.iter().map(|x| f64::from(*x).powi(2)).sum::<f64>().sqrt();
+        let c = if na == 0.0 || nb == 0.0 {
+            1.0
+        } else {
+            (dot / (na * nb)) as f32
+        };
+        if c < mn {
+            mn = c;
+        }
+    }
+    mn
+}
+
+fn skip_if_no_gpu() -> bool {
+    std::env::var("RMLX_SKIP_GPU").as_deref() == Ok("1")
+}
+
+const B: i32 = 1;
+const KV_H: i32 = 2;
+const HEADS_PER_KV: i32 = 4;
+const N_Q_HEADS: i32 = KV_H * HEADS_PER_KV;
+
+/// Reference vs grown-window agreement floor. The reference is the SAME K8V4
+/// TurboFlash codec pre-sized to a window decode never crosses, so with the
+/// window-grow fix the two are numerically the same up to f32 reduction-order
+/// noise from the differing head-major row stride. A frozen or truncated cache
+/// would blow through this floor (the attention prefix collapses).
+const CODEC_FLOOR: f32 = 0.999;
+
+fn bf16(data: &[f32], shape: &[i32], device: Device) -> Array {
+    make_f32_array(data, shape)
+        .astype(Dtype::Bf16, device)
+        .expect("bf16 cast")
+}
+
+/// Prefill `cache` with `prefill_len` tokens of head dim `head_dim`.
+fn prefill(cache: &mut KvCache, head_dim: i32, prefill_len: i32, device: Device) {
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+    cache.enter_prefill();
+    let shape = [B, KV_H, prefill_len, head_dim];
+    let n: usize = shape.iter().map(|&d| d as usize).product();
+    let k = bf16(&lcg_data(n, 0x1111_2222_3333_0001), &shape, device);
+    let v = bf16(&lcg_data(n, 0x1111_2222_3333_0002), &shape, device);
+    let q_shape = [B, N_Q_HEADS, prefill_len, head_dim];
+    let qn: usize = q_shape.iter().map(|&d| d as usize).product();
+    let q = bf16(&lcg_data(qn, 0x1111_2222_3333_0003), &q_shape, device);
+    cache
+        .update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+        .expect("prefill update_and_sdpa");
+    cache.exit_prefill(device).expect("exit_prefill");
+}
+
+/// Deterministic single-token decode inputs for step `step`.
+fn decode_inputs(head_dim: i32, step: u64, device: Device) -> (Array, Array, Array) {
+    let one = (KV_H * head_dim) as usize;
+    let k = bf16(
+        &lcg_data(one, 0x5000_0000 + step),
+        &[B, KV_H, 1, head_dim],
+        device,
+    );
+    let v = bf16(
+        &lcg_data(one, 0x6000_0000 + step),
+        &[B, KV_H, 1, head_dim],
+        device,
+    );
+    let q = bf16(
+        &lcg_data((N_Q_HEADS * head_dim) as usize, 0x7000_0000 + step),
+        &[B, N_Q_HEADS, 1, head_dim],
+        device,
+    );
+    (k, q, v)
+}
+
+/// Drive a K8V4 TurboFlash cache and a bf16 reference cache in lock-step across
+/// two power-of-two boundaries, asserting the flash decode neither crashes nor
+/// diverges from bf16.
+fn boundary_run(head_dim: i32, label: &str) {
+    let device = Device::Gpu;
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    // SAFETY: process-global env; --test-threads=1 is enforced by the ignore
+    // annotation. Must be set before any turbo_flash_* OnceLock read.
+    unsafe {
+        std::env::set_var("RMLX_TURBO_FLASH", "1");
+        std::env::set_var("RMLX_TURBO_FLASH_MIN", "0");
+    }
+
+    // `flash`: small window so decode crosses it cheaply. Prefill lands just
+    // under the first boundary (120 < 128); decode then crosses 128 and 256.
+    // `reference`: identical K8V4 TurboFlash codec, but pre-sized to a window
+    // decode never crosses — so it never exercises the freeze/grow. With the
+    // fix the two agree; without it, `flash` dies at the boundary.
+    let max_seq_init = 128;
+    let reference_window = 4096;
+    let prefill_len = 120;
+    let n_decode: u64 = 150; // reaches offset 270 → crosses 128 and 256
+
+    let mut flash = KvCache::with_quant_max_seq(KvQuant::K8V4, max_seq_init);
+    let mut reference = KvCache::with_quant_max_seq(KvQuant::K8V4, reference_window);
+    prefill(&mut flash, head_dim, prefill_len, device);
+    prefill(&mut reference, head_dim, prefill_len, device);
+
+    let dispatch_before = turbo_flash_dispatch_count();
+    let mut crossed_128 = false;
+    let mut crossed_256 = false;
+
+    for step in 0..n_decode {
+        let (k, q, v) = decode_inputs(head_dim, step, device);
+        let out_flash = flash
+            .update_and_sdpa(&q, &k, &v, scale, "", None, device)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{label}: flash decode step {step} (offset→{}) errored — the KV window \
+                     did not grow across the boundary: {e}",
+                    prefill_len as u64 + step + 1
+                )
+            });
+        let out_ref = reference
+            .update_and_sdpa(&q, &k, &v, scale, "", None, device)
+            .expect("reference decode");
+
+        let of = collect_f32(&out_flash);
+        let orf = collect_f32(&out_ref);
+        let cos = cosine_min(&of, &orf, head_dim as usize);
+        let offset = prefill_len as u64 + step + 1;
+        assert!(
+            cos >= CODEC_FLOOR,
+            "{label}: flash vs bf16 cosine {cos} < {CODEC_FLOOR} at offset {offset} — a frozen \
+             or truncated cache changes the attention output across the boundary"
+        );
+        if offset >= 129 {
+            crossed_128 = true;
+        }
+        if offset >= 257 {
+            crossed_256 = true;
+        }
+    }
+
+    assert_eq!(
+        flash.offset(),
+        prefill_len + n_decode as i32,
+        "{label}: every decode step must land (offset marches with the sequence)"
+    );
+    assert!(crossed_128, "{label}: test must cross the 128 boundary");
+    assert!(crossed_256, "{label}: test must cross the 256 boundary");
+    assert!(
+        turbo_flash_dispatch_count() > dispatch_before,
+        "{label}: TurboFlash never dispatched — the test exercised the legacy path, \
+         not the flash boundary bug"
+    );
+}
+
+// ── head_dim = 128 (Qwen3 family) ───────────────────────────────────────────
+
+#[test]
+#[ignore = "GPU Metal context: cargo test -p rmlx-kv-quant --test k8v4_flash_decode_grow -- --ignored --test-threads=1"]
+fn k8v4_flash_grows_across_pow2_boundary_head_dim_128() {
+    if skip_if_no_gpu() {
+        return;
+    }
+    boundary_run(128, "hd128");
+}
+
+// ── head_dim = 256 (Gemma4 family) ──────────────────────────────────────────
+
+#[test]
+#[ignore = "GPU Metal context: cargo test -p rmlx-kv-quant --test k8v4_flash_decode_grow -- --ignored --test-threads=1"]
+fn k8v4_flash_grows_across_pow2_boundary_head_dim_256() {
+    if skip_if_no_gpu() {
+        return;
+    }
+    boundary_run(256, "hd256");
+}

--- a/crates/rmlx-server/src/retry.rs
+++ b/crates/rmlx-server/src/retry.rs
@@ -401,6 +401,14 @@ pub fn replay_stream(
         let mut delivered: Vec<u32> = Vec::new();
         let mut attempts_remaining = max_retries + 1; // total attempts including the first
         let mut next_req: Option<GenerationRequest> = Some(initial_req);
+        // The real engine error that triggered the current replay attempt. A
+        // replay that then diverges from — or underruns — the delivered prefix
+        // must surface THIS cause, not a synthetic "prefix divergence" /
+        // "underrun" message that launders the true fault (e.g. a decode-step
+        // crash) into an unrelated error. A finish_reason-keying client cannot
+        // tell a laundered error from a clean short stop, so the real cause has
+        // to travel with the failure. `None` on attempt 1 (no prior error).
+        let mut root_error: Option<RmlxError> = None;
 
         loop {
             // Attempt 1 uses initial_req (holds the GPU admission permit).
@@ -444,13 +452,22 @@ pub fn replay_stream(
                                     position = skipped,
                                     "replay prefix divergence; aborting retry"
                                 );
-                                let _ = tx
-                                    .send(Err(RmlxError::Other(format!(
+                                // Surface the real fault that triggered this
+                                // replay (a decode-step crash reproduces at the
+                                // same boundary on retry). Sending only the
+                                // divergence message here would launder that
+                                // crash into an unrelated error — the exact
+                                // masked-failure shape the loud-error contract
+                                // exists to prevent. Fall back to the divergence
+                                // message only when there is no prior cause.
+                                let err = root_error.take().unwrap_or_else(|| {
+                                    RmlxError::Other(format!(
                                         "replay prefix divergence at {skipped}: \
                                          expected {expected} got {}",
                                         tok.token_id
-                                    ))))
-                                    .await;
+                                    ))
+                                });
+                                let _ = tx.send(Err(err)).await;
                                 return;
                             }
                             skipped += 1;
@@ -477,11 +494,15 @@ pub fn replay_stream(
                     skip_count,
                     "retry terminated before reproducing delivered prefix"
                 );
-                let _ = tx
-                    .send(Err(RmlxError::Other(
+                // Same laundering guard as the divergence path: surface the real
+                // cause that triggered this replay rather than a bare underrun
+                // message that hides it.
+                let err = root_error.take().unwrap_or_else(|| {
+                    RmlxError::Other(
                         "replay underrun: retry EOS before prefix reproduced".to_owned(),
-                    )))
-                    .await;
+                    )
+                });
+                let _ = tx.send(Err(err)).await;
                 return;
             }
 
@@ -521,6 +542,9 @@ pub fn replay_stream(
                         attempts_remaining,
                         "replay_stream migratable error, retrying"
                     );
+                    // Preserve the real cause so a divergence / underrun on the
+                    // coming attempt surfaces it rather than a synthetic message.
+                    root_error = Some(err);
                     // next_req is None — loop will call plan.build_request.
                 }
             }

--- a/crates/rmlx-server/src/retry_tests.rs
+++ b/crates/rmlx-server/src/retry_tests.rs
@@ -452,6 +452,85 @@ async fn replay_stream_prefix_divergence_aborts() {
     );
 }
 
+/// A real decode-step crash must NOT be laundered into a synthetic "prefix
+/// divergence" message on replay. A deterministic decode crash (e.g. a KV
+/// boundary reshape) reproduces at the same point on retry, so the replay's
+/// first regenerated token differs from the delivered prefix and the divergence
+/// guard fires. The error the client receives must still carry the REAL cause —
+/// otherwise a finish_reason-keying caller cannot tell a crashed stream from a
+/// clean short one.
+#[tokio::test]
+async fn replay_divergence_surfaces_real_crash_not_laundered_message() {
+    // Attempt 0: emit 0,1,2 then a distinctive decode crash (delivers 3).
+    // Attempt 1: diverge at prefix position 2 — the divergence guard fires.
+    const CRASH_MSG: &str = "reshape: Cannot reshape array of size 0 into shape (1,8,1,32)";
+    struct CrashThenDivergeGen {
+        call_count: Arc<AtomicUsize>,
+        tokens: Vec<u32>,
+    }
+    impl Generator for CrashThenDivergeGen {
+        fn generate(
+            &self,
+            _req: GenerationRequest,
+        ) -> Pin<Box<dyn futures::stream::Stream<Item = rmlx_core::Result<GenerationToken>> + Send>>
+        {
+            let attempt = self.call_count.fetch_add(1, Ordering::SeqCst);
+            let tokens = self.tokens.clone();
+            let items: Vec<rmlx_core::Result<GenerationToken>> = tokens
+                .iter()
+                .enumerate()
+                .flat_map(|(i, &token_id)| {
+                    if attempt == 0 && i == 3 {
+                        return vec![Err(E::Mlx(CRASH_MSG.to_owned()))];
+                    }
+                    if attempt >= 1 && i == 2 {
+                        return vec![Ok(GenerationToken {
+                            token_id: 0xDEAD,
+                            piece: "DIVERGED".to_owned(),
+                            done: false,
+                            finish_reason: None,
+                            is_thinking: false,
+                            logprobs: None,
+                        })];
+                    }
+                    vec![Ok(GenerationToken {
+                        token_id,
+                        piece: format!("t{token_id}"),
+                        done: false,
+                        finish_reason: None,
+                        is_thinking: false,
+                        logprobs: None,
+                    })]
+                })
+                .collect();
+            Box::pin(futures::stream::iter(items))
+        }
+    }
+
+    let gen = Arc::new(CrashThenDivergeGen {
+        call_count: Arc::new(AtomicUsize::new(0)),
+        tokens: (0u32..10).collect(),
+    });
+    let mut s = drive(gen, vec![99u32], 10, 2);
+    let mut last_error: Option<String> = None;
+    while let Some(item) = s.next().await {
+        if let Err(e) = item {
+            last_error = Some(e.to_string());
+            break;
+        }
+    }
+    let err = last_error.expect("a decode crash must reach the client as an error");
+    assert!(
+        err.contains("Cannot reshape array of size 0"),
+        "the real decode crash must reach the client, not a laundered message; got: {err}"
+    );
+    assert!(
+        !err.contains("prefix divergence"),
+        "the retry envelope must not launder the crash into a synthetic \
+         'prefix divergence' message; got: {err}"
+    );
+}
+
 /// Underrun: retry terminates before reproducing the delivered prefix —
 /// stream ends with an error.
 #[tokio::test]

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -433,6 +433,22 @@ tq4 is genuinely unsupported at that head_dim, not a missing feature. tq4
 remains available wherever the FA head_dim ∈ {128, 256} (e.g. Qwen3 @ 128,
 Qwen3.5-MoE @ 256) via the `sdpa_dispatch` TurboFlash path.
 
+**Decode-time window growth (power-of-two boundary).** The TurboFlash path
+maintains its own head-major `[B, kv_h, max_seq, .]` code/scale buffers
+(`flash_*`), and only dispatches once `kv_seq > RMLX_TURBO_FLASH_MIN`. Because
+that dispatch bypasses the legacy `KvCache::update`, it must apply the same
+decode-side capacity rule that path does: `update_and_sdpa_k8v4_flash_inner`
+calls `ensure_decode_capacity` before it appends, and `grow_flash_buffers`
+re-sizes the latched head-major buffers (copying the filled prefix forward)
+whenever the storage window has grown past `flash_max_seq`. Without both, the
+window froze at the prefill length and the append walked off the end at the
+next power-of-two boundary — a `reshape … size 0` mid-decode. The `--max-ctx`
+ceiling / hard cap still bound the growth: a request that genuinely cannot fit
+is rejected loudly, never truncated. The `rot_k_tq4v` codec shares the tq4 V
+*format* but not this path — it decodes through `update_and_sdpa_rot_k_tq4v`
+with an uncapped `QuantV` V append and a growing `MixedKvState` K, so it grows
+at decode without the head-major buffers.
+
 ### 5.6 `planar4` requires `head_dim % 32 == 0`
 
 PlanarQuant's group size is 32. Same divisibility rule as §5.1, just


### PR DESCRIPTION
## Summary
Closes #261. A `k8v4` decode crash at the next power-of-two KV boundary that reached the streaming client as a **masked short completion** (no `finish_reason`, a misleading error), not a real error.

**Root cause.** The K8V4 head-major "flash" decode path (`update_and_sdpa` → `sdpa_dispatch` → `update_and_sdpa_k8v4_flash_inner`) dispatches only once `kv_seq > RMLX_TURBO_FLASH_MIN` and **bypasses the legacy `KvCache::update`** — so it never ran `ensure_decode_capacity`. The storage `max_seq`, the bf16 mirror, and the latched head-major `flash_*` buffers all froze at the prefill window; the moment decode crossed the next power-of-two the head-major append sliced an empty tensor off the frozen mirror and the step died with `reshape: Cannot reshape array of size 0`. #238 fixed the legacy/rotor/planar/bf16-mirror decode-grow class but did **not** reach this flash path. (The issue's "paged 4-bit-V" = these head-major/paged flash buffers for the tq4 V codec, not `--paged-kv`, which actually disables TurboFlash.)

## The two-part fix
1. **Crash** — `update_and_sdpa_k8v4_flash_inner` now calls `ensure_decode_capacity` before its append (ceiling/hard-cap still reject an over-long request loudly), and `grow_flash_buffers` re-sizes the latched head-major buffers (copying the filled prefix forward) when the window grows past `flash_max_seq`. Model-agnostic — keyed off codec + geometry (`head_dim`, `kv_h`), lock-state agnostic (`RMLX_TURBO_FLASH_LOCK`).
2. **Masking** — a deterministic decode crash reproduces at the same boundary on retry, so the replay's first regenerated token diverges from the delivered prefix and the retry-envelope's divergence guard fired, replacing the real crash with a synthetic `replay prefix divergence` message (and no `finish_reason`). The envelope now preserves the real engine error across replay attempts and surfaces it on the divergence/underrun paths so the true cause reaches the client.

## Proof (red-first + mutation)
- New GPU test `k8v4_flash_decode_grow` crosses **128 and 256** at `head_dim` **128 and 256** vs a pre-sized K8V4 reference.
  - Mutation A (remove `ensure_decode_capacity`) → `reshape: Cannot reshape array of size 0 into shape (1,2,1,32)` at the boundary.
  - Mutation B (remove `grow_flash_buffers`) → loud `flash append: needed=129 exceeds the allocated flash window max_seq=128`.
- New unit test `replay_divergence_surfaces_real_crash_not_laundered_message`; mutation (drop the preserved error) → client gets `replay prefix divergence` (the real crash laundered away).
- **Real model, multi-arch, multi-ctx** — decode crossing at temp=0, all complete cleanly (`finish_reason=length`), zero `reshape`/`decode step failed`/`prefix divergence` in the server log:

| model | arch | head_dim | boundary | pre-fix | post-fix |
|---|---|---|---|---|---|
| Bonsai-27B (issue model) | Qwen3_5 dense | 256 | 4096 | `reshape … size 0 (1,4,1,64)`, masked `finish_reason:null` | `length`, 61 tok |
| Bonsai-8B | Qwen3 | 128 | 4096 & 8192 | 503 `prefix divergence` | `length` |
| gemma-e2b (control) | Gemma4 | 512 (TF off) | 4096 & 8192 | ok | ok |
| rot_k_tq4v (Bonsai-8B) | — | 128 | 4096 & 8192 | ok (uncapped QuantV path) | ok |

`rot_k_tq4v` shares the tq4 V *format* but decodes via `update_and_sdpa_rot_k_tq4v` (uncapped `QuantV` + growing `MixedKvState`), not the head-major buffers — verified crash-free at both boundaries.

`make ci` green end-to-end (exit 0); `make check-gpu-tests-ignored` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)