### PR TITLE
fix(server): retry envelope re-issues original prompt — stop double-counting delivered tokens (#272)

### DIFF
--- a/crates/rmlx-server/src/retry.rs
+++ b/crates/rmlx-server/src/retry.rs
@@ -90,8 +90,9 @@ use crate::openai::ItlStore;
 /// Whether an [`RmlxError`] permits a transparent token-replay retry.
 ///
 /// `Migratable` — the error is transient and the stream can be reconstructed
-/// by re-issuing the request with already-delivered tokens appended to the
-/// prompt.
+/// by re-issuing the **original** request at `temperature == 0`; the engine
+/// re-emits the already-delivered tokens deterministically and the replay loop
+/// skips them.
 ///
 /// `Fatal` — the error is permanent or intentional (e.g. client cancelled,
 /// logic error). No retry should be attempted.
@@ -183,7 +184,7 @@ pub struct RequestPlan {
     pub model_id: String,
     /// Token ids of the original (pre-retry) prompt, without any delivered tokens.
     pub original_prompt_tokens: Vec<u32>,
-    /// Maximum new tokens from the original request, before subtracting delivered tokens.
+    /// Maximum new tokens from the original request; re-issued unchanged on every replay attempt.
     pub original_max_tokens: u32,
     /// Sampling parameters (temperature, top-p, etc.) frozen at plan creation.
     pub sampling: SamplingParams,

--- a/crates/rmlx-server/src/retry.rs
+++ b/crates/rmlx-server/src/retry.rs
@@ -13,10 +13,11 @@
 //! 4. On a [`RetryClass::Migratable`] error: rebuilds the request via
 //!    [`RequestPlan::build_request`], increments the attempt counter, and
 //!    restarts from step 1 (attempts 2..=N use the plan, not the original req).
-//!    The new attempt re-runs from the extended prompt (original + delivered)
-//!    at `temperature == 0`, so it deterministically reproduces the same token
-//!    sequence. The task then *skips* the first `delivered.len()` tokens and
-//!    forwards only the new continuation, asserting prefix identity.
+//!    The new attempt re-runs from the *original* prompt at `temperature == 0`,
+//!    so it deterministically re-emits the already-delivered tokens as its
+//!    first outputs, then continues past the fault point. The task then *skips*
+//!    the first `delivered.len()` tokens and forwards only the new
+//!    continuation, asserting prefix identity.
 //! 5. On [`RetryClass::Fatal`] or attempt exhaustion: sends the error through
 //!    the channel and exits.
 //! 6. When the channel send fails (client disconnected / HTTP drop): exits
@@ -41,10 +42,15 @@
 //!
 //! ## Prompt-continuation strategy
 //!
-//! `build_request` concatenates `original_prompt_tokens` with `delivered_token_ids`
-//! into a single extended token sequence. At `temperature == 0` the decode is
-//! deterministic, so the model reproduces the same continuation — the client
-//! sees a seamless stream once the skip logic drops the prefix.
+//! `build_request` re-issues the *original* prompt unchanged. At
+//! `temperature == 0` the decode is deterministic, so the engine re-emits the
+//! already-delivered tokens as its first `delivered.len()` outputs and then
+//! continues past the fault point; the skip logic drops that reproduced prefix
+//! so the client sees a seamless stream. The delivered tokens are **not** also
+//! appended to the prompt: doing so would double-count them (consumed as
+//! prompt *and* skipped on output), so the engine's continuation would no
+//! longer line up with the delivered prefix and every legitimate
+//! partial-delivery replay would spuriously report a prefix divergence.
 //!
 //! ## single-emit invariant
 //!
@@ -269,21 +275,22 @@ impl RequestPlan {
 
     /// Build a [`GenerationRequest`] for a retry attempt (attempt 2 onward).
     ///
-    /// - `delivered` — token ids already sent to the client; appended to the
-    ///   original prompt so the engine re-generates from the extended prefix.
-    pub fn build_request(&self, delivered: &[u32]) -> GenerationRequest {
-        let mut prompt_tokens =
-            Vec::with_capacity(self.original_prompt_tokens.len() + delivered.len());
-        prompt_tokens.extend_from_slice(&self.original_prompt_tokens);
-        prompt_tokens.extend_from_slice(delivered);
-        let max_tokens = self
-            .original_max_tokens
-            .saturating_sub(u32::try_from(delivered.len()).unwrap_or(u32::MAX))
-            .max(1);
+    /// The replay re-issues the **original** prompt unchanged. At
+    /// `temperature == 0` the engine deterministically re-emits the
+    /// already-delivered tokens as its first outputs; the replay loop skips
+    /// exactly `delivered.len()` of them (its `skip_count`) while asserting
+    /// prefix identity, then forwards the continuation. The delivered tokens
+    /// are therefore **not** appended to the prompt, and the token budget stays
+    /// at the original value — the engine re-generates the delivered prefix and
+    /// then the remaining continuation, so the total new-token count still
+    /// equals `original_max_tokens`. Appending the delivered tokens to the
+    /// prompt (or shrinking the budget by their count) would double-count them
+    /// and make every legitimate partial-delivery replay spuriously diverge.
+    pub fn build_request(&self) -> GenerationRequest {
         GenerationRequest {
             model_id: self.model_id.clone(),
-            prompt_tokens,
-            max_tokens,
+            prompt_tokens: self.original_prompt_tokens.clone(),
+            max_tokens: self.original_max_tokens.max(1),
             sampling: self.sampling.clone(),
             stop: self.stop.clone(),
             stream: self.stream,
@@ -415,7 +422,7 @@ pub fn replay_stream(
             // Subsequent attempts build a fresh request from the plan.
             let req = match next_req.take() {
                 Some(r) => r,
-                None => plan.build_request(&delivered),
+                None => plan.build_request(),
             };
             let skip_count = delivered.len();
             let model_id = &plan.model_id;

--- a/crates/rmlx-server/src/retry_tests.rs
+++ b/crates/rmlx-server/src/retry_tests.rs
@@ -755,3 +755,192 @@ async fn row_count_all_retries_exhausted_three_attempts() {
         "exhausted-retry path must call generate 3 times"
     );
 }
+
+// ── prompt-aware replay reconstruction ─────────────────────────────────────
+//
+// `MockGenerator` ignores the prompt, so it re-emits the same sequence on
+// every attempt regardless of what `build_request` reconstructs — the blind
+// spot that let the prompt/skip_count double-count hide. The generators below
+// couple output to the prompt exactly as the real engine does (prefill the
+// prompt, emit only the deterministic continuation that follows it) so the
+// tests actually exercise the reconstructed (prompt, skip_count) pair.
+
+/// Prompt-aware engine model. `full` is the complete temp=0 generation for
+/// `base_prompt`. A request whose prompt extends `base_prompt` by `extra`
+/// tokens yields `full[extra..]` — the first `extra` continuation tokens are
+/// now part of the prompt, already consumed. Attempt 0 crashes after
+/// `crash_after` emitted tokens with a Migratable error; later attempts
+/// complete. A correct replay re-issues the *original* prompt (extra == 0), so
+/// the engine re-emits the delivered prefix and the loop skips exactly
+/// `delivered.len()` matching tokens. The buggy double-count appends the
+/// delivered tokens to the prompt (extra == delivered.len()), so the engine
+/// skips straight to the continuation and the skip compares mismatched
+/// positions → a spurious divergence.
+struct PromptAwareGen {
+    base_prompt_len: usize,
+    full: Vec<u32>,
+    crash_after: usize,
+    call_count: Arc<AtomicUsize>,
+}
+
+impl Generator for PromptAwareGen {
+    fn generate(
+        &self,
+        req: GenerationRequest,
+    ) -> Pin<Box<dyn futures::stream::Stream<Item = rmlx_core::Result<GenerationToken>> + Send>>
+    {
+        let attempt = self.call_count.fetch_add(1, Ordering::SeqCst);
+        let extra = req.prompt_tokens.len().saturating_sub(self.base_prompt_len);
+        let budget = req.max_tokens as usize;
+        let crash_after = self.crash_after;
+        let items: Vec<rmlx_core::Result<GenerationToken>> = self
+            .full
+            .iter()
+            .skip(extra)
+            .take(budget)
+            .copied()
+            .enumerate()
+            .flat_map(|(i, token_id)| {
+                if attempt == 0 && i == crash_after {
+                    return vec![Err(E::Mlx("Metal watchdog (mock)".to_owned()))];
+                }
+                vec![Ok(GenerationToken {
+                    token_id,
+                    piece: format!("t{token_id}"),
+                    done: false,
+                    finish_reason: None,
+                    is_thinking: false,
+                    logprobs: None,
+                })]
+            })
+            .collect();
+        Box::pin(futures::stream::iter(items))
+    }
+}
+
+/// Partial-delivery replay on the REAL prompt path must resume seamlessly.
+///
+/// Red-first: this fails against the double-count `build_request` (which
+/// appends the delivered tokens to the prompt *and* skips `delivered.len()`).
+/// With the prompt-aware engine the appended prompt shifts the continuation, so
+/// the skip compares `full[delivered.len()]` against `delivered[0]` and the
+/// replay spuriously diverges — the client receives an error instead of the
+/// full sequence. The consistent fix (original prompt, `skip_count =
+/// delivered.len()`) reproduces the delivered prefix exactly and resumes clean.
+#[tokio::test]
+async fn replay_partial_delivery_prompt_aware_seamless() {
+    let base_prompt = vec![7u32, 8, 9];
+    let full: Vec<u32> = vec![100, 101, 102, 103, 104, 105];
+    let gen = Arc::new(PromptAwareGen {
+        base_prompt_len: base_prompt.len(),
+        full: full.clone(),
+        crash_after: 2, // attempt 0 delivers 2 tokens then a Migratable error
+        call_count: Arc::new(AtomicUsize::new(0)),
+    });
+    let mut s = drive(gen, base_prompt, full.len() as u32, DEFAULT_MAX_RETRIES);
+    let mut received = vec![];
+    let mut err_msg: Option<String> = None;
+    while let Some(item) = s.next().await {
+        match item {
+            Ok(tok) => received.push(tok.token_id),
+            Err(e) => {
+                err_msg = Some(e.to_string());
+                break;
+            }
+        }
+    }
+    assert!(
+        err_msg.is_none(),
+        "prompt-aware partial-delivery replay must resume without a spurious \
+         prefix divergence; got error: {err_msg:?}"
+    );
+    assert_eq!(
+        received, full,
+        "client must see the full deterministic sequence exactly once across the replay"
+    );
+}
+
+/// A GENUINE prefix mismatch on replay must still surface as an error — the
+/// fix removes the *false* divergence, it must not disable divergence
+/// detection. `full_retry` differs from the delivered prefix at position 2
+/// even when replayed from the correct original prompt (simulated
+/// non-determinism), so the prefix-identity guard must fire.
+#[tokio::test]
+async fn replay_prompt_aware_true_divergence_still_caught() {
+    const DIVERGED_TOKEN: u32 = 999;
+    struct PromptAwareDivergeGen {
+        base_prompt_len: usize,
+        full_first: Vec<u32>,
+        full_retry: Vec<u32>,
+        crash_after: usize,
+        call_count: Arc<AtomicUsize>,
+    }
+    impl Generator for PromptAwareDivergeGen {
+        fn generate(
+            &self,
+            req: GenerationRequest,
+        ) -> Pin<Box<dyn futures::stream::Stream<Item = rmlx_core::Result<GenerationToken>> + Send>>
+        {
+            let attempt = self.call_count.fetch_add(1, Ordering::SeqCst);
+            let extra = req.prompt_tokens.len().saturating_sub(self.base_prompt_len);
+            let budget = req.max_tokens as usize;
+            let crash_after = self.crash_after;
+            let source = if attempt == 0 {
+                &self.full_first
+            } else {
+                &self.full_retry
+            };
+            let items: Vec<rmlx_core::Result<GenerationToken>> = source
+                .iter()
+                .skip(extra)
+                .take(budget)
+                .copied()
+                .enumerate()
+                .flat_map(|(i, token_id)| {
+                    if attempt == 0 && i == crash_after {
+                        return vec![Err(E::Mlx("Metal watchdog (mock)".to_owned()))];
+                    }
+                    vec![Ok(GenerationToken {
+                        token_id,
+                        piece: format!("t{token_id}"),
+                        done: false,
+                        finish_reason: None,
+                        is_thinking: false,
+                        logprobs: None,
+                    })]
+                })
+                .collect();
+            Box::pin(futures::stream::iter(items))
+        }
+    }
+
+    let base_prompt = vec![7u32, 8, 9];
+    let gen = Arc::new(PromptAwareDivergeGen {
+        base_prompt_len: base_prompt.len(),
+        // attempt 0 delivers 100,101,102 then crashes (crash_after = 3)
+        full_first: vec![100, 101, 102, 103, 104, 105],
+        // retry genuinely emits a different token at prefix position 2
+        full_retry: vec![100, 101, DIVERGED_TOKEN, 103, 104, 105],
+        crash_after: 3,
+        call_count: Arc::new(AtomicUsize::new(0)),
+    });
+    let mut s = drive(gen, base_prompt, 6, DEFAULT_MAX_RETRIES);
+    let mut delivered = vec![];
+    let mut got_error = false;
+    while let Some(item) = s.next().await {
+        if let Ok(tok) = item {
+            delivered.push(tok.token_id);
+        } else {
+            got_error = true;
+            break;
+        }
+    }
+    assert!(
+        got_error,
+        "a genuine prefix mismatch on replay must still surface as an error"
+    );
+    assert!(
+        !delivered.contains(&DIVERGED_TOKEN),
+        "the diverged token must never reach the client"
+    );
+}

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -969,11 +969,16 @@ When retry is disabled, the handler calls `generator.generate(req)` directly.
 1. Attempt 1 runs with the original `GenerationRequest` (holding the GPU
    admission permit).
 2. Each delivered token id is appended to `delivered`.
-3. On `Migratable` error: the request is rebuilt from a `RequestPlan` with
-   `prompt_tokens = original_prompt_tokens ++ delivered`. At `temperature=0`
-   the decode is deterministic, so the model reproduces the same continuation.
-   The task skips the first `delivered.len()` tokens of the new attempt,
-   asserting prefix identity, and forwards only the new continuation.
+3. On `Migratable` error: the request is rebuilt from a `RequestPlan` that
+   re-issues the **original** prompt unchanged with the full original
+   `max_tokens`. At `temperature=0` the decode is deterministic, so the engine
+   re-emits the already-delivered tokens as its first `delivered.len()` outputs
+   and then continues past the fault point. The task skips those first
+   `delivered.len()` tokens, asserting prefix identity, and forwards only the
+   new continuation. The delivered tokens are **not** appended to the prompt —
+   doing so would double-count them (consumed as prompt *and* skipped on
+   output), shifting the continuation so the skip compares mismatched positions
+   and every legitimate partial-delivery replay spuriously diverges.
 4. On `Fatal` error or attempt exhaustion: the error is forwarded to the caller.
 5. On channel-send failure (client disconnect): the task exits silently — that
    is intentional cancellation, not a transient fault.


### PR DESCRIPTION
## Summary

Fixes #272. The token-replay retry envelope (`crates/rmlx-server/src/retry.rs`) **double-counted** already-delivered tokens on a partial-delivery replay: `build_request` appended `delivered` to the prompt **and** the replay loop skipped `skip_count = delivered.len()` engine-output tokens.

The real engine (`arch_generator.rs::generate`) prefills `prompt_tokens` and emits **only new continuation** — never echoing the prompt. So appending `delivered` to the prompt shifts the engine's output past the delivered prefix; skipping `delivered.len()` more then compares mismatched positions and reports a **spurious prefix divergence**, turning a recoverable mid-stream migratable error into a hard failure.

## The consistent scheme (and why)

The consumer of `skip_count` is the replay loop's skip + prefix-identity assertion (`retry.rs:444`, `tok.token_id == delivered[skipped]`). That assertion is only meaningful if the engine **re-emits the delivered tokens as output** — which only happens when the prompt is the **original** prompt. So the fix keeps the original prompt and `skip_count = delivered.len()` (the model deterministically re-generates the delivered prefix at temp=0, the loop skips it, forwards the continuation). The token budget also stays at the original value (the engine re-generates the prefix then continues, so total new tokens still equals `original_max_tokens`).

The alternative (append `delivered` + `skip_count = 0`) would work numerically but **disables divergence detection** entirely — rejected, per the contract that genuine divergence must still surface.

## Proof

- **Red-first, real prompt path**: `replay_partial_delivery_prompt_aware_seamless` uses a prompt-aware generator that couples output to the prompt exactly as the engine does (the old mocks ignore the prompt — the blind spot that hid this). Against the double-count it fails with a spurious divergence; with the fix the replay resumes seamlessly.
- **True divergence still caught**: `replay_prompt_aware_true_divergence_still_caught` — a genuine prefix mismatch on replay still surfaces as an error and the diverged token never reaches the client.
- **Mutation-check**: reverting `build_request` to the double-count turns the seamless test red (`prompt-aware partial-delivery replay must resume without a spurious prefix divergence; got error: Some("mlx: Metal watchdog (mock)")`), while the true-divergence test stays green.
- `make ci` green end-to-end (exit 0).

Does not touch the KV/update path. #261's masking and #235/#240's propagation/exhaustive-mapping contracts are untouched — the divergence path still surfaces the real engine error (the mutation red shows the real cause `mlx: Metal watchdog (mock)`, not a synthetic string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)