### PR TITLE
chore(dev): advisory target/ size hint at end of make ci (#308)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,11 @@ Hard rules:
   scoped to that one `#[test]`, not the whole file. See `docs/TESTING.md`.
 - **Advisory: `make file-size-report`** prints files >1000 LOC. Non-failing.
   Also runs at the end of `make ci` (advisory, non-blocking).
+- **Advisory: `make target-size-report`** prints `target/` size and, past a
+  50 GB threshold, a hint to run `make target-gc` (the staleness-based
+  pruner, see `scripts/target_gc.sh`). `target/` has no size cap; this just
+  makes growth visible. Non-failing. Also runs at the end of `make ci`
+  (advisory, non-blocking).
 
 ## Comments and identifiers (hard rule)
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         build-perf build-debug test-perf ci-perf model-check model-check-full \
         profile-samply profile-samply-debug profile-instruments bench asm perf-iter \
         canary canary-gate \
-        mlx-preflight mlx-restore-pin target-gc profile-gputrace \
+        mlx-preflight mlx-restore-pin target-gc target-size-report profile-gputrace \
         ssd-canary ssd-canary-gate \
         bench-codec-cell \
         smoke-codec-matrix \
@@ -78,6 +78,9 @@ mlx-preflight:   ## verify the linked MLX stack (and nax kernels on M5+) before 
 
 target-gc:       ## report stale target/ profiles (APPLY=1 to prune; target/ has no size cap)
 	bash scripts/target_gc.sh $(if $(APPLY),--apply,) $(if $(ALL),--all,)
+
+target-size-report: ## advisory: print target/ size + hint when over threshold (non-failing; also runs at the end of `make ci`)
+	@bash scripts/target_size_report.sh
 
 profile-gputrace: ## capture a decode-window Metal GPU trace for Xcode (CODEC= MODEL= required)
 	@if [ -z "$(CODEC)" ] || [ -z "$(MODEL)" ]; then \
@@ -211,6 +214,7 @@ ci: fmt-check lint test deny audit ci-metrics ## full pre-merge gate: fmt + clip
 	@bash scripts/check_metal_format.sh
 	@bash scripts/check_metal_compiles.sh
 	@bash scripts/file_size_report.sh || true
+	@bash scripts/target_size_report.sh || true
 	@echo "ci ok"
 
 # tag: derive v<version> from the single source of truth

--- a/scripts/target_size_report.sh
+++ b/scripts/target_size_report.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/target_size_report.sh — advisory target/ size report for CI.
+#
+# `target/` has no size cap (see scripts/target_gc.sh) and a workspace this
+# size with several profiles in regular use (dev, release, release-perf,
+# release-debug) plus repeated `cargo test --workspace` runs can grow into the
+# hundreds of GB. This prints the current size and, past a threshold, a hint
+# pointing at `make target-gc`. Non-failing — advisory only, mirrors
+# file_size_report.sh.
+#
+# Usage:
+#   bash scripts/target_size_report.sh              # threshold=50 (GB)
+#   bash scripts/target_size_report.sh 100           # custom threshold
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+threshold_gb=${1:-50}
+target_dir="${REPO_ROOT}/target"
+
+if [ ! -d "$target_dir" ]; then
+	echo "target/ absent — nothing to report"
+	exit 0
+fi
+
+size_kb=$(du -sk "$target_dir" 2>/dev/null | awk '{print $1}')
+size_kb=${size_kb:-0}
+size_h=$(du -sh "$target_dir" 2>/dev/null | awk '{print $1}')
+size_gb=$((size_kb / 1024 / 1024))
+
+echo "target/: ${size_h:-unknown}"
+
+if [ "$size_gb" -ge "$threshold_gb" ]; then
+	echo "target/ is ${size_gb}G (>= ${threshold_gb}G advisory threshold) — run 'make target-gc' to see what's stale, 'make target-gc APPLY=1' to prune"
+fi
+
+exit 0


### PR DESCRIPTION
Closes the remaining open item from #308.

`scripts/target_gc.sh` and `make target-gc` landed earlier; what was still missing was any visibility into `target/` growth. `target/` has no size cap (the project's only size cap is `RMLX_LOG_CAP_MB`, which governs `<RMLX_HOME>/logs`), so it silently grew to 278 GB before anyone noticed.

`make ci` now ends with an advisory line printing `target/` size, plus a hint to run `make target-gc` past a 50 GB threshold. Mirrors the existing `file-size-report` advisory exactly: non-failing, guarded by `|| true` in the recipe, and the script itself has no `set -e` and returns `exit 0` on every path.

### Evidence

Both states verified against the real working tree (51 GB) and against a small tree:

- **Fires** — `bash scripts/target_size_report.sh` on the 51 GB tree prints the size line *and* the hint, `rc=0`.
- **Stays silent** — same script against a 5 MB `target/` prints only the size line, no hint, `rc=0`.
- **Cannot fail the gate** — the script has no path that returns non-zero, and the `|| true` guard in the recipe was separately shown to absorb a hard-failing command.
- **`make ci` green** on this branch (exit 0), with the new step wired in.

### Threshold

50 GB, passed as a positional argument (matching `file_size_report.sh 1000`), not an environment variable — per the project's rule against invisible config.
