### PR TITLE
feat(kv): iso_flash_decode_symv + general GPU-native norms-padding fix for iso/rotor short-prompt aborts (#220, #279, #286)

### DIFF
--- a/crates/rmlx-kv-quant/src/flash_decode_common.rs
+++ b/crates/rmlx-kv-quant/src/flash_decode_common.rs
@@ -1,0 +1,59 @@
+//! Shared scaffold for the symmetric (quant-K + quant-V) flash-decode MSL
+//! dispatchers — [`crate::iso_flash_decode_symv_msl`] and
+//! [`crate::rotor_flash_decode_symv_msl`].
+//!
+//! Both bind a per-token `norms` array as a kernel input. MLX's custom-kernel
+//! builder binds a small input array's outer-kernel parameter in the
+//! **`constant`** address space instead of `device` (an internal size
+//! heuristic), but both codecs' shared per-lane/per-group decode helpers
+//! (`if_decode_k_lane` in [`crate::iso_flash_decode_msl`]; `rf_decode_k_group`
+//! — the symv P1 kernel body calls this directly rather than the
+//! `rf_decode_k_lane` wrapper, since the Cl(3,0) sandwich needs the group
+//! result, not a single lane — in [`crate::rotor_flash_decode_msl`]) declare
+//! their `norms` parameter `device const float*` — an address-space mismatch
+//! that fails the MSL compile at first dispatch. The threshold was
+//! **measured** at 8 (a
+//! ring-only decode at `kv_h == 1` aborts for `kv_seq` 2–7 and succeeds from 8
+//! on, for every `head_dim`); [`NORMS_DEVICE_MIN`] is set above it for
+//! margin. Only `norms` (one f32 per token) crosses it at low `kv_seq` —
+//! `codes` / `scales` carry `n_groups` more elements per token, and rotor's
+//! `rotors` table is sized off `n_groups` alone, so both stay above the
+//! threshold at any `kv_seq >= 1`.
+//!
+//! [`pad_norms_to_device_floor`] zero-pads `norms` up to the floor before
+//! dispatch instead of falling back to a CPU dequant path: each kernel's
+//! per-tile loop bound is the real `kv_seq` carried in its `dims` buffer, not
+//! the `norms` buffer length, so the padding is allocated but never read.
+//! This keeps both fused kernels on the GPU for every `kv_seq >= 1` with no
+//! CPU dequant fallback (hard rule 10) — in particular for a normal short
+//! chat prompt against a single-KV-head model (Gemma4 global layers are
+//! `kv_h == 1`), where a 2-token prompt reaches `kv_seq == 2` on the first
+//! decode step, well below the compile floor.
+
+use rmlx_core::error::{Error, Result};
+use rmlx_mlx::{pad, Array, Device};
+
+/// Minimum per-token `norms` element count (`b * kv_h * kv_seq`) a symmetric
+/// flash-decode kernel (iso or rotor) is dispatched with. See the module doc
+/// for why this floor exists and how it is measured.
+pub(crate) const NORMS_DEVICE_MIN: i64 = 16;
+
+/// Zero-pad flat `norms` (`[tok_count]`) up to [`NORMS_DEVICE_MIN`] elements
+/// when `tok_count` is below it; returns `norms` unchanged otherwise.
+///
+/// # Errors
+///
+/// Returns [`Error::Mlx`] if the pad amount overflows `i32`, and forwards
+/// [`pad`] errors.
+pub(crate) fn pad_norms_to_device_floor(
+    norms: Array,
+    tok_count: i64,
+    device: Device,
+) -> Result<Array> {
+    if tok_count >= NORMS_DEVICE_MIN {
+        return Ok(norms);
+    }
+    let extra = i32::try_from(NORMS_DEVICE_MIN - tok_count)
+        .map_err(|_| Error::Mlx("pad_norms_to_device_floor: pad amount overflowed i32".into()))?;
+    pad(&norms, &[0], &[0], &[extra], device)
+}

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_symv_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_symv_msl.rs
@@ -1,0 +1,572 @@
+// unsafe_code: Metal kernel byte cast — slice::from_raw_parts over kernel
+// input data (dims arrays) for MSL dispatch.
+#![allow(unsafe_code)]
+
+//! `iso_flash_decode_symv`: fused QK over iso-quant K + online softmax +
+//! **iso-quant V** SV in a single MSL pass per (B, H, tile).
+//!
+//! # What this is
+//!
+//! The all-quant sibling of [`crate::iso_flash_decode_msl`]. That kernel decodes
+//! K from the iso store but still reads V out of a bf16 mirror; this one reads
+//! **both** axes straight from their packed iso rings, so the symmetric iso
+//! codecs ([`crate::storage::KvStorage::IsoSym3`] / `IsoSym4`) need no bf16 K or
+//! V buffer at all.
+//!
+//! # What it replaced
+//!
+//! `Iso{3,4}Sym` quantised both axes at `exit_prefill` and then decoded from a
+//! full bf16 K+V mirror (`decode_fp16_k` / `decode_fp16_v`), which
+//! `update_iso{3,4}_sym` short-circuits to on its first line. The codec was
+//! dormant: the packed store was written, never read. That bf16 mirror is the
+//! whole KV cost of the codec — a codec advertising ~3 bits/axis actually
+//! carried bf16 K + bf16 V *plus* its codes, i.e. **more** than plain bf16, the
+//! heaviest cell in the KV matrix (~3.43×). Dropping the mirror is what turns
+//! the codec's advertised compression into a real resident-byte win.
+//!
+//! Two Metal dispatches per call:
+//! * **Pass 1** (`rmlx_iso_flash_decode_symv_p1_b{3,4}`): per-tile threadgroups
+//!   compute partial outputs + per-tile LSE state `(tile_max, tile_sum_exp)`.
+//!   Each threadgroup runs `head_dim` threads over `TILE_SIZE` tokens.
+//! * **Pass 2** (`rmlx_iso_flash_decode_symv_p2`): one threadgroup per
+//!   `(B, head)` merges the per-tile partials via log-sum-exp. The body is the
+//!   codec-agnostic `metal/flash_decode_merge_p2.metal`, shared with
+//!   `iso_flash_decode_msl` / `rotor_flash_decode_msl` / `planar_flash_decode_msl`.
+//!
+//! # Reuse of the K-decode half
+//!
+//! [`crate::iso_flash_decode_msl`] emits its per-lane iso decode into the
+//! **header** as the MSL function `if_decode_k_lane(...)` precisely so a
+//! quantized-V kernel could call it unchanged. This kernel does exactly that,
+//! for both axes:
+//!
+//! * The header is [`crate::iso_flash_decode_msl::build_iso_flash_header`],
+//!   reused verbatim — no second copy of the Lloyd-Max codebook or the fixed
+//!   golden-ratio quaternion, and no second probe snapshot to keep in sync.
+//! * The body calls `if_decode_k_lane` twice per token: once over the K ring,
+//!   once over the V ring.
+//!
+//! That works because the iso codec is **axis-agnostic**: `iso_encode_fast`
+//! quantises K and V the same way (`r = q * v_unit`, a single left Hamilton
+//! product, decoded by `q̄ * r`). The per-lane decode is self-contained (lane
+//! `d` reads only its own group's word / scale plus the token's L2 norm), so
+//! unlike the rotor codec's Cl(3,0) block the iso V unpack needs neither
+//! cross-lane exchange nor a threadgroup stage in the SV loop.
+//!
+//! # Fixed quaternion
+//!
+//! Both axes rotate every group by the same golden-ratio unit quaternion
+//! ([`crate::isoquant::FIXED_QUAT`]), baked into the header as a constant. The
+//! rings therefore do not carry a quaternion table on either axis;
+//! [`crate::iso_flash_decode_msl::assert_fixed_quat_blocks`] rejects a store
+//! whose per-group quaternions are not the fixed constant, so a future
+//! per-group-quaternion encoder fails loudly at the dispatch boundary rather
+//! than decoding against the wrong rotation.
+//!
+//! # Bit-width parameterisation
+//!
+//! `bits ∈ {3, 4}` is a template parameter carried by the header, so one
+//! `metal/iso_flash_decode_symv_p1.metal` serves both variants. Selection is
+//! explicit — any other `bits` is an `Err`, never a silent fallback to the wrong
+//! unpack width. Both axes of a symmetric codec share one width by construction
+//! (`Iso3Sym` → 3/3, `Iso4Sym` → 4/4), so a single `IF_BITS` covers K and V.
+//!
+//! # Codec contract
+//!
+//! Bit-exact with [`crate::isoquant::iso_decode_fast`] on **both** axes. Per
+//! axis:
+//!
+//! * `codes`  u32 `[B * S_kv * kv_h * n_groups]` — 1 u32 per group of 4
+//!   quaternion components (both widths fit one group in one word).
+//! * `scales` f32 `[B * S_kv * kv_h * n_groups]` — one f32 per group of 4.
+//! * `norms`  f32 `[B * S_kv * kv_h]` — per-token L2 norm.
+//!
+//! Both rings are **sequence-major** (`[B, S, kv_h, ...]`).
+//!
+//! # Single-MLX claim
+//!
+//! Per CLAUDE.md "Single MLX process per Mac", callers must hold the
+//! `/tmp/rmlx.<port>.claim` lock before dispatching GPU kernels.
+//!
+//! # Pattern reference
+//!
+//! * [`crate::iso_flash_decode_msl`] — the bf16-V sibling; this kernel is its
+//!   shell with the SV read swapped for an iso unpack.
+//! * [`crate::rotor_flash_decode_symv_msl`] — the rotor quant-V sibling (the
+//!   same shell over the Cl(3,0) codec).
+//! * [`crate::isoquant::iso_decode_fast`] — CPU reference (Rust).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+use rmlx_core::error::{Error, Result};
+use rmlx_mlx::metal_kernel::{MetalKernel, MetalKernelInvoke};
+use rmlx_mlx::{Array, Device, Dtype};
+
+use crate::iso_flash_decode_msl::{build_iso_flash_header, ISO_FLASH_HEAD_DIM_MAX, TILE_SIZE};
+use crate::storage::{iso_n_groups_for, ISO_QUAT_BLOCK_SIZE};
+
+// ── Dispatch counters ─────────────────────────────────────────────────────────
+
+/// Incremented once per `iso_flash_decode_symv_sdpa::<3>` P1 enqueue.
+static ISO3_SYMV_FLASH_DECODE_DISPATCHES: AtomicU64 = AtomicU64::new(0);
+
+/// Incremented once per `iso_flash_decode_symv_sdpa::<4>` P1 enqueue.
+static ISO4_SYMV_FLASH_DECODE_DISPATCHES: AtomicU64 = AtomicU64::new(0);
+
+/// Process-lifetime count of iso3 quant-V flash-decode P1 dispatches.
+///
+/// Tests assert `delta > 0` to prove the MSL kernel actually fired rather than
+/// the caller silently falling back to the CPU dequant path. Production code
+/// does not consult this counter.
+pub fn iso3_symv_flash_decode_dispatch_count() -> u64 {
+    ISO3_SYMV_FLASH_DECODE_DISPATCHES.load(Ordering::Relaxed)
+}
+
+/// Process-lifetime count of iso4 quant-V flash-decode P1 dispatches.
+pub fn iso4_symv_flash_decode_dispatch_count() -> u64 {
+    ISO4_SYMV_FLASH_DECODE_DISPATCHES.load(Ordering::Relaxed)
+}
+
+/// Combined process-lifetime count (3-bit + 4-bit).
+pub fn iso_symv_flash_decode_dispatch_count() -> u64 {
+    iso3_symv_flash_decode_dispatch_count() + iso4_symv_flash_decode_dispatch_count()
+}
+
+// ── MSL sources ───────────────────────────────────────────────────────────────
+//
+// Grid: (n_tiles * head_dim, B * n_q_heads, 1).  Threadgroup: (head_dim, 1, 1).
+//
+// P1 buffer layout (must match `add_input` order in
+// `iso_flash_decode_symv_sdpa`). BOTH iso rings are SEQUENCE-major
+// (`[B, S, kv_h, ...]`) — there is no head-major bf16 V here.
+// 0.  query     : f32  [B * n_q_heads * head_dim]
+// 1.  k_codes   : u32  [B * kv_seq * kv_h * n_groups]
+// 2.  k_scales  : f32  [B * kv_seq * kv_h * n_groups]
+// 3.  k_norms   : f32  [B * kv_seq * kv_h]
+// 4.  v_codes   : u32  [B * kv_seq * kv_h * n_groups]
+// 5.  v_scales  : f32  [B * kv_seq * kv_h * n_groups]
+// 6.  v_norms   : f32  [B * kv_seq * kv_h]
+// 7.  mask_flat : f32  [B * n_q_heads * kv_seq] or [1] dummy when no mask
+// 8.  scale_arr : f32  [1]
+// 9.  dims      : u32  [8] — {head_dim, kv_seq, n_bh, kv_h, heads_per_kv,
+//                             n_tiles, has_mask, n_groups}
+//
+// P1 outputs:
+// 0. partial_o     : f32 [n_tiles * n_bh * head_dim]
+// 1. tile_max      : f32 [n_tiles * n_bh]
+// 2. tile_sum_exp  : f32 [n_tiles * n_bh]
+//
+// One body serves both bit widths — the unpack width arrives via the header's
+// IF_BITS / IF_MASK.
+const P1_SOURCE: &str = include_str!("metal/iso_flash_decode_symv_p1.metal");
+
+// P2 buffer layout:
+// 0. partial_o    : f32 [n_tiles * n_bh * head_dim]
+// 1. tile_max     : f32 [n_tiles * n_bh]
+// 2. tile_sum_exp : f32 [n_tiles * n_bh]
+// 3. dims_p2      : u32 [3] — {head_dim, n_tiles, n_bh}
+// Output:
+// 0. dst          : f32 [n_bh * head_dim]
+//
+// Codec-agnostic; shared with `iso_flash_decode_msl` / `rotor_flash_decode_msl`.
+const P2_SOURCE: &str = include_str!("metal/flash_decode_merge_p2.metal");
+
+// ── Kernel singletons (one P1 per BITS variant) ───────────────────────────────
+
+static P1_KERNEL_B3: OnceLock<std::result::Result<MetalKernel, String>> = OnceLock::new();
+static P1_KERNEL_B4: OnceLock<std::result::Result<MetalKernel, String>> = OnceLock::new();
+static P2_KERNEL: OnceLock<std::result::Result<MetalKernel, String>> = OnceLock::new();
+
+fn p1_kernel(bits: u8) -> Result<&'static MetalKernel> {
+    let (cell, name) = match bits {
+        3 => (&P1_KERNEL_B3, "rmlx_iso_flash_decode_symv_p1_b3"),
+        4 => (&P1_KERNEL_B4, "rmlx_iso_flash_decode_symv_p1_b4"),
+        _ => {
+            return Err(Error::Quant(format!(
+                "iso_flash_decode_symv: bits must be 3 or 4, got {bits}"
+            )))
+        }
+    };
+    cell.get_or_init(|| {
+        // Same header as the bf16-V sibling: IF_BITS / IF_MASK / ISO_CB / the
+        // fixed quaternion / `if_decode_k_lane` / tile + head-dim sizing. Both
+        // axes of a symmetric codec share one bit width, so one header covers
+        // the K and the V unpack.
+        let header = build_iso_flash_header(bits).map_err(|e| format!("{e}"))?;
+        MetalKernel::new(
+            name,
+            &header,
+            P1_SOURCE,
+            &[
+                "query",
+                "k_codes",
+                "k_scales",
+                "k_norms",
+                "v_codes",
+                "v_scales",
+                "v_norms",
+                "mask_flat",
+                "scale_arr",
+                "dims",
+            ],
+            &["partial_o", "tile_max", "tile_sum_exp"],
+        )
+        .map_err(|e| format!("{e}"))
+    })
+    .as_ref()
+    .map_err(|e| {
+        Error::Mlx(format!(
+            "iso_flash_decode_symv P1(bits={bits}) kernel init: {e}"
+        ))
+    })
+}
+
+fn p2_kernel() -> Result<&'static MetalKernel> {
+    P2_KERNEL
+        .get_or_init(|| {
+            MetalKernel::new(
+                "rmlx_iso_flash_decode_symv_p2",
+                "", // No header — P2 is generic over (head_dim, n_tiles, n_bh).
+                P2_SOURCE,
+                &["partial_o", "tile_max", "tile_sum_exp", "dims_p2"],
+                &["dst"],
+            )
+            .map_err(|e| format!("{e}"))
+        })
+        .as_ref()
+        .map_err(|e| Error::Mlx(format!("iso_flash_decode_symv P2 kernel init: {e}")))
+}
+
+/// The packed iso payload of one axis, as the dispatcher takes it.
+///
+/// Grouping the three buffers keeps `iso_flash_decode_symv_sdpa` from taking six
+/// positional `&Array`s in a row, where a K/V transposition at a call site would
+/// type-check and decode the wrong store.
+#[derive(Debug, Clone, Copy)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "plain parameter bundle — literal construction at the call site IS the intended use, \
+              and the field set is the codec's on-disk contract (codes/scales/norms). A new field \
+              would be a new codec layout, which must break every call site anyway"
+)]
+pub struct IsoPackedAxis<'a> {
+    /// Packed iso codes, flat `u32 [B * kv_seq * kv_h * n_groups]`
+    /// (sequence-major).
+    pub codes: &'a Array,
+    /// Per-group f32 scales, same flat length as `codes`.
+    pub scales: &'a Array,
+    /// Per-token f32 L2 norms, flat `[B * kv_seq * kv_h]`.
+    pub norms: &'a Array,
+}
+
+/// Shape metadata for one decode step.
+#[derive(Debug, Clone, Copy)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "plain parameter bundle — literal construction at the call site IS the intended use; \
+              every field is a required shape the dispatcher validates, so there is no default a \
+              non-exhaustive builder could supply"
+)]
+pub struct IsoFlashShape {
+    /// Batch size. Must be 1 — the rings do not interleave batch in their
+    /// per-step stride.
+    pub b: i32,
+    /// KV head count.
+    pub kv_h: i32,
+    /// Accumulated KV positions to attend.
+    pub kv_seq: i32,
+    /// Per-head dimension. Power of two, multiple of the quaternion block size,
+    /// `<= ISO_FLASH_HEAD_DIM_MAX`.
+    pub head_dim: i32,
+    /// Query heads per KV head (GQA fan-out).
+    pub heads_per_kv: i32,
+}
+
+// ── Public dispatcher ─────────────────────────────────────────────────────────
+
+/// Run the iso symmetric flash-decode kernel (fused QK over iso-quant K + online
+/// softmax + **iso-quant V** SV).
+///
+/// # Inputs
+///
+/// * `query` — Q for the new token, shape `[B, n_q_heads, 1, head_dim]`.
+/// * `k` / `v` — the two packed iso axes ([`IsoPackedAxis`]).
+/// * `additive_mask` — optional `f32 [B, n_q_heads, 1, kv_seq]`.
+/// * `shape` — [`IsoFlashShape`].
+/// * `scale` — softmax pre-scale (typically `1/sqrt(head_dim)`).
+/// * `device` — MLX device (must be GPU).
+///
+/// # Output
+///
+/// `f32` array of shape `[B, n_q_heads, 1, head_dim]`.
+///
+/// # Errors
+///
+/// * [`Error::Quant`] for `BITS` outside `{3, 4}`, shape-contract violations
+///   (`head_dim` not a power of two, not a multiple of the quaternion block
+///   size, above [`ISO_FLASH_HEAD_DIM_MAX`], non-positive shapes), or grid
+///   overflow.
+/// * [`Error::Mlx`] for kernel build / dispatch failures.
+#[allow(clippy::too_many_lines)]
+pub fn iso_flash_decode_symv_sdpa<const BITS: u8>(
+    query: &Array,
+    k: IsoPackedAxis<'_>,
+    v: IsoPackedAxis<'_>,
+    additive_mask: Option<&Array>,
+    shape: IsoFlashShape,
+    scale: f32,
+    device: Device,
+) -> Result<Array> {
+    if BITS != 3 && BITS != 4 {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode_symv: unsupported BITS={BITS} (only 3 and 4)"
+        )));
+    }
+    let IsoFlashShape {
+        b,
+        kv_h,
+        kv_seq,
+        head_dim,
+        heads_per_kv,
+    } = shape;
+
+    if head_dim <= 0 {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode_symv: head_dim={head_dim} must be positive"
+        )));
+    }
+    if !(head_dim as u32).is_power_of_two() {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode_symv: head_dim={head_dim} must be a power of two for the \
+             tree reduction; caller falls back to the CPU dequant path"
+        )));
+    }
+    if head_dim > ISO_FLASH_HEAD_DIM_MAX {
+        let max = ISO_FLASH_HEAD_DIM_MAX;
+        return Err(Error::Quant(format!(
+            "iso_flash_decode_symv: head_dim={head_dim} exceeds \
+             ISO_FLASH_HEAD_DIM_MAX={max}; raise the static threadgroup-array sizes in \
+             metal/iso_flash_decode_symv_p1.metal to support it"
+        )));
+    }
+    if !(head_dim as usize).is_multiple_of(ISO_QUAT_BLOCK_SIZE) {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode_symv: head_dim={head_dim} must be a multiple of the quaternion \
+             block size {ISO_QUAT_BLOCK_SIZE}"
+        )));
+    }
+    if heads_per_kv <= 0 {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode_symv: heads_per_kv must be > 0, got {heads_per_kv}"
+        )));
+    }
+    if b <= 0 || kv_seq <= 0 || kv_h <= 0 {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode_symv: b={b}, kv_h={kv_h}, kv_seq={kv_seq} must all be > 0"
+        )));
+    }
+
+    let n_q_heads = kv_h * heads_per_kv;
+    let n_bh = b * n_q_heads;
+    let n_tiles = (kv_seq + TILE_SIZE - 1) / TILE_SIZE;
+    let n_groups = iso_n_groups_for(head_dim as usize);
+    let n_groups_i64 = n_groups as i64;
+
+    // ── Flatten Q to [n_bh * head_dim] f32 ────────────────────────────────
+    let q_total: i64 = i64::from(n_bh) * i64::from(head_dim);
+    let q_flat = query.reshape(&[q_total as i32], device)?;
+    let q_f32 = if q_flat.dtype() == Dtype::F32 {
+        q_flat
+    } else {
+        q_flat.astype(Dtype::F32, device)?
+    };
+
+    // ── Flatten both packed axes ──────────────────────────────────────────
+    let tok_count: i64 = i64::from(b) * i64::from(kv_h) * i64::from(kv_seq);
+    let codes_total: i64 = tok_count * n_groups_i64;
+
+    let flatten_axis = |axis: IsoPackedAxis<'_>| -> Result<(Array, Array, Array)> {
+        Ok((
+            axis.codes.reshape(&[codes_total as i32], device)?,
+            axis.scales.reshape(&[codes_total as i32], device)?,
+            axis.norms.reshape(&[tok_count as i32], device)?,
+        ))
+    };
+    let (k_codes, k_scales, k_norms) = flatten_axis(k)?;
+    let (v_codes, v_scales, v_norms) = flatten_axis(v)?;
+
+    // ── Mask ──────────────────────────────────────────────────────────────
+    let (mask_flat, has_mask) = if let Some(m) = additive_mask {
+        let flat_len: i64 = i64::from(n_bh) * i64::from(kv_seq);
+        let m_f = if m.dtype() == Dtype::F32 {
+            m.reshape(&[flat_len as i32], device)?
+        } else {
+            m.astype(Dtype::F32, device)?
+                .reshape(&[flat_len as i32], device)?
+        };
+        (m_f, 1u32)
+    } else {
+        let zero_bytes = [0u8; 4];
+        Array::from_bytes(&zero_bytes, &[1], Dtype::F32)
+            .map(|a| (a, 0u32))
+            .map_err(|e| Error::Mlx(format!("iso_flash_decode_symv dummy mask: {e}")))?
+    };
+
+    // ── scale_arr ─────────────────────────────────────────────────────────
+    let scale_arr = {
+        let bytes = scale.to_le_bytes();
+        Array::from_bytes(&bytes, &[1], Dtype::F32)?
+    };
+
+    // ── dims (8 u32) ──────────────────────────────────────────────────────
+    // `bits` is not carried — the dispatcher selects the per-BITS kernel and
+    // its header supplies IF_BITS / IF_MASK.
+    let dims_arr = {
+        let dims: [u32; 8] = [
+            head_dim as u32,
+            kv_seq as u32,
+            n_bh as u32,
+            kv_h as u32,
+            heads_per_kv as u32,
+            n_tiles as u32,
+            has_mask,
+            n_groups as u32,
+        ];
+        // SAFETY:
+        // * `dims` is a stack-local `[u32; 8]` fully initialised above.
+        // * `u32` has stricter alignment than `u8`, so the cast is sound.
+        // * The byte length `8 * 4` equals `size_of::<[u32; 8]>()`.
+        // * The borrow is bounded by the enclosing block; `Array::from_bytes`
+        //   copies into mlx storage before this scope ends.
+        let bytes: &[u8] = unsafe { std::slice::from_raw_parts(dims.as_ptr().cast::<u8>(), 8 * 4) };
+        Array::from_bytes(bytes, &[8], Dtype::U32)
+            .map_err(|e| Error::Mlx(format!("iso_flash_decode_symv dims: {e}")))?
+    };
+
+    // Materialise inputs to flush any pending lazy ops before kernel dispatch.
+    // The MSL kernels read by raw linear offset and ignore MLX lazy-transpose
+    // strides, so a pending permutation must be resolved here.
+    q_f32.eval()?;
+    for arr in [&k_codes, &k_scales, &k_norms, &v_codes, &v_scales, &v_norms] {
+        arr.eval()?;
+    }
+    if has_mask == 1 {
+        mask_flat.eval()?;
+    }
+    scale_arr.eval()?;
+    dims_arr.eval()?;
+
+    // ── P1 dispatch ───────────────────────────────────────────────────────
+    let kern_p1 = p1_kernel(BITS)?;
+    let mut inv_p1 = MetalKernelInvoke::new();
+    inv_p1.add_input(&q_f32)?;
+    inv_p1.add_input(&k_codes)?;
+    inv_p1.add_input(&k_scales)?;
+    inv_p1.add_input(&k_norms)?;
+    inv_p1.add_input(&v_codes)?;
+    inv_p1.add_input(&v_scales)?;
+    inv_p1.add_input(&v_norms)?;
+    inv_p1.add_input(&mask_flat)?;
+    inv_p1.add_input(&scale_arr)?;
+    inv_p1.add_input(&dims_arr)?;
+
+    let partial_o_len: i64 = i64::from(n_tiles) * i64::from(n_bh) * i64::from(head_dim);
+    let tile_meta_len: i64 = i64::from(n_tiles) * i64::from(n_bh);
+    if partial_o_len > i64::from(i32::MAX) {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode_symv: partial_o length {partial_o_len} exceeds i32::MAX"
+        )));
+    }
+    inv_p1.add_output_shape(&[partial_o_len as i32], Dtype::F32)?;
+    inv_p1.add_output_shape(&[tile_meta_len as i32], Dtype::F32)?;
+    inv_p1.add_output_shape(&[tile_meta_len as i32], Dtype::F32)?;
+
+    // Grid X: n_tiles threadgroups × head_dim threads each.
+    let grid_x: i64 = i64::from(n_tiles) * i64::from(head_dim);
+    let grid_y: i64 = i64::from(n_bh);
+    if grid_x > i64::from(i32::MAX) || grid_y > i64::from(i32::MAX) {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode_symv: grid dimensions exceed i32::MAX (x={grid_x}, y={grid_y})"
+        )));
+    }
+    inv_p1.set_grid(grid_x as i32, grid_y as i32, 1)?;
+    inv_p1.set_thread_group(head_dim, 1, 1)?;
+
+    // Counter increment at the actual P1 enqueue point — after every
+    // validation gate, immediately before `.apply()`.
+    if BITS == 3 {
+        ISO3_SYMV_FLASH_DECODE_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+    } else {
+        ISO4_SYMV_FLASH_DECODE_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+    }
+    tracing::trace!(
+        bits = BITS,
+        b,
+        n_q_heads,
+        kv_h,
+        kv_seq,
+        head_dim,
+        has_mask,
+        n_groups,
+        n_tiles,
+        "iso_flash_decode_symv_sdpa: dispatch"
+    );
+
+    let mut p1_outs = kern_p1.apply(inv_p1, device)?;
+    if p1_outs.len() < 3 {
+        return Err(Error::Mlx(
+            "iso_flash_decode_symv P1: expected 3 outputs".into(),
+        ));
+    }
+    let partial_o = p1_outs.remove(0);
+    let tile_max = p1_outs.remove(0);
+    let tile_sum_exp = p1_outs.remove(0);
+
+    // ── P2 dispatch ───────────────────────────────────────────────────────
+    let dims_p2_arr = {
+        let dims_p2: [u32; 3] = [head_dim as u32, n_tiles as u32, n_bh as u32];
+        // SAFETY: same reasoning as the `dims` cast above — stack-local
+        // `[u32; 3]`, `u32` alignment ≥ `u8`, byte length `3 * 4` equals
+        // `size_of::<[u32; 3]>()`, and `Array::from_bytes` copies before the
+        // borrow ends.
+        let bytes: &[u8] =
+            unsafe { std::slice::from_raw_parts(dims_p2.as_ptr().cast::<u8>(), 3 * 4) };
+        Array::from_bytes(bytes, &[3], Dtype::U32)
+            .map_err(|e| Error::Mlx(format!("iso_flash_decode_symv dims_p2: {e}")))?
+    };
+
+    let kern_p2 = p2_kernel()?;
+    let mut inv_p2 = MetalKernelInvoke::new();
+    inv_p2.add_input(&partial_o)?;
+    inv_p2.add_input(&tile_max)?;
+    inv_p2.add_input(&tile_sum_exp)?;
+    inv_p2.add_input(&dims_p2_arr)?;
+
+    let dst_len: i64 = i64::from(n_bh) * i64::from(head_dim);
+    inv_p2.add_output_shape(&[dst_len as i32], Dtype::F32)?;
+
+    let p2_grid_x: i64 = i64::from(n_bh) * i64::from(head_dim);
+    if p2_grid_x > i64::from(i32::MAX) {
+        return Err(Error::Quant(format!(
+            "iso_flash_decode_symv P2: grid x {p2_grid_x} exceeds i32::MAX"
+        )));
+    }
+    inv_p2.set_grid(p2_grid_x as i32, 1, 1)?;
+    inv_p2.set_thread_group(head_dim, 1, 1)?;
+
+    let mut p2_outs = kern_p2.apply(inv_p2, device)?;
+    if p2_outs.is_empty() {
+        return Err(Error::Mlx(
+            "iso_flash_decode_symv P2: expected 1 output".into(),
+        ));
+    }
+    let dst_flat = p2_outs.remove(0);
+
+    // Reshape to canonical SDPA output.
+    dst_flat.reshape(&[b, n_q_heads, 1, head_dim], device)
+}
+
+#[cfg(test)]
+#[path = "iso_flash_decode_symv_msl_tests.rs"]
+mod iso_flash_decode_symv_msl_tests;

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_symv_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_symv_msl.rs
@@ -103,6 +103,7 @@ use rmlx_core::error::{Error, Result};
 use rmlx_mlx::metal_kernel::{MetalKernel, MetalKernelInvoke};
 use rmlx_mlx::{Array, Device, Dtype};
 
+use crate::flash_decode_common::pad_norms_to_device_floor;
 use crate::iso_flash_decode_msl::{build_iso_flash_header, ISO_FLASH_HEAD_DIM_MAX, TILE_SIZE};
 use crate::storage::{iso_n_groups_for, ISO_QUAT_BLOCK_SIZE};
 
@@ -395,6 +396,11 @@ pub fn iso_flash_decode_symv_sdpa<const BITS: u8>(
     };
     let (k_codes, k_scales, k_norms) = flatten_axis(k)?;
     let (v_codes, v_scales, v_norms) = flatten_axis(v)?;
+
+    // GPU-native small-`norms`-buffer floor — see
+    // [`crate::flash_decode_common::pad_norms_to_device_floor`].
+    let k_norms = pad_norms_to_device_floor(k_norms, tok_count, device)?;
+    let v_norms = pad_norms_to_device_floor(v_norms, tok_count, device)?;
 
     // ── Mask ──────────────────────────────────────────────────────────────
     let (mask_flat, has_mask) = if let Some(m) = additive_mask {

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_symv_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_symv_msl_tests.rs
@@ -1,0 +1,583 @@
+//! GPU parity tests for the iso symmetric (quant-K + quant-V) flash-decode
+//! kernel (BITS in {3, 4}).
+//!
+//! The oracle is the codec's own CPU dequant ([`crate::isoquant::iso_decode_fast`])
+//! applied to **both** axes and fed through a scalar reference attention chain.
+//! Decoding V with the codec's own reference — rather than comparing against the
+//! bf16 mirror this kernel deletes — is the point: it proves the in-kernel V
+//! unpack reproduces the codec, not that it agrees with a buffer that no longer
+//! exists.
+
+use super::*;
+use crate::isoquant::{iso_decode_fast, iso_encode_fast};
+use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
+use rmlx_mlx::{Array, Device, Dtype};
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn make_f32_array(data: &[f32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::F32).expect("make_f32_array")
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn make_u32_array(data: &[u32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|w| w.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::U32).expect("make_u32_array")
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: chunks_exact(4) guarantees length"
+)]
+fn array_to_f32(a: &Array) -> Vec<f32> {
+    a.eval().expect("array eval");
+    let bytes = a.to_bytes().expect("to_bytes");
+    bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
+        .collect()
+}
+
+/// Scalar reference attention over already-dequantized K **and** V.
+///
+/// Both `k_deq` and `v_deq` are sequence-major (`[(s * kv_h + h), head_dim]`) —
+/// the layout both iso rings accumulate and the kernel reads. This is the
+/// difference from the bf16-V sibling's reference, whose V was head-major.
+#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "test reference: all indices derived from the shape params under test"
+)]
+fn ref_attention_quant_v(
+    q: &[f32],
+    k_deq: &[f32],
+    v_deq: &[f32],
+    mask: Option<&[f32]>,
+    n_q_heads: usize,
+    kv_h: usize,
+    kv_seq: usize,
+    head_dim: usize,
+    scale: f32,
+) -> Vec<f32> {
+    let heads_per_kv = n_q_heads / kv_h;
+    let mut out = vec![0.0_f32; n_q_heads * head_dim];
+    for hq in 0..n_q_heads {
+        let h = hq / heads_per_kv;
+
+        // Scores over the whole prefix.
+        let mut scores = vec![0.0_f32; kv_seq];
+        for (s, score) in scores.iter_mut().enumerate() {
+            let k_row = (s * kv_h + h) * head_dim;
+            let mut acc = 0.0_f32;
+            for d in 0..head_dim {
+                acc += q[hq * head_dim + d] * k_deq[k_row + d];
+            }
+            *score = acc * scale;
+        }
+        if let Some(m) = mask {
+            // Additive mask, laid out [b, n_q_heads, 1, kv_seq] with b == 1.
+            for (s, score) in scores.iter_mut().enumerate() {
+                *score += m[hq * kv_seq + s];
+            }
+        }
+
+        // Softmax (max-subtracted, matching the kernel's online form).
+        let mut m = f32::NEG_INFINITY;
+        for &s in &scores {
+            if s > m {
+                m = s;
+            }
+        }
+        let mut denom = 0.0_f32;
+        for s in &mut scores {
+            *s = (*s - m).exp();
+            denom += *s;
+        }
+
+        // Weighted V sum — V read sequence-major, same as K.
+        for d in 0..head_dim {
+            let mut acc = 0.0_f32;
+            for (s, &p) in scores.iter().enumerate() {
+                acc += p * v_deq[(s * kv_h + h) * head_dim + d];
+            }
+            out[hq * head_dim + d] = acc / denom;
+        }
+    }
+    out
+}
+
+/// One axis's packed iso buffers plus the matching CPU dequant oracle.
+struct EncodedAxis {
+    codes: Array,
+    scales: Array,
+    norms: Array,
+    dequant: Vec<f32>,
+}
+
+impl EncodedAxis {
+    fn as_packed(&self) -> IsoPackedAxis<'_> {
+        IsoPackedAxis {
+            codes: &self.codes,
+            scales: &self.scales,
+            norms: &self.norms,
+        }
+    }
+}
+
+/// Encode `seq_major` with the iso codec on CPU and return the GPU-resident
+/// packed buffers plus the CPU dequant oracle. The per-group quaternion table
+/// (all `FIXED_QUAT`) is dropped — the kernel bakes the constant into its
+/// header and the ring never carries it.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn iso_encode_axis(seq_major: &[f32], head_dim: usize, bits: u8) -> EncodedAxis {
+    let (codes, scales, quaternions, norms) =
+        iso_encode_fast(seq_major, head_dim, ISO_QUAT_BLOCK_SIZE, bits).expect("iso_encode_fast");
+    let dequant = iso_decode_fast(
+        &codes,
+        &scales,
+        &quaternions,
+        &norms,
+        head_dim,
+        ISO_QUAT_BLOCK_SIZE,
+        bits,
+    )
+    .expect("iso_decode_fast");
+
+    EncodedAxis {
+        codes: make_u32_array(&codes, &[codes.len() as i32]),
+        scales: make_f32_array(&scales, &[scales.len() as i32]),
+        norms: make_f32_array(&norms, &[norms.len() as i32]),
+        dequant,
+    }
+}
+
+/// Run the kernel against the CPU-dequant oracle for one shape, with no mask.
+fn run_oracle(bits: u8, kv_h: usize, heads_per_kv: usize, kv_seq: usize, head_dim: usize) -> bool {
+    run_oracle_masked(bits, kv_h, heads_per_kv, kv_seq, head_dim, false)
+}
+
+/// Run the kernel against the CPU-dequant oracle for one shape.
+///
+/// When `with_mask`, feeds a per-(q_head, key) additive mask with a distinct
+/// value in every cell, so a transposed or mis-strided mask index in either the
+/// kernel or the dispatcher changes the result instead of cancelling out.
+///
+/// Returns `false` when the GPU is unavailable so the caller can skip.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+#[allow(clippy::too_many_arguments)]
+fn run_oracle_masked(
+    bits: u8,
+    kv_h: usize,
+    heads_per_kv: usize,
+    kv_seq: usize,
+    head_dim: usize,
+    with_mask: bool,
+) -> bool {
+    if skip_if_no_gpu_env() {
+        return false;
+    }
+    let b = 1_usize;
+    let n_q_heads = kv_h * heads_per_kv;
+    let n_tokens = kv_seq * kv_h;
+
+    let q = lcg_data(n_q_heads * head_dim, 0xA11CE);
+    // K and V are both generated in the stores' sequence-major order: token
+    // (s, h) at row (s * kv_h + h). Different seeds so a K/V buffer swap in the
+    // dispatcher cannot pass.
+    let k = lcg_data(n_tokens * head_dim, 0xB0B);
+    let v = lcg_data(n_tokens * head_dim, 0xC0FFEE);
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    let k_axis = iso_encode_axis(&k, head_dim, bits);
+    let v_axis = iso_encode_axis(&v, head_dim, bits);
+    let q_arr = make_f32_array(&q, &[b as i32, n_q_heads as i32, 1, head_dim as i32]);
+
+    // Asymmetric in both axes and never zero, so a (hq, s) index swap or a wrong
+    // stride shifts the scores rather than landing on an equal value. Includes a
+    // -inf-ish cell to exercise full suppression through the online softmax.
+    let mask_vec: Option<Vec<f32>> = with_mask.then(|| {
+        (0..n_q_heads * kv_seq)
+            .map(|i| {
+                let hq = i / kv_seq;
+                let s = i % kv_seq;
+                if hq == 0 && s == kv_seq / 2 {
+                    -1.0e30
+                } else {
+                    (hq as f32) * 0.25 - (s as f32) * 0.03125
+                }
+            })
+            .collect()
+    });
+    let mask_arr = mask_vec
+        .as_ref()
+        .map(|m| make_f32_array(m, &[b as i32, n_q_heads as i32, 1, kv_seq as i32]));
+
+    let shape = IsoFlashShape {
+        b: b as i32,
+        kv_h: kv_h as i32,
+        kv_seq: kv_seq as i32,
+        head_dim: head_dim as i32,
+        heads_per_kv: heads_per_kv as i32,
+    };
+
+    let out = match bits {
+        3 => iso_flash_decode_symv_sdpa::<3>(
+            &q_arr,
+            k_axis.as_packed(),
+            v_axis.as_packed(),
+            mask_arr.as_ref(),
+            shape,
+            scale,
+            Device::Gpu,
+        ),
+        _ => iso_flash_decode_symv_sdpa::<4>(
+            &q_arr,
+            k_axis.as_packed(),
+            v_axis.as_packed(),
+            mask_arr.as_ref(),
+            shape,
+            scale,
+            Device::Gpu,
+        ),
+    }
+    .expect("iso_flash_decode_symv_sdpa");
+
+    let got = array_to_f32(&out);
+    let want = ref_attention_quant_v(
+        &q,
+        &k_axis.dequant,
+        &v_axis.dequant,
+        mask_vec.as_deref(),
+        n_q_heads,
+        kv_h,
+        kv_seq,
+        head_dim,
+        scale,
+    );
+
+    assert_eq!(got.len(), want.len(), "bits={bits}: output length");
+    let mut max_err = 0.0_f32;
+    for (g, w) in got.iter().zip(want.iter()) {
+        max_err = max_err.max((g - w).abs());
+    }
+    // bf16 has ~8 mantissa bits (~3e-3 relative). The kernel accumulates in
+    // f32 but is fed the same quantized codes as the oracle, so the only
+    // divergence is summation order; this bound is well inside bf16 tolerance.
+    assert!(
+        max_err < 2e-3,
+        "bits={bits} kv_h={kv_h} hpk={heads_per_kv} S={kv_seq} D={head_dim}: \
+         max_err={max_err} exceeds bf16 tolerance"
+    );
+    true
+}
+
+// ── Oracle: kernel == CPU dequant reference on BOTH axes ──────────────────────
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso3_symv_flash_decode_matches_cpu_dequant_reference() {
+    // Bonsai / Qwen3 shape: head_dim 128, GQA 4:1.
+    run_oracle(3, 2, 4, 40, 128);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso4_symv_flash_decode_matches_cpu_dequant_reference() {
+    run_oracle(4, 2, 4, 40, 128);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso3_symv_flash_decode_matches_reference_across_tiles() {
+    // kv_seq is set above TILE_SIZE so the P2 log-sum-exp merge runs over
+    // several tiles rather than a single one.
+    run_oracle(3, 1, 8, (TILE_SIZE as usize) * 2 + 22, 128);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso4_symv_flash_decode_matches_reference_across_tiles() {
+    run_oracle(4, 1, 8, (TILE_SIZE as usize) * 2 + 22, 128);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso3_symv_flash_decode_matches_reference_head_dim_512() {
+    // Gemma4 e2b/e4b global layers run head_dim = 512 with a single KV head.
+    run_oracle(3, 1, 8, 70, 512);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso4_symv_flash_decode_matches_reference_head_dim_512() {
+    run_oracle(4, 1, 8, 70, 512);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso3_symv_flash_decode_matches_reference_head_dim_256() {
+    run_oracle(3, 1, 4, 70, 256);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso4_symv_flash_decode_matches_reference_head_dim_256() {
+    run_oracle(4, 2, 2, 40, 256);
+}
+
+// ── Additive mask + GQA ───────────────────────────────────────────────────────
+//
+// Without these the kernel's mask read
+// (`mask_flat[(b * n_q_heads + hq) * kv_seq + t]`) and the dispatcher's mask
+// flatten are never executed — every other test passes `None`, so a transposed
+// or mis-strided mask index would pass the whole suite.
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso3_symv_flash_decode_matches_reference_with_additive_mask() {
+    // kv_h=2, heads_per_kv=4 also pins the GQA (q_head -> kv_head) mapping: the
+    // mask is indexed by q_head while K/V are indexed by kv_head, so conflating
+    // the two shows up here.
+    run_oracle_masked(3, 2, 4, 40, 128, true);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso4_symv_flash_decode_matches_reference_with_additive_mask() {
+    run_oracle_masked(4, 2, 4, 40, 128, true);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso3_symv_flash_decode_matches_reference_with_mask_across_tiles() {
+    // Mask + multi-tile: the per-tile online softmax and the P2 merge both have
+    // to see the masked scores.
+    run_oracle_masked(3, 2, 4, (TILE_SIZE as usize) * 2 + 22, 128, true);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso4_symv_flash_decode_matches_reference_with_mask_high_gqa() {
+    // kv_h=2, heads_per_kv=8: a wider GQA fan-out than the shapes above, so a
+    // `hq / heads_per_kv` vs `hq % kv_h` mix-up in the kv-head mapping lands on
+    // a different KV row and fails here.
+    run_oracle_masked(4, 2, 8, 40, 128, true);
+}
+
+// ── Gates ─────────────────────────────────────────────────────────────────────
+//
+// Every gate below is a refusal, not a fallback: an unsupported shape or bit
+// width must error rather than decode against another codec's kernel.
+
+/// A one-element dummy axis for the shape-rejection gates, which reject before
+/// any buffer is read. Borrows the caller's locals — the gates never look at
+/// the contents, only at the shape metadata.
+fn dummy_axis<'a>(codes: &'a Array, f: &'a Array) -> IsoPackedAxis<'a> {
+    IsoPackedAxis {
+        codes,
+        scales: f,
+        norms: f,
+    }
+}
+
+#[test]
+fn iso_symv_flash_decode_rejects_non_pow2_head_dim() {
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    let axis = dummy_axis(&codes, &dummy);
+    let err = iso_flash_decode_symv_sdpa::<3>(
+        &dummy,
+        axis,
+        axis,
+        None,
+        IsoFlashShape {
+            b: 1,
+            kv_h: 1,
+            kv_seq: 8,
+            head_dim: 96,
+            heads_per_kv: 1,
+        },
+        1.0,
+        Device::Cpu,
+    );
+    assert!(
+        err.is_err(),
+        "head_dim=96 is not a power of two — the tree reduction requires one"
+    );
+}
+
+#[test]
+fn iso_symv_flash_decode_rejects_head_dim_above_max() {
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    let axis = dummy_axis(&codes, &dummy);
+    let over = ISO_FLASH_HEAD_DIM_MAX * 2;
+    let err = iso_flash_decode_symv_sdpa::<3>(
+        &dummy,
+        axis,
+        axis,
+        None,
+        IsoFlashShape {
+            b: 1,
+            kv_h: 1,
+            kv_seq: 8,
+            head_dim: over,
+            heads_per_kv: 1,
+        },
+        1.0,
+        Device::Cpu,
+    );
+    assert!(
+        err.is_err(),
+        "head_dim={over} exceeds the static threadgroup-array ceiling"
+    );
+}
+
+#[test]
+fn iso_symv_flash_decode_rejects_non_block_multiple_head_dim() {
+    // head_dim must be a multiple of the quaternion block size; a power-of-two
+    // that is not (there is none < block size, so use block_size/2 = 2) must be
+    // rejected rather than silently decoding a partial group.
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    let axis = dummy_axis(&codes, &dummy);
+    let err = iso_flash_decode_symv_sdpa::<3>(
+        &dummy,
+        axis,
+        axis,
+        None,
+        IsoFlashShape {
+            b: 1,
+            kv_h: 1,
+            kv_seq: 8,
+            head_dim: 2,
+            heads_per_kv: 1,
+        },
+        1.0,
+        Device::Cpu,
+    );
+    assert!(
+        err.is_err(),
+        "head_dim=2 is not a multiple of the quaternion block size"
+    );
+}
+
+#[test]
+fn iso_symv_flash_decode_rejects_unsupported_bits() {
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    let axis = dummy_axis(&codes, &dummy);
+    // An unknown bit width must be an explicit error, never a silent fallback
+    // to a kernel built for a different unpack width.
+    let err = iso_flash_decode_symv_sdpa::<5>(
+        &dummy,
+        axis,
+        axis,
+        None,
+        IsoFlashShape {
+            b: 1,
+            kv_h: 1,
+            kv_seq: 8,
+            head_dim: 128,
+            heads_per_kv: 1,
+        },
+        1.0,
+        Device::Cpu,
+    );
+    assert!(err.is_err(), "BITS=5 must be rejected");
+}
+
+#[test]
+fn iso_symv_flash_decode_rejects_non_positive_shapes() {
+    let dummy = make_f32_array(&[0.0], &[1]);
+    let codes = make_u32_array(&[0], &[1]);
+    let axis = dummy_axis(&codes, &dummy);
+    for (b, kv_h, kv_seq, heads_per_kv) in [(0, 1, 8, 1), (1, 0, 8, 1), (1, 1, 0, 1), (1, 1, 8, 0)]
+    {
+        let err = iso_flash_decode_symv_sdpa::<3>(
+            &dummy,
+            axis,
+            axis,
+            None,
+            IsoFlashShape {
+                b,
+                kv_h,
+                kv_seq,
+                head_dim: 128,
+                heads_per_kv,
+            },
+            1.0,
+            Device::Cpu,
+        );
+        assert!(
+            err.is_err(),
+            "b={b} kv_h={kv_h} kv_seq={kv_seq} heads_per_kv={heads_per_kv} must be rejected"
+        );
+    }
+}
+
+// ── Header reuse ──────────────────────────────────────────────────────────────
+
+#[test]
+fn symv_kernel_reuses_the_shared_iso_decode_fn() {
+    #[allow(
+        clippy::unwrap_used,
+        reason = "bits 3 is a supported width; a failure here is the assertion"
+    )]
+    let h = build_iso_flash_header(3).unwrap();
+    // This kernel's whole design rests on calling the sibling's per-lane iso
+    // decode unchanged, for both axes. If the header stops exposing it as a
+    // function, the body stops compiling — pin the contract here so the reason
+    // is legible rather than an MSL build error at first dispatch.
+    assert!(
+        h.contains("inline float if_decode_k_lane("),
+        "header must expose the shared per-lane iso decode as a function"
+    );
+    // Both axes are unpacked by the same body, so the body must call it twice —
+    // once per axis. A single call would mean one axis is being read some other
+    // way (or not at all).
+    let body = include_str!("metal/iso_flash_decode_symv_p1.metal");
+    assert_eq!(
+        body.matches("if_decode_k_lane(").count(),
+        2,
+        "symv body must decode exactly two axes through the shared per-lane decode"
+    );
+    assert!(
+        body.contains("if_decode_k_lane(k_codes, k_scales, k_norms,"),
+        "K axis must be read from the K ring"
+    );
+    assert!(
+        body.contains("if_decode_k_lane(v_codes, v_scales, v_norms,"),
+        "V axis must be read from the V ring"
+    );
+}
+
+// ── Dispatch counter ──────────────────────────────────────────────────────────
+
+// The counter is process-global and `cargo test` runs this binary's tests on
+// parallel threads, so only a **relative** delta around a known dispatch is
+// assertable here — a concurrent test can inflate it at any time. An absolute
+// "starts at zero" check would be a flake, and the negative case ("did not
+// fire") is asserted on cache-local state in the kvcache dispatch tests instead.
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode_symv -- --ignored --test-threads=1"]
+fn iso_symv_flash_decode_dispatch_count_increments_on_gpu() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let before3 = iso3_symv_flash_decode_dispatch_count();
+    let before4 = iso4_symv_flash_decode_dispatch_count();
+    assert!(run_oracle(3, 1, 2, 8, 128));
+    assert!(run_oracle(4, 1, 2, 8, 128));
+    assert!(
+        iso3_symv_flash_decode_dispatch_count() > before3,
+        "iso3 symv flash-decode kernel did not fire"
+    );
+    assert!(
+        iso4_symv_flash_decode_dispatch_count() > before4,
+        "iso4 symv flash-decode kernel did not fire"
+    );
+}

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -13,6 +13,7 @@ use rmlx_mlx::{
 };
 
 use crate::iso_flash_decode_msl::{iso_flash_decode_sdpa, ISO_FLASH_HEAD_DIM_MAX};
+use crate::iso_flash_decode_symv_msl::{iso_flash_decode_symv_sdpa, IsoFlashShape, IsoPackedAxis};
 use crate::mixed_quant::{mixed_quantized_sdpa, rot_k_tq4v_sdpa};
 use crate::planar_flash_decode_msl::{planar_flash_decode_enabled, planar_flash_decode_sdpa};
 use crate::planar_fused_qk::planar_fused_qk_enabled;
@@ -699,6 +700,30 @@ impl KvCache {
             }
         }
 
+        // 1d'. Iso symmetric quant-K + quant-V flash-decode fast path. Without it
+        // this codec decodes from a full bf16 K+V mirror seeded at
+        // `exit_prefill` — the packed store is written and never read, so the
+        // codec is dormant and its KV footprint is the heaviest in the matrix.
+        // The kernel reads both packed iso rings directly, so no bf16 mirror is
+        // needed on either axis. Iso has no QJL, so no equivalent gate.
+        if matches!(
+            self.storage,
+            KvStorage::IsoSym3 { .. } | KvStorage::IsoSym4 { .. }
+        ) && device == Device::Gpu
+            && queries.shape().get(2).copied().unwrap_or(0) == 1
+        {
+            if let Some(out) = self.update_and_sdpa_iso_sym_fused(
+                queries,
+                new_k,
+                new_v,
+                scale,
+                additive_mask,
+                device,
+            )? {
+                return Ok(out);
+            }
+        }
+
         // 1e. Rotor symmetric quant-K + quant-V flash-decode fast path. Without
         // it this codec decodes from a full bf16 K+V mirror seeded at
         // `exit_prefill` — the packed store is written and never read, so the
@@ -1046,6 +1071,35 @@ impl KvCache {
             }
         }
 
+        // Iso symmetric quant-K + quant-V flash-decode. Without it this codec is
+        // pushed onto the legacy bf16 path on any shared-KV model and its fused
+        // kernel is silently dead there.
+        if matches!(
+            self.storage,
+            KvStorage::IsoSym3 { .. } | KvStorage::IsoSym4 { .. }
+        ) && device == Device::Gpu
+            && q_seq_is_decode
+        {
+            if let Some(out) = self.update_and_sdpa_iso_sym_fused(
+                queries,
+                new_k,
+                new_v,
+                scale,
+                additive_mask,
+                device,
+            )? {
+                tracing::debug!(
+                    target: "rmlx_kv_quant::shared_kv",
+                    kernel = "iso_flash_symv",
+                    offset = self.offset,
+                    "fused kernel dispatched on the shared-KV producer path — \
+                     consumers attend the quant store"
+                );
+                let kv_len = iso_sym_accumulated_seq(&self.storage)?;
+                return Ok(Some((out, kv_len)));
+            }
+        }
+
         // Rotor symmetric quant-K + quant-V flash-decode. Without it this codec
         // is pushed onto the legacy bf16 path on any shared-KV model and its
         // fused kernel is silently dead there.
@@ -1196,6 +1250,11 @@ impl KvCache {
             }
             // Both axes come from the quant store — no `slice_decode_fp16_v`,
             // because this codec keeps no bf16 V to slice.
+            KvStorage::IsoSym3 { .. } | KvStorage::IsoSym4 { .. } => {
+                let kv_seq = iso_sym_accumulated_seq(&self.storage)?;
+                Self::check_shared_kv_len(kv_len, kv_seq)?;
+                self.iso_sym_flash_over_store(queries, scale, additive_mask, kv_seq, device)
+            }
             KvStorage::RotorSym3 { .. } | KvStorage::RotorSym4 { .. } => {
                 let kv_seq = rotor_sym_accumulated_seq(&self.storage)?;
                 Self::check_shared_kv_len(kv_len, kv_seq)?;
@@ -1290,7 +1349,32 @@ impl KvCache {
             }
             // Both axes dequantise off their own store. Cold path by contract —
             // this is the full-prefix CPU dequant the fused kernel exists to
-            // avoid, so it must never run per decode step.
+            // avoid, so it must never run per decode step. The iso stores rebuild
+            // their ring-only tail inside `dequant()` (`synced_iso_v_blocks`).
+            KvStorage::IsoSym3 {
+                k: Some(ks),
+                v: Some(vs),
+                ..
+            } => {
+                Self::check_shared_kv_len(kv_len, iso_sym_accumulated_seq(&self.storage)?)?;
+                (
+                    f32_vec_to_array(&ks.dequant()?, &ks.shape)?,
+                    f32_vec_to_array(&vs.dequant()?, &vs.shape)?,
+                    self.recorded_stream_dtype()?,
+                )
+            }
+            KvStorage::IsoSym4 {
+                k: Some(ks),
+                v: Some(vs),
+                ..
+            } => {
+                Self::check_shared_kv_len(kv_len, iso_sym_accumulated_seq(&self.storage)?)?;
+                (
+                    f32_vec_to_array(&ks.dequant()?, &ks.shape)?,
+                    f32_vec_to_array(&vs.dequant()?, &vs.shape)?,
+                    self.recorded_stream_dtype()?,
+                )
+            }
             KvStorage::RotorSym3 {
                 k: Some(ks),
                 v: Some(vs),
@@ -2620,6 +2704,257 @@ impl KvCache {
             Ok(None)
         }
     }
+
+    /// Flash-decode dispatch for the symmetric iso storage variants
+    /// (`IsoSym3` / `IsoSym4`), over **quant K and quant V**.
+    ///
+    /// Returns `Some(out)` when the fused kernel ran, `None` to fall through to
+    /// the legacy `update()` + SDPA path. Unlike the iso K-only sibling this
+    /// touches **no** bf16 buffer: V is read from its own iso ring, so the codec
+    /// keeps no bf16 K or V mirror. That is the memory win — the mirror is what
+    /// made a ~3-bit-per-axis codec cost more than plain bf16.
+    ///
+    /// Caller must have already gated `q_seq == 1` and `device == Gpu` BEFORE any
+    /// cache mutation: this helper mutates cache state (both appends) before it
+    /// can know whether the kernel is eligible, so a late fallback would
+    /// double-append. Mirror of [`Self::update_and_sdpa_rotor_sym_fused`].
+    #[allow(clippy::too_many_arguments)]
+    fn update_and_sdpa_iso_sym_fused(
+        &mut self,
+        queries: &Array,
+        new_k: &Array,
+        new_v: &Array,
+        scale: f32,
+        additive_mask: Option<&Array>,
+        device: Device,
+    ) -> Result<Option<Array>> {
+        let new_shape = new_k.shape();
+        if new_shape.len() != 4 {
+            return Err(Error::Mlx(format!(
+                "iso_sym_fused: new_k rank != 4, got {new_shape:?}"
+            )));
+        }
+        let new_seq = new_shape.get(2).copied().unwrap_or(0);
+
+        // Shape gates — checked BEFORE any mutation so a reject is a clean
+        // fall-through to the legacy path.
+        if !Self::iso_flash_shape_ok(&new_shape) {
+            return Ok(None);
+        }
+        if !matches!(
+            self.storage,
+            KvStorage::IsoSym3 { .. } | KvStorage::IsoSym4 { .. }
+        ) {
+            return Ok(None);
+        }
+
+        // Record the stream dtype before the append consumes `new_v`: this codec
+        // keeps no bf16 mirror, so this is the only witness of what the model
+        // pushes, and `materialise_shared_kv` needs it to hand a drafter K/V at
+        // the right width.
+        self.stream_dtype = Some(new_v.dtype());
+
+        let prev_seq = self.offset;
+        // Provision this step before the first mutation: both packed rings are
+        // capped by the storage `max_seq`, so it has to cover `prev_seq + new_seq`
+        // before either append runs.
+        self.ensure_decode_capacity(prev_seq + new_seq)?;
+        self.iso_sym_gpu_append(new_k, new_v, &new_shape, device)?;
+        self.offset = prev_seq + new_seq;
+
+        // Take `kv_seq` from the store the rings were written from, not from
+        // `self.offset` — one source of truth.
+        let kv_seq = iso_sym_accumulated_seq(&self.storage)?;
+        debug_assert_eq!(
+            kv_seq, self.offset,
+            "iso_sym_fused: store seq {kv_seq} != cache offset {} — the ring write \
+             and the attention length disagree",
+            self.offset
+        );
+        // Past this point the cache is already mutated (both stores appended,
+        // offset advanced), so `Ok(None)` is NOT available: it would send the
+        // caller into the legacy `update()` path, which appends K/V a second time.
+        let out = self.iso_sym_flash_over_store(queries, scale, additive_mask, kv_seq, device)?;
+        Ok(Some(out))
+    }
+
+    /// Run the iso symmetric quant-V flash-decode kernel over the K/V already
+    /// packed in this cache's stores — no append, no offset advance.
+    ///
+    /// Split out of [`Self::update_and_sdpa_iso_sym_fused`] so a shared-KV
+    /// **consumer** layer can attend the producer's stores through the same
+    /// kernel. Sibling of [`Self::rotor_sym_flash_over_store`].
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "indices validated by shape contracts at entry"
+    )]
+    fn iso_sym_flash_over_store(
+        &self,
+        queries: &Array,
+        scale: f32,
+        additive_mask: Option<&Array>,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Array> {
+        // Select the bit width from the live storage variant. No wildcard arm.
+        let bits: u8 = if matches!(self.storage, KvStorage::IsoSym3 { .. }) {
+            3
+        } else if matches!(self.storage, KvStorage::IsoSym4 { .. }) {
+            4
+        } else {
+            return Err(Error::KvStorageMismatch {
+                expected: "IsoSym3 | IsoSym4",
+                got: storage_variant_name(&self.storage),
+            });
+        };
+        let Some((k_view, v_view)) = self.iso_sym_packed_views(kv_seq, device)? else {
+            return Err(Error::Mlx(format!(
+                "iso_sym_fused: GPU ring absent after a maintained append \
+                 (kv_seq={kv_seq}, bits={bits}) — internal invariant violated"
+            )));
+        };
+        let (k_codes, k_scales, k_norms) = k_view;
+        let (v_codes, v_scales, v_norms) = v_view;
+
+        let store_shape = iso_sym_store_shape(&self.storage)?;
+        let b = store_shape.first().copied().unwrap_or(0);
+        let kv_h = store_shape.get(1).copied().unwrap_or(0);
+        let head_dim = store_shape.get(3).copied().unwrap_or(0);
+
+        let q_shape = queries.shape();
+        if q_shape.len() != 4 {
+            return Err(Error::Mlx(format!(
+                "iso_sym_fused: Q shape rank != 4, got {q_shape:?}"
+            )));
+        }
+        let q_seq = q_shape.get(2).copied().unwrap_or(0);
+        let n_q_heads = q_shape.get(1).copied().unwrap_or(0);
+        // Defence-in-depth: the call site already gates decode-only.
+        if q_seq != 1 {
+            return Err(Error::Mlx(format!(
+                "iso_sym_fused: q_seq must be 1 (decode-only), got {q_seq}"
+            )));
+        }
+        if kv_h <= 0 || n_q_heads % kv_h != 0 {
+            return Err(Error::Mlx(format!(
+                "iso_sym_fused: n_q_heads={n_q_heads} not divisible by kv_h={kv_h}"
+            )));
+        }
+        let heads_per_kv = n_q_heads / kv_h;
+
+        let shape = IsoFlashShape {
+            b,
+            kv_h,
+            kv_seq,
+            head_dim,
+            heads_per_kv,
+        };
+        let k_axis = IsoPackedAxis {
+            codes: &k_codes,
+            scales: &k_scales,
+            norms: &k_norms,
+        };
+        let v_axis = IsoPackedAxis {
+            codes: &v_codes,
+            scales: &v_scales,
+            norms: &v_norms,
+        };
+
+        tracing::Span::current().record("path", "iso_flash_decode_symv");
+        // Select the bit width explicitly — a wildcard arm would decode one
+        // width's codes at the other's unpack stride, silently wrong.
+        let flash_out = match bits {
+            3 => iso_flash_decode_symv_sdpa::<3>(
+                queries,
+                k_axis,
+                v_axis,
+                additive_mask,
+                shape,
+                scale,
+                device,
+            )?,
+            4 => iso_flash_decode_symv_sdpa::<4>(
+                queries,
+                k_axis,
+                v_axis,
+                additive_mask,
+                shape,
+                scale,
+                device,
+            )?,
+            other => {
+                return Err(Error::Quant(format!(
+                    "iso_sym_fused: unsupported bits={other} (only 3 and 4); \
+                     refusing to decode with another width's kernel"
+                )))
+            }
+        };
+        if flash_out.dtype() == queries.dtype() {
+            Ok(flash_out)
+        } else {
+            flash_out.astype(queries.dtype(), device)
+        }
+    }
+
+    /// GPU-append `new_k` / `new_v` into whichever iso symmetric store is active.
+    fn iso_sym_gpu_append(
+        &mut self,
+        new_k: &Array,
+        new_v: &Array,
+        new_shape: &[i32],
+        device: Device,
+    ) -> Result<()> {
+        if matches!(self.storage, KvStorage::IsoSym3 { .. }) {
+            super::update::iso3_sym_gpu_append(self, new_k, new_v, new_shape, device)
+        } else if matches!(self.storage, KvStorage::IsoSym4 { .. }) {
+            super::update::iso4_sym_gpu_append(self, new_k, new_v, new_shape, device)
+        } else {
+            Err(Error::KvStorageMismatch {
+                expected: "IsoSym3 | IsoSym4",
+                got: storage_variant_name(&self.storage),
+            })
+        }
+    }
+
+    /// `(codes, scales, norms)` GPU views of BOTH axes of the active iso
+    /// symmetric store at `kv_seq`, or `None` when either ring is not live.
+    ///
+    /// Both-or-neither: a half-live pair would mean one axis reads the store and
+    /// the other reads zeros.
+    #[allow(clippy::type_complexity)]
+    fn iso_sym_packed_views(
+        &self,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Option<((Array, Array, Array), (Array, Array, Array))>> {
+        let (k_view, v_view) = if let KvStorage::IsoSym3 {
+            k: Some(ks),
+            v: Some(vs),
+            ..
+        } = &self.storage
+        {
+            (
+                ks.gpu_packed_view(kv_seq, device)?,
+                vs.gpu_packed_view(kv_seq, device)?,
+            )
+        } else if let KvStorage::IsoSym4 {
+            k: Some(ks),
+            v: Some(vs),
+            ..
+        } = &self.storage
+        {
+            (
+                ks.gpu_packed_view(kv_seq, device)?,
+                vs.gpu_packed_view(kv_seq, device)?,
+            )
+        } else {
+            return Ok(None);
+        };
+        let (Some(k), Some(v)) = (k_view, v_view) else {
+            return Ok(None);
+        };
+        Ok(Some((k, v)))
+    }
 }
 
 /// Whether the active rotor K-only store carries the QJL residual sideband.
@@ -2786,6 +3121,70 @@ fn iso_k_accumulated_seq(storage: &KvStorage) -> Result<i32> {
             "iso_k_fused: iso K store shape {shape:?} has no seq axis"
         ))
     })
+}
+
+/// The K store's accumulated `[B, kv_h, S, D]` shape for the active iso
+/// symmetric variant.
+fn iso_sym_store_shape(storage: &KvStorage) -> Result<&[i32]> {
+    if let KvStorage::IsoSym3 { k: Some(ks), .. } = storage {
+        Ok(&ks.shape)
+    } else if let KvStorage::IsoSym4 { k: Some(ks), .. } = storage {
+        Ok(&ks.shape)
+    } else {
+        Err(Error::KvStorageMismatch {
+            expected: "IsoSym3 | IsoSym4 with a live K buffer",
+            got: storage_variant_name(storage),
+        })
+    }
+}
+
+/// Accumulated sequence length held by the active iso symmetric store.
+///
+/// Reads the **K** store's `shape[2]` and checks the V store agrees. The two are
+/// appended in lockstep, so a divergence means one axis's ring was fed and the
+/// other was not — which would attend K over one prefix and V over another,
+/// silently. Sibling of [`rotor_sym_accumulated_seq`].
+#[allow(
+    clippy::wildcard_enum_match_arm,
+    reason = "the wildcard arm returns Err — it never selects a concrete codec, so a new storage \
+              variant fails loudly here instead of being silently decoded as another"
+)]
+fn iso_sym_accumulated_seq(storage: &KvStorage) -> Result<i32> {
+    let (k_shape, v_shape) = match storage {
+        KvStorage::IsoSym3 {
+            k: Some(ks),
+            v: Some(vs),
+            ..
+        } => (&ks.shape, &vs.shape),
+        KvStorage::IsoSym4 {
+            k: Some(ks),
+            v: Some(vs),
+            ..
+        } => (&ks.shape, &vs.shape),
+        other => {
+            return Err(Error::KvStorageMismatch {
+                expected: "IsoSym3 | IsoSym4 with live K and V buffers",
+                got: storage_variant_name(other),
+            })
+        }
+    };
+    let k_seq = k_shape.get(2).copied().ok_or_else(|| {
+        Error::Mlx(format!(
+            "iso_sym_fused: iso K store shape {k_shape:?} has no seq axis"
+        ))
+    })?;
+    let v_seq = v_shape.get(2).copied().ok_or_else(|| {
+        Error::Mlx(format!(
+            "iso_sym_fused: iso V store shape {v_shape:?} has no seq axis"
+        ))
+    })?;
+    if k_seq != v_seq {
+        return Err(Error::Mlx(format!(
+            "iso_sym_fused: K store seq {k_seq} != V store seq {v_seq} — the two axes \
+             would attend different prefixes"
+        )));
+    }
+    Ok(k_seq)
 }
 
 /// `max_seq` of the active iso K-only storage variant.

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -28,6 +28,23 @@ use super::helpers::{f32_vec_to_array, storage_variant_name};
 use super::shared_kv::SharedKv;
 use super::KvCache;
 
+/// Minimum per-token norms element count (`b * kv_h * kv_seq`) for which the iso
+/// quant-V flash kernel may be dispatched.
+///
+/// The ring's per-token norms slice is handed to the kernel as an input buffer.
+/// MLX binds an input in the **`constant`** address space when its element count
+/// is small, but the shared `if_decode_k_lane` declares its norms parameter
+/// `device const float*` — an address-space mismatch that fails the MSL compile
+/// at first dispatch. The threshold was **measured** at 8 (a ring-only decode at
+/// `kv_h == 1` aborts for `kv_seq` 2–7 and succeeds from 8 on, for every
+/// `head_dim`); this floor is set above it for margin. Below it the caller falls
+/// back to the CPU dequant path — correct, and the KV at that point is tiny.
+///
+/// This is reachable on a normal short chat prompt against a single-KV-head model
+/// (Gemma4 global layers are `kv_h == 1`): a 2-token prompt reaches `kv_seq == 2`
+/// on the first decode step, well below the compile floor.
+const RING_NORMS_DEVICE_MIN: i64 = 16;
+
 impl KvCache {
     /// Mixed-precision one-shot append + quantized SDPA.
     ///
@@ -2747,6 +2764,17 @@ impl KvCache {
         ) {
             return Ok(None);
         }
+        // Short-kv_seq guard (checked BEFORE any mutation so the reject is a clean
+        // fall-through to the legacy CPU dequant path): the flash kernel's ring
+        // norms slice binds `constant` when its element count is small — see
+        // [`RING_NORMS_DEVICE_MIN`]. At `kv_h == 1` (Gemma4 global layers) this is
+        // reachable by a normal short chat prompt, so it is a hard gate.
+        let b = new_shape.first().copied().unwrap_or(0);
+        let kv_h = new_shape.get(1).copied().unwrap_or(0);
+        let kv_seq_after = self.offset + new_seq;
+        if i64::from(b) * i64::from(kv_h) * i64::from(kv_seq_after) < RING_NORMS_DEVICE_MIN {
+            return Ok(None);
+        }
 
         // Record the stream dtype before the append consumes `new_v`: this codec
         // keeps no bf16 mirror, so this is the only witness of what the model
@@ -2763,14 +2791,11 @@ impl KvCache {
         self.offset = prev_seq + new_seq;
 
         // Take `kv_seq` from the store the rings were written from, not from
-        // `self.offset` — one source of truth.
+        // `self.offset` — one source of truth. (`iso_sym_accumulated_seq` is that
+        // source and cross-checks the K and V store lengths; no `debug_assert`
+        // stands in for a KV invariant here, since it compiles out under
+        // release-perf.)
         let kv_seq = iso_sym_accumulated_seq(&self.storage)?;
-        debug_assert_eq!(
-            kv_seq, self.offset,
-            "iso_sym_fused: store seq {kv_seq} != cache offset {} — the ring write \
-             and the attention length disagree",
-            self.offset
-        );
         // Past this point the cache is already mutated (both stores appended,
         // offset advanced), so `Ok(None)` is NOT available: it would send the
         // caller into the legacy `update()` path, which appends K/V a second time.
@@ -2807,6 +2832,19 @@ impl KvCache {
                 got: storage_variant_name(&self.storage),
             });
         };
+        let store_shape = iso_sym_store_shape(&self.storage)?;
+        let b = store_shape.first().copied().unwrap_or(0);
+        let kv_h = store_shape.get(1).copied().unwrap_or(0);
+        let head_dim = store_shape.get(3).copied().unwrap_or(0);
+
+        // Short-kv_seq guard for the shared-KV **consumer** path (which cannot
+        // `Ok(None)`-fall-through like the producer): dequant both stores and run
+        // standard SDPA when the ring norms slice would bind `constant`. Same
+        // floor as the producer — see [`RING_NORMS_DEVICE_MIN`].
+        if i64::from(b) * i64::from(kv_h) * i64::from(kv_seq) < RING_NORMS_DEVICE_MIN {
+            return self.iso_sym_cpu_sdpa_fallback(queries, scale, additive_mask, device);
+        }
+
         let Some((k_view, v_view)) = self.iso_sym_packed_views(kv_seq, device)? else {
             return Err(Error::Mlx(format!(
                 "iso_sym_fused: GPU ring absent after a maintained append \
@@ -2815,11 +2853,6 @@ impl KvCache {
         };
         let (k_codes, k_scales, k_norms) = k_view;
         let (v_codes, v_scales, v_norms) = v_view;
-
-        let store_shape = iso_sym_store_shape(&self.storage)?;
-        let b = store_shape.first().copied().unwrap_or(0);
-        let kv_h = store_shape.get(1).copied().unwrap_or(0);
-        let head_dim = store_shape.get(3).copied().unwrap_or(0);
 
         let q_shape = queries.shape();
         if q_shape.len() != 4 {
@@ -2893,6 +2926,72 @@ impl KvCache {
             Ok(flash_out)
         } else {
             flash_out.astype(queries.dtype(), device)
+        }
+    }
+
+    /// CPU-dequant SDPA fallback for the iso symmetric codecs, used only when the
+    /// accumulated `kv_seq` is below [`RING_NORMS_DEVICE_MIN`] (the first few
+    /// short-prompt decode steps, where the flash kernel's ring norms slice would
+    /// bind `constant`). Dequants both stores — rebuilding any ring-only tail via
+    /// their own `dequant()` — into head-major `[B, kv_h, S, D]` f32 and runs
+    /// standard SDPA (GQA + additive mask handled by `scaled_dot_product_attention`).
+    /// The KV is tiny here, so the full-prefix dequant is cheap.
+    #[allow(
+        clippy::wildcard_enum_match_arm,
+        reason = "the wildcard arm returns Err — a new storage variant fails loudly rather than \
+                  being silently attended as another"
+    )]
+    fn iso_sym_cpu_sdpa_fallback(
+        &self,
+        queries: &Array,
+        scale: f32,
+        additive_mask: Option<&Array>,
+        device: Device,
+    ) -> Result<Array> {
+        let (k_full, k_shape, v_full, v_shape) = match &self.storage {
+            KvStorage::IsoSym3 {
+                k: Some(ks),
+                v: Some(vs),
+                ..
+            } => (
+                ks.dequant()?,
+                ks.shape.clone(),
+                vs.dequant()?,
+                vs.shape.clone(),
+            ),
+            KvStorage::IsoSym4 {
+                k: Some(ks),
+                v: Some(vs),
+                ..
+            } => (
+                ks.dequant()?,
+                ks.shape.clone(),
+                vs.dequant()?,
+                vs.shape.clone(),
+            ),
+            other => {
+                return Err(Error::KvStorageMismatch {
+                    expected: "IsoSym3 | IsoSym4 with live K and V buffers",
+                    got: storage_variant_name(other),
+                })
+            }
+        };
+        let k_arr = f32_vec_to_array(&k_full, &k_shape)?;
+        let v_arr = f32_vec_to_array(&v_full, &v_shape)?;
+        let mask_mode = if additive_mask.is_some() { "array" } else { "" };
+        let out = scaled_dot_product_attention(
+            queries,
+            &k_arr,
+            &v_arr,
+            scale,
+            mask_mode,
+            additive_mask,
+            device,
+        )?;
+        if out.dtype() == queries.dtype() {
+            Ok(out)
+        } else {
+            out.astype(queries.dtype(), device)
         }
     }
 

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -28,23 +28,6 @@ use super::helpers::{f32_vec_to_array, storage_variant_name};
 use super::shared_kv::SharedKv;
 use super::KvCache;
 
-/// Minimum per-token norms element count (`b * kv_h * kv_seq`) for which the iso
-/// quant-V flash kernel may be dispatched.
-///
-/// The ring's per-token norms slice is handed to the kernel as an input buffer.
-/// MLX binds an input in the **`constant`** address space when its element count
-/// is small, but the shared `if_decode_k_lane` declares its norms parameter
-/// `device const float*` — an address-space mismatch that fails the MSL compile
-/// at first dispatch. The threshold was **measured** at 8 (a ring-only decode at
-/// `kv_h == 1` aborts for `kv_seq` 2–7 and succeeds from 8 on, for every
-/// `head_dim`); this floor is set above it for margin. Below it the caller falls
-/// back to the CPU dequant path — correct, and the KV at that point is tiny.
-///
-/// This is reachable on a normal short chat prompt against a single-KV-head model
-/// (Gemma4 global layers are `kv_h == 1`): a 2-token prompt reaches `kv_seq == 2`
-/// on the first decode step, well below the compile floor.
-const RING_NORMS_DEVICE_MIN: i64 = 16;
-
 impl KvCache {
     /// Mixed-precision one-shot append + quantized SDPA.
     ///
@@ -2764,18 +2747,6 @@ impl KvCache {
         ) {
             return Ok(None);
         }
-        // Short-kv_seq guard (checked BEFORE any mutation so the reject is a clean
-        // fall-through to the legacy CPU dequant path): the flash kernel's ring
-        // norms slice binds `constant` when its element count is small — see
-        // [`RING_NORMS_DEVICE_MIN`]. At `kv_h == 1` (Gemma4 global layers) this is
-        // reachable by a normal short chat prompt, so it is a hard gate.
-        let b = new_shape.first().copied().unwrap_or(0);
-        let kv_h = new_shape.get(1).copied().unwrap_or(0);
-        let kv_seq_after = self.offset + new_seq;
-        if i64::from(b) * i64::from(kv_h) * i64::from(kv_seq_after) < RING_NORMS_DEVICE_MIN {
-            return Ok(None);
-        }
-
         // Record the stream dtype before the append consumes `new_v`: this codec
         // keeps no bf16 mirror, so this is the only witness of what the model
         // pushes, and `materialise_shared_kv` needs it to hand a drafter K/V at
@@ -2836,14 +2807,6 @@ impl KvCache {
         let b = store_shape.first().copied().unwrap_or(0);
         let kv_h = store_shape.get(1).copied().unwrap_or(0);
         let head_dim = store_shape.get(3).copied().unwrap_or(0);
-
-        // Short-kv_seq guard for the shared-KV **consumer** path (which cannot
-        // `Ok(None)`-fall-through like the producer): dequant both stores and run
-        // standard SDPA when the ring norms slice would bind `constant`. Same
-        // floor as the producer — see [`RING_NORMS_DEVICE_MIN`].
-        if i64::from(b) * i64::from(kv_h) * i64::from(kv_seq) < RING_NORMS_DEVICE_MIN {
-            return self.iso_sym_cpu_sdpa_fallback(queries, scale, additive_mask, device);
-        }
 
         let Some((k_view, v_view)) = self.iso_sym_packed_views(kv_seq, device)? else {
             return Err(Error::Mlx(format!(
@@ -2926,72 +2889,6 @@ impl KvCache {
             Ok(flash_out)
         } else {
             flash_out.astype(queries.dtype(), device)
-        }
-    }
-
-    /// CPU-dequant SDPA fallback for the iso symmetric codecs, used only when the
-    /// accumulated `kv_seq` is below [`RING_NORMS_DEVICE_MIN`] (the first few
-    /// short-prompt decode steps, where the flash kernel's ring norms slice would
-    /// bind `constant`). Dequants both stores — rebuilding any ring-only tail via
-    /// their own `dequant()` — into head-major `[B, kv_h, S, D]` f32 and runs
-    /// standard SDPA (GQA + additive mask handled by `scaled_dot_product_attention`).
-    /// The KV is tiny here, so the full-prefix dequant is cheap.
-    #[allow(
-        clippy::wildcard_enum_match_arm,
-        reason = "the wildcard arm returns Err — a new storage variant fails loudly rather than \
-                  being silently attended as another"
-    )]
-    fn iso_sym_cpu_sdpa_fallback(
-        &self,
-        queries: &Array,
-        scale: f32,
-        additive_mask: Option<&Array>,
-        device: Device,
-    ) -> Result<Array> {
-        let (k_full, k_shape, v_full, v_shape) = match &self.storage {
-            KvStorage::IsoSym3 {
-                k: Some(ks),
-                v: Some(vs),
-                ..
-            } => (
-                ks.dequant()?,
-                ks.shape.clone(),
-                vs.dequant()?,
-                vs.shape.clone(),
-            ),
-            KvStorage::IsoSym4 {
-                k: Some(ks),
-                v: Some(vs),
-                ..
-            } => (
-                ks.dequant()?,
-                ks.shape.clone(),
-                vs.dequant()?,
-                vs.shape.clone(),
-            ),
-            other => {
-                return Err(Error::KvStorageMismatch {
-                    expected: "IsoSym3 | IsoSym4 with live K and V buffers",
-                    got: storage_variant_name(other),
-                })
-            }
-        };
-        let k_arr = f32_vec_to_array(&k_full, &k_shape)?;
-        let v_arr = f32_vec_to_array(&v_full, &v_shape)?;
-        let mask_mode = if additive_mask.is_some() { "array" } else { "" };
-        let out = scaled_dot_product_attention(
-            queries,
-            &k_arr,
-            &v_arr,
-            scale,
-            mask_mode,
-            additive_mask,
-            device,
-        )?;
-        if out.dtype() == queries.dtype() {
-            Ok(out)
-        } else {
-            out.astype(queries.dtype(), device)
         }
     }
 

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -184,8 +184,29 @@ fn iso4_gpu_append_into_k_blocks(
 ) -> Result<()> {
     let head_dim = head_dim_from_shape(new_shape, "iso4_gpu_append_into_k_blocks")?;
     let seq_major = packed_k_chunk_seq_major(new_k, new_shape, device)?;
+    if is_ring_only_append(feed, new_shape) {
+        // Ring-only tail — see [`iso3_gpu_append_into_k_blocks`].
+        let gpu = iso_gpu_encode_ring_only(&seq_major, new_shape, ISO_K4_BITS)?;
+        iso4_sync_ring(
+            ks,
+            &gpu,
+            RingFeed::Maintain,
+            new_shape,
+            head_dim,
+            max_seq,
+            device,
+        )?;
+        bump_rotor_k_shape(&mut ks.shape, new_shape);
+        return Ok(());
+    }
+    materialize_iso_k4_ring_tail(ks, device)?;
+    let block_feed = if feed == RingFeed::Skip {
+        RingFeed::Skip
+    } else {
+        RingFeed::Maintain
+    };
     let (block, gpu) = iso_gpu_encode_block_retaining(&seq_major, new_shape, ISO_K4_BITS)?;
-    iso4_sync_ring(ks, &gpu, feed, new_shape, head_dim, max_seq, device)?;
+    iso4_sync_ring(ks, &gpu, block_feed, new_shape, head_dim, max_seq, device)?;
     push_iso4_k_block(ks, block, new_shape);
     Ok(())
 }
@@ -243,8 +264,36 @@ fn iso3_gpu_append_into_k_blocks(
 ) -> Result<()> {
     let head_dim = head_dim_from_shape(new_shape, "iso3_gpu_append_into_k_blocks")?;
     let seq_major = packed_k_chunk_seq_major(new_k, new_shape, device)?;
+    if is_ring_only_append(feed, new_shape) {
+        // Ring-only tail: feed the GPU ring, advance `shape[2]`, and skip the
+        // per-step host download + CPU block push. The ring is the source of
+        // truth for the decode tail; the blocks are rebuilt on demand at a
+        // `dequant()` / SSD-spill boundary (`synced_iso_v_blocks`).
+        let gpu = iso_gpu_encode_ring_only(&seq_major, new_shape, ISO_K3_BITS)?;
+        iso3_sync_ring(
+            ks,
+            &gpu,
+            RingFeed::Maintain,
+            new_shape,
+            head_dim,
+            max_seq,
+            device,
+        )?;
+        bump_rotor_k_shape(&mut ks.shape, new_shape);
+        return Ok(());
+    }
+    // Block path: prefill / non-fused decode (Maintain) and the K-side of the
+    // legacy sym fallback (Skip). A ring-only feed that reaches here is a `b > 1`
+    // chunk — normalise it to Maintain so the shared ring feeder clears the ring
+    // for the un-representable batch and the CPU block carries the data.
+    materialize_iso_k3_ring_tail(ks, device)?;
+    let block_feed = if feed == RingFeed::Skip {
+        RingFeed::Skip
+    } else {
+        RingFeed::Maintain
+    };
     let (block, gpu) = iso_gpu_encode_block_retaining(&seq_major, new_shape, ISO_K3_BITS)?;
-    iso3_sync_ring(ks, &gpu, feed, new_shape, head_dim, max_seq, device)?;
+    iso3_sync_ring(ks, &gpu, block_feed, new_shape, head_dim, max_seq, device)?;
     push_iso3_k_block(ks, block, new_shape);
     Ok(())
 }
@@ -1460,6 +1509,119 @@ fn iso_gpu_encode_block_retaining(
     ))
 }
 
+/// GPU-encode one iso K/V chunk for the **ring-only** append path: feed the GPU
+/// ring without paying the per-step host download that
+/// [`iso_gpu_encode_block_retaining`] does.
+///
+/// The fused decode kernel reads the ring, never the CPU `IsoBlocks`, so
+/// downloading and materialising a block per decode step is pure host work in
+/// the path whose purpose is removing host work. Skipping it leaves the ring the
+/// sole source of truth for the decode tail; the CPU blocks are rebuilt from the
+/// ring on demand at a `dequant()` / SSD-spill boundary (`synced_iso_v_blocks`),
+/// and the `blocks`-vs-`shape[2]` invariant is enforced loudly there — never
+/// zero-padded. Mirror of [`rotor_gpu_encode_ring_only`].
+///
+/// `bits` selects the encode kernel explicitly; anything but 3 or 4 is an error.
+fn iso_gpu_encode_ring_only(
+    new_kv: &Array,
+    new_shape: &[i32],
+    bits: u8,
+) -> Result<PackedKEncodedGpu> {
+    let head_dim = head_dim_from_shape(new_shape, "iso_gpu_encode_ring_only")?;
+    let (b, kv_h, s) = b_kv_h_new_seq(new_shape)?;
+    let n_tokens_total = (b as usize) * (kv_h as usize) * (s as usize);
+    let n_groups = iso_n_groups_for(head_dim);
+    if n_groups == 0 {
+        return Err(Error::Quant(format!(
+            "iso_gpu_encode_ring_only: head_dim={head_dim} yields no quaternion groups"
+        )));
+    }
+    let (codes_arr, scales_arr, _quats_arr, norms_arr) = match bits {
+        ISO_K3_BITS => crate::isoquant_msl::iso_quantize_v3_gpu(new_kv, head_dim, Device::Gpu)?,
+        ISO_K4_BITS => crate::isoquant_msl_v4::iso_quantize_v4_gpu(new_kv, head_dim, Device::Gpu)?,
+        other => {
+            return Err(Error::Quant(format!(
+                "iso_gpu_encode_ring_only: unsupported bits={other} (only 3 and 4); \
+                 refusing to encode with another width's kernel"
+            )))
+        }
+    };
+    // Collapse per-group norms to the per-token form the ring stores (GPU-side,
+    // no host round-trip).
+    let norms_per_token = collapse_group_norms_to_token(&norms_arr, n_tokens_total, n_groups)?;
+    Ok(PackedKEncodedGpu {
+        codes: codes_arr,
+        scales: scales_arr,
+        norms: norms_per_token,
+    })
+}
+
+/// Reconcile a pre-existing ring-only decode tail into `ks.blocks` before a
+/// block-path append — iso mirror of [`materialize_rotor_k3_ring_tail`]. No-op
+/// when `blocks` already cover `shape[2]` (reads no GPU).
+fn materialize_iso_k3_ring_tail(ks: &mut QuantIsoK3, device: Device) -> Result<()> {
+    if !ks.gpu.is_allocated() {
+        return Ok(());
+    }
+    let rebuilt = match crate::storage::synced_iso_v_blocks(&ks.blocks, &ks.shape, &ks.gpu, device)?
+    {
+        std::borrow::Cow::Owned(full) => Some(full),
+        std::borrow::Cow::Borrowed(_) => None,
+    };
+    if let Some(full) = rebuilt {
+        ks.blocks = full;
+    }
+    Ok(())
+}
+
+/// Mirror of [`materialize_iso_k3_ring_tail`] for [`QuantIsoK4`].
+fn materialize_iso_k4_ring_tail(ks: &mut QuantIsoK4, device: Device) -> Result<()> {
+    if !ks.gpu.is_allocated() {
+        return Ok(());
+    }
+    let rebuilt = match crate::storage::synced_iso_v_blocks(&ks.blocks, &ks.shape, &ks.gpu, device)?
+    {
+        std::borrow::Cow::Owned(full) => Some(full),
+        std::borrow::Cow::Borrowed(_) => None,
+    };
+    if let Some(full) = rebuilt {
+        ks.blocks = full;
+    }
+    Ok(())
+}
+
+/// Mirror of [`materialize_iso_k3_ring_tail`] for [`QuantIsoV3`].
+fn materialize_iso_v3_ring_tail(vs: &mut QuantIsoV3, device: Device) -> Result<()> {
+    if !vs.gpu.is_allocated() {
+        return Ok(());
+    }
+    let rebuilt = match crate::storage::synced_iso_v_blocks(&vs.blocks, &vs.shape, &vs.gpu, device)?
+    {
+        std::borrow::Cow::Owned(full) => Some(full),
+        std::borrow::Cow::Borrowed(_) => None,
+    };
+    if let Some(full) = rebuilt {
+        vs.blocks = full;
+    }
+    Ok(())
+}
+
+/// Mirror of [`materialize_iso_v3_ring_tail`] for [`QuantIsoV4`].
+fn materialize_iso_v4_ring_tail(vs: &mut QuantIsoV4, device: Device) -> Result<()> {
+    if !vs.gpu.is_allocated() {
+        return Ok(());
+    }
+    let rebuilt = match crate::storage::synced_iso_v_blocks(&vs.blocks, &vs.shape, &vs.gpu, device)?
+    {
+        std::borrow::Cow::Owned(full) => Some(full),
+        std::borrow::Cow::Borrowed(_) => None,
+    };
+    if let Some(full) = rebuilt {
+        vs.blocks = full;
+    }
+    Ok(())
+}
+
 /// Append `new_k` into a live `IsoKOnly3` store's GPU ring (+ CPU blocks),
 /// lazily creating the store on first use. No dequant — this is the entry point
 /// the iso flash-decode SDPA path uses.
@@ -1491,7 +1653,19 @@ pub(super) fn iso3_k_only_gpu_append(
     let Some(ks) = k.as_mut() else {
         return Err(Error::Mlx("IsoKOnly3 K buffer absent after init".into()));
     };
-    iso3_gpu_append_into_k_blocks(ks, new_k, new_shape, device, RingFeed::Maintain, max_seq)
+    // Ring-only tail: the fused iso K-only flash decode reads the ring, never the
+    // CPU blocks, so skip the per-step host download; the blocks are rebuilt from
+    // the ring on demand at a `dequant()` / SSD-spill boundary.
+    iso3_gpu_append_into_k_blocks(
+        ks,
+        new_k,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )?;
+    drop_blocks_when_ring_live_iso_k3(ks);
+    Ok(())
 }
 
 /// Mirror of [`iso3_k_only_gpu_append`] for `IsoKOnly4`.
@@ -1523,7 +1697,309 @@ pub(super) fn iso4_k_only_gpu_append(
     let Some(ks) = k.as_mut() else {
         return Err(Error::Mlx("IsoKOnly4 K buffer absent after init".into()));
     };
-    iso4_gpu_append_into_k_blocks(ks, new_k, new_shape, device, RingFeed::Maintain, max_seq)
+    // Ring-only tail — see [`iso3_k_only_gpu_append`].
+    iso4_gpu_append_into_k_blocks(
+        ks,
+        new_k,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )?;
+    drop_blocks_when_ring_live_iso_k4(ks);
+    Ok(())
+}
+
+/// Append `new_k` / `new_v` into a live `IsoSym3` store's GPU rings (ring-only
+/// tail on both axes), lazily creating the stores on first use. No dequant on
+/// either axis — this is the entry point the iso symmetric quant-V flash-decode
+/// SDPA path uses. Mirror of [`rotor3_sym_gpu_append`].
+///
+/// # Errors
+///
+/// Returns [`Error::KvStorageMismatch`] when the active storage is not
+/// `IsoSym3`, and forwards encode / ring errors.
+pub(super) fn iso3_sym_gpu_append(
+    cache: &mut KvCache,
+    new_k: &Array,
+    new_v: &Array,
+    new_shape: &[i32],
+    device: Device,
+) -> Result<()> {
+    let KvStorage::IsoSym3 { k, v, max_seq } = &mut cache.storage else {
+        return Err(Error::KvStorageMismatch {
+            expected: "IsoSym3",
+            got: storage_variant_name(&cache.storage),
+        });
+    };
+    let max_seq = *max_seq;
+    let mut init_shape = new_shape.to_vec();
+    if let Some(s) = init_shape.get_mut(2) {
+        *s = 0;
+    }
+    if k.is_none() {
+        *k = Some(QuantIsoK3::new(init_shape.clone(), max_seq));
+    }
+    if v.is_none() {
+        *v = Some(QuantIsoV3::new(init_shape));
+    }
+    let Some(ks) = k.as_mut() else {
+        return Err(Error::Mlx("IsoSym3 K buffer absent after init".into()));
+    };
+    iso3_gpu_append_into_k_blocks(
+        ks,
+        new_k,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )?;
+    // Ring is now the sole resident store for K — drop the redundant CPU blocks
+    // (the prefill prefix, seeded into the ring on the first fused-decode step).
+    drop_blocks_when_ring_live_iso_k3(ks);
+    let Some(vs) = v.as_mut() else {
+        return Err(Error::Mlx("IsoSym3 V buffer absent after init".into()));
+    };
+    iso3_gpu_append_into_v_blocks(
+        vs,
+        new_v,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )?;
+    // The GPU ring holds the full prefix; the fused decode reads the ring, and
+    // `dequant` / SSD spill / clone / truncate rebuild the CPU blocks on demand
+    // from it (`synced_iso_v_blocks`).
+    drop_blocks_when_ring_live_iso_v3(vs);
+    Ok(())
+}
+
+/// Mirror of [`iso3_sym_gpu_append`] for `IsoSym4`.
+///
+/// # Errors
+///
+/// Returns [`Error::KvStorageMismatch`] when the active storage is not
+/// `IsoSym4`, and forwards encode / ring errors.
+pub(super) fn iso4_sym_gpu_append(
+    cache: &mut KvCache,
+    new_k: &Array,
+    new_v: &Array,
+    new_shape: &[i32],
+    device: Device,
+) -> Result<()> {
+    let KvStorage::IsoSym4 { k, v, max_seq } = &mut cache.storage else {
+        return Err(Error::KvStorageMismatch {
+            expected: "IsoSym4",
+            got: storage_variant_name(&cache.storage),
+        });
+    };
+    let max_seq = *max_seq;
+    let mut init_shape = new_shape.to_vec();
+    if let Some(s) = init_shape.get_mut(2) {
+        *s = 0;
+    }
+    if k.is_none() {
+        *k = Some(QuantIsoK4::new(init_shape.clone(), max_seq));
+    }
+    if v.is_none() {
+        *v = Some(QuantIsoV4::new(init_shape, max_seq));
+    }
+    let Some(ks) = k.as_mut() else {
+        return Err(Error::Mlx("IsoSym4 K buffer absent after init".into()));
+    };
+    iso4_gpu_append_into_k_blocks(
+        ks,
+        new_k,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )?;
+    drop_blocks_when_ring_live_iso_k4(ks);
+    let Some(vs) = v.as_mut() else {
+        return Err(Error::Mlx("IsoSym4 V buffer absent after init".into()));
+    };
+    iso4_gpu_append_into_v_blocks(
+        vs,
+        new_v,
+        new_shape,
+        device,
+        RingFeed::MaintainRingOnly,
+        max_seq,
+    )?;
+    drop_blocks_when_ring_live_iso_v4(vs);
+    Ok(())
+}
+
+/// Drop an iso K store's CPU blocks once its GPU ring is live — the ring is then
+/// the sole resident copy. No-op until the ring is allocated or for any store
+/// that never feeds a ring.
+fn drop_blocks_when_ring_live_iso_k3(ks: &mut QuantIsoK3) {
+    if ks.gpu.is_allocated() {
+        ks.blocks.clear();
+        ks.blocks.shrink_to_fit();
+    }
+}
+
+/// Mirror of [`drop_blocks_when_ring_live_iso_k3`] for [`QuantIsoK4`].
+fn drop_blocks_when_ring_live_iso_k4(ks: &mut QuantIsoK4) {
+    if ks.gpu.is_allocated() {
+        ks.blocks.clear();
+        ks.blocks.shrink_to_fit();
+    }
+}
+
+/// Drop an iso V store's CPU blocks once its GPU ring is live.
+fn drop_blocks_when_ring_live_iso_v3(vs: &mut QuantIsoV3) {
+    if vs.gpu.is_allocated() {
+        vs.blocks.clear();
+        vs.blocks.shrink_to_fit();
+    }
+}
+
+/// Mirror of [`drop_blocks_when_ring_live_iso_v3`] for [`QuantIsoV4`].
+fn drop_blocks_when_ring_live_iso_v4(vs: &mut QuantIsoV4) {
+    if vs.gpu.is_allocated() {
+        vs.blocks.clear();
+        vs.blocks.shrink_to_fit();
+    }
+}
+
+/// V-side append with a ring-only branch — mirror of
+/// [`iso3_gpu_append_into_k_blocks`] for [`QuantIsoV3`]. The iso codec is
+/// axis-agnostic, so V encodes through the same kernel as K.
+fn iso3_gpu_append_into_v_blocks(
+    vs: &mut QuantIsoV3,
+    new_v: &Array,
+    new_shape: &[i32],
+    device: Device,
+    feed: RingFeed,
+    max_seq: i32,
+) -> Result<()> {
+    let head_dim = head_dim_from_shape(new_shape, "iso3_gpu_append_into_v_blocks")?;
+    let seq_major = packed_k_chunk_seq_major(new_v, new_shape, device)?;
+    if is_ring_only_append(feed, new_shape) {
+        let gpu = iso_gpu_encode_ring_only(&seq_major, new_shape, ISO_K3_BITS)?;
+        iso3_v_sync_ring(
+            vs,
+            &gpu,
+            RingFeed::Maintain,
+            new_shape,
+            head_dim,
+            max_seq,
+            device,
+        )?;
+        bump_rotor_k_shape(&mut vs.shape, new_shape);
+        return Ok(());
+    }
+    materialize_iso_v3_ring_tail(vs, device)?;
+    let block_feed = if feed == RingFeed::Skip {
+        RingFeed::Skip
+    } else {
+        RingFeed::Maintain
+    };
+    let (block, gpu) = iso_gpu_encode_block_retaining(&seq_major, new_shape, ISO_K3_BITS)?;
+    iso3_v_sync_ring(vs, &gpu, block_feed, new_shape, head_dim, max_seq, device)?;
+    vs.blocks.push(block);
+    bump_rotor_k_shape(&mut vs.shape, new_shape);
+    Ok(())
+}
+
+/// Mirror of [`iso3_gpu_append_into_v_blocks`] for [`QuantIsoV4`].
+fn iso4_gpu_append_into_v_blocks(
+    vs: &mut QuantIsoV4,
+    new_v: &Array,
+    new_shape: &[i32],
+    device: Device,
+    feed: RingFeed,
+    max_seq: i32,
+) -> Result<()> {
+    let head_dim = head_dim_from_shape(new_shape, "iso4_gpu_append_into_v_blocks")?;
+    let seq_major = packed_k_chunk_seq_major(new_v, new_shape, device)?;
+    if is_ring_only_append(feed, new_shape) {
+        let gpu = iso_gpu_encode_ring_only(&seq_major, new_shape, ISO_K4_BITS)?;
+        iso4_v_sync_ring(
+            vs,
+            &gpu,
+            RingFeed::Maintain,
+            new_shape,
+            head_dim,
+            max_seq,
+            device,
+        )?;
+        bump_rotor_k_shape(&mut vs.shape, new_shape);
+        return Ok(());
+    }
+    materialize_iso_v4_ring_tail(vs, device)?;
+    let block_feed = if feed == RingFeed::Skip {
+        RingFeed::Skip
+    } else {
+        RingFeed::Maintain
+    };
+    let (block, gpu) = iso_gpu_encode_block_retaining(&seq_major, new_shape, ISO_K4_BITS)?;
+    iso4_v_sync_ring(vs, &gpu, block_feed, new_shape, head_dim, max_seq, device)?;
+    vs.blocks.push(block);
+    bump_rotor_k_shape(&mut vs.shape, new_shape);
+    Ok(())
+}
+
+/// V-side mirror of [`iso3_sync_ring`] for [`QuantIsoV3`].
+fn iso3_v_sync_ring(
+    vs: &mut QuantIsoV3,
+    gpu: &PackedKEncodedGpu,
+    feed: RingFeed,
+    new_shape: &[i32],
+    head_dim: usize,
+    max_seq: i32,
+    device: Device,
+) -> Result<()> {
+    let (b, kv_h, new_seq) = b_kv_h_new_seq(new_shape)?;
+    if feed != RingFeed::Maintain || b != 1 {
+        vs.gpu.clear();
+        return Ok(());
+    }
+    let prev_seq = accumulated_seq(&vs.shape);
+    vs.gpu_append(
+        &gpu.codes,
+        &gpu.scales,
+        &gpu.norms,
+        kv_h,
+        head_dim as i32,
+        prev_seq,
+        new_seq,
+        max_seq,
+        device,
+    )
+}
+
+/// Mirror of [`iso3_v_sync_ring`] for [`QuantIsoV4`].
+fn iso4_v_sync_ring(
+    vs: &mut QuantIsoV4,
+    gpu: &PackedKEncodedGpu,
+    feed: RingFeed,
+    new_shape: &[i32],
+    head_dim: usize,
+    max_seq: i32,
+    device: Device,
+) -> Result<()> {
+    let (b, kv_h, new_seq) = b_kv_h_new_seq(new_shape)?;
+    if feed != RingFeed::Maintain || b != 1 {
+        vs.gpu.clear();
+        return Ok(());
+    }
+    let prev_seq = accumulated_seq(&vs.shape);
+    vs.gpu_append(
+        &gpu.codes,
+        &gpu.scales,
+        &gpu.norms,
+        kv_h,
+        head_dim as i32,
+        prev_seq,
+        new_seq,
+        max_seq,
+        device,
+    )
 }
 
 /// Feed one encoded iso3 chunk into the store's GPU ring.

--- a/crates/rmlx-kv-quant/src/kvcache/warm_ttft_cross_codec_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/warm_ttft_cross_codec_tests.rs
@@ -6,13 +6,17 @@
 //! than code-reading:
 //!
 //! 1. **Shortcut codecs** (`decode_fp16_k.is_some()` early-return present):
-//!    K8V4, K8V8, Iso3Sym (asserted in this file). TurboSym3 is covered by
-//!    code-reading (same `update_decode_fp16` dispatch path); PlanarK is
-//!    asserted in the sibling `warm_ttft_tests.rs`. After `exit_prefill`
-//!    the bf16 K+V mirror is live; every decode `update()` routes through
-//!    `update_decode_fp16` and the quant codec stays **frozen** (its
-//!    `shape[2]` does not advance past the prefill length). Decode-phase K
-//!    AND V are bf16, not re-quantised.
+//!    K8V4, K8V8 (asserted in this file). TurboSym3 is covered by code-reading
+//!    (same `update_decode_fp16` dispatch path); PlanarK is asserted in the
+//!    sibling `warm_ttft_tests.rs`. After `exit_prefill` the bf16 K+V mirror is
+//!    live; every decode `update()` routes through `update_decode_fp16` and the
+//!    quant codec stays **frozen** (its `shape[2]` does not advance past the
+//!    prefill length). Decode-phase K AND V are bf16, not re-quantised.
+//!
+//!    `Iso3Sym` used to be in this class but is now a **fused symmetric** codec:
+//!    it keeps no bf16 mirror on either axis (decode reads both packed iso
+//!    rings), so it is asserted alongside the K-only family below rather than
+//!    here — see `iso_sym3_fused_no_seed_at_decode`.
 //!
 //! 2. **K-only codecs** (no `decode_fp16_k.is_some()` shortcut in the
 //!    `update_<arch>` body; V via the V-only helper): IsoKOnly3,
@@ -233,9 +237,38 @@ fn k8v8_warm_ttft_freezes_codec() {
     assert_shortcut_codec(KvQuant::K8V8, k8_codec_seq);
 }
 
+/// Fused-symmetric contract: `Iso3Sym` is NOT a warm-TTFT shortcut codec. Its
+/// decode is the quant-V flash kernel over both packed iso rings (on GPU) / a
+/// re-quantise of both axes (on CPU), so NEITHER bf16 seed is materialised
+/// (`feeds_bf16_k_at_decode` and `feeds_bf16_v_at_decode` are both `false`) and
+/// the K codec advances one position per decode step rather than freezing.
 #[test]
-fn iso_sym3_warm_ttft_freezes_codec() {
-    assert_shortcut_codec(KvQuant::Iso3Sym, iso_sym3_k_codec_seq);
+fn iso_sym3_fused_no_seed_at_decode() {
+    let device = Device::Cpu;
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::Iso3Sym, TEST_MAX_SEQ);
+    let out = drive_one_decode(&mut cache, device);
+
+    // Fused symmetric: neither bf16 seed is materialised — the codec exists to
+    // delete that mirror.
+    assert!(
+        !out.k_seed_live,
+        "Iso3Sym: exit_prefill must NOT populate decode_fp16_k (fused, no mirror)"
+    );
+    assert!(
+        !out.v_seed_live,
+        "Iso3Sym: exit_prefill must NOT populate decode_fp16_v (fused, no mirror)"
+    );
+    // The K codec advances at decode — no warm-TTFT shortcut.
+    assert_eq!(
+        iso_sym3_k_codec_seq(&cache),
+        TEST_PREFILL_SEQ + 1,
+        "Iso3Sym: K codec MUST advance by 1 per decode step (no bf16 seed to freeze on)"
+    );
+    assert_eq!(
+        out.offset,
+        TEST_PREFILL_SEQ + 1,
+        "Iso3Sym offset after one decode step"
+    );
 }
 
 /// K-only contract: IsoKOnly3 quantises K at every decode step and

--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -44,6 +44,7 @@ pub(crate) mod bytes;
 pub mod clifford;
 pub(crate) mod fused_qk_common;
 pub mod iso_flash_decode_msl;
+pub mod iso_flash_decode_symv_msl;
 pub mod iso_fused_qk_msl;
 pub mod isoquant;
 pub mod isoquant_msl;

--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -42,6 +42,7 @@ pub(crate) mod test_utils;
 
 pub(crate) mod bytes;
 pub mod clifford;
+pub(crate) mod flash_decode_common;
 pub(crate) mod fused_qk_common;
 pub mod iso_flash_decode_msl;
 pub mod iso_flash_decode_symv_msl;

--- a/crates/rmlx-kv-quant/src/metal/iso_flash_decode_symv_p1.metal
+++ b/crates/rmlx-kv-quant/src/metal/iso_flash_decode_symv_p1.metal
@@ -1,0 +1,129 @@
+
+// ── Thread / threadgroup coordinates ──────────────────────────────────
+uint head_dim     = dims[0];
+uint kv_seq       = dims[1];
+uint n_bh         = dims[2];
+uint kv_h         = dims[3];
+uint heads_per_kv = dims[4];
+uint n_tiles      = dims[5];
+uint has_mask     = dims[6];
+uint n_groups     = dims[7];
+
+uint tile_idx = threadgroup_position_in_grid.x;
+uint bh       = threadgroup_position_in_grid.y;
+uint tid      = thread_position_in_threadgroup.x;
+
+// SIMD-group coordinates (Apple GPU: 32 lanes per simdgroup). The threadgroup
+// is exactly `head_dim` threads (power-of-two, dispatcher-enforced). The fold
+// below uses the runtime `n_simd = simdgroups_per_threadgroup`, which covers the
+// head whether or not the last simdgroup is full.
+uint simd_lane = thread_index_in_simdgroup;
+uint simd_id   = simdgroup_index_in_threadgroup;
+uint n_simd    = simdgroups_per_threadgroup;
+
+if (bh >= n_bh)
+    return;
+if (tile_idx >= n_tiles)
+    return;
+
+uint n_q_heads = kv_h * heads_per_kv;
+uint b         = bh / n_q_heads;
+uint hq        = bh % n_q_heads;
+uint kv_h_idx  = hq / heads_per_kv;
+
+uint tile_start = tile_idx * IF_TILE_SIZE;
+uint tile_end   = tile_start + IF_TILE_SIZE;
+if (tile_end > kv_seq)
+    tile_end = kv_seq;
+
+// ── Load this lane's Q into a register ────────────────────────────────
+// Each lane only ever multiplies its own head-dim slot, so Q lives in a
+// register rather than threadgroup memory.
+float q_lane = query[bh * head_dim + tid];
+
+// ── Online-softmax broadcast slots ───────────────────────────────────
+// Thread 0 owns the authoritative running (max, sum) in registers across the
+// tile and broadcasts the per-token correction / exp-score so every lane can
+// rescale its V accumulator.
+threadgroup float s_corr[1];
+threadgroup float s_expsc[1];
+
+float run_max = -INFINITY;
+float run_sum = 0.0f;
+
+// Per-thread V accumulator (registers — never spills to threadgroup mem).
+float acc_v = 0.0f;
+
+// Per-simdgroup QK-dot partials (folded by thread 0).
+threadgroup float dot_partials[IF_HEAD_DIM_MAX / 32];
+
+for (uint t = tile_start; t < tile_end; t++) {
+    // ── Decode K[tid] for this (b, kv_h_idx, t) ──────────────────────
+    // BOTH iso rings are SEQUENCE-major (`[B, S, kv_h, n_groups]`): per token
+    // all heads are contiguous, matching the chunk-append layout. Unlike the
+    // bf16-V sibling kernel, V here has no head-major mirror — it is read
+    // straight from its own packed iso ring at the same token index as K,
+    // through the identical per-lane decode. The iso decode is self-contained
+    // per lane (one quaternion block fits one u32), so it stays in registers
+    // with no threadgroup stage on either axis.
+    uint kv_tok = (b * kv_seq + t) * kv_h + kv_h_idx;
+
+    float k_val = if_decode_k_lane(k_codes, k_scales, k_norms, kv_tok, n_groups, tid);
+
+    // ── QK dot via simdgroup reduction ───────────────────────────────
+    // simd_sum folds each simdgroup's 32 lanes with no threadgroup barrier and
+    // no idle-lane tree; one partial per simdgroup then folds on thread 0.
+    float prod     = q_lane * k_val;
+    float lane_sum = simd_sum(prod);
+    if (simd_lane == 0u) {
+        dot_partials[simd_id] = lane_sum;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // ── Thread 0: fold partials + online-softmax update + broadcast ───
+    if (tid == 0u) {
+        float raw = 0.0f;
+        for (uint i = 0u; i < n_simd; i++) {
+            raw += dot_partials[i];
+        }
+        raw *= scale_arr[0];
+        // Mask is per (b, q_head, t) — add inside thread 0.
+        float mask_val = 0.0f;
+        if (has_mask != 0u) {
+            mask_val = mask_flat[(b * n_q_heads + hq) * kv_seq + t];
+        }
+        float score = raw + mask_val;
+
+        float old_max = run_max;
+        float new_max = (score > old_max) ? score : old_max;
+        float corr    = exp(old_max - new_max);
+        float es      = exp(score - new_max);
+
+        run_max    = new_max;
+        run_sum    = run_sum * corr + es;
+        s_corr[0]  = corr;
+        s_expsc[0] = es;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // ── Quant-V decode + softmax-weighted accumulation ───────────────
+    // The iso codec is axis-agnostic: V decodes through the same per-lane
+    // quaternion block as K, from the V store's own codes / scales / norms.
+    // No bf16 V exists in device memory — that mirror is exactly what this
+    // kernel deletes. Self-contained per lane, so no threadgroup stage.
+    float corr  = s_corr[0];
+    float es    = s_expsc[0];
+    float v_val = if_decode_k_lane(v_codes, v_scales, v_norms, kv_tok, n_groups, tid);
+
+    acc_v = acc_v * corr + es * v_val;
+}
+
+// ── Write per-tile partials ──────────────────────────────────────────
+uint out_base             = (tile_idx * n_bh + bh) * head_dim;
+partial_o[out_base + tid] = acc_v;
+
+if (tid == 0u) {
+    uint meta          = tile_idx * n_bh + bh;
+    tile_max[meta]     = run_max;
+    tile_sum_exp[meta] = run_sum;
+}

--- a/crates/rmlx-kv-quant/src/metal/probes/kernels.manifest
+++ b/crates/rmlx-kv-quant/src/metal/probes/kernels.manifest
@@ -24,6 +24,12 @@
 # line over the same body.
 iso_flash_decode_p1.metal | iso_flash_decode_p1_b3.hdr.metal | query:f,codes:u,scales:f,norms:f,v_flat:f,mask_flat:f,scale_arr:f,dims:u,partial_o:f,tile_max:f,tile_sum_exp:f
 iso_flash_decode_p1.metal | iso_flash_decode_p1_b4.hdr.metal | query:f,codes:u,scales:f,norms:f,v_flat:f,mask_flat:f,scale_arr:f,dims:u,partial_o:f,tile_max:f,tile_sum_exp:f
+# The all-quant sibling: same two headers (both axes of a symmetric iso codec
+# share one bit width, so IF_BITS covers the K and the V unpack), and it calls
+# the header's `if_decode_k_lane` for both. V arrives as its own packed ring
+# instead of a bf16 mirror, hence v_codes/v_scales/v_norms in place of v_flat.
+iso_flash_decode_symv_p1.metal | iso_flash_decode_p1_b3.hdr.metal | query:f,k_codes:u,k_scales:f,k_norms:f,v_codes:u,v_scales:f,v_norms:f,mask_flat:f,scale_arr:f,dims:u,partial_o:f,tile_max:f,tile_sum_exp:f
+iso_flash_decode_symv_p1.metal | iso_flash_decode_p1_b4.hdr.metal | query:f,k_codes:u,k_scales:f,k_norms:f,v_codes:u,v_scales:f,v_norms:f,mask_flat:f,scale_arr:f,dims:u,partial_o:f,tile_max:f,tile_sum_exp:f
 iso_fused_qk_b3.metal | iso_fused_qk_b3.hdr.metal | query:f,codes:u,scales:f,norms:f,mask:f,scale_arr:f,dims:u,out:f
 iso_fused_qk_b4.metal | iso_fused_qk_b4.hdr.metal | query:f,codes:u,scales:f,norms:f,mask:f,scale_arr:f,dims:u,out:f
 isoquant_quantize_iso3.metal | isoquant_iso3.hdr.metal | inp:f,n_groups:u,codes_out:u,scales_out:f,norms_out:f

--- a/crates/rmlx-kv-quant/src/precompile_tests.rs
+++ b/crates/rmlx-kv-quant/src/precompile_tests.rs
@@ -60,15 +60,14 @@ fn v_only_iso_rotor_families_are_cpu_fallback_with_reason() {
     // encode that runs (at prefill) is CPU. They carry MSL (q8 K-side) but must
     // report a CPU-hot-path reason. This is grounded in the dispatcher, not by
     // fiat — flip the verdict and this test must flip with it.
-    // Note: the rotor **symmetric** codecs (`Rotor3Sym` / `Rotor4Sym`) are NOT
-    // in this list — with QJL off (the default) their decode is the quant-V
-    // flash kernel over both packed rings, so their hot path is Metal. That
-    // verdict is checked in `rotor_symmetric_families_are_metal_when_qjl_off`.
+    // Note: the **symmetric** codecs (`Iso{3,4}Sym`, `Rotor{3,4}Sym`) are NOT in
+    // this list — their decode is the quant-V flash kernel over both packed
+    // rings, so their hot path is Metal. Those verdicts are checked in
+    // `iso_symmetric_families_are_metal` /
+    // `rotor_symmetric_families_are_metal_when_qjl_off`.
     for kq in [
         KvQuant::Iso3,
         KvQuant::Iso4,
-        KvQuant::Iso3Sym,
-        KvQuant::Iso4Sym,
         KvQuant::Rotor3,
         KvQuant::Rotor4,
         KvQuant::RotorK3Asym {
@@ -111,6 +110,24 @@ fn rotor_symmetric_families_are_metal_when_qjl_off() {
         assert!(
             kq.cpu_hot_path_reason().is_none(),
             "{kq} decodes through the quant-V flash kernel with QJL off — must be Metal (None)"
+        );
+    }
+}
+
+#[test]
+fn iso_symmetric_families_are_metal() {
+    // `Iso3Sym` / `Iso4Sym` have NO bf16 decode-seed early-return: decode is the
+    // quant-V flash kernel over both packed iso rings, so the verdict must be
+    // `None` (Metal). Iso carries no QJL sideband, so there is no CPU-fallback
+    // gate — unlike the rotor sym mirror. Grounded in the dispatcher, not by fiat.
+    for kq in [KvQuant::Iso3Sym, KvQuant::Iso4Sym] {
+        assert!(
+            kq.carries_msl(),
+            "{kq} carries MSL (iso K + quant-V flash kernels)"
+        );
+        assert!(
+            kq.cpu_hot_path_reason().is_none(),
+            "{kq} decodes through the quant-V flash kernel — must be Metal (None)"
         );
     }
 }
@@ -184,7 +201,7 @@ fn precompile_skips_cpu_hot_path_codecs() {
     // Even on a GPU device the precompile is a documented no-op for the V-only
     // iso/rotor CPU-fallback codecs (nothing to warm). We can only assert the
     // classifier off-device, which the function consults to take the skip branch.
-    for kq in [KvQuant::Rotor3, KvQuant::Iso3, KvQuant::Iso4Sym] {
+    for kq in [KvQuant::Rotor3, KvQuant::Iso3, KvQuant::Iso4] {
         assert!(
             kq.cpu_hot_path_reason().is_some(),
             "{kq} drives the precompile cpu_hot_path skip branch"

--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -515,13 +515,15 @@ impl KvQuant {
             //
             // * K-only (IsoKOnly*, RotorKOnly*) — K is re-quantised at every
             //   decode step; V routes through `update_decode_fp16_v_only`.
-            // * Fused rotor symmetric (Rotor{3,4}Sym) — decode runs a flash
-            //   kernel straight off the packed K and V rings, so neither axis
-            //   reads a mirror (see `feeds_bf16_v_at_decode`).
+            // * Fused symmetric (Iso{3,4}Sym, Rotor{3,4}Sym) — decode runs a
+            //   flash kernel straight off the packed K and V rings, so neither
+            //   axis reads a mirror (see `feeds_bf16_v_at_decode`).
             KvQuant::IsoKOnly3
             | KvQuant::IsoKOnly4
             | KvQuant::RotorKOnly3
             | KvQuant::RotorKOnly4
+            | KvQuant::Iso3Sym
+            | KvQuant::Iso4Sym
             | KvQuant::Rotor3Sym
             | KvQuant::Rotor4Sym => false,
             // All other variants: decode reads the bf16 K seed materialised by
@@ -543,8 +545,6 @@ impl KvQuant {
             | KvQuant::TurboSym4
             | KvQuant::Iso3
             | KvQuant::Iso4
-            | KvQuant::Iso3Sym
-            | KvQuant::Iso4Sym
             | KvQuant::Rotor3
             | KvQuant::Rotor4
             | KvQuant::RotorK3Asym { .. }
@@ -560,9 +560,9 @@ impl KvQuant {
     /// `update_decode_fp16_v_only`, and `KvQuant::None` stores its bf16 V here
     /// outright.
     ///
-    /// **False only for the fused rotor symmetric codecs** (`Rotor3Sym`,
-    /// `Rotor4Sym`): `rotor_flash_decode_symv` unpacks V straight out of the
-    /// packed rotor ring inside the SV loop, so a bf16 V is never read. Keeping
+    /// **False only for the fused symmetric codecs** (`Iso3Sym`, `Iso4Sym`,
+    /// `Rotor3Sym`, `Rotor4Sym`): the quant-V flash kernel unpacks V straight out
+    /// of the packed ring inside the SV loop, so a bf16 V is never read. Keeping
     /// one is not a small waste — a full `seq * head_dim * 2` bytes per layer of
     /// V (plus the same for K) is the *dominant* term in these codecs' residency
     /// and is what made a ~3-bits-per-axis codec cost more than plain bf16.
@@ -571,9 +571,9 @@ impl KvQuant {
     /// variant must be classified rather than silently inherit a mirror.
     pub fn feeds_bf16_v_at_decode(&self) -> bool {
         match self {
-            // Fused rotor symmetric: V is unpacked from the quant store inside
-            // the flash kernel's SV loop; no bf16 V exists.
-            KvQuant::Rotor3Sym | KvQuant::Rotor4Sym => false,
+            // Fused symmetric: V is unpacked from the quant store inside the
+            // flash kernel's SV loop; no bf16 V exists.
+            KvQuant::Iso3Sym | KvQuant::Iso4Sym | KvQuant::Rotor3Sym | KvQuant::Rotor4Sym => false,
             // Everything else reads the bf16 V seed at decode — including the
             // K-only family (via `update_decode_fp16_v_only`) and `None`, whose
             // bf16 V *is* this buffer.
@@ -594,8 +594,6 @@ impl KvQuant {
             | KvQuant::TurboSym4
             | KvQuant::Iso3
             | KvQuant::Iso4
-            | KvQuant::Iso3Sym
-            | KvQuant::Iso4Sym
             | KvQuant::IsoKOnly3
             | KvQuant::IsoKOnly4
             | KvQuant::Rotor3
@@ -709,11 +707,16 @@ impl KvQuant {
             // `update_iso3*` early-returns to the warm-TTFT bf16 decode seed
             // (`decode_fp16_k.is_some()`), so the GPU iso branch is shadowed;
             // the iso V-encode that does run (at prefill) is CPU.
-            KvQuant::Iso3 | KvQuant::Iso4 | KvQuant::Iso3Sym | KvQuant::Iso4Sym => Some(
+            KvQuant::Iso3 | KvQuant::Iso4 => Some(
                 "IsoQuant (quaternion SO(4)) V-only: a GPU iso encode/dequant branch \
                  exists but is shadowed by the bf16 decode seed; prefill V-encode runs \
                  on CPU",
             ),
+            // Symmetric iso variants: NO bf16 decode-seed early-return — decode
+            // is the quant-V flash kernel over both packed iso rings. Iso carries
+            // no QJL sideband, so there is no CPU-fallback gate; the hot path is
+            // Metal.
+            KvQuant::Iso3Sym | KvQuant::Iso4Sym => None,
             // K-only iso variants: NO bf16 decode-seed early-return — the iso K
             // codec fires every decode step. On GPU, `update_iso_k_only_{3,4}`
             // dispatches the real iso{3,4} MSL encode kernel; IsoKOnly3 also runs

--- a/crates/rmlx-kv-quant/src/quant_tests.rs
+++ b/crates/rmlx-kv-quant/src/quant_tests.rs
@@ -359,16 +359,27 @@ fn estimator_matches_actual_iso_rotor_encode_bytes() {
         crate::isoquant::iso_encode_fast(&v, head_dim, 4, 3).unwrap();
     let iso_side_actual = 4 * (codes.len() + scales.len() + quats.len() + norms.len()) as u64;
 
-    // Iso3Sym quantizes BOTH sides with the iso codec and retains bf16 seeds
-    // for both (warm-TTFT): estimate = 2*(side + seed).
+    // Iso3Sym quantizes BOTH sides with the iso codec and — like Rotor3Sym —
+    // retains **no** bf16 seed on either: its decode is the quant-V flash kernel
+    // over both packed iso rings, so estimate = 2*side with no seed term. (The
+    // estimator still counts the quaternion sideband, matching the CPU encode
+    // bytes; the resident ring drops it, so real residency is below this — the
+    // estimate is a conservative upper bound, not a census.)
     let elems = seq * head_dim as u64 * kv_heads;
     let seed = elems * 2;
     let est = KvQuant::Iso3Sym.estimated_resident_bytes_per_layer(seq, head_dim as u64, kv_heads);
-    let expected = 2 * (iso_side_actual + seed);
+    let expected = 2 * iso_side_actual;
     let tol = expected / 10; // ±10%
     assert!(
         est.abs_diff(expected) <= tol,
         "Iso3Sym estimate {est} not within 10% of actual {expected}"
+    );
+    // The seedless estimate must be strictly below the seeded sibling's — the
+    // point of the fused path.
+    assert!(
+        est < 2 * (iso_side_actual + seed),
+        "Iso3Sym must not carry a bf16 mirror: {est} should be below the seeded {}",
+        2 * (iso_side_actual + seed)
     );
 
     // rotor3: per-token = n_groups*(code u32 + scale f32) + norm f32.

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl.rs
@@ -112,6 +112,7 @@ use rmlx_core::error::{Error, Result};
 use rmlx_mlx::metal_kernel::{MetalKernel, MetalKernelInvoke};
 use rmlx_mlx::{Array, Device, Dtype};
 
+use crate::flash_decode_common::pad_norms_to_device_floor;
 use crate::rotor_flash_decode_msl::{
     build_rotor_flash_header, ROTOR_FLASH_HEAD_DIM_MAX, TILE_SIZE,
 };
@@ -412,6 +413,13 @@ pub fn rotor_flash_decode_symv_sdpa<const BITS: u8>(
     };
     let (k_codes, k_scales, k_norms, k_rotors) = flatten_axis(k)?;
     let (v_codes, v_scales, v_norms, v_rotors) = flatten_axis(v)?;
+
+    // GPU-native small-`norms`-buffer floor — see
+    // [`crate::flash_decode_common::pad_norms_to_device_floor`]. Same trap and
+    // fix as the iso sibling: `rf_decode_k_lane` also declares `norms`
+    // `device const float*`.
+    let k_norms = pad_norms_to_device_floor(k_norms, tok_count, device)?;
+    let v_norms = pad_norms_to_device_floor(v_norms, tok_count, device)?;
 
     // ── Mask ──────────────────────────────────────────────────────────────
     let (mask_flat, has_mask) = if let Some(m) = additive_mask {

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl.rs
@@ -416,8 +416,8 @@ pub fn rotor_flash_decode_symv_sdpa<const BITS: u8>(
 
     // GPU-native small-`norms`-buffer floor — see
     // [`crate::flash_decode_common::pad_norms_to_device_floor`]. Same trap and
-    // fix as the iso sibling: `rf_decode_k_lane` also declares `norms`
-    // `device const float*`.
+    // fix as the iso sibling: `rf_decode_k_group` (the decoder the symv P1 body
+    // calls) also declares `norms` `device const float*`.
     let k_norms = pad_norms_to_device_floor(k_norms, tok_count, device)?;
     let v_norms = pad_norms_to_device_floor(v_norms, tok_count, device)?;
 

--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -63,6 +63,7 @@ pub use quant_iso_k::{
     iso_n_groups_for, QuantIsoK3, ISO_K3_BITS, ISO_K3_GROUP_SIZE, ISO_QUAT_BLOCK_SIZE,
 };
 pub use quant_iso_k4::{QuantIsoK4, ISO_K4_BITS, ISO_K4_GROUP_SIZE};
+pub(crate) use quant_iso_v::synced_iso_v_blocks;
 pub use quant_iso_v::{IsoBlocks, QuantIsoV3, ISO3_BITS, ISO3_GROUP_SIZE};
 pub use quant_iso_v4::{QuantIsoV4, ISO4_BITS, ISO4_GROUP_SIZE};
 pub use quant_k::QuantK;

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -20,7 +20,7 @@ use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{Array, Device, Dtype};
 
 use crate::isoquant::{iso_decode_fast, iso_encode_fast, IsoQuantError};
-use crate::storage::quant_iso_v::IsoBlocks;
+use crate::storage::quant_iso_v::{synced_iso_v_blocks, IsoBlocks};
 
 use super::QuantKGpuRing;
 
@@ -225,6 +225,17 @@ impl QuantIsoK3 {
     }
 
     /// Truncate the accumulated sequence to `n` tokens.
+    ///
+    /// The GPU ring is **kept**, not cleared — mirror of the rotor K store's
+    /// `truncate_to`. Lowering `shape[2]` to `n` makes the ring's logical fill
+    /// `n`; the stale `[n, prev)` capacity is overwritten by the next append and
+    /// never read (`packed_view` slices to `shape[2]`). This preserves any
+    /// ring-only decode tail up to `n`, so `dequant` / an SSD spill can still
+    /// rebuild it via [`synced_iso_v_blocks`]. Clearing the ring here would
+    /// discard the tail (the only copy of `[frozen_prefix, n)`), leaving `blocks`
+    /// short of `shape[2]` with no ring — the divergent state `dequant` rejects
+    /// loudly, which would abort generation on the speculative-decode rollback
+    /// path.
     pub fn truncate_to(&mut self, n: i32) {
         let n_usize = n.max(0) as usize;
         let mut acc: usize = 0;
@@ -238,26 +249,32 @@ impl QuantIsoK3 {
             }
         }
         self.blocks.truncate(keep);
-        // The ring's filled prefix no longer matches `blocks`; drop it rather
-        // than leave a longer-than-truncated prefix live.
-        self.gpu.clear();
+        // NB: no `self.gpu.clear()` — the ring is the source of truth for a
+        // ring-only decode tail; see the doc comment above.
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }
     }
 
-    /// Deep-clone (CPU path is plain `Vec` clones).
+    /// Deep-clone.
+    ///
+    /// Materialises any ring-only decode tail into complete CPU blocks first —
+    /// mirror of [`super::QuantIsoV3::try_deep_clone`]. A short-blocks clone with
+    /// no ring would silently truncate the store; [`synced_iso_v_blocks`] rejects
+    /// that loudly instead.
     ///
     /// # Errors
-    /// Currently infallible on the CPU path; returns `Result` for parity.
+    /// Forwards a [`synced_iso_v_blocks`] reconciliation error.
     pub fn try_deep_clone(&self) -> Result<Self> {
+        let blocks =
+            synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?.into_owned();
         Ok(Self {
-            blocks: self.blocks.clone(),
             // The clone starts CPU-only: `blocks` carries the full payload, so
             // the ring re-seeds from them on the clone's first GPU append.
             // Sharing the source's Arrays would alias one ring across two
             // independent caches.
             gpu: QuantKGpuRing::default(),
+            blocks,
             shape: self.shape.clone(),
             max_seq: self.max_seq,
             bits: self.bits,
@@ -384,7 +401,29 @@ impl QuantIsoK3 {
         let head_dim = self.shape[3] as usize;
         let total_elems: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out: Vec<f32> = Vec::with_capacity(total_elems);
-        for blk in &self.blocks {
+
+        // Reconcile the CPU blocks with the GPU ring: on the fused K-only /
+        // symmetric decode path the decode tail lives only in the ring
+        // (`blocks` trail `shape[2]`), and this rebuilds it on demand rather than
+        // decoding a short prefix and zero-padding the gap. Loud on any
+        // unrecoverable disagreement.
+        let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?;
+
+        if blocks.is_empty() {
+            // Loud on a lost decode tail — see [`super::QuantIsoV3::dequant`].
+            // (Zeros are layout-invariant, so the genuine no-token case needs no
+            // reorder.)
+            if total_elems != 0 {
+                return Err(Error::Mlx(format!(
+                    "QuantIsoK3::dequant: no blocks but shape {:?} implies {total_elems} elems — \
+                     refusing to zero-pad a lost decode tail",
+                    self.shape
+                )));
+            }
+            return Ok(out);
+        }
+
+        for blk in blocks.iter() {
             let dec = iso_decode_fast(
                 &blk.codes,
                 &blk.scales,
@@ -397,10 +436,16 @@ impl QuantIsoK3 {
             .map_err(|e: IsoQuantError| Error::Mlx(format!("iso_k3 decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
-        if out.len() < total_elems {
-            out.resize(total_elems, 0.0);
-        } else if out.len() > total_elems {
-            out.truncate(total_elems);
+        // `synced_iso_v_blocks` guarantees the blocks cover `shape[2]`, so a
+        // length mismatch here is an internal invariant break — surface it loudly
+        // rather than zero-padding or truncating a decoded prefix.
+        if out.len() != total_elems {
+            return Err(Error::Mlx(format!(
+                "QuantIsoK3::dequant: decoded {} elems but shape {:?} implies {total_elems} — \
+                 refusing to zero-pad / truncate",
+                out.len(),
+                self.shape
+            )));
         }
         // Blocks are sequence-major (see `append`); reorder back to the logical
         // head-major `[B, kv_h, S, D]`.

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
@@ -11,12 +11,12 @@
 )]
 //! Quantized K buffer: `QuantIsoK4` (IsoQuant 4-bit K codec).
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{Array, Device};
 
 use crate::isoquant::{iso_decode_fast, iso_encode_fast, IsoQuantError};
 use crate::storage::quant_iso_k::iso_n_groups_i32;
-use crate::storage::quant_iso_v::IsoBlocks;
+use crate::storage::quant_iso_v::{synced_iso_v_blocks, IsoBlocks};
 
 use super::QuantKGpuRing;
 
@@ -82,7 +82,7 @@ impl QuantIsoK4 {
     /// Forwards any [`IsoQuantError`] from [`iso_encode_fast`].
     pub fn append(&mut self, f32_data: &[f32], new_shape: &[i32]) -> Result<()> {
         if new_shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantIsoK4::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
@@ -99,9 +99,8 @@ impl QuantIsoK4 {
             super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
 
         let (codes, scales, quaternions, norms) =
-            iso_encode_fast(&seq_major, head_dim, ISO_K4_GROUP_SIZE, ISO_K4_BITS).map_err(
-                |e: IsoQuantError| rmlx_core::error::Error::Mlx(format!("iso_k4 encode: {e}")),
-            )?;
+            iso_encode_fast(&seq_major, head_dim, ISO_K4_GROUP_SIZE, ISO_K4_BITS)
+                .map_err(|e: IsoQuantError| Error::Mlx(format!("iso_k4 encode: {e}")))?;
 
         self.blocks.push(IsoBlocks {
             codes,
@@ -159,6 +158,10 @@ impl QuantIsoK4 {
     }
 
     /// Truncate the accumulated sequence to `n` tokens.
+    ///
+    /// The GPU ring is **kept**, not cleared — mirror of
+    /// [`crate::storage::QuantIsoK3::truncate_to`] (the ring-only-tail
+    /// treatment). Clearing it would discard a ring-only decode tail.
     pub fn truncate_to(&mut self, n: i32) {
         let n_usize = n.max(0) as usize;
         let mut acc: usize = 0;
@@ -172,9 +175,8 @@ impl QuantIsoK4 {
             }
         }
         self.blocks.truncate(keep);
-        // The ring's filled prefix no longer matches `blocks`; drop it rather
-        // than leave a longer-than-truncated prefix live.
-        self.gpu.clear();
+        // NB: no `self.gpu.clear()` — the ring is the source of truth for a
+        // ring-only decode tail; see the doc comment above.
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }
@@ -182,14 +184,19 @@ impl QuantIsoK4 {
 
     /// Deep-clone.
     ///
+    /// Materialises any ring-only decode tail into complete CPU blocks first —
+    /// mirror of [`crate::storage::QuantIsoK3::try_deep_clone`].
+    ///
     /// # Errors
-    /// Currently infallible on the CPU path; returns `Result` for parity.
+    /// Forwards a [`synced_iso_v_blocks`] reconciliation error.
     pub fn try_deep_clone(&self) -> Result<Self> {
+        let blocks =
+            synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?.into_owned();
         Ok(Self {
-            blocks: self.blocks.clone(),
             // The clone starts CPU-only — see
             // [`crate::storage::QuantIsoK3::try_deep_clone`].
             gpu: QuantKGpuRing::default(),
+            blocks,
             shape: self.shape.clone(),
             max_seq: self.max_seq,
             bits: self.bits,
@@ -224,7 +231,7 @@ impl QuantIsoK4 {
     ///
     /// # Errors
     ///
-    /// Returns [`rmlx_core::error::Error::Quant`] when `head_dim` violates the
+    /// Returns [`Error::Quant`] when `head_dim` violates the
     /// group-size invariant, and forwards ring errors.
     #[allow(clippy::too_many_arguments)]
     pub fn gpu_append(
@@ -289,7 +296,7 @@ impl QuantIsoK4 {
     /// Returns an `Error::Mlx` if the underlying [`iso_decode_fast`] fails.
     pub fn dequant(&self) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantIsoK4::dequant: malformed shape {:?}",
                 self.shape
             )));
@@ -297,7 +304,24 @@ impl QuantIsoK4 {
         let head_dim = self.shape[3] as usize;
         let total_elems: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out: Vec<f32> = Vec::with_capacity(total_elems);
-        for blk in &self.blocks {
+
+        // Reconcile the ring-only decode tail — see
+        // [`crate::storage::QuantIsoK3::dequant`].
+        let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?;
+
+        if blocks.is_empty() {
+            // Loud on a lost decode tail — see [`crate::storage::QuantIsoK3::dequant`].
+            if total_elems != 0 {
+                return Err(Error::Mlx(format!(
+                    "QuantIsoK4::dequant: no blocks but shape {:?} implies {total_elems} elems — \
+                     refusing to zero-pad a lost decode tail",
+                    self.shape
+                )));
+            }
+            return Ok(out);
+        }
+
+        for blk in blocks.iter() {
             let dec = iso_decode_fast(
                 &blk.codes,
                 &blk.scales,
@@ -307,15 +331,17 @@ impl QuantIsoK4 {
                 ISO_K4_GROUP_SIZE,
                 ISO_K4_BITS,
             )
-            .map_err(|e: IsoQuantError| {
-                rmlx_core::error::Error::Mlx(format!("iso_k4 decode: {e}"))
-            })?;
+            .map_err(|e: IsoQuantError| Error::Mlx(format!("iso_k4 decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
-        if out.len() < total_elems {
-            out.resize(total_elems, 0.0);
-        } else if out.len() > total_elems {
-            out.truncate(total_elems);
+        // Loud invariant — see [`crate::storage::QuantIsoK3::dequant`].
+        if out.len() != total_elems {
+            return Err(Error::Mlx(format!(
+                "QuantIsoK4::dequant: decoded {} elems but shape {:?} implies {total_elems} — \
+                 refusing to zero-pad / truncate",
+                out.len(),
+                self.shape
+            )));
         }
         // Blocks are sequence-major (see `append`); reorder back to head-major
         // `[B, kv_h, S, D]`.

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -16,12 +16,12 @@
 )]
 //! Quantized V buffer: `QuantIsoV3` (IsoQuant 3-bit V codec).
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{zeros, Array, Device, Dtype};
 
-use crate::isoquant::{iso_decode_fast, iso_encode_fast, IsoQuantError};
+use crate::isoquant::{iso_decode_fast, iso_encode_fast, IsoQuantError, FIXED_QUAT};
 
-use super::KV_PAGE_SIZE;
+use super::{iso_n_groups_for, QuantKGpuRing, KV_PAGE_SIZE};
 
 /// Bit-width of the iso3 V codec (fixed at 3-bit — see
 /// [`crate::isoquant::iso_encode_fast`]).
@@ -88,6 +88,15 @@ pub struct QuantIsoV3 {
     /// Accumulated per-token blocks (one entry per append call; `dequant`
     /// flattens them).
     pub blocks: Vec<IsoBlocks>,
+    /// GPU-resident packed ring for the fused symmetric flash-decode path.
+    /// Empty until the first [`Self::gpu_append`]. Distinct from the bespoke
+    /// `gpu_*_buf` mirror below (which is gated off in production and serves
+    /// `dequant_gpu`): the ring stores per-token norms in the sequence-major
+    /// `(codes, scales, norms)` form the flash kernel reads, mirroring the K
+    /// store and the rotor V store. When live it is the SOLE resident copy —
+    /// the CPU `blocks` are dropped and rebuilt on demand via
+    /// [`synced_iso_v_blocks`].
+    pub gpu: QuantKGpuRing,
     /// Accumulated shape `[B, kv_h, S_total, D]`.
     pub shape: Vec<i32>,
     // The provisioned window is deliberately NOT a field: it lives on the
@@ -136,6 +145,7 @@ impl std::fmt::Debug for QuantIsoV3 {
         // Summarise mirror presence + sizing instead.
         f.debug_struct("QuantIsoV3")
             .field("n_blocks", &self.blocks.len())
+            .field("gpu_resident", &self.gpu.is_allocated())
             .field("shape", &self.shape)
             .field("bits", &self.bits)
             .field("gpu_capacity", &self.gpu_capacity)
@@ -164,6 +174,7 @@ impl QuantIsoV3 {
     pub fn new(init_shape: Vec<i32>) -> Self {
         Self {
             blocks: Vec::new(),
+            gpu: QuantKGpuRing::default(),
             shape: init_shape,
             bits: ISO3_BITS,
             gpu_codes_buf: None,
@@ -188,7 +199,7 @@ impl QuantIsoV3 {
     /// Forwards any [`IsoQuantError`] from [`iso_encode_fast`].
     pub fn append(&mut self, f32_data: &[f32], new_shape: &[i32]) -> Result<()> {
         if new_shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantIsoV3::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
@@ -209,9 +220,8 @@ impl QuantIsoV3 {
             super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
 
         let (codes, scales, quaternions, norms) =
-            iso_encode_fast(&seq_major, head_dim, ISO3_GROUP_SIZE, ISO3_BITS).map_err(
-                |e: IsoQuantError| rmlx_core::error::Error::Mlx(format!("iso3 encode: {e}")),
-            )?;
+            iso_encode_fast(&seq_major, head_dim, ISO3_GROUP_SIZE, ISO3_BITS)
+                .map_err(|e: IsoQuantError| Error::Mlx(format!("iso3 encode: {e}")))?;
 
         self.blocks.push(IsoBlocks {
             codes,
@@ -220,6 +230,10 @@ impl QuantIsoV3 {
             norms,
             n_tokens: n_tokens_total,
         });
+
+        // A CPU append does not touch the GPU ring, so any live ring is now a
+        // stale prefix. Drop it; the next `gpu_append` re-seeds from `blocks`.
+        self.gpu.clear();
 
         // Bookkeeping: advance the seq dim of the accumulated shape.
         // shape[0]/shape[1]/shape[3] must be initialised by the caller (or set on
@@ -249,6 +263,9 @@ impl QuantIsoV3 {
         );
         Self {
             blocks,
+            // Hydrated caches start CPU-only; the ring is rebuilt lazily from
+            // the next GPU append.
+            gpu: QuantKGpuRing::default(),
             shape,
             bits: ISO3_BITS,
             // Hydrate path leaves the GPU mirror unallocated. The next
@@ -268,6 +285,9 @@ impl QuantIsoV3 {
     /// reuse on the next request.
     pub fn reset(&mut self) {
         self.blocks.clear();
+        // The ring would otherwise keep a prefix the CPU blocks no longer
+        // claim. Dropped here; the next `gpu_append` re-seeds from `blocks`.
+        self.gpu.clear();
         if self.shape.len() >= 4 {
             self.shape[2] = 0;
         }
@@ -291,6 +311,17 @@ impl QuantIsoV3 {
     /// Drops trailing blocks until the cumulative `n_tokens` count is `<= n`
     /// and lowers `shape[2]` to `n`. The codec is per-token so block
     /// boundaries align with token boundaries.
+    ///
+    /// The GPU ring is **kept**, not cleared — mirror of the rotor V store's
+    /// `truncate_to`. Lowering `shape[2]` to `n` makes the ring's logical fill
+    /// `n`; the stale `[n, prev)` capacity is overwritten by the next append and
+    /// never read (`packed_view` slices to `shape[2]`). This preserves any
+    /// ring-only decode tail up to `n`, so `dequant` / an SSD spill can still
+    /// rebuild it via [`synced_iso_v_blocks`]. Clearing the ring here would
+    /// discard the tail (the only copy of `[frozen_prefix, n)`), leaving `blocks`
+    /// short of `shape[2]` with no ring — the divergent state `dequant` rejects
+    /// loudly, which would abort generation on the speculative-decode rollback
+    /// path.
     pub fn truncate_to(&mut self, n: i32) {
         let n_usize = n.max(0) as usize;
         // shape[0] * shape[1] is the per-token row multiplier; iso codec
@@ -307,6 +338,8 @@ impl QuantIsoV3 {
             }
         }
         self.blocks.truncate(keep);
+        // NB: no `self.gpu.clear()` — the ring is the source of truth for a
+        // ring-only decode tail; see the doc comment above.
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }
@@ -319,15 +352,29 @@ impl QuantIsoV3 {
         }
     }
 
-    /// Deep-clone (CPU path is plain `Vec` clones).
+    /// Deep-clone.
+    ///
+    /// Materialises any ring-only decode tail into complete CPU blocks first:
+    /// the clone starts CPU-only (the ring is not cloned), and both the
+    /// prompt-cache snapshot and the SSD spill clone route through here, so this
+    /// is the single point where a store leaving the live decode loop reconciles
+    /// its blocks with the ring. A short-blocks clone with no ring would silently
+    /// truncate the store — refused loudly by [`synced_iso_v_blocks`] instead.
     ///
     /// # Errors
     ///
-    /// Currently infallible on the CPU path; returns `Result` for parity with
-    /// the other `Quant*` structs (their GPU buffers fallibly clone Arrays).
+    /// Forwards a [`synced_iso_v_blocks`] reconciliation error (blocks over-run
+    /// `shape[2]`, or a ring-only tail exists but the ring is absent / too short).
     pub fn try_deep_clone(&self) -> Result<Self> {
+        let blocks =
+            synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?.into_owned();
         Ok(Self {
-            blocks: self.blocks.clone(),
+            // The clone starts CPU-only: `blocks` carries the full payload, so
+            // the ring re-seeds from them on the clone's first GPU append.
+            // Sharing the source's Arrays would alias one ring across two
+            // independent caches.
+            gpu: QuantKGpuRing::default(),
+            blocks,
             shape: self.shape.clone(),
             bits: self.bits,
             // Handle refcount via `try_clone` (clone of the lazy MLX handle,
@@ -351,6 +398,103 @@ impl QuantIsoV3 {
         })
     }
 
+    /// Concatenate the accumulated CPU blocks into flat sequence-major
+    /// `(codes, scales, norms)` — the form [`QuantKGpuRing::seed_from_cpu`]
+    /// wants. The per-group quaternion table is dropped: it is the fixed
+    /// golden-ratio constant on every group, which the ring never carries.
+    fn flatten_blocks(&self) -> (Vec<u32>, Vec<f32>, Vec<f32>) {
+        // Exact capacities — the prefill seed concatenates the whole prefix
+        // (millions of entries at long context), so growing from empty would
+        // realloc+memcpy repeatedly.
+        let (n_codes, n_scales, n_norms) = self.blocks.iter().fold((0, 0, 0), |(c, s, n), blk| {
+            (
+                c + blk.codes.len(),
+                s + blk.scales.len(),
+                n + blk.norms.len(),
+            )
+        });
+        let mut codes = Vec::with_capacity(n_codes);
+        let mut scales = Vec::with_capacity(n_scales);
+        let mut norms = Vec::with_capacity(n_norms);
+        for blk in &self.blocks {
+            codes.extend_from_slice(&blk.codes);
+            scales.extend_from_slice(&blk.scales);
+            norms.extend_from_slice(&blk.norms);
+        }
+        (codes, scales, norms)
+    }
+
+    /// Push one GPU-encoded chunk into the GPU ring, seeding the ring from the
+    /// accumulated CPU blocks first when it is not yet live.
+    ///
+    /// `codes` / `scales` / `norms` are the iso encode kernel's GPU outputs for
+    /// a **sequence-major** chunk; `norms` must already be per-token. `prev_seq`
+    /// is the accumulated sequence length **before** this chunk.
+    ///
+    /// This only maintains the ring — a ring-only-tail caller then drops the CPU
+    /// blocks (`drop_blocks_when_ring_live`), which are rebuilt on demand from
+    /// the ring at `dequant()` / SSD-spill boundaries.
+    ///
+    /// `max_seq` is the window the cache is provisioned for **right now**, read
+    /// from the active `KvStorage` variant by the caller. It is a parameter
+    /// rather than a field so it cannot go stale as the window grows during
+    /// decode — the same contract the K-side ring uses.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Quant`] when `head_dim` yields no quaternion groups, and
+    /// forwards [`QuantKGpuRing::seed_from_cpu`] / [`QuantKGpuRing::append_encoded`]
+    /// errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gpu_append(
+        &mut self,
+        codes: &Array,
+        scales: &Array,
+        norms: &Array,
+        kv_h: i32,
+        head_dim: i32,
+        prev_seq: i32,
+        new_seq: i32,
+        max_seq: i32,
+        device: Device,
+    ) -> Result<()> {
+        let n_groups = i32::try_from(iso_n_groups_for(
+            usize::try_from(head_dim.max(0)).unwrap_or(0),
+        ))
+        .map_err(|_| {
+            Error::Quant(format!(
+                "QuantIsoV3::gpu_append: n_groups for head_dim={head_dim} exceeds i32::MAX"
+            ))
+        })?;
+        if n_groups <= 0 {
+            return Err(Error::Quant(format!(
+                "QuantIsoV3::gpu_append: head_dim={head_dim} yields no quaternion groups"
+            )));
+        }
+        if !self.gpu.is_allocated() && prev_seq > 0 {
+            let (c, s, n) = self.flatten_blocks();
+            self.gpu
+                .seed_from_cpu(&c, &s, &n, kv_h, n_groups, prev_seq, max_seq, device)?;
+        }
+        self.gpu.append_encoded(
+            codes, scales, norms, kv_h, n_groups, prev_seq, new_seq, max_seq, device,
+        )
+    }
+
+    /// GPU packed view of the first `kv_seq` positions, or `None` when the ring
+    /// is not live (CPU path — caller falls back to `dequant`).
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`QuantKGpuRing::packed_view`] errors.
+    pub fn gpu_packed_view(
+        &self,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Option<(Array, Array, Array)>> {
+        self.gpu.packed_view(kv_seq, device)
+    }
+
     /// Resident bytes held by this store: CPU blocks plus the GPU mirror.
     ///
     /// Both are summed unconditionally. `gpu_offset` advances independently of
@@ -364,6 +508,7 @@ impl QuantIsoV3 {
     pub fn byte_size(&self) -> u64 {
         let Self {
             blocks,
+            gpu,
             gpu_codes_buf,
             gpu_scales_buf,
             gpu_norms_buf,
@@ -376,6 +521,7 @@ impl QuantIsoV3 {
             gpu_offset: _,
         } = self;
         blocks.iter().map(IsoBlocks::byte_size).sum::<u64>()
+            + gpu.byte_size()
             + crate::bytes::opt_array_bytes(gpu_codes_buf.as_ref())
             + crate::bytes::opt_array_bytes(gpu_scales_buf.as_ref())
             + crate::bytes::opt_array_bytes(gpu_norms_buf.as_ref())
@@ -392,7 +538,7 @@ impl QuantIsoV3 {
     /// any block.
     pub fn dequant(&self) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantIsoV3::dequant: malformed shape {:?}",
                 self.shape
             )));
@@ -400,7 +546,31 @@ impl QuantIsoV3 {
         let head_dim = self.shape[3] as usize;
         let total_elems: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out: Vec<f32> = Vec::with_capacity(total_elems);
-        for blk in &self.blocks {
+
+        // Reconcile the CPU blocks with the GPU ring: on the fused symmetric
+        // decode path the decode tail lives only in the ring (`blocks` trail
+        // `shape[2]`), and this rebuilds it on demand rather than decoding a
+        // short prefix and zero-padding the gap. Loud on any unrecoverable
+        // disagreement.
+        let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?;
+
+        if blocks.is_empty() {
+            // Empty blocks are valid only when the store genuinely holds no
+            // tokens (shape[2] == 0 => total_elems == 0). A non-zero declared
+            // shape with no blocks means the ring-only decode tail was lost and
+            // `synced_iso_v_blocks` could not rebuild it — reject loudly rather
+            // than fabricate a zeroed prefix.
+            if total_elems != 0 {
+                return Err(Error::Mlx(format!(
+                    "QuantIsoV3::dequant: no blocks but shape {:?} implies {total_elems} elems — \
+                     refusing to zero-pad a lost decode tail",
+                    self.shape
+                )));
+            }
+            return Ok(out);
+        }
+
+        for blk in blocks.iter() {
             let dec = iso_decode_fast(
                 &blk.codes,
                 &blk.scales,
@@ -410,19 +580,19 @@ impl QuantIsoV3 {
                 ISO3_GROUP_SIZE,
                 ISO3_BITS,
             )
-            .map_err(|e: IsoQuantError| {
-                rmlx_core::error::Error::Mlx(format!("iso3 decode: {e}"))
-            })?;
+            .map_err(|e: IsoQuantError| Error::Mlx(format!("iso3 decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
-        // dequant may stop short of total_elems if shape[2] hasn't been
-        // advanced past the appended blocks — caller treats this as best-
-        // effort. Pad with zeros so the returned vec matches the declared
-        // shape if needed.
-        if out.len() < total_elems {
-            out.resize(total_elems, 0.0);
-        } else if out.len() > total_elems {
-            out.truncate(total_elems);
+        // `synced_iso_v_blocks` guarantees the blocks cover `shape[2]`, so a
+        // length mismatch here is an internal invariant break — surface it
+        // loudly rather than zero-padding or truncating a decoded prefix.
+        if out.len() != total_elems {
+            return Err(Error::Mlx(format!(
+                "QuantIsoV3::dequant: decoded {} elems but shape {:?} implies {total_elems} — \
+                 refusing to zero-pad / truncate",
+                out.len(),
+                self.shape
+            )));
         }
         // Blocks are sequence-major (see `append`); reorder the concatenated
         // decode back to the logical head-major `[B, kv_h, S, D]`.
@@ -467,7 +637,7 @@ impl QuantIsoV3 {
         device: Device,
     ) -> Result<()> {
         if new_shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantIsoV3::append_gpu: expected 4D new_shape, got {new_shape:?}"
             )));
         }
@@ -476,7 +646,7 @@ impl QuantIsoV3 {
         let s_new = new_shape[2] as usize;
         let head_dim = new_shape[3] as usize;
         if head_dim == 0 || !head_dim.is_multiple_of(ISO3_GROUP_SIZE) {
-            return Err(rmlx_core::error::Error::Quant(format!(
+            return Err(Error::Quant(format!(
                 "QuantIsoV3::append_gpu: head_dim={head_dim} must be a positive multiple of \
                  ISO3_GROUP_SIZE={ISO3_GROUP_SIZE}"
             )));
@@ -486,9 +656,7 @@ impl QuantIsoV3 {
             .checked_mul(kv_h)
             .and_then(|v| v.checked_mul(s_new))
             .ok_or_else(|| {
-                rmlx_core::error::Error::Quant(
-                    "QuantIsoV3::append_gpu: n_tokens_total overflow".to_owned(),
-                )
+                Error::Quant("QuantIsoV3::append_gpu: n_tokens_total overflow".to_owned())
             })?;
 
         // ── 1. Dispatch the MSL encode kernel. ─────────────────────────────
@@ -554,15 +722,11 @@ impl QuantIsoV3 {
             .checked_mul(kv_h)
             .and_then(|v| v.checked_mul(n_groups))
             .and_then(|v| v.checked_mul(crate::isoquant_msl::ISO3_WORDS_PER_GROUP))
-            .ok_or_else(|| {
-                rmlx_core::error::Error::Quant("append_gpu: words_per_step overflow".to_owned())
-            })?;
+            .ok_or_else(|| Error::Quant("append_gpu: words_per_step overflow".to_owned()))?;
         let groups_per_step = b
             .checked_mul(kv_h)
             .and_then(|v| v.checked_mul(n_groups))
-            .ok_or_else(|| {
-                rmlx_core::error::Error::Quant("append_gpu: groups_per_step overflow".to_owned())
-            })?;
+            .ok_or_else(|| Error::Quant("append_gpu: groups_per_step overflow".to_owned()))?;
 
         // HIGH-1 torn-state guard: all GPU work below builds new Arrays in
         // locals first; `self.gpu_*` fields are only mutated after every
@@ -700,7 +864,7 @@ impl QuantIsoV3 {
                 new_cap = new_cap.min(max_seq);
             }
             if new_cap < needed {
-                return Err(rmlx_core::error::Error::Quant(format!(
+                return Err(Error::Quant(format!(
                     "append_gpu: needed={needed} > max_seq={max_seq} — caller exceeded \
                      declared cache capacity"
                 )));
@@ -723,7 +887,7 @@ impl QuantIsoV3 {
                 self.gpu_scales_buf.as_ref(),
                 self.gpu_norms_buf.as_ref(),
             ) else {
-                return Err(rmlx_core::error::Error::Quant(
+                return Err(Error::Quant(
                     "append_gpu grow: mirror in inconsistent partial-Some state".to_owned(),
                 ));
             };
@@ -794,7 +958,7 @@ impl QuantIsoV3 {
             self.gpu_scales_buf.as_ref(),
             self.gpu_norms_buf.as_ref(),
         ) else {
-            return Err(rmlx_core::error::Error::Quant(
+            return Err(Error::Quant(
                 "append_gpu write: mirror in inconsistent partial-Some state".to_owned(),
             ));
         };
@@ -842,14 +1006,14 @@ impl QuantIsoV3 {
     ///   not a positive multiple of [`ISO3_GROUP_SIZE`].
     pub fn dequant_gpu(&self, device: Device) -> Result<Array> {
         if self.shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantIsoV3::dequant_gpu: malformed shape {:?}",
                 self.shape
             )));
         }
         let head_dim = self.shape[3] as usize;
         if head_dim == 0 || !head_dim.is_multiple_of(ISO3_GROUP_SIZE) {
-            return Err(rmlx_core::error::Error::Quant(format!(
+            return Err(Error::Quant(format!(
                 "QuantIsoV3::dequant_gpu: head_dim={head_dim} must be a positive multiple of \
                  ISO3_GROUP_SIZE={ISO3_GROUP_SIZE}"
             )));
@@ -875,7 +1039,7 @@ impl QuantIsoV3 {
                 // diverged (caller mutated `shape[2]` directly, or mixed
                 // `append` and `append_gpu` calls). Surfacing a typed error
                 // is safer than silently dequanting a stale region.
-                return Err(rmlx_core::error::Error::Quant(format!(
+                return Err(Error::Quant(format!(
                     "dequant_gpu: shape[2]={s_active} != gpu_offset={gpu_off} — \
                      GPU mirror diverged from accumulated shape",
                     gpu_off = self.gpu_offset
@@ -887,17 +1051,10 @@ impl QuantIsoV3 {
             }
             let codes_active = s_active
                 .checked_mul(self.gpu_words_per_step)
-                .ok_or_else(|| {
-                    rmlx_core::error::Error::Quant("dequant_gpu: codes_active overflow".to_owned())
-                })?;
-            let groups_active =
-                s_active
-                    .checked_mul(self.gpu_groups_per_step)
-                    .ok_or_else(|| {
-                        rmlx_core::error::Error::Quant(
-                            "dequant_gpu: groups_active overflow".to_owned(),
-                        )
-                    })?;
+                .ok_or_else(|| Error::Quant("dequant_gpu: codes_active overflow".to_owned()))?;
+            let groups_active = s_active
+                .checked_mul(self.gpu_groups_per_step)
+                .ok_or_else(|| Error::Quant("dequant_gpu: groups_active overflow".to_owned()))?;
             let codes_slice = codes_buf.slice(&[0], &[codes_active], &[1], device)?;
             let scales_slice = scales_buf.slice(&[0], &[groups_active], &[1], device)?;
             let norms_slice = norms_buf.slice(&[0], &[groups_active], &[1], device)?;
@@ -956,13 +1113,11 @@ impl QuantIsoV3 {
             // resulting buffer-vs-shape mismatch would otherwise surface as a
             // confusing kernel-dispatch error downstream.
             let blk_groups = blk.n_tokens.checked_mul(n_groups).ok_or_else(|| {
-                rmlx_core::error::Error::Quant(
-                    "dequant_gpu: blk.n_tokens * n_groups overflow".to_owned(),
-                )
+                Error::Quant("dequant_gpu: blk.n_tokens * n_groups overflow".to_owned())
             })?;
-            total_groups = total_groups.checked_add(blk_groups).ok_or_else(|| {
-                rmlx_core::error::Error::Quant("dequant_gpu: total_groups overflow".to_owned())
-            })?;
+            total_groups = total_groups
+                .checked_add(blk_groups)
+                .ok_or_else(|| Error::Quant("dequant_gpu: total_groups overflow".to_owned()))?;
         }
 
         // Guard against silent shape divergence between `dequant_gpu`
@@ -972,12 +1127,10 @@ impl QuantIsoV3 {
         // than producing a garbage Array.
         let declared_total: usize = self.shape.iter().map(|&d| d as usize).product();
         let actual_total: usize = total_groups.checked_mul(ISO3_GROUP_SIZE).ok_or_else(|| {
-            rmlx_core::error::Error::Quant(
-                "dequant_gpu: total_groups * ISO3_GROUP_SIZE overflow".to_owned(),
-            )
+            Error::Quant("dequant_gpu: total_groups * ISO3_GROUP_SIZE overflow".to_owned())
         })?;
         if actual_total != declared_total {
-            return Err(rmlx_core::error::Error::Quant(format!(
+            return Err(Error::Quant(format!(
                 "dequant_gpu: actual_total={actual_total} (blocks×groups×group_size) != \
                  declared_total={declared_total} (prod(shape)={:?}); refusing to silently \
                  truncate/pad",
@@ -1018,6 +1171,104 @@ impl QuantIsoV3 {
         let out = flat.reshape(&seq_major_shape, device)?;
         out.transpose(&[0, 2, 1, 3], device)?.contiguous(device)
     }
+}
+
+/// Reconcile an iso-V store's CPU `blocks` with its GPU ring so the returned
+/// slice covers the full accumulated `shape[2]`.
+///
+/// On the fused symmetric decode path the per-step CPU block download is skipped
+/// — the GPU ring is the source of truth for the decode tail, and `blocks` trail
+/// `shape[2]` (a **ring-only tail**). This rebuilds the missing prefix from the
+/// ring on demand — the single point where a block consumer (`dequant`, or the
+/// SSD spill via `try_deep_clone`) reconciles the two. When `blocks` already
+/// cover `shape[2]` (the CPU append and SSD-hydrate paths, and every V-only iso
+/// cache, which never feeds the ring) the borrow is returned untouched, so those
+/// paths pay no GPU readback.
+///
+/// The rebuilt block's per-group quaternion table is synthesised as the fixed
+/// golden-ratio constant on every group — exactly what `iso_encode_fast` writes
+/// and the ring drops (see [`crate::isoquant::FIXED_QUAT`]).
+///
+/// **Invariant (enforced loudly, never zero-padded):** `blocks` track the ring
+/// exactly, or the ring exists and supplies the tail. Any state where the CPU
+/// blocks fall short of `shape[2]` and the ring cannot make up the difference is
+/// an `Error` — the caller must not fabricate a zeroed gap.
+///
+/// Shared by [`QuantIsoV3`] / [`super::QuantIsoV4`] and the iso K stores
+/// ([`super::QuantIsoK3`] / [`super::QuantIsoK4`]) — the `IsoBlocks` payload and
+/// ring layout are identical across both axes and both bit widths (iso carries
+/// no K-side sideband, unlike the rotor codec). Mirror of the rotor-side
+/// `synced_rotor_v_blocks`, plus the fixed-quaternion synthesis.
+///
+/// # Errors
+///
+/// Returns [`Error::Quant`] on a malformed shape, when the blocks over-run
+/// `shape[2]`, or when a ring-only tail exists but the ring is absent / too
+/// short to cover it.
+pub(crate) fn synced_iso_v_blocks<'a>(
+    blocks: &'a [IsoBlocks],
+    shape: &[i32],
+    gpu: &QuantKGpuRing,
+    device: Device,
+) -> Result<std::borrow::Cow<'a, [IsoBlocks]>> {
+    if shape.len() != 4 {
+        return Err(Error::Quant(format!(
+            "synced_iso_v_blocks: malformed shape {shape:?}"
+        )));
+    }
+    let b = shape.first().copied().unwrap_or(0).max(0) as usize;
+    let kv_h = shape.get(1).copied().unwrap_or(0).max(0) as usize;
+    let full_seq = shape.get(2).copied().unwrap_or(0).max(0) as usize;
+    let head_dim = shape.get(3).copied().unwrap_or(0).max(0) as usize;
+    let full_tokens = b * kv_h * full_seq;
+    let blocks_tokens: usize = blocks.iter().map(|blk| blk.n_tokens).sum();
+
+    if blocks_tokens == full_tokens {
+        return Ok(std::borrow::Cow::Borrowed(blocks));
+    }
+    if blocks_tokens > full_tokens {
+        return Err(Error::Quant(format!(
+            "iso V store: CPU blocks hold {blocks_tokens} tokens but shape[2] implies \
+             {full_tokens} — blocks over-run the accumulated shape (internal invariant)"
+        )));
+    }
+
+    // Ring-only tail: the GPU ring must supply the whole prefix. It is
+    // sequence-major and stores per-token norms already, so the readback is one
+    // block covering `[0, full_seq)`. Refuse to fabricate a zeroed gap.
+    let seq_i32 = i32::try_from(full_seq)
+        .map_err(|_| Error::Quant(format!("iso V store: shape[2]={full_seq} exceeds i32::MAX")))?;
+    let Some((codes, scales, norms)) = gpu.packed_view_cpu(seq_i32, device)? else {
+        return Err(Error::Quant(format!(
+            "iso V store: CPU blocks cover {blocks_tokens} tokens but shape[2] needs \
+             {full_tokens} and the GPU ring is absent — refusing to zero-pad the decode tail"
+        )));
+    };
+    let n_groups = iso_n_groups_for(head_dim);
+    let want_codes = full_tokens * n_groups;
+    if codes.len() != want_codes || scales.len() != want_codes || norms.len() != full_tokens {
+        return Err(Error::Quant(format!(
+            "iso V store: ring readback size mismatch (codes {} scales {} norms {}, \
+             want codes/scales {want_codes} norms {full_tokens}) — cannot rebuild blocks",
+            codes.len(),
+            scales.len(),
+            norms.len(),
+        )));
+    }
+    // The ring drops the per-group quaternion table (it is the fixed constant on
+    // every group); rebuild it so `iso_decode_fast` reads the same rotation the
+    // encoder wrote.
+    let mut quaternions = Vec::with_capacity(want_codes * FIXED_QUAT.len());
+    for _ in 0..want_codes {
+        quaternions.extend_from_slice(&FIXED_QUAT);
+    }
+    Ok(std::borrow::Cow::Owned(vec![IsoBlocks {
+        codes,
+        scales,
+        quaternions,
+        norms,
+        n_tokens: full_tokens,
+    }]))
 }
 
 #[cfg(test)]

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
@@ -17,10 +17,13 @@
 )]
 //! Quantized V buffer: `QuantIsoV4` (IsoQuant 4-bit V codec).
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
+use rmlx_mlx::{Array, Device};
 
 use crate::isoquant::{iso_decode_fast, iso_encode_fast, IsoQuantError};
-use crate::storage::quant_iso_v::IsoBlocks;
+use crate::storage::quant_iso_v::{synced_iso_v_blocks, IsoBlocks};
+
+use super::{iso_n_groups_for, QuantKGpuRing};
 
 /// Bit-width of the iso4 V codec (fixed at 4-bit).
 pub const ISO4_BITS: u8 = 4;
@@ -42,6 +45,11 @@ pub struct QuantIsoV4 {
     /// Accumulated per-token blocks (one entry per append call; `dequant`
     /// flattens them).
     pub blocks: Vec<IsoBlocks>,
+    /// GPU-resident packed ring for the fused symmetric flash-decode path.
+    /// Empty until the first [`Self::gpu_append`]. When live it is the SOLE
+    /// resident copy — the CPU `blocks` are dropped and rebuilt on demand via
+    /// [`synced_iso_v_blocks`]. Mirror of [`super::QuantIsoV3::gpu`].
+    pub gpu: QuantKGpuRing,
     /// Accumulated shape `[B, kv_h, S_total, D]`.
     pub shape: Vec<i32>,
     /// Maximum sequence length the storage was provisioned for.
@@ -55,6 +63,7 @@ impl std::fmt::Debug for QuantIsoV4 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QuantIsoV4")
             .field("n_blocks", &self.blocks.len())
+            .field("gpu_resident", &self.gpu.is_allocated())
             .field("shape", &self.shape)
             .field("max_seq", &self.max_seq)
             .field("bits", &self.bits)
@@ -68,6 +77,7 @@ impl QuantIsoV4 {
     pub fn new(init_shape: Vec<i32>, max_seq: i32) -> Self {
         Self {
             blocks: Vec::new(),
+            gpu: QuantKGpuRing::default(),
             shape: init_shape,
             max_seq,
             bits: ISO4_BITS,
@@ -81,7 +91,7 @@ impl QuantIsoV4 {
     /// Forwards any [`IsoQuantError`] from [`iso_encode_fast`].
     pub fn append(&mut self, f32_data: &[f32], new_shape: &[i32]) -> Result<()> {
         if new_shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantIsoV4::append: expected 4D new_shape, got {new_shape:?}"
             )));
         }
@@ -98,9 +108,8 @@ impl QuantIsoV4 {
             super::seq_layout::transpose_heads_seq(f32_data, b, kv_h, new_seq, head_dim);
 
         let (codes, scales, quaternions, norms) =
-            iso_encode_fast(&seq_major, head_dim, ISO4_GROUP_SIZE, ISO4_BITS).map_err(
-                |e: IsoQuantError| rmlx_core::error::Error::Mlx(format!("iso4 encode: {e}")),
-            )?;
+            iso_encode_fast(&seq_major, head_dim, ISO4_GROUP_SIZE, ISO4_BITS)
+                .map_err(|e: IsoQuantError| Error::Mlx(format!("iso4 encode: {e}")))?;
 
         self.blocks.push(IsoBlocks {
             codes,
@@ -109,6 +118,10 @@ impl QuantIsoV4 {
             norms,
             n_tokens: n_tokens_total,
         });
+
+        // A CPU append does not touch the GPU ring, so any live ring is now a
+        // stale prefix. Drop it; the next `gpu_append` re-seeds from `blocks`.
+        self.gpu.clear();
 
         if self.shape.len() != 4 || self.shape[0] == 0 {
             self.shape = new_shape.to_vec();
@@ -128,6 +141,9 @@ impl QuantIsoV4 {
         let max_seq = if shape.len() >= 3 { shape[2] } else { 0 };
         Self {
             blocks,
+            // Hydrated caches start CPU-only; the ring is rebuilt lazily from
+            // the next GPU append.
+            gpu: QuantKGpuRing::default(),
             shape,
             max_seq,
             bits: ISO4_BITS,
@@ -138,12 +154,19 @@ impl QuantIsoV4 {
     /// reuse on the next request.
     pub fn reset(&mut self) {
         self.blocks.clear();
+        // The ring would otherwise keep a prefix the CPU blocks no longer
+        // claim. Dropped here; the next `gpu_append` re-seeds from `blocks`.
+        self.gpu.clear();
         if self.shape.len() >= 4 {
             self.shape[2] = 0;
         }
     }
 
     /// Truncate the accumulated sequence to `n` tokens.
+    ///
+    /// Mirror of [`super::QuantIsoV3::truncate_to`]: the GPU ring is **kept**,
+    /// not cleared, so a ring-only decode tail up to `n` survives and `dequant` /
+    /// an SSD spill can rebuild it via [`synced_iso_v_blocks`].
     pub fn truncate_to(&mut self, n: i32) {
         let n_usize = n.max(0) as usize;
         let mut acc: usize = 0;
@@ -157,28 +180,113 @@ impl QuantIsoV4 {
             }
         }
         self.blocks.truncate(keep);
+        // NB: no `self.gpu.clear()` — the ring is the source of truth for a
+        // ring-only decode tail; see [`super::QuantIsoV3::truncate_to`].
         if self.shape.len() >= 4 {
             self.shape[2] = n;
         }
     }
 
-    /// Deep-clone (CPU path is plain `Vec` clones).
+    /// Deep-clone. Materialises any ring-only decode tail into complete blocks
+    /// first — mirror of [`super::QuantIsoV3::try_deep_clone`].
     ///
     /// # Errors
     ///
-    /// Currently infallible on the CPU path; returns `Result` for parity with
-    /// the other `Quant*` structs.
+    /// Forwards a [`synced_iso_v_blocks`] reconciliation error.
     pub fn try_deep_clone(&self) -> Result<Self> {
+        let blocks =
+            synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?.into_owned();
         Ok(Self {
-            blocks: self.blocks.clone(),
+            // The clone starts CPU-only: `blocks` carries the full payload, so
+            // the ring re-seeds from them on the clone's first GPU append.
+            gpu: QuantKGpuRing::default(),
+            blocks,
             shape: self.shape.clone(),
             max_seq: self.max_seq,
             bits: self.bits,
         })
     }
 
-    /// Resident bytes held by this store (CPU blocks; this codec has no GPU
-    /// mirror).
+    /// Concatenate the accumulated CPU blocks into flat sequence-major
+    /// `(codes, scales, norms)` — mirror of [`super::QuantIsoV3::flatten_blocks`].
+    fn flatten_blocks(&self) -> (Vec<u32>, Vec<f32>, Vec<f32>) {
+        let (n_codes, n_scales, n_norms) = self.blocks.iter().fold((0, 0, 0), |(c, s, n), blk| {
+            (
+                c + blk.codes.len(),
+                s + blk.scales.len(),
+                n + blk.norms.len(),
+            )
+        });
+        let mut codes = Vec::with_capacity(n_codes);
+        let mut scales = Vec::with_capacity(n_scales);
+        let mut norms = Vec::with_capacity(n_norms);
+        for blk in &self.blocks {
+            codes.extend_from_slice(&blk.codes);
+            scales.extend_from_slice(&blk.scales);
+            norms.extend_from_slice(&blk.norms);
+        }
+        (codes, scales, norms)
+    }
+
+    /// Push one GPU-encoded chunk into the GPU ring, seeding it from the
+    /// accumulated CPU blocks first when it is not yet live. Mirror of
+    /// [`super::QuantIsoV3::gpu_append`].
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`QuantKGpuRing::seed_from_cpu`] / [`QuantKGpuRing::append_encoded`]
+    /// errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gpu_append(
+        &mut self,
+        codes: &Array,
+        scales: &Array,
+        norms: &Array,
+        kv_h: i32,
+        head_dim: i32,
+        prev_seq: i32,
+        new_seq: i32,
+        max_seq: i32,
+        device: Device,
+    ) -> Result<()> {
+        let n_groups = i32::try_from(iso_n_groups_for(
+            usize::try_from(head_dim.max(0)).unwrap_or(0),
+        ))
+        .map_err(|_| {
+            Error::Quant(format!(
+                "QuantIsoV4::gpu_append: n_groups for head_dim={head_dim} exceeds i32::MAX"
+            ))
+        })?;
+        if n_groups <= 0 {
+            return Err(Error::Quant(format!(
+                "QuantIsoV4::gpu_append: head_dim={head_dim} yields no quaternion groups"
+            )));
+        }
+        if !self.gpu.is_allocated() && prev_seq > 0 {
+            let (c, s, n) = self.flatten_blocks();
+            self.gpu
+                .seed_from_cpu(&c, &s, &n, kv_h, n_groups, prev_seq, max_seq, device)?;
+        }
+        self.gpu.append_encoded(
+            codes, scales, norms, kv_h, n_groups, prev_seq, new_seq, max_seq, device,
+        )
+    }
+
+    /// GPU packed view of the first `kv_seq` positions, or `None` when the ring
+    /// is not live.
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`QuantKGpuRing::packed_view`] errors.
+    pub fn gpu_packed_view(
+        &self,
+        kv_seq: i32,
+        device: Device,
+    ) -> Result<Option<(Array, Array, Array)>> {
+        self.gpu.packed_view(kv_seq, device)
+    }
+
+    /// Resident bytes held by this store: CPU blocks plus the GPU ring.
     ///
     /// The exhaustive destructure is the drift guard: a new buffer cannot be
     /// added to this struct without this failing to compile.
@@ -186,12 +294,13 @@ impl QuantIsoV4 {
     pub fn byte_size(&self) -> u64 {
         let Self {
             blocks,
+            gpu,
             // Geometry / tags, not allocations.
             shape: _,
             max_seq: _,
             bits: _,
         } = self;
-        blocks.iter().map(IsoBlocks::byte_size).sum()
+        blocks.iter().map(IsoBlocks::byte_size).sum::<u64>() + gpu.byte_size()
     }
 
     /// Dequantize all accumulated V slices into one flat f32 vector of length
@@ -202,7 +311,7 @@ impl QuantIsoV4 {
     /// Returns an `Error::Mlx` if the underlying [`iso_decode_fast`] fails.
     pub fn dequant(&self) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
-            return Err(rmlx_core::error::Error::Mlx(format!(
+            return Err(Error::Mlx(format!(
                 "QuantIsoV4::dequant: malformed shape {:?}",
                 self.shape
             )));
@@ -210,7 +319,23 @@ impl QuantIsoV4 {
         let head_dim = self.shape[3] as usize;
         let total_elems: usize = self.shape.iter().map(|&d| d as usize).product();
         let mut out: Vec<f32> = Vec::with_capacity(total_elems);
-        for blk in &self.blocks {
+
+        // Reconcile the ring-only decode tail — see [`super::QuantIsoV3::dequant`].
+        let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?;
+
+        if blocks.is_empty() {
+            // Loud on a lost decode tail — see [`super::QuantIsoV3::dequant`].
+            if total_elems != 0 {
+                return Err(Error::Mlx(format!(
+                    "QuantIsoV4::dequant: no blocks but shape {:?} implies {total_elems} elems — \
+                     refusing to zero-pad a lost decode tail",
+                    self.shape
+                )));
+            }
+            return Ok(out);
+        }
+
+        for blk in blocks.iter() {
             let dec = iso_decode_fast(
                 &blk.codes,
                 &blk.scales,
@@ -220,15 +345,17 @@ impl QuantIsoV4 {
                 ISO4_GROUP_SIZE,
                 ISO4_BITS,
             )
-            .map_err(|e: IsoQuantError| {
-                rmlx_core::error::Error::Mlx(format!("iso4 decode: {e}"))
-            })?;
+            .map_err(|e: IsoQuantError| Error::Mlx(format!("iso4 decode: {e}")))?;
             out.extend_from_slice(&dec);
         }
-        if out.len() < total_elems {
-            out.resize(total_elems, 0.0);
-        } else if out.len() > total_elems {
-            out.truncate(total_elems);
+        // Loud invariant — see [`super::QuantIsoV3::dequant`].
+        if out.len() != total_elems {
+            return Err(Error::Mlx(format!(
+                "QuantIsoV4::dequant: decoded {} elems but shape {:?} implies {total_elems} — \
+                 refusing to zero-pad / truncate",
+                out.len(),
+                self.shape
+            )));
         }
         // Blocks are sequence-major (see `append`); reorder back to head-major
         // `[B, kv_h, S, D]`.

--- a/crates/rmlx-kv-ssd/src/block_io.rs
+++ b/crates/rmlx-kv-ssd/src/block_io.rs
@@ -1380,6 +1380,12 @@ fn write_quant_iso_v3(
     out: &mut Vec<(String, OwnedTensor)>,
 ) -> Result<()> {
     let Some(qv) = v else { return Ok(()) };
+    ensure_iso_blocks_cover_shape(
+        qv.blocks.iter().map(|b| b.n_tokens).sum(),
+        &qv.shape,
+        idx,
+        "v",
+    )?;
     let mut codes: Vec<u8> = Vec::new();
     let mut scales: Vec<f32> = Vec::new();
     let mut quaternions: Vec<f32> = Vec::new();
@@ -1423,6 +1429,12 @@ fn write_quant_iso_v4(
     out: &mut Vec<(String, OwnedTensor)>,
 ) -> Result<()> {
     let Some(qv) = v else { return Ok(()) };
+    ensure_iso_blocks_cover_shape(
+        qv.blocks.iter().map(|b| b.n_tokens).sum(),
+        &qv.shape,
+        idx,
+        "v",
+    )?;
     let mut codes: Vec<u8> = Vec::new();
     let mut scales: Vec<f32> = Vec::new();
     let mut quaternions: Vec<f32> = Vec::new();
@@ -1463,6 +1475,12 @@ fn write_quant_iso_k3(
     out: &mut Vec<(String, OwnedTensor)>,
 ) -> Result<()> {
     let Some(qk) = k else { return Ok(()) };
+    ensure_iso_blocks_cover_shape(
+        qk.blocks.iter().map(|b| b.n_tokens).sum(),
+        &qk.shape,
+        idx,
+        "k",
+    )?;
     let mut codes: Vec<u8> = Vec::new();
     let mut scales: Vec<f32> = Vec::new();
     let mut quaternions: Vec<f32> = Vec::new();
@@ -1503,6 +1521,12 @@ fn write_quant_iso_k4(
     out: &mut Vec<(String, OwnedTensor)>,
 ) -> Result<()> {
     let Some(qk) = k else { return Ok(()) };
+    ensure_iso_blocks_cover_shape(
+        qk.blocks.iter().map(|b| b.n_tokens).sum(),
+        &qk.shape,
+        idx,
+        "k",
+    )?;
     let mut codes: Vec<u8> = Vec::new();
     let mut scales: Vec<f32> = Vec::new();
     let mut quaternions: Vec<f32> = Vec::new();
@@ -1591,6 +1615,33 @@ fn ensure_rotor_v_blocks_cover_shape(
     if blocks_tokens != full_tokens {
         return Err(BlockIoError::TruncatedStore(format!(
             "l{idx}.v rotor store: CPU blocks hold {blocks_tokens} tokens but shape {shape:?} \
+             implies {full_tokens} — the ring-only decode tail was not materialised before spill"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+/// Iso mirror of [`ensure_rotor_v_blocks_cover_shape`], for either axis.
+///
+/// An iso K store (K-only or symmetric) and an iso V store (symmetric) both keep
+/// a ring-only decode tail on the fused path; the spill clone
+/// (`KvCache::try_deep_clone`) materialises it into complete blocks first. Reject
+/// a short store rather than persist a truncated iso payload. `axis` is `"k"` or
+/// `"v"` for the diagnostic.
+fn ensure_iso_blocks_cover_shape(
+    blocks_tokens: usize,
+    shape: &[i32],
+    idx: usize,
+    axis: &str,
+) -> Result<()> {
+    if shape.len() != 4 {
+        return Ok(());
+    }
+    let full_tokens: usize = shape.iter().take(3).map(|&d| d.max(0) as usize).product();
+    if blocks_tokens != full_tokens {
+        return Err(BlockIoError::TruncatedStore(format!(
+            "l{idx}.{axis} iso store: CPU blocks hold {blocks_tokens} tokens but shape {shape:?} \
              implies {full_tokens} — the ring-only decode tail was not materialised before spill"
         ))
         .into());

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -3246,8 +3246,9 @@ fn ref_attn_head_major(
 /// numerically-correct output (vs a scalar reference over the store's own
 /// dequant) for `kv_seq` 2, 3, 4, 7, 15 — all below the compile floor.
 ///
-/// Mutation check: force `iso_flash_decode_symv_sdpa`'s norms-padding closure to
-/// skip padding (return the unpadded array unconditionally) → the `kv_seq == 2`
+/// Mutation check: force `iso_flash_decode_symv_sdpa`'s norms-padding helper
+/// `pad_norms_to_device_floor` to skip padding (return the unpadded array
+/// unconditionally) → the `kv_seq == 2`
 /// step aborts with "Unable to build metal library from source … cannot pass
 /// pointer to address space 'constant' as a pointer to address space 'device' …
 /// if_decode_k_lane" (RED).
@@ -3364,8 +3365,9 @@ fn iso_sym_short_kv_seq_kv_h1_stays_on_gpu() {
 /// against random per-step K/V/Q — not just quantisation noise.
 ///
 /// Mutation check: same as [`iso_sym_short_kv_seq_kv_h1_stays_on_gpu`] —
-/// forcing `iso_flash_decode_symv_sdpa`'s norms-padding closure to skip
-/// padding makes the very first decode step (`kv_seq == 2`) abort before
+/// forcing `iso_flash_decode_symv_sdpa`'s norms-padding helper
+/// `pad_norms_to_device_floor` to skip padding makes the very first decode
+/// step (`kv_seq == 2`) abort before
 /// this test can reach the floor at all.
 #[test]
 #[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd iso_sym_transition_across_ring_norms_floor -- --ignored --test-threads=1"]
@@ -3474,7 +3476,7 @@ fn iso_sym_transition_across_ring_norms_floor() {
 /// as iso — same root cause, same [`crate::flash_decode_common`] fix.
 ///
 /// Mutation check: forcing `rotor_flash_decode_symv_sdpa`'s norms-padding
-/// closure (`pad_norms_to_device_floor`) to skip padding makes the very first
+/// helper `pad_norms_to_device_floor` to skip padding makes the very first
 /// decode step (`kv_seq == 2`) abort with the same address-space-mismatch
 /// class of MSL error (`rf_decode_k_group`, `constant` vs `device`) before
 /// this test can reach the floor at all.

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -3187,6 +3187,139 @@ fn iso_sym3_probe(cache: &KvCache) -> (Vec<f32>, Vec<f32>, i32, usize, usize) {
     }
 }
 
+/// Scalar reference attention over head-major (`[1, kv_h, S, D]`) K/V, for the
+/// short-kv_seq fallback correctness check.
+#[allow(clippy::indexing_slicing, clippy::too_many_arguments)]
+fn ref_attn_head_major(
+    q: &[f32],
+    k: &[f32],
+    v: &[f32],
+    n_q: usize,
+    kv_h: usize,
+    s: usize,
+    d: usize,
+    scale: f32,
+) -> Vec<f32> {
+    let hpk = n_q / kv_h;
+    let mut out = vec![0.0_f32; n_q * d];
+    for hq in 0..n_q {
+        let h = hq / hpk;
+        let mut scores = vec![0.0_f32; s];
+        for (si, sc) in scores.iter_mut().enumerate() {
+            let mut acc = 0.0_f32;
+            for di in 0..d {
+                acc += q[hq * d + di] * k[(h * s + si) * d + di];
+            }
+            *sc = acc * scale;
+        }
+        let m = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let mut den = 0.0_f32;
+        for sc in &mut scores {
+            *sc = (*sc - m).exp();
+            den += *sc;
+        }
+        for di in 0..d {
+            let mut acc = 0.0_f32;
+            for (si, &p) in scores.iter().enumerate() {
+                acc += p * v[(h * s + si) * d + di];
+            }
+            out[hq * d + di] = acc / den;
+        }
+    }
+    out
+}
+
+/// Short-prompt smoke (hard rule 6) for the `kv_h == 1` single-KV-head shape
+/// (Gemma4 global layers): with the fused `iso3_sym` codec live, a decode at a
+/// small `kv_seq` used to abort because MLX binds the ring's tiny norms slice in
+/// the `constant` address space, which the flash kernel's `if_decode_k_lane`
+/// rejects. The `RING_NORMS_DEVICE_MIN` gate now falls those steps back to a CPU
+/// dequant SDPA. Asserts no abort AND numerically-correct output (vs a scalar
+/// reference over the store's own dequant) for `kv_seq` 2, 3, 4, 7, 15 — all
+/// below the compile floor.
+///
+/// Mutation check: delete the `RING_NORMS_DEVICE_MIN` gate in
+/// `update_and_sdpa_iso_sym_fused` (and the consumer guard in
+/// `iso_sym_flash_over_store`) → the `kv_seq == 2` step aborts with
+/// "Unable to build metal library from source … if_decode_k_lane" (RED).
+#[test]
+#[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd iso_sym_short_kv_seq_kv_h1 -- --ignored --test-threads=1"]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+fn iso_sym_short_kv_seq_kv_h1_falls_back_correctly() {
+    let device = Device::Gpu;
+    let n_q = 8_i32;
+    let kv_h = 1_i32; // single KV head — the Gemma4 global-layer shape
+    let head_dim = 512_i32;
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    for kv_seq in [2_i32, 3, 4, 7, 15] {
+        let prefill = kv_seq - 1;
+        let mut c = seeded_iso_sym3_cache(kv_h, head_dim, 512);
+        let k = arr(
+            &lcg((prefill * kv_h * head_dim) as usize, 31),
+            &[1, kv_h, prefill, head_dim],
+        );
+        let v = arr(
+            &lcg((prefill * kv_h * head_dim) as usize, 32),
+            &[1, kv_h, prefill, head_dim],
+        );
+        let q = arr(
+            &lcg((prefill * n_q * head_dim) as usize, 33),
+            &[1, n_q, prefill, head_dim],
+        );
+        c.update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+            .unwrap();
+        c.exit_prefill(device).unwrap();
+
+        let qd = lcg((n_q * head_dim) as usize, 41);
+        let q1 = arr(&qd, &[1, n_q, 1, head_dim]);
+        let k1 = arr(
+            &lcg((kv_h * head_dim) as usize, 42),
+            &[1, kv_h, 1, head_dim],
+        );
+        let v1 = arr(
+            &lcg((kv_h * head_dim) as usize, 43),
+            &[1, kv_h, 1, head_dim],
+        );
+
+        // MUST NOT abort — the gate falls back to CPU dequant SDPA.
+        let out = c
+            .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .expect("short kv_seq at kv_h==1 must not abort — the fused gate falls back to CPU");
+        let got = to_vec(&out);
+        assert_eq!(
+            got.len(),
+            (n_q * head_dim) as usize,
+            "kv_seq={kv_seq}: shape"
+        );
+        assert!(
+            got.iter().all(|x| x.is_finite()),
+            "kv_seq={kv_seq}: output must be finite"
+        );
+
+        // Correctness: scalar attention over the store's own dequant (which the
+        // fallback rebuilds from the ring). Both decode the same iso values, so
+        // the only divergence is summation order — well inside bf16 tolerance.
+        let (k_deq, v_deq, seq, _, _) = iso_sym3_probe(&c);
+        assert_eq!(seq, kv_seq, "kv_seq={kv_seq}: store length");
+        let want = ref_attn_head_major(
+            &qd,
+            &k_deq,
+            &v_deq,
+            n_q as usize,
+            kv_h as usize,
+            kv_seq as usize,
+            head_dim as usize,
+            scale,
+        );
+        let err = max_abs_err(&got, &want);
+        assert!(
+            err < 2e-3,
+            "kv_seq={kv_seq}: fallback output max_abs_err={err} exceeds bf16 tolerance"
+        );
+    }
+}
+
 /// The write path refuses to persist an iso **V** store whose CPU blocks fall
 /// short of `shape[2]` with no ring — a truncated store. Runs on CPU (no Metal).
 ///

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -3189,7 +3189,11 @@ fn iso_sym3_probe(cache: &KvCache) -> (Vec<f32>, Vec<f32>, i32, usize, usize) {
 
 /// Scalar reference attention over head-major (`[1, kv_h, S, D]`) K/V, for the
 /// short-kv_seq fallback correctness check.
-#[allow(clippy::indexing_slicing, clippy::too_many_arguments)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by \
+              slice length"
+)]
 fn ref_attn_head_major(
     q: &[f32],
     k: &[f32],
@@ -3231,21 +3235,32 @@ fn ref_attn_head_major(
 
 /// Short-prompt smoke (hard rule 6) for the `kv_h == 1` single-KV-head shape
 /// (Gemma4 global layers): with the fused `iso3_sym` codec live, a decode at a
-/// small `kv_seq` used to abort because MLX binds the ring's tiny norms slice in
-/// the `constant` address space, which the flash kernel's `if_decode_k_lane`
-/// rejects. The `RING_NORMS_DEVICE_MIN` gate now falls those steps back to a CPU
-/// dequant SDPA. Asserts no abort AND numerically-correct output (vs a scalar
-/// reference over the store's own dequant) for `kv_seq` 2, 3, 4, 7, 15 — all
-/// below the compile floor.
+/// small `kv_seq` used to abort because MLX binds the ring's tiny per-token
+/// `norms` slice in the `constant` address space, which the flash kernel's
+/// `if_decode_k_lane` (`device const float*`) rejects. `iso_flash_decode_symv_sdpa`
+/// now zero-pads `norms` up to its `NORMS_DEVICE_MIN` floor (16) before
+/// dispatch whenever `b*kv_h*kv_seq` is below it, so the fused GPU kernel runs at
+/// every `kv_seq >= 1` with no CPU dequant fallback (hard rule 10): the padding
+/// is allocated but never read, since the kernel's per-tile loop bound is the
+/// real `kv_seq` carried in `dims`, not the buffer length. Asserts no abort AND
+/// numerically-correct output (vs a scalar reference over the store's own
+/// dequant) for `kv_seq` 2, 3, 4, 7, 15 — all below the compile floor.
 ///
-/// Mutation check: delete the `RING_NORMS_DEVICE_MIN` gate in
-/// `update_and_sdpa_iso_sym_fused` (and the consumer guard in
-/// `iso_sym_flash_over_store`) → the `kv_seq == 2` step aborts with
-/// "Unable to build metal library from source … if_decode_k_lane" (RED).
+/// Mutation check: force `iso_flash_decode_symv_sdpa`'s norms-padding closure to
+/// skip padding (return the unpadded array unconditionally) → the `kv_seq == 2`
+/// step aborts with "Unable to build metal library from source … cannot pass
+/// pointer to address space 'constant' as a pointer to address space 'device' …
+/// if_decode_k_lane" (RED).
 #[test]
 #[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd iso_sym_short_kv_seq_kv_h1 -- --ignored --test-threads=1"]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
-fn iso_sym_short_kv_seq_kv_h1_falls_back_correctly() {
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test: values established by construction; GPU dispatch failures asserted via \
+              .expect messages"
+)]
+fn iso_sym_short_kv_seq_kv_h1_stays_on_gpu() {
     let device = Device::Gpu;
     let n_q = 8_i32;
     let kv_h = 1_i32; // single KV head — the Gemma4 global-layer shape
@@ -3282,10 +3297,12 @@ fn iso_sym_short_kv_seq_kv_h1_falls_back_correctly() {
             &[1, kv_h, 1, head_dim],
         );
 
-        // MUST NOT abort — the gate falls back to CPU dequant SDPA.
+        // MUST NOT abort — the kernel dispatcher pads the small norms buffer.
         let out = c
             .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
-            .expect("short kv_seq at kv_h==1 must not abort — the fused gate falls back to CPU");
+            .expect(
+                "short kv_seq at kv_h==1 must not abort — norms is zero-padded before dispatch",
+            );
         let got = to_vec(&out);
         assert_eq!(
             got.len(),
@@ -3297,9 +3314,10 @@ fn iso_sym_short_kv_seq_kv_h1_falls_back_correctly() {
             "kv_seq={kv_seq}: output must be finite"
         );
 
-        // Correctness: scalar attention over the store's own dequant (which the
-        // fallback rebuilds from the ring). Both decode the same iso values, so
-        // the only divergence is summation order — well inside bf16 tolerance.
+        // Correctness: scalar attention over the store's own dequant (which
+        // transparently rebuilds the ring-only tail). Both decode the same iso
+        // values, so the only divergence is summation order — well inside bf16
+        // tolerance.
         let (k_deq, v_deq, seq, _, _) = iso_sym3_probe(&c);
         assert_eq!(seq, kv_seq, "kv_seq={kv_seq}: store length");
         let want = ref_attn_head_major(
@@ -3315,9 +3333,239 @@ fn iso_sym_short_kv_seq_kv_h1_falls_back_correctly() {
         let err = max_abs_err(&got, &want);
         assert!(
             err < 2e-3,
-            "kv_seq={kv_seq}: fallback output max_abs_err={err} exceeds bf16 tolerance"
+            "kv_seq={kv_seq}: padded-dispatch output max_abs_err={err} exceeds bf16 tolerance"
         );
     }
+}
+
+/// CONTINUITY correctness across the `NORMS_DEVICE_MIN` padding floor (16): a
+/// single continuous `kv_h == 1` iso3_sym cache decoded ONE token at a time
+/// from below the floor through well above it, on the SAME cache/ring for
+/// every step, driven **in parallel** with an independent `KvStorage::None`
+/// (unquantised bf16/f32) reference cache fed the identical per-step tokens.
+/// Unlike [`iso_sym_short_kv_seq_kv_h1_stays_on_gpu`] above (which builds a
+/// **fresh** cache per `kv_seq` via a bulk prefill call, so each `kv_seq` is
+/// only ever reached once), this exercises the ring-only decode tail growing
+/// continuously through the point where `iso_flash_decode_symv_sdpa` stops
+/// padding `norms` (once `b*kv_h*kv_seq >= 16`) and starts passing it through
+/// unpadded.
+///
+/// The reference is deliberately **independent of the store under test**: an
+/// earlier version of this test compared the kernel's output against a
+/// scalar reference built from `iso_sym3_probe`'s `dequant()` — which
+/// rebuilds from the SAME ring the kernel just read. A ring corruption both
+/// reads see identically (e.g. a dropped or duplicated append) would pass
+/// that check with `err≈0`; "didn't error" is not "correct" for a silent-KV
+/// class of bug. The bf16 cache instead runs its own `update()` /
+/// `scaled_dot_product_attention` over its own independently-accumulated
+/// K/V, sharing no state with the iso ring at all, so a dropped/misordered
+/// token in the iso ring surfaces as a real divergence between the two
+/// outputs — a gross softmax shift over a materially different key set,
+/// against random per-step K/V/Q — not just quantisation noise.
+///
+/// Mutation check: same as [`iso_sym_short_kv_seq_kv_h1_stays_on_gpu`] —
+/// forcing `iso_flash_decode_symv_sdpa`'s norms-padding closure to skip
+/// padding makes the very first decode step (`kv_seq == 2`) abort before
+/// this test can reach the floor at all.
+#[test]
+#[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd iso_sym_transition_across_ring_norms_floor -- --ignored --test-threads=1"]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test: values established by construction; GPU dispatch failures asserted via \
+              .expect/.unwrap_or_else messages"
+)]
+fn iso_sym_transition_across_ring_norms_floor() {
+    let device = Device::Gpu;
+    let n_q = 8_i32;
+    let kv_h = 1_i32; // single KV head — the Gemma4 global-layer shape
+    let head_dim = 512_i32;
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+    const FLOOR: i32 = 16; // mirrors NORMS_DEVICE_MIN in flash_decode_common.rs
+                           // 3-bit iso quant error on both K and V vs the independent bf16
+                           // reference: measured max_abs_err ~0.14 at kv_seq=2, staying under 0.2
+                           // through kv_seq=24 over this test's random LCG data. A single wrong
+                           // token's V fed to the reference (simulating a dropped/misordered token)
+                           // measured max_abs_err ~0.57 at the same kv_seq=2 — comfortably above
+                           // this floor, so genuine quant noise and a lost-token bug do not overlap.
+    const ISO_QUANT_TOL: f32 = 0.3;
+
+    let mut iso = seeded_iso_sym3_cache(kv_h, head_dim, 512);
+    let mut bf16 = KvCache::from_storage(KvStorage::None { max_seq: 512 }, KvQuant::None, 0, 0);
+
+    // Identical one-token prefill on both caches, matching a realistic short
+    // chat prompt: kv_seq == 1 before the first decode step.
+    let prefill = 1_i32;
+    let k0 = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 51),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let v0 = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 52),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let q0 = arr(
+        &lcg((prefill * n_q * head_dim) as usize, 53),
+        &[1, n_q, prefill, head_dim],
+    );
+    iso.update_and_sdpa(&q0, &k0, &v0, scale, "causal", None, device)
+        .unwrap();
+    iso.exit_prefill(device).unwrap();
+    bf16.update_and_sdpa(&q0, &k0, &v0, scale, "causal", None, device)
+        .unwrap();
+    bf16.exit_prefill(device).unwrap();
+
+    // Decode one token at a time, kv_seq 2..24 — well below the floor through
+    // well above it — feeding the identical tokens into both caches.
+    let mut crossed_floor = false;
+    for step in 0_i32..23 {
+        let kv_seq = 2 + step;
+        let qd = lcg((n_q * head_dim) as usize, 1_000 + step as u64);
+        let kd = lcg((kv_h * head_dim) as usize, 2_000 + step as u64);
+        let vd = lcg((kv_h * head_dim) as usize, 3_000 + step as u64);
+        let q1 = arr(&qd, &[1, n_q, 1, head_dim]);
+        let k1 = arr(&kd, &[1, kv_h, 1, head_dim]);
+        let v1 = arr(&vd, &[1, kv_h, 1, head_dim]);
+
+        let iso_out = iso
+            .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .unwrap_or_else(|e| {
+                panic!("kv_seq={kv_seq}: must not abort across the ring-norms floor: {e}")
+            });
+        let bf16_out = bf16
+            .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .expect("bf16 reference cache must not fail — plain SDPA, no custom kernel");
+
+        let got = to_vec(&iso_out);
+        let want = to_vec(&bf16_out);
+        assert!(
+            got.iter().all(|x| x.is_finite()),
+            "kv_seq={kv_seq}: output must be finite"
+        );
+
+        // Decisive check: the iso3_sym kernel's output vs the INDEPENDENT
+        // bf16 reference cache's output — two separate stores, two separate
+        // code paths, sharing no ring — so a dropped or misordered pre-floor
+        // token in the iso ring cannot pass silently.
+        let err = max_abs_err(&got, &want);
+        assert!(
+            err < ISO_QUANT_TOL,
+            "kv_seq={kv_seq}: iso3_sym vs independent bf16 reference max_abs_err={err} exceeds \
+             tolerance {ISO_QUANT_TOL} (floor={FLOOR}) — the ring's per-step append/reseed \
+             bookkeeping likely dropped or misordered a token"
+        );
+
+        if kv_seq >= FLOOR {
+            crossed_floor = true;
+        }
+    }
+    assert!(
+        crossed_floor,
+        "test did not actually reach kv_seq >= {FLOOR} — padding floor unexercised"
+    );
+}
+
+/// Rotor sibling of [`iso_sym_transition_across_ring_norms_floor`] — same
+/// independent-bf16-reference design, same `kv_h == 1` continuity coverage
+/// across [`flash_decode_common::NORMS_DEVICE_MIN`], for the `rotor3_sym`
+/// codec (`rotor_flash_decode_symv_sdpa`, `rf_decode_k_group`). Rotor's
+/// `norms` buffer hits the identical MLX small-buffer `constant`-binding trap
+/// as iso — same root cause, same [`crate::flash_decode_common`] fix.
+///
+/// Mutation check: forcing `rotor_flash_decode_symv_sdpa`'s norms-padding
+/// closure (`pad_norms_to_device_floor`) to skip padding makes the very first
+/// decode step (`kv_seq == 2`) abort with the same address-space-mismatch
+/// class of MSL error (`rf_decode_k_group`, `constant` vs `device`) before
+/// this test can reach the floor at all.
+#[test]
+#[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd rotor_sym_transition_across_ring_norms_floor -- --ignored --test-threads=1"]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test: values established by construction; GPU dispatch failures asserted via \
+              .expect/.unwrap_or_else messages"
+)]
+fn rotor_sym_transition_across_ring_norms_floor() {
+    let device = Device::Gpu;
+    let n_q = 8_i32;
+    let kv_h = 1_i32; // single KV head — the Gemma4 global-layer shape
+    let head_dim = 512_i32;
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+    const FLOOR: i32 = 16; // mirrors NORMS_DEVICE_MIN in flash_decode_common.rs
+                           // 3-bit rotor quant error on both K and V vs the independent bf16
+                           // reference: measured max_abs_err ~0.15 at kv_seq=2, staying under 0.2
+                           // through kv_seq=24 over this test's random LCG data — same order as
+                           // ISO_QUANT_TOL above, same margin reasoning.
+    const ROTOR_QUANT_TOL: f32 = 0.3;
+
+    let mut rotor = seeded_rotor_sym3_cache(kv_h, head_dim, 512);
+    let mut bf16 = KvCache::from_storage(KvStorage::None { max_seq: 512 }, KvQuant::None, 0, 0);
+
+    let prefill = 1_i32;
+    let k0 = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 61),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let v0 = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 62),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let q0 = arr(
+        &lcg((prefill * n_q * head_dim) as usize, 63),
+        &[1, n_q, prefill, head_dim],
+    );
+    rotor
+        .update_and_sdpa(&q0, &k0, &v0, scale, "causal", None, device)
+        .unwrap();
+    rotor.exit_prefill(device).unwrap();
+    bf16.update_and_sdpa(&q0, &k0, &v0, scale, "causal", None, device)
+        .unwrap();
+    bf16.exit_prefill(device).unwrap();
+
+    let mut crossed_floor = false;
+    for step in 0_i32..23 {
+        let kv_seq = 2 + step;
+        let qd = lcg((n_q * head_dim) as usize, 4_000 + step as u64);
+        let kd = lcg((kv_h * head_dim) as usize, 5_000 + step as u64);
+        let vd = lcg((kv_h * head_dim) as usize, 6_000 + step as u64);
+        let q1 = arr(&qd, &[1, n_q, 1, head_dim]);
+        let k1 = arr(&kd, &[1, kv_h, 1, head_dim]);
+        let v1 = arr(&vd, &[1, kv_h, 1, head_dim]);
+
+        let rotor_out = rotor
+            .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .unwrap_or_else(|e| {
+                panic!("kv_seq={kv_seq}: must not abort across the ring-norms floor: {e}")
+            });
+        let bf16_out = bf16
+            .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .expect("bf16 reference cache must not fail — plain SDPA, no custom kernel");
+
+        let got = to_vec(&rotor_out);
+        let want = to_vec(&bf16_out);
+        assert!(
+            got.iter().all(|x| x.is_finite()),
+            "kv_seq={kv_seq}: output must be finite"
+        );
+
+        let err = max_abs_err(&got, &want);
+        assert!(
+            err < ROTOR_QUANT_TOL,
+            "kv_seq={kv_seq}: rotor3_sym vs independent bf16 reference max_abs_err={err} exceeds \
+             tolerance {ROTOR_QUANT_TOL} (floor={FLOOR}) — the ring's per-step append/reseed \
+             bookkeeping likely dropped or misordered a token"
+        );
+
+        if kv_seq >= FLOOR {
+            crossed_floor = true;
+        }
+    }
+    assert!(
+        crossed_floor,
+        "test did not actually reach kv_seq >= {FLOOR} — padding floor unexercised"
+    );
 }
 
 /// The write path refuses to persist an iso **V** store whose CPU blocks fall

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -3146,6 +3146,282 @@ fn rotor_sym_ring_only_tail_ssd_round_trip() {
     );
 }
 
+// ── Iso symmetric ring-only-tail (sole-store) ─────────────────────────────────
+
+fn seeded_iso_sym3_cache(kv_h: i32, head_dim: i32, max_seq: i32) -> KvCache {
+    let storage = KvStorage::IsoSym3 {
+        k: Some(QuantIsoK3::from_cpu_blocks(
+            Vec::new(),
+            vec![1, kv_h, 0, head_dim],
+            max_seq,
+        )),
+        v: Some(QuantIsoV3::from_cpu_blocks(
+            Vec::new(),
+            vec![1, kv_h, 0, head_dim],
+        )),
+        max_seq,
+    };
+    KvCache::from_storage(storage, KvQuant::Iso3Sym, 0, 0)
+}
+
+/// `(k_dequant, v_dequant, shape[2], k_block_tokens, v_block_tokens)` for an
+/// iso3 symmetric cache.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper: values established by construction"
+)]
+fn iso_sym3_probe(cache: &KvCache) -> (Vec<f32>, Vec<f32>, i32, usize, usize) {
+    match cache.storage() {
+        KvStorage::IsoSym3 {
+            k: Some(ks),
+            v: Some(vs),
+            ..
+        } => (
+            ks.dequant().unwrap(),
+            vs.dequant().unwrap(),
+            ks.shape.get(2).copied().unwrap_or(0),
+            ks.blocks.iter().map(|b| b.n_tokens).sum(),
+            vs.blocks.iter().map(|b| b.n_tokens).sum(),
+        ),
+        _ => panic!("expected a live IsoSym3 store"),
+    }
+}
+
+/// The write path refuses to persist an iso **V** store whose CPU blocks fall
+/// short of `shape[2]` with no ring — a truncated store. Runs on CPU (no Metal).
+///
+/// Mutation check: delete the `ensure_iso_blocks_cover_shape` guard in
+/// `write_quant_iso_v3` — the writer then silently serializes the short prefix
+/// and this assertion flips RED (`write` returns `Ok`).
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test: values established by construction earlier in this fn"
+)]
+fn write_rejects_truncated_iso_store() {
+    let kv_h = 2_i32;
+    let head_dim = 8_i32; // multiple of ISO_QUAT_BLOCK_SIZE (4); n_groups = 2
+    let data = lcg((kv_h * 2 * head_dim) as usize, 0x1D0);
+
+    // A real single V block covering 2 tokens.
+    let mut src = QuantIsoV3::new(vec![1, kv_h, 0, head_dim]);
+    src.append(&data, &[1, kv_h, 2, head_dim]).unwrap();
+
+    // Claim shape[2] == 4 while the blocks cover only 2 tokens and no ring
+    // exists — the ring-only tail with the ring missing. Pair with a well-formed
+    // K store so the sym layer is valid on the K side.
+    let truncated_v = QuantIsoV3::from_cpu_blocks(src.blocks.clone(), vec![1, kv_h, 4, head_dim]);
+    let mut k_src = QuantIsoK3::new(vec![1, kv_h, 0, head_dim], 64);
+    let k_data = lcg((kv_h * 4 * head_dim) as usize, 0x2E0);
+    k_src.append(&k_data, &[1, kv_h, 4, head_dim]).unwrap();
+
+    let layers = vec![KvStorage::IsoSym3 {
+        k: Some(k_src),
+        v: Some(truncated_v),
+        max_seq: 64,
+    }];
+    let path = tmp_path("iso_v_truncated");
+    let res =
+        KvBlockWriter::new(MODEL_ID, KvQuant::Iso3Sym, &layers, &[]).write(&path, Device::Cpu);
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        res.is_err(),
+        "writer must reject a truncated iso V store (short blocks, no ring), got Ok"
+    );
+}
+
+/// Full SSD spill/hydrate round-trip after a **symmetric** iso ring-only-tail
+/// decode: both K and V decode tails live only in their GPU rings, are
+/// materialised by the spill clone, and hydrate byte-exact. Also proves the V
+/// dequant-full-prefix rebuild (`synced_iso_v_blocks`) from the ring.
+///
+/// Mutation checks:
+/// * dequant skip-rebuild: make `synced_iso_v_blocks` return
+///   `Cow::Borrowed(blocks)` always — the frozen short prefix trips the loud
+///   `refusing to zero-pad` error in `dequant` (RED, not a silent zero-pad).
+/// * SSD spill: make `QuantIsoV3::try_deep_clone` clone `self.blocks` directly
+///   (drop the synced reconcile) — `write_caches` trips
+///   `ensure_iso_blocks_cover_shape` → `TruncatedStore` (RED).
+#[test]
+#[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd iso_sym_ring_only_tail_ssd -- --ignored --test-threads=1"]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test: values established by construction earlier in this fn"
+)]
+fn iso_sym_ring_only_tail_ssd_round_trip() {
+    let device = Device::Gpu;
+    let (kv_h, n_q, head_dim, prefill, steps) = (2_i32, 8_i32, 128_i32, 6_i32, 5_i32);
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    let mut c = seeded_iso_sym3_cache(kv_h, head_dim, 512);
+    let k = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 61),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let v = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 62),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let q = arr(
+        &lcg((prefill * n_q * head_dim) as usize, 63),
+        &[1, n_q, prefill, head_dim],
+    );
+    c.update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+        .unwrap();
+    c.exit_prefill(device).unwrap();
+    for i in 0..steps {
+        let k1 = arr(
+            &lcg((kv_h * head_dim) as usize, 71 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let v1 = arr(
+            &lcg((kv_h * head_dim) as usize, 81 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let q1 = arr(
+            &lcg((n_q * head_dim) as usize, 91 + i as u64),
+            &[1, n_q, 1, head_dim],
+        );
+        c.update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .unwrap()
+            .eval()
+            .unwrap();
+    }
+
+    // Ring-as-sole-store precondition on BOTH axes + live full-prefix dequant.
+    let (orig_k, orig_v, orig_seq, k_block_tokens, v_block_tokens) = iso_sym3_probe(&c);
+    assert_eq!(orig_seq, prefill + steps, "shape[2] advanced with the ring");
+    assert_eq!(
+        k_block_tokens, 0,
+        "K CPU blocks dropped — the ring is the sole resident store"
+    );
+    assert_eq!(
+        v_block_tokens, 0,
+        "V CPU blocks dropped — the ring is the sole resident store (dequant rebuilt from ring)"
+    );
+
+    // Spill clone (materialises both tails) → write → hydrate.
+    let clone = c.try_deep_clone().unwrap();
+    let path = tmp_path("iso_sym_ring_only_tail");
+    write_caches(&path, device, MODEL_ID, KvQuant::Iso3Sym, &[clone], &[])
+        .expect("write_caches must persist the full materialised sym store");
+    let (hydrated, _lin) = read_caches(&path, device, MODEL_ID, KvQuant::Iso3Sym).unwrap();
+    let _ = std::fs::remove_file(&path);
+
+    let (hy_k, hy_v, hy_seq, _, _) = iso_sym3_probe(&hydrated[0]);
+    assert_eq!(
+        hy_seq,
+        prefill + steps,
+        "hydrated sym store must carry the full decoded length"
+    );
+    assert_eq!(hy_k.len(), orig_k.len(), "hydrated K length mismatch");
+    assert_eq!(hy_v.len(), orig_v.len(), "hydrated V length mismatch");
+    assert!(
+        max_abs_err(&orig_k, &hy_k) < 1e-6,
+        "hydrated K must match the live ring-only-tail dequant byte-for-byte"
+    );
+    assert!(
+        max_abs_err(&orig_v, &hy_v) < 1e-6,
+        "hydrated V must match the live ring-only-tail dequant byte-for-byte"
+    );
+}
+
+/// `truncate_to` keeps the V ring so a ring-only decode tail survives the
+/// speculative-decode rollback: after truncating mid-fused-decode, `dequant`
+/// still rebuilds the full `[0, n)` prefix from the ring instead of aborting on
+/// a short-blocks store.
+///
+/// On the sole-store path the CPU blocks are already empty (dropped once the ring
+/// went live), so `truncate_to`'s block loop is a no-op and the pre-existing
+/// `n_tokens`-vs-`n` unit mismatch (a separate, out-of-scope bug that only bites a
+/// non-empty `kv_h > 1` block set) does not engage — the ring supplies the whole
+/// kept prefix. `kv_h == 2` here to keep the fused kernel on the same
+/// multi-head path the round-trip test exercises.
+///
+/// Mutation check: re-add `self.gpu.clear()` to `QuantIsoV3::truncate_to` — the
+/// ring is dropped, the V blocks fall short of `shape[2]` with no ring, and
+/// `dequant()` returns the loud `synced_iso_v_blocks` error (RED).
+#[test]
+#[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd iso_sym_truncate_keeps_ring -- --ignored --test-threads=1"]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test: values established by construction earlier in this fn"
+)]
+fn iso_sym_truncate_keeps_ring_tail() {
+    let device = Device::Gpu;
+    let (kv_h, n_q, head_dim, prefill, steps) = (2_i32, 8_i32, 128_i32, 6_i32, 6_i32);
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    let mut c = seeded_iso_sym3_cache(kv_h, head_dim, 512);
+    let k = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 101),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let v = arr(
+        &lcg((prefill * kv_h * head_dim) as usize, 102),
+        &[1, kv_h, prefill, head_dim],
+    );
+    let q = arr(
+        &lcg((prefill * n_q * head_dim) as usize, 103),
+        &[1, n_q, prefill, head_dim],
+    );
+    c.update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+        .unwrap();
+    c.exit_prefill(device).unwrap();
+    for i in 0..steps {
+        let k1 = arr(
+            &lcg((kv_h * head_dim) as usize, 111 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let v1 = arr(
+            &lcg((kv_h * head_dim) as usize, 121 + i as u64),
+            &[1, kv_h, 1, head_dim],
+        );
+        let q1 = arr(
+            &lcg((n_q * head_dim) as usize, 131 + i as u64),
+            &[1, n_q, 1, head_dim],
+        );
+        c.update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .unwrap()
+            .eval()
+            .unwrap();
+    }
+
+    // Full-length dequant before truncation (the reference prefix).
+    let (_ok, orig_v, orig_seq, _, _) = iso_sym3_probe(&c);
+    assert_eq!(orig_seq, prefill + steps);
+    let per_tok = (kv_h * head_dim) as usize;
+
+    // Truncate into the ring-only tail and confirm dequant still rebuilds it.
+    let keep = prefill + steps - 3;
+    c.truncate_to(keep);
+    let (_k2, v_after, seq_after, _, _) = iso_sym3_probe(&c);
+    assert_eq!(seq_after, keep, "shape[2] lowered to the truncation point");
+    assert_eq!(
+        v_after.len(),
+        (keep as usize) * per_tok,
+        "V dequant covers the kept prefix — the ring supplied the tail, no abort"
+    );
+    // Both dequants are head-major `[1, kv_h, S, D]`, so the sequence axis is in
+    // the middle — compare per (head, seq-position) rather than a flat slice.
+    let (orig_s, hd) = ((prefill + steps) as usize, head_dim as usize);
+    let keep_s = keep as usize;
+    for h in 0..kv_h as usize {
+        for s in 0..keep_s {
+            let a = &orig_v[(h * orig_s + s) * hd..(h * orig_s + s) * hd + hd];
+            let b = &v_after[(h * keep_s + s) * hd..(h * keep_s + s) * hd + hd];
+            assert!(
+                max_abs_err(a, b) < 1e-6,
+                "kept V (head {h}, pos {s}) must match the pre-truncation dequant"
+            );
+        }
+    }
+}
+
 /// `truncate_to` keeps the V ring so a ring-only decode tail survives the
 /// speculative-decode rollback: after truncating mid-fused-decode, `dequant`
 /// still rebuilds the full `[0, n)` prefix from the ring instead of aborting on

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -695,7 +695,25 @@ graph.
 The `source` parameter is the **body** of the kernel function. MLX wraps it
 with the Metal function signature and buffer declarations automatically:
 
-- Input buffers: `device const T* <name>` (auto-typed from array dtype).
+- Input buffers: `device const T* <name>` for most arrays (auto-typed from
+  array dtype) — **but not always**. MLX silently switches an input's
+  outer-kernel parameter to the `constant` address space instead of `device`
+  when the array is small (measured trip point: fewer than 8 elements, for
+  every dtype and shape tried); this is an internal MLX size heuristic, not
+  something a caller can pin per-argument. If the kernel body calls a
+  header/body helper function whose parameter is hard-declared
+  `device const T*`, that call fails the MSL compile the moment a small
+  enough array reaches it (`Unable to build metal library from source: no
+  matching function ... cannot pass pointer to address space 'constant' as a
+  pointer to address space 'device'`) — a **first-dispatch** failure, not a
+  `MetalKernel::new`-time one, so it can ship silently until a small enough
+  input shows up in production. Any kernel whose input can legitimately be
+  tiny at a valid call (e.g. a per-token `norms` buffer at low `kv_seq`) must
+  pad that array up past the trip point before dispatch rather than assume
+  `device` binding. See `rmlx_kv_quant::flash_decode_common::pad_norms_to_device_floor`
+  (floor 16, 2× the measured 8-element trip point for margin) — the general
+  fix shared by `iso_flash_decode_symv_sdpa` and `rotor_flash_decode_symv_sdpa`,
+  documented per-codec in `docs/KV_QUANT.md`.
 - Output buffers: `device T* <name>`.
 - Built-ins: `thread_position_in_grid` (uint3),
   `threadgroup_position_in_grid` (uint3),

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -399,7 +399,8 @@ be classified or the build fails.
 | `k8v4` / `k8v8` / `planar` / `planar3` / `planar_k` | **Metal** | q8_0 K + tq4 / planar V GPU kernels |
 | `mixed_*` / `rot_k_v*` / `rot_k_tq4v` | **Metal** | MLX-affine `mx.quantize` K + tq4/affine V (compiled Metal ops) |
 | `k8vturbo3` / `k8vturbo2` / `*tcq` / `tsym3` / `tsym4` | **Metal K**, CPU V (bounded) | K=q8_0 GPU; V CPU-forced by the −1 %/−2 % TPS gate, cost small |
-| `iso3` / `iso4` / `iso3_sym` / `iso4_sym` | **CPU** | bf16 decode seed shadows the GPU iso branch; prefill V-encode on host |
+| `iso3` / `iso4` | **CPU** | bf16 decode seed shadows the GPU iso branch; prefill V-encode on host |
+| `iso3_sym` / `iso4_sym` | **fully Metal** | both axes iso-quantized; decode is `iso_flash_decode_symv` over both packed rings (no bf16 mirror). Ring-as-sole-store. `cpu_hot_path_reason() == None` |
 | `k_iso3` / `k_iso4` | **fully Metal** | iso K MSL encode into the packed ring + `iso_flash_decode` fused decode over that ring. No host restaging. `cpu_hot_path_reason() == None` |
 | `rotor3` / `rotor4` / `rotor*_sym` / `rotor_k_*_asym_*` | **CPU** | bf16 decode seed shadows the GPU branch; GPU fused-QK encoder is `RMLX_FUSED_QK`-only |
 | `k_rotor3` / `k_rotor4` | **QJL-dependent (default off)** | QJL off (default) → **fully Metal**: rotor K MSL encode + `rotor_flash_decode` fused decode; QJL on (`--rotor-qjl on`) → CPU. Gate reads the store's sticky `use_qjl()` |
@@ -2874,7 +2875,7 @@ dequant path.
 |---|---|---|
 | `KvStorage::IsoKOnly3` / `IsoKOnly4`, `b == 1` | **YES** | GPU ring + `iso_flash_decode_sdpa`. |
 | `KvStorage::IsoKOnly{3,4}`, `b > 1` | NO | Ring stride does not interleave batch. |
-| `Iso{3,4}Sym` | NO | V side is also iso-quantized; this kernel takes bf16 V only. Shares the K-decode half when a quant-V kernel lands. |
+| `Iso{3,4}Sym` | NO (this kernel) | Both axes are iso-quantized; they decode through the all-quant sibling `iso_flash_decode_symv` instead, which reads V from its own packed ring rather than a bf16 mirror (ring-as-sole-store). Shares the per-lane K-decode half (`if_decode_k_lane`). |
 
 ### Measured
 

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2784,6 +2784,51 @@ resident KV is the binding constraint, not when peak decode TPS is. Closing the
 speed gap needs a single-pass simdgroup flash-decode that beats MLX bf16 flash
 (tracked with `#45`).
 
+### Short-prompt abort at `kv_h == 1` — small-`norms`-buffer device floor
+
+Both symv kernels — this one and `iso_flash_decode_symv` below — bind a
+per-token `norms` array as a kernel input. MLX's custom-kernel builder binds
+a small input array's outer-kernel parameter in the **`constant`** address
+space instead of `device` (an internal size heuristic — see
+`docs/FFI.md` § "MSL source conventions"), but the shared decode helpers each
+kernel calls (`if_decode_k_lane` for iso, `rf_decode_k_group` for rotor)
+declare their `norms` parameter `device const float*` — an address-space
+mismatch that fails the MSL compile at first dispatch
+(`cannot pass pointer to address space 'constant' as a pointer to address
+space 'device'`). Measured trip point: `b * kv_h * kv_seq < 8` aborts, `>= 8`
+does not, for every `head_dim`.
+
+This is reachable on a **normal short chat prompt** against a single-KV-head
+model — Gemma4 global layers are `kv_h == 1`, so a 2-token prompt reaches
+`kv_seq == 2` on the very first decode step, well below the trip point.
+
+**Fix (general, both codecs).**
+`rmlx_kv_quant::flash_decode_common::pad_norms_to_device_floor` zero-pads the
+flat `norms` array up to `NORMS_DEVICE_MIN` (16, a 2× margin over the
+measured 8-element trip point) before dispatch whenever
+`b * kv_h * kv_seq` is below it. Both kernels' per-tile decode loop is
+bounded by the real `kv_seq` carried in their `dims` buffer, not by the
+`norms` buffer's allocated length, so the padding is allocated but never
+read — correctness is unaffected. `iso_flash_decode_symv_sdpa` and
+`rotor_flash_decode_symv_sdpa` both call this one shared helper; there is no
+per-codec copy. This keeps both fused kernels on the GPU at **every**
+`kv_seq >= 1` with **no CPU dequant fallback** (hard rule 10) — an earlier,
+superseded version of this fix routed small-`kv_seq` steps to a CPU dequant
+SDPA (`RING_NORMS_DEVICE_MIN` gate + `iso_sym_cpu_sdpa_fallback`); that gate
+and fallback function are gone, replaced by the padding above.
+
+Regression coverage (hard rule 6): `iso_sym_short_kv_seq_kv_h1_stays_on_gpu`
+and the continuity tests `iso_sym_transition_across_ring_norms_floor` /
+`rotor_sym_transition_across_ring_norms_floor` in
+`crates/rmlx-kv-ssd/src/block_io_tests.rs` drive `kv_h == 1` decode across
+and through the padding floor, on both codecs, checked against an
+**independent** `KvStorage::None` (bf16/f32) reference cache fed the
+identical per-step tokens — not a scalar reference rebuilt from the same
+ring the kernel just read, which a ring corruption both reads see
+identically would pass silently. Mutation: disabling
+`pad_norms_to_device_floor` reproduces the `kv_seq == 2` abort on both
+codecs (`if_decode_k_lane` / `rf_decode_k_group`, `constant` vs `device`).
+
 ---
 
 ## `iso_flash_decode` — fused MSL flash-decode over iso-quant K


### PR DESCRIPTION
## What

Makes the iso symmetric KV codecs (`Iso3Sym` / `Iso4Sym`) a **fused quant-V
sole-store**, mirroring the rotor sole-store (#281) — adapted to iso's structure.
Two issues on one branch:

- **#220** — `iso_flash_decode_symv`: decode reads **both** K and V straight from
  their packed iso rings via the shared per-lane `if_decode_k_lane`; the bf16 K+V
  mirror (the heaviest cell in the KV matrix, ~3.43×) is dropped.
- **#279** — the iso **K-only** fused decode gets the #231 ring-only-tail
  treatment (`MaintainRingOnly` + drop-CPU-blocks + rebuild-on-demand).

### Layers
1. **Kernel** (commit 1): `metal/iso_flash_decode_symv_p1.metal` +
   `iso_flash_decode_symv_msl.rs`, reusing `build_iso_flash_header` /
   `if_decode_k_lane`. Numerical oracle green (13 GPU tests, head_dim 128/256/512,
   GQA, mask, multi-tile, bits 3&4); V-unpack mutation → RED.
2. **Sole-store + wiring** (commit 2): `QuantIsoV{3,4}` gain a `QuantKGpuRing`;
   `synced_iso_v_blocks` rebuilds a ring-only tail (synthesising the fixed
   quaternion the ring drops); `dequant` reconciles + refuses to zero-pad loudly
   (incl. the empty-blocks-with-shape case); `truncate_to` keeps the ring;
   `try_deep_clone` materialises first; `byte_size` counts the ring. iso K3/K4
   share the same reconcile. `update_and_sdpa_iso_sym_fused` +
   `iso_sym_flash_over_store` + `iso_sym_packed_views` dispatch the symv kernel;
   `iso{3,4}_sym_gpu_append` feed both rings then drop blocks. #279:
   `iso{3,4}_k_only_gpu_append` → `MaintainRingOnly`. `feeds_bf16_{k,v}_at_decode`
   + `cpu_hot_path_reason` move Iso*Sym to the fused (Metal, no-mirror) class.
   SSD `ensure_iso_blocks_cover_shape` rejects a truncated store.
3. **Short-prompt abort fix, generalized (commits 3–4, this update)** — see
   "Follow-up: general GPU-native fix (#220 hardening + #286)" below. Closes
   the "known edge" noted in the original verification pass, and folds in
   **#286** (the identical abort on `rotor*_sym`, same root cause, unfixed on
   `main` since #281).

Model-agnostic; no ticket refs in code; `rmlx-kv-quant ⊄ rmlx-models` preserved.

## Verification (original kernel + sole-store work)

- **3 mutation reds** (each quoted in the executor report): dequant skip-rebuild
  → loud `refusing to zero-pad a lost decode tail`; SSD spill → `TruncatedStore`;
  truncate re-add `gpu.clear()` → `GPU ring is absent — refusing to zero-pad`.
- iso sole-store SSD round-trip + truncate GPU tests + CPU truncated-store guard
  green; #220 quant-V oracle + #234 iso K oracles stay green; 448 non-GPU
  kv-quant/kv-ssd tests pass.
- **Real model, temp=0**: gemma-4-e2b + Ternary-Bonsai-8B serve `iso3_sym`
  coherently, the symv kernel dispatching **every** decode step (637 / 1950
  dispatches, 0 errors), no bf16 mirror.
- **RESIDENT memory (sole-store vs bf16 mirror, ~823 tok)**: gemma-4-e2b
  12.6 MB vs 25.4 MB (**−50.4%**); Bonsai-8B 153 MB vs 365 MB (**−58.0%**).
  Both beat rotor's ~34% (iso's mirror is the heaviest).
- **Decode TPS (honest)**: gemma-4-e2b 51.4 tok/s (sole-store) vs 132.1 tok/s
  (bf16 mirror) — ~2.6× **slower**, inherent to the two-pass flash shell (#45),
  same profile as the rotor #219 codec.
- Binaries symbol-verified distinct (branch 2 / main 0 `iso_flash_decode_symv_p1`).

## Follow-up: general GPU-native fix (#220 hardening + #286)

The original pass above shipped with a documented "known edge": a very small
`kv_seq` at `kv_h == 1` (e.g. Gemma4 global layers on a short chat prompt)
made MLX bind the ring's tiny per-token `norms` slice in the `constant`
address space instead of `device`, which the shared decode helper
(`if_decode_k_lane`) rejects — an MSL compile abort on the first decode step.
An interim fix landed a `RING_NORMS_DEVICE_MIN` gate that routed those steps
to a CPU dequant SDPA fallback.

This update **replaces that CPU fallback with the actual root-cause fix** and
generalizes it to `rotor*_sym` (issue #286 — the identical abort, same root
cause, live on `main` since #281 and never fixed):

- `iso_flash_decode_symv_sdpa` / `rotor_flash_decode_symv_sdpa` now zero-pad
  their flat `norms` input up to a floor (16, measured trip point is 8) before
  dispatch whenever `b*kv_h*kv_seq` is below it. Each kernel's per-tile decode
  loop is bounded by the real `kv_seq` in its `dims` buffer, not the `norms`
  buffer length, so the padding is allocated but never read — correctness is
  unaffected, and the fused kernel now runs on the GPU at **every**
  `kv_seq >= 1`, with **zero CPU dequant fallback** (hard rule 10).
- One shared helper (`flash_decode_common::pad_norms_to_device_floor`) serves
  both codecs — not two copies. The `RING_NORMS_DEVICE_MIN` gates and the
  `iso_sym_cpu_sdpa_fallback` function are deleted from `sdpa.rs` entirely.
- Both GPU regression tests (`iso_sym_short_kv_seq_kv_h1_stays_on_gpu`, the
  continuity tests for both codecs) now check against an **independent**
  `KvStorage::None` (bf16/f32) reference cache fed the identical per-step
  tokens, rather than a scalar reference rebuilt from the same ring the
  kernel just read (a ring corruption both reads see identically would have
  passed the old check silently).
- **Real-model 2-arch proof, temp=0**: gemma-4-e2b (`kv_h == 1`) and
  Ternary-Bonsai-8B (`kv_h == 8`) both serve `rotor3_sym` coherently across
  the padding floor (short prompts crossing `kv_seq == 16` mid-decode),
  matching the `--kv-quant none` bf16 baseline byte-for-byte or
  semantically; `iso3_sym` re-confirmed unaffected by the refactor.
- **Mutation check**: disabling `pad_norms_to_device_floor` reproduces the
  `kv_seq == 2` abort identically for both codecs (`if_decode_k_lane` /
  `rf_decode_k_group`, `constant` vs `device`); reverted and reconfirmed
  green.
- `make ci` (fmt + clippy `-D warnings` + full workspace test suite + deny +
  audit + inline-test/scalar-f32/decode-swallow/GPU-ignore/metal-format
  gates) green on a clean scratch `RMLX_HOME`.
- Docs updated: `docs/FFI.md` corrects the previously-stale "inputs are
  always `device`" claim about MLX's custom-kernel builder; `docs/KV_QUANT.md`
  documents the shared fix under `rotor_flash_decode_symv`.

## Shippability

**Ship** as the `iso*_sym` / `rotor*_sym` default — a memory-efficient codec
(**50–58% resident KV reduction** for iso) at a **documented decode-speed
cost (~2.6× slower)**, exactly the #219 rotor decision. Both codecs are now
GPU-resident at every `kv_seq`, with no CPU-fallback edge case remaining.

Related: #220, #279, #286, #281 (rotor template), #234 (shell), #231
(ring-only tail), #45 (fused-kernel speed gap).

Closes #220
Closes #279
Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
