### PR TITLE
fix(test): repair 3 stale ignored ring/truncate tests (#282)

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/resident_ring_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/resident_ring_tests.rs
@@ -109,6 +109,22 @@ fn drive_to_ring(cache: &mut KvCache, prefill: i32) -> u64 {
     let device = Device::Gpu;
     let scale = 1.0_f32 / (HEAD_DIM as f32).sqrt();
 
+    // `enter_prefill()` is load-bearing here, not cosmetic: without it
+    // `in_prefill` stays `false` (the `from_storage` / `with_quant_max_seq`
+    // default), so the "prefill" call below does not take the raw bf16
+    // accumulator path (`update_prefill_raw`) — it falls through
+    // `update_and_sdpa`'s legacy arm straight into the per-codec decode-style
+    // updater (`update_rotor_k_only_3`), which — for RotorKOnly3, once
+    // `--rotor-qjl` defaults off — GPU-encodes and stands the ring up right
+    // there, even for a multi-token chunk. That is a real production path too
+    // (e.g. an SSD-hydrated cache fed a multi-token catch-up chunk), but it is
+    // not what this helper means by "prefill": calling `enter_prefill()`
+    // routes the chunk through the true raw-accumulator prefill path (ring
+    // stays dormant until the first single-token decode step), matching every
+    // other codec's `drive_to_ring` behaviour and restoring the precondition
+    // this test actually wants to check.
+    cache.enter_prefill();
+
     // Prefill goes through the legacy path: CPU blocks accumulate, no ring yet.
     let pf = (prefill * KV_H * HEAD_DIM) as usize;
     let k = f32_array(&lcg_data(pf, 1), &[1, KV_H, prefill, HEAD_DIM]);

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
@@ -316,33 +316,81 @@ fn quant_rotor_k3_reset_drops_the_gpu_ring() {
     );
 }
 
+/// `truncate_to()` must KEEP the GPU ring, not drop it.
+///
+/// The ring is the only copy of a fused-decode ring-only tail (`blocks` can
+/// trail `shape[2]` on that path — see `synced_rotor_k_blocks`), and a whole
+/// CPU block that does not wholly fit the truncated target is dropped
+/// outright rather than split. Clearing the ring here (the pre-fix behaviour)
+/// would strand the kept prefix with nothing to rebuild it from, and
+/// `dequant()` / an SSD spill would hit the "blocks short of shape[2], no
+/// ring" guard and abort instead of returning the kept tokens.
+///
+/// `kv_h = 1` keeps `RotorKBlocks::n_tokens` (`b * kv_h * seq`) directly
+/// comparable to the truncate target `n` (a raw sequence position), so which
+/// blocks `truncate_to` keeps is unambiguous here.
+///
+/// Mutation check: re-introduce `self.gpu.clear()` in `truncate_to`. The ring
+/// (the only remaining copy of the kept token, since the 2-token CPU block
+/// was dropped) is then gone, so `dequant()` hits the no-ring guard and
+/// returns `Err` instead of `Ok` — RED.
 #[test]
 #[ignore = "GPU Metal context — run in isolation: cargo test quant_rotor_k3 -- --ignored --test-threads=1"]
-fn quant_rotor_k3_truncate_to_drops_the_gpu_ring() {
+fn quant_rotor_k3_truncate_to_keeps_the_gpu_ring() {
     if crate::test_utils::skip_if_no_gpu_env() {
         return;
     }
-    let (kv_h, head_dim) = (2_i32, 6_i32);
+    let (kv_h, head_dim) = (1_i32, 6_i32);
     let mut ks = QuantRotorK3::new(vec![1, kv_h, 0, head_dim], 0);
     ks.rotors = make_rotor_table(0, 0, n_groups_for(head_dim as usize));
 
-    // Two CPU appends so `truncate_to` has block boundaries to cut on.
+    // One CPU-side append covering 2 tokens.
     let per_tok = (kv_h * head_dim) as usize;
     let d1 = lcg_data(per_tok * 2, TEST_SEED);
-    ks.append(&d1, &[1, kv_h, 2, head_dim]).expect("append 1");
-    let d2 = lcg_data(per_tok, TEST_SEED + 1);
-    ks.append(&d2, &[1, kv_h, 1, head_dim]).expect("append 2");
-    assert_eq!(ks.shape[2], 3);
+    ks.append(&d1, &[1, kv_h, 2, head_dim]).expect("append");
+    assert_eq!(ks.shape[2], 2);
 
-    // A live ring covering all 3 tokens, then truncate back to 2.
-    seed_ring_via_gpu_append(&mut ks, kv_h, head_dim, 3, RING_TEST_MAX_SEQ);
+    // A live ring covering both tokens.
+    seed_ring_via_gpu_append(&mut ks, kv_h, head_dim, 2, RING_TEST_MAX_SEQ);
     assert!(ks.gpu.is_allocated());
 
-    ks.truncate_to(2);
-    assert_eq!(ks.shape[2], 2);
+    // Truncate to seq=1, mid-block: the sole 2-token CPU block does not wholly
+    // fit the target, so it is dropped entirely rather than split — the kept
+    // token must be rebuilt from the ring, not zero-padded or errored.
+    ks.truncate_to(1);
+    assert_eq!(ks.shape[2], 1);
     assert!(
-        !ks.gpu.is_allocated(),
-        "truncate_to() must drop the ring — otherwise packed_view() would still \
-         expose the truncated token"
+        ks.blocks.is_empty(),
+        "precondition: the 2-token block doesn't wholly fit target seq=1, so it \
+         is dropped — the kept token must come from the ring"
+    );
+    assert!(
+        ks.gpu.is_allocated(),
+        "truncate_to() must KEEP the ring — it is the source of truth for a \
+         ring-only decode tail; dropping it here would strand the only copy \
+         of the kept token and abort the next dequant/spill"
+    );
+
+    // dequant() must rebuild the kept token from the ring — not error, not
+    // zero-pad — and must return the ring's actual bytes, not garbage.
+    let dq = ks
+        .dequant()
+        .expect("dequant after truncate must read the kept token from the ring");
+    let n_groups = n_groups_for(head_dim as usize);
+    let ref_codes: Vec<u32> = (0..n_groups as u32).collect();
+    let ref_scales: Vec<f32> = (0..n_groups).map(|i| i as f32).collect();
+    let ref_norms = vec![0.0_f32];
+    let reference = rotor3_decode(
+        &ref_codes,
+        &ref_scales,
+        &ref_norms,
+        &ks.rotors,
+        head_dim as usize,
+    )
+    .expect("reference decode of the seeded ring token");
+    assert_eq!(
+        dq, reference,
+        "dequant() after truncate must return the ring's actual content for the \
+         kept token, not a zero-padded/garbage buffer"
     );
 }


### PR DESCRIPTION
## Summary
- `quant_rotor_k3_truncate_to_drops_the_gpu_ring` asserted the pre-#231 `truncate_to()` behaviour (drop the ring) that was deliberately replaced — `truncate_to()` now keeps the ring so a fused-decode ring-only tail survives a speculative-decode rollback. Renamed to `..._keeps_the_gpu_ring`, rewritten (`kv_h=1` to keep the block-boundary math unambiguous) to assert the ring stays allocated, `shape[2]` is correct, and `dequant()` rebuilds the kept token from the ring byte-for-byte (not zero-padded). Mutation-checked: re-introducing `self.gpu.clear()` in `truncate_to` flips it red.
- `ring_stays_counted_across_contexts` / `rotor_k_only3_ring_is_counted_in_resident_bytes`: root cause was **not** #231. Their `drive_to_ring` helper never called `KvCache::enter_prefill()`, so the "prefill" call fell through to the per-codec decode-style updater instead of the raw bf16 accumulator path. For `RotorKOnly3` that updater feeds the GPU ring unconditionally once GPU encode is eligible — which became reachable by default once `--rotor-qjl` defaulted off (#245/#230), surfacing a ring before the helper's "no ring before first decode" precondition expected one. Fixed the helper to call `enter_prefill()` (matching production prefill semantics and every other codec's helper), which restores the original, still-true invariant — no assertion was changed. Mutation-checked against the byte-accounting bug this file exists to guard (dropping `+ gpu.byte_size()` from `QuantRotorK3::byte_size()` flips it red).

## Test plan
- [x] `cargo test -p rmlx-kv-quant --lib -- --ignored --test-threads=1 quant_rotor_k3_truncate_to_keeps_the_gpu_ring ring_stays_counted_across_contexts rotor_k_only3_ring_is_counted_in_resident_bytes` → 3 passed, 0 failed
- [x] Full ignored GPU suite: `cargo test -p rmlx-kv-quant --lib -- --ignored --test-threads=1` → 201 passed, 0 failed
- [x] `cargo fmt --all -- --check` → clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean
- [x] `make check-no-inline-tests` → OK
- [x] `cargo test -p rmlx-kv-quant --lib` (non-ignored) → 361 passed, 0 failed, 201 ignored
- Each fix mutation-checked (reds captured and reverted before commit)

Fixes #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)