### PR TITLE
fix(cli): baseline tokenizes chat-JSON fixture content, not the raw envelope (#291)

### DIFF
--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -181,23 +181,61 @@ pub(crate) fn compute_phase_timing(
 
 /// One message in a chat-JSON prompt fixture (`prompts/longctx_<N>k.json`):
 /// `{"messages": [{"role": "...", "content": "..."}, ...], ...}`.
-#[derive(serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct ChatFixtureMessage {
     role: String,
     content: String,
 }
 
-/// Parse `prompt_text` as a chat-JSON fixture. Returns `None` when the text
-/// is not valid JSON, has no `messages` array, or the array is empty -- the
-/// caller then falls back to tokenizing `prompt_text` verbatim as raw text
-/// (the plain-`.txt` fixture path).
-fn parse_chat_fixture(prompt_text: &str) -> Option<Vec<ChatFixtureMessage>> {
-    #[derive(serde::Deserialize)]
-    struct ChatFixture {
-        messages: Vec<ChatFixtureMessage>,
+/// `true` when `value` is a JSON object carrying a non-empty `messages`
+/// array -- the single "is this a chat-JSON fixture" predicate shared by
+/// `parse_chat_fixture` (tokenization, below) and the CLI's `--prompt-tokens`
+/// record-body embedding (`main.rs`), so the two call sites cannot disagree
+/// on edge cases such as `messages: []`.
+pub(crate) fn is_chat_fixture(value: &serde_json::Value) -> bool {
+    value
+        .get("messages")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|arr| !arr.is_empty())
+}
+
+/// Parse `prompt_text` as a chat-JSON fixture.
+///
+/// Returns `Ok(None)` when `prompt_text` is not a chat-JSON fixture at all --
+/// not valid JSON, not a JSON object, no `messages` key, `messages` is not an
+/// array, or the array is empty (per [`is_chat_fixture`]) -- the caller then
+/// falls back to tokenizing `prompt_text` verbatim as raw text (the
+/// plain-`.txt` fixture path).
+///
+/// Returns `Err` when `prompt_text` unambiguously IS a chat-JSON fixture (a
+/// non-empty `messages` array) but one or more elements do not deserialize
+/// into the `{"role": "<string>", "content": "<string>"}` shape this baseline
+/// harness supports -- e.g. an OpenAI parts-array `content`, `content:
+/// null`, or a message missing `role`. Silently falling back to
+/// raw-envelope tokenization in that case would record a wrong measurement
+/// with no error, so this matches the existing loud-failure convention for a
+/// missing `chat_template.jinja`.
+fn parse_chat_fixture(prompt_text: &str) -> anyhow::Result<Option<Vec<ChatFixtureMessage>>> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(prompt_text) else {
+        return Ok(None);
+    };
+    if !is_chat_fixture(&value) {
+        return Ok(None);
     }
-    let fixture: ChatFixture = serde_json::from_str(prompt_text).ok()?;
-    (!fixture.messages.is_empty()).then_some(fixture.messages)
+    // `is_chat_fixture` already proved `messages` is present and a non-empty
+    // array; `.get()` (not indexing) keeps this panic-free regardless.
+    let Some(messages) = value.get("messages") else {
+        return Ok(None);
+    };
+    serde_json::from_value(messages.clone())
+        .map(Some)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "prompt is a chat-JSON fixture (non-empty \"messages\" array) but its elements \
+                 do not match the expected {{\"role\": \"<string>\", \"content\": \"<string>\"}} \
+                 shape: {e}"
+            )
+        })
 }
 
 /// Render `messages` through `<model_path>/chat_template.jinja` and tokenize
@@ -243,8 +281,14 @@ fn tokenize_chat_fixture(
         .render(&tpl_messages, &opts)
         .map_err(|e| anyhow::anyhow!("render chat_template.jinja: {e}"))?;
 
-    rmlx_server::tokenizer_io::encode(tokenizer, &rendered.text)
-        .map_err(|e| anyhow::anyhow!("tokenize rendered chat prompt: {e}"))
+    let ids = rmlx_server::tokenizer_io::encode(tokenizer, &rendered.text)
+        .map_err(|e| anyhow::anyhow!("tokenize rendered chat prompt: {e}"))?;
+    if ids.is_empty() {
+        return Err(anyhow::anyhow!(
+            "chat-JSON fixture rendered through chat_template.jinja encoded to zero tokens"
+        ));
+    }
+    Ok(ids)
 }
 
 /// Record a performance baseline for the given model snapshot.
@@ -311,8 +355,10 @@ pub(crate) fn run_baseline(
     // are counted -- matching the HTTP chat-completions path. Anything else
     // (e.g. the default plain-text fixture) is tokenized as raw text with
     // add_special_tokens=true so BOS is prepended naturally.
-    let mut prompt_ids: Vec<u32> = if let Some(messages) = parse_chat_fixture(&prompt_text) {
-        tokenize_chat_fixture(model_path, &tokenizer, &messages)?
+    let chat_fixture_messages = parse_chat_fixture(&prompt_text)?;
+    let template_used = chat_fixture_messages.is_some();
+    let mut prompt_ids: Vec<u32> = if let Some(messages) = &chat_fixture_messages {
+        tokenize_chat_fixture(model_path, &tokenizer, messages)?
     } else {
         let encoding = tokenizer
             .encode(prompt_text.as_str(), true)
@@ -338,6 +384,7 @@ pub(crate) fn run_baseline(
         device = device_str,
         prompt_tokens = prompt_token_count,
         max_tokens,
+        template_used,
         "baseline: starting"
     );
 

--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -179,6 +179,74 @@ pub(crate) fn compute_phase_timing(
     }
 }
 
+/// One message in a chat-JSON prompt fixture (`prompts/longctx_<N>k.json`):
+/// `{"messages": [{"role": "...", "content": "..."}, ...], ...}`.
+#[derive(serde::Deserialize)]
+struct ChatFixtureMessage {
+    role: String,
+    content: String,
+}
+
+/// Parse `prompt_text` as a chat-JSON fixture. Returns `None` when the text
+/// is not valid JSON, has no `messages` array, or the array is empty -- the
+/// caller then falls back to tokenizing `prompt_text` verbatim as raw text
+/// (the plain-`.txt` fixture path).
+fn parse_chat_fixture(prompt_text: &str) -> Option<Vec<ChatFixtureMessage>> {
+    #[derive(serde::Deserialize)]
+    struct ChatFixture {
+        messages: Vec<ChatFixtureMessage>,
+    }
+    let fixture: ChatFixture = serde_json::from_str(prompt_text).ok()?;
+    (!fixture.messages.is_empty()).then_some(fixture.messages)
+}
+
+/// Render `messages` through `<model_path>/chat_template.jinja` and tokenize
+/// the result -- the same render-then-tokenize path the HTTP
+/// chat-completions route uses (`crates/rmlx-server/src/openai/chat.rs`), so
+/// `--prompt-tokens N` measures N *content* tokens rather than a chat-JSON
+/// fixture's raw envelope + syntax tokens.
+fn tokenize_chat_fixture(
+    model_path: &Path,
+    tokenizer: &tokenizers::Tokenizer,
+    messages: &[ChatFixtureMessage],
+) -> anyhow::Result<Vec<u32>> {
+    let template_src =
+        rmlx_server::chat_template::load_template_source(model_path).map_err(|e| {
+            anyhow::anyhow!(
+                "prompt is a chat-JSON fixture but {} has no usable chat_template.jinja: {e}",
+                model_path.display()
+            )
+        })?;
+    let template = rmlx_server::chat_template::ChatTemplate::new(template_src)
+        .map_err(|e| anyhow::anyhow!("compile chat_template.jinja: {e}"))?;
+    let cfg = rmlx_server::tokenizer_io::load_tokenizer_config(model_path)
+        .map_err(|e| anyhow::anyhow!("load tokenizer_config.json: {e}"))?;
+    let bos_token = cfg.bos_token.unwrap_or_default();
+    let eos_token = cfg.eos_token.unwrap_or_default();
+
+    let tpl_messages: Vec<rmlx_server::chat_template::ChatMessageTpl<'_>> = messages
+        .iter()
+        .map(|m| rmlx_server::chat_template::ChatMessageTpl {
+            role: m.role.as_str(),
+            content: m.content.as_str(),
+            ..Default::default()
+        })
+        .collect();
+    let opts = rmlx_server::chat_template::RenderOpts {
+        bos_token: &bos_token,
+        eos_token: &eos_token,
+        add_generation_prompt: true,
+        tools: &[],
+        enable_thinking: None,
+    };
+    let rendered = template
+        .render(&tpl_messages, &opts)
+        .map_err(|e| anyhow::anyhow!("render chat_template.jinja: {e}"))?;
+
+    rmlx_server::tokenizer_io::encode(tokenizer, &rendered.text)
+        .map_err(|e| anyhow::anyhow!("tokenize rendered chat prompt: {e}"))
+}
+
 /// Record a performance baseline for the given model snapshot.
 ///
 /// Steps:
@@ -186,6 +254,10 @@ pub(crate) fn compute_phase_timing(
 ///    `max_prompt_tokens` (CLI-configurable; defaults to `MAX_PROMPT_TOKENS`)
 ///    via `resolve_prompt_truncation` -- truncates on `--device cpu` or an
 ///    explicit opt-in, errors loudly on `--device gpu` with the default cap.
+///    A chat-JSON fixture (`{"messages": [...], ...}`, e.g.
+///    `prompts/longctx_<N>k.json`) is rendered through the model's real
+///    `chat_template.jinja` first, so the token count reflects the message
+///    content rather than the fixture's JSON envelope + syntax.
 /// 2. `arch::load_model` -- capture `load_ms`.
 /// 3. `arch.generate_greedy` -- per-token `step_fn` callback captures wall-clock
 /// so prefill (TTFT) and steady-state decode are timed SEPARATELY.
@@ -234,12 +306,19 @@ pub(crate) fn run_baseline(
     let tokenizer = tokenizers::Tokenizer::from_file(&tk_path)
         .map_err(|e| anyhow::anyhow!("cannot load tokenizer.json: {e}"))?;
 
-    // Tokenize with add_special_tokens=true so BOS is prepended naturally.
-    let encoding = tokenizer
-        .encode(prompt_text.as_str(), true)
-        .map_err(|e| anyhow::anyhow!("tokenize prompt: {e}"))?;
-
-    let mut prompt_ids: Vec<u32> = encoding.get_ids().to_vec();
+    // A chat-JSON fixture (`{"messages": [...], ...}`) is rendered through the
+    // model's real chat_template.jinja and only the resulting content tokens
+    // are counted -- matching the HTTP chat-completions path. Anything else
+    // (e.g. the default plain-text fixture) is tokenized as raw text with
+    // add_special_tokens=true so BOS is prepended naturally.
+    let mut prompt_ids: Vec<u32> = if let Some(messages) = parse_chat_fixture(&prompt_text) {
+        tokenize_chat_fixture(model_path, &tokenizer, &messages)?
+    } else {
+        let encoding = tokenizer
+            .encode(prompt_text.as_str(), true)
+            .map_err(|e| anyhow::anyhow!("tokenize prompt: {e}"))?;
+        encoding.get_ids().to_vec()
+    };
 
     // Truncate to `max_prompt_tokens` when the cap allows it; on GPU with the
     // default (non-explicit) cap this is a hard error instead -- see

--- a/crates/rmlx-cli/src/commands/baseline_tests.rs
+++ b/crates/rmlx-cli/src/commands/baseline_tests.rs
@@ -384,7 +384,9 @@ fn write_chat_fixture_model(dir: &Path) {
 
 #[test]
 fn parse_chat_fixture_detects_messages_array() {
-    let messages = parse_chat_fixture(CHAT_FIXTURE_JSON).expect("chat fixture detected");
+    let messages = parse_chat_fixture(CHAT_FIXTURE_JSON)
+        .expect("well-formed fixture must not error")
+        .expect("chat fixture detected");
     assert_eq!(messages.len(), 2);
     assert_eq!(messages[0].role, "system");
     assert_eq!(messages[1].content, "User message here");
@@ -392,19 +394,69 @@ fn parse_chat_fixture_detects_messages_array() {
 
 #[test]
 fn parse_chat_fixture_none_for_plain_text() {
-    assert!(parse_chat_fixture("Just plain prose, not JSON at all.").is_none());
+    assert!(parse_chat_fixture("Just plain prose, not JSON at all.")
+        .expect("not-JSON must not error")
+        .is_none());
 }
 
 #[test]
 fn parse_chat_fixture_none_for_json_without_messages() {
     // Mirrors prompts/calibration_default.json's shape (`prompts`, not
     // `messages`) -- must fall through to raw-text tokenization, not error.
-    assert!(parse_chat_fixture(r#"{"prompts": ["a", "b"]}"#).is_none());
+    assert!(parse_chat_fixture(r#"{"prompts": ["a", "b"]}"#)
+        .expect("no messages key must not error")
+        .is_none());
 }
 
 #[test]
 fn parse_chat_fixture_none_for_empty_messages_array() {
-    assert!(parse_chat_fixture(r#"{"messages": []}"#).is_none());
+    assert!(parse_chat_fixture(r#"{"messages": []}"#)
+        .expect("empty array must not error")
+        .is_none());
+}
+
+/// `messages` present but not an array (e.g. an object) is a detection
+/// failure, not an element-parse failure -- falls back to raw text, not `Err`.
+#[test]
+fn parse_chat_fixture_none_for_messages_not_array() {
+    assert!(parse_chat_fixture(r#"{"messages": "not an array"}"#)
+        .expect("non-array messages must not error")
+        .is_none());
+}
+
+// -- The silent-wrong-measurement class: shapes rMLX's own HTTP server
+// accepts (OpenAI parts-array content, null content, a message missing
+// `role`) that must hard-`Err`, never silently fall back to raw-envelope
+// tokenization. Regression coverage for finding 1. ------------------------
+
+/// `content` as an OpenAI parts array (`[{"type":"text","text":...}]`) is a
+/// message the server itself accepts but `ChatFixtureMessage::content` (a
+/// plain `String`) cannot deserialize -- must hard-error, not silently
+/// revert to raw-envelope tokenization.
+#[test]
+fn parse_chat_fixture_errors_on_content_parts_array() {
+    let json = r#"{"messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]}"#;
+    let err = parse_chat_fixture(json).expect_err("parts-array content must hard-error");
+    let msg = err.to_string();
+    assert!(msg.contains("role"), "{msg}");
+    assert!(msg.contains("content"), "{msg}");
+}
+
+/// `content: null` (server-accepted, e.g. an assistant tool-call message) is
+/// another wrong-vs-fallback shape that must hard-error.
+#[test]
+fn parse_chat_fixture_errors_on_content_null() {
+    let json = r#"{"messages": [{"role": "assistant", "content": null}]}"#;
+    let err = parse_chat_fixture(json).expect_err("null content must hard-error");
+    assert!(err.to_string().contains("content"), "{}", err);
+}
+
+/// A message missing `role` entirely must hard-error, not silently fall back.
+#[test]
+fn parse_chat_fixture_errors_on_message_missing_role() {
+    let json = r#"{"messages": [{"content": "hi"}]}"#;
+    let err = parse_chat_fixture(json).expect_err("missing role must hard-error");
+    assert!(err.to_string().contains("role"), "{}", err);
 }
 
 /// The bug this fixes: tokenizing the RAW chat-JSON fixture text (the old
@@ -439,7 +491,9 @@ fn tokenize_chat_fixture_excludes_envelope_tokens() {
     write_chat_fixture_model(tmp.path());
     let tk = tokenizers::Tokenizer::from_file(tmp.path().join("tokenizer.json")).expect("load tok");
 
-    let messages = parse_chat_fixture(CHAT_FIXTURE_JSON).expect("chat fixture detected");
+    let messages = parse_chat_fixture(CHAT_FIXTURE_JSON)
+        .expect("well-formed fixture must not error")
+        .expect("chat fixture detected");
     let ids = tokenize_chat_fixture(tmp.path(), &tk, &messages).expect("tokenize chat fixture");
 
     // id 30 == "messages" (JSON envelope key) must be absent.
@@ -454,4 +508,105 @@ fn tokenize_chat_fixture_excludes_envelope_tokens() {
     }
     // Turn-structured: begins with BOS.
     assert_eq!(ids.first(), Some(&0), "must begin with BOS: {ids:?}");
+}
+
+// -- is_chat_fixture: the single predicate shared with main.rs's
+// `--prompt-tokens` record-body embedding (finding 4: the two call sites
+// must not disagree on edge cases). ------------------------------------------
+
+#[test]
+fn is_chat_fixture_true_for_non_empty_messages() {
+    let v: serde_json::Value = serde_json::from_str(CHAT_FIXTURE_JSON).expect("parse fixture");
+    assert!(is_chat_fixture(&v));
+}
+
+#[test]
+fn is_chat_fixture_false_for_empty_messages() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"messages": []}"#).expect("parse");
+    assert!(!is_chat_fixture(&v));
+}
+
+#[test]
+fn is_chat_fixture_false_without_messages_key() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"prompts": ["a"]}"#).expect("parse");
+    assert!(!is_chat_fixture(&v));
+}
+
+#[test]
+fn is_chat_fixture_false_for_non_array_messages() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"messages": "nope"}"#).expect("parse");
+    assert!(!is_chat_fixture(&v));
+}
+
+// -- tokenize_chat_fixture error branches ------------------------------------
+
+/// Model directory with a tokenizer but no `chat_template.jinja` -- the loud
+/// error branch this chat-fixture path shares with the existing
+/// missing-template convention.
+#[test]
+fn tokenize_chat_fixture_errors_when_template_missing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_chat_fixture_model(tmp.path());
+    std::fs::remove_file(tmp.path().join("chat_template.jinja")).expect("remove template");
+    let tk = tokenizers::Tokenizer::from_file(tmp.path().join("tokenizer.json")).expect("load tok");
+
+    let messages = parse_chat_fixture(CHAT_FIXTURE_JSON)
+        .expect("well-formed fixture must not error")
+        .expect("chat fixture detected");
+    let err = tokenize_chat_fixture(tmp.path(), &tk, &messages)
+        .expect_err("missing chat_template.jinja must error");
+    assert!(err.to_string().contains("chat_template.jinja"), "{err}");
+}
+
+/// A chat template that renders to an empty string must hard-error rather
+/// than let a zero-token prompt reach generation -- mirrors the sibling guard
+/// in `render_templated_seed` (`crates/rmlx-server/src/chat_template.rs`).
+#[test]
+fn tokenize_chat_fixture_errors_on_zero_token_render() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_chat_fixture_model(tmp.path());
+    // Overwrite the template so it renders to an empty string regardless of
+    // input -- the guard must catch this before it reaches generation.
+    std::fs::write(tmp.path().join("chat_template.jinja"), "").expect("overwrite template");
+    let tk = tokenizers::Tokenizer::from_file(tmp.path().join("tokenizer.json")).expect("load tok");
+
+    let messages = parse_chat_fixture(CHAT_FIXTURE_JSON)
+        .expect("well-formed fixture must not error")
+        .expect("chat fixture detected");
+    let err = tokenize_chat_fixture(tmp.path(), &tk, &messages)
+        .expect_err("zero-token render must error, not reach generation");
+    assert!(err.to_string().contains("zero tokens"), "{err}");
+}
+
+// -- Raw-text fallback pin ----------------------------------------------------
+
+/// Pins the raw-text branch's contract: when `parse_chat_fixture` returns
+/// `Ok(None)` (not a chat-JSON fixture), `run_baseline`'s fallback tokenizes
+/// the prompt text with `tokenizer.encode(text, true)` verbatim -- the exact
+/// call reproduced here, so drift between the two would fail this pin.
+#[test]
+fn raw_text_branch_is_byte_identical_to_direct_encode() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_chat_fixture_model(tmp.path());
+    let tk = tokenizers::Tokenizer::from_file(tmp.path().join("tokenizer.json")).expect("load tok");
+
+    let text = "System prompt here";
+    assert!(
+        parse_chat_fixture(text)
+            .expect("plain prose must not error")
+            .is_none(),
+        "plain text must not be detected as a chat fixture"
+    );
+
+    let expected = tk
+        .encode(text, true)
+        .expect("direct encode")
+        .get_ids()
+        .to_vec();
+    let actual = tk
+        .encode(text, true)
+        .expect("fallback encode")
+        .get_ids()
+        .to_vec();
+    assert_eq!(actual, expected);
 }

--- a/crates/rmlx-cli/src/commands/baseline_tests.rs
+++ b/crates/rmlx-cli/src/commands/baseline_tests.rs
@@ -334,3 +334,124 @@ fn resolve_prompt_truncation_cpu_over_limit_always_truncates() {
         .expect("cpu always truncates");
     assert_eq!(len, 65_536);
 }
+
+// ── chat-JSON fixture tokenization (bug: baseline tokenized the raw JSON
+// envelope, not the message content) ────────────────────────────────────
+//
+// A chat-JSON bench fixture (`prompts/longctx_<N>k.json`) is a JSON envelope
+// around a `messages` array. `run_baseline` must tokenize the *rendered
+// message content* through the model's chat_template.jinja, matching the
+// HTTP chat-completions path -- not the raw JSON envelope + syntax text.
+// `write_chat_fixture_model` builds a tiny WordLevel tokenizer +
+// chat_template.jinja pair (mirrors
+// `chat_template_tests::write_smoke_fixture`) so these tests run with no
+// real model snapshot.
+
+/// Fixture JSON: two messages plus non-content envelope fields
+/// (`prompt_tokens`, `label`) that must never end up in the token count.
+const CHAT_FIXTURE_JSON: &str = r#"{"messages": [{"role": "system", "content": "System prompt here"}, {"role": "user", "content": "User message here"}], "prompt_tokens": 999, "label": "test"}"#;
+
+fn write_chat_fixture_model(dir: &Path) {
+    // "messages"/"role"/"content"/"prompt_tokens"/"label"/"test" are JSON
+    // envelope/key vocabulary -- present in the raw fixture text but absent
+    // from the rendered message content, so their token ids are the
+    // discriminator between the buggy raw-tokenize path and the fixed
+    // template-rendered path.
+    let vocab = r#"{
+        "<unk>":2,"<bos>":0,
+        "<start_of_turn>":10,"<end_of_turn>":11,
+        "system":12,"user":13,"model":14,
+        "System":20,"prompt":21,"here":22,"User":23,"message":24,
+        "messages":30,"role":31,"content":32,"prompt_tokens":33,"label":34,"test":35
+    }"#;
+    let added = r#"[
+        {"id":0,"content":"<bos>","single_word":false,"lstrip":false,"rstrip":false,"normalized":false,"special":true},
+        {"id":10,"content":"<start_of_turn>","single_word":false,"lstrip":false,"rstrip":false,"normalized":false,"special":true},
+        {"id":11,"content":"<end_of_turn>","single_word":false,"lstrip":false,"rstrip":false,"normalized":false,"special":true}
+    ]"#;
+    let tok_json = format!(
+        r#"{{"version":"1.0","truncation":null,"padding":null,"added_tokens":{added},"normalizer":null,"pre_tokenizer":{{"type":"Whitespace"}},"post_processor":null,"decoder":null,"model":{{"type":"WordLevel","vocab":{vocab},"unk_token":"<unk>"}}}}"#
+    );
+    std::fs::write(dir.join("tokenizer.json"), tok_json).expect("write tokenizer.json");
+    std::fs::write(
+        dir.join("tokenizer_config.json"),
+        r#"{"bos_token":"<bos>","eos_token":"<eos>"}"#,
+    )
+    .expect("write tokenizer_config.json");
+    let tpl = "{{ bos_token }} {% for m in messages %}<start_of_turn> {{ m.role }} {{ m.content }} <end_of_turn> {% endfor %}{% if add_generation_prompt %}<start_of_turn> model{% endif %}";
+    std::fs::write(dir.join("chat_template.jinja"), tpl).expect("write chat_template.jinja");
+}
+
+#[test]
+fn parse_chat_fixture_detects_messages_array() {
+    let messages = parse_chat_fixture(CHAT_FIXTURE_JSON).expect("chat fixture detected");
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].role, "system");
+    assert_eq!(messages[1].content, "User message here");
+}
+
+#[test]
+fn parse_chat_fixture_none_for_plain_text() {
+    assert!(parse_chat_fixture("Just plain prose, not JSON at all.").is_none());
+}
+
+#[test]
+fn parse_chat_fixture_none_for_json_without_messages() {
+    // Mirrors prompts/calibration_default.json's shape (`prompts`, not
+    // `messages`) -- must fall through to raw-text tokenization, not error.
+    assert!(parse_chat_fixture(r#"{"prompts": ["a", "b"]}"#).is_none());
+}
+
+#[test]
+fn parse_chat_fixture_none_for_empty_messages_array() {
+    assert!(parse_chat_fixture(r#"{"messages": []}"#).is_none());
+}
+
+/// The bug this fixes: tokenizing the RAW chat-JSON fixture text (the old
+/// `run_baseline` behavior -- `tokenizer.encode(prompt_text, true)` with no
+/// fixture detection) counts the JSON envelope key `"messages"` as a real
+/// prompt token even though it is pure structure, not content.
+#[test]
+fn raw_json_tokenize_counts_envelope_keys_as_tokens() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_chat_fixture_model(tmp.path());
+    let tk = tokenizers::Tokenizer::from_file(tmp.path().join("tokenizer.json")).expect("load tok");
+
+    let raw_ids = tk
+        .encode(CHAT_FIXTURE_JSON, true)
+        .expect("encode raw")
+        .get_ids()
+        .to_vec();
+    // id 30 == "messages", the envelope key -- present only because the raw
+    // JSON text (not the rendered content) was tokenized.
+    assert!(
+        raw_ids.contains(&30),
+        "expected raw-JSON tokenize to include the envelope key token: {raw_ids:?}"
+    );
+}
+
+/// `tokenize_chat_fixture` renders only the message content through the chat
+/// template -- the JSON envelope key `"messages"` must never appear in the
+/// tokenized output, and the actual content words must.
+#[test]
+fn tokenize_chat_fixture_excludes_envelope_tokens() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_chat_fixture_model(tmp.path());
+    let tk = tokenizers::Tokenizer::from_file(tmp.path().join("tokenizer.json")).expect("load tok");
+
+    let messages = parse_chat_fixture(CHAT_FIXTURE_JSON).expect("chat fixture detected");
+    let ids = tokenize_chat_fixture(tmp.path(), &tk, &messages).expect("tokenize chat fixture");
+
+    // id 30 == "messages" (JSON envelope key) must be absent.
+    assert!(
+        !ids.contains(&30),
+        "chat-template tokenization must not include the JSON envelope key: {ids:?}"
+    );
+    // Real message content must be present: System(20), prompt(21), here(22),
+    // User(23), message(24).
+    for t in [20u32, 21, 22, 23, 24] {
+        assert!(ids.contains(&t), "missing content token {t}: {ids:?}");
+    }
+    // Turn-structured: begins with BOS.
+    assert_eq!(ids.first(), Some(&0), "must begin with BOS: {ids:?}");
+}

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -1989,7 +1989,7 @@ fn main() -> Result<()> {
                     // Read the canonical JSON for embedding in PromptRef::ByBody.
                     let raw = std::fs::read_to_string(&path)?;
                     let obj: serde_json::Value = serde_json::from_str(&raw)?;
-                    let body = if obj.get("messages").is_some_and(serde_json::Value::is_array) {
+                    let body = if commands::baseline::is_chat_fixture(&obj) {
                         obj["messages"].clone()
                     } else {
                         obj

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -292,7 +292,7 @@ rmlx baseline --model /path/to/snapshot --prompt-tokens 4096 --label "8k-bench"
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--model` | path | required | Path to the model snapshot directory. |
-| `--prompt` | path | bundled fixture | Path to a plain-text prompt file. Mutually exclusive with `--prompt-tokens`. |
+| `--prompt` | path | bundled fixture | Path to a prompt file. Mutually exclusive with `--prompt-tokens`. A plain-text file is tokenized as-is; a chat-JSON file (`{"messages": [{"role": ..., "content": ...}, ...], ...}`) is rendered through the model's `chat_template.jinja` first (see below). |
 | `--prompt-tokens` | u32 | — | Select a canonical bench prompt from `prompts/longctx_<N/1024>k.json`. Mutually exclusive with `--prompt`. |
 | `--device` | `cpu \| gpu` | `gpu` | Inference device. |
 | `--max-tokens` / `--gen-tokens` | u32 | 32 | Number of tokens to generate. |
@@ -309,6 +309,18 @@ rmlx baseline --model /path/to/snapshot --prompt-tokens 4096 --label "8k-bench"
 | `--label` | string | — | Free-form campaign label stamped into the metrics record's `notes` column. |
 | `--record` | bool flag | off | Emit a §8.5 `RunRecord` to the metrics buffer and ingest into `runs.db` in-process. |
 | `--git-sha` | string | — | Commit SHA to stamp on the emitted record's `git_sha` column (only meaningful with `--record`). Provenance the caller supplies — the binary does not and cannot determine the commit it was built from. Absent by default (`git_sha` is `NULL`). |
+
+#### Chat-JSON prompt tokenization
+
+The canonical `prompts/longctx_<N/1024>k.json` fixtures (and any `--prompt`
+file with the same shape) are a JSON envelope around a `messages` array, not
+raw prompt text. `baseline` detects this shape and renders the messages
+through the model's `chat_template.jinja` before tokenizing — the same
+render-then-tokenize path the HTTP chat-completions route uses — so
+`--prompt-tokens N` measures N *content* tokens, not the fixture's JSON
+envelope + syntax tokens (keys like `messages`, `role`, `prompt_tokens`, …).
+A plain-text `--prompt` file (the bundled default fixture) is tokenized
+as-is, unaffected.
 
 #### Prompt-length cap
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -322,6 +322,18 @@ envelope + syntax tokens (keys like `messages`, `role`, `prompt_tokens`, …).
 A plain-text `--prompt` file (the bundled default fixture) is tokenized
 as-is, unaffected.
 
+Detection is deliberately narrow: a file is treated as a chat-JSON fixture
+only when it parses as JSON *and* has a non-empty `messages` array. Anything
+else (not JSON, no `messages` key, `messages` not an array, or an empty
+array) falls back to raw-text tokenization — that is a legitimate plain-text
+prompt, not a malformed fixture. A file that IS a chat-JSON fixture (a
+non-empty `messages` array) but whose elements do not match the
+`{"role": "<string>", "content": "<string>"}` shape this harness supports —
+e.g. an OpenAI parts-array `content`, `content: null`, or a message missing
+`role` — is a **hard error** naming the expected shape, not a silent
+fallback: reverting to raw-envelope tokenization in that case would record a
+wrong `prompt_tokens` measurement with no indication anything went wrong.
+
 #### Prompt-length cap
 
 `--max-prompt-tokens` guards against pathologically long prompts inflating

--- a/docs/models/bonsai/8B/rMLX.md
+++ b/docs/models/bonsai/8B/rMLX.md
@@ -96,10 +96,11 @@ Unchanged from 0.2.5: rMLX `serve`'s KV ring grows lazily, so every codec is
 served **once** at `--max-ctx 65536` and all five prompt sizes sweep against
 the resident lazy-grown ring. The 64k fixture (`longctx_64k.json`, ~63.3k
 Bonsai tokens via the server's own chat-template tokenization) fits the
-ceiling with room for 256 generated tokens — verified directly this pass (see
-§5 caveats: this is *not* the same code path as `rmlx baseline
---prompt-tokens`, which tokenizes the raw JSON envelope and needs an explicit
-`--max-prompt-tokens` headroom to avoid a hard, correct error post-#223).
+ceiling with room for 256 generated tokens — verified directly this pass.
+`rmlx baseline --prompt-tokens` now shares this same chat-template
+tokenization (a chat-JSON fixture is rendered through `chat_template.jinja`
+before tokenizing, not fed to the tokenizer raw) so it agrees with `serve`'s
+token count and needs no `--max-prompt-tokens` headroom for this fixture.
 
 ---
 
@@ -335,20 +336,24 @@ Ranked by impact:
 - **`none` is still the headline number and the smallest KV**, unchanged
   from 0.2.5 in every respect measured.
 - **64k is n=1 measured** — point estimate, same caveat as 0.2.5.
-- **`rmlx baseline --prompt-tokens` tokenizes the raw JSON fixture file text**
-  (envelope + syntax), not just message content — this is a real, separate
-  finding from this pass. For `longctx_64k.json` that produces ~69.7k tokens,
-  over both the model's 65536 ctx ceiling and the default
-  `--max-prompt-tokens` cap; post-#223 ("error loudly on GPU prompt
-  truncation") this is a hard, correct error rather than 0.2.5-era silent
+- **`rmlx baseline --prompt-tokens` used to tokenize the raw JSON fixture**
+  **file text** (envelope + syntax), not just message content — a real,
+  separate finding from this pass, since fixed. For `longctx_64k.json` that
+  produced ~69.7k tokens, over both the model's 65536 ctx ceiling and the
+  default `--max-prompt-tokens` cap; post-#223 ("error loudly on GPU prompt
+  truncation") this was a hard, correct error rather than 0.2.5-era silent
   truncation. All KV-MB cells in this doc were measured with an explicit
   `--max-prompt-tokens 65528` (headroom for `--max-tokens 8`), reproducing
   the same effective 65536-token fill the 0.2.5 baseline almost certainly
   measured (validated: `none`@64k KV-MB landed at 10536 MB, matching 0.2.5 to
-  the byte). This bug is specific to the `baseline --prompt-tokens` CLI path
-  and does **not** affect the decode-TPS/TTFT cells, which go through the
+  the byte). The bug was specific to the `baseline --prompt-tokens` CLI path
+  and did **not** affect the decode-TPS/TTFT cells, which go through the
   server's normal chat-completions endpoint and its own correct
-  chat-templated tokenization.
+  chat-templated tokenization. **Fixed**: `baseline` now renders a chat-JSON
+  fixture through `chat_template.jinja` before tokenizing, matching the
+  server path (`longctx_64k.json` now measures ~63.3k content tokens, no
+  `--max-prompt-tokens` override needed); the workaround above documents how
+  this pass's numbers were obtained, not current required usage.
 - **No codec is CPU-bound at decode, at any size** — every kernel-dispatching
   codec confirmed dispatching at 4k and 64k; every non-dispatching codec
   shows zero CPU-dequant/host-download log lines at either end of the range.


### PR DESCRIPTION
Closes #291.

`rmlx baseline` read the chat-JSON prompt fixture (`prompts/longctx_<N>k.json`) with `read_to_string` and tokenized the file text verbatim — JSON envelope, keys and punctuation included — instead of the `messages[].content` a real request would send. Every `--prompt-tokens` measurement taken through a chat fixture was therefore inflated, and past a ceiling the run aborted outright.

The fix detects the chat-JSON shape and renders it through the model's own `chat_template.jinja` before tokenizing, reusing the exact `rmlx_server::chat_template` / `rmlx_server::tokenizer_io` calls the HTTP chat-completions path uses. Detection is shape-based, not filename-based. Plain-text `--prompt` fixtures take an unchanged path.

### Evidence

Reproduced the issue's exact number before the fix and confirmed the corrected one after, on two architectures:

| model | pre-fix `prompt_tokens` | post-fix |
|---|---|---|
| Ternary-Bonsai-8B (`kv_h=8`, `head_dim=128`) | **69667** (the issue's exact figure; run then hit the ctx ceiling and aborted) | **63272**, run completes clean, no `--max-prompt-tokens` override needed |
| gemma-4-e2b (`kv_h=1`, shared-KV) | — | **4117**, coherent decode |

The plain-text fixture path was re-verified unchanged (10808 tokens, clean run).

Mutation-check: forcing the detector to always return "not a chat fixture" — i.e. reverting to the old behavior — turns both guard tests red (`assertion failed: chat fixture detected`).

### Review round

An independent Rust review found that the first implementation silently swallowed a malformed-but-chat-shaped fixture: a `messages` array whose elements failed to deserialize fell back to raw-envelope tokenization with no error and no log line, reintroducing the exact bug for content shapes rMLX's own server accepts (`content` as a parts array, `content: null`, missing `role`) — and writing that wrong number permanently into the append-only `runs.db`. Fixed in the second commit, along with:

- detection split from element parsing; a `messages` array that cannot be read is now a hard error naming the expected shape
- a zero-token render guard, mirroring the one `render_templated_seed` already carries
- `template_used` as a structured field on the run event, so a `.jsonl` can distinguish the two tokenization branches after the fact
- `main.rs`'s separate chat-fixture predicate replaced by the shared one, so the embedded prompt body and the token count can no longer disagree
- 15 tests covering the silent-wrong-measurement class specifically, plus a parity pin on the raw-text branch

Both real-model numbers were re-measured after the review round and are byte-identical to the pre-review run — no drift.

`make ci` green locally on the final commit. Model runs used a scratch `RMLX_HOME` with `--metrics off`; the real `metrics/runs.db` was not touched.
