### PR TITLE
fix(kv): truncate_to converts seq target to rows before comparing n_tokens (#284)

### DIFF
--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -89,6 +89,11 @@ mod quant_rotor_k_qjl_tests;
 #[path = "quant_planar_k_tests.rs"]
 mod quant_planar_k_tests;
 
+// `truncate_keep_count` row/sequence unit-conversion tests (#284).
+#[cfg(test)]
+#[path = "truncate_keep_count_tests.rs"]
+mod truncate_keep_count_tests;
+
 // ── Paged KV growth ───────────────────────────────────────────────────────────
 //
 // GPU quantized buffers are allocated in multiples of PAGE_SIZE tokens instead
@@ -102,3 +107,50 @@ mod quant_planar_k_tests;
 // capped at max_seq. At 64K / 256 that is at most 256 reallocations total per
 // layer per request — acceptable versus ~40% peak-memory reduction.
 pub const KV_PAGE_SIZE: i32 = 256;
+
+// ── Shared truncate-to-sequence helper ───────────────────────────────────────
+//
+// Every rotor/iso K and V store accumulates per-append blocks whose `n_tokens`
+// field counts **rows** (`b * kv_h * seq_of_block`), not raw sequence
+// positions — see the dequant-time reconciliation guards (e.g.
+// `synced_rotor_v_blocks`, `synced_iso_v_blocks`) that sum `n_tokens` and
+// compare against `b * kv_h * shape[2]`. `truncate_to(n)` takes `n` as a
+// **sequence** target, so `n` must be converted to the same row units before
+// it is compared against the cumulative `n_tokens` — otherwise, at `kv_h > 1`
+// (or `b > 1`), each block's `n_tokens` is inflated by that factor and the
+// walk overshoots the target early, dropping blocks that should have been
+// kept. This was invisible at `b * kv_h == 1` (the row and sequence counts
+// coincide there), which is how the bug shipped.
+
+/// Compute how many leading blocks to keep when truncating a KV-quant store's
+/// accumulated sequence to `n` tokens.
+///
+/// `block_tokens` is each block's `n_tokens` (rows), in append order.
+/// `shape` is the store's `[b, kv_h, seq, head_dim]`. Returns the count of
+/// leading blocks whose summed `n_tokens` is `<= n * b * kv_h`.
+///
+/// A degenerate `b * kv_h == 0` shape (nothing appended yet) keeps no blocks.
+pub(crate) fn truncate_keep_count(
+    block_tokens: impl Iterator<Item = usize>,
+    shape: &[i32],
+    n: i32,
+) -> usize {
+    let b = shape.first().copied().unwrap_or(0).max(0) as usize;
+    let kv_h = shape.get(1).copied().unwrap_or(0).max(0) as usize;
+    let factor = b.saturating_mul(kv_h);
+    if factor == 0 {
+        return 0;
+    }
+    let n_rows = (n.max(0) as usize).saturating_mul(factor);
+    let mut acc: usize = 0;
+    let mut keep = 0usize;
+    for (i, tokens) in block_tokens.enumerate() {
+        if acc + tokens <= n_rows {
+            acc += tokens;
+            keep = i + 1;
+        } else {
+            break;
+        }
+    }
+    keep
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -237,17 +237,8 @@ impl QuantIsoK3 {
     /// loudly, which would abort generation on the speculative-decode rollback
     /// path.
     pub fn truncate_to(&mut self, n: i32) {
-        let n_usize = n.max(0) as usize;
-        let mut acc: usize = 0;
-        let mut keep = 0usize;
-        for (i, blk) in self.blocks.iter().enumerate() {
-            if acc + blk.n_tokens <= n_usize {
-                acc += blk.n_tokens;
-                keep = i + 1;
-            } else {
-                break;
-            }
-        }
+        let keep =
+            super::truncate_keep_count(self.blocks.iter().map(|blk| blk.n_tokens), &self.shape, n);
         self.blocks.truncate(keep);
         // NB: no `self.gpu.clear()` — the ring is the source of truth for a
         // ring-only decode tail; see the doc comment above.

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
@@ -163,17 +163,8 @@ impl QuantIsoK4 {
     /// [`crate::storage::QuantIsoK3::truncate_to`] (the ring-only-tail
     /// treatment). Clearing it would discard a ring-only decode tail.
     pub fn truncate_to(&mut self, n: i32) {
-        let n_usize = n.max(0) as usize;
-        let mut acc: usize = 0;
-        let mut keep = 0usize;
-        for (i, blk) in self.blocks.iter().enumerate() {
-            if acc + blk.n_tokens <= n_usize {
-                acc += blk.n_tokens;
-                keep = i + 1;
-            } else {
-                break;
-            }
-        }
+        let keep =
+            super::truncate_keep_count(self.blocks.iter().map(|blk| blk.n_tokens), &self.shape, n);
         self.blocks.truncate(keep);
         // NB: no `self.gpu.clear()` — the ring is the source of truth for a
         // ring-only decode tail; see the doc comment above.

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4_tests.rs
@@ -159,3 +159,74 @@ fn quant_iso_k4_multi_append_matches_single_shot_gqa() {
     );
     let _ = (ISO_K4_BITS, ISO_K4_GROUP_SIZE);
 }
+
+/// Falsifies #284: at `kv_h > 1`, `truncate_to(n)` must keep exactly the
+/// leading blocks covering sequence `[0, n)`, not `floor(n / kv_h)` of them.
+/// CPU-only (no GPU ring touched). See `quant_iso_k_tests.rs` for the full
+/// rationale + mutation-check note.
+#[test]
+fn quant_iso_k4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
+    let head_dim = 8_usize;
+    let total_tokens = 4_usize;
+    let keep_tokens = 2_usize;
+    let val = |h: usize, tok: usize, d: usize| {
+        (h as f32) * 100.0 + (tok as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+
+    for kv_h in [1_usize, 4_usize] {
+        let token_data = |tok: usize| -> Vec<f32> {
+            let mut out = vec![0.0_f32; kv_h * head_dim];
+            for h in 0..kv_h {
+                for d in 0..head_dim {
+                    out[h * head_dim + d] = val(h, tok, d);
+                }
+            }
+            out
+        };
+        let new_shape = [1_i32, kv_h as i32, 1, head_dim as i32];
+
+        let mut store = QuantIsoK4::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 64);
+        for tok in 0..total_tokens {
+            store.append(&token_data(tok), &new_shape).unwrap();
+        }
+        assert_eq!(
+            store.blocks.len(),
+            total_tokens,
+            "one block per token append (kv_h={kv_h})"
+        );
+
+        store.truncate_to(keep_tokens as i32);
+
+        assert_eq!(
+            store.shape[2], keep_tokens as i32,
+            "shape[2] must equal keep_tokens (kv_h={kv_h})"
+        );
+        assert_eq!(
+            store.blocks.len(),
+            keep_tokens,
+            "truncate_to must keep exactly keep_tokens blocks, not floor(keep_tokens / kv_h) (kv_h={kv_h})"
+        );
+        let kept_rows: usize = store.blocks.iter().map(|blk| blk.n_tokens).sum();
+        assert_eq!(
+            kept_rows,
+            keep_tokens * kv_h,
+            "kept rows must equal keep_tokens * b * kv_h (kv_h={kv_h})"
+        );
+
+        let decoded = store
+            .dequant()
+            .expect("dequant must succeed after truncate at kv_h>1 (#284)");
+
+        let mut reference = QuantIsoK4::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 64);
+        for tok in 0..keep_tokens {
+            reference.append(&token_data(tok), &new_shape).unwrap();
+        }
+        let ref_decoded = reference.dequant().unwrap();
+
+        assert_eq!(
+            decoded, ref_decoded,
+            "truncated store must exactly match a store built from only the \
+             first keep_tokens (kv_h={kv_h})"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
@@ -247,3 +247,83 @@ fn iso_k3_gpu_multi_append_matches_single_shot_gqa() {
          head↔seq layout scramble"
     );
 }
+
+/// Falsifies #284: at `kv_h > 1`, `truncate_to(n)` must keep exactly the
+/// leading blocks covering sequence `[0, n)`, not `floor(n / kv_h)` of them.
+///
+/// Builds one block per token (CPU-only, no GPU ring ever touched), truncates
+/// mid-sequence at a block boundary, and requires the result to exactly match
+/// a reference store built from only the first `keep_tokens`.
+///
+/// Runs both `kv_h == 1` (historical, accidentally-correct) and `kv_h > 1`
+/// (where the pre-fix code undercounted) in one test.
+///
+/// Mutation check: reverting `truncate_to` to compare
+/// `acc + blk.n_tokens <= n as usize` (raw, not row-scaled) makes the
+/// `kv_h > 1` case RED — `blocks.len()` drops and `dequant()` returns `Err`.
+#[test]
+fn quant_iso_k3_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
+    let head_dim = 8_usize;
+    let total_tokens = 4_usize;
+    let keep_tokens = 2_usize;
+    let val = |h: usize, tok: usize, d: usize| {
+        (h as f32) * 100.0 + (tok as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+
+    for kv_h in [1_usize, 4_usize] {
+        let token_data = |tok: usize| -> Vec<f32> {
+            let mut out = vec![0.0_f32; kv_h * head_dim];
+            for h in 0..kv_h {
+                for d in 0..head_dim {
+                    out[h * head_dim + d] = val(h, tok, d);
+                }
+            }
+            out
+        };
+        let new_shape = [1_i32, kv_h as i32, 1, head_dim as i32];
+
+        let mut store = QuantIsoK3::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 64);
+        for tok in 0..total_tokens {
+            store.append(&token_data(tok), &new_shape).unwrap();
+        }
+        assert_eq!(
+            store.blocks.len(),
+            total_tokens,
+            "one block per token append (kv_h={kv_h})"
+        );
+
+        store.truncate_to(keep_tokens as i32);
+
+        assert_eq!(
+            store.shape[2], keep_tokens as i32,
+            "shape[2] must equal keep_tokens (kv_h={kv_h})"
+        );
+        assert_eq!(
+            store.blocks.len(),
+            keep_tokens,
+            "truncate_to must keep exactly keep_tokens blocks, not floor(keep_tokens / kv_h) (kv_h={kv_h})"
+        );
+        let kept_rows: usize = store.blocks.iter().map(|blk| blk.n_tokens).sum();
+        assert_eq!(
+            kept_rows,
+            keep_tokens * kv_h,
+            "kept rows must equal keep_tokens * b * kv_h (kv_h={kv_h})"
+        );
+
+        let decoded = store
+            .dequant()
+            .expect("dequant must succeed after truncate at kv_h>1 (#284)");
+
+        let mut reference = QuantIsoK3::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 64);
+        for tok in 0..keep_tokens {
+            reference.append(&token_data(tok), &new_shape).unwrap();
+        }
+        let ref_decoded = reference.dequant().unwrap();
+
+        assert_eq!(
+            decoded, ref_decoded,
+            "truncated store must exactly match a store built from only the \
+             first keep_tokens (kv_h={kv_h})"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -308,9 +308,9 @@ impl QuantIsoV3 {
 
     /// Truncate the accumulated sequence to `n` tokens.
     ///
-    /// Drops trailing blocks until the cumulative `n_tokens` count is `<= n`
-    /// and lowers `shape[2]` to `n`. The codec is per-token so block
-    /// boundaries align with token boundaries.
+    /// Drops trailing blocks until the cumulative `n_tokens` count is `<= n *
+    /// b * kv_h` (block `n_tokens` counts rows, not sequence positions — see
+    /// [`super::truncate_keep_count`]) and lowers `shape[2]` to `n`.
     ///
     /// The GPU ring is **kept**, not cleared — mirror of the rotor V store's
     /// `truncate_to`. Lowering `shape[2]` to `n` makes the ring's logical fill
@@ -323,20 +323,8 @@ impl QuantIsoV3 {
     /// loudly, which would abort generation on the speculative-decode rollback
     /// path.
     pub fn truncate_to(&mut self, n: i32) {
-        let n_usize = n.max(0) as usize;
-        // shape[0] * shape[1] is the per-token row multiplier; iso codec
-        // operates on flat rows so n_tokens already counts rows. For decode
-        // (B=1, kv_h fixed) the relationship is trivial.
-        let mut acc: usize = 0;
-        let mut keep = 0usize;
-        for (i, blk) in self.blocks.iter().enumerate() {
-            if acc + blk.n_tokens <= n_usize {
-                acc += blk.n_tokens;
-                keep = i + 1;
-            } else {
-                break;
-            }
-        }
+        let keep =
+            super::truncate_keep_count(self.blocks.iter().map(|blk| blk.n_tokens), &self.shape, n);
         self.blocks.truncate(keep);
         // NB: no `self.gpu.clear()` — the ring is the source of truth for a
         // ring-only decode tail; see the doc comment above.

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
@@ -168,17 +168,8 @@ impl QuantIsoV4 {
     /// not cleared, so a ring-only decode tail up to `n` survives and `dequant` /
     /// an SSD spill can rebuild it via [`synced_iso_v_blocks`].
     pub fn truncate_to(&mut self, n: i32) {
-        let n_usize = n.max(0) as usize;
-        let mut acc: usize = 0;
-        let mut keep = 0usize;
-        for (i, blk) in self.blocks.iter().enumerate() {
-            if acc + blk.n_tokens <= n_usize {
-                acc += blk.n_tokens;
-                keep = i + 1;
-            } else {
-                break;
-            }
-        }
+        let keep =
+            super::truncate_keep_count(self.blocks.iter().map(|blk| blk.n_tokens), &self.shape, n);
         self.blocks.truncate(keep);
         // NB: no `self.gpu.clear()` — the ring is the source of truth for a
         // ring-only decode tail; see [`super::QuantIsoV3::truncate_to`].

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v4_tests.rs
@@ -195,3 +195,83 @@ fn quant_iso_v4_multi_append_matches_single_shot_gqa() {
     );
     let _ = (ISO4_BITS, ISO4_GROUP_SIZE);
 }
+
+/// Falsifies #284: `quant_iso_v4_truncate_to_keeps_first_n` above only runs at
+/// `kv_h == 1`, where each block's `n_tokens` already equals its sequence
+/// length (rows == seq). At `kv_h > 1`, `n_tokens` is inflated by `kv_h` and
+/// `truncate_to(n)` must convert `n` to row units before comparing, or it
+/// keeps `floor(n / kv_h)` blocks instead of `n`.
+///
+/// Builds one block per token (CPU-only, no GPU ring ever touched), truncates
+/// mid-sequence at a block boundary, and requires the result to exactly match
+/// a reference store built from only the first `keep_tokens`.
+///
+/// Mutation check: reverting `truncate_to` to compare
+/// `acc + blk.n_tokens <= n as usize` (raw, not row-scaled) makes the
+/// `kv_h > 1` case RED — `blocks.len()` drops and `dequant()` returns `Err`.
+#[test]
+fn quant_iso_v4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
+    let head_dim = 8_usize;
+    let total_tokens = 4_usize;
+    let keep_tokens = 2_usize;
+    let val = |h: usize, tok: usize, d: usize| {
+        (h as f32) * 100.0 + (tok as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+
+    for kv_h in [1_usize, 4_usize] {
+        let token_data = |tok: usize| -> Vec<f32> {
+            let mut out = vec![0.0_f32; kv_h * head_dim];
+            for h in 0..kv_h {
+                for d in 0..head_dim {
+                    out[h * head_dim + d] = val(h, tok, d);
+                }
+            }
+            out
+        };
+        let new_shape = [1_i32, kv_h as i32, 1, head_dim as i32];
+
+        let mut store = QuantIsoV4::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 64);
+        for tok in 0..total_tokens {
+            store.append(&token_data(tok), &new_shape).unwrap();
+        }
+        assert_eq!(
+            store.blocks.len(),
+            total_tokens,
+            "one block per token append (kv_h={kv_h})"
+        );
+
+        store.truncate_to(keep_tokens as i32);
+
+        assert_eq!(
+            store.shape[2], keep_tokens as i32,
+            "shape[2] must equal keep_tokens (kv_h={kv_h})"
+        );
+        assert_eq!(
+            store.blocks.len(),
+            keep_tokens,
+            "truncate_to must keep exactly keep_tokens blocks, not floor(keep_tokens / kv_h) (kv_h={kv_h})"
+        );
+        let kept_rows: usize = store.blocks.iter().map(|blk| blk.n_tokens).sum();
+        assert_eq!(
+            kept_rows,
+            keep_tokens * kv_h,
+            "kept rows must equal keep_tokens * b * kv_h (kv_h={kv_h})"
+        );
+
+        let decoded = store
+            .dequant()
+            .expect("dequant must succeed after truncate at kv_h>1 (#284)");
+
+        let mut reference = QuantIsoV4::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 64);
+        for tok in 0..keep_tokens {
+            reference.append(&token_data(tok), &new_shape).unwrap();
+        }
+        let ref_decoded = reference.dequant().unwrap();
+
+        assert_eq!(
+            decoded, ref_decoded,
+            "truncated store must exactly match a store built from only the \
+             first keep_tokens (kv_h={kv_h})"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
@@ -689,3 +689,83 @@ fn iso_v3_ssd_roundtrip_preserves_dequant_output() {
         "spill→hydrate dequant divergence max_abs = {max_abs:.6} (>= 1e-5)"
     );
 }
+
+/// Falsifies #284: `quant_iso_v_truncate_to_keeps_first_n` above only runs at
+/// `kv_h == 1`, where each block's `n_tokens` already equals its sequence
+/// length (rows == seq). At `kv_h > 1`, `n_tokens` is inflated by `kv_h` and
+/// `truncate_to(n)` must convert `n` to row units before comparing, or it
+/// keeps `floor(n / kv_h)` blocks instead of `n`.
+///
+/// Builds one block per token (CPU-only, no GPU ring ever touched), truncates
+/// mid-sequence at a block boundary, and requires the result to exactly match
+/// a reference store built from only the first `keep_tokens`.
+///
+/// Mutation check: reverting `truncate_to` to compare
+/// `acc + blk.n_tokens <= n as usize` (raw, not row-scaled) makes the
+/// `kv_h > 1` case RED — `blocks.len()` drops and `dequant()` returns `Err`.
+#[test]
+fn quant_iso_v_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
+    let head_dim = 8_usize;
+    let total_tokens = 4_usize;
+    let keep_tokens = 2_usize;
+    let val = |h: usize, tok: usize, d: usize| {
+        (h as f32) * 100.0 + (tok as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+
+    for kv_h in [1_usize, 4_usize] {
+        let token_data = |tok: usize| -> Vec<f32> {
+            let mut out = vec![0.0_f32; kv_h * head_dim];
+            for h in 0..kv_h {
+                for d in 0..head_dim {
+                    out[h * head_dim + d] = val(h, tok, d);
+                }
+            }
+            out
+        };
+        let new_shape = [1_i32, kv_h as i32, 1, head_dim as i32];
+
+        let mut store = QuantIsoV3::new(vec![1_i32, kv_h as i32, 0, head_dim as i32]);
+        for tok in 0..total_tokens {
+            store.append(&token_data(tok), &new_shape).unwrap();
+        }
+        assert_eq!(
+            store.blocks.len(),
+            total_tokens,
+            "one block per token append (kv_h={kv_h})"
+        );
+
+        store.truncate_to(keep_tokens as i32);
+
+        assert_eq!(
+            store.shape[2], keep_tokens as i32,
+            "shape[2] must equal keep_tokens (kv_h={kv_h})"
+        );
+        assert_eq!(
+            store.blocks.len(),
+            keep_tokens,
+            "truncate_to must keep exactly keep_tokens blocks, not floor(keep_tokens / kv_h) (kv_h={kv_h})"
+        );
+        let kept_rows: usize = store.blocks.iter().map(|blk| blk.n_tokens).sum();
+        assert_eq!(
+            kept_rows,
+            keep_tokens * kv_h,
+            "kept rows must equal keep_tokens * b * kv_h (kv_h={kv_h})"
+        );
+
+        let decoded = store
+            .dequant()
+            .expect("dequant must succeed after truncate at kv_h>1 (#284)");
+
+        let mut reference = QuantIsoV3::new(vec![1_i32, kv_h as i32, 0, head_dim as i32]);
+        for tok in 0..keep_tokens {
+            reference.append(&token_data(tok), &new_shape).unwrap();
+        }
+        let ref_decoded = reference.dequant().unwrap();
+
+        assert_eq!(
+            decoded, ref_decoded,
+            "truncated store must exactly match a store built from only the \
+             first keep_tokens (kv_h={kv_h})"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
@@ -389,17 +389,8 @@ impl QuantRotorK3 {
     )]
     pub fn truncate_to(&mut self, n: i32) {
         let n = n.max(0);
-        let n_usize = n as usize;
-        let mut acc: usize = 0;
-        let mut keep = 0usize;
-        for (i, blk) in self.blocks.iter().enumerate() {
-            if acc + blk.n_tokens <= n_usize {
-                acc += blk.n_tokens;
-                keep = i + 1;
-            } else {
-                break;
-            }
-        }
+        let keep =
+            super::truncate_keep_count(self.blocks.iter().map(|blk| blk.n_tokens), &self.shape, n);
         self.blocks.truncate(keep);
         // NB: no `self.gpu.clear()` — the ring is the source of truth for a
         // ring-only decode tail; see the doc comment above.

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
@@ -394,3 +394,96 @@ fn quant_rotor_k3_truncate_to_keeps_the_gpu_ring() {
          kept token, not a zero-padded/garbage buffer"
     );
 }
+
+/// Falsifies #284: at `kv_h > 1`, `truncate_to(n)` must keep exactly the
+/// leading blocks covering sequence `[0, n)`, not `floor(n / kv_h)` of them.
+///
+/// Builds one block per token (CPU-only, no GPU ring ever touched), truncates
+/// mid-sequence at a block boundary, and requires the result to exactly match
+/// a reference store built from only the first `keep_tokens` — same shape,
+/// same layer (so the same static rotor table), fully deterministic encode.
+///
+/// Runs both `kv_h == 1` (the historical, accidentally-correct case) and
+/// `kv_h > 1` (where the pre-fix code compared row-counted `n_tokens` against
+/// a raw sequence target and undercounted) in one test.
+///
+/// Mutation check: reverting the `truncate_to` body to compare
+/// `acc + blk.n_tokens <= n as usize` (raw, not row-scaled) makes the
+/// `kv_h > 1` case RED — `blocks.len()` drops to `keep_tokens / kv_h` and
+/// `dequant()` returns `Err` (blocks short of `shape[2]`, no ring to rebuild
+/// from).
+#[test]
+fn quant_rotor_k3_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
+    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
+        .lock()
+        .expect("env lock poisoned");
+    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer.
+    unsafe { std::env::set_var("RMLX_ROTOR_QJL", "0") };
+
+    let head_dim = 9_usize; // n_groups = 3, exact
+    let total_tokens = 4_usize;
+    let keep_tokens = 2_usize;
+    let val = |h: usize, tok: usize, d: usize| {
+        (h as f32) * 100.0 + (tok as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+
+    for kv_h in [1_usize, 4_usize] {
+        let token_data = |tok: usize| -> Vec<f32> {
+            let mut out = vec![0.0_f32; kv_h * head_dim];
+            for h in 0..kv_h {
+                for d in 0..head_dim {
+                    out[h * head_dim + d] = val(h, tok, d);
+                }
+            }
+            out
+        };
+        let new_shape = [1_i32, kv_h as i32, 1, head_dim as i32];
+
+        let mut store = QuantRotorK3::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 5);
+        for tok in 0..total_tokens {
+            store.append(&token_data(tok), &new_shape).unwrap();
+        }
+        assert_eq!(
+            store.blocks.len(),
+            total_tokens,
+            "one block per token append (kv_h={kv_h})"
+        );
+
+        store.truncate_to(keep_tokens as i32);
+
+        assert_eq!(
+            store.shape[2], keep_tokens as i32,
+            "shape[2] must equal keep_tokens (kv_h={kv_h})"
+        );
+        assert_eq!(
+            store.blocks.len(),
+            keep_tokens,
+            "truncate_to must keep exactly keep_tokens blocks, not floor(keep_tokens / kv_h) (kv_h={kv_h})"
+        );
+        let kept_rows: usize = store.blocks.iter().map(|blk| blk.n_tokens).sum();
+        assert_eq!(
+            kept_rows,
+            keep_tokens * kv_h,
+            "kept rows must equal keep_tokens * b * kv_h (kv_h={kv_h})"
+        );
+
+        let decoded = store
+            .dequant()
+            .expect("dequant must succeed after truncate at kv_h>1 (#284)");
+
+        let mut reference = QuantRotorK3::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 5);
+        for tok in 0..keep_tokens {
+            reference.append(&token_data(tok), &new_shape).unwrap();
+        }
+        let ref_decoded = reference.dequant().unwrap();
+
+        assert_eq!(
+            decoded, ref_decoded,
+            "truncated store must exactly match a store built from only the \
+             first keep_tokens (kv_h={kv_h})"
+        );
+    }
+
+    // SAFETY: ROTOR_QJL_ENV_LOCK still held.
+    unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
@@ -279,17 +279,8 @@ impl QuantRotorK4 {
     )]
     pub fn truncate_to(&mut self, n: i32) {
         let n = n.max(0);
-        let n_usize = n as usize;
-        let mut acc: usize = 0;
-        let mut keep = 0usize;
-        for (i, blk) in self.blocks.iter().enumerate() {
-            if acc + blk.n_tokens <= n_usize {
-                acc += blk.n_tokens;
-                keep = i + 1;
-            } else {
-                break;
-            }
-        }
+        let keep =
+            super::truncate_keep_count(self.blocks.iter().map(|blk| blk.n_tokens), &self.shape, n);
         self.blocks.truncate(keep);
         // NB: no `self.gpu.clear()` — the ring holds the ring-only decode tail.
         if self.shape.len() >= 4 {

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
@@ -160,3 +160,83 @@ fn quant_rotor_k4_multi_append_matches_single_shot_gqa_with_qjl() {
     );
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
 }
+
+/// Falsifies #284: at `kv_h > 1`, `truncate_to(n)` must keep exactly the
+/// leading blocks covering sequence `[0, n)`, not `floor(n / kv_h)` of them.
+/// CPU-only (no GPU ring touched). See `quant_rotor_k3_tests.rs` for the
+/// full rationale + mutation-check note.
+#[test]
+fn quant_rotor_k4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
+    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
+        .lock()
+        .expect("env lock poisoned");
+    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer.
+    unsafe { std::env::set_var("RMLX_ROTOR_QJL", "0") };
+
+    let head_dim = 9_usize;
+    let total_tokens = 4_usize;
+    let keep_tokens = 2_usize;
+    let val = |h: usize, tok: usize, d: usize| {
+        (h as f32) * 100.0 + (tok as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+
+    for kv_h in [1_usize, 4_usize] {
+        let token_data = |tok: usize| -> Vec<f32> {
+            let mut out = vec![0.0_f32; kv_h * head_dim];
+            for h in 0..kv_h {
+                for d in 0..head_dim {
+                    out[h * head_dim + d] = val(h, tok, d);
+                }
+            }
+            out
+        };
+        let new_shape = [1_i32, kv_h as i32, 1, head_dim as i32];
+
+        let mut store = QuantRotorK4::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 5);
+        for tok in 0..total_tokens {
+            store.append(&token_data(tok), &new_shape).unwrap();
+        }
+        assert_eq!(
+            store.blocks.len(),
+            total_tokens,
+            "one block per token append (kv_h={kv_h})"
+        );
+
+        store.truncate_to(keep_tokens as i32);
+
+        assert_eq!(
+            store.shape[2], keep_tokens as i32,
+            "shape[2] must equal keep_tokens (kv_h={kv_h})"
+        );
+        assert_eq!(
+            store.blocks.len(),
+            keep_tokens,
+            "truncate_to must keep exactly keep_tokens blocks, not floor(keep_tokens / kv_h) (kv_h={kv_h})"
+        );
+        let kept_rows: usize = store.blocks.iter().map(|blk| blk.n_tokens).sum();
+        assert_eq!(
+            kept_rows,
+            keep_tokens * kv_h,
+            "kept rows must equal keep_tokens * b * kv_h (kv_h={kv_h})"
+        );
+
+        let decoded = store
+            .dequant()
+            .expect("dequant must succeed after truncate at kv_h>1 (#284)");
+
+        let mut reference = QuantRotorK4::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 5);
+        for tok in 0..keep_tokens {
+            reference.append(&token_data(tok), &new_shape).unwrap();
+        }
+        let ref_decoded = reference.dequant().unwrap();
+
+        assert_eq!(
+            decoded, ref_decoded,
+            "truncated store must exactly match a store built from only the \
+             first keep_tokens (kv_h={kv_h})"
+        );
+    }
+
+    // SAFETY: ROTOR_QJL_ENV_LOCK still held.
+    unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
@@ -263,8 +263,10 @@ impl QuantRotorV3 {
 
     /// Truncate the accumulated sequence to `n` tokens.
     ///
-    /// Drops trailing blocks until the cumulative `n_tokens` count is `<= n`
-    /// and lowers `shape[2]` to `n`. Does **not** touch the rotor table.
+    /// Drops trailing blocks until the cumulative `n_tokens` count is
+    /// `<= n * b * kv_h` (block `n_tokens` counts rows, not sequence positions —
+    /// see [`super::truncate_keep_count`]) and lowers `shape[2]` to `n`. Does
+    /// **not** touch the rotor table.
     ///
     /// The GPU ring is **kept**, not cleared — mirror of the K store's
     /// `truncate_to`. Lowering `shape[2]` to `n` makes the ring's logical fill

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
@@ -277,17 +277,8 @@ impl QuantRotorV3 {
     /// loudly, which would abort generation on the speculative-decode rollback
     /// path.
     pub fn truncate_to(&mut self, n: i32) {
-        let n_usize = n.max(0) as usize;
-        let mut acc: usize = 0;
-        let mut keep = 0usize;
-        for (i, blk) in self.blocks.iter().enumerate() {
-            if acc + blk.n_tokens <= n_usize {
-                acc += blk.n_tokens;
-                keep = i + 1;
-            } else {
-                break;
-            }
-        }
+        let keep =
+            super::truncate_keep_count(self.blocks.iter().map(|blk| blk.n_tokens), &self.shape, n);
         self.blocks.truncate(keep);
         // NB: no `self.gpu.clear()` — the ring is the source of truth for a
         // ring-only decode tail; see the doc comment above.

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3_tests.rs
@@ -177,3 +177,85 @@ fn quant_rotor_v3_multi_append_matches_single_shot_gqa() {
     );
     let _ = ROTOR3_V_BITS;
 }
+
+/// Falsifies #284: at `kv_h > 1`, `truncate_to(n)` must keep exactly the
+/// leading blocks covering sequence `[0, n)`, not `floor(n / kv_h)` of them.
+///
+/// Builds one block per token (CPU-only, no GPU ring ever touched), truncates
+/// mid-sequence at a block boundary, and requires the result to exactly match
+/// a reference store built from only the first `keep_tokens` — same shape,
+/// same layer (so the same static rotor table), fully deterministic encode.
+///
+/// Runs both `kv_h == 1` (the historical, accidentally-correct case) and
+/// `kv_h > 1` (where the pre-fix code compared row-counted `n_tokens` against
+/// a raw sequence target and undercounted) in one test.
+///
+/// Mutation check: reverting `truncate_to` to compare
+/// `acc + blk.n_tokens <= n as usize` (raw, not row-scaled) makes the
+/// `kv_h > 1` case RED — `blocks.len()` drops and `dequant()` returns `Err`.
+#[test]
+fn quant_rotor_v3_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
+    let head_dim = 96_usize;
+    let total_tokens = 4_usize;
+    let keep_tokens = 2_usize;
+    let val = |h: usize, tok: usize, d: usize| {
+        (h as f32) * 100.0 + (tok as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+
+    for kv_h in [1_usize, 4_usize] {
+        let token_data = |tok: usize| -> Vec<f32> {
+            let mut out = vec![0.0_f32; kv_h * head_dim];
+            for h in 0..kv_h {
+                for d in 0..head_dim {
+                    out[h * head_dim + d] = val(h, tok, d);
+                }
+            }
+            out
+        };
+        let new_shape = [1_i32, kv_h as i32, 1, head_dim as i32];
+
+        let mut store = QuantRotorV3::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 64, 5);
+        for tok in 0..total_tokens {
+            store.append(&token_data(tok), &new_shape).unwrap();
+        }
+        assert_eq!(
+            store.blocks.len(),
+            total_tokens,
+            "one block per token append (kv_h={kv_h})"
+        );
+
+        store.truncate_to(keep_tokens as i32);
+
+        assert_eq!(
+            store.shape[2], keep_tokens as i32,
+            "shape[2] must equal keep_tokens (kv_h={kv_h})"
+        );
+        assert_eq!(
+            store.blocks.len(),
+            keep_tokens,
+            "truncate_to must keep exactly keep_tokens blocks, not floor(keep_tokens / kv_h) (kv_h={kv_h})"
+        );
+        let kept_rows: usize = store.blocks.iter().map(|blk| blk.n_tokens).sum();
+        assert_eq!(
+            kept_rows,
+            keep_tokens * kv_h,
+            "kept rows must equal keep_tokens * b * kv_h (kv_h={kv_h})"
+        );
+
+        let decoded = store
+            .dequant()
+            .expect("dequant must succeed after truncate at kv_h>1 (#284)");
+
+        let mut reference = QuantRotorV3::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 64, 5);
+        for tok in 0..keep_tokens {
+            reference.append(&token_data(tok), &new_shape).unwrap();
+        }
+        let ref_decoded = reference.dequant().unwrap();
+
+        assert_eq!(
+            decoded, ref_decoded,
+            "truncated store must exactly match a store built from only the \
+             first keep_tokens (kv_h={kv_h})"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
@@ -225,17 +225,8 @@ impl QuantRotorV4 {
     /// not cleared, so a ring-only decode tail up to `n` survives and `dequant` /
     /// an SSD spill can rebuild it via [`synced_rotor_v_blocks`].
     pub fn truncate_to(&mut self, n: i32) {
-        let n_usize = n.max(0) as usize;
-        let mut acc: usize = 0;
-        let mut keep = 0usize;
-        for (i, blk) in self.blocks.iter().enumerate() {
-            if acc + blk.n_tokens <= n_usize {
-                acc += blk.n_tokens;
-                keep = i + 1;
-            } else {
-                break;
-            }
-        }
+        let keep =
+            super::truncate_keep_count(self.blocks.iter().map(|blk| blk.n_tokens), &self.shape, n);
         self.blocks.truncate(keep);
         // NB: no `self.gpu.clear()` — the ring is the source of truth for a
         // ring-only decode tail; see [`super::QuantRotorV3::truncate_to`].

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v4_tests.rs
@@ -175,3 +175,74 @@ fn quant_rotor_v4_multi_append_matches_single_shot_gqa() {
         "rotor4 multi-append vs single-shot max_abs_err = {max_abs:.6} (>= 1.0) — head↔seq scramble"
     );
 }
+
+/// Falsifies #284: at `kv_h > 1`, `truncate_to(n)` must keep exactly the
+/// leading blocks covering sequence `[0, n)`, not `floor(n / kv_h)` of them.
+/// CPU-only (no GPU ring touched). See `quant_rotor_v3_tests.rs` for the
+/// full rationale + mutation-check note.
+#[test]
+fn quant_rotor_v4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
+    let head_dim = 96_usize;
+    let total_tokens = 4_usize;
+    let keep_tokens = 2_usize;
+    let val = |h: usize, tok: usize, d: usize| {
+        (h as f32) * 100.0 + (tok as f32) * 10.0 + (d as f32) * 0.5 + 1.0
+    };
+
+    for kv_h in [1_usize, 4_usize] {
+        let token_data = |tok: usize| -> Vec<f32> {
+            let mut out = vec![0.0_f32; kv_h * head_dim];
+            for h in 0..kv_h {
+                for d in 0..head_dim {
+                    out[h * head_dim + d] = val(h, tok, d);
+                }
+            }
+            out
+        };
+        let new_shape = [1_i32, kv_h as i32, 1, head_dim as i32];
+
+        let mut store = QuantRotorV4::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 64, 5);
+        for tok in 0..total_tokens {
+            store.append(&token_data(tok), &new_shape).unwrap();
+        }
+        assert_eq!(
+            store.blocks.len(),
+            total_tokens,
+            "one block per token append (kv_h={kv_h})"
+        );
+
+        store.truncate_to(keep_tokens as i32);
+
+        assert_eq!(
+            store.shape[2], keep_tokens as i32,
+            "shape[2] must equal keep_tokens (kv_h={kv_h})"
+        );
+        assert_eq!(
+            store.blocks.len(),
+            keep_tokens,
+            "truncate_to must keep exactly keep_tokens blocks, not floor(keep_tokens / kv_h) (kv_h={kv_h})"
+        );
+        let kept_rows: usize = store.blocks.iter().map(|blk| blk.n_tokens).sum();
+        assert_eq!(
+            kept_rows,
+            keep_tokens * kv_h,
+            "kept rows must equal keep_tokens * b * kv_h (kv_h={kv_h})"
+        );
+
+        let decoded = store
+            .dequant()
+            .expect("dequant must succeed after truncate at kv_h>1 (#284)");
+
+        let mut reference = QuantRotorV4::new(vec![1_i32, kv_h as i32, 0, head_dim as i32], 64, 5);
+        for tok in 0..keep_tokens {
+            reference.append(&token_data(tok), &new_shape).unwrap();
+        }
+        let ref_decoded = reference.dequant().unwrap();
+
+        assert_eq!(
+            decoded, ref_decoded,
+            "truncated store must exactly match a store built from only the \
+             first keep_tokens (kv_h={kv_h})"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/truncate_keep_count_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/truncate_keep_count_tests.rs
@@ -1,0 +1,98 @@
+//! Unit tests for [`crate::storage::truncate_keep_count`] — the shared
+//! row/sequence unit-conversion helper behind every rotor/iso K and V store's
+//! `truncate_to` (#284).
+//!
+//! Root cause: each per-append block's `n_tokens` counts **rows**
+//! (`b * kv_h * seq_of_block`), not raw sequence positions. `truncate_to(n)`
+//! takes `n` as a **sequence** target, so `n` must be scaled to `n * b *
+//! kv_h` before it is compared against the cumulative `n_tokens`. At
+//! `b * kv_h == 1` the two units coincide, which is how the bug shipped
+//! unnoticed — every `kv_h > 1` store silently undercounted.
+
+use crate::storage::truncate_keep_count;
+
+/// At `b * kv_h == 1` each block's `n_tokens` already equals its sequence
+/// length, so rows and sequence positions coincide — the historical
+/// (masked) case. No regression here after the fix.
+#[test]
+fn truncate_keep_count_kv_h_one_is_identity() {
+    let shape = [1_i32, 1, 0, 8];
+    // Four one-token blocks; n_tokens == 1 each (b * kv_h * 1).
+    let blocks = [1_usize, 1, 1, 1];
+    assert_eq!(truncate_keep_count(blocks.iter().copied(), &shape, 2), 2);
+    assert_eq!(truncate_keep_count(blocks.iter().copied(), &shape, 0), 0);
+    assert_eq!(truncate_keep_count(blocks.iter().copied(), &shape, 4), 4);
+}
+
+/// At `kv_h > 1` each block's `n_tokens` is inflated by `b * kv_h` — the
+/// target must be converted to row units before comparison, or the walk
+/// overshoots early and drops blocks that should be kept (#284).
+#[test]
+fn truncate_keep_count_kv_h_gt_1_converts_to_rows() {
+    let kv_h = 4_usize;
+    let shape = [1_i32, kv_h as i32, 0, 8];
+    // Four one-token blocks; each holds b * kv_h = 4 rows.
+    let blocks = [4_usize, 4, 4, 4];
+
+    // Keep 2 of 4 tokens -> row target = 2 * 4 = 8 -> keep 2 blocks.
+    assert_eq!(
+        truncate_keep_count(blocks.iter().copied(), &shape, 2),
+        2,
+        "must keep 2 blocks (row target 8), not floor(2/4)=0 blocks"
+    );
+    // Keep all 4 tokens -> row target = 16 -> keep all 4 blocks.
+    assert_eq!(truncate_keep_count(blocks.iter().copied(), &shape, 4), 4);
+    // Keep 0 tokens -> keep no blocks.
+    assert_eq!(truncate_keep_count(blocks.iter().copied(), &shape, 0), 0);
+}
+
+/// Mutation guard: comparing `n_tokens` against the raw sequence target
+/// (the pre-#284-fix behaviour) undercounts at `kv_h > 1`. This test pins
+/// down what that regression looks like so it is visible without hand-
+/// reverting the source.
+#[test]
+fn truncate_keep_count_kv_h_gt_1_would_undercount_with_raw_comparison() {
+    let n_usize = 2_usize; // raw seq target, NOT converted to rows
+    let blocks = [4_usize, 4, 4, 4]; // kv_h=4 rows per one-token block
+    let mut acc = 0_usize;
+    let mut keep_buggy = 0_usize;
+    for (i, tokens) in blocks.iter().copied().enumerate() {
+        if acc + tokens <= n_usize {
+            acc += tokens;
+            keep_buggy = i + 1;
+        } else {
+            break;
+        }
+    }
+    assert_eq!(
+        keep_buggy, 0,
+        "the pre-#284-fix raw comparison keeps 0 of 4 blocks for a target of 2 tokens"
+    );
+
+    let kv_h = 4_usize;
+    let shape = [1_i32, kv_h as i32, 0, 8];
+    let fixed = truncate_keep_count(blocks.iter().copied(), &shape, 2);
+    assert_eq!(
+        fixed, 2,
+        "the fixed helper keeps 2 blocks for the same input"
+    );
+}
+
+/// A degenerate `b * kv_h == 0` shape (nothing appended yet) keeps no blocks.
+#[test]
+fn truncate_keep_count_zero_factor_keeps_nothing() {
+    let shape = [0_i32, 4, 0, 8];
+    let blocks = [4_usize, 4];
+    assert_eq!(truncate_keep_count(blocks.iter().copied(), &shape, 2), 0);
+}
+
+/// Multi-batch (`b > 1`) also inflates `n_tokens` and must be converted the
+/// same way as `kv_h > 1`.
+#[test]
+fn truncate_keep_count_batch_gt_1_converts_to_rows() {
+    let b = 2_usize;
+    let shape = [b as i32, 1, 0, 8];
+    // Four one-token blocks; each holds b * kv_h = 2 rows.
+    let blocks = [2_usize, 2, 2, 2];
+    assert_eq!(truncate_keep_count(blocks.iter().copied(), &shape, 3), 3);
+}

--- a/crates/rmlx-models/src/kv_cache/tests.rs
+++ b/crates/rmlx-models/src/kv_cache/tests.rs
@@ -746,6 +746,77 @@ mod tests {
         }
     }
 
+    /// Falsifies #284 at the real production entry point: `KvCache::update` →
+    /// dispatch → `QuantIsoV3::append`, then `KvCache::truncate_to` → dispatch
+    /// → `QuantIsoV3::truncate_to`, at `kv_h = 4` (`kv_h == 1` is the masked
+    /// case that hides the bug — see `kv_cache_truncate_k8v8_path` above,
+    /// which stays at `kv_h == 1` on purpose as the pre-existing regression
+    /// baseline).
+    ///
+    /// One token appended per `update` call so every block is exactly one
+    /// sequence position (block boundaries align with truncate targets).
+    /// This is the same production path SWA-context-slide, speculative-decode
+    /// rollback, and prompt-cache partial-prefix trim all drive — see
+    /// `docs/KV_QUANT.md` for the reachability audit per arch (Bonsai-8B
+    /// currently has no live serve trigger; Gemma4's prompt-cache `Partial`
+    /// reuse policy does).
+    #[test]
+    #[allow(
+        clippy::expect_used,
+        reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
+    )]
+    #[allow(
+        clippy::wildcard_enum_match_arm,
+        reason = "wildcard arm is the correct fallthrough for unsupported arch/quant variants; exhaustive expansion would require updating on every new variant"
+    )]
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "shape[2] index bounded by the codec's fixed 4-element [B, kv_h, S, D] shape, established by construction"
+    )]
+    fn kv_cache_truncate_iso3_kv_h_gt_1_path() {
+        let mut cache = KvCache::with_quant_max_seq(KvQuant::Iso3, 32);
+
+        let device = Device::Cpu;
+        let kv_h = 4_i32;
+        let head_dim = 32_i32; // kv_h * head_dim = 128 = Q8_GROUP_SIZE (K-side q8_0)
+        let total_tokens = 8;
+        for tok in 0..total_tokens {
+            let k = make_lcg_array(&[1, kv_h, 1, head_dim], 10 + tok as u64).0;
+            let v = make_lcg_array(&[1, kv_h, 1, head_dim], 11 + tok as u64).0;
+            cache.update(&k, &v, device).expect("update must not fail");
+        }
+        assert_eq!(cache.offset(), total_tokens);
+
+        let keep = 3;
+        cache.truncate_to(keep);
+        assert_eq!(cache.offset(), keep, "offset must equal truncation target");
+        match &cache.storage {
+            KvStorage::IsoV3 { v, .. } => {
+                let vs = v
+                    .as_ref()
+                    .expect("V codec must be populated after 8 appends");
+                assert_eq!(
+                    vs.shape[2], keep,
+                    "QuantIsoV3 shape[2] must equal truncation target"
+                );
+                assert_eq!(
+                    vs.blocks.len(),
+                    keep as usize,
+                    "must keep exactly `keep` blocks, not floor(keep / kv_h) (#284)"
+                );
+                let kept_rows: usize = vs.blocks.iter().map(|b| b.n_tokens).sum();
+                assert_eq!(
+                    kept_rows,
+                    keep as usize * kv_h as usize,
+                    "kept rows must equal keep * kv_h, not keep (#284)"
+                );
+                vs.dequant()
+                    .expect("dequant must succeed after truncate at kv_h>1 (#284)");
+            }
+            _ => panic!("expected IsoV3 storage"),
+        }
+    }
+
     // ── kv_quant_for_layer unit tests ────────────────────────────────────────
 
     #[test]

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2659,6 +2659,43 @@ mutators reconcile: the block-path append (`materialize_*_ring_tail`)
 materialises any pre-existing ring-only tail into `blocks` before pushing, so
 `blocks` stay a contiguous prefix.
 
+**Row vs. sequence units.** Every rotor/iso K and V store's per-append
+`RotorBlocks` / `IsoBlocks` carries `n_tokens` counting **rows**
+(`b * kv_h * seq_of_block`), not sequence positions, but `truncate_to(n)`
+takes `n` as a **sequence** target. Deciding which leading blocks to keep must
+therefore compare cumulative `n_tokens` against `n * b * kv_h`, not against
+`n` directly — at `kv_h > 1` (or `b > 1`) a raw comparison undercounts and
+drops blocks that should have been kept, landing the store in exactly the
+forbidden gap described below. This was invisible at `b * kv_h == 1` (rows and
+sequence positions coincide), which is how the bug shipped and how it stayed
+latent until a `kv_h > 1` truncation path was exercised (#284). All eight
+rotor/iso K and V codecs share one crate-internal conversion helper,
+`truncate_keep_count` in `rmlx-kv-quant/src/storage/mod.rs`, so the unit
+conversion is defined once rather than re-derived per codec.
+
+**Real-serve reachability audit (per #284).** `KvCache::truncate_to` has three
+production callers: prompt-cache partial-prefix trim
+(`PromptCacheEntry::truncate_kv_to`), SWA context handling, and
+speculative-decode partial-accept rollback (MTP / DFlash / Eagle3 / the
+gemma4-assistant self-speculative path). Whether any of them can reach a
+`kv_h > 1` rotor/iso store depends on the arch:
+- **Bonsai (`Qwen3ForCausalLM`, `kv_h = 8`)** — no live trigger today.
+  Its prompt-cache `ReusePolicy` is `ExactOnly` (partial-prefix trim never
+  fires), and no speculative-decode drafter currently targets plain
+  `Qwen3ForCausalLM`.
+- **Gemma4 (e.g. e4b, `kv_h = 2`)** — reachable in principle: its
+  `ReusePolicy::Partial` performs exactly this trim on a real partial-prefix
+  cache hit, and gemma4-assistant self-speculative decode also rolls back via
+  `truncate_to`.
+
+The fix is proven at the codec level (all eight `*_tests.rs` files, `kv_h`
+values 1 and 4) and at the full `KvCache::update` / `KvCache::truncate_to`
+dispatch level (`kv_cache_truncate_iso3_kv_h_gt_1_path` in
+`rmlx-models/src/kv_cache/tests.rs`, `kv_h = 4`) rather than via a live HTTP
+trigger. `truncate_keep_count` reads `shape[1]` directly with no per-arch or
+hardcoded head-count branch, so `kv_h = 4` and Bonsai's real `kv_h = 8`
+exercise the identical code path — no arch-specific behavior exists to miss.
+
 The forbidden state is `blocks` short of `shape[2]` with **no** ring to supply
 the tail: `dequant()` would zero-pad the gap (silently wrong attention) and an
 SSD spill would persist a truncated store. That state is rejected **loudly**


### PR DESCRIPTION
## Problem
Every rotor/iso K and V block store's `n_tokens` field counts **rows** (`b·kv_h·seq`), not raw sequence positions — proven by the dequant reconciliation guards that sum `n_tokens` and compare against `b·kv_h·shape[2]` (e.g. `quant_rotor_v3.rs:550`). But `truncate_to(n)` took `n` as a **sequence** target (it sets `shape[2]=n`) and compared it directly against cumulative `n_tokens`. At `kv_h>1` (or `b>1`) each block's `n_tokens` is inflated by that factor, so the walk overshoots early and **drops valid CPU blocks**, leaving the store short of `shape[2]`. With no live GPU ring to rebuild from, the next `dequant()` hits its loud short-blocks guard and aborts (or returns wrong output). Invisible at `b·kv_h==1` — how it shipped.

## Fix (general, model-agnostic)
Shared helper `storage::truncate_keep_count(block_tokens, shape, n)` converts `n` to rows (`n·b·kv_h`) once; all **8** codec `truncate_to` sites (rotor_k3/k4, rotor_v3/v4, iso_k/k4, iso_v/v4) delegate to it. Keyed off shape, not arch.

## Proof
- Per-codec `kv_h>1` keeps-exact-prefix tests + helper edge tests (batch>1, kv_h==1 identity, zero-factor, and a standing `raw-comparison-undercount` mutation guard).
- KvCache-level integration test `kv_cache_truncate_iso3_kv_h_gt_1_path` drives the real `update()×8 → truncate_to(3) → dequant()` path (blocks==3 not 0).
- Red-first: pre-fix → 11 failures (keeps 0 blocks instead of N); fix → rmlx-kv-quant 381/0, rmlx-models 694/0; mutation restores RED.
- 2-arch no-regression serve smokes: Bonsai-8B (iso3, 112.8 TPS) + Gemma4-e4b (iso3, kv_h=2, 77.2 TPS).
- Note: live serve on Bonsai (Qwen3ForCausalLM, ExactOnly policy, no drafter) does not reach truncate_to; the integration test drives the identical production code path. Gemma4's live prompt-cache-partial trigger not driven end-to-end (documented gap).

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)