### PR TITLE
perf(kv): rotor fused decode ring-only tail — drop per-step host download (#231)

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
@@ -479,3 +479,136 @@ fn rotor_k_only_4_ring_only_tail_dequant_is_full_prefix() {
     }
     ring_only_tail_dequant_is_full_prefix(KvQuant::RotorKOnly4);
 }
+
+/// Truncating a LIVE rotor-K-only cache mid single-token fused decode (the
+/// speculative-decode partial-accept rollback) must NOT discard the ring-only
+/// tail: a subsequent decode step + `dequant` succeed with the correct full
+/// prefix, not an abort or a zero-padded gap.
+///
+/// After prefill + `steps` fused decode steps the store carries a ring-only
+/// tail. `truncate_to(prefill + keep)` rolls back the rejected tail; the GPU
+/// ring is kept (mirroring the flat GPU-buffer codecs), so the kept prefix
+/// `[0, prefill + keep)` survives in the ring. One more decode step then
+/// overwrites position `prefill + keep`, and `dequant` returns the full
+/// `prefill + keep + 1` prefix — byte/cosine-exact vs a CPU re-encode of the
+/// surviving tokens.
+///
+/// Mutation check: re-introduce `self.gpu.clear()` in `QuantRotorK{3,4}::
+/// truncate_to`. The ring (the only copy of the tail) is then dropped; the next
+/// fused append `seed_from_cpu`s the frozen prefill blocks against the larger
+/// `shape[2]` and errors (length mismatch), so `.expect("decode after
+/// truncate")` panics — RED.
+#[allow(clippy::expect_used, reason = "test: invariants documented")]
+fn ring_only_tail_truncate_then_decode(quant: KvQuant) {
+    let device = Device::Gpu;
+    let (kv_h, n_q_heads, head_dim, prefill, steps, keep) =
+        (2_i32, 8_i32, 128_i32, 6_i32, 5_i32, 2_i32);
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    let pf_n = (prefill * kv_h * head_dim) as usize;
+    let k_prefill = lcg_data(pf_n, 101);
+    let step_ks: Vec<Vec<f32>> = (0..steps)
+        .map(|s| lcg_data((kv_h * head_dim) as usize, 201 + s as u64))
+        .collect();
+    let k_new = lcg_data((kv_h * head_dim) as usize, 999);
+
+    let mut cache = seeded_cache(quant, kv_h, head_dim, false);
+    let k = f32_array(&k_prefill, &[1, kv_h, prefill, head_dim]);
+    let v = f32_array(&lcg_data(pf_n, 102), &[1, kv_h, prefill, head_dim]);
+    let q = f32_array(
+        &lcg_data((prefill * n_q_heads * head_dim) as usize, 103),
+        &[1, n_q_heads, prefill, head_dim],
+    );
+    cache
+        .update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+        .expect("prefill update_and_sdpa");
+    cache.exit_prefill(device).expect("exit_prefill");
+    for (i, ks_step) in step_ks.iter().enumerate() {
+        let k1 = f32_array(ks_step, &[1, kv_h, 1, head_dim]);
+        let v1 = f32_array(
+            &lcg_data((kv_h * head_dim) as usize, 301 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let q1 = f32_array(
+            &lcg_data((n_q_heads * head_dim) as usize, 401 + i as u64),
+            &[1, n_q_heads, 1, head_dim],
+        );
+        cache
+            .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .expect("decode update_and_sdpa")
+            .eval()
+            .expect("decode out eval");
+    }
+
+    // Roll back to prefill + keep (partial-accept), then decode one more token.
+    let m = prefill + keep;
+    cache.truncate_to(m);
+    assert_eq!(
+        cache.offset(),
+        m,
+        "offset must roll back to the truncate target"
+    );
+    {
+        let k1 = f32_array(&k_new, &[1, kv_h, 1, head_dim]);
+        let v1 = f32_array(
+            &lcg_data((kv_h * head_dim) as usize, 777),
+            &[1, kv_h, 1, head_dim],
+        );
+        let q1 = f32_array(
+            &lcg_data((n_q_heads * head_dim) as usize, 888),
+            &[1, n_q_heads, 1, head_dim],
+        );
+        cache
+            .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .expect("decode after truncate")
+            .eval()
+            .expect("post-truncate decode eval");
+    }
+
+    let (dq, shape, _blocks_tokens, ring_live) = rotor_k_store_probe(&cache);
+    assert!(
+        ring_live,
+        "ring must stay live across truncate (kept, not cleared)"
+    );
+    let final_seq = m + 1;
+    assert_eq!(
+        shape.get(2).copied().unwrap_or(0),
+        final_seq,
+        "shape[2] must be prefill+keep+1 after the post-truncate decode"
+    );
+    assert_eq!(
+        dq.len(),
+        (kv_h * final_seq * head_dim) as usize,
+        "dequant must cover the full post-truncate prefix (no abort, no zero-pad)"
+    );
+
+    // Reference: prefill + the kept decode tokens + the new token.
+    let mut surviving: Vec<Vec<f32>> = step_ks[..keep as usize].to_vec();
+    surviving.push(k_new);
+    let ref_dq = cpu_reference_dequant(quant, kv_h, head_dim, &k_prefill, &surviving, prefill);
+    assert_eq!(ref_dq.len(), dq.len(), "reference length mismatch");
+    let cos = mean_cosine(&dq, &ref_dq);
+    assert!(
+        cos > 0.99,
+        "post-truncate dequant vs CPU reference cosine {cos} too low — the ring-only \
+         tail was discarded (rejected/zeroed tokens) instead of the kept prefix"
+    );
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --ignored --test-threads=1"]
+fn rotor_k_only_3_ring_only_tail_truncate_then_decode() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    ring_only_tail_truncate_then_decode(KvQuant::RotorKOnly3);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --ignored --test-threads=1"]
+fn rotor_k_only_4_ring_only_tail_truncate_then_decode() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    ring_only_tail_truncate_then_decode(KvQuant::RotorKOnly4);
+}

--- a/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
@@ -300,3 +300,182 @@ fn rotor_k_only_decode_stays_cpu_when_store_carries_qjl() {
          missing the QJL residual"
     );
 }
+
+/// Global cosine over two flat vectors (0 when either is all-zeros).
+fn mean_cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na * nb)
+}
+
+/// `(dequant, shape, cpu_block_tokens, ring_live)` for the active rotor K store.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn rotor_k_store_probe(cache: &KvCache) -> (Vec<f32>, Vec<i32>, usize, bool) {
+    // if-let chain (not a `match` with a wildcard arm) — matches the negative-case
+    // helpers above and stays clear of `clippy::wildcard_enum_match_arm`.
+    if let KvStorage::RotorKOnly3 { k: Some(ks), .. } = cache.storage() {
+        (
+            ks.dequant().expect("rotor3 dequant"),
+            ks.shape.clone(),
+            ks.blocks.iter().map(|b| b.n_tokens).sum(),
+            ks.gpu.is_allocated(),
+        )
+    } else if let KvStorage::RotorKOnly4 { k: Some(ks), .. } = cache.storage() {
+        (
+            ks.dequant().expect("rotor4 dequant"),
+            ks.shape.clone(),
+            ks.blocks.iter().map(|b| b.n_tokens).sum(),
+            ks.gpu.is_allocated(),
+        )
+    } else {
+        panic!("expected a live rotor K-only store")
+    }
+}
+
+/// Reference K reconstruction: feed the identical K tokens through a CPU-only
+/// rotor K store (complete blocks, no ring) and dequant.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn cpu_reference_dequant(
+    quant: KvQuant,
+    kv_h: i32,
+    head_dim: i32,
+    k_prefill: &[f32],
+    step_ks: &[Vec<f32>],
+    prefill: i32,
+) -> Vec<f32> {
+    let n_groups = n_groups_for(head_dim as usize);
+    let rotors = make_rotor_table(0, 0, n_groups);
+    let shape0 = vec![1, kv_h, 0, head_dim];
+    let pf_shape = [1, kv_h, prefill, head_dim];
+    let step_shape = [1, kv_h, 1, head_dim];
+    if quant == KvQuant::RotorKOnly4 {
+        let mut ks = QuantRotorK4::from_cpu_blocks(rotors, None, Vec::new(), shape0, 0);
+        ks.append(k_prefill, &pf_shape)
+            .expect("ref rotor4 prefill append");
+        for s in step_ks {
+            ks.append(s, &step_shape).expect("ref rotor4 step append");
+        }
+        ks.dequant().expect("ref rotor4 dequant")
+    } else {
+        let mut ks = QuantRotorK3::from_cpu_blocks(rotors, None, Vec::new(), shape0, 0);
+        ks.append(k_prefill, &pf_shape)
+            .expect("ref rotor3 prefill append");
+        for s in step_ks {
+            ks.append(s, &step_shape).expect("ref rotor3 step append");
+        }
+        ks.dequant().expect("ref rotor3 dequant")
+    }
+}
+
+/// Full-prefix correctness of the ring-only decode tail.
+///
+/// After prefill + N fused decode steps the rotor K store's CPU `blocks` stay
+/// frozen at the prefill prefix — the per-step host download is skipped, so the
+/// decode tail lives only in the GPU ring. `dequant()` must still return the
+/// FULL prefix, rebuilt from the ring, with **no zero-padded gap**. Proven
+/// against a CPU-only reference store fed the identical K tokens.
+///
+/// Mutation check: make `dequant()` decode `self.blocks` directly instead of
+/// `synced_rotor_k_blocks(...)`. It then decodes only the frozen prefill prefix
+/// and the loud length guard fires (`dequant` → `Err`, `.expect` panics — RED),
+/// catching exactly the truncation / zero-pad the ring rebuild prevents.
+#[allow(clippy::expect_used, reason = "test: invariants documented")]
+fn ring_only_tail_dequant_is_full_prefix(quant: KvQuant) {
+    let device = Device::Gpu;
+    let (kv_h, n_q_heads, head_dim, prefill, steps) = (2_i32, 8_i32, 128_i32, 6_i32, 5_i32);
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    // Known K tokens: one prefill chunk + `steps` single-token decode chunks.
+    let pf_n = (prefill * kv_h * head_dim) as usize;
+    let k_prefill = lcg_data(pf_n, 101);
+    let step_ks: Vec<Vec<f32>> = (0..steps)
+        .map(|s| lcg_data((kv_h * head_dim) as usize, 201 + s as u64))
+        .collect();
+
+    // Fused cache: prefill + decode through the production entry point.
+    let mut cache = seeded_cache(quant, kv_h, head_dim, false);
+    let k = f32_array(&k_prefill, &[1, kv_h, prefill, head_dim]);
+    let v = f32_array(&lcg_data(pf_n, 102), &[1, kv_h, prefill, head_dim]);
+    let q = f32_array(
+        &lcg_data((prefill * n_q_heads * head_dim) as usize, 103),
+        &[1, n_q_heads, prefill, head_dim],
+    );
+    cache
+        .update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+        .expect("prefill update_and_sdpa");
+    cache.exit_prefill(device).expect("exit_prefill");
+    for (i, ks_step) in step_ks.iter().enumerate() {
+        let k1 = f32_array(ks_step, &[1, kv_h, 1, head_dim]);
+        let v1 = f32_array(
+            &lcg_data((kv_h * head_dim) as usize, 301 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let q1 = f32_array(
+            &lcg_data((n_q_heads * head_dim) as usize, 401 + i as u64),
+            &[1, n_q_heads, 1, head_dim],
+        );
+        cache
+            .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .expect("decode update_and_sdpa")
+            .eval()
+            .expect("decode out eval");
+    }
+
+    let (fused_dq, shape, blocks_tokens, ring_live) = rotor_k_store_probe(&cache);
+    let full_seq = prefill + steps;
+    let full_len = (kv_h * full_seq * head_dim) as usize;
+
+    // Ring-only-tail precondition: blocks froze at the prefill prefix, and the
+    // ring carries the decode tail.
+    assert!(ring_live, "ring must be live for the fused decode tail");
+    assert_eq!(
+        blocks_tokens,
+        (prefill * kv_h) as usize,
+        "CPU blocks must stay frozen at the prefill prefix (ring-only tail); got \
+         {blocks_tokens} tokens, shape[2]={}",
+        shape.get(2).copied().unwrap_or(0)
+    );
+    assert_eq!(
+        shape.get(2).copied().unwrap_or(0),
+        full_seq,
+        "shape[2] must advance with the ring"
+    );
+
+    // dequant returns the FULL prefix — no truncation, no zero-padded gap.
+    assert_eq!(
+        fused_dq.len(),
+        full_len,
+        "dequant must cover the full [1,{kv_h},{full_seq},{head_dim}] prefix"
+    );
+    let ref_dq = cpu_reference_dequant(quant, kv_h, head_dim, &k_prefill, &step_ks, prefill);
+    assert_eq!(ref_dq.len(), fused_dq.len(), "reference length mismatch");
+
+    let cos = mean_cosine(&fused_dq, &ref_dq);
+    assert!(
+        cos > 0.99,
+        "ring-only-tail dequant vs CPU reference cosine {cos} too low — a zero-padded \
+         or truncated tail would drop it well below this"
+    );
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --ignored --test-threads=1"]
+fn rotor_k_only_3_ring_only_tail_dequant_is_full_prefix() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    ring_only_tail_dequant_is_full_prefix(KvQuant::RotorKOnly3);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_dispatch -- --ignored --test-threads=1"]
+fn rotor_k_only_4_ring_only_tail_dequant_is_full_prefix() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    ring_only_tail_dequant_is_full_prefix(KvQuant::RotorKOnly4);
+}

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -775,6 +775,7 @@ fn rotor3_gpu_append_into_k_blocks(
     // is a `b > 1` chunk — normalise it to Maintain so the shared ring feeder
     // clears the ring for the un-representable batch and the CPU block carries
     // the data.
+    materialize_rotor_k3_ring_tail(ks, device)?;
     let block_feed = if feed == RingFeed::Skip {
         RingFeed::Skip
     } else {
@@ -788,6 +789,54 @@ fn rotor3_gpu_append_into_k_blocks(
     )?;
     rotor3_sync_ring(ks, &gpu, block_feed, new_shape, head_dim, max_seq, device)?;
     push_rotor3_k_block(ks, block, new_shape);
+    Ok(())
+}
+
+/// Reconcile a pre-existing ring-only decode tail into `ks.blocks` before a
+/// block-path append, so `blocks` stay a contiguous prefix after the push.
+///
+/// Both rotor-K mutators must reconcile the ring: `truncate_to` keeps the ring
+/// (the tail lives there), and this block-path append materialises the tail
+/// into `blocks` so a later push does not leave a non-contiguous
+/// prefix-then-gap-then-tail. No-op when `blocks` already cover `shape[2]` (the
+/// common prefill / asym case — reads no GPU). Not reachable today (batch dim is
+/// fixed per request, so a fused→multi-token-append transition does not occur),
+/// but closing it keeps the "blocks are always a contiguous prefix" invariant
+/// true at every mutator.
+fn materialize_rotor_k3_ring_tail(
+    ks: &mut crate::storage::QuantRotorK3,
+    device: Device,
+) -> Result<()> {
+    if !ks.gpu.is_allocated() {
+        return Ok(());
+    }
+    let rebuilt =
+        match crate::storage::synced_rotor_k_blocks(&ks.blocks, &ks.shape, &ks.gpu, device)? {
+            std::borrow::Cow::Owned(full) => Some(full),
+            std::borrow::Cow::Borrowed(_) => None,
+        };
+    if let Some(full) = rebuilt {
+        ks.blocks = full;
+    }
+    Ok(())
+}
+
+/// Mirror of [`materialize_rotor_k3_ring_tail`] for [`crate::storage::QuantRotorK4`].
+fn materialize_rotor_k4_ring_tail(
+    ks: &mut crate::storage::QuantRotorK4,
+    device: Device,
+) -> Result<()> {
+    if !ks.gpu.is_allocated() {
+        return Ok(());
+    }
+    let rebuilt =
+        match crate::storage::synced_rotor_k_blocks(&ks.blocks, &ks.shape, &ks.gpu, device)? {
+            std::borrow::Cow::Owned(full) => Some(full),
+            std::borrow::Cow::Borrowed(_) => None,
+        };
+    if let Some(full) = rebuilt {
+        ks.blocks = full;
+    }
     Ok(())
 }
 
@@ -825,6 +874,7 @@ fn rotor4_gpu_append_into_k_blocks(
     }
     // Block path — see [`rotor3_gpu_append_into_k_blocks`] (b>1 ring-only
     // fallback normalises to Maintain).
+    materialize_rotor_k4_ring_tail(ks, device)?;
     let block_feed = if feed == RingFeed::Skip {
         RingFeed::Skip
     } else {

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -289,18 +289,15 @@ struct PackedKEncodedGpu {
     norms: Array,
 }
 
-/// [`rotor_gpu_encode_block`] that also hands back the GPU arrays.
-///
-/// The download to CPU still happens — `RotorBlocks` remains the source of
-/// truth for `dequant()` and the SSD spill/hydrate round-trip — but the K-side
-/// ring feed reuses the pre-download GPU arrays, so keeping the store
-/// GPU-resident costs no extra encode work.
-fn rotor_gpu_encode_block_retaining(
+/// GPU-encode one rotor K/V chunk, returning the raw kernel arrays plus the
+/// `(n_tokens_total, n_groups)` geometry the CPU download and ring feed both
+/// need. Shared by the block-retaining and ring-only encode wrappers.
+fn rotor_gpu_encode_arrays(
     new_kv: &Array,
     new_shape: &[i32],
     rotors: &[f32],
     bits: u8,
-) -> Result<(RotorBlocks, PackedKEncodedGpu)> {
+) -> Result<(Array, Array, Array, usize, usize)> {
     if new_shape.len() != 4 {
         return Err(Error::Mlx(format!(
             "rotor_gpu_encode_block: expected 4D new_shape, got {new_shape:?}"
@@ -330,25 +327,30 @@ fn rotor_gpu_encode_block_retaining(
     } else {
         crate::rotorquant_msl::rotor_quantize_v4_gpu(new_kv, &rotors_arr, head_dim, Device::Gpu)?
     };
-    // This download is a host round-trip per layer per decode step, and the
-    // fused decode path never reads the `RotorBlocks` it produces — so it looks
-    // like pure waste on that path. It is kept deliberately:
-    //
-    // * `RotorBlocks` is the source of truth for `dequant()` AND for the SSD
-    //   tier, which serialises `RotorKOnly{3,4}` block-by-block
-    //   (`rmlx_kv_ssd::block_io`). `push_*_k_block` bumps `shape[2]` in lockstep
-    //   with the push, so skipping the block would leave `blocks` shorter than
-    //   `shape[2]` — a gap `dequant()` silently zero-pads and a spill would
-    //   persist as a truncated store.
-    // * The win does not pay for that risk. Measured (Bonsai-8B, 4k, k_rotor3,
-    //   3 runs, decode TPS): with download 13.2 / 16.3 / 15.7 (median 15.7),
-    //   skipping it 19.0 / 16.8 / 17.1 (median 17.1) — ~9% on the median but the
-    //   ranges overlap, because the flash dispatcher already evaluates the ring
-    //   slices each step, so the encode is materialised either way and only the
-    //   host memcpy is saved.
-    //
-    // Dropping it needs a ring-only-tail design that can rebuild blocks on
-    // demand (or an SSD path that reads the ring), not a flag.
+    Ok((codes_arr, scales_arr, norms_arr, n_tokens_total, n_groups))
+}
+
+/// [`rotor_gpu_encode_block`] that also hands back the GPU arrays.
+///
+/// Used by the CPU-authoritative append paths (prefill, and the non-fused
+/// decode fallback): the `RotorBlocks` is the source of truth for `dequant()`
+/// and the SSD spill/hydrate round-trip, while the K-side ring feed reuses the
+/// pre-download GPU arrays so keeping the store GPU-resident costs no extra
+/// encode work.
+///
+/// The fused decode path does **not** use this — it uses
+/// [`rotor_gpu_encode_ring_only`], which skips the per-step host download
+/// entirely (a ring-only tail; the blocks are rebuilt from the ring on demand
+/// when `dequant()` / an SSD spill actually needs them).
+fn rotor_gpu_encode_block_retaining(
+    new_kv: &Array,
+    new_shape: &[i32],
+    rotors: &[f32],
+    bits: u8,
+) -> Result<(RotorBlocks, PackedKEncodedGpu)> {
+    let (codes_arr, scales_arr, norms_arr, n_tokens_total, n_groups) =
+        rotor_gpu_encode_arrays(new_kv, new_shape, rotors, bits)?;
+
     let (codes, scales, norms) = crate::rotorquant_msl::rotor_gpu_outputs_to_cpu(
         &codes_arr,
         &scales_arr,
@@ -378,6 +380,35 @@ fn rotor_gpu_encode_block_retaining(
             norms: norms_per_token,
         },
     ))
+}
+
+/// GPU-encode one rotor K chunk for the **ring-only** append path: feed the GPU
+/// ring without paying the per-step host download that
+/// [`rotor_gpu_encode_block_retaining`] does.
+///
+/// The fused decode kernel reads the ring, never the CPU `RotorBlocks`, so
+/// downloading and materialising a block per decode step is pure host work in
+/// the path whose purpose is removing host work. Skipping it leaves the ring
+/// the sole source of truth for the decode tail; the CPU blocks are rebuilt
+/// from the ring on demand at a `dequant()` / SSD-spill boundary
+/// (`synced_rotor_k_blocks`), and the `blocks`-vs-`shape[2]` invariant is
+/// enforced loudly there — never zero-padded.
+fn rotor_gpu_encode_ring_only(
+    new_kv: &Array,
+    new_shape: &[i32],
+    rotors: &[f32],
+    bits: u8,
+) -> Result<PackedKEncodedGpu> {
+    let (codes_arr, scales_arr, norms_arr, n_tokens_total, n_groups) =
+        rotor_gpu_encode_arrays(new_kv, new_shape, rotors, bits)?;
+    // Collapse per-group norms to the per-token form the ring stores (GPU-side,
+    // no host round-trip).
+    let norms_per_token = collapse_group_norms_to_token(&norms_arr, n_tokens_total, n_groups)?;
+    Ok(PackedKEncodedGpu {
+        codes: codes_arr,
+        scales: scales_arr,
+        norms: norms_per_token,
+    })
 }
 
 /// Collapse a packed-K encode kernel's per-group norms (`[n_tokens, n_groups]`,
@@ -484,13 +515,25 @@ fn push_rotor4_v_block(vs: &mut QuantRotorV4, block: RotorBlocks, new_shape: &[i
     }
 }
 
+/// Advance a rotor K store's accumulated `shape` by one appended chunk,
+/// matching the `QuantRotorK{3,4}::append` bookkeeping. Shared by the
+/// block-pushing and ring-only append paths so `shape[2]` advances identically
+/// whether or not a CPU block is materialised.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "shape rank-4 guard above each indexing site; new_shape rank validated by upstream encoder helper"
+)]
+fn bump_rotor_k_shape(shape: &mut Vec<i32>, new_shape: &[i32]) {
+    if shape.len() != 4 || shape[0] == 0 {
+        *shape = new_shape.to_vec();
+    } else {
+        shape[2] += new_shape[2];
+    }
+}
+
 /// Push a pre-built [`RotorBlocks`] onto a [`QuantRotorK3`] buffer (QJL OFF
 /// path — caller has already verified [`crate::rotor_qjl::rotor_qjl_enabled`]
 /// is `false`).
-#[allow(
-    clippy::indexing_slicing,
-    reason = "ks.shape rank-4 guard above each indexing site; new_shape rank validated by upstream encoder helper"
-)]
 fn push_rotor3_k_block(
     ks: &mut crate::storage::QuantRotorK3,
     block: RotorBlocks,
@@ -504,17 +547,9 @@ fn push_rotor3_k_block(
         qjl_norms: Vec::new(),
         n_tokens: block.n_tokens,
     });
-    if ks.shape.len() != 4 || ks.shape[0] == 0 {
-        ks.shape = new_shape.to_vec();
-    } else {
-        ks.shape[2] += new_shape[2];
-    }
+    bump_rotor_k_shape(&mut ks.shape, new_shape);
 }
 
-#[allow(
-    clippy::indexing_slicing,
-    reason = "ks.shape rank-4 guard above each indexing site; new_shape rank validated by upstream encoder helper"
-)]
 fn push_rotor4_k_block(
     ks: &mut crate::storage::QuantRotorK4,
     block: RotorBlocks,
@@ -528,11 +563,7 @@ fn push_rotor4_k_block(
         qjl_norms: Vec::new(),
         n_tokens: block.n_tokens,
     });
-    if ks.shape.len() != 4 || ks.shape[0] == 0 {
-        ks.shape = new_shape.to_vec();
-    } else {
-        ks.shape[2] += new_shape[2];
-    }
+    bump_rotor_k_shape(&mut ks.shape, new_shape);
 }
 
 /// Recover `head_dim` from a 4-D new_shape without silently swallowing
@@ -604,8 +635,17 @@ fn rotor4_gpu_append_into_blocks(
 /// hydrate, deep clone, and a mid-run fall back to the CPU append).
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum RingFeed {
-    /// Maintain the ring — the rotor flash-decode kernel will read it.
+    /// Maintain the ring **and** push a CPU block — the ring is the source of
+    /// truth for the flash-decode kernel, the block for `dequant()` / SSD spill.
+    /// Used by prefill and the non-fused decode fallback, which `dequant()` the
+    /// whole prefix on the same step and so need the block immediately.
     Maintain,
+    /// Maintain the ring **without** pushing a CPU block — a **ring-only tail**.
+    /// The fused decode path never reads the block, so skipping the per-step
+    /// host download is the win; the blocks are rebuilt from the ring on demand
+    /// at a `dequant()` / SSD-spill boundary. `shape[2]` still advances so the
+    /// ring and the attention length stay in lockstep.
+    MaintainRingOnly,
     /// Skip the ring. Any live ring is dropped (see the invariant below).
     Skip,
 }
@@ -634,7 +674,7 @@ fn rotor3_sync_ring(
     device: Device,
 ) -> Result<()> {
     let (b, kv_h, new_seq) = b_kv_h_new_seq(new_shape)?;
-    if feed != RingFeed::Maintain || b != 1 {
+    if feed == RingFeed::Skip || b != 1 {
         ks.gpu.clear();
         return Ok(());
     }
@@ -665,7 +705,7 @@ fn rotor4_sync_ring(
     device: Device,
 ) -> Result<()> {
     let (b, kv_h, new_seq) = b_kv_h_new_seq(new_shape)?;
-    if feed != RingFeed::Maintain || b != 1 {
+    if feed == RingFeed::Skip || b != 1 {
         ks.gpu.clear();
         return Ok(());
     }
@@ -707,13 +747,46 @@ fn rotor3_gpu_append_into_k_blocks(
     // encode itself ignores the JL projection — this path is QJL-off-only by
     // dispatcher contract.
     let seq_major = packed_k_chunk_seq_major(new_k, new_shape, device)?;
+    if is_ring_only_append(feed, new_shape) {
+        // Ring-only tail: feed the GPU ring, advance `shape[2]`, and skip the
+        // per-step host download + CPU block push. The ring is the source of
+        // truth for the decode tail; the blocks are rebuilt on demand at a
+        // `dequant()` / SSD-spill boundary.
+        let gpu = rotor_gpu_encode_ring_only(
+            &seq_major,
+            new_shape,
+            &ks.rotors,
+            crate::rotorquant::ROTOR3_BITS,
+        )?;
+        rotor3_sync_ring(
+            ks,
+            &gpu,
+            RingFeed::Maintain,
+            new_shape,
+            head_dim,
+            max_seq,
+            device,
+        )?;
+        bump_rotor_k_shape(&mut ks.shape, new_shape);
+        return Ok(());
+    }
+    // Block path: prefill / non-fused decode (Maintain), asym (Skip), and the
+    // `b > 1` fallback of a ring-only append. A ring-only feed that reaches here
+    // is a `b > 1` chunk — normalise it to Maintain so the shared ring feeder
+    // clears the ring for the un-representable batch and the CPU block carries
+    // the data.
+    let block_feed = if feed == RingFeed::Skip {
+        RingFeed::Skip
+    } else {
+        RingFeed::Maintain
+    };
     let (block, gpu) = rotor_gpu_encode_block_retaining(
         &seq_major,
         new_shape,
         &ks.rotors,
         crate::rotorquant::ROTOR3_BITS,
     )?;
-    rotor3_sync_ring(ks, &gpu, feed, new_shape, head_dim, max_seq, device)?;
+    rotor3_sync_ring(ks, &gpu, block_feed, new_shape, head_dim, max_seq, device)?;
     push_rotor3_k_block(ks, block, new_shape);
     Ok(())
 }
@@ -730,13 +803,40 @@ fn rotor4_gpu_append_into_k_blocks(
     let head_dim = head_dim_from_shape(new_shape, "rotor4_gpu_append_into_k_blocks")?;
     ensure_k4_rotors(ks, head_dim);
     let seq_major = packed_k_chunk_seq_major(new_k, new_shape, device)?;
+    if is_ring_only_append(feed, new_shape) {
+        // Ring-only tail — see [`rotor3_gpu_append_into_k_blocks`].
+        let gpu = rotor_gpu_encode_ring_only(
+            &seq_major,
+            new_shape,
+            &ks.rotors,
+            crate::rotorquant::ROTOR4_BITS,
+        )?;
+        rotor4_sync_ring(
+            ks,
+            &gpu,
+            RingFeed::Maintain,
+            new_shape,
+            head_dim,
+            max_seq,
+            device,
+        )?;
+        bump_rotor_k_shape(&mut ks.shape, new_shape);
+        return Ok(());
+    }
+    // Block path — see [`rotor3_gpu_append_into_k_blocks`] (b>1 ring-only
+    // fallback normalises to Maintain).
+    let block_feed = if feed == RingFeed::Skip {
+        RingFeed::Skip
+    } else {
+        RingFeed::Maintain
+    };
     let (block, gpu) = rotor_gpu_encode_block_retaining(
         &seq_major,
         new_shape,
         &ks.rotors,
         crate::rotorquant::ROTOR4_BITS,
     )?;
-    rotor4_sync_ring(ks, &gpu, feed, new_shape, head_dim, max_seq, device)?;
+    rotor4_sync_ring(ks, &gpu, block_feed, new_shape, head_dim, max_seq, device)?;
     push_rotor4_k_block(ks, block, new_shape);
     Ok(())
 }
@@ -775,7 +875,14 @@ pub(super) fn rotor3_k_only_gpu_append(
     let Some(ks) = k.as_mut() else {
         return Err(Error::Mlx("RotorKOnly3 K buffer absent after init".into()));
     };
-    rotor3_gpu_append_into_k_blocks(ks, new_k, new_shape, device, RingFeed::Maintain, max_seq)
+    rotor3_gpu_append_into_k_blocks(
+        ks,
+        new_k,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )
 }
 
 /// Mirror of [`rotor3_k_only_gpu_append`] for `RotorKOnly4`.
@@ -810,7 +917,14 @@ pub(super) fn rotor4_k_only_gpu_append(
     let Some(ks) = k.as_mut() else {
         return Err(Error::Mlx("RotorKOnly4 K buffer absent after init".into()));
     };
-    rotor4_gpu_append_into_k_blocks(ks, new_k, new_shape, device, RingFeed::Maintain, max_seq)
+    rotor4_gpu_append_into_k_blocks(
+        ks,
+        new_k,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )
 }
 
 /// Accumulated sequence length held by a rotor K storage `shape`
@@ -820,6 +934,21 @@ fn accumulated_seq(shape: &[i32]) -> i32 {
         return 0;
     }
     shape.get(2).copied().unwrap_or(0).max(0)
+}
+
+/// Whether an append should take the ring-only tail path (no CPU block push).
+///
+/// Only `feed == MaintainRingOnly` **and** `b == 1` qualify: the ring's
+/// per-step stride does not interleave batch, so a `b > 1` chunk cannot be laid
+/// into it. Because the ring-only path pushes no CPU block, a `b > 1` chunk
+/// here would clear the ring in `rotor*_sync_ring` and silently drop the chunk
+/// while still advancing `shape[2]` — the ring-vs-blocks divergence the
+/// invariant forbids. So `b > 1` falls back to the block-pushing path, which
+/// handles batch and keeps the CPU blocks the source of truth. (Per request the
+/// batch dim is fixed, so a `b > 1` cache never builds a ring-only tail to
+/// lose.)
+fn is_ring_only_append(feed: RingFeed, new_shape: &[i32]) -> bool {
+    feed == RingFeed::MaintainRingOnly && matches!(b_kv_h_new_seq(new_shape), Ok((1, _, _)))
 }
 
 /// `(b, kv_h, new_seq)` from a rank-4 `[B, kv_h, S, D]` shape.

--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -71,6 +71,7 @@ pub use quant_k_turbo3::{QuantKTurbo3, TURBO3_K_BITS};
 pub use quant_k_turbo4::QuantKTurbo4;
 pub use quant_planar_k::QuantPlanarK;
 pub use quant_planar_v::QuantPlanarV;
+pub(crate) use quant_rotor_k3::synced_rotor_k_blocks;
 pub use quant_rotor_k3::{QuantRotorK3, RotorKBlocks, ROTOR3_K_BITS, ROTOR3_K_GROUP_SIZE};
 pub use quant_rotor_k4::{QuantRotorK4, ROTOR4_K_BITS, ROTOR4_K_GROUP_SIZE};
 pub use quant_rotor_v3::{QuantRotorV3, RotorBlocks, ROTOR3_V_BITS, ROTOR3_V_GROUP_SIZE};

--- a/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring.rs
@@ -313,6 +313,38 @@ impl QuantKGpuRing {
         Ok(Some((codes, scales, norms)))
     }
 
+    /// Download the first `kv_seq` filled positions to CPU as flat
+    /// sequence-major `(codes, per-group scales, per-token norms)` vectors.
+    ///
+    /// The CPU form the packed K stores accumulate their `blocks` in
+    /// (`RotorKBlocks` / `IsoBlocks`) is byte-identical to this download: the
+    /// ring was fed the encode kernel's own GPU arrays, and it already stores
+    /// **per-token** norms (collapsed at feed time), so no group→token collapse
+    /// is applied here. Returns `None` when the ring is not live.
+    ///
+    /// Cold path — used to rebuild the CPU blocks on demand for a store whose
+    /// decode tail lives only in the ring (`dequant` / SSD spill), never per
+    /// decode step.
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`Self::packed_view`] errors and any MLX eval / readback
+    /// failure.
+    pub fn packed_view_cpu(
+        &self,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Option<(Vec<u32>, Vec<f32>, Vec<f32>)>> {
+        let Some((codes, scales, norms)) = self.packed_view(kv_seq, device)? else {
+            return Ok(None);
+        };
+        Ok(Some((
+            array_to_u32_vec(&codes)?,
+            array_to_f32_vec(&scales)?,
+            array_to_f32_vec(&norms)?,
+        )))
+    }
+
     fn alloc(&mut self, cap: i32, device: Device) -> Result<()> {
         let cps = self.codes_per_step;
         let nps = self.norms_per_step;
@@ -437,6 +469,32 @@ fn f32_slice_to_array(vals: &[f32]) -> Result<Array> {
     let len = i32::try_from(vals.len())
         .map_err(|_| Error::Quant("QuantKGpuRing: f32 prefix exceeds i32::MAX".into()))?;
     Array::from_bytes(bytes, &[len], Dtype::F32)
+}
+
+/// Download a flat `u32` GPU array to a `Vec<u32>`.
+#[allow(
+    clippy::expect_used,
+    reason = "chunks_exact(4) yields slices of exactly 4 bytes"
+)]
+fn array_to_u32_vec(a: &Array) -> Result<Vec<u32>> {
+    a.eval()?;
+    Ok(a.to_bytes()?
+        .chunks_exact(4)
+        .map(|b| u32::from_le_bytes(b.try_into().expect("len 4 by chunks_exact contract")))
+        .collect())
+}
+
+/// Download a flat `f32` GPU array to a `Vec<f32>`.
+#[allow(
+    clippy::expect_used,
+    reason = "chunks_exact(4) yields slices of exactly 4 bytes"
+)]
+fn array_to_f32_vec(a: &Array) -> Result<Vec<f32>> {
+    a.eval()?;
+    Ok(a.to_bytes()?
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().expect("len 4 by chunks_exact contract")))
+        .collect())
 }
 
 fn slice_prefix(buf: Option<&Array>, len: i32, what: &str, device: Device) -> Result<Array> {

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
@@ -14,6 +14,8 @@
 )]
 //! Quantized K buffer: `QuantRotorK3` (rotor3 K codec).
 
+use std::borrow::Cow;
+
 use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{Array, Device};
 
@@ -400,6 +402,14 @@ impl QuantRotorK3 {
     /// # Errors
     /// Currently infallible on the CPU path; returns `Result` for parity.
     pub fn try_deep_clone(&self) -> Result<Self> {
+        // Materialise any ring-only tail into complete CPU blocks first: the
+        // clone starts CPU-only (the ring is not cloned), and both the
+        // prompt-cache snapshot and the SSD spill clone route through here, so
+        // this is the single point where a store leaving the live decode loop
+        // reconciles its blocks with the ring. A short-blocks clone with no
+        // ring would silently truncate the store — refused loudly instead.
+        let blocks =
+            synced_rotor_k_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?.into_owned();
         Ok(Self {
             rotors: self.rotors.clone(),
             // The clone starts CPU-only: `blocks` carries the full payload, so
@@ -408,7 +418,7 @@ impl QuantRotorK3 {
             // independent caches.
             gpu: QuantKGpuRing::default(),
             qjl_s_matrix: self.qjl_s_matrix.clone(),
-            blocks: self.blocks.clone(),
+            blocks,
             shape: self.shape.clone(),
             layer_idx: self.layer_idx,
             head_idx: self.head_idx,
@@ -471,7 +481,13 @@ impl QuantRotorK3 {
         let total_elems: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out: Vec<f32> = Vec::with_capacity(total_elems);
 
-        if self.blocks.is_empty() {
+        // Reconcile the CPU blocks with the GPU ring: on the fused decode path
+        // the decode tail lives only in the ring (`blocks` trail `shape[2]`),
+        // and this rebuilds it on demand rather than decoding a short prefix and
+        // zero-padding the gap. Loud on any unrecoverable disagreement.
+        let blocks = synced_rotor_k_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?;
+
+        if blocks.is_empty() {
             out.resize(total_elems, 0.0);
             return Ok(out);
         }
@@ -482,7 +498,7 @@ impl QuantRotorK3 {
             ));
         }
 
-        for blk in &self.blocks {
+        for blk in blocks.iter() {
             let dec = rotor3_k_decode(
                 &blk.codes,
                 &blk.scales,
@@ -496,10 +512,16 @@ impl QuantRotorK3 {
             .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor3_k decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
-        if out.len() < total_elems {
-            out.resize(total_elems, 0.0);
-        } else if out.len() > total_elems {
-            out.truncate(total_elems);
+        // `synced_rotor_k_blocks` guarantees the blocks cover `shape[2]`, so a
+        // length mismatch here is an internal invariant break — surface it
+        // loudly rather than zero-padding or truncating a decoded prefix.
+        if out.len() != total_elems {
+            return Err(Error::Mlx(format!(
+                "QuantRotorK3::dequant: decoded {} elems but shape {:?} implies {total_elems} — \
+                 refusing to zero-pad / truncate",
+                out.len(),
+                self.shape
+            )));
         }
         // Blocks are sequence-major (see `append`); reorder back to head-major
         // `[B, kv_h, S, D]`.
@@ -509,6 +531,95 @@ impl QuantRotorK3 {
         let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
         Ok(out)
     }
+}
+
+/// Reconcile a rotor-K store's CPU `blocks` with its GPU ring so the returned
+/// slice covers the full accumulated `shape[2]`.
+///
+/// On the fused decode path the per-step CPU block download is skipped — the
+/// GPU ring is the source of truth for the decode tail, and `blocks` trail
+/// `shape[2]` (a **ring-only tail**). This rebuilds the missing prefix from the
+/// ring on demand — the single point where a block consumer (`dequant`, or the
+/// SSD spill via `try_deep_clone`) reconciles the two. When `blocks` already
+/// cover `shape[2]` (the CPU append, QJL, and SSD-hydrate paths) the borrow is
+/// returned untouched, so those paths pay no GPU readback.
+///
+/// **Invariant (enforced loudly, never zero-padded):** `blocks` track the ring
+/// exactly, or the ring exists and supplies the tail. Any state where the CPU
+/// blocks fall short of `shape[2]` and the ring cannot make up the difference is
+/// an `Error` — the caller must not fabricate a zeroed gap.
+///
+/// Shared by `QuantRotorK3` and `QuantRotorK4` (the block payload and ring
+/// layout are identical modulo codes bit-width).
+///
+/// # Errors
+///
+/// Returns [`Error::Quant`] on a malformed shape, when the blocks over-run
+/// `shape[2]`, or when a ring-only tail exists but the ring is absent /
+/// too short to cover it.
+pub(crate) fn synced_rotor_k_blocks<'a>(
+    blocks: &'a [RotorKBlocks],
+    shape: &[i32],
+    gpu: &QuantKGpuRing,
+    device: Device,
+) -> Result<Cow<'a, [RotorKBlocks]>> {
+    if shape.len() != 4 {
+        return Err(Error::Quant(format!(
+            "synced_rotor_k_blocks: malformed shape {shape:?}"
+        )));
+    }
+    let b = shape.first().copied().unwrap_or(0).max(0) as usize;
+    let kv_h = shape.get(1).copied().unwrap_or(0).max(0) as usize;
+    let full_seq = shape.get(2).copied().unwrap_or(0).max(0) as usize;
+    let head_dim = shape.get(3).copied().unwrap_or(0).max(0) as usize;
+    let full_tokens = b * kv_h * full_seq;
+    let blocks_tokens: usize = blocks.iter().map(|blk| blk.n_tokens).sum();
+
+    if blocks_tokens == full_tokens {
+        return Ok(Cow::Borrowed(blocks));
+    }
+    if blocks_tokens > full_tokens {
+        return Err(Error::Quant(format!(
+            "rotor K store: CPU blocks hold {blocks_tokens} tokens but shape[2] implies \
+             {full_tokens} — blocks over-run the accumulated shape (internal invariant)"
+        )));
+    }
+
+    // Ring-only tail: the GPU ring must supply the whole prefix. It is
+    // sequence-major and stores per-token norms already, so the readback is one
+    // block covering `[0, full_seq)`. Refuse to fabricate a zeroed gap.
+    let seq_i32 = i32::try_from(full_seq).map_err(|_| {
+        Error::Quant(format!(
+            "rotor K store: shape[2]={full_seq} exceeds i32::MAX"
+        ))
+    })?;
+    let Some((codes, scales, norms)) = gpu.packed_view_cpu(seq_i32, device)? else {
+        return Err(Error::Quant(format!(
+            "rotor K store: CPU blocks cover {blocks_tokens} tokens but shape[2] needs \
+             {full_tokens} and the GPU ring is absent — refusing to zero-pad the decode tail"
+        )));
+    };
+    let n_groups = n_groups_for(head_dim);
+    let want_codes = full_tokens * n_groups;
+    if codes.len() != want_codes || scales.len() != want_codes || norms.len() != full_tokens {
+        return Err(Error::Quant(format!(
+            "rotor K store: ring readback size mismatch (codes {} scales {} norms {}, \
+             want codes/scales {want_codes} norms {full_tokens}) — cannot rebuild blocks",
+            codes.len(),
+            scales.len(),
+            norms.len(),
+        )));
+    }
+    Ok(Cow::Owned(vec![RotorKBlocks {
+        codes,
+        scales,
+        norms,
+        // The GPU ring path is QJL-off by dispatcher contract, so the rebuilt
+        // block carries no residual sideband.
+        qjl_codes: Vec::new(),
+        qjl_norms: Vec::new(),
+        n_tokens: full_tokens,
+    }]))
 }
 
 #[cfg(test)]

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
@@ -371,13 +371,25 @@ impl QuantRotorK3 {
         }
     }
 
-    /// Truncate the accumulated sequence to `n` tokens.
+    /// Truncate the accumulated sequence to `n` positions.
+    ///
+    /// The GPU ring is **kept**, not cleared: this mirrors how the flat GPU-buffer
+    /// codecs truncate (`QuantK` / K8V4 etc. just lower `shape[2]` and overwrite
+    /// on the next append). Lowering `shape[2]` to `n` makes the ring's logical
+    /// fill `n`; the stale `[n, prev)` capacity is overwritten by the next append
+    /// and never read (`packed_view` always slices to `shape[2]`). This preserves
+    /// any ring-only decode tail up to `n`, so `dequant` / an SSD spill can still
+    /// rebuild it. Clearing the ring here — the previous behaviour — discarded
+    /// the tail (the only copy of `[frozen_prefix, n)`), leaving `blocks` short
+    /// of `shape[2]` with no ring: the divergent state the codec rejects loudly,
+    /// which would abort generation on the speculative-decode rollback path.
     #[allow(
         clippy::indexing_slicing,
         reason = "shape.len() >= 4 checked immediately before indexing shape[2]"
     )]
     pub fn truncate_to(&mut self, n: i32) {
-        let n_usize = n.max(0) as usize;
+        let n = n.max(0);
+        let n_usize = n as usize;
         let mut acc: usize = 0;
         let mut keep = 0usize;
         for (i, blk) in self.blocks.iter().enumerate() {
@@ -389,9 +401,8 @@ impl QuantRotorK3 {
             }
         }
         self.blocks.truncate(keep);
-        // The ring's filled prefix no longer matches `blocks`; drop it rather
-        // than leave a longer-than-truncated prefix live.
-        self.gpu.clear();
+        // NB: no `self.gpu.clear()` — the ring is the source of truth for a
+        // ring-only decode tail; see the doc comment above.
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
@@ -63,6 +63,56 @@ fn quant_rotor_k3_roundtrip_no_qjl_matches_v_side() {
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
 }
 
+/// The `blocks == shape[2]` invariant is enforced loudly, never zero-padded.
+///
+/// A store whose CPU `blocks` cover fewer tokens than `shape[2]` claims, with
+/// no GPU ring to supply the tail, is the forbidden state (the naive "skip the
+/// per-step download" bug). Both `dequant()` and `try_deep_clone()` must reject
+/// it with an `Error` rather than fabricate a zeroed gap (`dequant`) or persist
+/// a truncated store (`try_deep_clone` — the SSD spill / prompt-cache clone).
+///
+/// Mutation check: revert `dequant()` to decode `self.blocks` + `out.resize(_,
+/// 0.0)` (the old zero-pad), or drop the `synced_rotor_k_blocks` reconcile —
+/// then `dequant()` returns `Ok` with a zeroed tail and this assertion flips
+/// RED.
+#[test]
+fn quant_rotor_k3_short_blocks_without_ring_is_loud_not_zero_padded() {
+    let kv_h = 2_i32;
+    let head_dim = 9_i32; // n_groups = 3, exact
+    let data = lcg_data((kv_h * 2 * head_dim) as usize, TEST_SEED);
+
+    // A real single block covering 2 tokens (QJL off via env-independent seed).
+    let mut src = QuantRotorK3::new(vec![1, kv_h, 0, head_dim], 0);
+    src.append(&data, &[1, kv_h, 2, head_dim]).expect("append");
+    assert_eq!(src.blocks.len(), 1, "one block for the 2-token append");
+
+    // Reassemble a store that *claims* shape[2] == 4 while its blocks cover only
+    // 2 tokens and no ring exists — the ring-only tail with the ring missing.
+    let truncated = QuantRotorK3::from_cpu_blocks(
+        src.rotors.clone(),
+        None,
+        src.blocks.clone(),
+        vec![1, kv_h, 4, head_dim],
+        0,
+    );
+    assert!(
+        !truncated.gpu.is_allocated(),
+        "precondition: no ring to cover the tail"
+    );
+
+    let dq = truncated.dequant();
+    assert!(
+        dq.is_err(),
+        "dequant must reject a short-blocks/no-ring store loudly, not zero-pad the tail; \
+         got Ok(len={:?})",
+        dq.map(|v| v.len())
+    );
+    assert!(
+        truncated.try_deep_clone().is_err(),
+        "try_deep_clone must refuse to materialise a truncated store (SSD spill / snapshot)"
+    );
+}
+
 #[test]
 fn quant_rotor_k3_qjl_default_on() {
     let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
@@ -19,7 +19,7 @@ use crate::rotorquant::{
     make_qjl_projection, n_groups_for, rotor4_k_decode, rotor4_k_encode, RotorQuantError,
     ROTOR4_BITS, ROTOR4_GROUP_SIZE,
 };
-use crate::storage::quant_rotor_k3::RotorKBlocks;
+use crate::storage::quant_rotor_k3::{synced_rotor_k_blocks, RotorKBlocks};
 
 use super::QuantKGpuRing;
 
@@ -299,6 +299,11 @@ impl QuantRotorK4 {
     /// # Errors
     /// Infallible on the CPU path; returns `Result` for parity.
     pub fn try_deep_clone(&self) -> Result<Self> {
+        // Materialise any ring-only tail into complete CPU blocks first — see
+        // [`QuantRotorK3::try_deep_clone`] for the full rationale (this is the
+        // single reconcile point for the prompt-cache and SSD spill clones).
+        let blocks =
+            synced_rotor_k_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?.into_owned();
         Ok(Self {
             rotors: self.rotors.clone(),
             // The clone starts CPU-only: `blocks` carries the full payload, so
@@ -307,7 +312,7 @@ impl QuantRotorK4 {
             // independent caches.
             gpu: QuantKGpuRing::default(),
             qjl_s_matrix: self.qjl_s_matrix.clone(),
-            blocks: self.blocks.clone(),
+            blocks,
             shape: self.shape.clone(),
             layer_idx: self.layer_idx,
             head_idx: self.head_idx,
@@ -366,7 +371,11 @@ impl QuantRotorK4 {
         let total_elems: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out: Vec<f32> = Vec::with_capacity(total_elems);
 
-        if self.blocks.is_empty() {
+        // Reconcile CPU blocks with the GPU ring (ring-only decode tail rebuild;
+        // loud on an unrecoverable gap). See [`QuantRotorK3::dequant`].
+        let blocks = synced_rotor_k_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?;
+
+        if blocks.is_empty() {
             out.resize(total_elems, 0.0);
             return Ok(out);
         }
@@ -377,7 +386,7 @@ impl QuantRotorK4 {
             ));
         }
 
-        for blk in &self.blocks {
+        for blk in blocks.iter() {
             let dec = rotor4_k_decode(
                 &blk.codes,
                 &blk.scales,
@@ -391,10 +400,15 @@ impl QuantRotorK4 {
             .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor4_k decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
-        if out.len() < total_elems {
-            out.resize(total_elems, 0.0);
-        } else if out.len() > total_elems {
-            out.truncate(total_elems);
+        // `synced_rotor_k_blocks` guarantees full coverage — a mismatch is an
+        // internal invariant break, surfaced loudly rather than zero-padded.
+        if out.len() != total_elems {
+            return Err(Error::Mlx(format!(
+                "QuantRotorK4::dequant: decoded {} elems but shape {:?} implies {total_elems} — \
+                 refusing to zero-pad / truncate",
+                out.len(),
+                self.shape
+            )));
         }
         // Blocks are sequence-major (see `append`); reorder back to head-major
         // `[B, kv_h, S, D]`.

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
@@ -268,13 +268,18 @@ impl QuantRotorK4 {
         }
     }
 
-    /// Truncate the accumulated sequence to `n` tokens.
+    /// Truncate the accumulated sequence to `n` positions.
+    ///
+    /// See [`QuantRotorK3::truncate_to`] — the GPU ring is kept (not cleared) so
+    /// a ring-only decode tail up to `n` survives, matching the flat GPU-buffer
+    /// codecs' truncate semantics.
     #[allow(
         clippy::indexing_slicing,
         reason = "shape.len() >= 4 checked immediately before indexing shape[2]"
     )]
     pub fn truncate_to(&mut self, n: i32) {
-        let n_usize = n.max(0) as usize;
+        let n = n.max(0);
+        let n_usize = n as usize;
         let mut acc: usize = 0;
         let mut keep = 0usize;
         for (i, blk) in self.blocks.iter().enumerate() {
@@ -286,9 +291,7 @@ impl QuantRotorK4 {
             }
         }
         self.blocks.truncate(keep);
-        // The ring's filled prefix no longer matches `blocks`; drop it rather
-        // than leave a longer-than-truncated prefix live.
-        self.gpu.clear();
+        // NB: no `self.gpu.clear()` — the ring holds the ring-only decode tail.
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }

--- a/crates/rmlx-kv-ssd/src/block_io.rs
+++ b/crates/rmlx-kv-ssd/src/block_io.rs
@@ -135,6 +135,10 @@ pub enum BlockIoError {
     /// A referenced tensor was absent from the file.
     #[error("KV block: missing tensor '{0}'")]
     MissingTensor(String),
+    /// A store was handed to serialization with its CPU blocks shorter than its
+    /// accumulated `shape[2]` — persisting it would truncate the store.
+    #[error("KV block: refusing to persist a truncated store: {0}")]
+    TruncatedStore(String),
 }
 
 impl From<BlockIoError> for Error {
@@ -1541,16 +1545,42 @@ fn write_quant_iso_k4(
 /// The QJL fields are omitted when the cache has no `qjl_s_matrix`. The
 /// geometry tag (`ROTOR_SYM_3_QJL_LAYOUT_TAG` vs. `ROTOR_SYM_3_LAYOUT_TAG`)
 /// is the load-bearing signal to the reader.
-#[allow(
-    clippy::unnecessary_wraps,
-    reason = "returns Result<()> for consistency with all other write_quant_* helpers; callers use ? on this"
-)]
+/// Loud guard: a rotor K store must reach serialization with its CPU `blocks`
+/// covering the full accumulated `shape[2]`.
+///
+/// On the fused decode path the store keeps a **ring-only tail** — `blocks`
+/// trail `shape[2]`, with the GPU ring holding the decode tail. The spill clone
+/// (`KvCache::try_deep_clone`) materialises that tail into complete blocks
+/// before the store reaches here; if it did not, serializing `qk.blocks`
+/// directly would persist a **truncated** store. Rather than silently write the
+/// short prefix, reject it — the invariant is enforced at the persistence
+/// boundary too, not only at the codec.
+fn ensure_rotor_k_blocks_cover_shape(
+    blocks_tokens: usize,
+    shape: &[i32],
+    idx: usize,
+) -> Result<()> {
+    if shape.len() != 4 {
+        return Ok(());
+    }
+    let full_tokens: usize = shape.iter().take(3).map(|&d| d.max(0) as usize).product();
+    if blocks_tokens != full_tokens {
+        return Err(BlockIoError::TruncatedStore(format!(
+            "l{idx}.k rotor store: CPU blocks hold {blocks_tokens} tokens but shape {shape:?} \
+             implies {full_tokens} — the ring-only decode tail was not materialised before spill"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
 fn write_quant_rotor_k3(
     idx: usize,
     k: Option<&QuantRotorK3>,
     out: &mut Vec<(String, OwnedTensor)>,
 ) -> Result<()> {
     let Some(qk) = k else { return Ok(()) };
+    ensure_rotor_k_blocks_cover_shape(qk.blocks.iter().map(|b| b.n_tokens).sum(), &qk.shape, idx)?;
     let mut codes: Vec<u8> = Vec::new();
     let mut scales: Vec<f32> = Vec::new();
     let mut norms: Vec<f32> = Vec::new();
@@ -1592,16 +1622,13 @@ fn write_quant_rotor_k3(
 /// Serialize a `QuantRotorK4` K payload (rotor4 K codec).
 /// Identical wire layout to [`write_quant_rotor_k3`]; bit-width encoded in
 /// the geometry tag.
-#[allow(
-    clippy::unnecessary_wraps,
-    reason = "returns Result<()> for consistency with all other write_quant_* helpers; callers use ? on this"
-)]
 fn write_quant_rotor_k4(
     idx: usize,
     k: Option<&QuantRotorK4>,
     out: &mut Vec<(String, OwnedTensor)>,
 ) -> Result<()> {
     let Some(qk) = k else { return Ok(()) };
+    ensure_rotor_k_blocks_cover_shape(qk.blocks.iter().map(|b| b.n_tokens).sum(), &qk.shape, idx)?;
     let mut codes: Vec<u8> = Vec::new();
     let mut scales: Vec<f32> = Vec::new();
     let mut norms: Vec<f32> = Vec::new();

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -2756,3 +2756,187 @@ fn ssd_roundtrip_preserves_layer_idx_positional() {
 
     let _ = std::fs::remove_file(&path);
 }
+
+// ── Rotor K-only ring-only tail: SSD spill preserves the full store ──────────
+
+/// Global cosine / max-abs-err helpers for the ring-only-tail round-trip.
+fn max_abs_err(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0_f32, f32::max)
+}
+
+/// Build a rotor3 K-only cache with QJL pinned OFF (env-independent: a
+/// pre-seeded rotor table keeps `qjl_s_matrix == None`). This is the state the
+/// fused GPU decode path requires.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: values established by construction"
+)]
+fn seeded_rotor_k3_cache(kv_h: i32, head_dim: i32, max_seq: i32) -> KvCache {
+    let n_groups = rmlx_kv_quant::rotorquant::n_groups_for(head_dim as usize);
+    let rotors = rmlx_kv_quant::clifford::make_rotor_table(0, 0, n_groups);
+    let storage = KvStorage::RotorKOnly3 {
+        k: Some(QuantRotorK3::from_cpu_blocks(
+            rotors,
+            None,
+            Vec::new(),
+            vec![1, kv_h, 0, head_dim],
+            0,
+        )),
+        max_seq,
+    };
+    KvCache::from_storage(storage, KvQuant::RotorKOnly3, 0, 0)
+}
+
+/// `(dequant, shape[2], cpu_block_tokens)` for a rotor3 K-only cache.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: values established by construction"
+)]
+fn rotor_k3_probe(cache: &KvCache) -> (Vec<f32>, i32, usize) {
+    match cache.storage() {
+        KvStorage::RotorKOnly3 { k: Some(ks), .. } => (
+            ks.dequant().unwrap(),
+            ks.shape.get(2).copied().unwrap_or(0),
+            ks.blocks.iter().map(|b| b.n_tokens).sum(),
+        ),
+        _ => panic!("expected a live RotorKOnly3 store"),
+    }
+}
+
+/// The write path refuses to persist a rotor K store whose CPU blocks fall
+/// short of `shape[2]` with no ring — a truncated store. Runs on CPU (no Metal).
+///
+/// Mutation check: delete the `ensure_rotor_k_blocks_cover_shape` guard in
+/// `write_quant_rotor_k3` — the writer then silently serializes the short prefix
+/// and this assertion flips RED (`write` returns `Ok`).
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test: values established by construction earlier in this fn"
+)]
+fn write_rejects_truncated_rotor_k_store() {
+    let kv_h = 2_i32;
+    let head_dim = 9_i32; // n_groups = 3, exact
+    let data = lcg((kv_h * 2 * head_dim) as usize, 0x51D);
+
+    // A real single block covering 2 tokens.
+    let mut src = QuantRotorK3::new(vec![1, kv_h, 0, head_dim], 0);
+    src.append(&data, &[1, kv_h, 2, head_dim]).unwrap();
+
+    // Claim shape[2] == 4 while the blocks cover only 2 tokens and no ring
+    // exists — the ring-only tail with the ring missing.
+    let truncated = QuantRotorK3::from_cpu_blocks(
+        src.rotors.clone(),
+        None,
+        src.blocks.clone(),
+        vec![1, kv_h, 4, head_dim],
+        0,
+    );
+    let layers = vec![KvStorage::RotorKOnly3 {
+        k: Some(truncated),
+        max_seq: 64,
+    }];
+    let path = tmp_path("rotor_k_truncated");
+    let res =
+        KvBlockWriter::new(MODEL_ID, KvQuant::RotorKOnly3, &layers, &[]).write(&path, Device::Cpu);
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        res.is_err(),
+        "writer must reject a truncated rotor K store (short blocks, no ring), got Ok"
+    );
+}
+
+/// Full SSD spill/hydrate round-trip after a ring-only-tail decode.
+///
+/// After prefill + N fused decode steps the store keeps a ring-only tail (CPU
+/// blocks frozen at prefill; the decode tail lives only in the GPU ring). The
+/// spill clone (`KvCache::try_deep_clone`) materialises that tail into complete
+/// blocks, so `write_caches` → hydrate restores the **full** store — not a
+/// prefix truncated at the last CPU block. Asserted byte-exact against the live
+/// store's own `dequant()`.
+///
+/// Mutation check: make `try_deep_clone` clone `self.blocks` directly (drop the
+/// `synced_rotor_k_blocks` reconcile) — the clone then carries only the frozen
+/// prefill prefix, `write_caches` trips the `ensure_rotor_k_blocks_cover_shape`
+/// guard, and `.expect("write_caches")` panics (RED).
+#[test]
+#[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd rotor_k_only_ring_only_tail_ssd -- --ignored --test-threads=1"]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test: values established by construction earlier in this fn"
+)]
+fn rotor_k_only_ring_only_tail_ssd_round_trip() {
+    let device = Device::Gpu;
+    let (kv_h, n_q, head_dim, prefill, steps) = (2_i32, 8_i32, 128_i32, 6_i32, 5_i32);
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    let mut c = seeded_rotor_k3_cache(kv_h, head_dim, 512);
+    let k = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 11),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let v = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 12),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let q = arr(
+        &lcg((prefill * n_q * head_dim) as usize, 13),
+        &[1, n_q, prefill, head_dim],
+    );
+    c.update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+        .unwrap();
+    c.exit_prefill(device).unwrap();
+    for i in 0..steps {
+        let k1 = arr(
+            &lcg((kv_h * head_dim) as usize, 31 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let v1 = arr(
+            &lcg((kv_h * head_dim) as usize, 41 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let q1 = arr(
+            &lcg((n_q * head_dim) as usize, 51 + i as u64),
+            &[1, n_q, 1, head_dim],
+        );
+        c.update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .unwrap()
+            .eval()
+            .unwrap();
+    }
+
+    // Ring-only tail precondition + live full-prefix dequant.
+    let (orig_dq, orig_seq, block_tokens) = rotor_k3_probe(&c);
+    assert_eq!(orig_seq, prefill + steps, "shape[2] advanced with the ring");
+    assert_eq!(
+        block_tokens,
+        (prefill * kv_h) as usize,
+        "CPU blocks frozen at prefill (ring-only tail)"
+    );
+
+    // Spill clone (materialises the tail) → write → hydrate.
+    let clone = c.try_deep_clone().unwrap();
+    let path = tmp_path("rotor_k_ring_only_tail");
+    write_caches(&path, device, MODEL_ID, KvQuant::RotorKOnly3, &[clone], &[])
+        .expect("write_caches must persist the full materialised store");
+    let (hydrated, _lin) = read_caches(&path, device, MODEL_ID, KvQuant::RotorKOnly3).unwrap();
+    let _ = std::fs::remove_file(&path);
+
+    let (hy_dq, hy_seq, _) = rotor_k3_probe(&hydrated[0]);
+    assert_eq!(
+        hy_seq,
+        prefill + steps,
+        "hydrated store must carry the full decoded length, not a truncated prefix"
+    );
+    assert_eq!(hy_dq.len(), orig_dq.len(), "hydrated K length mismatch");
+    let err = max_abs_err(&orig_dq, &hy_dq);
+    assert!(
+        err < 1e-6,
+        "hydrated K must match the live ring-only-tail dequant byte-for-byte (err={err})"
+    );
+}

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2640,13 +2640,22 @@ Two regimes satisfy it:
 
 - *Blocks-authoritative* (Maintain / CPU `append` / SSD hydrate): `blocks` cover
   the full `shape[2]`; the ring, when live, mirrors them and re-seeds from
-  `blocks` (`seed_from_cpu`) after any drop (`reset()`, `truncate_to()`, a CPU
-  `append()`).
+  `blocks` (`seed_from_cpu`) after a drop (`reset()`, a CPU `append()`).
 - *Ring-only tail* (fused decode): `blocks` freeze at the prefill prefix while
   the ring carries the decode tail, so `blocks` trail `shape[2]`. The blocks are
   rebuilt from the ring on demand — `synced_rotor_k_blocks` reconciles them at
   every consumer boundary (`dequant`, and the SSD-spill / prompt-cache clone
   `try_deep_clone`).
+
+`truncate_to` **keeps** the ring (it does not `clear()`): it lowers `shape[2]`
+to `n` and leaves the ring's `[n, prev)` capacity to be overwritten by the next
+append, exactly like the flat GPU-buffer codecs (`QuantK` / K8V4 just lower
+`shape[2]`). This preserves a ring-only decode tail up to `n` across the
+speculative-decode partial-accept rollback; clearing it there would discard the
+tail (the only copy of `[frozen_prefix, n)`) and abort the next `dequant`. Both
+mutators reconcile: the block-path append (`materialize_*_ring_tail`)
+materialises any pre-existing ring-only tail into `blocks` before pushing, so
+`blocks` stay a contiguous prefix.
 
 The forbidden state is `blocks` short of `shape[2]` with **no** ring to supply
 the tail: `dequant()` would zero-pad the gap (silently wrong attention) and an

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2615,27 +2615,54 @@ must not change how existing bytes are read.
 ### Ring eligibility is passed down, not inferred
 
 `QuantKGpuRing` is only built for the codecs that can actually read it. The rotor K
-GPU encode takes a `RingFeed` from its caller: `Maintain` from the two K-only
-paths (prefill `update_rotor_k_only_*` and the fused decode entry), `Skip` from
-the sym/asym mirrors. A ring for a non-eligible codec is not free —
+GPU encode takes a `RingFeed` from its caller, one of three modes:
+
+- **`Maintain`** — feed the ring **and** push a CPU block. Used by prefill
+  (`update_rotor_k_only_*`) and the non-fused decode fallback, which `dequant()`
+  the whole prefix on the same step and so need the block immediately.
+- **`MaintainRingOnly`** — feed the ring **without** pushing a CPU block: a
+  **ring-only tail**. Used by the fused decode entry
+  (`rotor{3,4}_k_only_gpu_append`). The flash kernel reads the ring, never the
+  block, so skipping the per-step host download (`rotor_gpu_outputs_to_cpu`) is
+  the win; `shape[2]` still advances so the ring and the attention length stay
+  in lockstep.
+- **`Skip`** — clear the ring. Used by the sym/asym mirrors, and as the `b > 1`
+  fallback of a ring-only feed (which reverts to the block path).
+
+A ring for a non-eligible codec is not free —
 `capacity * kv_h * n_groups * 8 + capacity * kv_h * 4` bytes per layer, growing
 with context (order of a few hundred MB across a 36-layer model at 4k) — and
 nothing would ever read it.
 
-**Invariant: the ring either tracks `blocks` exactly, or it does not exist.** A
-skipped feed *clears* rather than leaving the ring behind. A stale ring (blocks
-grown, ring not) is the dangerous state: the next append takes `prev_seq` from
-the longer `shape` and writes past the ring's filled region, leaving the gap
-zeroed and attention silently wrong. Because a cleared ring re-seeds from
-`blocks` on the next maintained append (`seed_from_cpu`), this is self-healing —
-`reset()` / `truncate_to()` / a CPU `append()` all just drop it.
+**Invariant: the CPU `blocks` track `shape[2]` exactly, or the GPU ring holds
+the tail and the blocks are rebuilt from it on demand — never a silent gap.**
+Two regimes satisfy it:
+
+- *Blocks-authoritative* (Maintain / CPU `append` / SSD hydrate): `blocks` cover
+  the full `shape[2]`; the ring, when live, mirrors them and re-seeds from
+  `blocks` (`seed_from_cpu`) after any drop (`reset()`, `truncate_to()`, a CPU
+  `append()`).
+- *Ring-only tail* (fused decode): `blocks` freeze at the prefill prefix while
+  the ring carries the decode tail, so `blocks` trail `shape[2]`. The blocks are
+  rebuilt from the ring on demand — `synced_rotor_k_blocks` reconciles them at
+  every consumer boundary (`dequant`, and the SSD-spill / prompt-cache clone
+  `try_deep_clone`).
+
+The forbidden state is `blocks` short of `shape[2]` with **no** ring to supply
+the tail: `dequant()` would zero-pad the gap (silently wrong attention) and an
+SSD spill would persist a truncated store. That state is rejected **loudly**
+(an `Error`, never a `debug_assert` — those compile out under `release-perf`):
+`synced_rotor_k_blocks` at the codec and `ensure_rotor_k_blocks_cover_shape` at
+the SSD serialization boundary both refuse it rather than fabricate zeros.
 
 **`b > 1` skips.** The ring's per-step stride is `kv_h * n_groups` and does not
 interleave batch, so a batched chunk cannot be laid into it (the encode carries
-`b` × the span). That degrades to the CPU dequant path, which handles `b > 1`
-correctly — it must not error, since a batched rotor cache worked before this
-kernel existed. Both the append (`rotor{3,4}_sync_ring`) and the dispatcher
-(`rotor_flash_shape_ok`) gate on it.
+`b` × the span). A `MaintainRingOnly` feed with `b > 1` therefore falls back to
+the block path (which handles `b > 1` correctly and keeps the CPU blocks the
+source of truth) — it must not error, since a batched rotor cache worked before
+this kernel existed. Per request the batch dim is fixed, so a `b > 1` cache
+never builds a ring-only tail to lose. Both the append (`rotor{3,4}_sync_ring`)
+and the dispatcher (`rotor_flash_shape_ok`) gate on it.
 
 ### Arch reachability
 

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -276,6 +276,18 @@ exceeded), the spill hook receives the evicted entry. The spiller:
    `sync_channel` (depth 16). If the channel is full, the job is dropped and a
    `warn!` is logged — back-pressure never stalls decode.
 
+   The clone is `KvCache::try_deep_clone`. For a rotor K-only cache (`k_rotor3`
+   / `k_rotor4`) this is also the point where a **ring-only decode tail** is
+   reconciled: the fused decode path keeps the CPU `blocks` frozen at the
+   prefill prefix while the GPU ring carries the decode tail (see
+   `docs/KV_QUANT.md` § "Ring eligibility"), so the clone materialises the tail
+   back into complete CPU blocks from the ring. `block_io::write_quant_rotor_k{3,4}`
+   serialize `blocks`, so without this the spill would persist a store truncated
+   at the last CPU block. The serializer additionally refuses to write any rotor
+   K store whose blocks fall short of `shape[2]`
+   (`ensure_rotor_k_blocks_cover_shape` → `BlockIoError::TruncatedStore`) — the
+   invariant is enforced at the persistence boundary, not only at the codec.
+
 2. **Drain thread (`rmlx-kv-spill`):** receives jobs from the channel.
    - Serializes via `block_io::write_caches` — forces MLX arrays to host
      bytes (CPU eval), writes to `<namespace_dir>/<hash>.kvb`.


### PR DESCRIPTION
Fixes #231. Follow-up to #217 (which measured and deliberately deferred this).

## Problem
On the rotor K-only fused decode path every step ran `rotor_gpu_outputs_to_cpu` (via `rotor_gpu_encode_block_retaining`), downloading the encoded chunk to the host and building a per-layer/per-token `RotorBlocks` **the flash kernel never reads** — a host copy + GPU sync per layer per step in the path whose whole purpose is removing host work from decode.

## The trap (why #217 deferred it)
The CPU blocks are not dead weight: `rmlx_kv_ssd::block_io` serialises `RotorKOnly{3,4}` blocks for the SSD tier, and `push_*_k_block` bumps `shape[2]` in lockstep. Naively skipping the download leaves `blocks` shorter than `shape[2]` — a gap `dequant()` silently **zero-pads** (the silent-KV-corruption class) and an SSD spill would persist a **truncated** store.

## Fix — a ring-only tail (rebuild-on-demand)
- New `RingFeed::MaintainRingOnly`, used by the fused decode entry: feed the GPU ring, advance `shape[2]`, and skip the per-step host download + CPU block push. The GPU ring is the source of truth for the decode tail.
- The CPU blocks are rebuilt from the ring **on demand** at the only two consumer boundaries — `dequant()` and the SSD-spill / prompt-cache clone (`try_deep_clone`) — via `synced_rotor_k_blocks`.
- `b > 1` (un-representable in the ring stride) falls back to the block path, preserving prior behaviour.

## Invariant — enforced LOUDLY (an `Error`, never a `debug_assert`)
Any state where the CPU blocks fall short of `shape[2]` with no ring to supply the tail is **rejected**, never zero-padded: `synced_rotor_k_blocks` at the codec (`dequant` / clone) and `ensure_rotor_k_blocks_cover_shape` at the SSD serialization boundary (`BlockIoError::TruncatedStore`). `debug_assert` compiles out under `release-perf`, so these are real `Error`s.

## Proof
- **No numerical change:** `dequant()` after a ring-only-tail decode returns the full prefix (no zero-pad), byte/cosine-exact vs a CPU re-encode — `rotor_k_only_{3,4}_ring_only_tail_dequant_is_full_prefix` (GPU, K3+K4 pass). Mutation red: decode `self.blocks` directly → `dequant` returns `Ok(len=72)` zero-padded → RED.
- **SSD round-trip:** spill/hydrate after a ring-only-tail decode preserves the full store, byte-exact — `rotor_k_only_ring_only_tail_ssd_round_trip` (GPU, pass). Mutation red: clone short blocks → `TruncatedStore` guard fires (`CPU blocks hold 12 tokens but shape [1,2,11,128] implies 22`) → RED.
- **CPU loud-guard tests** (run in `make ci`): `quant_rotor_k3_short_blocks_without_ring_is_loud_not_zero_padded` and `write_rejects_truncated_rotor_k_store`; both pass, both mutation-red.
- **Perf** (decode TPS, `k_rotor3`, `--rotor-qjl off`, 4k prompt, 100 gen, medians of 5, `release-perf`, binaries symbol-verified distinct):
  - Bonsai-8B: 16.88 → **17.53** (+3.9%; run ranges overlap — a weak-but-real win)
  - medgemma-4B: 53.55 → **55.67** (+4.0%; ranges mostly separate — a clearer win)

  Modest positive median on both models; honest significance is a small win, consistent with #217's "~9% median, overlapping ranges" note.
- Regression: full rotor GPU suite green (`rotor_flash_dispatch` 9, `rotor_decode_grow_legacy` 3), `make ci` green.

Docs: `docs/KV_QUANT.md` (ring source-of-truth relationship) + `docs/SSD_TIER.md` (spill-clone materialisation).

Related: #217, #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)