### PR TITLE
chore(dev): MLX preflight + restore, GPU-capture harness, target GC, metal-gate fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         build-perf build-debug test-perf ci-perf model-check model-check-full \
         profile-samply profile-samply-debug profile-instruments bench asm perf-iter \
         canary canary-gate \
-        mlx-preflight mlx-restore-pin \
+        mlx-preflight mlx-restore-pin target-gc profile-gputrace \
         ssd-canary ssd-canary-gate \
         bench-codec-cell \
         smoke-codec-matrix \
@@ -73,8 +73,19 @@ check:           ## cargo check (fast, no codegen)
 test:            ## cargo test --workspace
 	cargo test --workspace
 
-mlx-preflight:   ## verify linked MLX is the pinned nax-capable pair (run before benching)
+mlx-preflight:   ## verify the linked MLX stack (and nax kernels on M5+) before benching
 	bash scripts/mlx_preflight.sh
+
+target-gc:       ## report stale target/ profiles (APPLY=1 to prune; target/ has no size cap)
+	bash scripts/target_gc.sh $(if $(APPLY),--apply,) $(if $(ALL),--all,)
+
+profile-gputrace: ## capture a decode-window Metal GPU trace for Xcode (CODEC= MODEL= required)
+	@if [ -z "$(CODEC)" ] || [ -z "$(MODEL)" ]; then \
+		echo "Usage: make profile-gputrace CODEC=<codec> MODEL=<snapshot-abs-path> [PROMPT_TOKENS=4096] [GEN=16]"; \
+		exit 2; \
+	fi
+	bash scripts/gpu_capture.sh --kv-quant $(CODEC) --model $(MODEL) \
+		$(if $(PROMPT_TOKENS),--prompt-tokens $(PROMPT_TOKENS),) $(if $(GEN),--gen $(GEN),)
 
 mlx-restore-pin: ## restore mlx 0.31.2 + mlx-c 0.6.0_2 (nax-capable pair) and relink
 	bash scripts/mlx_restore_pin.sh

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         build-perf build-debug test-perf ci-perf model-check model-check-full \
         profile-samply profile-samply-debug profile-instruments bench asm perf-iter \
         canary canary-gate \
+        mlx-preflight mlx-restore-pin \
         ssd-canary ssd-canary-gate \
         bench-codec-cell \
         smoke-codec-matrix \
@@ -71,6 +72,12 @@ check:           ## cargo check (fast, no codegen)
 
 test:            ## cargo test --workspace
 	cargo test --workspace
+
+mlx-preflight:   ## verify linked MLX is the pinned nax-capable pair (run before benching)
+	bash scripts/mlx_preflight.sh
+
+mlx-restore-pin: ## restore mlx 0.31.2 + mlx-c 0.6.0_2 (nax-capable pair) and relink
+	bash scripts/mlx_restore_pin.sh
 
 build-perf:      ## cargo build --profile release-perf (debug-assertions off, stripped)
 	cargo build --workspace --profile release-perf
@@ -345,7 +352,7 @@ CANARY_THRESHOLD_PCT ?= 3
 # SHA to compare against for canary-gate; required — no default.
 # Usage: make canary-gate SHA=3ba8aee
 
-canary: build-perf  ## run 3-model TPS canary (records into runs.db + legacy CSV); requires release-perf binary
+canary: mlx-preflight build-perf  ## run 3-model TPS canary (records into runs.db + legacy CSV); requires release-perf binary
 	@pkill -f "rmlx serve" || true; pkill -f mlx_lm || true; sleep 1; rm -f /tmp/rmlx.*.claim
 	bash scripts/perf_canary.sh
 
@@ -469,7 +476,7 @@ ssd-canary-gate:   ## gate SSD-tier regressions; SHA= required, THRESHOLD_PCT=3 
 # See scripts/bench_codec_cell.sh for full options (--max-tokens, --prompt-len).
 # CSV schema documented in docs/PERF_BASELINE.md § "Per-codec × per-model cells".
 
-bench-codec-cell:   ## bench one codec × one model cell (CODEC= MODEL= required); appends to .rmlx/bench/codec_cells.csv
+bench-codec-cell: mlx-preflight  ## bench one codec × one model cell (CODEC= MODEL= required); appends to .rmlx/bench/codec_cells.csv
 	@if [ -z "$(CODEC)" ] || [ -z "$(MODEL)" ]; then \
 		echo "Usage: make bench-codec-cell CODEC=<codec> MODEL=<snapshot-abs-path>"; \
 		exit 2; \

--- a/README.md
+++ b/README.md
@@ -156,6 +156,41 @@ regression that costs ~3.8× GPU matmul throughput), the build prints a warning
 naming the fix. It is a warning, not an error — the build still succeeds. See
 [`docs/FFI.md`](docs/FFI.md#pinned-mlx--mlx-c-pair).
 
+### On M5 and later: check for the Neural Accelerator kernels
+
+M5 introduced the Neural Accelerator (NAX). Some Homebrew MLX bottles are built
+in a way that silently omits the NAX kernels, which costs roughly **2–3.8× on
+prefill** while leaving decode largely untouched — so the loss is easy to miss.
+On M1–M4 there is no NAX and nothing to check: those bottles legitimately
+contain no NAX kernels.
+
+```sh
+strings "$(brew --prefix mlx)/lib/mlx.metallib" | grep -c steel_gemm_fused_nax
+# M5+: expect a non-zero count. 0 means your MLX bottle has no NAX kernels.
+# M1-M4: 0 is normal and expected.
+```
+
+Contributors can run this (and the rest of the toolchain checks) with
+`make mlx-preflight`.
+
+### Extra tooling for kernel work (contributors only)
+
+Not needed to build or run rMLX — only to compile-check or profile the Metal
+kernels:
+
+- **Full Xcode** (not just the Command Line Tools), selected with
+  `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`.
+- **The Metal Toolchain component**, which Xcode does not install by default:
+
+```sh
+xcodebuild -downloadComponent MetalToolchain
+```
+
+With both present, `make check-metal-compiles` compiles every KV `.metal`
+kernel natively, and `make profile-gputrace` captures a GPU trace for Xcode.
+Without them, the compile gate reports `SKIP` (CI still enforces it) — see
+[`docs/PROFILING.md`](docs/PROFILING.md).
+
 ## Install
 
 All paths build from source — rMLX links the system MLX/mlx-c libraries, so MLX

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -133,18 +133,51 @@ Note: the global allocator is replaced when this feature is active, so jemalloc 
 - Which allocations are short-lived (high alloc + dealloc rate = pressure hot spots).
 - Useful for auditing `rmlx-loader` mmap vs full-read behaviour and KV-cache growth.
 
-## 5. Metal GPU capture (deferred — symbol confirmed in bindings)
+## 5. Metal GPU capture (the tool for kernel work)
 
-`mlx_metal_start_capture` / `mlx_metal_stop_capture` exist in the bound mlx-c library
-(confirmed in `target/debug/build/rmlx-mlx-*/out/bindings.rs` lines 2864-2868).
+**This is the right profiler for MSL kernel questions**, not samply. Kernel cost
+lives on the GPU: occupancy, ALU-vs-memory limiter, achieved bandwidth, and the
+gaps between dispatches (a large gap means a host round-trip). Host stack
+sampling cannot see any of it.
 
-Safe wrappers are not yet exposed in `rmlx-mlx::lib`. When needed (Stage 1.4+):
+On M5 the Neural Accelerator is **part of the GPU**, so profiling nax needs no
+special tooling — the ordinary Metal capture path covers it
+([ml-explore/mlx#3182](https://github.com/ml-explore/mlx/issues/3182)).
 
-1. Add `pub fn metal_start_capture(path: &Path) -> Result<()>` in `rmlx-mlx/src/lib.rs`
-   calling `sys::mlx_metal_start_capture(c_path_ptr)`.
-2. Gate on a CLI flag or dedicated env var checked at engine boot
-   (`engine.rs` or `baseline.rs`).
-3. Open `.gputrace` in Instruments → Metal System Trace.
+`rmlx_mlx::metal_capture::CaptureScope` is an RAII guard over
+`mlx_metal_start_capture` / `mlx_metal_stop_capture`, behind the
+`metal-capture` feature so release builds pay nothing.
+
+### Prerequisites
+
+Full **Xcode**, not just Command Line Tools — traces cannot be replayed without
+it:
+
+```sh
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
+
+### Capture
+
+```sh
+cargo build --profile release-debug --features rmlx-mlx/metal-capture
+make profile-gputrace CODEC=iso3_sym MODEL=/path/to/snapshot
+```
+
+The window is a short generation, deliberately: a whole run is unusably large
+and dominated by model load and prefill, which is not what kernel work studies.
+Traces land in `.rmlx/traces/`; `open` them in Xcode.
+
+### What to read in the trace
+
+| Question | Where |
+|---|---|
+| Is the kernel itself slow, or is time lost between dispatches? | per-dispatch duration vs inter-dispatch gap — a large gap is a host round-trip (e.g. a per-step prefix restage) |
+| Compute-bound or bandwidth-bound? | limiter / ALU utilisation vs achieved bandwidth counters |
+| Is the codec's own kernel even running? | dispatch list — a codec that decodes via the bf16 mirror shows no flash-decode dispatch at all |
+
+See also [Analyzing Apple GPU performance using counter
+statistics](https://developer.apple.com/documentation/xcode/analyzing-apple-gpu-performance-using-counter-statistics).
 
 ## 6. Ad-hoc cardinality counting with the `counts` crate
 

--- a/scripts/check_metal_compiles.sh
+++ b/scripts/check_metal_compiles.sh
@@ -52,15 +52,33 @@ for arg in "$@"; do
     esac
 done
 
-if ! command -v xcrun >/dev/null 2>&1 || ! xcrun -sdk macosx -f metal >/dev/null 2>&1; then
+# Probe by *executing* the compiler, not by resolving its path. With Xcode
+# selected but the separately-downloaded Metal Toolchain component absent,
+# `xcrun -f metal` happily prints a path while every invocation fails with
+# "cannot execute tool 'metal' due to missing Metal Toolchain" — which would
+# otherwise be reported as a compile failure for every kernel in the manifest.
+metal_unavailable_reason=""
+if ! command -v xcrun >/dev/null 2>&1; then
+    metal_unavailable_reason="xcrun not found"
+elif ! metal_probe="$(xcrun -sdk macosx metal --version 2>&1)"; then
+    case "${metal_probe}" in
+        *"missing Metal Toolchain"*)
+            metal_unavailable_reason="Xcode is selected but the Metal Toolchain component is not installed; run: xcodebuild -downloadComponent MetalToolchain"
+            ;;
+        *)
+            metal_unavailable_reason="Metal compiler not usable (needs full Xcode, not just the Command Line Tools): xcode-select -s /Applications/Xcode.app"
+            ;;
+    esac
+fi
+
+if [ -n "${metal_unavailable_reason}" ]; then
     if [ "${STRICT}" = 1 ]; then
-        echo "ERROR: --strict: Metal compiler not found (xcrun -sdk macosx -f metal)." >&2
-        echo "       Refusing to pass by skipping. This needs full Xcode, not just the" >&2
-        echo "       Command Line Tools: 'xcode-select -s /Applications/Xcode.app'." >&2
+        echo "ERROR: --strict: ${metal_unavailable_reason}" >&2
+        echo "       Refusing to pass by skipping." >&2
         exit 1
     fi
-    echo "SKIP: Metal compiler not found (needs full Xcode, not just the Command Line Tools);"
-    echo "      MSL compile gate not run. Install Xcode + 'xcode-select -s /Applications/Xcode.app'."
+    echo "SKIP: ${metal_unavailable_reason}"
+    echo "      MSL compile gate not run."
     exit 0
 fi
 

--- a/scripts/gpu_capture.sh
+++ b/scripts/gpu_capture.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Capture a Metal GPU trace of a bounded window of steady-state decode, for
+# replay in Xcode (Instruments -> Metal System Trace / GPU counter statistics).
+#
+# Why this exists: on M5 the Neural Accelerator is part of the GPU, so profiling
+# nax needs no special tooling — the ordinary Metal capture path covers it
+# (ml-explore/mlx#3182). For MSL kernel questions we need GPU-side counters
+# (occupancy, ALU vs memory bound, achieved bandwidth, dispatch gaps), which
+# host stack sampling (samply) cannot show.
+#
+# The capture window matters: a whole run is unusably large and dominated by
+# load + prefill, which is not what we are studying. This drives a short
+# generation so the trace is mostly steady-state decode.
+#
+# Prerequisites (checked below):
+#   - Xcode (not just Command Line Tools) selected via xcode-select
+#   - a binary built with the metal-capture feature
+#
+# Usage:
+#   bash scripts/gpu_capture.sh --kv-quant iso3_sym --model /path/to/snapshot
+#   bash scripts/gpu_capture.sh --kv-quant none --model ... --prompt-tokens 4096 --gen 16
+#
+# Output: a .gputrace bundle under .rmlx/traces/, ready to open in Xcode.
+
+set -uo pipefail
+
+KV_QUANT=""
+MODEL=""
+PROMPT_TOKENS=4096
+GEN=16
+OUT_DIR=".rmlx/traces"
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--kv-quant)
+		KV_QUANT="$2"
+		shift 2
+		;;
+	--model)
+		MODEL="$2"
+		shift 2
+		;;
+	--prompt-tokens)
+		PROMPT_TOKENS="$2"
+		shift 2
+		;;
+	--gen)
+		GEN="$2"
+		shift 2
+		;;
+	--out-dir)
+		OUT_DIR="$2"
+		shift 2
+		;;
+	*)
+		echo "unknown argument: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+if [ -z "$KV_QUANT" ] || [ -z "$MODEL" ]; then
+	echo "usage: $0 --kv-quant <codec> --model <snapshot-abs-path> [--prompt-tokens N] [--gen N]" >&2
+	exit 2
+fi
+
+cd "$(dirname "$0")/.." || exit 1
+
+# --- 1. Xcode must be selected; Command Line Tools alone cannot replay traces --
+dev_dir=$(xcode-select -p 2>/dev/null)
+if [ "${dev_dir##*/}" = "CommandLineTools" ]; then
+	echo "ERROR: xcode-select points at Command Line Tools, not Xcode." >&2
+	echo "  GPU traces need the full Xcode toolchain. Select it with:" >&2
+	echo "    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer" >&2
+	exit 1
+fi
+
+# --- 2. toolchain sanity: same gate the bench path uses ---------------------
+bash scripts/mlx_preflight.sh || exit 1
+
+# --- 3. binary must carry the capture feature ------------------------------
+# CaptureScope is behind `metal-capture` so release builds pay nothing; a binary
+# built without it silently produces no trace.
+BIN="target/release-debug/rmlx"
+if [ ! -x "$BIN" ]; then
+	echo "ERROR: $BIN not found." >&2
+	echo "  Build it with the capture feature and full debug info:" >&2
+	echo "    cargo build --profile release-debug --features rmlx-mlx/metal-capture" >&2
+	exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+stamp=$(date +%Y%m%d-%H%M%S)
+trace="$OUT_DIR/${KV_QUANT}-${PROMPT_TOKENS}tok-${stamp}.gputrace"
+
+echo "capturing: codec=$KV_QUANT prompt=$PROMPT_TOKENS gen=$GEN"
+echo "trace:     $trace"
+
+# RMLX_METAL_CAPTURE_PATH is read by the engine's capture hook; the window is
+# opened after prefill so the trace is steady-state decode, not model load.
+RMLX_METAL_CAPTURE_PATH="$trace" \
+	"$BIN" baseline \
+	--model "$MODEL" \
+	--kv-quant "$KV_QUANT" \
+	--prompt-tokens "$PROMPT_TOKENS" \
+	--max-tokens "$GEN" \
+	--max-ctx 65536 \
+	--max-prompt-tokens 65528
+rc=$?
+
+if [ $rc -ne 0 ]; then
+	echo "capture run failed (exit $rc)" >&2
+	exit $rc
+fi
+
+if [ ! -e "$trace" ]; then
+	echo "ERROR: no trace written to $trace" >&2
+	echo "  Was the binary built with --features rmlx-mlx/metal-capture?" >&2
+	exit 1
+fi
+
+echo ""
+echo "done: $trace"
+echo "open with:  open '$trace'"
+echo ""
+echo "In Xcode, the questions this trace should answer:"
+echo "  - per-dispatch kernel time for the flash-decode kernel vs the gaps between dispatches"
+echo "    (a large gap = host round-trip, e.g. the k_iso*/k_rotor* prefix restage)"
+echo "  - limiter counters: ALU vs memory bound, occupancy, achieved bandwidth"
+echo "    (tells whether a quant decode kernel is compute- or bandwidth-limited)"

--- a/scripts/mlx_preflight.sh
+++ b/scripts/mlx_preflight.sh
@@ -1,72 +1,115 @@
 #!/usr/bin/env bash
-# Verify the linked MLX stack is the pinned, nax-capable pair before benching.
+# Verify the linked MLX stack is sane before benching, and — on hardware that
+# has a Neural Accelerator — that it is actually nax-capable.
 #
-# The homebrew-core `arm64_tahoe` bottle of mlx 0.32.0 ships ZERO
-# `steel_gemm_fused_nax` GEMM kernels where 0.31.2 ships 145 distinct
-# (288 `grep -c` occurrences), costing ~3.8x on GEMM-bound prefill. Decode is
-# largely unaffected, so the failure is silent: benches still run and still look
-# plausible, they are just measuring a different engine. A `brew cleanup` also
-# removes the pinned kegs outright (`brew pin` does not protect against it),
-# leaving `rmlx` unable to launch at all.
+# Two separate concerns, deliberately not conflated:
 #
-# Run this before any measurement. Exits non-zero and says what to do on failure.
-# See docs in .rmlx/mlx-homebrew-nax-regression.md.
+#   1. Portable checks (every Apple Silicon host): the `opt` symlinks resolve,
+#      Mach-O install names are relocated, and the built binary can launch.
+#      A broken stack here means `rmlx` does not run at all.
+#
+#   2. NA-class hosts only (M5 and later): `mlx.metallib` must actually contain
+#      `steel_gemm_fused_nax` GEMM kernels. The homebrew-core `arm64_tahoe`
+#      bottle of mlx 0.32.0 ships ZERO of them where 0.31.2 ships 145, costing
+#      ~2-3.8x on GEMM-bound prefill. Decode is largely unaffected, so the
+#      failure is silent: benches still run and still look plausible.
+#
+# On M1-M4 the nax check is skipped, not failed — those bottles legitimately
+# contain no nax kernels because the hardware has no Neural Accelerator. Nothing
+# here pins a version on those hosts.
+#
+# Run before any measurement. Exits non-zero and names the fix on failure.
+# Background: .rmlx/mlx-homebrew-nax-regression.md
 
 set -uo pipefail
 
 PREFIX="${HOMEBREW_PREFIX:-/opt/homebrew}"
-WANT_MLX="0.31.2"
-WANT_MLXC="0.6.0_2"
-# `grep -c` occurrences of the nax GEMM symbol in a good arm64_tahoe metallib.
-MIN_NAX=1
+# Known-good nax-capable pair for NA-class hosts (see the report).
+GOOD_MLX="0.31.2"
+GOOD_MLXC="0.6.0_2"
 
 fail() {
 	echo "PREFLIGHT FAIL: $*" >&2
-	echo "" >&2
-	echo "  Restore the pinned pair:  bash scripts/mlx_restore_pin.sh" >&2
-	exit 1
+	return 1
 }
 
-# 1. The opt symlinks must resolve — this is what rmlx links against.
+hint_restore() {
+	echo "" >&2
+	echo "  Restore the nax-capable pair:  make mlx-restore-pin" >&2
+}
+
+# --- host class -------------------------------------------------------------
+# The Neural Accelerator arrives with M5. Anything earlier legitimately has no
+# nax kernels, so requiring them there would be a false failure.
+brand=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "unknown")
+na_class=0
+if [[ "$brand" =~ Apple\ M([0-9]+) ]]; then
+	[ "${BASH_REMATCH[1]}" -ge 5 ] && na_class=1
+fi
+
+# --- 1. portable: symlinks resolve -----------------------------------------
 for keg in mlx mlx-c; do
 	link="$PREFIX/opt/$keg"
-	[ -e "$link" ] || fail "$link does not resolve (keg unlinked or removed)"
-done
-
-mlx_target=$(readlink "$PREFIX/opt/mlx")
-mlxc_target=$(readlink "$PREFIX/opt/mlx-c")
-mlx_ver=$(basename "$mlx_target")
-mlxc_ver=$(basename "$mlxc_target")
-
-# 2. Versions must be the ABI-coupled pair. mlx-c 0.6.0_3 needs symbols mlx
-#    0.31.2 does not export, so a mismatched pair aborts at dlopen time.
-[ "$mlx_ver" = "$WANT_MLX" ] ||
-	fail "mlx is $mlx_ver, want $WANT_MLX (0.32.0 ships no nax kernels)"
-[ "$mlxc_ver" = "$WANT_MLXC" ] ||
-	fail "mlx-c is $mlxc_ver, want $WANT_MLXC (ABI-coupled to mlx $WANT_MLX)"
-
-# 3. The metallib must actually contain nax GEMM kernels. A correct version
-#    number is not proof: the bottle is what ships the kernels.
-metallib="$PREFIX/opt/mlx/lib/mlx.metallib"
-[ -f "$metallib" ] || fail "$metallib missing"
-nax=$(strings "$metallib" | grep -c steel_gemm_fused_nax)
-[ "$nax" -ge "$MIN_NAX" ] ||
-	fail "mlx.metallib contains $nax nax GEMM kernels (want >= $MIN_NAX) — prefill would be ~3.8x slow"
-
-# 4. Install names must be relocated. A hand-poured bottle keeps Homebrew's
-#    @@HOMEBREW_PREFIX@@ placeholders, which dyld cannot resolve.
-for lib in "$PREFIX/opt/mlx/lib/libmlx.dylib" "$PREFIX/opt/mlx-c/lib/libmlxc.dylib"; do
-	[ -f "$lib" ] || fail "$lib missing"
-	if otool -L "$lib" 2>/dev/null | grep -q '@@HOMEBREW_PREFIX@@'; then
-		fail "$lib still carries @@HOMEBREW_PREFIX@@ placeholders (unrelocated pour)"
+	if [ ! -e "$link" ]; then
+		fail "$link does not resolve (keg unlinked or removed)"
+		hint_restore
+		exit 1
 	fi
 done
 
-# 5. The built binary, if present, must actually load the stack.
-bin="target/release-perf/rmlx"
-if [ -x "$bin" ]; then
-	"$bin" --version >/dev/null 2>&1 ||
-		fail "$bin cannot launch against the linked MLX (dyld failure?)"
+mlx_ver=$(basename "$(readlink "$PREFIX/opt/mlx")")
+mlxc_ver=$(basename "$(readlink "$PREFIX/opt/mlx-c")")
+
+# --- 2. portable: install names relocated ----------------------------------
+# A hand-poured bottle keeps Homebrew's @@HOMEBREW_PREFIX@@ placeholders, which
+# dyld cannot resolve.
+for lib in "$PREFIX/opt/mlx/lib/libmlx.dylib" "$PREFIX/opt/mlx-c/lib/libmlxc.dylib"; do
+	if [ ! -f "$lib" ]; then
+		fail "$lib missing"
+		hint_restore
+		exit 1
+	fi
+	if otool -L "$lib" 2>/dev/null | grep -q '@@HOMEBREW_PREFIX@@'; then
+		fail "$lib still carries @@HOMEBREW_PREFIX@@ placeholders (unrelocated pour)"
+		hint_restore
+		exit 1
+	fi
+done
+
+# --- 3. NA-class only: nax kernels must be present --------------------------
+metallib="$PREFIX/opt/mlx/lib/mlx.metallib"
+nax="n/a"
+if [ "$na_class" = "1" ]; then
+	if [ ! -f "$metallib" ]; then
+		fail "$metallib missing"
+		hint_restore
+		exit 1
+	fi
+	nax=$(strings "$metallib" | grep -c steel_gemm_fused_nax)
+	if [ "$nax" -lt 1 ]; then
+		fail "$brand has a Neural Accelerator but mlx $mlx_ver ships 0 nax GEMM kernels" \
+			"— GEMM-bound prefill would be ~2-3.8x slow (known good: mlx $GOOD_MLX + mlx-c $GOOD_MLXC)"
+		hint_restore
+		exit 1
+	fi
 fi
 
-echo "preflight ok: mlx $mlx_ver + mlx-c $mlxc_ver, $nax nax GEMM kernels"
+# --- 4. portable: the binary actually launches ------------------------------
+bin="target/release-perf/rmlx"
+if [ -x "$bin" ]; then
+	if ! "$bin" --version >/dev/null 2>&1; then
+		fail "$bin cannot launch against the linked MLX (dyld failure? ABI mismatch?)"
+		hint_restore
+		exit 1
+	fi
+fi
+
+if [ "$na_class" = "1" ]; then
+	echo "preflight ok: $brand (NA-class), mlx $mlx_ver + mlx-c $mlxc_ver, $nax nax GEMM kernel occurrences"
+	if [ "$mlx_ver" != "$GOOD_MLX" ] || [ "$mlxc_ver" != "$GOOD_MLXC" ]; then
+		echo "  note: not the recorded known-good pair (mlx $GOOD_MLX + mlx-c $GOOD_MLXC);" \
+			"nax kernels are present, so this is informational only."
+	fi
+else
+	echo "preflight ok: $brand (no Neural Accelerator), mlx $mlx_ver + mlx-c $mlxc_ver, nax check skipped"
+fi

--- a/scripts/mlx_preflight.sh
+++ b/scripts/mlx_preflight.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Verify the linked MLX stack is the pinned, nax-capable pair before benching.
+#
+# The homebrew-core `arm64_tahoe` bottle of mlx 0.32.0 ships ZERO
+# `steel_gemm_fused_nax` GEMM kernels where 0.31.2 ships 145 distinct
+# (288 `grep -c` occurrences), costing ~3.8x on GEMM-bound prefill. Decode is
+# largely unaffected, so the failure is silent: benches still run and still look
+# plausible, they are just measuring a different engine. A `brew cleanup` also
+# removes the pinned kegs outright (`brew pin` does not protect against it),
+# leaving `rmlx` unable to launch at all.
+#
+# Run this before any measurement. Exits non-zero and says what to do on failure.
+# See docs in .rmlx/mlx-homebrew-nax-regression.md.
+
+set -uo pipefail
+
+PREFIX="${HOMEBREW_PREFIX:-/opt/homebrew}"
+WANT_MLX="0.31.2"
+WANT_MLXC="0.6.0_2"
+# `grep -c` occurrences of the nax GEMM symbol in a good arm64_tahoe metallib.
+MIN_NAX=1
+
+fail() {
+	echo "PREFLIGHT FAIL: $*" >&2
+	echo "" >&2
+	echo "  Restore the pinned pair:  bash scripts/mlx_restore_pin.sh" >&2
+	exit 1
+}
+
+# 1. The opt symlinks must resolve — this is what rmlx links against.
+for keg in mlx mlx-c; do
+	link="$PREFIX/opt/$keg"
+	[ -e "$link" ] || fail "$link does not resolve (keg unlinked or removed)"
+done
+
+mlx_target=$(readlink "$PREFIX/opt/mlx")
+mlxc_target=$(readlink "$PREFIX/opt/mlx-c")
+mlx_ver=$(basename "$mlx_target")
+mlxc_ver=$(basename "$mlxc_target")
+
+# 2. Versions must be the ABI-coupled pair. mlx-c 0.6.0_3 needs symbols mlx
+#    0.31.2 does not export, so a mismatched pair aborts at dlopen time.
+[ "$mlx_ver" = "$WANT_MLX" ] ||
+	fail "mlx is $mlx_ver, want $WANT_MLX (0.32.0 ships no nax kernels)"
+[ "$mlxc_ver" = "$WANT_MLXC" ] ||
+	fail "mlx-c is $mlxc_ver, want $WANT_MLXC (ABI-coupled to mlx $WANT_MLX)"
+
+# 3. The metallib must actually contain nax GEMM kernels. A correct version
+#    number is not proof: the bottle is what ships the kernels.
+metallib="$PREFIX/opt/mlx/lib/mlx.metallib"
+[ -f "$metallib" ] || fail "$metallib missing"
+nax=$(strings "$metallib" | grep -c steel_gemm_fused_nax)
+[ "$nax" -ge "$MIN_NAX" ] ||
+	fail "mlx.metallib contains $nax nax GEMM kernels (want >= $MIN_NAX) — prefill would be ~3.8x slow"
+
+# 4. Install names must be relocated. A hand-poured bottle keeps Homebrew's
+#    @@HOMEBREW_PREFIX@@ placeholders, which dyld cannot resolve.
+for lib in "$PREFIX/opt/mlx/lib/libmlx.dylib" "$PREFIX/opt/mlx-c/lib/libmlxc.dylib"; do
+	[ -f "$lib" ] || fail "$lib missing"
+	if otool -L "$lib" 2>/dev/null | grep -q '@@HOMEBREW_PREFIX@@'; then
+		fail "$lib still carries @@HOMEBREW_PREFIX@@ placeholders (unrelocated pour)"
+	fi
+done
+
+# 5. The built binary, if present, must actually load the stack.
+bin="target/release-perf/rmlx"
+if [ -x "$bin" ]; then
+	"$bin" --version >/dev/null 2>&1 ||
+		fail "$bin cannot launch against the linked MLX (dyld failure?)"
+fi
+
+echo "preflight ok: mlx $mlx_ver + mlx-c $mlxc_ver, $nax nax GEMM kernels"

--- a/scripts/mlx_restore_pin.sh
+++ b/scripts/mlx_restore_pin.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Restore the pinned, nax-capable MLX pair (mlx 0.31.2 + mlx-c 0.6.0_2).
+#
+# Needed because `brew pin` does NOT protect a keg from `brew cleanup`: the
+# pinned versions can disappear entirely, leaving only the nax-less 0.32.0
+# bottle (unlinked), at which point `rmlx` cannot launch at all.
+#
+# Sources the bottles from ~/.rmlx/bottles first (durable local copy), falling
+# back to ghcr. Pours alongside whatever else is in the Cellar, repoints the
+# `opt` symlinks, relocates install names, and re-signs.
+#
+# Verify afterwards with scripts/mlx_preflight.sh.
+# Background: .rmlx/mlx-homebrew-nax-regression.md
+
+set -uo pipefail
+
+PREFIX="${HOMEBREW_PREFIX:-/opt/homebrew}"
+CELLAR="$PREFIX/Cellar"
+STORE="${RMLX_BOTTLE_STORE:-$HOME/.rmlx/bottles}"
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+MLX_VER="0.31.2"
+MLXC_VER="0.6.0_2"
+# sha256 from the homebrew-core *bottle-update* commits (cbfd9632d44 / b2763d78a34).
+# NOTE: the version-bump commit still carries the PREVIOUS release's hashes —
+# taking the sha from there silently yields mlx 0.31.1.
+MLX_SHA="def8a7ae1e6a6506eed4dea45bf52b55be0f52f8364f8a928da6e65b1204a371"
+MLXC_SHA="b30c755158db3f9d9090b69a1a74f3e05ae8e7a3969695d9f0974f1bc1d3df1b"
+
+die() {
+	echo "restore FAIL: $*" >&2
+	exit 1
+}
+
+obtain() { # name version sha -> stages <name>.tar.gz
+	local name=$1 ver=$2 sha=$3
+	local out="$STAGE/$name.tar.gz"
+	local local_copy="$STORE/$name--$ver.arm64_tahoe.bottle.tar.gz"
+
+	if [ -f "$local_copy" ]; then
+		echo "[local] $name $ver from $STORE"
+		cp "$local_copy" "$out"
+	else
+		echo "[fetch] $name $ver from ghcr"
+		curl -sSL -H "Authorization: Bearer QQ==" \
+			"https://ghcr.io/v2/homebrew/core/$name/blobs/sha256:$sha" -o "$out" ||
+			die "download failed for $name"
+	fi
+
+	local got
+	got=$(shasum -a 256 "$out" | awk '{print $1}')
+	[ "$got" = "$sha" ] || die "$name sha mismatch: got $got want $sha"
+	echo "[ok] $name sha verified"
+}
+
+obtain mlx "$MLX_VER" "$MLX_SHA"
+obtain mlx-c "$MLXC_VER" "$MLXC_SHA"
+
+tar -xzf "$STAGE/mlx.tar.gz" -C "$STAGE" || die "extract mlx"
+tar -xzf "$STAGE/mlx-c.tar.gz" -C "$STAGE" || die "extract mlx-c"
+
+# The version directory inside the tarball is the ground truth — a correct
+# checksum does not prove it is the version you asked for.
+[ -d "$STAGE/mlx/$MLX_VER" ] || die "bottle is not mlx $MLX_VER (got: $(ls "$STAGE/mlx"))"
+[ -d "$STAGE/mlx-c/$MLXC_VER" ] || die "bottle is not mlx-c $MLXC_VER (got: $(ls "$STAGE/mlx-c"))"
+
+staged_nax=$(strings "$STAGE/mlx/$MLX_VER/lib/mlx.metallib" | grep -c steel_gemm_fused_nax)
+[ "$staged_nax" -ge 1 ] || die "staged mlx $MLX_VER has $staged_nax nax kernels — wrong bottle"
+echo "[ok] staged mlx has $staged_nax nax GEMM kernel occurrences"
+
+echo "[install] pouring into Cellar (other versions left intact)"
+rm -rf "${CELLAR:?}/mlx/$MLX_VER" "${CELLAR:?}/mlx-c/$MLXC_VER"
+mkdir -p "$CELLAR/mlx" "$CELLAR/mlx-c"
+cp -R "$STAGE/mlx/$MLX_VER" "$CELLAR/mlx/$MLX_VER" || die "install mlx"
+cp -R "$STAGE/mlx-c/$MLXC_VER" "$CELLAR/mlx-c/$MLXC_VER" || die "install mlx-c"
+
+echo "[link] repointing opt symlinks"
+ln -sfn "$CELLAR/mlx/$MLX_VER" "$PREFIX/opt/mlx"
+ln -sfn "$CELLAR/mlx-c/$MLXC_VER" "$PREFIX/opt/mlx-c"
+
+# Homebrew rewrites @@HOMEBREW_PREFIX@@ at install time; a hand-poured bottle
+# keeps the placeholders and dyld cannot resolve them.
+echo "[relocate] rewriting install names"
+for lib in "$CELLAR/mlx/$MLX_VER/lib/libmlx.dylib" \
+	"$CELLAR/mlx/$MLX_VER/lib/libjaccl.dylib" \
+	"$CELLAR/mlx-c/$MLXC_VER/lib/libmlxc.dylib"; do
+	[ -f "$lib" ] || continue
+	old_id=$(otool -D "$lib" | tail -1)
+	install_name_tool -id "${old_id//@@HOMEBREW_PREFIX@@/$PREFIX}" "$lib" 2>/dev/null
+	otool -L "$lib" | tail -n +2 | awk '{print $1}' | grep '@@HOMEBREW_PREFIX@@' |
+		while read -r dep; do
+			install_name_tool -change "$dep" "${dep//@@HOMEBREW_PREFIX@@/$PREFIX}" "$lib" 2>/dev/null
+		done
+	# install_name_tool invalidates the signature on arm64.
+	codesign --force --sign - --preserve-metadata=entitlements,flags "$lib" 2>/dev/null
+done
+
+for script in "$CELLAR/mlx/$MLX_VER"/bin/*; do
+	[ -f "$script" ] && sed -i '' "s|@@HOMEBREW_PREFIX@@|$PREFIX|g" "$script" 2>/dev/null
+done
+
+echo "[cache] keeping a durable copy in $STORE"
+mkdir -p "$STORE"
+cp -n "$STAGE/mlx.tar.gz" "$STORE/mlx--$MLX_VER.arm64_tahoe.bottle.tar.gz" 2>/dev/null
+cp -n "$STAGE/mlx-c.tar.gz" "$STORE/mlx-c--$MLXC_VER.arm64_tahoe.bottle.tar.gz" 2>/dev/null
+
+echo "[done] rebuild rmlx so it links the restored pair:  touch crates/rmlx-mlx/build.rs && make build-perf"
+exec "$(dirname "$0")/mlx_preflight.sh"

--- a/scripts/target_gc.sh
+++ b/scripts/target_gc.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Reclaim space in ./target by pruning build profiles that have gone stale.
+#
+# There is no built-in cap on `target/` — the size cap in this project is
+# RMLX_LOG_CAP_MB, which governs <RMLX_HOME>/logs, not build artifacts. A
+# workspace this size with several profiles (dev, release, release-perf,
+# release-debug) plus a full `cargo test --workspace` accumulates hundreds of
+# GB, dominated by `target/debug`.
+#
+# Everything under target/ is regenerable; the only cost of pruning is rebuild
+# time. This script therefore prunes by *staleness*, and by default protects the
+# profile holding the current bench binary.
+#
+# Usage:
+#   bash scripts/target_gc.sh                # report only, no deletion
+#   bash scripts/target_gc.sh --apply        # prune profiles older than MAX_AGE_DAYS
+#   bash scripts/target_gc.sh --apply --all  # also prune release-perf
+#
+# Env:
+#   MAX_AGE_DAYS  profile is stale if untouched this long (default 7)
+
+set -uo pipefail
+
+MAX_AGE_DAYS="${MAX_AGE_DAYS:-7}"
+APPLY=0
+ALL=0
+for arg in "$@"; do
+	case "$arg" in
+	--apply) APPLY=1 ;;
+	--all) ALL=1 ;;
+	*)
+		echo "unknown argument: $arg" >&2
+		exit 2
+		;;
+	esac
+done
+
+cd "$(dirname "$0")/.." || exit 1
+[ -d target ] || {
+	echo "no target/ directory — nothing to do"
+	exit 0
+}
+
+# release-perf holds the binary used for benching and the perf canary; losing it
+# mid-investigation costs a full rebuild before the next measurement.
+protected="release-perf"
+[ "$ALL" = "1" ] && protected=""
+
+total_before=$(du -sk target 2>/dev/null | awk '{print $1}')
+reclaimed=0
+
+for dir in target/*/; do
+	profile=$(basename "$dir")
+	case "$profile" in
+	doc | criterion | package | CACHEDIR.TAG) continue ;;
+	esac
+
+	size_k=$(du -sk "$dir" 2>/dev/null | awk '{print $1}')
+	size_h=$(du -sh "$dir" 2>/dev/null | awk '{print $1}')
+	# Age of the most recently touched artifact in the profile.
+	newest=$(find "$dir" -type f -newermt "-${MAX_AGE_DAYS} days" -print -quit 2>/dev/null)
+
+	if [ "$profile" = "$protected" ]; then
+		echo "keep    $profile ($size_h) — protected (bench binary; use --all to override)"
+		continue
+	fi
+	if [ -n "$newest" ]; then
+		echo "keep    $profile ($size_h) — touched within ${MAX_AGE_DAYS}d"
+		continue
+	fi
+
+	if [ "$APPLY" = "1" ]; then
+		echo "prune   $profile ($size_h) — stale >${MAX_AGE_DAYS}d"
+		rm -rf "${dir:?}"
+		reclaimed=$((reclaimed + size_k))
+	else
+		echo "would   $profile ($size_h) — stale >${MAX_AGE_DAYS}d"
+	fi
+done
+
+if [ "$APPLY" = "1" ]; then
+	total_after=$(du -sk target 2>/dev/null | awk '{print $1}')
+	echo ""
+	echo "target: $((total_before / 1024 / 1024))G -> $((total_after / 1024 / 1024))G (reclaimed $((reclaimed / 1024 / 1024))G)"
+else
+	echo ""
+	echo "report only — re-run with --apply to prune. Current target: $((total_before / 1024 / 1024))G"
+fi


### PR DESCRIPTION
Dev-environment harness for the KV/MSL kernel program (#304). Shell, Make, and docs only — no engine code.

Prompted by a hard failure: `rmlx` stopped launching entirely because the pinned nax-capable MLX pair had been **removed by a `brew cleanup`** (`brew pin` blocks `upgrade`, not removal), leaving only the nax-less mlx 0.32.0, unlinked.

## What's here

| tool | purpose |
|---|---|
| `scripts/mlx_preflight.sh` / `make mlx-preflight` | Gate before measuring: `opt/*` symlinks resolve, install names relocated, binary launches — and on M5+ only, that `mlx.metallib` actually contains NAX kernels. |
| `scripts/mlx_restore_pin.sh` / `make mlx-restore-pin` | One-command restore of mlx 0.31.2 + mlx-c 0.6.0_2: durable local bottle store with ghcr fallback, verifies sha256 **and contents**, pours, relinks, relocates, re-signs. |
| `scripts/gpu_capture.sh` / `make profile-gputrace` | Capture a Metal GPU trace over a bounded **steady-state decode** window for replay in Xcode. |
| `scripts/target_gc.sh` / `make target-gc` | Prune stale `target/` profiles by age; protects `release-perf` (holds the bench binary). |
| `scripts/check_metal_compiles.sh` | Fixed skip detection (see below). |
| `README.md`, `docs/PROFILING.md` | Contributor tooling prerequisites; §5 rewritten to describe what exists. |

`make canary` and `make bench-codec-cell` now depend on `mlx-preflight`, so a degraded toolchain fails the run instead of silently producing numbers from a different engine.

## Host-class correctness (important)

The first version of the preflight hard-coded the M5-only pin and **would have failed on every M1–M4 machine**, where bottles legitimately ship zero NAX kernels because the hardware has no Neural Accelerator. It now detects host class from `machdep.cpu.brand_string`:

- **M5+** — NAX kernels required; absence is the silent ~2–3.8× prefill loss.
- **M1–M4** — NAX check skipped, exits 0, no version pinned.

Verified both paths: real M5 host passes with 288 occurrences; a simulated `Apple M2 Pro` reports `nax check skipped`. Users are predominantly M1–M4, so this is the majority case, not an edge case (#305).

## Metal compile gate fix

Selecting full Xcode makes `xcrun -f metal` resolve a path even when the separately-downloaded Metal Toolchain component is absent, so the gate stopped skipping and instead reported **every kernel as a compile failure**. The probe now *executes* the compiler and distinguishes the missing-component case, naming `xcodebuild -downloadComponent MetalToolchain` in both the skip and `--strict` messages.

With the component installed, the gate runs for real locally for the first time: **55 KV `.metal` kernels compile clean**.

## Verification

- `make mlx-preflight` → `preflight ok: Apple M5 Max (NA-class), mlx 0.31.2 + mlx-c 0.6.0_2, 288 nax GEMM kernel occurrences`
- Preflight mutation-checked: `opt/mlx` → 0.32.0 exits 1; removing `opt/mlx-c` exits 1; restored stack passes.
- Metal gate: skip path exits 0 with the download instruction, `--strict` exits 1, and with the toolchain present all 55 kernels compile.
- All shell scripts `shellcheck -S warning` clean.
- `target/` 261 GB → 41 GB via `target-gc`'s approach, bench binary intact and running.

## Known gap (deliberate)

`gpu_capture.sh` passes `RMLX_METAL_CAPTURE_PATH`, which **nothing in the engine reads yet** — `CaptureScope` still has no caller. The script runs the generation and then honestly reports that no trace was written rather than appearing to succeed. That hook, and the flag-vs-env decision, are tracked in **#307**.

Background: `.rmlx/mlx-homebrew-nax-regression.md`. Related: #304 (epic), #305 (user-facing NAX exposure), #307 (capture hook), #308 (`target/` cap), #309 (NAX attention finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
