### PR TITLE
feat(kv): rotor_flash_decode_symv — quant-V SV kernel for rotor*_sym (#219)

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/core.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/core.rs
@@ -9,7 +9,7 @@
 #![allow(unsafe_code)]
 #![allow(clippy::too_many_lines)]
 
-use rmlx_mlx::Array;
+use rmlx_mlx::{Array, Dtype};
 
 use crate::kvcache::fused_qk_shadow::FusedQkShadow;
 use crate::rotating::RotatingState;
@@ -59,6 +59,18 @@ pub struct KvCache {
     pub(super) in_prefill: bool,
     pub(super) decode_fp16_k: Option<Array>,
     pub(super) decode_fp16_v: Option<Array>,
+    /// Activation-stream dtype the model appends into this cache, captured at
+    /// append time. `None` until the first append.
+    ///
+    /// Only the codecs that keep **no** bf16 mirror need it: every other path
+    /// reads the stream dtype straight off `decode_fp16_v`.
+    /// [`KvCache::materialise_shared_kv`] has to hand a drafter K/V at the
+    /// stream's dtype — the stores dequantise through `Vec<f32>`, and returning
+    /// that f32 would promote the drafter's whole attention stream and double
+    /// its KV residency, while hard-coding bf16 would silently downcast a wider
+    /// stream. Once the mirror is gone neither is derivable, so the dtype the
+    /// model actually pushed is recorded instead of guessed.
+    pub(super) stream_dtype: Option<Dtype>,
     /// If `Some`, this cache uses the SWA ring-buffer code path
     /// (RotatingKvCache port). Activated by SWA layers in
     /// `KvQuant::None` mode only.
@@ -224,6 +236,7 @@ impl KvCache {
             in_prefill: false,
             decode_fp16_k: None,
             decode_fp16_v: None,
+            stream_dtype: None,
             rotating: None,
             flash_k_codes: None,
             flash_k_scales: None,
@@ -252,6 +265,7 @@ impl KvCache {
             in_prefill: false,
             decode_fp16_k: None,
             decode_fp16_v: None,
+            stream_dtype: None,
             rotating: None,
             flash_k_codes: None,
             flash_k_scales: None,

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -18,6 +18,9 @@ use crate::planar_flash_decode_msl::{planar_flash_decode_enabled, planar_flash_d
 use crate::planar_fused_qk::planar_fused_qk_enabled;
 use crate::planar_fused_qk_msl::planar_fused_qk;
 use crate::rotor_flash_decode_msl::{rotor_flash_decode_sdpa, ROTOR_FLASH_HEAD_DIM_MAX};
+use crate::rotor_flash_decode_symv_msl::{
+    rotor_flash_decode_symv_sdpa, RotorFlashShape, RotorPackedAxis,
+};
 use crate::storage::{KvStorage, ISO_QUAT_BLOCK_SIZE};
 
 use super::helpers::{f32_vec_to_array, storage_variant_name};
@@ -696,6 +699,35 @@ impl KvCache {
             }
         }
 
+        // 1e. Rotor symmetric quant-K + quant-V flash-decode fast path. Without
+        // it this codec decodes from a full bf16 K+V mirror seeded at
+        // `exit_prefill` — the packed store is written and never read, so the
+        // codec is dormant and its KV footprint is *larger* than plain bf16.
+        // The kernel reads both packed rings directly, so no bf16 mirror is
+        // needed on either axis.
+        //
+        // Same gate ordering as the K-only arm above: decode-only checked HERE,
+        // before the helper mutates cache state; QJL-carrying stores keep the
+        // CPU dequant path.
+        if matches!(
+            self.storage,
+            KvStorage::RotorSym3 { .. } | KvStorage::RotorSym4 { .. }
+        ) && device == Device::Gpu
+            && !rotor_sym_store_uses_qjl(&self.storage)
+            && queries.shape().get(2).copied().unwrap_or(0) == 1
+        {
+            if let Some(out) = self.update_and_sdpa_rotor_sym_fused(
+                queries,
+                new_k,
+                new_v,
+                scale,
+                additive_mask,
+                device,
+            )? {
+                return Ok(out);
+            }
+        }
+
         // 2. K8V4 TurboFlash path (returns None when not eligible).
         if let Some(out) =
             self.sdpa_dispatch(queries, new_k, new_v, scale, additive_mask, device)?
@@ -1014,6 +1046,36 @@ impl KvCache {
             }
         }
 
+        // Rotor symmetric quant-K + quant-V flash-decode. Without it this codec
+        // is pushed onto the legacy bf16 path on any shared-KV model and its
+        // fused kernel is silently dead there.
+        if matches!(
+            self.storage,
+            KvStorage::RotorSym3 { .. } | KvStorage::RotorSym4 { .. }
+        ) && device == Device::Gpu
+            && !rotor_sym_store_uses_qjl(&self.storage)
+            && q_seq_is_decode
+        {
+            if let Some(out) = self.update_and_sdpa_rotor_sym_fused(
+                queries,
+                new_k,
+                new_v,
+                scale,
+                additive_mask,
+                device,
+            )? {
+                tracing::debug!(
+                    target: "rmlx_kv_quant::shared_kv",
+                    kernel = "rotor_flash_symv",
+                    offset = self.offset,
+                    "fused kernel dispatched on the shared-KV producer path — \
+                     consumers attend the quant store"
+                );
+                let kv_len = rotor_sym_accumulated_seq(&self.storage)?;
+                return Ok(Some((out, kv_len)));
+            }
+        }
+
         Ok(None)
     }
 
@@ -1132,6 +1194,13 @@ impl KvCache {
                 let v_full = self.slice_decode_fp16_v(kv_seq, device)?;
                 self.iso_k_flash_over_store(queries, &v_full, scale, additive_mask, kv_seq, device)
             }
+            // Both axes come from the quant store — no `slice_decode_fp16_v`,
+            // because this codec keeps no bf16 V to slice.
+            KvStorage::RotorSym3 { .. } | KvStorage::RotorSym4 { .. } => {
+                let kv_seq = rotor_sym_accumulated_seq(&self.storage)?;
+                Self::check_shared_kv_len(kv_len, kv_seq)?;
+                self.rotor_sym_flash_over_store(queries, scale, additive_mask, kv_seq, device)
+            }
             KvStorage::PlanarK { .. } => {
                 let kv_seq = planar_k_accumulated_seq(&self.storage)?;
                 Self::check_shared_kv_len(kv_len, kv_seq)?;
@@ -1180,32 +1249,71 @@ impl KvCache {
                   storage variant fails loudly here instead of being silently decoded as another"
     )]
     pub fn materialise_shared_kv(&self, kv_len: i32, device: Device) -> Result<(Array, Array)> {
-        let v_full = self.slice_decode_fp16_v(kv_len, device)?;
-        let stream_dtype = v_full.dtype();
-        let k_full = match &self.storage {
+        // Codecs that keep a bf16 V mirror take the stream dtype from it. The
+        // all-quant codecs kept none — by design, that mirror is what they exist
+        // to delete — so they read the dtype recorded at append time instead.
+        let (k_full, v_full, stream_dtype) = match &self.storage {
             KvStorage::RotorKOnly3 { k: Some(ks), .. } => {
                 Self::check_shared_kv_len(kv_len, rotor_k_accumulated_seq(&self.storage)?)?;
-                f32_vec_to_array(&ks.dequant()?, &ks.shape)?
+                let v_full = self.slice_decode_fp16_v(kv_len, device)?;
+                let dt = v_full.dtype();
+                (f32_vec_to_array(&ks.dequant()?, &ks.shape)?, v_full, dt)
             }
             KvStorage::RotorKOnly4 { k: Some(ks), .. } => {
                 Self::check_shared_kv_len(kv_len, rotor_k_accumulated_seq(&self.storage)?)?;
-                f32_vec_to_array(&ks.dequant()?, &ks.shape)?
+                let v_full = self.slice_decode_fp16_v(kv_len, device)?;
+                let dt = v_full.dtype();
+                (f32_vec_to_array(&ks.dequant()?, &ks.shape)?, v_full, dt)
             }
             KvStorage::IsoKOnly3 { k: Some(ks), .. } => {
                 Self::check_shared_kv_len(kv_len, iso_k_accumulated_seq(&self.storage)?)?;
-                f32_vec_to_array(&ks.dequant()?, &ks.shape)?
+                let v_full = self.slice_decode_fp16_v(kv_len, device)?;
+                let dt = v_full.dtype();
+                (f32_vec_to_array(&ks.dequant()?, &ks.shape)?, v_full, dt)
             }
             KvStorage::IsoKOnly4 { k: Some(ks), .. } => {
                 Self::check_shared_kv_len(kv_len, iso_k_accumulated_seq(&self.storage)?)?;
-                f32_vec_to_array(&ks.dequant()?, &ks.shape)?
+                let v_full = self.slice_decode_fp16_v(kv_len, device)?;
+                let dt = v_full.dtype();
+                (f32_vec_to_array(&ks.dequant()?, &ks.shape)?, v_full, dt)
             }
             KvStorage::PlanarK { k: Some(ks), .. } => {
                 Self::check_shared_kv_len(kv_len, planar_k_accumulated_seq(&self.storage)?)?;
-                let (k_recon, k_arr) = ks.dequantize_choice(device, stream_dtype)?;
-                match k_arr {
+                let v_full = self.slice_decode_fp16_v(kv_len, device)?;
+                let dt = v_full.dtype();
+                let (k_recon, k_arr) = ks.dequantize_choice(device, dt)?;
+                let k_full = match k_arr {
                     Some(arr) => arr,
                     None => f32_vec_to_array(&k_recon, &ks.shape)?,
-                }
+                };
+                (k_full, v_full, dt)
+            }
+            // Both axes dequantise off their own store. Cold path by contract —
+            // this is the full-prefix CPU dequant the fused kernel exists to
+            // avoid, so it must never run per decode step.
+            KvStorage::RotorSym3 {
+                k: Some(ks),
+                v: Some(vs),
+                ..
+            } => {
+                Self::check_shared_kv_len(kv_len, rotor_sym_accumulated_seq(&self.storage)?)?;
+                (
+                    f32_vec_to_array(&ks.dequant()?, &ks.shape)?,
+                    f32_vec_to_array(&vs.dequant()?, &vs.shape)?,
+                    self.recorded_stream_dtype()?,
+                )
+            }
+            KvStorage::RotorSym4 {
+                k: Some(ks),
+                v: Some(vs),
+                ..
+            } => {
+                Self::check_shared_kv_len(kv_len, rotor_sym_accumulated_seq(&self.storage)?)?;
+                (
+                    f32_vec_to_array(&ks.dequant()?, &ks.shape)?,
+                    f32_vec_to_array(&vs.dequant()?, &vs.shape)?,
+                    self.recorded_stream_dtype()?,
+                )
             }
             other => {
                 return Err(Error::Mlx(format!(
@@ -1213,6 +1321,11 @@ impl KvCache {
                     storage_variant_name(other)
                 )))
             }
+        };
+        let v_full = if v_full.dtype() == stream_dtype {
+            v_full
+        } else {
+            v_full.astype(stream_dtype, device)?
         };
         let k_full = if k_full.dtype() == stream_dtype {
             k_full
@@ -1231,6 +1344,22 @@ impl KvCache {
             )));
         }
         Ok((k_full, v_full))
+    }
+
+    /// The activation-stream dtype recorded at append time.
+    ///
+    /// The mirror-free codecs' only witness of what the model pushes. Absent
+    /// means nothing was ever appended, so there is no K/V to materialise
+    /// either — an error, not a guessed default: picking one here is exactly the
+    /// silent dtype promotion/downcast [`Self::materialise_shared_kv`] documents.
+    fn recorded_stream_dtype(&self) -> Result<Dtype> {
+        self.stream_dtype.ok_or_else(|| {
+            Error::Mlx(
+                "materialise_shared_kv: no stream dtype recorded — the cache holds a \
+                 store-backed share but nothing was ever appended through the fused path"
+                    .to_owned(),
+            )
+        })
     }
 
     /// Reject a producer/consumer length desync rather than attend the wrong
@@ -1935,6 +2064,297 @@ impl KvCache {
         Ok(Some((codes, scales, norms, rotors_arr)))
     }
 
+    /// Flash-decode dispatch for the symmetric rotor storage variants
+    /// (`RotorSym3` / `RotorSym4`), over **quant K and quant V**.
+    ///
+    /// Returns `Some(out)` when the fused kernel ran, `None` to fall through to
+    /// the legacy `update()` + SDPA path.
+    ///
+    /// Steps:
+    ///   1. Append `new_k` **and** `new_v` into their rotor stores — GPU encode
+    ///      into the packed rings, no dequant on either axis.
+    ///   2. Take both rings' GPU packed views at the current `S`.
+    ///   3. Run [`rotor_flash_decode_symv_sdpa`] — QK over packed K + online
+    ///      softmax + SV over packed V, in two Metal dispatches.
+    ///
+    /// Unlike the K-only sibling this touches **no** bf16 buffer: there is no
+    /// `update_decode_fp16_v_only` call, because V is read from its own store.
+    /// That is the memory win — the codec's bf16 K+V mirror is what made a
+    /// ~3-bit-per-axis codec cost more than plain bf16.
+    ///
+    /// Caller must have already gated `q_seq == 1` and `device == Gpu` BEFORE
+    /// any cache mutation: this helper mutates cache state (both appends)
+    /// before it can know whether the kernel is eligible, so a late fallback
+    /// would double-append.
+    #[allow(clippy::too_many_arguments)]
+    fn update_and_sdpa_rotor_sym_fused(
+        &mut self,
+        queries: &Array,
+        new_k: &Array,
+        new_v: &Array,
+        scale: f32,
+        additive_mask: Option<&Array>,
+        device: Device,
+    ) -> Result<Option<Array>> {
+        let new_shape = new_k.shape();
+        if new_shape.len() != 4 {
+            return Err(Error::Mlx(format!(
+                "rotor_sym_fused: new_k rank != 4, got {new_shape:?}"
+            )));
+        }
+        let new_seq = new_shape.get(2).copied().unwrap_or(0);
+
+        // Shape gates — checked BEFORE any mutation so a reject is a clean
+        // fall-through to the legacy path.
+        if !Self::rotor_flash_shape_ok(&new_shape) {
+            return Ok(None);
+        }
+        // Not a rotor symmetric cache: the caller's gate should have kept us
+        // out. Fall through rather than mutate.
+        if !matches!(
+            self.storage,
+            KvStorage::RotorSym3 { .. } | KvStorage::RotorSym4 { .. }
+        ) {
+            return Ok(None);
+        }
+
+        // Record the stream dtype before the append consumes `new_v`: this codec
+        // keeps no bf16 mirror, so this is the only witness of what the model
+        // pushes, and `materialise_shared_kv` needs it to hand a drafter K/V at
+        // the right width.
+        self.stream_dtype = Some(new_v.dtype());
+
+        let prev_seq = self.offset;
+        // Provision this step before the first mutation: both packed rings are
+        // capped by the storage `max_seq`, so it has to cover
+        // `prev_seq + new_seq` before either append runs. Without it the window
+        // freezes at whatever the prompt needed and decode dies mid-stream once
+        // it crosses that bound — on both axes here, since neither has a bf16
+        // mirror to fall back to.
+        self.ensure_decode_capacity(prev_seq + new_seq)?;
+        self.rotor_sym_gpu_append(new_k, new_v, &new_shape, device)?;
+        self.offset = prev_seq + new_seq;
+
+        // Take `kv_seq` from the store the rings were written from, not from
+        // `self.offset` — one source of truth. Same precedent as
+        // `update_and_sdpa_rotor_k_fused`.
+        let kv_seq = rotor_sym_accumulated_seq(&self.storage)?;
+        debug_assert_eq!(
+            kv_seq, self.offset,
+            "rotor_sym_fused: store seq {kv_seq} != cache offset {} — the ring write \
+             and the attention length disagree",
+            self.offset
+        );
+        // Past this point the cache is already mutated (both stores appended,
+        // offset advanced), so `Ok(None)` is NOT available: it would send the
+        // caller into the legacy `update()` path, which appends K/V a second
+        // time and advances `offset` again. Every not-eligible condition is
+        // screened at the call-site gate and by `rotor_flash_shape_ok` BEFORE
+        // any mutation; reaching here without a ring means an internal
+        // invariant broke, so fail loudly.
+        let out = self.rotor_sym_flash_over_store(queries, scale, additive_mask, kv_seq, device)?;
+        Ok(Some(out))
+    }
+
+    /// Run the rotor symmetric quant-V flash-decode kernel over the K/V already
+    /// packed in this cache's stores — no append, no offset advance.
+    ///
+    /// Split out of [`Self::update_and_sdpa_rotor_sym_fused`] so a shared-KV
+    /// **consumer** layer can attend the producer's stores through the exact
+    /// same kernel the producer used, instead of the producer having to
+    /// materialise bf16 K/V for it.
+    fn rotor_sym_flash_over_store(
+        &self,
+        queries: &Array,
+        scale: f32,
+        additive_mask: Option<&Array>,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Array> {
+        // Select the bit width from the live storage variant. No wildcard arm:
+        // an unexpected variant must not be decoded with another codec's
+        // kernel.
+        let bits: u8 = if matches!(self.storage, KvStorage::RotorSym3 { .. }) {
+            3
+        } else if matches!(self.storage, KvStorage::RotorSym4 { .. }) {
+            4
+        } else {
+            return Err(Error::KvStorageMismatch {
+                expected: "RotorSym3 | RotorSym4",
+                got: storage_variant_name(&self.storage),
+            });
+        };
+        let Some((k_view, v_view)) = self.rotor_sym_packed_views(kv_seq, device)? else {
+            return Err(Error::Mlx(format!(
+                "rotor_sym_fused: GPU ring absent after a maintained append \
+                 (kv_seq={kv_seq}, bits={bits}) — internal invariant violated"
+            )));
+        };
+        let (k_codes, k_scales, k_norms, k_rotors) = k_view;
+        let (v_codes, v_scales, v_norms, v_rotors) = v_view;
+
+        let store_shape = rotor_sym_store_shape(&self.storage)?;
+        let b = store_shape.first().copied().unwrap_or(0);
+        let kv_h = store_shape.get(1).copied().unwrap_or(0);
+        let head_dim = store_shape.get(3).copied().unwrap_or(0);
+
+        let q_shape = queries.shape();
+        if q_shape.len() != 4 {
+            return Err(Error::Mlx(format!(
+                "rotor_sym_fused: Q shape rank != 4, got {q_shape:?}"
+            )));
+        }
+        let q_seq = q_shape.get(2).copied().unwrap_or(0);
+        let n_q_heads = q_shape.get(1).copied().unwrap_or(0);
+        // Defence-in-depth: the call site already gates decode-only.
+        if q_seq != 1 {
+            return Err(Error::Mlx(format!(
+                "rotor_sym_fused: q_seq must be 1 (decode-only), got {q_seq}"
+            )));
+        }
+        if kv_h <= 0 || n_q_heads % kv_h != 0 {
+            return Err(Error::Mlx(format!(
+                "rotor_sym_fused: n_q_heads={n_q_heads} not divisible by kv_h={kv_h}"
+            )));
+        }
+        let heads_per_kv = n_q_heads / kv_h;
+
+        let shape = RotorFlashShape {
+            b,
+            kv_h,
+            kv_seq,
+            head_dim,
+            heads_per_kv,
+        };
+        let k_axis = RotorPackedAxis {
+            codes: &k_codes,
+            scales: &k_scales,
+            norms: &k_norms,
+            rotors: &k_rotors,
+        };
+        let v_axis = RotorPackedAxis {
+            codes: &v_codes,
+            scales: &v_scales,
+            norms: &v_norms,
+            rotors: &v_rotors,
+        };
+
+        tracing::Span::current().record("path", "rotor_flash_decode_symv");
+        // Select the bit width explicitly. A wildcard arm here would map any
+        // unexpected `bits` onto one width's kernel and decode the other's codes
+        // at the wrong unpack stride — silently wrong K/V, no error. `bits` is a
+        // plain integer, so no exhaustiveness lint would catch that.
+        let flash_out = match bits {
+            3 => rotor_flash_decode_symv_sdpa::<3>(
+                queries,
+                k_axis,
+                v_axis,
+                additive_mask,
+                shape,
+                scale,
+                device,
+            )?,
+            4 => rotor_flash_decode_symv_sdpa::<4>(
+                queries,
+                k_axis,
+                v_axis,
+                additive_mask,
+                shape,
+                scale,
+                device,
+            )?,
+            other => {
+                return Err(Error::Quant(format!(
+                    "rotor_sym_fused: unsupported bits={other} (only 3 and 4); \
+                     refusing to decode with another width's kernel"
+                )))
+            }
+        };
+        if flash_out.dtype() == queries.dtype() {
+            Ok(flash_out)
+        } else {
+            flash_out.astype(queries.dtype(), device)
+        }
+    }
+
+    /// GPU-append `new_k` / `new_v` into whichever rotor symmetric store is
+    /// active.
+    fn rotor_sym_gpu_append(
+        &mut self,
+        new_k: &Array,
+        new_v: &Array,
+        new_shape: &[i32],
+        device: Device,
+    ) -> Result<()> {
+        if matches!(self.storage, KvStorage::RotorSym3 { .. }) {
+            super::update::rotor3_sym_gpu_append(self, new_k, new_v, new_shape, device)
+        } else if matches!(self.storage, KvStorage::RotorSym4 { .. }) {
+            super::update::rotor4_sym_gpu_append(self, new_k, new_v, new_shape, device)
+        } else {
+            Err(Error::KvStorageMismatch {
+                expected: "RotorSym3 | RotorSym4",
+                got: storage_variant_name(&self.storage),
+            })
+        }
+    }
+
+    /// `(codes, scales, norms, rotors)` GPU views of BOTH axes of the active
+    /// rotor symmetric store at `kv_seq`, or `None` when either ring is not
+    /// live.
+    ///
+    /// Both-or-neither: a half-live pair would mean one axis reads the store and
+    /// the other reads zeros.
+    #[allow(clippy::type_complexity)]
+    fn rotor_sym_packed_views(
+        &self,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Option<((Array, Array, Array, Array), (Array, Array, Array, Array))>> {
+        // if-let chain rather than a match with a `_` arm: the codec pair is
+        // narrow and a wildcard over `KvStorage` would silently absorb a new
+        // variant into "no ring" instead of naming it.
+        let (k_view, k_rotors, v_view, v_rotors) = if let KvStorage::RotorSym3 {
+            k: Some(ks),
+            v: Some(vs),
+            ..
+        } = &self.storage
+        {
+            (
+                ks.gpu_packed_view(kv_seq, device)?,
+                &ks.rotors,
+                vs.gpu_packed_view(kv_seq, device)?,
+                &vs.rotors,
+            )
+        } else if let KvStorage::RotorSym4 {
+            k: Some(ks),
+            v: Some(vs),
+            ..
+        } = &self.storage
+        {
+            (
+                ks.gpu_packed_view(kv_seq, device)?,
+                &ks.rotors,
+                vs.gpu_packed_view(kv_seq, device)?,
+                &vs.rotors,
+            )
+        } else {
+            return Ok(None);
+        };
+        let (Some((k_codes, k_scales, k_norms)), Some((v_codes, v_scales, v_norms))) =
+            (k_view, v_view)
+        else {
+            return Ok(None);
+        };
+        // Each axis carries its own table — reading V's codes against K's rotors
+        // would be silently wrong the day the two seeds diverge.
+        let k_rotors_arr = crate::rotorquant_msl::rotor_table_to_array(k_rotors)?;
+        let v_rotors_arr = crate::rotorquant_msl::rotor_table_to_array(v_rotors)?;
+        Ok(Some((
+            (k_codes, k_scales, k_norms, k_rotors_arr),
+            (v_codes, v_scales, v_norms, v_rotors_arr),
+        )))
+    }
+
     /// Flash-decode dispatch for the iso K-only storage variants
     /// (`IsoKOnly3` / `IsoKOnly4`).
     ///
@@ -2218,6 +2638,87 @@ fn rotor_k_store_uses_qjl(storage: &KvStorage) -> bool {
     } else {
         crate::rotor_qjl::rotor_qjl_enabled()
     }
+}
+
+/// Whether the active rotor symmetric store carries the K-side QJL residual.
+///
+/// Same store-is-the-authority reasoning as [`rotor_k_store_uses_qjl`]: the
+/// codec fixes QJL at first append and never adds or drops the sideband
+/// mid-stream, so a toggle flipped afterwards must not change how existing bytes
+/// are read. Before the first append there is no store yet, so the global toggle
+/// — the value the store is about to be built with — is the answer.
+fn rotor_sym_store_uses_qjl(storage: &KvStorage) -> bool {
+    if let KvStorage::RotorSym3 { k: Some(ks), .. } = storage {
+        ks.use_qjl()
+    } else if let KvStorage::RotorSym4 { k: Some(ks), .. } = storage {
+        ks.use_qjl()
+    } else {
+        crate::rotor_qjl::rotor_qjl_enabled()
+    }
+}
+
+/// The K store's accumulated `[B, kv_h, S, D]` shape for the active rotor
+/// symmetric variant.
+fn rotor_sym_store_shape(storage: &KvStorage) -> Result<&[i32]> {
+    if let KvStorage::RotorSym3 { k: Some(ks), .. } = storage {
+        Ok(&ks.shape)
+    } else if let KvStorage::RotorSym4 { k: Some(ks), .. } = storage {
+        Ok(&ks.shape)
+    } else {
+        Err(Error::KvStorageMismatch {
+            expected: "RotorSym3 | RotorSym4 with a live K buffer",
+            got: storage_variant_name(storage),
+        })
+    }
+}
+
+/// Accumulated sequence length held by the active rotor symmetric store.
+///
+/// Reads the **K** store's `shape[2]` and checks the V store agrees. The two are
+/// appended in lockstep, so a divergence means one axis's ring was fed and the
+/// other was not — which would attend K over one prefix and V over another,
+/// silently. Sibling of [`rotor_k_accumulated_seq`].
+#[allow(
+    clippy::wildcard_enum_match_arm,
+    reason = "the wildcard arm returns Err — it never selects a concrete codec, so a new storage \
+              variant fails loudly here instead of being silently decoded as another"
+)]
+fn rotor_sym_accumulated_seq(storage: &KvStorage) -> Result<i32> {
+    let (k_shape, v_shape) = match storage {
+        KvStorage::RotorSym3 {
+            k: Some(ks),
+            v: Some(vs),
+            ..
+        } => (&ks.shape, &vs.shape),
+        KvStorage::RotorSym4 {
+            k: Some(ks),
+            v: Some(vs),
+            ..
+        } => (&ks.shape, &vs.shape),
+        other => {
+            return Err(Error::KvStorageMismatch {
+                expected: "RotorSym3 | RotorSym4 with live K and V buffers",
+                got: storage_variant_name(other),
+            })
+        }
+    };
+    let k_seq = k_shape.get(2).copied().ok_or_else(|| {
+        Error::Mlx(format!(
+            "rotor_sym_fused: rotor K store shape {k_shape:?} has no seq axis"
+        ))
+    })?;
+    let v_seq = v_shape.get(2).copied().ok_or_else(|| {
+        Error::Mlx(format!(
+            "rotor_sym_fused: rotor V store shape {v_shape:?} has no seq axis"
+        ))
+    })?;
+    if k_seq != v_seq {
+        return Err(Error::Mlx(format!(
+            "rotor_sym_fused: K store seq {k_seq} != V store seq {v_seq} — the two axes \
+             would attend different prefixes"
+        )));
+    }
+    Ok(k_seq)
 }
 
 /// Accumulated sequence length held by the active rotor K-only store.

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -587,14 +587,67 @@ fn rotor3_gpu_append_into_blocks(
     let head_dim = head_dim_from_shape(new_shape, "rotor3_gpu_append_into_blocks")?;
     ensure_v3_rotors(vs, head_dim);
     let seq_major = packed_k_chunk_seq_major(new_v, new_shape, device)?;
+    if is_ring_only_append(feed, new_shape) {
+        // Ring-only tail: feed the GPU ring, advance `shape[2]`, and skip the
+        // per-step host download + CPU block push. The ring is the source of
+        // truth for the decode tail; the blocks are rebuilt on demand at a
+        // `dequant()` / SSD-spill boundary (`synced_rotor_v_blocks`). Mirror of
+        // the K-side `rotor3_gpu_append_into_k_blocks`.
+        let gpu = rotor_gpu_encode_ring_only(
+            &seq_major,
+            new_shape,
+            &vs.rotors,
+            crate::rotorquant::ROTOR3_BITS,
+        )?;
+        rotor3_v_sync_ring(
+            vs,
+            &gpu,
+            RingFeed::Maintain,
+            new_shape,
+            head_dim,
+            max_seq,
+            device,
+        )?;
+        bump_rotor_k_shape(&mut vs.shape, new_shape);
+        return Ok(());
+    }
+    // Block path: prefill / non-fused decode (Maintain) and the V-only variants
+    // (Skip). A ring-only feed that reaches here is a `b > 1` chunk — normalise
+    // it to Maintain so the shared ring feeder clears the ring for the
+    // un-representable batch and the CPU block carries the data.
+    materialize_rotor_v3_ring_tail(vs, device)?;
+    let block_feed = if feed == RingFeed::Skip {
+        RingFeed::Skip
+    } else {
+        RingFeed::Maintain
+    };
     let (block, gpu) = rotor_gpu_encode_block_retaining(
         &seq_major,
         new_shape,
         &vs.rotors,
         crate::rotorquant::ROTOR3_BITS,
     )?;
-    rotor3_v_sync_ring(vs, &gpu, feed, new_shape, head_dim, max_seq, device)?;
+    rotor3_v_sync_ring(vs, &gpu, block_feed, new_shape, head_dim, max_seq, device)?;
     push_rotor3_v_block(vs, block, new_shape);
+    Ok(())
+}
+
+/// Reconcile a pre-existing ring-only decode tail into `vs.blocks` before a
+/// block-path append — mirror of [`materialize_rotor_k3_ring_tail`]. No-op when
+/// `blocks` already cover `shape[2]` (the common prefill / V-only case — reads
+/// no GPU).
+fn materialize_rotor_v3_ring_tail(vs: &mut QuantRotorV3, device: Device) -> Result<()> {
+    if !vs.gpu.is_allocated() {
+        return Ok(());
+    }
+    let rebuilt =
+        match crate::storage::synced_rotor_v_blocks(&vs.blocks, &vs.shape, &vs.gpu, device)? {
+            std::borrow::Cow::Owned(full) => Some(full),
+            std::borrow::Cow::Borrowed(_) => None,
+        };
+    if let Some(full) = rebuilt {
+        vs.blocks = full;
+    }
     Ok(())
 }
 
@@ -610,23 +663,66 @@ fn rotor4_gpu_append_into_blocks(
     let head_dim = head_dim_from_shape(new_shape, "rotor4_gpu_append_into_blocks")?;
     ensure_v4_rotors(vs, head_dim);
     let seq_major = packed_k_chunk_seq_major(new_v, new_shape, device)?;
+    if is_ring_only_append(feed, new_shape) {
+        // Ring-only tail — see [`rotor3_gpu_append_into_blocks`].
+        let gpu = rotor_gpu_encode_ring_only(
+            &seq_major,
+            new_shape,
+            &vs.rotors,
+            crate::rotorquant::ROTOR4_BITS,
+        )?;
+        rotor4_v_sync_ring(
+            vs,
+            &gpu,
+            RingFeed::Maintain,
+            new_shape,
+            head_dim,
+            max_seq,
+            device,
+        )?;
+        bump_rotor_k_shape(&mut vs.shape, new_shape);
+        return Ok(());
+    }
+    // Block path — see [`rotor3_gpu_append_into_blocks`].
+    materialize_rotor_v4_ring_tail(vs, device)?;
+    let block_feed = if feed == RingFeed::Skip {
+        RingFeed::Skip
+    } else {
+        RingFeed::Maintain
+    };
     let (block, gpu) = rotor_gpu_encode_block_retaining(
         &seq_major,
         new_shape,
         &vs.rotors,
         crate::rotorquant::ROTOR4_BITS,
     )?;
-    rotor4_v_sync_ring(vs, &gpu, feed, new_shape, head_dim, max_seq, device)?;
+    rotor4_v_sync_ring(vs, &gpu, block_feed, new_shape, head_dim, max_seq, device)?;
     push_rotor4_v_block(vs, block, new_shape);
+    Ok(())
+}
+
+/// Mirror of [`materialize_rotor_v3_ring_tail`] for [`QuantRotorV4`].
+fn materialize_rotor_v4_ring_tail(vs: &mut QuantRotorV4, device: Device) -> Result<()> {
+    if !vs.gpu.is_allocated() {
+        return Ok(());
+    }
+    let rebuilt =
+        match crate::storage::synced_rotor_v_blocks(&vs.blocks, &vs.shape, &vs.gpu, device)? {
+            std::borrow::Cow::Owned(full) => Some(full),
+            std::borrow::Cow::Borrowed(_) => None,
+        };
+    if let Some(full) = rebuilt {
+        vs.blocks = full;
+    }
     Ok(())
 }
 
 /// V-side mirror of [`rotor3_sync_ring`] for [`QuantRotorV3`].
 ///
 /// Same invariant, same `b > 1` skip, same self-healing re-seed — the ring type
-/// and its contract are axis-agnostic. `MaintainRingOnly` is never fed to V (the
-/// symmetric append uses `Maintain` on both axes), so anything other than
-/// `Maintain` clears.
+/// and its contract are axis-agnostic. Only ever receives `Maintain` (ring-only
+/// tail and block path both feed the ring) or `Skip` (V-only), so anything other
+/// than `Maintain` clears.
 fn rotor3_v_sync_ring(
     vs: &mut QuantRotorV3,
     gpu: &PackedKEncodedGpu,
@@ -1091,11 +1187,71 @@ pub(super) fn rotor3_sym_gpu_append(
     let Some(ks) = k.as_mut() else {
         return Err(Error::Mlx("RotorSym3 K buffer absent after init".into()));
     };
-    rotor3_gpu_append_into_k_blocks(ks, new_k, new_shape, device, RingFeed::Maintain, max_seq)?;
+    rotor3_gpu_append_into_k_blocks(
+        ks,
+        new_k,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )?;
+    // Ring is now the sole resident store for K — drop the redundant CPU blocks
+    // (the prefill prefix, seeded into the ring on the first fused-decode step).
+    // See the note in the V append below; this is what turns the codec's ~34%
+    // logical compression into a resident-RAM win.
+    drop_blocks_when_ring_live_k3(ks);
     let Some(vs) = v.as_mut() else {
         return Err(Error::Mlx("RotorSym3 V buffer absent after init".into()));
     };
-    rotor3_gpu_append_into_blocks(vs, new_v, new_shape, device, RingFeed::Maintain, max_seq)
+    rotor3_gpu_append_into_blocks(
+        vs,
+        new_v,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )?;
+    // The GPU ring holds the full prefix; the fused decode reads the ring, and
+    // `dequant` / SSD spill / clone / truncate rebuild the CPU blocks on demand
+    // from it (`synced_rotor_v_blocks`). A later GPU chunk (spec-verify) takes
+    // the block path, which materialises the ring tail before its Skip clear, so
+    // no ring-clear ever loses data; a CPU-only run never allocates the ring.
+    drop_blocks_when_ring_live_v3(vs);
+    Ok(())
+}
+
+/// Drop a rotor K store's CPU blocks once its GPU ring is live — the ring is
+/// then the sole resident copy. No-op until the ring is allocated (before the
+/// first GPU append) or for any store that never feeds a ring.
+fn drop_blocks_when_ring_live_k3(ks: &mut crate::storage::QuantRotorK3) {
+    if ks.gpu.is_allocated() {
+        ks.blocks.clear();
+        ks.blocks.shrink_to_fit();
+    }
+}
+
+/// Mirror of [`drop_blocks_when_ring_live_k3`] for [`QuantRotorK4`].
+fn drop_blocks_when_ring_live_k4(ks: &mut crate::storage::QuantRotorK4) {
+    if ks.gpu.is_allocated() {
+        ks.blocks.clear();
+        ks.blocks.shrink_to_fit();
+    }
+}
+
+/// Drop a rotor V store's CPU blocks once its GPU ring is live.
+fn drop_blocks_when_ring_live_v3(vs: &mut QuantRotorV3) {
+    if vs.gpu.is_allocated() {
+        vs.blocks.clear();
+        vs.blocks.shrink_to_fit();
+    }
+}
+
+/// Mirror of [`drop_blocks_when_ring_live_v3`] for [`QuantRotorV4`].
+fn drop_blocks_when_ring_live_v4(vs: &mut QuantRotorV4) {
+    if vs.gpu.is_allocated() {
+        vs.blocks.clear();
+        vs.blocks.shrink_to_fit();
+    }
 }
 
 /// Mirror of [`rotor3_sym_gpu_append`] for `RotorSym4`.
@@ -1135,11 +1291,28 @@ pub(super) fn rotor4_sym_gpu_append(
     let Some(ks) = k.as_mut() else {
         return Err(Error::Mlx("RotorSym4 K buffer absent after init".into()));
     };
-    rotor4_gpu_append_into_k_blocks(ks, new_k, new_shape, device, RingFeed::Maintain, max_seq)?;
+    rotor4_gpu_append_into_k_blocks(
+        ks,
+        new_k,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )?;
+    drop_blocks_when_ring_live_k4(ks);
     let Some(vs) = v.as_mut() else {
         return Err(Error::Mlx("RotorSym4 V buffer absent after init".into()));
     };
-    rotor4_gpu_append_into_blocks(vs, new_v, new_shape, device, RingFeed::Maintain, max_seq)
+    rotor4_gpu_append_into_blocks(
+        vs,
+        new_v,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )?;
+    drop_blocks_when_ring_live_v4(vs);
+    Ok(())
 }
 
 /// Accumulated sequence length held by a rotor K storage `shape`

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -251,32 +251,6 @@ fn iso3_gpu_append_into_k_blocks(
 
 // ── Rotor3 / rotor4 MSL helpers ───────────────────────────────────────────────
 
-/// Encode a KV chunk (`new_kv`, shape `[B, kv_h, S, D]`) via the
-/// `bits`-bit rotor MSL kernel and return the resulting CPU
-/// [`RotorBlocks`].
-///
-/// The kernel is axis-agnostic: V-side and K-side (QJL off) callers feed
-/// identically-shaped slices and consume the same `(codes, scales, norms)`
-/// triple. The `rotors` slice is the static per-(layer, head) rotor table,
-/// flat `[n_groups * 4]` f32.
-///
-/// # Errors
-///
-/// Forwards Metal kernel / shape errors as `Error::Mlx` / `Error::Quant`.
-#[allow(
-    clippy::indexing_slicing,
-    reason = "shape rank guarded to 4 immediately above each indexing site; new_shape[0..=3] are always in-bounds"
-)]
-fn rotor_gpu_encode_block(
-    new_kv: &Array,
-    new_shape: &[i32],
-    rotors: &[f32],
-    bits: u8,
-) -> Result<RotorBlocks> {
-    let (block, _gpu) = rotor_gpu_encode_block_retaining(new_kv, new_shape, rotors, bits)?;
-    Ok(block)
-}
-
 /// The GPU-resident `(codes, scales, norms)` triple a packed-K encode produced
 /// (rotor or iso), retained so a caller can push it straight into a GPU ring
 /// instead of re-uploading the downloaded CPU copy.
@@ -588,30 +562,128 @@ fn head_dim_from_shape(new_shape: &[i32], ctx: &str) -> Result<usize> {
 
 /// V-side convenience wrapper: GPU-encode + push onto a [`QuantRotorV3`]
 /// buffer. Lazy-inits the rotor table on first call.
+///
+/// `feed` decides whether the GPU ring is maintained — see [`RingFeed`]. Only
+/// the symmetric codecs have a kernel that reads the V ring; the V-only rotor
+/// variants pass `Skip`.
+///
+/// `max_seq` is the window the cache is currently provisioned for, read from the
+/// active `KvStorage` variant by the caller and forwarded to the ring — same
+/// contract as the K-side sibling. Ignored when `feed` is `Skip`.
+///
+/// The chunk is reordered head-major -> sequence-major before encoding, exactly
+/// as the CPU `QuantRotorV3::append` and the K GPU path already do: the ring and
+/// `dequant()` both read sequence-major, so a multi-token chunk with `kv_h > 1`
+/// must not be encoded head-major. For the decode step (`S == 1`) the reorder is
+/// the identity.
 fn rotor3_gpu_append_into_blocks(
     vs: &mut QuantRotorV3,
     new_v: &Array,
     new_shape: &[i32],
+    device: Device,
+    feed: RingFeed,
+    max_seq: i32,
 ) -> Result<()> {
     let head_dim = head_dim_from_shape(new_shape, "rotor3_gpu_append_into_blocks")?;
     ensure_v3_rotors(vs, head_dim);
-    let block =
-        rotor_gpu_encode_block(new_v, new_shape, &vs.rotors, crate::rotorquant::ROTOR3_BITS)?;
+    let seq_major = packed_k_chunk_seq_major(new_v, new_shape, device)?;
+    let (block, gpu) = rotor_gpu_encode_block_retaining(
+        &seq_major,
+        new_shape,
+        &vs.rotors,
+        crate::rotorquant::ROTOR3_BITS,
+    )?;
+    rotor3_v_sync_ring(vs, &gpu, feed, new_shape, head_dim, max_seq, device)?;
     push_rotor3_v_block(vs, block, new_shape);
     Ok(())
 }
 
+/// Mirror of [`rotor3_gpu_append_into_blocks`] for [`QuantRotorV4`].
 fn rotor4_gpu_append_into_blocks(
     vs: &mut QuantRotorV4,
     new_v: &Array,
     new_shape: &[i32],
+    device: Device,
+    feed: RingFeed,
+    max_seq: i32,
 ) -> Result<()> {
     let head_dim = head_dim_from_shape(new_shape, "rotor4_gpu_append_into_blocks")?;
     ensure_v4_rotors(vs, head_dim);
-    let block =
-        rotor_gpu_encode_block(new_v, new_shape, &vs.rotors, crate::rotorquant::ROTOR4_BITS)?;
+    let seq_major = packed_k_chunk_seq_major(new_v, new_shape, device)?;
+    let (block, gpu) = rotor_gpu_encode_block_retaining(
+        &seq_major,
+        new_shape,
+        &vs.rotors,
+        crate::rotorquant::ROTOR4_BITS,
+    )?;
+    rotor4_v_sync_ring(vs, &gpu, feed, new_shape, head_dim, max_seq, device)?;
     push_rotor4_v_block(vs, block, new_shape);
     Ok(())
+}
+
+/// V-side mirror of [`rotor3_sync_ring`] for [`QuantRotorV3`].
+///
+/// Same invariant, same `b > 1` skip, same self-healing re-seed — the ring type
+/// and its contract are axis-agnostic. `MaintainRingOnly` is never fed to V (the
+/// symmetric append uses `Maintain` on both axes), so anything other than
+/// `Maintain` clears.
+fn rotor3_v_sync_ring(
+    vs: &mut QuantRotorV3,
+    gpu: &PackedKEncodedGpu,
+    feed: RingFeed,
+    new_shape: &[i32],
+    head_dim: usize,
+    max_seq: i32,
+    device: Device,
+) -> Result<()> {
+    let (b, kv_h, new_seq) = b_kv_h_new_seq(new_shape)?;
+    if feed != RingFeed::Maintain || b != 1 {
+        vs.gpu.clear();
+        return Ok(());
+    }
+    // Feed BEFORE `push_rotor3_v_block` — the push bumps `vs.shape[2]`, and the
+    // ring append needs `prev_seq`, the length before this chunk.
+    let prev_seq = accumulated_seq(&vs.shape);
+    vs.gpu_append(
+        &gpu.codes,
+        &gpu.scales,
+        &gpu.norms,
+        kv_h,
+        head_dim as i32,
+        prev_seq,
+        new_seq,
+        max_seq,
+        device,
+    )
+}
+
+/// Mirror of [`rotor3_v_sync_ring`] for [`QuantRotorV4`].
+fn rotor4_v_sync_ring(
+    vs: &mut QuantRotorV4,
+    gpu: &PackedKEncodedGpu,
+    feed: RingFeed,
+    new_shape: &[i32],
+    head_dim: usize,
+    max_seq: i32,
+    device: Device,
+) -> Result<()> {
+    let (b, kv_h, new_seq) = b_kv_h_new_seq(new_shape)?;
+    if feed != RingFeed::Maintain || b != 1 {
+        vs.gpu.clear();
+        return Ok(());
+    }
+    let prev_seq = accumulated_seq(&vs.shape);
+    vs.gpu_append(
+        &gpu.codes,
+        &gpu.scales,
+        &gpu.norms,
+        kv_h,
+        head_dim as i32,
+        prev_seq,
+        new_seq,
+        max_seq,
+        device,
+    )
 }
 
 /// Whether a rotor K GPU append should also maintain the store's GPU ring.
@@ -975,6 +1047,99 @@ pub(super) fn rotor4_k_only_gpu_append(
         RingFeed::MaintainRingOnly,
         max_seq,
     )
+}
+
+/// Append `new_k` / `new_v` into a live `RotorSym3` store's GPU rings (+ CPU
+/// blocks), lazily creating the stores on first use. No dequant on either axis —
+/// this is the entry point the rotor symmetric quant-V flash-decode SDPA path
+/// uses.
+///
+/// Both axes maintain their ring: the quant-V kernel reads K's *and* V's.
+///
+/// # Errors
+///
+/// Returns [`Error::KvStorageMismatch`] when the active storage is not
+/// `RotorSym3`, and forwards encode / ring errors.
+pub(super) fn rotor3_sym_gpu_append(
+    cache: &mut KvCache,
+    new_k: &Array,
+    new_v: &Array,
+    new_shape: &[i32],
+    device: Device,
+) -> Result<()> {
+    let layer_idx = layer_idx_u32(cache.layer_idx);
+    let KvStorage::RotorSym3 { k, v, max_seq } = &mut cache.storage else {
+        return Err(Error::KvStorageMismatch {
+            expected: "RotorSym3",
+            got: storage_variant_name(&cache.storage),
+        });
+    };
+    let max_seq = *max_seq;
+    let mut init_shape = new_shape.to_vec();
+    if let Some(s) = init_shape.get_mut(2) {
+        *s = 0;
+    }
+    if k.is_none() {
+        *k = Some(crate::storage::QuantRotorK3::new(
+            init_shape.clone(),
+            layer_idx,
+        ));
+    }
+    if v.is_none() {
+        *v = Some(QuantRotorV3::new(init_shape, max_seq, layer_idx));
+    }
+    let Some(ks) = k.as_mut() else {
+        return Err(Error::Mlx("RotorSym3 K buffer absent after init".into()));
+    };
+    rotor3_gpu_append_into_k_blocks(ks, new_k, new_shape, device, RingFeed::Maintain, max_seq)?;
+    let Some(vs) = v.as_mut() else {
+        return Err(Error::Mlx("RotorSym3 V buffer absent after init".into()));
+    };
+    rotor3_gpu_append_into_blocks(vs, new_v, new_shape, device, RingFeed::Maintain, max_seq)
+}
+
+/// Mirror of [`rotor3_sym_gpu_append`] for `RotorSym4`.
+///
+/// # Errors
+///
+/// Returns [`Error::KvStorageMismatch`] when the active storage is not
+/// `RotorSym4`, and forwards encode / ring errors.
+pub(super) fn rotor4_sym_gpu_append(
+    cache: &mut KvCache,
+    new_k: &Array,
+    new_v: &Array,
+    new_shape: &[i32],
+    device: Device,
+) -> Result<()> {
+    let layer_idx = layer_idx_u32(cache.layer_idx);
+    let KvStorage::RotorSym4 { k, v, max_seq } = &mut cache.storage else {
+        return Err(Error::KvStorageMismatch {
+            expected: "RotorSym4",
+            got: storage_variant_name(&cache.storage),
+        });
+    };
+    let max_seq = *max_seq;
+    let mut init_shape = new_shape.to_vec();
+    if let Some(s) = init_shape.get_mut(2) {
+        *s = 0;
+    }
+    if k.is_none() {
+        *k = Some(crate::storage::QuantRotorK4::new(
+            init_shape.clone(),
+            layer_idx,
+        ));
+    }
+    if v.is_none() {
+        *v = Some(QuantRotorV4::new(init_shape, max_seq, layer_idx));
+    }
+    let Some(ks) = k.as_mut() else {
+        return Err(Error::Mlx("RotorSym4 K buffer absent after init".into()));
+    };
+    rotor4_gpu_append_into_k_blocks(ks, new_k, new_shape, device, RingFeed::Maintain, max_seq)?;
+    let Some(vs) = v.as_mut() else {
+        return Err(Error::Mlx("RotorSym4 V buffer absent after init".into()));
+    };
+    rotor4_gpu_append_into_blocks(vs, new_v, new_shape, device, RingFeed::Maintain, max_seq)
 }
 
 /// Accumulated sequence length held by a rotor K storage `shape`
@@ -1914,15 +2079,17 @@ impl KvCache {
         // full max_seq-sized raw buffer. Saves up to (max_seq - total_seq) ×
         // B × kv_h × head_dim × 2 bytes per layer during the prefill phase.
         //
-        // The bf16 K seed is only materialised when a consumer actually reads
-        // it — either the `KvStorage::None` bf16 fallback below (always needs
-        // K) or a quant arm whose decode path honours the
-        // `decode_fp16_k.is_some()` shortcut (`feeds_bf16_k_at_decode()`).
-        // The K-only family reads neither, so its K clone+eval is skipped
-        // entirely. The V seed is always materialised — every quant arm reads
-        // it at decode.
-        let need_k_seed =
-            matches!(self.storage, KvStorage::None { .. }) || self.quant.feeds_bf16_k_at_decode();
+        // Each bf16 seed is only materialised when a consumer actually reads
+        // it — either the `KvStorage::None` bf16 fallback below (which IS these
+        // buffers, so it needs both) or a quant arm whose decode path honours
+        // the `decode_fp16_{k,v}` shortcut. The K-only family reads no K seed;
+        // the fused rotor symmetric codecs read neither, because their decode is
+        // a flash kernel over both packed rings. An unread seed is not a small
+        // waste: it is `total_seq * B * kv_h * head_dim * 2` bytes per layer per
+        // axis, the dominant residency term at long context.
+        let is_bf16_storage = matches!(self.storage, KvStorage::None { .. });
+        let need_k_seed = is_bf16_storage || self.quant.feeds_bf16_k_at_decode();
+        let need_v_seed = is_bf16_storage || self.quant.feeds_bf16_v_at_decode();
         let k_buf = if need_k_seed {
             let k = k_full.try_clone()?;
             k.eval()?;
@@ -1930,12 +2097,18 @@ impl KvCache {
         } else {
             None
         };
-        let v_buf = v_full.try_clone()?;
-        v_buf.eval()?;
+        let v_buf = if need_v_seed {
+            let v = v_full.try_clone()?;
+            v.eval()?;
+            Some(v)
+        } else {
+            None
+        };
         tracing::debug!(
             total_seq,
             max_seq = shape[2],
             k_seeded = need_k_seed,
+            v_seeded = need_v_seed,
             "exit_prefill: compact fp16 decode seed materialised (total_seq tokens)"
         );
         let decode_fp16_pair = Some((k_buf, v_buf));
@@ -1949,10 +2122,10 @@ impl KvCache {
         // unreachable!() when they find KvStorage::None instead.
         if matches!(self.storage, KvStorage::None { .. }) {
             if let Some((k_seed, v_seed)) = decode_fp16_pair {
-                // `need_k_seed` is true on this path (KvStorage::None), so the
-                // K clone above was materialised.
+                // `is_bf16_storage` is true on this path, so both clones above
+                // were materialised — these buffers *are* this codec's storage.
                 self.decode_fp16_k = k_seed;
-                self.decode_fp16_v = Some(v_seed);
+                self.decode_fp16_v = v_seed;
             }
             return Ok(());
         }
@@ -3066,15 +3239,16 @@ impl KvCache {
         //
         // For the K-only family (IsoKOnly3/4, RotorKOnly3/4) the K codec runs
         // every decode step and never reads `decode_fp16_k`, so populating the
-        // bf16 K seed was dead memory. The K seed is gated on
-        // `feeds_bf16_k_at_decode()` and dropped for those variants. The bf16
-        // **V** seed stays unconditional — the K-only decode path reads it
-        // via `update_decode_fp16_v_only`. Pure RAM reclaim; output unchanged.
+        // bf16 K seed was dead memory; they still read the bf16 **V** seed via
+        // `update_decode_fp16_v_only`. The fused rotor symmetric codecs
+        // (Rotor3Sym/Rotor4Sym) read neither — their decode is a flash kernel
+        // over both packed rings — so both seeds are dropped. Pure RAM reclaim;
+        // output unchanged.
         if let Some((k_buf, v_buf)) = decode_fp16_pair {
-            // `k_buf` is `Some` iff `feeds_bf16_k_at_decode()` (the K-only
-            // family produced `None` above and so seeds no bf16 K mirror).
+            // Each is `Some` iff the matching `feeds_bf16_{k,v}_at_decode()`
+            // said this codec's decode actually reads it.
             self.decode_fp16_k = k_buf;
-            self.decode_fp16_v = Some(v_buf);
+            self.decode_fp16_v = v_buf;
         }
 
         Ok(())
@@ -3153,6 +3327,7 @@ impl KvCache {
             quant: _,
             layer_idx: _,
             in_prefill: _,
+            stream_dtype: _,
             flash_max_seq: _,
             flash_filled: _,
             max_seq_ceiling: _,
@@ -5767,6 +5942,9 @@ impl KvCache {
                 Some(a) => Some(a.try_clone()?),
                 None => None,
             },
+            // The clone serves the same model, so it inherits the stream dtype
+            // rather than re-learning it on its first append.
+            stream_dtype: self.stream_dtype,
             rotating: match &self.rotating {
                 Some(r) => Some(r.try_deep_clone()?),
                 None => None,
@@ -6495,7 +6673,7 @@ impl KvCache {
         }
         let vs = v.as_mut().unwrap();
         if device == Device::Gpu {
-            rotor3_gpu_append_into_blocks(vs, new_v, &new_shape)?;
+            rotor3_gpu_append_into_blocks(vs, new_v, &new_shape, device, RingFeed::Skip, max_seq)?;
         } else {
             vs.append(&v_f32, &new_shape)?;
         }
@@ -6594,7 +6772,7 @@ impl KvCache {
         }
         let vs = v.as_mut().unwrap();
         if device == Device::Gpu {
-            rotor4_gpu_append_into_blocks(vs, new_v, &new_shape)?;
+            rotor4_gpu_append_into_blocks(vs, new_v, &new_shape, device, RingFeed::Skip, max_seq)?;
         } else {
             vs.append(&v_f32, &new_shape)?;
         }
@@ -6699,7 +6877,7 @@ impl KvCache {
             return Err(Error::Mlx("RotorSym3 V buffer absent after init".into()));
         };
         if use_gpu {
-            rotor3_gpu_append_into_blocks(vs, new_v, &new_shape)?;
+            rotor3_gpu_append_into_blocks(vs, new_v, &new_shape, device, RingFeed::Skip, max_seq)?;
         } else {
             vs.append(&v_f32, &new_shape)?;
         }
@@ -6795,7 +6973,7 @@ impl KvCache {
             return Err(Error::Mlx("RotorSym4 V buffer absent after init".into()));
         };
         if use_gpu {
-            rotor4_gpu_append_into_blocks(vs, new_v, &new_shape)?;
+            rotor4_gpu_append_into_blocks(vs, new_v, &new_shape, device, RingFeed::Skip, max_seq)?;
         } else {
             vs.append(&v_f32, &new_shape)?;
         }

--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -67,6 +67,7 @@ pub mod rot_k;
 pub mod rot_k_msl;
 pub mod rotating;
 pub mod rotor_flash_decode_msl;
+pub mod rotor_flash_decode_symv_msl;
 pub mod rotor_fused_qk_msl;
 pub mod rotor_qjl;
 pub mod rotorquant;

--- a/crates/rmlx-kv-quant/src/metal/probes/kernels.manifest
+++ b/crates/rmlx-kv-quant/src/metal/probes/kernels.manifest
@@ -63,6 +63,13 @@ rot_k_fwht_rotate_d512.metal | rot_k.hdr.metal | inp:f,out:f
 # line over the same body.
 rotor_flash_decode_p1.metal | rotor_flash_decode_p1_b3.hdr.metal | query:f,codes:u,scales:f,norms:f,rotors:f,v_flat:f,mask_flat:f,scale_arr:f,dims:u,partial_o:f,tile_max:f,tile_sum_exp:f
 rotor_flash_decode_p1.metal | rotor_flash_decode_p1_b4.hdr.metal | query:f,codes:u,scales:f,norms:f,rotors:f,v_flat:f,mask_flat:f,scale_arr:f,dims:u,partial_o:f,tile_max:f,tile_sum_exp:f
+# The all-quant sibling: same two headers (both axes of a symmetric rotor codec
+# share one bit width, so RF_BITS covers the K and the V unpack), and it calls
+# the header's `rf_decode_k_group` for both. V arrives as its own packed ring
+# instead of a bf16 mirror, hence v_codes/v_scales/v_norms/v_rotors in place of
+# v_flat.
+rotor_flash_decode_symv_p1.metal | rotor_flash_decode_p1_b3.hdr.metal | query:f,k_codes:u,k_scales:f,k_norms:f,k_rotors:f,v_codes:u,v_scales:f,v_norms:f,v_rotors:f,mask_flat:f,scale_arr:f,dims:u,partial_o:f,tile_max:f,tile_sum_exp:f
+rotor_flash_decode_symv_p1.metal | rotor_flash_decode_p1_b4.hdr.metal | query:f,k_codes:u,k_scales:f,k_norms:f,k_rotors:f,v_codes:u,v_scales:f,v_norms:f,v_rotors:f,mask_flat:f,scale_arr:f,dims:u,partial_o:f,tile_max:f,tile_sum_exp:f
 # One fused-QK body serves both rotor bit widths — the unpack width arrives via
 # the header (RF_BITS / RF_MASK), so each header gets its own probe line over the
 # same body.

--- a/crates/rmlx-kv-quant/src/metal/rotor_flash_decode_symv_p1.metal
+++ b/crates/rmlx-kv-quant/src/metal/rotor_flash_decode_symv_p1.metal
@@ -1,0 +1,163 @@
+
+// ── Thread / threadgroup coordinates ──────────────────────────────────
+uint head_dim     = dims[0];
+uint kv_seq       = dims[1];
+uint n_bh         = dims[2];
+uint kv_h         = dims[3];
+uint heads_per_kv = dims[4];
+uint n_tiles      = dims[5];
+uint has_mask     = dims[6];
+uint n_groups     = dims[7];
+
+uint tile_idx = threadgroup_position_in_grid.x;
+uint bh       = threadgroup_position_in_grid.y;
+uint tid      = thread_position_in_threadgroup.x;
+
+// SIMD-group coordinates (Apple GPU: 32 lanes per simdgroup). The threadgroup
+// is exactly `head_dim` threads (power-of-two, dispatcher-enforced). The fold
+// below uses the runtime `n_simd = simdgroups_per_threadgroup`, which covers the
+// head whether or not the last simdgroup is full.
+uint simd_lane = thread_index_in_simdgroup;
+uint simd_id   = simdgroup_index_in_threadgroup;
+uint n_simd    = simdgroups_per_threadgroup;
+
+if (bh >= n_bh)
+    return;
+if (tile_idx >= n_tiles)
+    return;
+
+uint n_q_heads = kv_h * heads_per_kv;
+uint b         = bh / n_q_heads;
+uint hq        = bh % n_q_heads;
+uint kv_h_idx  = hq / heads_per_kv;
+
+uint tile_start = tile_idx * RF_TILE_SIZE;
+uint tile_end   = tile_start + RF_TILE_SIZE;
+if (tile_end > kv_seq)
+    tile_end = kv_seq;
+
+// ── Load this lane's Q into a register ────────────────────────────────
+// Each lane only ever multiplies its own head-dim slot, so Q lives in a
+// register rather than threadgroup memory.
+float q_lane = query[bh * head_dim + tid];
+
+// ── Online-softmax broadcast slots ───────────────────────────────────
+// Thread 0 owns the authoritative running (max, sum) in registers across the
+// tile and broadcasts the per-token correction / exp-score so every lane can
+// rescale its V accumulator.
+threadgroup float s_corr[1];
+threadgroup float s_expsc[1];
+
+float run_max = -INFINITY;
+float run_sum = 0.0f;
+
+// Per-thread V accumulator (registers — never spills to threadgroup mem).
+float acc_v = 0.0f;
+
+// One decode per group: the group leader stages all its lanes' K and V here so
+// the ~64-FMA inverse sandwich runs once per Cl(3,0) block instead of once per
+// lane. K and V take separate staging buffers — the QK dot must have consumed
+// this token's K before the V leader overwrites it, and separate arrays make
+// that ordering explicit rather than resting on a reuse hazard.
+threadgroup float k_shared[RF_HEAD_DIM_MAX];
+threadgroup float v_shared[RF_HEAD_DIM_MAX];
+// Per-simdgroup QK-dot partials (folded by thread 0).
+threadgroup float dot_partials[RF_HEAD_DIM_MAX / 32];
+
+// This lane's Cl(3,0) block (each owns RF_GROUP_SIZE consecutive head-dim slots).
+uint group_id_in_head = tid / RF_GROUP_SIZE;
+uint lane_in_group    = tid - group_id_in_head * RF_GROUP_SIZE;
+
+for (uint t = tile_start; t < tile_end; t++) {
+    // ── One decode per group ─────────────────────────────────────────
+    // BOTH rotor rings are SEQUENCE-major (`[B, S, kv_h, n_groups]`): per
+    // token all heads are contiguous, matching the chunk-append layout. Unlike
+    // the bf16-V sibling kernel, V here has no head-major mirror — it is read
+    // straight from its own packed rotor ring at the same token index as K,
+    // through the identical per-block decode. Only lane 0 of each group runs
+    // the sandwich, then scatters the block's RF_GROUP_SIZE grade-1 lanes.
+    uint kv_tok = (b * kv_seq + t) * kv_h + kv_h_idx;
+    if (lane_in_group == 0u) {
+        float kg[RF_GROUP_SIZE];
+        rf_decode_k_group(k_codes, k_scales, k_norms, k_rotors, kv_tok, n_groups,
+                          group_id_in_head, kg);
+        for (uint e = 0u; e < RF_GROUP_SIZE; ++e) {
+            uint slot = tid + e;
+            if (slot < head_dim) {
+                k_shared[slot] = kg[e];
+            }
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // ── QK dot via simdgroup reduction ───────────────────────────────
+    // simd_sum folds each simdgroup's 32 lanes with no threadgroup barrier and
+    // no idle-lane tree; one partial per simdgroup then folds on thread 0.
+    float prod     = q_lane * k_shared[tid];
+    float lane_sum = simd_sum(prod);
+    if (simd_lane == 0u) {
+        dot_partials[simd_id] = lane_sum;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // ── Thread 0: fold partials + online-softmax update + broadcast ───
+    if (tid == 0u) {
+        float raw = 0.0f;
+        for (uint i = 0u; i < n_simd; i++) {
+            raw += dot_partials[i];
+        }
+        raw *= scale_arr[0];
+        // Mask is per (b, q_head, t) — add inside thread 0.
+        float mask_val = 0.0f;
+        if (has_mask != 0u) {
+            mask_val = mask_flat[(b * n_q_heads + hq) * kv_seq + t];
+        }
+        float score = raw + mask_val;
+
+        float old_max = run_max;
+        float new_max = (score > old_max) ? score : old_max;
+        float corr    = exp(old_max - new_max);
+        float es      = exp(score - new_max);
+
+        run_max    = new_max;
+        run_sum    = run_sum * corr + es;
+        s_corr[0]  = corr;
+        s_expsc[0] = es;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // ── Quant-V decode (one per group) + softmax-weighted accumulation ─
+    // The rotor codec is axis-agnostic: V decodes through the same block
+    // sandwich as K, from the V store's own codes / scales / norms / rotor
+    // table. The leader stages the block; every lane then reads its own slot.
+    // No bf16 V exists in device memory — that mirror is exactly what this
+    // kernel deletes.
+    if (lane_in_group == 0u) {
+        float vg[RF_GROUP_SIZE];
+        rf_decode_k_group(v_codes, v_scales, v_norms, v_rotors, kv_tok, n_groups,
+                          group_id_in_head, vg);
+        for (uint e = 0u; e < RF_GROUP_SIZE; ++e) {
+            uint slot = tid + e;
+            if (slot < head_dim) {
+                v_shared[slot] = vg[e];
+            }
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float corr  = s_corr[0];
+    float es    = s_expsc[0];
+    float v_val = v_shared[tid];
+
+    acc_v = acc_v * corr + es * v_val;
+}
+
+// ── Write per-tile partials ──────────────────────────────────────────
+uint out_base             = (tile_idx * n_bh + bh) * head_dim;
+partial_o[out_base + tid] = acc_v;
+
+if (tid == 0u) {
+    uint meta          = tile_idx * n_bh + bh;
+    tile_max[meta]     = run_max;
+    tile_sum_exp[meta] = run_sum;
+}

--- a/crates/rmlx-kv-quant/src/precompile_tests.rs
+++ b/crates/rmlx-kv-quant/src/precompile_tests.rs
@@ -60,6 +60,10 @@ fn v_only_iso_rotor_families_are_cpu_fallback_with_reason() {
     // encode that runs (at prefill) is CPU. They carry MSL (q8 K-side) but must
     // report a CPU-hot-path reason. This is grounded in the dispatcher, not by
     // fiat — flip the verdict and this test must flip with it.
+    // Note: the rotor **symmetric** codecs (`Rotor3Sym` / `Rotor4Sym`) are NOT
+    // in this list — with QJL off (the default) their decode is the quant-V
+    // flash kernel over both packed rings, so their hot path is Metal. That
+    // verdict is checked in `rotor_symmetric_families_are_metal_when_qjl_off`.
     for kq in [
         KvQuant::Iso3,
         KvQuant::Iso4,
@@ -67,8 +71,6 @@ fn v_only_iso_rotor_families_are_cpu_fallback_with_reason() {
         KvQuant::Iso4Sym,
         KvQuant::Rotor3,
         KvQuant::Rotor4,
-        KvQuant::Rotor3Sym,
-        KvQuant::Rotor4Sym,
         KvQuant::RotorK3Asym {
             v_bits: 8,
             v_group_size: 128,
@@ -85,6 +87,30 @@ fn v_only_iso_rotor_families_are_cpu_fallback_with_reason() {
         assert!(
             kq.cpu_hot_path_reason().is_some(),
             "{kq} (V-only iso/rotor or rotor-K-asym) must be flagged as a CPU-hot-path codec"
+        );
+    }
+}
+
+#[test]
+fn rotor_symmetric_families_are_metal_when_qjl_off() {
+    // `Rotor3Sym` / `Rotor4Sym` have NO bf16 decode-seed early-return: with QJL
+    // off (the default) decode is the quant-V flash kernel over both packed
+    // rings, so the verdict must be `None` (Metal) — mirror of the K-only iso
+    // test. A QJL-carrying store still keeps the CPU dequant path; that branch
+    // is gated on the global toggle and not exercised here (QJL is off by
+    // default). Grounded in the dispatcher, not by fiat.
+    assert!(
+        !crate::rotor_qjl::rotor_qjl_enabled(),
+        "test assumes the default QJL-off state"
+    );
+    for kq in [KvQuant::Rotor3Sym, KvQuant::Rotor4Sym] {
+        assert!(
+            kq.carries_msl(),
+            "{kq} carries MSL (rotor K + quant-V flash kernels)"
+        );
+        assert!(
+            kq.cpu_hot_path_reason().is_none(),
+            "{kq} decodes through the quant-V flash kernel with QJL off — must be Metal (None)"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -490,9 +490,9 @@ impl KvQuant {
     }
 
     /// True when the decode path reads the bf16 `decode_fp16_k` seed that
-    /// `exit_prefill` materialises (the warm-TTFT shortcut codecs: K8V*, *Sym,
-    /// Planar*, Turbo*, Iso*, Rotor* with a quantised-or-bf16 K mirror that
-    /// decode consults).
+    /// `exit_prefill` materialises (the warm-TTFT shortcut codecs: K8V*,
+    /// Planar*, Turbo*, Iso* with a quantised-or-bf16 K mirror that decode
+    /// consults).
     ///
     /// **False for the K-only family** (`IsoKOnly3/4`, `RotorKOnly3/4`): these
     /// re-quantise K at every decode step (`ks.append`) and route V through
@@ -501,19 +501,29 @@ impl KvQuant {
     /// dead memory. The bf16 **V** seed (`decode_fp16_v`) is still populated for
     /// them; only the K seed is gated.
     ///
+    /// **False for the fused rotor symmetric codecs** (`Rotor3Sym`,
+    /// `Rotor4Sym`): their decode is a flash kernel over both packed rings, so
+    /// neither axis reads a mirror. See [`Self::feeds_bf16_v_at_decode`].
+    ///
     /// The match is **exhaustive on purpose** (no wildcard `_`): adding a new
     /// `KvQuant` variant will produce a compile error until it is classified
     /// here, preventing a new K-only-style variant from silently defaulting to
-    /// `true` and reintroducing the F2 dead-seed leak.
+    /// `true` and reintroducing the dead-seed leak.
     pub fn feeds_bf16_k_at_decode(&self) -> bool {
         match self {
-            // K-only family: K is re-quantised at every decode step; decode
-            // never reads decode_fp16_k. exit_prefill skips the K seed for
-            // these variants.
+            // Two families never read a bf16 K at decode, for two reasons:
+            //
+            // * K-only (IsoKOnly*, RotorKOnly*) — K is re-quantised at every
+            //   decode step; V routes through `update_decode_fp16_v_only`.
+            // * Fused rotor symmetric (Rotor{3,4}Sym) — decode runs a flash
+            //   kernel straight off the packed K and V rings, so neither axis
+            //   reads a mirror (see `feeds_bf16_v_at_decode`).
             KvQuant::IsoKOnly3
             | KvQuant::IsoKOnly4
             | KvQuant::RotorKOnly3
-            | KvQuant::RotorKOnly4 => false,
+            | KvQuant::RotorKOnly4
+            | KvQuant::Rotor3Sym
+            | KvQuant::Rotor4Sym => false,
             // All other variants: decode reads the bf16 K seed materialised by
             // exit_prefill (the warm-TTFT shortcut codecs and bf16 KV).
             KvQuant::None
@@ -537,8 +547,61 @@ impl KvQuant {
             | KvQuant::Iso4Sym
             | KvQuant::Rotor3
             | KvQuant::Rotor4
-            | KvQuant::Rotor3Sym
-            | KvQuant::Rotor4Sym
+            | KvQuant::RotorK3Asym { .. }
+            | KvQuant::RotorK4Asym { .. } => true,
+        }
+    }
+
+    /// True when the decode path reads the bf16 `decode_fp16_v` seed that
+    /// `exit_prefill` materialises.
+    ///
+    /// Sibling of [`Self::feeds_bf16_k_at_decode`] for the V axis. Almost every
+    /// codec is `true`: even the K-only re-quantise family routes V through
+    /// `update_decode_fp16_v_only`, and `KvQuant::None` stores its bf16 V here
+    /// outright.
+    ///
+    /// **False only for the fused rotor symmetric codecs** (`Rotor3Sym`,
+    /// `Rotor4Sym`): `rotor_flash_decode_symv` unpacks V straight out of the
+    /// packed rotor ring inside the SV loop, so a bf16 V is never read. Keeping
+    /// one is not a small waste — a full `seq * head_dim * 2` bytes per layer of
+    /// V (plus the same for K) is the *dominant* term in these codecs' residency
+    /// and is what made a ~3-bits-per-axis codec cost more than plain bf16.
+    ///
+    /// Exhaustive on purpose, same reasoning as the K-side predicate: a new
+    /// variant must be classified rather than silently inherit a mirror.
+    pub fn feeds_bf16_v_at_decode(&self) -> bool {
+        match self {
+            // Fused rotor symmetric: V is unpacked from the quant store inside
+            // the flash kernel's SV loop; no bf16 V exists.
+            KvQuant::Rotor3Sym | KvQuant::Rotor4Sym => false,
+            // Everything else reads the bf16 V seed at decode — including the
+            // K-only family (via `update_decode_fp16_v_only`) and `None`, whose
+            // bf16 V *is* this buffer.
+            KvQuant::None
+            | KvQuant::K8V4
+            | KvQuant::K8V8
+            | KvQuant::Planar
+            | KvQuant::Planar3
+            | KvQuant::PlanarK
+            | KvQuant::Mixed { .. }
+            | KvQuant::RotK { .. }
+            | KvQuant::RotKTq4V
+            | KvQuant::K8VTurbo3
+            | KvQuant::K8VTurbo3Tcq
+            | KvQuant::K8VTurbo2
+            | KvQuant::K8VTurbo2Tcq
+            | KvQuant::TurboSym3
+            | KvQuant::TurboSym4
+            | KvQuant::Iso3
+            | KvQuant::Iso4
+            | KvQuant::Iso3Sym
+            | KvQuant::Iso4Sym
+            | KvQuant::IsoKOnly3
+            | KvQuant::IsoKOnly4
+            | KvQuant::Rotor3
+            | KvQuant::Rotor4
+            | KvQuant::RotorKOnly3
+            | KvQuant::RotorKOnly4
             | KvQuant::RotorK3Asym { .. }
             | KvQuant::RotorK4Asym { .. } => true,
         }
@@ -664,14 +727,30 @@ impl KvQuant {
             // is opt-in (RMLX_FUSED_QK) and does not fire on the standard flow.
             KvQuant::Rotor3
             | KvQuant::Rotor4
-            | KvQuant::Rotor3Sym
-            | KvQuant::Rotor4Sym
             | KvQuant::RotorK3Asym { .. }
             | KvQuant::RotorK4Asym { .. } => Some(
                 "RotorQuant (Clifford Cl(3,0)) encode + dequant run on CPU on the \
                  default hot path (the bf16 decode seed shadows the GPU branch); the \
                  GPU fused-QK encoder is opt-in (RMLX_FUSED_QK)",
             ),
+            // Symmetric rotor variants: NO bf16 decode-seed early-return — decode
+            // is the quant-V flash kernel over both packed rings. Same QJL gate as
+            // the K-only family, and for the same reason: the QJL residual cannot
+            // be reproduced in the flash inner loop, so a QJL-carrying store keeps
+            // the CPU dequant path on BOTH axes.
+            KvQuant::Rotor3Sym | KvQuant::Rotor4Sym => {
+                if crate::rotor_qjl::rotor_qjl_enabled() {
+                    Some(
+                        "RotorQuant (Clifford Cl(3,0)) symmetric with QJL enabled \
+                         (rotor_qjl_enabled): the QJL residual forces K and V onto the \
+                         CPU encode + dequant path every decode step; disable QJL \
+                         (--rotor-qjl off) to route both axes through the Metal \
+                         flash-decode kernel",
+                    )
+                } else {
+                    None
+                }
+            }
             // K-only rotor variants: NO bf16 decode-seed early-return — the rotor
             // K codec fires every decode step. `update_rotor_k_only_{3,4}` gates
             // the GPU K encode on the store's sticky QJL flag (`use_qjl()`, fixed
@@ -830,11 +909,12 @@ impl KvQuant {
     /// the V-only variants (`Iso3`/`Iso4`/`Rotor3`/`Rotor4`) keep an 8-bit
     /// affine K, so their K side takes the generic path.
     ///
-    /// - **bf16 decode seed**: when [`Self::feeds_bf16_k_at_decode`] is true the
-    ///   codec keeps a full `seq * head_dim * 2` bf16 mirror of **V** (always)
-    ///   and **K** (unless it is a K-only re-quantize family). This is the
-    ///   warm-TTFT shortcut buffer and is the dominant term that can make a
-    ///   quantized global layer *larger* than bf16.
+    /// - **bf16 decode seed**: a codec keeps a full `seq * head_dim * 2` bf16
+    ///   mirror of each axis whose decode reads it —
+    ///   [`Self::feeds_bf16_k_at_decode`] for K, [`Self::feeds_bf16_v_at_decode`]
+    ///   for V. This is the warm-TTFT shortcut buffer and is the dominant term
+    ///   that can make a quantized global layer *larger* than bf16. Codecs with
+    ///   a fused decode over both packed axes keep neither.
     ///
     /// `None` (bf16) returns just the two bf16 buffers and no seed.
     ///
@@ -940,11 +1020,13 @@ impl KvQuant {
                 | KvQuant::Rotor3Sym
                 | KvQuant::Rotor4Sym
         );
-        // V seed is always retained by the warm-TTFT shortcut codecs (every
-        // quant arm reads `decode_fp16_v` at decode). K seed is retained unless
-        // this is a K-only re-quantize family (`feeds_bf16_k_at_decode == false`).
+        // Each seed is retained only when this codec's decode actually reads it
+        // — the same two predicates `exit_prefill` gates the real allocation on,
+        // so the estimate cannot drift from what is materialised. The K-only
+        // re-quantize family drops the K seed; the fused rotor symmetric codecs
+        // drop both.
         let k_bytes = side_bytes(k_bits, self.feeds_bf16_k_at_decode(), k_uses_family);
-        let v_bytes = side_bytes(v_bits, true, v_uses_family);
+        let v_bytes = side_bytes(v_bits, self.feeds_bf16_v_at_decode(), v_uses_family);
         k_bytes.saturating_add(v_bytes)
     }
 

--- a/crates/rmlx-kv-quant/src/quant_tests.rs
+++ b/crates/rmlx-kv-quant/src/quant_tests.rs
@@ -379,11 +379,23 @@ fn estimator_matches_actual_iso_rotor_encode_bytes() {
     let rotor_side_actual = 4 * (r_codes.len() + r_scales.len() + r_norms.len()) as u64;
     let est_r =
         KvQuant::Rotor3Sym.estimated_resident_bytes_per_layer(seq, head_dim as u64, kv_heads);
-    let expected_r = 2 * (rotor_side_actual + seed);
+    // Rotor3Sym quantizes BOTH sides and — unlike Iso3Sym — retains **no** bf16
+    // seed on either: its decode is a flash kernel over the two packed rings, so
+    // estimate = 2*side with no seed term. This is the codec's whole memory
+    // claim; if a seed ever creeps back the estimate and this test move together.
+    let expected_r = 2 * rotor_side_actual;
     let tol_r = expected_r / 10;
     assert!(
         est_r.abs_diff(expected_r) <= tol_r,
         "Rotor3Sym estimate {est_r} not within 10% of actual {expected_r}"
+    );
+    // The seedless estimate must be strictly below the seeded sibling's — the
+    // point of the fused path. Same codec shape, same bit width, so the gap is
+    // exactly the two mirrors.
+    assert!(
+        est_r < 2 * (rotor_side_actual + seed),
+        "Rotor3Sym must not carry a bf16 mirror: {est_r} should be below the seeded {}",
+        2 * (rotor_side_actual + seed)
     );
 
     // Net-saving must now be NEGATIVE for iso at head_dim=128.

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl.rs
@@ -1,0 +1,593 @@
+// unsafe_code: Metal kernel byte cast — slice::from_raw_parts over kernel
+// input data (dims arrays) for MSL dispatch.
+#![allow(unsafe_code)]
+
+//! `rotor_flash_decode_symv`: fused QK over rotor-quant K + online softmax +
+//! **rotor-quant V** SV in a single MSL pass per (B, H, tile).
+//!
+//! # What this is
+//!
+//! The all-quant sibling of [`crate::rotor_flash_decode_msl`]. That kernel
+//! decodes K from the rotor store but still reads V out of a bf16 mirror; this
+//! one reads **both** axes straight from their packed rotor rings, so the
+//! symmetric rotor codecs ([`crate::storage::KvStorage::RotorSym3`] /
+//! `RotorSym4`) need no bf16 K or V buffer at all.
+//!
+//! # What it replaced
+//!
+//! `Rotor{3,4}Sym` quantised both axes at `exit_prefill` and then decoded from
+//! a full bf16 K+V mirror (`decode_fp16_k` / `decode_fp16_v`), which
+//! `update_rotor{3,4}_sym` short-circuits to on its first line. The codec was
+//! dormant: the packed store was written, never read. The mirror is the whole
+//! KV cost of the codec — a codec advertising ~3 bits/axis actually carried
+//! bf16 K + bf16 V *plus* its codes, i.e. **more** than plain bf16. Dropping
+//! the mirror is what turns the codec's advertised compression into a real
+//! resident-byte win.
+//!
+//! Two Metal dispatches per call:
+//! * **Pass 1** (`rmlx_rotor_flash_decode_symv_p1_b{3,4}`): per-tile
+//!   threadgroups compute partial outputs + per-tile LSE state
+//!   `(tile_max, tile_sum_exp)`. Each threadgroup runs `head_dim` threads over
+//!   `TILE_SIZE` tokens.
+//! * **Pass 2** (`rmlx_rotor_flash_decode_symv_p2`): one threadgroup per
+//!   `(B, head)` merges the per-tile partials via log-sum-exp. The body is the
+//!   codec-agnostic `metal/flash_decode_merge_p2.metal`, shared with
+//!   `planar_flash_decode_msl` and `rotor_flash_decode_msl`.
+//!
+//! # Reuse of the K-decode half
+//!
+//! [`crate::rotor_flash_decode_msl`] emits its per-lane rotor decode into the
+//! **header** as the MSL function `rf_decode_k_lane(...)` precisely so a
+//! quantized-V kernel could call it unchanged. This kernel does exactly that,
+//! for both axes:
+//!
+//! * The header is [`crate::rotor_flash_decode_msl::build_rotor_flash_header`],
+//!   reused verbatim — no second copy of the Lloyd-Max codebook or the Cl(3,0)
+//!   multiplication table, and no second probe snapshot to keep in sync.
+//! * The body calls `rf_decode_k_lane` twice per token: once over the K ring,
+//!   once over the V ring.
+//!
+//! That works because the rotor codec is **axis-agnostic**: `rotor{3,4}_encode`
+//! (V) and `rotor{3,4}_k_encode` (K) are the same function, the K fork only
+//! adding the optional QJL sideband — and the dispatcher fires only with QJL
+//! off. The per-lane decode is also self-contained (lane `d` reads only its own
+//! group's word / scale / rotor plus the token's L2 norm), so unlike a
+//! Hadamard-rotated codec the V unpack needs no cross-lane exchange in the SV
+//! loop.
+//!
+//! # Bit-width parameterisation
+//!
+//! `bits ∈ {3, 4}` is a template parameter carried by the header, so one
+//! `metal/rotor_flash_decode_symv_p1.metal` serves both variants. Selection is
+//! explicit — any other `bits` is an `Err`, never a silent fallback to the
+//! wrong unpack width. Both axes of a symmetric codec share one width by
+//! construction (`Rotor3Sym` → 3/3, `Rotor4Sym` → 4/4), so a single `RF_BITS`
+//! covers K and V.
+//!
+//! # Codec contract
+//!
+//! Bit-exact with [`crate::rotorquant::rotor3_decode`] /
+//! [`crate::rotorquant::rotor4_decode`] on **both** axes. Per axis:
+//!
+//! * `codes`  u32 `[B * S_kv * kv_h * n_groups]` — 1 u32 per group of 8 Cl(3,0)
+//!   multivector components. Element `e ∈ 0..8` occupies bits
+//!   `[e*BITS, e*BITS + BITS)` LSB-first.
+//! * `scales` f32 `[B * S_kv * kv_h * n_groups]` — one f32 per group of 3
+//!   head-dim slots.
+//! * `norms`  f32 `[B * S_kv * kv_h]` — per-token L2 norm.
+//! * `rotors` f32 `[n_groups * 4]` — static per-(layer, head) rotor table in
+//!   compact `[s, b12, b13, b23]` form.
+//!
+//! Both rings are **sequence-major** (`[B, S, kv_h, ...]`). The K and V rotor
+//! tables are passed separately rather than shared: each store owns its table,
+//! and reading V's codes against K's table would be silently wrong the day the
+//! two seeds diverge.
+//!
+//! # QJL sideband
+//!
+//! K-side only, and not reproducible in the flash inner loop without reading a
+//! dense `[head_dim, head_dim]` projection per token per threadgroup. The
+//! dispatcher fires only when QJL is off; with QJL on the caller keeps the CPU
+//! dequant path. Same gate as [`crate::rotor_flash_decode_msl`].
+//!
+//! # Single-MLX claim
+//!
+//! Per CLAUDE.md "Single MLX process per Mac", callers must hold the
+//! `/tmp/rmlx.<port>.claim` lock before dispatching GPU kernels.
+//!
+//! # Pattern reference
+//!
+//! * [`crate::rotor_flash_decode_msl`] — the bf16-V sibling; this kernel is its
+//!   shell with the SV read swapped for a rotor unpack.
+//! * `multi-turboquant` `PLANAR_FUSED_SV_KERNEL` (MIT) — the prior art for
+//!   unpacking a quantized V inside the SV accumulation loop (one thread per
+//!   output lane, decode that lane per token, weight by the softmax term,
+//!   accumulate in a register).
+//! * [`crate::rotorquant::rotor3_decode`] — CPU reference (Rust).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+use rmlx_core::error::{Error, Result};
+use rmlx_mlx::metal_kernel::{MetalKernel, MetalKernelInvoke};
+use rmlx_mlx::{Array, Device, Dtype};
+
+use crate::rotor_flash_decode_msl::{
+    build_rotor_flash_header, ROTOR_FLASH_HEAD_DIM_MAX, TILE_SIZE,
+};
+use crate::rotorquant::n_groups_for;
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Per-group rotor stride in the rotor table (`[s, b12, b13, b23]`).
+const ROTOR_STRIDE: i64 = 4;
+
+// ── Dispatch counters ─────────────────────────────────────────────────────────
+
+/// Incremented once per `rotor_flash_decode_symv_sdpa::<3>` P1 enqueue.
+static ROTOR3_SYMV_FLASH_DECODE_DISPATCHES: AtomicU64 = AtomicU64::new(0);
+
+/// Incremented once per `rotor_flash_decode_symv_sdpa::<4>` P1 enqueue.
+static ROTOR4_SYMV_FLASH_DECODE_DISPATCHES: AtomicU64 = AtomicU64::new(0);
+
+/// Process-lifetime count of rotor3 quant-V flash-decode P1 dispatches.
+///
+/// Tests assert `delta > 0` to prove the MSL kernel actually fired rather than
+/// the caller silently falling back to the CPU dequant path. Production code
+/// does not consult this counter.
+pub fn rotor3_symv_flash_decode_dispatch_count() -> u64 {
+    ROTOR3_SYMV_FLASH_DECODE_DISPATCHES.load(Ordering::Relaxed)
+}
+
+/// Process-lifetime count of rotor4 quant-V flash-decode P1 dispatches.
+pub fn rotor4_symv_flash_decode_dispatch_count() -> u64 {
+    ROTOR4_SYMV_FLASH_DECODE_DISPATCHES.load(Ordering::Relaxed)
+}
+
+/// Combined process-lifetime count (3-bit + 4-bit).
+pub fn rotor_symv_flash_decode_dispatch_count() -> u64 {
+    rotor3_symv_flash_decode_dispatch_count() + rotor4_symv_flash_decode_dispatch_count()
+}
+
+// ── MSL sources ───────────────────────────────────────────────────────────────
+//
+// Grid: (n_tiles * head_dim, B * n_q_heads, 1).  Threadgroup: (head_dim, 1, 1).
+//
+// P1 buffer layout (must match `add_input` order in
+// `rotor_flash_decode_symv_sdpa`). BOTH rotor rings are SEQUENCE-major
+// (`[B, S, kv_h, ...]`) — there is no head-major bf16 V here.
+// 0.  query     : f32  [B * n_q_heads * head_dim]
+// 1.  k_codes   : u32  [B * kv_seq * kv_h * n_groups]
+// 2.  k_scales  : f32  [B * kv_seq * kv_h * n_groups]
+// 3.  k_norms   : f32  [B * kv_seq * kv_h]
+// 4.  k_rotors  : f32  [n_groups * 4]
+// 5.  v_codes   : u32  [B * kv_seq * kv_h * n_groups]
+// 6.  v_scales  : f32  [B * kv_seq * kv_h * n_groups]
+// 7.  v_norms   : f32  [B * kv_seq * kv_h]
+// 8.  v_rotors  : f32  [n_groups * 4]
+// 9.  mask_flat : f32  [B * n_q_heads * kv_seq] or [1] dummy when no mask
+// 10. scale_arr : f32  [1]
+// 11. dims      : u32  [8] — {head_dim, kv_seq, n_bh, kv_h, heads_per_kv,
+//                             n_tiles, has_mask, n_groups}
+//
+// P1 outputs:
+// 0. partial_o     : f32 [n_tiles * n_bh * head_dim]
+// 1. tile_max      : f32 [n_tiles * n_bh]
+// 2. tile_sum_exp  : f32 [n_tiles * n_bh]
+//
+// One body serves both bit widths — the unpack width arrives via the header's
+// RF_BITS / RF_MASK.
+const P1_SOURCE: &str = include_str!("metal/rotor_flash_decode_symv_p1.metal");
+
+// P2 buffer layout:
+// 0. partial_o    : f32 [n_tiles * n_bh * head_dim]
+// 1. tile_max     : f32 [n_tiles * n_bh]
+// 2. tile_sum_exp : f32 [n_tiles * n_bh]
+// 3. dims_p2      : u32 [3] — {head_dim, n_tiles, n_bh}
+// Output:
+// 0. dst          : f32 [n_bh * head_dim]
+//
+// Codec-agnostic; shared with `planar_flash_decode_msl` / `rotor_flash_decode_msl`.
+const P2_SOURCE: &str = include_str!("metal/flash_decode_merge_p2.metal");
+
+// ── Kernel singletons (one P1 per BITS variant) ───────────────────────────────
+
+static P1_KERNEL_B3: OnceLock<std::result::Result<MetalKernel, String>> = OnceLock::new();
+static P1_KERNEL_B4: OnceLock<std::result::Result<MetalKernel, String>> = OnceLock::new();
+static P2_KERNEL: OnceLock<std::result::Result<MetalKernel, String>> = OnceLock::new();
+
+fn p1_kernel(bits: u8) -> Result<&'static MetalKernel> {
+    let (cell, name) = match bits {
+        3 => (&P1_KERNEL_B3, "rmlx_rotor_flash_decode_symv_p1_b3"),
+        4 => (&P1_KERNEL_B4, "rmlx_rotor_flash_decode_symv_p1_b4"),
+        _ => {
+            return Err(Error::Quant(format!(
+                "rotor_flash_decode_symv: bits must be 3 or 4, got {bits}"
+            )))
+        }
+    };
+    cell.get_or_init(|| {
+        // Same header as the bf16-V sibling: RF_BITS / RF_MASK / RF_CB / the
+        // Cl(3,0) MUL table / `rf_decode_k_lane` / tile + head-dim sizing. Both
+        // axes of a symmetric codec share one bit width, so one header covers
+        // the K and the V unpack.
+        let header = build_rotor_flash_header(bits).map_err(|e| format!("{e}"))?;
+        MetalKernel::new(
+            name,
+            &header,
+            P1_SOURCE,
+            &[
+                "query",
+                "k_codes",
+                "k_scales",
+                "k_norms",
+                "k_rotors",
+                "v_codes",
+                "v_scales",
+                "v_norms",
+                "v_rotors",
+                "mask_flat",
+                "scale_arr",
+                "dims",
+            ],
+            &["partial_o", "tile_max", "tile_sum_exp"],
+        )
+        .map_err(|e| format!("{e}"))
+    })
+    .as_ref()
+    .map_err(|e| {
+        Error::Mlx(format!(
+            "rotor_flash_decode_symv P1(bits={bits}) kernel init: {e}"
+        ))
+    })
+}
+
+fn p2_kernel() -> Result<&'static MetalKernel> {
+    P2_KERNEL
+        .get_or_init(|| {
+            MetalKernel::new(
+                "rmlx_rotor_flash_decode_symv_p2",
+                "", // No header — P2 is generic over (head_dim, n_tiles, n_bh).
+                P2_SOURCE,
+                &["partial_o", "tile_max", "tile_sum_exp", "dims_p2"],
+                &["dst"],
+            )
+            .map_err(|e| format!("{e}"))
+        })
+        .as_ref()
+        .map_err(|e| Error::Mlx(format!("rotor_flash_decode_symv P2 kernel init: {e}")))
+}
+
+/// The packed rotor payload of one axis, as the dispatcher takes it.
+///
+/// Grouping the four buffers keeps `rotor_flash_decode_symv_sdpa` from taking
+/// eight positional `&Array`s in a row, where a K/V transposition at a call
+/// site would type-check and decode the wrong store.
+#[derive(Debug, Clone, Copy)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "plain parameter bundle — literal construction at the call site IS the intended use, \
+              and the field set is the codec's on-disk contract (codes/scales/norms/rotors). A \
+              new field would be a new codec layout, which must break every call site anyway"
+)]
+pub struct RotorPackedAxis<'a> {
+    /// Packed rotor codes, flat `u32 [B * kv_seq * kv_h * n_groups]`
+    /// (sequence-major).
+    pub codes: &'a Array,
+    /// Per-group f32 scales, same flat length as `codes`.
+    pub scales: &'a Array,
+    /// Per-token f32 L2 norms, flat `[B * kv_seq * kv_h]`.
+    pub norms: &'a Array,
+    /// Static per-(layer, head) rotor table, flat `[n_groups * 4]` f32 in
+    /// `[s, b12, b13, b23]` order.
+    pub rotors: &'a Array,
+}
+
+/// Shape metadata for one decode step.
+#[derive(Debug, Clone, Copy)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "plain parameter bundle — literal construction at the call site IS the intended use; \
+              every field is a required shape the dispatcher validates, so there is no default a \
+              non-exhaustive builder could supply"
+)]
+pub struct RotorFlashShape {
+    /// Batch size. Must be 1 — the rings do not interleave batch in their
+    /// per-step stride.
+    pub b: i32,
+    /// KV head count.
+    pub kv_h: i32,
+    /// Accumulated KV positions to attend.
+    pub kv_seq: i32,
+    /// Per-head dimension. Power of two, `<= ROTOR_FLASH_HEAD_DIM_MAX`.
+    pub head_dim: i32,
+    /// Query heads per KV head (GQA fan-out).
+    pub heads_per_kv: i32,
+}
+
+// ── Public dispatcher ─────────────────────────────────────────────────────────
+
+/// Run the rotor symmetric flash-decode kernel (fused QK over rotor-quant K +
+/// online softmax + **rotor-quant V** SV).
+///
+/// # Inputs
+///
+/// * `query` — Q for the new token, shape `[B, n_q_heads, 1, head_dim]`.
+/// * `k` / `v` — the two packed rotor axes ([`RotorPackedAxis`]).
+/// * `additive_mask` — optional `f32 [B, n_q_heads, 1, kv_seq]`.
+/// * `shape` — [`RotorFlashShape`].
+/// * `scale` — softmax pre-scale (typically `1/sqrt(head_dim)`).
+/// * `device` — MLX device (must be GPU).
+///
+/// # Output
+///
+/// `f32` array of shape `[B, n_q_heads, 1, head_dim]`.
+///
+/// # Errors
+///
+/// * [`Error::Quant`] for `BITS` outside `{3, 4}`, shape-contract violations
+///   (`head_dim` not a power of two, above [`ROTOR_FLASH_HEAD_DIM_MAX`],
+///   non-positive shapes), or grid overflow.
+/// * [`Error::Mlx`] for kernel build / dispatch failures.
+#[allow(clippy::too_many_lines)]
+pub fn rotor_flash_decode_symv_sdpa<const BITS: u8>(
+    query: &Array,
+    k: RotorPackedAxis<'_>,
+    v: RotorPackedAxis<'_>,
+    additive_mask: Option<&Array>,
+    shape: RotorFlashShape,
+    scale: f32,
+    device: Device,
+) -> Result<Array> {
+    if BITS != 3 && BITS != 4 {
+        return Err(Error::Quant(format!(
+            "rotor_flash_decode_symv: unsupported BITS={BITS} (only 3 and 4)"
+        )));
+    }
+    let RotorFlashShape {
+        b,
+        kv_h,
+        kv_seq,
+        head_dim,
+        heads_per_kv,
+    } = shape;
+
+    if head_dim <= 0 {
+        return Err(Error::Quant(format!(
+            "rotor_flash_decode_symv: head_dim={head_dim} must be positive"
+        )));
+    }
+    if !(head_dim as u32).is_power_of_two() {
+        return Err(Error::Quant(format!(
+            "rotor_flash_decode_symv: head_dim={head_dim} must be a power of two for the \
+             tree reduction; caller falls back to the CPU dequant path"
+        )));
+    }
+    if head_dim > ROTOR_FLASH_HEAD_DIM_MAX {
+        let max = ROTOR_FLASH_HEAD_DIM_MAX;
+        return Err(Error::Quant(format!(
+            "rotor_flash_decode_symv: head_dim={head_dim} exceeds \
+             ROTOR_FLASH_HEAD_DIM_MAX={max}; raise the static threadgroup-array sizes in \
+             metal/rotor_flash_decode_symv_p1.metal to support it"
+        )));
+    }
+    if heads_per_kv <= 0 {
+        return Err(Error::Quant(format!(
+            "rotor_flash_decode_symv: heads_per_kv must be > 0, got {heads_per_kv}"
+        )));
+    }
+    if b <= 0 || kv_seq <= 0 || kv_h <= 0 {
+        return Err(Error::Quant(format!(
+            "rotor_flash_decode_symv: b={b}, kv_h={kv_h}, kv_seq={kv_seq} must all be > 0"
+        )));
+    }
+
+    let n_q_heads = kv_h * heads_per_kv;
+    let n_bh = b * n_q_heads;
+    let n_tiles = (kv_seq + TILE_SIZE - 1) / TILE_SIZE;
+    let n_groups = n_groups_for(head_dim as usize);
+    let n_groups_i64 = n_groups as i64;
+
+    // ── Flatten Q to [n_bh * head_dim] f32 ────────────────────────────────
+    let q_total: i64 = i64::from(n_bh) * i64::from(head_dim);
+    let q_flat = query.reshape(&[q_total as i32], device)?;
+    let q_f32 = if q_flat.dtype() == Dtype::F32 {
+        q_flat
+    } else {
+        q_flat.astype(Dtype::F32, device)?
+    };
+
+    // ── Flatten both packed axes ──────────────────────────────────────────
+    let tok_count: i64 = i64::from(b) * i64::from(kv_h) * i64::from(kv_seq);
+    let codes_total: i64 = tok_count * n_groups_i64;
+    let rotors_total: i64 = n_groups_i64 * ROTOR_STRIDE;
+
+    let flatten_axis = |axis: RotorPackedAxis<'_>| -> Result<(Array, Array, Array, Array)> {
+        Ok((
+            axis.codes.reshape(&[codes_total as i32], device)?,
+            axis.scales.reshape(&[codes_total as i32], device)?,
+            axis.norms.reshape(&[tok_count as i32], device)?,
+            axis.rotors.reshape(&[rotors_total as i32], device)?,
+        ))
+    };
+    let (k_codes, k_scales, k_norms, k_rotors) = flatten_axis(k)?;
+    let (v_codes, v_scales, v_norms, v_rotors) = flatten_axis(v)?;
+
+    // ── Mask ──────────────────────────────────────────────────────────────
+    let (mask_flat, has_mask) = if let Some(m) = additive_mask {
+        let flat_len: i64 = i64::from(n_bh) * i64::from(kv_seq);
+        let m_f = if m.dtype() == Dtype::F32 {
+            m.reshape(&[flat_len as i32], device)?
+        } else {
+            m.astype(Dtype::F32, device)?
+                .reshape(&[flat_len as i32], device)?
+        };
+        (m_f, 1u32)
+    } else {
+        let zero_bytes = [0u8; 4];
+        Array::from_bytes(&zero_bytes, &[1], Dtype::F32)
+            .map(|a| (a, 0u32))
+            .map_err(|e| Error::Mlx(format!("rotor_flash_decode_symv dummy mask: {e}")))?
+    };
+
+    // ── scale_arr ─────────────────────────────────────────────────────────
+    let scale_arr = {
+        let bytes = scale.to_le_bytes();
+        Array::from_bytes(&bytes, &[1], Dtype::F32)?
+    };
+
+    // ── dims (8 u32) ──────────────────────────────────────────────────────
+    // `bits` is not carried — the dispatcher selects the per-BITS kernel and
+    // its header supplies RF_BITS / RF_MASK.
+    let dims_arr = {
+        let dims: [u32; 8] = [
+            head_dim as u32,
+            kv_seq as u32,
+            n_bh as u32,
+            kv_h as u32,
+            heads_per_kv as u32,
+            n_tiles as u32,
+            has_mask,
+            n_groups as u32,
+        ];
+        // SAFETY:
+        // * `dims` is a stack-local `[u32; 8]` fully initialised above.
+        // * `u32` has stricter alignment than `u8`, so the cast is sound.
+        // * The byte length `8 * 4` equals `size_of::<[u32; 8]>()`.
+        // * The borrow is bounded by the enclosing block; `Array::from_bytes`
+        //   copies into mlx storage before this scope ends.
+        let bytes: &[u8] = unsafe { std::slice::from_raw_parts(dims.as_ptr().cast::<u8>(), 8 * 4) };
+        Array::from_bytes(bytes, &[8], Dtype::U32)
+            .map_err(|e| Error::Mlx(format!("rotor_flash_decode_symv dims: {e}")))?
+    };
+
+    // Materialise inputs to flush any pending lazy ops before kernel dispatch.
+    // The MSL kernels read by raw linear offset and ignore MLX lazy-transpose
+    // strides, so a pending permutation must be resolved here.
+    q_f32.eval()?;
+    for arr in [
+        &k_codes, &k_scales, &k_norms, &k_rotors, &v_codes, &v_scales, &v_norms, &v_rotors,
+    ] {
+        arr.eval()?;
+    }
+    if has_mask == 1 {
+        mask_flat.eval()?;
+    }
+    scale_arr.eval()?;
+    dims_arr.eval()?;
+
+    // ── P1 dispatch ───────────────────────────────────────────────────────
+    let kern_p1 = p1_kernel(BITS)?;
+    let mut inv_p1 = MetalKernelInvoke::new();
+    inv_p1.add_input(&q_f32)?;
+    inv_p1.add_input(&k_codes)?;
+    inv_p1.add_input(&k_scales)?;
+    inv_p1.add_input(&k_norms)?;
+    inv_p1.add_input(&k_rotors)?;
+    inv_p1.add_input(&v_codes)?;
+    inv_p1.add_input(&v_scales)?;
+    inv_p1.add_input(&v_norms)?;
+    inv_p1.add_input(&v_rotors)?;
+    inv_p1.add_input(&mask_flat)?;
+    inv_p1.add_input(&scale_arr)?;
+    inv_p1.add_input(&dims_arr)?;
+
+    let partial_o_len: i64 = i64::from(n_tiles) * i64::from(n_bh) * i64::from(head_dim);
+    let tile_meta_len: i64 = i64::from(n_tiles) * i64::from(n_bh);
+    if partial_o_len > i64::from(i32::MAX) {
+        return Err(Error::Quant(format!(
+            "rotor_flash_decode_symv: partial_o length {partial_o_len} exceeds i32::MAX"
+        )));
+    }
+    inv_p1.add_output_shape(&[partial_o_len as i32], Dtype::F32)?;
+    inv_p1.add_output_shape(&[tile_meta_len as i32], Dtype::F32)?;
+    inv_p1.add_output_shape(&[tile_meta_len as i32], Dtype::F32)?;
+
+    // Grid X: n_tiles threadgroups × head_dim threads each.
+    let grid_x: i64 = i64::from(n_tiles) * i64::from(head_dim);
+    let grid_y: i64 = i64::from(n_bh);
+    if grid_x > i64::from(i32::MAX) || grid_y > i64::from(i32::MAX) {
+        return Err(Error::Quant(format!(
+            "rotor_flash_decode_symv: grid dimensions exceed i32::MAX (x={grid_x}, y={grid_y})"
+        )));
+    }
+    inv_p1.set_grid(grid_x as i32, grid_y as i32, 1)?;
+    inv_p1.set_thread_group(head_dim, 1, 1)?;
+
+    // Counter increment at the actual P1 enqueue point — after every
+    // validation gate, immediately before `.apply()`.
+    if BITS == 3 {
+        ROTOR3_SYMV_FLASH_DECODE_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+    } else {
+        ROTOR4_SYMV_FLASH_DECODE_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+    }
+    tracing::trace!(
+        bits = BITS,
+        b,
+        n_q_heads,
+        kv_h,
+        kv_seq,
+        head_dim,
+        has_mask,
+        n_groups,
+        n_tiles,
+        "rotor_flash_decode_symv_sdpa: dispatch"
+    );
+
+    let mut p1_outs = kern_p1.apply(inv_p1, device)?;
+    if p1_outs.len() < 3 {
+        return Err(Error::Mlx(
+            "rotor_flash_decode_symv P1: expected 3 outputs".into(),
+        ));
+    }
+    let partial_o = p1_outs.remove(0);
+    let tile_max = p1_outs.remove(0);
+    let tile_sum_exp = p1_outs.remove(0);
+
+    // ── P2 dispatch ───────────────────────────────────────────────────────
+    let dims_p2_arr = {
+        let dims_p2: [u32; 3] = [head_dim as u32, n_tiles as u32, n_bh as u32];
+        // SAFETY: same reasoning as the `dims` cast above — stack-local
+        // `[u32; 3]`, `u32` alignment ≥ `u8`, byte length `3 * 4` equals
+        // `size_of::<[u32; 3]>()`, and `Array::from_bytes` copies before the
+        // borrow ends.
+        let bytes: &[u8] =
+            unsafe { std::slice::from_raw_parts(dims_p2.as_ptr().cast::<u8>(), 3 * 4) };
+        Array::from_bytes(bytes, &[3], Dtype::U32)
+            .map_err(|e| Error::Mlx(format!("rotor_flash_decode_symv dims_p2: {e}")))?
+    };
+
+    let kern_p2 = p2_kernel()?;
+    let mut inv_p2 = MetalKernelInvoke::new();
+    inv_p2.add_input(&partial_o)?;
+    inv_p2.add_input(&tile_max)?;
+    inv_p2.add_input(&tile_sum_exp)?;
+    inv_p2.add_input(&dims_p2_arr)?;
+
+    let dst_len: i64 = i64::from(n_bh) * i64::from(head_dim);
+    inv_p2.add_output_shape(&[dst_len as i32], Dtype::F32)?;
+
+    let p2_grid_x: i64 = i64::from(n_bh) * i64::from(head_dim);
+    if p2_grid_x > i64::from(i32::MAX) {
+        return Err(Error::Quant(format!(
+            "rotor_flash_decode_symv P2: grid x {p2_grid_x} exceeds i32::MAX"
+        )));
+    }
+    inv_p2.set_grid(p2_grid_x as i32, 1, 1)?;
+    inv_p2.set_thread_group(head_dim, 1, 1)?;
+
+    let mut p2_outs = kern_p2.apply(inv_p2, device)?;
+    if p2_outs.is_empty() {
+        return Err(Error::Mlx(
+            "rotor_flash_decode_symv P2: expected 1 output".into(),
+        ));
+    }
+    let dst_flat = p2_outs.remove(0);
+
+    // Reshape to canonical SDPA output.
+    dst_flat.reshape(&[b, n_q_heads, 1, head_dim], device)
+}
+
+#[cfg(test)]
+#[path = "rotor_flash_decode_symv_msl_tests.rs"]
+mod rotor_flash_decode_symv_msl_tests;

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl_tests.rs
@@ -1,0 +1,569 @@
+//! GPU parity tests for the rotor symmetric (quant-K + quant-V) flash-decode
+//! kernel (BITS in {3, 4}).
+//!
+//! The oracle is the codec's own CPU dequant
+//! ([`crate::rotorquant::rotor3_decode`] / [`rotor4_decode`]) applied to **both**
+//! axes and fed through a scalar reference attention chain. Decoding V with the
+//! codec's own reference — rather than comparing against the bf16 mirror this
+//! kernel deletes — is the point: it proves the in-kernel V unpack reproduces
+//! the codec, not that it agrees with a buffer that no longer exists.
+
+use super::*;
+use crate::clifford::make_rotor_table;
+use crate::rotor_flash_decode_msl::build_rotor_flash_header;
+use crate::rotorquant::{rotor3_decode, rotor3_encode, rotor4_decode, rotor4_encode};
+use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
+use rmlx_mlx::{Array, Device, Dtype};
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn make_f32_array(data: &[f32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::F32).expect("make_f32_array")
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn make_u32_array(data: &[u32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|w| w.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::U32).expect("make_u32_array")
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: chunks_exact(4) guarantees length"
+)]
+fn array_to_f32(a: &Array) -> Vec<f32> {
+    a.eval().expect("array eval");
+    let bytes = a.to_bytes().expect("to_bytes");
+    bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
+        .collect()
+}
+
+/// Scalar reference attention over already-dequantized K **and** V.
+///
+/// Both `k_deq` and `v_deq` are sequence-major (`[(s * kv_h + h), head_dim]`) —
+/// the layout both rotor rings accumulate and the kernel reads. This is the
+/// difference from the bf16-V sibling's reference, whose V was head-major.
+#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "test reference: all indices derived from the shape params under test"
+)]
+fn ref_attention_quant_v(
+    q: &[f32],
+    k_deq: &[f32],
+    v_deq: &[f32],
+    mask: Option<&[f32]>,
+    n_q_heads: usize,
+    kv_h: usize,
+    kv_seq: usize,
+    head_dim: usize,
+    scale: f32,
+) -> Vec<f32> {
+    let heads_per_kv = n_q_heads / kv_h;
+    let mut out = vec![0.0_f32; n_q_heads * head_dim];
+    for hq in 0..n_q_heads {
+        let h = hq / heads_per_kv;
+
+        // Scores over the whole prefix.
+        let mut scores = vec![0.0_f32; kv_seq];
+        for (s, score) in scores.iter_mut().enumerate() {
+            let k_row = (s * kv_h + h) * head_dim;
+            let mut acc = 0.0_f32;
+            for d in 0..head_dim {
+                acc += q[hq * head_dim + d] * k_deq[k_row + d];
+            }
+            *score = acc * scale;
+        }
+        if let Some(m) = mask {
+            // Additive mask, laid out [b, n_q_heads, 1, kv_seq] with b == 1.
+            for (s, score) in scores.iter_mut().enumerate() {
+                *score += m[hq * kv_seq + s];
+            }
+        }
+
+        // Softmax (max-subtracted, matching the kernel's online form).
+        let mut m = f32::NEG_INFINITY;
+        for &s in &scores {
+            if s > m {
+                m = s;
+            }
+        }
+        let mut denom = 0.0_f32;
+        for s in &mut scores {
+            *s = (*s - m).exp();
+            denom += *s;
+        }
+
+        // Weighted V sum — V read sequence-major, same as K.
+        for d in 0..head_dim {
+            let mut acc = 0.0_f32;
+            for (s, &p) in scores.iter().enumerate() {
+                acc += p * v_deq[(s * kv_h + h) * head_dim + d];
+            }
+            out[hq * head_dim + d] = acc / denom;
+        }
+    }
+    out
+}
+
+/// One axis's packed rotor buffers plus the matching CPU dequant oracle.
+struct EncodedAxis {
+    codes: Array,
+    scales: Array,
+    norms: Array,
+    rotors: Array,
+    dequant: Vec<f32>,
+}
+
+impl EncodedAxis {
+    fn as_packed(&self) -> RotorPackedAxis<'_> {
+        RotorPackedAxis {
+            codes: &self.codes,
+            scales: &self.scales,
+            norms: &self.norms,
+            rotors: &self.rotors,
+        }
+    }
+}
+
+/// Encode `seq_major` with the rotor codec on CPU and return the GPU-resident
+/// packed buffers plus the CPU dequant oracle.
+///
+/// `layer_idx` seeds the rotor table: the K and V stores of a real cache each
+/// build their own, so the tests feed distinct tables to prove the kernel reads
+/// each axis against its own rotors rather than reusing K's for V.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn rotor_encode_axis(seq_major: &[f32], head_dim: usize, bits: u8, layer_idx: u32) -> EncodedAxis {
+    let n_groups = n_groups_for(head_dim);
+    let rotors = make_rotor_table(layer_idx, 0, n_groups);
+
+    let (codes, scales, norms) = if bits == 3 {
+        rotor3_encode(seq_major, &rotors, head_dim).expect("rotor3_encode")
+    } else {
+        rotor4_encode(seq_major, &rotors, head_dim).expect("rotor4_encode")
+    };
+    let dequant = if bits == 3 {
+        rotor3_decode(&codes, &scales, &norms, &rotors, head_dim).expect("rotor3_decode")
+    } else {
+        rotor4_decode(&codes, &scales, &norms, &rotors, head_dim).expect("rotor4_decode")
+    };
+
+    EncodedAxis {
+        codes: make_u32_array(&codes, &[codes.len() as i32]),
+        scales: make_f32_array(&scales, &[scales.len() as i32]),
+        norms: make_f32_array(&norms, &[norms.len() as i32]),
+        rotors: make_f32_array(&rotors, &[rotors.len() as i32]),
+        dequant,
+    }
+}
+
+/// Run the kernel against the CPU-dequant oracle for one shape, with no mask.
+fn run_oracle(bits: u8, kv_h: usize, heads_per_kv: usize, kv_seq: usize, head_dim: usize) -> bool {
+    run_oracle_masked(bits, kv_h, heads_per_kv, kv_seq, head_dim, false)
+}
+
+/// Run the kernel against the CPU-dequant oracle for one shape.
+///
+/// When `with_mask`, feeds a per-(q_head, key) additive mask with a distinct
+/// value in every cell, so a transposed or mis-strided mask index in either the
+/// kernel or the dispatcher changes the result instead of cancelling out.
+///
+/// Returns `false` when the GPU is unavailable so the caller can skip.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+#[allow(clippy::too_many_arguments)]
+fn run_oracle_masked(
+    bits: u8,
+    kv_h: usize,
+    heads_per_kv: usize,
+    kv_seq: usize,
+    head_dim: usize,
+    with_mask: bool,
+) -> bool {
+    if skip_if_no_gpu_env() {
+        return false;
+    }
+    let b = 1_usize;
+    let n_q_heads = kv_h * heads_per_kv;
+    let n_tokens = kv_seq * kv_h;
+
+    let q = lcg_data(n_q_heads * head_dim, 0xA11CE);
+    // K and V are both generated in the stores' sequence-major order: token
+    // (s, h) at row (s * kv_h + h). Different seeds so a K/V buffer swap in the
+    // dispatcher cannot pass.
+    let k = lcg_data(n_tokens * head_dim, 0xB0B);
+    let v = lcg_data(n_tokens * head_dim, 0xC0FFEE);
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    // Distinct layer_idx per axis => distinct rotor tables, as a real cache has.
+    let k_axis = rotor_encode_axis(&k, head_dim, bits, 0);
+    let v_axis = rotor_encode_axis(&v, head_dim, bits, 1);
+    let q_arr = make_f32_array(&q, &[b as i32, n_q_heads as i32, 1, head_dim as i32]);
+
+    // Asymmetric in both axes and never zero, so a (hq, s) index swap or a wrong
+    // stride shifts the scores rather than landing on an equal value. Includes a
+    // -inf-ish cell to exercise full suppression through the online softmax.
+    let mask_vec: Option<Vec<f32>> = with_mask.then(|| {
+        (0..n_q_heads * kv_seq)
+            .map(|i| {
+                let hq = i / kv_seq;
+                let s = i % kv_seq;
+                if hq == 0 && s == kv_seq / 2 {
+                    -1.0e30
+                } else {
+                    (hq as f32) * 0.25 - (s as f32) * 0.03125
+                }
+            })
+            .collect()
+    });
+    let mask_arr = mask_vec
+        .as_ref()
+        .map(|m| make_f32_array(m, &[b as i32, n_q_heads as i32, 1, kv_seq as i32]));
+
+    let shape = RotorFlashShape {
+        b: b as i32,
+        kv_h: kv_h as i32,
+        kv_seq: kv_seq as i32,
+        head_dim: head_dim as i32,
+        heads_per_kv: heads_per_kv as i32,
+    };
+
+    let out = match bits {
+        3 => rotor_flash_decode_symv_sdpa::<3>(
+            &q_arr,
+            k_axis.as_packed(),
+            v_axis.as_packed(),
+            mask_arr.as_ref(),
+            shape,
+            scale,
+            Device::Gpu,
+        ),
+        _ => rotor_flash_decode_symv_sdpa::<4>(
+            &q_arr,
+            k_axis.as_packed(),
+            v_axis.as_packed(),
+            mask_arr.as_ref(),
+            shape,
+            scale,
+            Device::Gpu,
+        ),
+    }
+    .expect("rotor_flash_decode_symv_sdpa");
+
+    let got = array_to_f32(&out);
+    let want = ref_attention_quant_v(
+        &q,
+        &k_axis.dequant,
+        &v_axis.dequant,
+        mask_vec.as_deref(),
+        n_q_heads,
+        kv_h,
+        kv_seq,
+        head_dim,
+        scale,
+    );
+
+    assert_eq!(got.len(), want.len(), "bits={bits}: output length");
+    let mut max_err = 0.0_f32;
+    for (g, w) in got.iter().zip(want.iter()) {
+        max_err = max_err.max((g - w).abs());
+    }
+    // bf16 has ~8 mantissa bits (~3e-3 relative). The kernel accumulates in
+    // f32 but is fed the same quantized codes as the oracle, so the only
+    // divergence is summation order; this bound is well inside bf16 tolerance.
+    assert!(
+        max_err < 2e-3,
+        "bits={bits} kv_h={kv_h} hpk={heads_per_kv} S={kv_seq} D={head_dim}: \
+         max_err={max_err} exceeds bf16 tolerance"
+    );
+    true
+}
+
+// ── Oracle: kernel == CPU dequant reference on BOTH axes ──────────────────────
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor3_symv_flash_decode_matches_cpu_dequant_reference() {
+    // Bonsai / Qwen3 shape: head_dim 128, GQA 4:1.
+    run_oracle(3, 2, 4, 40, 128);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor4_symv_flash_decode_matches_cpu_dequant_reference() {
+    run_oracle(4, 2, 4, 40, 128);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor3_symv_flash_decode_matches_reference_across_tiles() {
+    // kv_seq is set above TILE_SIZE so the P2 log-sum-exp merge runs over
+    // several tiles rather than a single one.
+    run_oracle(3, 1, 8, (TILE_SIZE as usize) * 2 + 22, 128);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor4_symv_flash_decode_matches_reference_across_tiles() {
+    run_oracle(4, 1, 8, (TILE_SIZE as usize) * 2 + 22, 128);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor3_symv_flash_decode_matches_reference_head_dim_512() {
+    // Gemma4 e2b/e4b global layers run head_dim = 512 with a single KV head.
+    // head_dim % 3 != 0, so the last rotor group is tail-padded.
+    run_oracle(3, 1, 8, 70, 512);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor4_symv_flash_decode_matches_reference_head_dim_512() {
+    run_oracle(4, 1, 8, 70, 512);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor3_symv_flash_decode_matches_reference_head_dim_256() {
+    run_oracle(3, 1, 4, 70, 256);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor4_symv_flash_decode_matches_reference_head_dim_64() {
+    // Smallest production-plausible head_dim; head_dim % 3 != 0 again, and a
+    // single rotor-group tail lane.
+    run_oracle(4, 2, 2, 40, 64);
+}
+
+// ── Additive mask + GQA ───────────────────────────────────────────────────────
+//
+// Without these the kernel's mask read
+// (`mask_flat[(b * n_q_heads + hq) * kv_seq + t]`) and the dispatcher's mask
+// flatten are never executed — every other test passes `None`, so a transposed
+// or mis-strided mask index would pass the whole suite.
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor3_symv_flash_decode_matches_reference_with_additive_mask() {
+    // kv_h=2, heads_per_kv=4 also pins the GQA (q_head -> kv_head) mapping: the
+    // mask is indexed by q_head while K/V are indexed by kv_head, so conflating
+    // the two shows up here.
+    run_oracle_masked(3, 2, 4, 40, 128, true);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor4_symv_flash_decode_matches_reference_with_additive_mask() {
+    run_oracle_masked(4, 2, 4, 40, 128, true);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor3_symv_flash_decode_matches_reference_with_mask_across_tiles() {
+    // Mask + multi-tile: the per-tile online softmax and the P2 merge both have
+    // to see the masked scores.
+    run_oracle_masked(3, 2, 4, (TILE_SIZE as usize) * 2 + 22, 128, true);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor4_symv_flash_decode_matches_reference_with_mask_high_gqa() {
+    // kv_h=2, heads_per_kv=8: a wider GQA fan-out than the shapes above, so a
+    // `hq / heads_per_kv` vs `hq % kv_h` mix-up in the kv-head mapping lands on
+    // a different KV row and fails here.
+    run_oracle_masked(4, 2, 8, 40, 128, true);
+}
+
+// ── Gates ─────────────────────────────────────────────────────────────────────
+//
+// Every gate below is a refusal, not a fallback: an unsupported shape or bit
+// width must error rather than decode against another codec's kernel.
+
+/// A one-element dummy axis for the shape-rejection gates, which reject before
+/// any buffer is read. Borrows the caller's locals — the gates never look at
+/// the contents, only at the shape metadata.
+fn dummy_axis<'a>(codes: &'a Array, f: &'a Array) -> RotorPackedAxis<'a> {
+    RotorPackedAxis {
+        codes,
+        scales: f,
+        norms: f,
+        rotors: f,
+    }
+}
+
+#[test]
+fn rotor_symv_flash_decode_rejects_non_pow2_head_dim() {
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    let axis = dummy_axis(&codes, &dummy);
+    let err = rotor_flash_decode_symv_sdpa::<3>(
+        &dummy,
+        axis,
+        axis,
+        None,
+        RotorFlashShape {
+            b: 1,
+            kv_h: 1,
+            kv_seq: 8,
+            head_dim: 96,
+            heads_per_kv: 1,
+        },
+        1.0,
+        Device::Cpu,
+    );
+    assert!(
+        err.is_err(),
+        "head_dim=96 is not a power of two — the tree reduction requires one"
+    );
+}
+
+#[test]
+fn rotor_symv_flash_decode_rejects_head_dim_above_max() {
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    let axis = dummy_axis(&codes, &dummy);
+    let over = ROTOR_FLASH_HEAD_DIM_MAX * 2;
+    let err = rotor_flash_decode_symv_sdpa::<3>(
+        &dummy,
+        axis,
+        axis,
+        None,
+        RotorFlashShape {
+            b: 1,
+            kv_h: 1,
+            kv_seq: 8,
+            head_dim: over,
+            heads_per_kv: 1,
+        },
+        1.0,
+        Device::Cpu,
+    );
+    assert!(
+        err.is_err(),
+        "head_dim={over} exceeds the static threadgroup-array ceiling"
+    );
+}
+
+#[test]
+fn rotor_symv_flash_decode_rejects_unsupported_bits() {
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    let axis = dummy_axis(&codes, &dummy);
+    // An unknown bit width must be an explicit error, never a silent fallback
+    // to a kernel built for a different unpack width.
+    let err = rotor_flash_decode_symv_sdpa::<5>(
+        &dummy,
+        axis,
+        axis,
+        None,
+        RotorFlashShape {
+            b: 1,
+            kv_h: 1,
+            kv_seq: 8,
+            head_dim: 128,
+            heads_per_kv: 1,
+        },
+        1.0,
+        Device::Cpu,
+    );
+    assert!(err.is_err(), "BITS=5 must be rejected");
+}
+
+#[test]
+fn rotor_symv_flash_decode_rejects_non_positive_shapes() {
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    let axis = dummy_axis(&codes, &dummy);
+    for (b, kv_h, kv_seq, heads_per_kv) in [(0, 1, 8, 1), (1, 0, 8, 1), (1, 1, 0, 1), (1, 1, 8, 0)]
+    {
+        let err = rotor_flash_decode_symv_sdpa::<3>(
+            &dummy,
+            axis,
+            axis,
+            None,
+            RotorFlashShape {
+                b,
+                kv_h,
+                kv_seq,
+                head_dim: 128,
+                heads_per_kv,
+            },
+            1.0,
+            Device::Cpu,
+        );
+        assert!(
+            err.is_err(),
+            "b={b} kv_h={kv_h} kv_seq={kv_seq} heads_per_kv={heads_per_kv} must be rejected"
+        );
+    }
+}
+
+// ── Header reuse ──────────────────────────────────────────────────────────────
+
+#[test]
+fn symv_kernel_reuses_the_shared_rotor_decode_fn() {
+    #[allow(
+        clippy::unwrap_used,
+        reason = "bits 3 is a supported width; a failure here is the assertion"
+    )]
+    let h = build_rotor_flash_header(3).unwrap();
+    // This kernel's whole design rests on calling the sibling's rotor block
+    // decode unchanged, for both axes — one decode per Cl(3,0) block, the shell's
+    // one-decode-per-group form. If the header stops exposing it as a function,
+    // the body stops compiling — pin the contract here so the reason is legible
+    // rather than an MSL build error at first dispatch.
+    assert!(
+        h.contains("inline void rf_decode_k_group("),
+        "header must expose the shared per-block rotor decode as a function"
+    );
+    // Both axes are unpacked by the same body, so the body must call it twice —
+    // once per axis. A single call would mean one axis is being read some other
+    // way (or not at all).
+    let body = include_str!("metal/rotor_flash_decode_symv_p1.metal");
+    assert_eq!(
+        body.matches("rf_decode_k_group(").count(),
+        2,
+        "symv body must decode exactly two axes through the shared block decode"
+    );
+    assert!(
+        body.contains("rf_decode_k_group(k_codes, k_scales, k_norms, k_rotors,"),
+        "K axis must be read from the K ring"
+    );
+    assert!(
+        body.contains("rf_decode_k_group(v_codes, v_scales, v_norms, v_rotors,"),
+        "V axis must be read from the V ring, with the V store's own rotor table"
+    );
+}
+
+// ── Dispatch counter ──────────────────────────────────────────────────────────
+
+// The counter is process-global and `cargo test` runs this binary's tests on
+// parallel threads, so only a **relative** delta around a known dispatch is
+// assertable here — a concurrent test can inflate it at any time. An absolute
+// "starts at zero" check would be a flake, and the negative case ("did not
+// fire") is asserted on cache-local state in
+// `kvcache::rotor_flash_dispatch_tests` instead.
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test rotor_flash_decode_symv -- --ignored --test-threads=1"]
+fn rotor_symv_flash_decode_dispatch_count_increments_on_gpu() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let before3 = rotor3_symv_flash_decode_dispatch_count();
+    let before4 = rotor4_symv_flash_decode_dispatch_count();
+    assert!(run_oracle(3, 1, 2, 8, 128));
+    assert!(run_oracle(4, 1, 2, 8, 128));
+    assert!(
+        rotor3_symv_flash_decode_dispatch_count() > before3,
+        "rotor3 symv flash-decode kernel did not fire"
+    );
+    assert!(
+        rotor4_symv_flash_decode_dispatch_count() > before4,
+        "rotor4 symv flash-decode kernel did not fire"
+    );
+}

--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -74,6 +74,7 @@ pub use quant_planar_v::QuantPlanarV;
 pub(crate) use quant_rotor_k3::synced_rotor_k_blocks;
 pub use quant_rotor_k3::{QuantRotorK3, RotorKBlocks, ROTOR3_K_BITS, ROTOR3_K_GROUP_SIZE};
 pub use quant_rotor_k4::{QuantRotorK4, ROTOR4_K_BITS, ROTOR4_K_GROUP_SIZE};
+pub(crate) use quant_rotor_v3::synced_rotor_v_blocks;
 pub use quant_rotor_v3::{QuantRotorV3, RotorBlocks, ROTOR3_V_BITS, ROTOR3_V_GROUP_SIZE};
 pub use quant_rotor_v4::{QuantRotorV4, ROTOR4_V_BITS, ROTOR4_V_GROUP_SIZE};
 pub use quant_v::QuantV;

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
@@ -11,12 +11,15 @@
 )]
 //! Quantized V buffer: `QuantRotorV3` (rotor3 V codec).
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
+use rmlx_mlx::{Array, Device};
 
 use crate::clifford::make_rotor_table;
 use crate::rotorquant::{
     n_groups_for, rotor3_decode, rotor3_encode, RotorQuantError, ROTOR3_BITS, ROTOR3_GROUP_SIZE,
 };
+
+use super::QuantKGpuRing;
 
 /// Bit-width of the rotor3 V codec (fixed at 3-bit — see
 /// [`crate::rotorquant::rotor3_encode`]).
@@ -72,14 +75,24 @@ impl RotorBlocks {
 ///   * `blocks` — per-append payload (`RotorBlocks`).
 ///   * `shape` — accumulated `[B, kv_h, S_total, D]`.
 ///
-/// CPU-only. SDPA falls through to the dequant-then-SDPA legacy fallback path
-/// (same as iso3 and iso4). The MSL kernel is deferred — see
-/// [`crate::rotorquant`] module docs.
+/// Carries both forms of the payload:
+///
+/// * `blocks` — CPU `RotorBlocks`, the source of truth for `dequant()` and the
+///   SSD spill/hydrate round-trip.
+/// * `gpu` — the optional GPU-resident packed ring ([`QuantKGpuRing`]),
+///   populated by `gpu_append`. When present it lets a fused flash-decode kernel
+///   read the V quant store directly instead of attending a bf16 mirror of V.
+///
+/// The ring type is named for the K side it landed with, but its payload
+/// (codes / per-group scales / per-token L2 norms) is exactly the rotor codec's
+/// own — the codec is axis-agnostic, so the V side reuses it verbatim.
 pub struct QuantRotorV3 {
     /// Static rotor table for this layer/head, flat `[n_groups * 4]` f32 in
     /// `[s, b12, b13, b23]` per-rotor order. Initialised lazily on first
     /// `append`; never replaced.
     pub rotors: Vec<f32>,
+    /// GPU-resident packed ring. Empty until the first `gpu_append`.
+    pub gpu: QuantKGpuRing,
     /// Accumulated per-token blocks (one entry per append call; `dequant`
     /// flattens them).
     pub blocks: Vec<RotorBlocks>,
@@ -101,6 +114,7 @@ impl std::fmt::Debug for QuantRotorV3 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QuantRotorV3")
             .field("n_rotors", &(self.rotors.len() / 4))
+            .field("gpu_resident", &self.gpu.is_allocated())
             .field("n_blocks", &self.blocks.len())
             .field("shape", &self.shape)
             .field("max_seq", &self.max_seq)
@@ -122,6 +136,7 @@ impl QuantRotorV3 {
     pub fn new(init_shape: Vec<i32>, max_seq: i32, layer_idx: u32) -> Self {
         Self {
             rotors: Vec::new(),
+            gpu: QuantKGpuRing::default(),
             blocks: Vec::new(),
             shape: init_shape,
             max_seq,
@@ -142,6 +157,7 @@ impl QuantRotorV3 {
     ) -> Self {
         Self {
             rotors,
+            gpu: QuantKGpuRing::default(),
             blocks: Vec::new(),
             shape: init_shape,
             max_seq,
@@ -166,6 +182,9 @@ impl QuantRotorV3 {
         let max_seq = if shape.len() >= 3 { shape[2] } else { 0 };
         Self {
             rotors,
+            // Hydrated caches start CPU-only; the ring is rebuilt lazily from
+            // the next GPU append.
+            gpu: QuantKGpuRing::default(),
             blocks,
             shape,
             max_seq,
@@ -186,7 +205,7 @@ impl QuantRotorV3 {
     /// Forwards any [`RotorQuantError`] from [`rotor3_encode`].
     pub fn append(&mut self, f32_data: &[f32], new_shape: &[i32]) -> Result<()> {
         if new_shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantRotorV3::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
@@ -210,10 +229,8 @@ impl QuantRotorV3 {
         let seq_major =
             super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
 
-        let (codes, scales, norms) =
-            rotor3_encode(&seq_major, &self.rotors, head_dim).map_err(|e: RotorQuantError| {
-                rmlx_core::error::Error::Mlx(format!("rotor3 encode: {e}"))
-            })?;
+        let (codes, scales, norms) = rotor3_encode(&seq_major, &self.rotors, head_dim)
+            .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor3 encode: {e}")))?;
 
         self.blocks.push(RotorBlocks {
             codes,
@@ -221,6 +238,10 @@ impl QuantRotorV3 {
             norms,
             n_tokens: n_tokens_total,
         });
+
+        // A CPU append does not touch the GPU ring, so any live ring is now a
+        // stale prefix. Drop it; the next `gpu_append` re-seeds from `blocks`.
+        self.gpu.clear();
 
         if self.shape.len() != 4 || self.shape[0] == 0 {
             self.shape = new_shape.to_vec();
@@ -234,6 +255,7 @@ impl QuantRotorV3 {
     /// Does **not** touch the rotor table — that is layer-static.
     pub fn reset(&mut self) {
         self.blocks.clear();
+        self.gpu.clear();
         if self.shape.len() >= 4 {
             self.shape[2] = 0;
         }
@@ -256,6 +278,9 @@ impl QuantRotorV3 {
             }
         }
         self.blocks.truncate(keep);
+        // The ring's filled prefix no longer matches `blocks`; drop it rather
+        // than leave a longer-than-truncated prefix live.
+        self.gpu.clear();
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }
@@ -270,6 +295,11 @@ impl QuantRotorV3 {
     pub fn try_deep_clone(&self) -> Result<Self> {
         Ok(Self {
             rotors: self.rotors.clone(),
+            // The clone starts CPU-only: `blocks` carries the full payload, so
+            // the ring re-seeds from them on the clone's first GPU append.
+            // Sharing the source's Arrays would alias one ring across two
+            // independent caches.
+            gpu: QuantKGpuRing::default(),
             blocks: self.blocks.clone(),
             shape: self.shape.clone(),
             max_seq: self.max_seq,
@@ -279,10 +309,99 @@ impl QuantRotorV3 {
         })
     }
 
+    /// Concatenate the accumulated CPU blocks into flat sequence-major
+    /// `(codes, scales, norms)` — the form [`QuantKGpuRing::seed_from_cpu`]
+    /// wants.
+    fn flatten_blocks(&self) -> (Vec<u32>, Vec<f32>, Vec<f32>) {
+        // Exact capacities — the prefill seed concatenates the whole prefix
+        // (millions of entries at long context), so growing from empty would
+        // realloc+memcpy repeatedly.
+        let (n_codes, n_scales, n_norms) = self.blocks.iter().fold((0, 0, 0), |(c, s, n), blk| {
+            (
+                c + blk.codes.len(),
+                s + blk.scales.len(),
+                n + blk.norms.len(),
+            )
+        });
+        let mut codes = Vec::with_capacity(n_codes);
+        let mut scales = Vec::with_capacity(n_scales);
+        let mut norms = Vec::with_capacity(n_norms);
+        for blk in &self.blocks {
+            codes.extend_from_slice(&blk.codes);
+            scales.extend_from_slice(&blk.scales);
+            norms.extend_from_slice(&blk.norms);
+        }
+        (codes, scales, norms)
+    }
+
+    /// Push one GPU-encoded chunk into the GPU ring, seeding the ring from the
+    /// accumulated CPU blocks first when it is not yet live.
+    ///
+    /// `codes` / `scales` / `norms` are the rotor encode kernel's GPU outputs
+    /// for a sequence-major chunk; `prev_seq` is the accumulated sequence length
+    /// **before** this chunk.
+    ///
+    /// This only maintains the ring — the caller still pushes the matching CPU
+    /// block, which stays the source of truth for `dequant()` and SSD spill.
+    ///
+    /// `max_seq` is the window the cache is provisioned for **right now**, read
+    /// from the active `KvStorage` variant by the caller. It is a parameter
+    /// rather than the `self.max_seq` field so it cannot go stale as the window
+    /// grows during decode — the same contract the K-side ring uses.
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`QuantKGpuRing::seed_from_cpu`] / [`QuantKGpuRing::append_encoded`]
+    /// errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gpu_append(
+        &mut self,
+        codes: &Array,
+        scales: &Array,
+        norms: &Array,
+        kv_h: i32,
+        head_dim: i32,
+        prev_seq: i32,
+        new_seq: i32,
+        max_seq: i32,
+        device: Device,
+    ) -> Result<()> {
+        // The ring is codec-agnostic and takes `n_groups`; the rotor group rule
+        // stays here, in the codec's own store.
+        let n_groups = i32::try_from(n_groups_for(usize::try_from(head_dim.max(0)).unwrap_or(0)))
+            .map_err(|_| {
+            Error::Quant(format!(
+                "QuantRotorV3::gpu_append: n_groups for head_dim={head_dim} exceeds i32::MAX"
+            ))
+        })?;
+        if !self.gpu.is_allocated() && prev_seq > 0 {
+            let (c, s, n) = self.flatten_blocks();
+            self.gpu
+                .seed_from_cpu(&c, &s, &n, kv_h, n_groups, prev_seq, max_seq, device)?;
+        }
+        self.gpu.append_encoded(
+            codes, scales, norms, kv_h, n_groups, prev_seq, new_seq, max_seq, device,
+        )
+    }
+
+    /// GPU packed view of the first `kv_seq` positions, or `None` when the ring
+    /// is not live (CPU path — caller falls back to `dequant`).
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`QuantKGpuRing::packed_view`] errors.
+    pub fn gpu_packed_view(
+        &self,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Option<(Array, Array, Array)>> {
+        self.gpu.packed_view(kv_seq, device)
+    }
+
     /// Resident bytes held by this store.
     ///
     /// Counts the rotor table **once** (it is layer-static) plus all
-    /// accumulated per-token block buffers.
+    /// accumulated per-token block buffers and the GPU ring when live.
     ///
     /// The exhaustive destructure is the drift guard: a new buffer cannot be
     /// added to this struct without this failing to compile.
@@ -290,6 +409,7 @@ impl QuantRotorV3 {
     pub fn byte_size(&self) -> u64 {
         let Self {
             rotors,
+            gpu,
             blocks,
             // Geometry / tags, not allocations.
             shape: _,
@@ -298,7 +418,9 @@ impl QuantRotorV3 {
             head_idx: _,
             bits: _,
         } = self;
-        crate::bytes::vec_bytes(rotors) + blocks.iter().map(RotorBlocks::byte_size).sum::<u64>()
+        crate::bytes::vec_bytes(rotors)
+            + blocks.iter().map(RotorBlocks::byte_size).sum::<u64>()
+            + gpu.byte_size()
     }
 
     /// Dequantize all accumulated V slices into one flat f32 vector of length
@@ -310,7 +432,7 @@ impl QuantRotorV3 {
     /// any block, or if `rotors` is empty (no append happened yet).
     pub fn dequant(&self) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantRotorV3::dequant: malformed shape {:?}",
                 self.shape
             )));
@@ -326,16 +448,14 @@ impl QuantRotorV3 {
         }
 
         if self.rotors.is_empty() {
-            return Err(rmlx_core::error::Error::Mlx(
+            return Err(Error::Mlx(
                 "QuantRotorV3::dequant: rotor table is empty but blocks were appended".into(),
             ));
         }
 
         for blk in &self.blocks {
             let dec = rotor3_decode(&blk.codes, &blk.scales, &blk.norms, &self.rotors, head_dim)
-                .map_err(|e: RotorQuantError| {
-                    rmlx_core::error::Error::Mlx(format!("rotor3 decode: {e}"))
-                })?;
+                .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor3 decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
         if out.len() < total_elems {

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
@@ -265,6 +265,17 @@ impl QuantRotorV3 {
     ///
     /// Drops trailing blocks until the cumulative `n_tokens` count is `<= n`
     /// and lowers `shape[2]` to `n`. Does **not** touch the rotor table.
+    ///
+    /// The GPU ring is **kept**, not cleared — mirror of the K store's
+    /// `truncate_to`. Lowering `shape[2]` to `n` makes the ring's logical fill
+    /// `n`; the stale `[n, prev)` capacity is overwritten by the next append and
+    /// never read (`packed_view` slices to `shape[2]`). This preserves any
+    /// ring-only decode tail up to `n`, so `dequant` / an SSD spill can still
+    /// rebuild it via `synced_rotor_v_blocks`. Clearing the ring here would
+    /// discard the tail (the only copy of `[frozen_prefix, n)`), leaving `blocks`
+    /// short of `shape[2]` with no ring — the divergent state `dequant` rejects
+    /// loudly, which would abort generation on the speculative-decode rollback
+    /// path.
     pub fn truncate_to(&mut self, n: i32) {
         let n_usize = n.max(0) as usize;
         let mut acc: usize = 0;
@@ -278,21 +289,29 @@ impl QuantRotorV3 {
             }
         }
         self.blocks.truncate(keep);
-        // The ring's filled prefix no longer matches `blocks`; drop it rather
-        // than leave a longer-than-truncated prefix live.
-        self.gpu.clear();
+        // NB: no `self.gpu.clear()` — the ring is the source of truth for a
+        // ring-only decode tail; see the doc comment above.
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }
     }
 
-    /// Deep-clone (CPU path is plain `Vec` clones).
+    /// Deep-clone.
+    ///
+    /// Materialises any ring-only decode tail into complete CPU blocks first:
+    /// the clone starts CPU-only (the ring is not cloned), and both the
+    /// prompt-cache snapshot and the SSD spill clone route through here, so this
+    /// is the single point where a store leaving the live decode loop reconciles
+    /// its blocks with the ring. A short-blocks clone with no ring would silently
+    /// truncate the store — refused loudly by `synced_rotor_v_blocks` instead.
     ///
     /// # Errors
     ///
-    /// Currently infallible on the CPU path; returns `Result` for parity with
-    /// the other `Quant*` structs.
+    /// Forwards a [`synced_rotor_v_blocks`] reconciliation error (blocks over-run
+    /// `shape[2]`, or a ring-only tail exists but the ring is absent / too short).
     pub fn try_deep_clone(&self) -> Result<Self> {
+        let blocks =
+            synced_rotor_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?.into_owned();
         Ok(Self {
             rotors: self.rotors.clone(),
             // The clone starts CPU-only: `blocks` carries the full payload, so
@@ -300,7 +319,7 @@ impl QuantRotorV3 {
             // Sharing the source's Arrays would alias one ring across two
             // independent caches.
             gpu: QuantKGpuRing::default(),
-            blocks: self.blocks.clone(),
+            blocks,
             shape: self.shape.clone(),
             max_seq: self.max_seq,
             layer_idx: self.layer_idx,
@@ -428,8 +447,9 @@ impl QuantRotorV3 {
     ///
     /// # Errors
     ///
-    /// Returns an `Error::Mlx` if the underlying [`rotor3_decode`] fails for
-    /// any block, or if `rotors` is empty (no append happened yet).
+    /// Returns an `Error::Mlx` if the underlying [`rotor3_decode`] fails for any
+    /// block, if `rotors` is empty (no append happened yet), or a
+    /// [`synced_rotor_v_blocks`] reconciliation error.
     pub fn dequant(&self) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
             return Err(Error::Mlx(format!(
@@ -441,7 +461,14 @@ impl QuantRotorV3 {
         let total_elems: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out: Vec<f32> = Vec::with_capacity(total_elems);
 
-        if self.blocks.is_empty() {
+        // Reconcile the CPU blocks with the GPU ring: on the fused symmetric
+        // decode path the decode tail lives only in the ring (`blocks` trail
+        // `shape[2]`), and this rebuilds it on demand rather than decoding a
+        // short prefix and zero-padding the gap. Loud on any unrecoverable
+        // disagreement.
+        let blocks = synced_rotor_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?;
+
+        if blocks.is_empty() {
             // No tokens written yet — return zeros padded to the declared shape.
             out.resize(total_elems, 0.0);
             return Ok(out);
@@ -453,15 +480,21 @@ impl QuantRotorV3 {
             ));
         }
 
-        for blk in &self.blocks {
+        for blk in blocks.iter() {
             let dec = rotor3_decode(&blk.codes, &blk.scales, &blk.norms, &self.rotors, head_dim)
                 .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor3 decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
-        if out.len() < total_elems {
-            out.resize(total_elems, 0.0);
-        } else if out.len() > total_elems {
-            out.truncate(total_elems);
+        // `synced_rotor_v_blocks` guarantees the blocks cover `shape[2]`, so a
+        // length mismatch here is an internal invariant break — surface it loudly
+        // rather than zero-padding or truncating a decoded prefix.
+        if out.len() != total_elems {
+            return Err(Error::Mlx(format!(
+                "QuantRotorV3::dequant: decoded {} elems but shape {:?} implies {total_elems} — \
+                 refusing to zero-pad / truncate",
+                out.len(),
+                self.shape
+            )));
         }
         // Blocks are sequence-major (see `append`); reorder back to head-major
         // `[B, kv_h, S, D]`.
@@ -471,6 +504,93 @@ impl QuantRotorV3 {
         let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
         Ok(out)
     }
+}
+
+/// Reconcile a rotor-V store's CPU `blocks` with its GPU ring so the returned
+/// slice covers the full accumulated `shape[2]`.
+///
+/// On the fused symmetric decode path the per-step CPU block download is skipped
+/// — the GPU ring is the source of truth for the decode tail, and `blocks` trail
+/// `shape[2]` (a **ring-only tail**). This rebuilds the missing prefix from the
+/// ring on demand — the single point where a block consumer (`dequant`, or the
+/// SSD spill via `try_deep_clone`) reconciles the two. When `blocks` already
+/// cover `shape[2]` (the CPU append and SSD-hydrate paths, and every V-only
+/// rotor cache, which never feeds the ring) the borrow is returned untouched, so
+/// those paths pay no GPU readback.
+///
+/// **Invariant (enforced loudly, never zero-padded):** `blocks` track the ring
+/// exactly, or the ring exists and supplies the tail. Any state where the CPU
+/// blocks fall short of `shape[2]` and the ring cannot make up the difference is
+/// an `Error` — the caller must not fabricate a zeroed gap.
+///
+/// Shared by [`QuantRotorV3`] and [`super::QuantRotorV4`] (the block payload and
+/// ring layout are identical modulo codes bit-width). Mirror of the K-side
+/// `synced_rotor_k_blocks`.
+///
+/// # Errors
+///
+/// Returns [`rmlx_core::error::Error::Quant`] on a malformed shape, when the
+/// blocks over-run `shape[2]`, or when a ring-only tail exists but the ring is
+/// absent / too short to cover it.
+pub(crate) fn synced_rotor_v_blocks<'a>(
+    blocks: &'a [RotorBlocks],
+    shape: &[i32],
+    gpu: &QuantKGpuRing,
+    device: Device,
+) -> Result<std::borrow::Cow<'a, [RotorBlocks]>> {
+    if shape.len() != 4 {
+        return Err(Error::Quant(format!(
+            "synced_rotor_v_blocks: malformed shape {shape:?}"
+        )));
+    }
+    let b = shape.first().copied().unwrap_or(0).max(0) as usize;
+    let kv_h = shape.get(1).copied().unwrap_or(0).max(0) as usize;
+    let full_seq = shape.get(2).copied().unwrap_or(0).max(0) as usize;
+    let head_dim = shape.get(3).copied().unwrap_or(0).max(0) as usize;
+    let full_tokens = b * kv_h * full_seq;
+    let blocks_tokens: usize = blocks.iter().map(|blk| blk.n_tokens).sum();
+
+    if blocks_tokens == full_tokens {
+        return Ok(std::borrow::Cow::Borrowed(blocks));
+    }
+    if blocks_tokens > full_tokens {
+        return Err(Error::Quant(format!(
+            "rotor V store: CPU blocks hold {blocks_tokens} tokens but shape[2] implies \
+             {full_tokens} — blocks over-run the accumulated shape (internal invariant)"
+        )));
+    }
+
+    // Ring-only tail: the GPU ring must supply the whole prefix. It is
+    // sequence-major and stores per-token norms already, so the readback is one
+    // block covering `[0, full_seq)`. Refuse to fabricate a zeroed gap.
+    let seq_i32 = i32::try_from(full_seq).map_err(|_| {
+        Error::Quant(format!(
+            "rotor V store: shape[2]={full_seq} exceeds i32::MAX"
+        ))
+    })?;
+    let Some((codes, scales, norms)) = gpu.packed_view_cpu(seq_i32, device)? else {
+        return Err(Error::Quant(format!(
+            "rotor V store: CPU blocks cover {blocks_tokens} tokens but shape[2] needs \
+             {full_tokens} and the GPU ring is absent — refusing to zero-pad the decode tail"
+        )));
+    };
+    let n_groups = n_groups_for(head_dim);
+    let want_codes = full_tokens * n_groups;
+    if codes.len() != want_codes || scales.len() != want_codes || norms.len() != full_tokens {
+        return Err(Error::Quant(format!(
+            "rotor V store: ring readback size mismatch (codes {} scales {} norms {}, \
+             want codes/scales {want_codes} norms {full_tokens}) — cannot rebuild blocks",
+            codes.len(),
+            scales.len(),
+            norms.len(),
+        )));
+    }
+    Ok(std::borrow::Cow::Owned(vec![RotorBlocks {
+        codes,
+        scales,
+        norms,
+        n_tokens: full_tokens,
+    }]))
 }
 
 #[cfg(test)]

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
@@ -18,13 +18,16 @@
 )]
 //! Quantized V buffer: `QuantRotorV4` (rotor4 V codec).
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
+use rmlx_mlx::{Array, Device};
 
 use crate::clifford::make_rotor_table;
 use crate::rotorquant::{
     n_groups_for, rotor4_decode, rotor4_encode, RotorQuantError, ROTOR4_BITS, ROTOR4_GROUP_SIZE,
 };
 use crate::storage::quant_rotor_v3::RotorBlocks;
+
+use super::QuantKGpuRing;
 
 /// Bit-width of the rotor4 V codec (fixed at 4-bit — see
 /// [`crate::rotorquant::rotor4_encode`]).
@@ -43,14 +46,16 @@ pub const ROTOR4_V_GROUP_SIZE: usize = ROTOR4_GROUP_SIZE;
 ///   * `blocks` — per-append payload ([`RotorBlocks`]).
 ///   * `shape` — accumulated `[B, kv_h, S_total, D]`.
 ///
-/// CPU-only. SDPA falls through to the dequant-then-SDPA legacy fallback path
-/// (same as rotor3 / iso3 / iso4). The MSL kernel is deferred — see
-/// [`crate::rotorquant`] module docs.
+/// Carries both forms of the payload — CPU `blocks` (source of truth for
+/// `dequant()` and the SSD round-trip) plus the optional GPU-resident packed
+/// ring `gpu`. Mirror of [`super::QuantRotorV3`]; see its docs.
 pub struct QuantRotorV4 {
     /// Static rotor table for this layer/head, flat `[n_groups * 4]` f32 in
     /// `[s, b12, b13, b23]` per-rotor order. Initialised lazily on first
     /// `append`; never replaced.
     pub rotors: Vec<f32>,
+    /// GPU-resident packed ring. Empty until the first `gpu_append`.
+    pub gpu: QuantKGpuRing,
     /// Accumulated per-token blocks (one entry per append call; `dequant`
     /// flattens them). Reuses [`RotorBlocks`] — the struct is bits-agnostic.
     pub blocks: Vec<RotorBlocks>,
@@ -70,6 +75,7 @@ impl std::fmt::Debug for QuantRotorV4 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QuantRotorV4")
             .field("n_rotors", &(self.rotors.len() / 4))
+            .field("gpu_resident", &self.gpu.is_allocated())
             .field("n_blocks", &self.blocks.len())
             .field("shape", &self.shape)
             .field("max_seq", &self.max_seq)
@@ -91,6 +97,7 @@ impl QuantRotorV4 {
     pub fn new(init_shape: Vec<i32>, max_seq: i32, layer_idx: u32) -> Self {
         Self {
             rotors: Vec::new(),
+            gpu: QuantKGpuRing::default(),
             blocks: Vec::new(),
             shape: init_shape,
             max_seq,
@@ -111,6 +118,7 @@ impl QuantRotorV4 {
     ) -> Self {
         Self {
             rotors,
+            gpu: QuantKGpuRing::default(),
             blocks: Vec::new(),
             shape: init_shape,
             max_seq,
@@ -135,6 +143,9 @@ impl QuantRotorV4 {
         let max_seq = if shape.len() >= 3 { shape[2] } else { 0 };
         Self {
             rotors,
+            // Hydrated caches start CPU-only; the ring is rebuilt lazily from
+            // the next GPU append.
+            gpu: QuantKGpuRing::default(),
             blocks,
             shape,
             max_seq,
@@ -155,7 +166,7 @@ impl QuantRotorV4 {
     /// Forwards any [`RotorQuantError`] from [`rotor4_encode`].
     pub fn append(&mut self, f32_data: &[f32], new_shape: &[i32]) -> Result<()> {
         if new_shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantRotorV4::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
@@ -176,10 +187,8 @@ impl QuantRotorV4 {
         let seq_major =
             super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
 
-        let (codes, scales, norms) =
-            rotor4_encode(&seq_major, &self.rotors, head_dim).map_err(|e: RotorQuantError| {
-                rmlx_core::error::Error::Mlx(format!("rotor4 encode: {e}"))
-            })?;
+        let (codes, scales, norms) = rotor4_encode(&seq_major, &self.rotors, head_dim)
+            .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor4 encode: {e}")))?;
 
         self.blocks.push(RotorBlocks {
             codes,
@@ -187,6 +196,10 @@ impl QuantRotorV4 {
             norms,
             n_tokens: n_tokens_total,
         });
+
+        // A CPU append does not touch the GPU ring, so any live ring is now a
+        // stale prefix. Drop it; the next `gpu_append` re-seeds from `blocks`.
+        self.gpu.clear();
 
         if self.shape.len() != 4 || self.shape[0] == 0 {
             self.shape = new_shape.to_vec();
@@ -200,6 +213,7 @@ impl QuantRotorV4 {
     /// Does **not** touch the rotor table — that is layer-static.
     pub fn reset(&mut self) {
         self.blocks.clear();
+        self.gpu.clear();
         if self.shape.len() >= 4 {
             self.shape[2] = 0;
         }
@@ -222,6 +236,9 @@ impl QuantRotorV4 {
             }
         }
         self.blocks.truncate(keep);
+        // The ring's filled prefix no longer matches `blocks`; drop it rather
+        // than leave a longer-than-truncated prefix live.
+        self.gpu.clear();
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }
@@ -236,6 +253,11 @@ impl QuantRotorV4 {
     pub fn try_deep_clone(&self) -> Result<Self> {
         Ok(Self {
             rotors: self.rotors.clone(),
+            // The clone starts CPU-only: `blocks` carries the full payload, so
+            // the ring re-seeds from them on the clone's first GPU append.
+            // Sharing the source's Arrays would alias one ring across two
+            // independent caches.
+            gpu: QuantKGpuRing::default(),
             blocks: self.blocks.clone(),
             shape: self.shape.clone(),
             max_seq: self.max_seq,
@@ -245,10 +267,84 @@ impl QuantRotorV4 {
         })
     }
 
+    /// Concatenate the accumulated CPU blocks into flat sequence-major
+    /// `(codes, scales, norms)` — the form [`QuantKGpuRing::seed_from_cpu`]
+    /// wants.
+    fn flatten_blocks(&self) -> (Vec<u32>, Vec<f32>, Vec<f32>) {
+        let (n_codes, n_scales, n_norms) = self.blocks.iter().fold((0, 0, 0), |(c, s, n), blk| {
+            (
+                c + blk.codes.len(),
+                s + blk.scales.len(),
+                n + blk.norms.len(),
+            )
+        });
+        let mut codes = Vec::with_capacity(n_codes);
+        let mut scales = Vec::with_capacity(n_scales);
+        let mut norms = Vec::with_capacity(n_norms);
+        for blk in &self.blocks {
+            codes.extend_from_slice(&blk.codes);
+            scales.extend_from_slice(&blk.scales);
+            norms.extend_from_slice(&blk.norms);
+        }
+        (codes, scales, norms)
+    }
+
+    /// Push one GPU-encoded chunk into the GPU ring, seeding it from the
+    /// accumulated CPU blocks first when it is not yet live. Mirror of
+    /// [`super::QuantRotorV3::gpu_append`], including the per-call `max_seq`
+    /// window contract.
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`QuantKGpuRing::seed_from_cpu`] / [`QuantKGpuRing::append_encoded`]
+    /// errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gpu_append(
+        &mut self,
+        codes: &Array,
+        scales: &Array,
+        norms: &Array,
+        kv_h: i32,
+        head_dim: i32,
+        prev_seq: i32,
+        new_seq: i32,
+        max_seq: i32,
+        device: Device,
+    ) -> Result<()> {
+        let n_groups = i32::try_from(n_groups_for(usize::try_from(head_dim.max(0)).unwrap_or(0)))
+            .map_err(|_| {
+            Error::Quant(format!(
+                "QuantRotorV4::gpu_append: n_groups for head_dim={head_dim} exceeds i32::MAX"
+            ))
+        })?;
+        if !self.gpu.is_allocated() && prev_seq > 0 {
+            let (c, s, n) = self.flatten_blocks();
+            self.gpu
+                .seed_from_cpu(&c, &s, &n, kv_h, n_groups, prev_seq, max_seq, device)?;
+        }
+        self.gpu.append_encoded(
+            codes, scales, norms, kv_h, n_groups, prev_seq, new_seq, max_seq, device,
+        )
+    }
+
+    /// GPU packed view of the first `kv_seq` positions, or `None` when the ring
+    /// is not live (CPU path — caller falls back to `dequant`).
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`QuantKGpuRing::packed_view`] errors.
+    pub fn gpu_packed_view(
+        &self,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Option<(Array, Array, Array)>> {
+        self.gpu.packed_view(kv_seq, device)
+    }
+
     /// Resident bytes held by this store.
     ///
     /// Counts the rotor table **once** (it is layer-static) plus all
-    /// accumulated per-token block buffers.
+    /// accumulated per-token block buffers and the GPU ring when live.
     ///
     /// The exhaustive destructure is the drift guard: a new buffer cannot be
     /// added to this struct without this failing to compile.
@@ -256,6 +352,7 @@ impl QuantRotorV4 {
     pub fn byte_size(&self) -> u64 {
         let Self {
             rotors,
+            gpu,
             blocks,
             // Geometry / tags, not allocations.
             shape: _,
@@ -264,7 +361,9 @@ impl QuantRotorV4 {
             head_idx: _,
             bits: _,
         } = self;
-        crate::bytes::vec_bytes(rotors) + blocks.iter().map(RotorBlocks::byte_size).sum::<u64>()
+        crate::bytes::vec_bytes(rotors)
+            + blocks.iter().map(RotorBlocks::byte_size).sum::<u64>()
+            + gpu.byte_size()
     }
 
     /// Dequantize all accumulated V slices into one flat f32 vector of length
@@ -276,7 +375,7 @@ impl QuantRotorV4 {
     /// any block, or if `rotors` is empty (no append happened yet).
     pub fn dequant(&self) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantRotorV4::dequant: malformed shape {:?}",
                 self.shape
             )));
@@ -291,16 +390,14 @@ impl QuantRotorV4 {
         }
 
         if self.rotors.is_empty() {
-            return Err(rmlx_core::error::Error::Mlx(
+            return Err(Error::Mlx(
                 "QuantRotorV4::dequant: rotor table is empty but blocks were appended".into(),
             ));
         }
 
         for blk in &self.blocks {
             let dec = rotor4_decode(&blk.codes, &blk.scales, &blk.norms, &self.rotors, head_dim)
-                .map_err(|e: RotorQuantError| {
-                    rmlx_core::error::Error::Mlx(format!("rotor4 decode: {e}"))
-                })?;
+                .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor4 decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
         if out.len() < total_elems {

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
@@ -25,7 +25,7 @@ use crate::clifford::make_rotor_table;
 use crate::rotorquant::{
     n_groups_for, rotor4_decode, rotor4_encode, RotorQuantError, ROTOR4_BITS, ROTOR4_GROUP_SIZE,
 };
-use crate::storage::quant_rotor_v3::RotorBlocks;
+use crate::storage::quant_rotor_v3::{synced_rotor_v_blocks, RotorBlocks};
 
 use super::QuantKGpuRing;
 
@@ -221,8 +221,9 @@ impl QuantRotorV4 {
 
     /// Truncate the accumulated sequence to `n` tokens.
     ///
-    /// Drops trailing blocks until the cumulative `n_tokens` count is `<= n`
-    /// and lowers `shape[2]` to `n`. Does **not** touch the rotor table.
+    /// Mirror of [`super::QuantRotorV3::truncate_to`]: the GPU ring is **kept**,
+    /// not cleared, so a ring-only decode tail up to `n` survives and `dequant` /
+    /// an SSD spill can rebuild it via [`synced_rotor_v_blocks`].
     pub fn truncate_to(&mut self, n: i32) {
         let n_usize = n.max(0) as usize;
         let mut acc: usize = 0;
@@ -236,21 +237,22 @@ impl QuantRotorV4 {
             }
         }
         self.blocks.truncate(keep);
-        // The ring's filled prefix no longer matches `blocks`; drop it rather
-        // than leave a longer-than-truncated prefix live.
-        self.gpu.clear();
+        // NB: no `self.gpu.clear()` — the ring is the source of truth for a
+        // ring-only decode tail; see [`super::QuantRotorV3::truncate_to`].
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }
     }
 
-    /// Deep-clone (CPU path is plain `Vec` clones).
+    /// Deep-clone. Materialises any ring-only decode tail into complete blocks
+    /// first — mirror of [`super::QuantRotorV3::try_deep_clone`].
     ///
     /// # Errors
     ///
-    /// Currently infallible on the CPU path; returns `Result` for parity with
-    /// the other `Quant*` structs.
+    /// Forwards a [`synced_rotor_v_blocks`] reconciliation error.
     pub fn try_deep_clone(&self) -> Result<Self> {
+        let blocks =
+            synced_rotor_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?.into_owned();
         Ok(Self {
             rotors: self.rotors.clone(),
             // The clone starts CPU-only: `blocks` carries the full payload, so
@@ -258,7 +260,7 @@ impl QuantRotorV4 {
             // Sharing the source's Arrays would alias one ring across two
             // independent caches.
             gpu: QuantKGpuRing::default(),
-            blocks: self.blocks.clone(),
+            blocks,
             shape: self.shape.clone(),
             max_seq: self.max_seq,
             layer_idx: self.layer_idx,
@@ -371,8 +373,9 @@ impl QuantRotorV4 {
     ///
     /// # Errors
     ///
-    /// Returns an `Error::Mlx` if the underlying [`rotor4_decode`] fails for
-    /// any block, or if `rotors` is empty (no append happened yet).
+    /// Returns an `Error::Mlx` if the underlying [`rotor4_decode`] fails for any
+    /// block, if `rotors` is empty (no append happened yet), or a
+    /// [`synced_rotor_v_blocks`] reconciliation error.
     pub fn dequant(&self) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
             return Err(Error::Mlx(format!(
@@ -384,7 +387,11 @@ impl QuantRotorV4 {
         let total_elems: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out: Vec<f32> = Vec::with_capacity(total_elems);
 
-        if self.blocks.is_empty() {
+        // Reconcile the ring-only decode tail — see
+        // [`super::QuantRotorV3::dequant`].
+        let blocks = synced_rotor_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?;
+
+        if blocks.is_empty() {
             out.resize(total_elems, 0.0);
             return Ok(out);
         }
@@ -395,15 +402,19 @@ impl QuantRotorV4 {
             ));
         }
 
-        for blk in &self.blocks {
+        for blk in blocks.iter() {
             let dec = rotor4_decode(&blk.codes, &blk.scales, &blk.norms, &self.rotors, head_dim)
                 .map_err(|e: RotorQuantError| Error::Mlx(format!("rotor4 decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
-        if out.len() < total_elems {
-            out.resize(total_elems, 0.0);
-        } else if out.len() > total_elems {
-            out.truncate(total_elems);
+        // Loud invariant — see [`super::QuantRotorV3::dequant`].
+        if out.len() != total_elems {
+            return Err(Error::Mlx(format!(
+                "QuantRotorV4::dequant: decoded {} elems but shape {:?} implies {total_elems} — \
+                 refusing to zero-pad / truncate",
+                out.len(),
+                self.shape
+            )));
         }
         // Blocks are sequence-major (see `append`); reorder back to head-major
         // `[B, kv_h, S, D]`.

--- a/crates/rmlx-kv-ssd/src/block_io.rs
+++ b/crates/rmlx-kv-ssd/src/block_io.rs
@@ -1574,6 +1574,30 @@ fn ensure_rotor_k_blocks_cover_shape(
     Ok(())
 }
 
+/// V-side mirror of [`ensure_rotor_k_blocks_cover_shape`]: a rotor V store must
+/// reach serialization with its CPU `blocks` covering the full accumulated
+/// `shape[2]`. On the fused symmetric decode path the store keeps a ring-only
+/// tail; the spill clone (`KvCache::try_deep_clone`) materialises it into
+/// complete blocks first. Reject a short store rather than persist a truncated V.
+fn ensure_rotor_v_blocks_cover_shape(
+    blocks_tokens: usize,
+    shape: &[i32],
+    idx: usize,
+) -> Result<()> {
+    if shape.len() != 4 {
+        return Ok(());
+    }
+    let full_tokens: usize = shape.iter().take(3).map(|&d| d.max(0) as usize).product();
+    if blocks_tokens != full_tokens {
+        return Err(BlockIoError::TruncatedStore(format!(
+            "l{idx}.v rotor store: CPU blocks hold {blocks_tokens} tokens but shape {shape:?} \
+             implies {full_tokens} — the ring-only decode tail was not materialised before spill"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
 fn write_quant_rotor_k3(
     idx: usize,
     k: Option<&QuantRotorK3>,
@@ -1691,6 +1715,7 @@ fn write_quant_rotor_v3(
     out: &mut Vec<(String, OwnedTensor)>,
 ) -> Result<()> {
     let Some(qv) = v else { return Ok(()) };
+    ensure_rotor_v_blocks_cover_shape(qv.blocks.iter().map(|b| b.n_tokens).sum(), &qv.shape, idx)?;
     let mut codes: Vec<u8> = Vec::new();
     let mut scales: Vec<f32> = Vec::new();
     let mut norms: Vec<f32> = Vec::new();
@@ -1731,6 +1756,7 @@ fn write_quant_rotor_v4(
     out: &mut Vec<(String, OwnedTensor)>,
 ) -> Result<()> {
     let Some(qv) = v else { return Ok(()) };
+    ensure_rotor_v_blocks_cover_shape(qv.blocks.iter().map(|b| b.n_tokens).sum(), &qv.shape, idx)?;
     let mut codes: Vec<u8> = Vec::new();
     let mut scales: Vec<f32> = Vec::new();
     let mut norms: Vec<f32> = Vec::new();

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -2940,3 +2940,297 @@ fn rotor_k_only_ring_only_tail_ssd_round_trip() {
         "hydrated K must match the live ring-only-tail dequant byte-for-byte (err={err})"
     );
 }
+
+// ── Rotor symmetric (quant-K + quant-V) ring-only tail ───────────────────────
+
+/// Build a rotor3 **symmetric** cache with QJL pinned OFF (pre-seeded rotor
+/// tables keep `qjl_s_matrix == None`). Both axes are rotor-quantized; the fused
+/// quant-V decode path requires QJL off.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: values established by construction"
+)]
+fn seeded_rotor_sym3_cache(kv_h: i32, head_dim: i32, max_seq: i32) -> KvCache {
+    let n_groups = rmlx_kv_quant::rotorquant::n_groups_for(head_dim as usize);
+    let k_rotors = rmlx_kv_quant::clifford::make_rotor_table(0, 0, n_groups);
+    let v_rotors = rmlx_kv_quant::clifford::make_rotor_table(0, 0, n_groups);
+    let storage = KvStorage::RotorSym3 {
+        k: Some(QuantRotorK3::from_cpu_blocks(
+            k_rotors,
+            None,
+            Vec::new(),
+            vec![1, kv_h, 0, head_dim],
+            0,
+        )),
+        v: Some(QuantRotorV3::from_cpu_blocks(
+            v_rotors,
+            Vec::new(),
+            vec![1, kv_h, 0, head_dim],
+            0,
+        )),
+        max_seq,
+    };
+    KvCache::from_storage(storage, KvQuant::Rotor3Sym, 0, 0)
+}
+
+/// `(k_dequant, v_dequant, shape[2], k_block_tokens, v_block_tokens)` for a
+/// rotor3 symmetric cache.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: values established by construction"
+)]
+fn rotor_sym3_probe(cache: &KvCache) -> (Vec<f32>, Vec<f32>, i32, usize, usize) {
+    match cache.storage() {
+        KvStorage::RotorSym3 {
+            k: Some(ks),
+            v: Some(vs),
+            ..
+        } => (
+            ks.dequant().unwrap(),
+            vs.dequant().unwrap(),
+            ks.shape.get(2).copied().unwrap_or(0),
+            ks.blocks.iter().map(|b| b.n_tokens).sum(),
+            vs.blocks.iter().map(|b| b.n_tokens).sum(),
+        ),
+        _ => panic!("expected a live RotorSym3 store"),
+    }
+}
+
+/// The write path refuses to persist a rotor **V** store whose CPU blocks fall
+/// short of `shape[2]` with no ring — a truncated store. Runs on CPU (no Metal).
+///
+/// Mutation check: delete the `ensure_rotor_v_blocks_cover_shape` guard in
+/// `write_quant_rotor_v3` — the writer then silently serializes the short prefix
+/// and this assertion flips RED (`write` returns `Ok`).
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test: values established by construction earlier in this fn"
+)]
+fn write_rejects_truncated_rotor_v_store() {
+    let kv_h = 2_i32;
+    let head_dim = 9_i32; // n_groups = 3, exact
+    let data = lcg((kv_h * 2 * head_dim) as usize, 0x71D);
+
+    // A real single V block covering 2 tokens.
+    let mut src = QuantRotorV3::new(vec![1, kv_h, 0, head_dim], 64, 0);
+    src.append(&data, &[1, kv_h, 2, head_dim]).unwrap();
+
+    // Claim shape[2] == 4 while the blocks cover only 2 tokens and no ring
+    // exists — the ring-only tail with the ring missing. Pair it with a matching
+    // K store so the sym layer is well-formed on the K side.
+    let mut k_src = QuantRotorK3::new(vec![1, kv_h, 0, head_dim], 0);
+    let k_data = lcg((kv_h * 4 * head_dim) as usize, 0x72E);
+    k_src.append(&k_data, &[1, kv_h, 4, head_dim]).unwrap();
+    let truncated_v = QuantRotorV3::from_cpu_blocks(
+        src.rotors.clone(),
+        src.blocks.clone(),
+        vec![1, kv_h, 4, head_dim],
+        0,
+    );
+    let layers = vec![KvStorage::RotorSym3 {
+        k: Some(k_src),
+        v: Some(truncated_v),
+        max_seq: 64,
+    }];
+    let path = tmp_path("rotor_v_truncated");
+    let res =
+        KvBlockWriter::new(MODEL_ID, KvQuant::Rotor3Sym, &layers, &[]).write(&path, Device::Cpu);
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        res.is_err(),
+        "writer must reject a truncated rotor V store (short blocks, no ring), got Ok"
+    );
+}
+
+/// Full SSD spill/hydrate round-trip after a **symmetric** ring-only-tail
+/// decode: both K and V decode tails live only in their GPU rings, are
+/// materialised by the spill clone, and hydrate byte-exact.
+///
+/// Also the V dequant-full-prefix rebuild proof: the live `vs.dequant()` at
+/// `orig_v` covers `prefill + steps` while the V CPU blocks are frozen at
+/// prefill — so `synced_rotor_v_blocks` rebuilt the tail from the ring rather
+/// than zero-padding.
+///
+/// Mutation check: make `QuantRotorV3::try_deep_clone` clone `self.blocks`
+/// directly (drop the `synced_rotor_v_blocks` reconcile) — the clone carries
+/// only the frozen prefill prefix, `write_caches` trips the
+/// `ensure_rotor_v_blocks_cover_shape` guard, and `.expect(...)` panics (RED).
+#[test]
+#[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd rotor_sym_ring_only_tail_ssd -- --ignored --test-threads=1"]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test: values established by construction earlier in this fn"
+)]
+fn rotor_sym_ring_only_tail_ssd_round_trip() {
+    let device = Device::Gpu;
+    let (kv_h, n_q, head_dim, prefill, steps) = (2_i32, 8_i32, 128_i32, 6_i32, 5_i32);
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    let mut c = seeded_rotor_sym3_cache(kv_h, head_dim, 512);
+    let k = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 61),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let v = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 62),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let q = arr(
+        &lcg((prefill * n_q * head_dim) as usize, 63),
+        &[1, n_q, prefill, head_dim],
+    );
+    c.update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+        .unwrap();
+    c.exit_prefill(device).unwrap();
+    for i in 0..steps {
+        let k1 = arr(
+            &lcg((kv_h * head_dim) as usize, 71 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let v1 = arr(
+            &lcg((kv_h * head_dim) as usize, 81 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let q1 = arr(
+            &lcg((n_q * head_dim) as usize, 91 + i as u64),
+            &[1, n_q, 1, head_dim],
+        );
+        c.update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .unwrap()
+            .eval()
+            .unwrap();
+    }
+
+    // Ring-as-sole-store precondition on BOTH axes + live full-prefix dequant.
+    // The sym append drops the CPU blocks once the ring is live, so both axes'
+    // blocks are empty while the ring holds the full `prefill + steps` prefix —
+    // the resident-memory win. `dequant` therefore rebuilds the whole prefix
+    // from the ring, not a zero-padded prefix.
+    let (orig_k, orig_v, orig_seq, k_block_tokens, v_block_tokens) = rotor_sym3_probe(&c);
+    assert_eq!(orig_seq, prefill + steps, "shape[2] advanced with the ring");
+    assert_eq!(
+        k_block_tokens, 0,
+        "K CPU blocks dropped — the ring is the sole resident store"
+    );
+    assert_eq!(
+        v_block_tokens, 0,
+        "V CPU blocks dropped — the ring is the sole resident store (dequant rebuilt from ring)"
+    );
+
+    // Spill clone (materialises both tails) → write → hydrate.
+    let clone = c.try_deep_clone().unwrap();
+    let path = tmp_path("rotor_sym_ring_only_tail");
+    write_caches(&path, device, MODEL_ID, KvQuant::Rotor3Sym, &[clone], &[])
+        .expect("write_caches must persist the full materialised sym store");
+    let (hydrated, _lin) = read_caches(&path, device, MODEL_ID, KvQuant::Rotor3Sym).unwrap();
+    let _ = std::fs::remove_file(&path);
+
+    let (hy_k, hy_v, hy_seq, _, _) = rotor_sym3_probe(&hydrated[0]);
+    assert_eq!(
+        hy_seq,
+        prefill + steps,
+        "hydrated sym store must carry the full decoded length"
+    );
+    assert_eq!(hy_k.len(), orig_k.len(), "hydrated K length mismatch");
+    assert_eq!(hy_v.len(), orig_v.len(), "hydrated V length mismatch");
+    assert!(
+        max_abs_err(&orig_k, &hy_k) < 1e-6,
+        "hydrated K must match the live ring-only-tail dequant byte-for-byte"
+    );
+    assert!(
+        max_abs_err(&orig_v, &hy_v) < 1e-6,
+        "hydrated V must match the live ring-only-tail dequant byte-for-byte"
+    );
+}
+
+/// `truncate_to` keeps the V ring so a ring-only decode tail survives the
+/// speculative-decode rollback: after truncating mid-fused-decode, `dequant`
+/// still rebuilds the full `[0, n)` prefix from the ring instead of aborting on
+/// a short-blocks store.
+///
+/// Mutation check: re-add `self.gpu.clear()` to `QuantRotorV3::truncate_to` —
+/// the ring is dropped, the V blocks fall short of `shape[2]` with no ring, and
+/// `dequant()` returns the loud `synced_rotor_v_blocks` error (RED).
+#[test]
+#[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd rotor_sym_truncate_keeps_ring -- --ignored --test-threads=1"]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test: values established by construction earlier in this fn"
+)]
+fn rotor_sym_truncate_keeps_ring_tail() {
+    let device = Device::Gpu;
+    let (kv_h, n_q, head_dim, prefill, steps) = (2_i32, 8_i32, 128_i32, 6_i32, 6_i32);
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    let mut c = seeded_rotor_sym3_cache(kv_h, head_dim, 512);
+    let k = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 101),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let v = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 102),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let q = arr(
+        &lcg((prefill * n_q * head_dim) as usize, 103),
+        &[1, n_q, prefill, head_dim],
+    );
+    c.update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+        .unwrap();
+    c.exit_prefill(device).unwrap();
+    for i in 0..steps {
+        let k1 = arr(
+            &lcg((kv_h * head_dim) as usize, 111 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let v1 = arr(
+            &lcg((kv_h * head_dim) as usize, 121 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let q1 = arr(
+            &lcg((n_q * head_dim) as usize, 131 + i as u64),
+            &[1, n_q, 1, head_dim],
+        );
+        c.update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .unwrap()
+            .eval()
+            .unwrap();
+    }
+
+    // Full-length dequant before truncation (the reference prefix).
+    let (_ok, orig_v, orig_seq, _, _) = rotor_sym3_probe(&c);
+    assert_eq!(orig_seq, prefill + steps);
+    let per_tok = (kv_h * head_dim) as usize;
+
+    // Truncate into the ring-only tail (below the last CPU block, inside the
+    // ring-held region) and confirm dequant still rebuilds the kept prefix.
+    let keep = prefill + steps - 3;
+    c.truncate_to(keep);
+    let (_k2, v_after, seq_after, _, _) = rotor_sym3_probe(&c);
+    assert_eq!(seq_after, keep, "shape[2] lowered to the truncation point");
+    assert_eq!(
+        v_after.len(),
+        (keep as usize) * per_tok,
+        "V dequant covers the kept prefix — the ring supplied the tail, no abort"
+    );
+    // The kept prefix must be byte-exact with the pre-truncation dequant.
+    // Both are head-major `[1, kv_h, S, D]`, so the sequence axis is in the
+    // middle — compare per (head, seq-position) rather than a flat prefix slice.
+    let (orig_s, hd) = ((prefill + steps) as usize, head_dim as usize);
+    let keep_s = keep as usize;
+    for h in 0..kv_h as usize {
+        for s in 0..keep_s {
+            let a = &orig_v[(h * orig_s + s) * hd..(h * orig_s + s) * hd + hd];
+            let b = &v_after[(h * keep_s + s) * hd..(h * keep_s + s) * hd + hd];
+            assert!(
+                max_abs_err(a, b) < 1e-6,
+                "kept V (head {h}, pos {s}) must match the pre-truncation dequant"
+            );
+        }
+    }
+}

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2610,7 +2610,8 @@ must not change how existing bytes are read.
 | `KvStorage::RotorKOnly3` / `RotorKOnly4`, QJL off, `b == 1` | **YES** | GPU ring + `rotor_flash_decode_sdpa`. |
 | `KvStorage::RotorKOnly{3,4}`, QJL on | NO | Kernel cannot reproduce the QJL residual. |
 | `KvStorage::RotorKOnly{3,4}`, `b > 1` | NO | Ring stride does not interleave batch — see below. |
-| `Rotor{3,4}Sym`, `RotorK{3,4}Asym` | NO | V side is also rotor / affine-quantized; this kernel takes bf16 V only. Shares the K-decode half when a quant-V kernel lands. |
+| `Rotor{3,4}Sym` | NO (this kernel) | Both axes are rotor-quantized; they decode through the all-quant sibling `rotor_flash_decode_symv` instead (see below), which reads V from its own packed ring rather than a bf16 mirror. |
+| `RotorK{3,4}Asym` | NO | V is affine-quantized (TurboQuant), not rotor; no fused kernel yet, so it keeps the bf16 decode path. |
 
 ### Ring eligibility is passed down, not inferred
 
@@ -2716,6 +2717,71 @@ below `none` (Bonsai bf16 ≈ 110 TPS). The rotor sandwich is ~64 FMAs per group
 per lane and each of a group's 3 lanes redoes it, so the inner loop is
 compute-bound, not KV-bandwidth-bound. Narrowing that gap (sparse geometric
 product, one decode per group instead of per lane) is future work.
+
+---
+
+## `rotor_flash_decode_symv` — fused flash-decode over rotor-quant K **and** V
+
+The all-quant sibling of `rotor_flash_decode`, for `KvStorage::RotorSym3` /
+`RotorSym4`. It reads **both** axes straight from their packed rotor rings —
+there is no bf16 K or V mirror at all — so the symmetric rotor codecs finally
+carry only their advertised ~3-bits-per-axis cost.
+
+**What it replaced.** `Rotor{3,4}Sym` quantized both axes at `exit_prefill` and
+then decoded from a full bf16 K+V mirror (`decode_fp16_k` / `decode_fp16_v`),
+which `update_rotor{3,4}_sym` short-circuited to on its first line: the packed
+store was written and never read. The codec was dormant, and a codec advertising
+~3 bits/axis actually carried bf16 K + bf16 V *plus* its codes — i.e. **more**
+resident KV than plain bf16. Dropping the mirror turns the advertised
+compression into a real resident-byte win (measured ≈ −34% resident KV: Bonsai-8B
+590.0 → 390.8 MB, gemma-4-e2b 36.1 → 23.5 MB on a 1838-token prompt).
+
+### Reuse of the K-decode half
+
+The header ([`build_rotor_flash_header`], shared verbatim with the bf16-V
+sibling) emits the Cl(3,0) block decode as the MSL function `rf_decode_k_group`.
+This kernel calls it **twice per token** — once over the K ring, once over the
+V ring — because the rotor codec is axis-agnostic (`rotor{3,4}_encode` (V) and
+`rotor{3,4}_k_encode` (K) are the same function; the K fork only adds the
+optional QJL sideband, and the dispatcher fires only with QJL off). Both axes
+share one bit width by construction, so a single `RF_BITS` covers the K and the
+V unpack, and both probe against the existing header snapshots. Following the
+one-decode-per-group shell, each block's leader stages its group's grade-1 lanes
+into threadgroup memory (separate `k_shared` / `v_shared`) so the ~64-FMA
+sandwich runs once per Cl(3,0) block per axis rather than once per lane.
+
+### Files
+
+* `crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl.rs` — dispatcher +
+  counters; reuses the sibling's header builder.
+* `crates/rmlx-kv-quant/src/metal/rotor_flash_decode_symv_p1.metal` — pass-1
+  body (one body for both bit widths). Pass-2 is the shared LSE merge.
+* `crates/rmlx-kv-quant/src/storage/quant_rotor_v{3,4}.rs` — the V stores gain
+  the same `QuantKGpuRing` the K stores carry, fed via `RingFeed::Maintain` from
+  the symmetric append.
+* `crates/rmlx-kv-quant/src/kvcache/sdpa.rs::update_and_sdpa_rotor_sym_fused` —
+  dispatch site (main + shared-KV producer + consumer paths).
+
+### Gate
+
+Same shape as the K-only path: device is GPU, storage is `RotorSym{3,4}`, the
+store does **not** carry QJL, `q_seq == 1`, `b == 1`, `head_dim` a power of two
+`<= 512`. A QJL-carrying store keeps the CPU dequant path on both axes (the QJL
+residual is not reproducible in the flash inner loop). `feeds_bf16_k_at_decode`
+**and** `feeds_bf16_v_at_decode` are both false for these variants, so
+`exit_prefill` allocates neither seed and the resident-byte estimate reads the
+same two predicates — it cannot drift from what is materialised.
+
+### Speed vs. the mirror (honest)
+
+Dropping the mirror is a **memory** win, not a decode-speed win on the current
+two-pass shell. Against the MLX bf16 flash attention the dormant mirror used, the
+fused quant-K + quant-V path is materially slower at long context — the dominant
+gap is the two-pass flash-decode shell, not the V unpack. So `rotor*_sym` remains
+opt-in (`--kv-quant rotor3_sym` / `rotor4_sym`); it is the right pick when
+resident KV is the binding constraint, not when peak decode TPS is. Closing the
+speed gap needs a single-pass simdgroup flash-decode that beats MLX bf16 flash
+(tracked with `#45`).
 
 ---
 


### PR DESCRIPTION
## Summary

`rotor3_sym` / `rotor4_sym` decoded from a full bf16 K+V mirror (the packed store
was written and never read). This PR adds the fused **quant-K + quant-V**
`rotor_flash_decode_symv` kernel (on the #234/#280 simdgroup shell) so V is read
straight from its own packed rotor ring, and makes that ring the **sole resident
store** — turning the codec's ~34% logical compression into a real resident-RAM
win.

Two commits: (1) the quant-V SV kernel + wiring; (2) ring-as-sole-store so the
memory win is resident, not just logical.

## The memory win is real (resident, post-#258 allocation-derived accounting)

`kv_cache_bytes`, quant-V-sole-store vs the bf16 mirror it replaces, A/B binaries
symbol-verified distinct (`symv`: this branch 20, main 0):

| model | ctx | quant-V (this) | bf16-mirror | delta |
|---|---|---|---|---|
| Bonsai-8B | 4k | 0.885 GB | 1.285 GB | **−31%** |
| Bonsai-8B | 32k | 6.98 GB | 10.54 GB | **−34%** |
| gemma-4-e2b | 4k | 44.2 MB | 69.9 MB | **−37%** |

(≈ −40% vs the naive blocks+ring double-store that the first commit alone
produced — the sole-store commit is what makes it a win rather than a regression.)

## Speed — a documented, inherent loss (this is #45's territory)

Decode is **2.4×–5.5× slower** than the bf16 mirror it deletes (Bonsai 4k ~15 vs
78 TPS; e2b 4k ~59 vs 118; Bonsai 32k 5.3 vs 29) — the two-pass flash-decode
shell, not the V unpack (#280 improved the shell but did not beat MLX bf16 flash).
`rotor*_sym` is the pick when resident KV is the binding constraint; `bf16` /
`none` remain the speed choices. The sole-store change did **not** regress decode
TPS.

## The #212 128k stall is orthogonal

Already fixed by #225 (over-cap prompt-cache snapshots are refused cleanly). The
smaller quant-V snapshot still exceeds the default 2 GB cap at 32k/128k, so both
codecs are refused with no stall. This PR is a memory play, not a stall fix.

## Correctness (the silent-KV-corruption zone — held to #231's bar)

- **Numerical oracle** (quant-V, both axes vs CPU dequant): 13/13 GPU across
  head_dim 64/128/256/512, GQA, additive mask, multi-tile. Mutation on the V
  unpack → RED (`max_err=0.1258`). #234's bf16-V K oracle unchanged (12/12).
- **Ring-as-sole-store** (V mirrors the #231 K-side): `synced_rotor_v_blocks`
  rebuilds a ring-only tail; `dequant` refuses to zero-pad a short store (loud
  `Error`, not `debug_assert`); `truncate_to` keeps the ring; `try_deep_clone`
  and the SSD writer (`ensure_rotor_v_blocks_cover_shape`) guard the invariant at
  every boundary. Three guards, each **mutation-red-verified**:
  - dequant skip-rebuild → `decoded 1536 … implies 2816 — refusing to zero-pad`
  - clone skip-synced → `TruncatedStore: l0.v … blocks hold 12 … implies 22`
  - truncate re-add `gpu.clear()` → `blocks cover 0 … needs 18 … ring is absent`
- **SSD spill/hydrate round-trip** byte-exact on both axes; truncate-mid-fused-
  decode rebuilds the kept prefix; CPU writer rejects a truncated V store.
- **Real-model**: gemma-4-e2b ("Red, Yellow, Blue") and Ternary-Bonsai-8B ("The
  capital of France is Paris.") served temp=0, coherent, with the symv kernel
  GPU-resident (dispatch witness `path="rotor_flash_decode_symv"`).

## Why sole-store is safe (no data loss on ring-clear)

The ring becomes the only copy, so every ring-clear is guarded: `truncate_to`
keeps the ring; a GPU spec-verify chunk takes the block path, which
`materialize_rotor_v{3,4}_ring_tail` reconciles into blocks **before** its `Skip`
clear; a CPU-only run never allocates a ring. `dequant` / clone / SSD rebuild
from the ring on demand.

## Recommendation

`rotor*_sym` is now a genuine memory-efficient rotation codec: it finally saves
the resident KV it advertises (≈ −34% at long ctx), at a documented decode-speed
cost that is #45's remit. Defensible as the `rotor*_sym` decode path; users who
want speed use `bf16` / `none`.

Refs #219, #234, #212, #225, #231, #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
