### PR TITLE
feat(bench): rmlx bench — a repeated-run decode instrument that refuses bad numbers (#303)

### DIFF
--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -215,6 +215,29 @@ pub(crate) fn is_chat_fixture(value: &serde_json::Value) -> bool {
 /// raw-envelope tokenization in that case would record a wrong measurement
 /// with no error, so this matches the existing loud-failure convention for a
 /// missing `chat_template.jinja`.
+/// Tokenize a prompt file the way the bench harnesses measure it.
+///
+/// Returns `(prompt_ids, template_used)`. A chat-JSON fixture is rendered
+/// through the model's `chat_template.jinja` first; anything else is tokenized
+/// as raw text with `add_special_tokens=true`. Shared by `rmlx baseline` and
+/// `rmlx bench` so the two cannot disagree on what "N prompt tokens" means.
+pub(crate) fn tokenize_prompt_text(
+    model_path: &Path,
+    tokenizer: &tokenizers::Tokenizer,
+    prompt_text: &str,
+) -> anyhow::Result<(Vec<u32>, bool)> {
+    if let Some(messages) = parse_chat_fixture(prompt_text)? {
+        return Ok((
+            tokenize_chat_fixture(model_path, tokenizer, &messages)?,
+            true,
+        ));
+    }
+    let encoding = tokenizer
+        .encode(prompt_text, true)
+        .map_err(|e| anyhow::anyhow!("tokenize prompt: {e}"))?;
+    Ok((encoding.get_ids().to_vec(), false))
+}
+
 fn parse_chat_fixture(prompt_text: &str) -> anyhow::Result<Option<Vec<ChatFixtureMessage>>> {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(prompt_text) else {
         return Ok(None);
@@ -355,16 +378,8 @@ pub(crate) fn run_baseline(
     // are counted -- matching the HTTP chat-completions path. Anything else
     // (e.g. the default plain-text fixture) is tokenized as raw text with
     // add_special_tokens=true so BOS is prepended naturally.
-    let chat_fixture_messages = parse_chat_fixture(&prompt_text)?;
-    let template_used = chat_fixture_messages.is_some();
-    let mut prompt_ids: Vec<u32> = if let Some(messages) = &chat_fixture_messages {
-        tokenize_chat_fixture(model_path, &tokenizer, messages)?
-    } else {
-        let encoding = tokenizer
-            .encode(prompt_text.as_str(), true)
-            .map_err(|e| anyhow::anyhow!("tokenize prompt: {e}"))?;
-        encoding.get_ids().to_vec()
-    };
+    let (mut prompt_ids, template_used) =
+        tokenize_prompt_text(model_path, &tokenizer, &prompt_text)?;
 
     // Truncate to `max_prompt_tokens` when the cap allows it; on GPU with the
     // default (non-explicit) cap this is a hard error instead -- see

--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -466,6 +466,7 @@ pub(crate) fn run_baseline(
         last_cb_s = elapsed;
         None
     };
+    let kv_before = model.kv_cache_bytes_sample();
     let steps = model
         .generate_greedy(
             &tokenizer,
@@ -486,9 +487,37 @@ pub(crate) fn run_baseline(
         .map_err(|e| anyhow::anyhow!("generate_greedy: {e}"))?;
     let generate_elapsed = ts_generate_start.elapsed();
     // Read actual on-device KV-cache bytes from the arch-specific static that
-    // `generate_greedy` writes via `store_kv_cache_bytes`.  Returns 0 for
-    // architectures that do not yet maintain that static.
-    let kv_cache_bytes: u64 = model.kv_cache_bytes();
+    // `generate_greedy` writes via `store_kv_cache_bytes`.
+    //
+    // `--record` appends to the metrics store, where a wrong row is permanent,
+    // so the figure is attributed to *this* generation before it is kept: the
+    // store sequence must have advanced across the call. Anything else — an
+    // arch that does not maintain the static, a prefill that returned early —
+    // leaves an earlier generation's byte count readable, and recording that
+    // under this run's label is the failure the sequence exists to prevent.
+    // Both unusable verdicts collapse to `0`, which the downstream `> 0` gates
+    // already omit from the record; the `warn!` says which one happened.
+    let kv_cache_bytes: u64 =
+        match rmlx_models::classify_kv_bytes(kv_before, model.kv_cache_bytes_sample()) {
+            rmlx_models::KvBytesVerdict::Reported(n) => n,
+            rmlx_models::KvBytesVerdict::Unreported => {
+                tracing::warn!(
+                    arch = model.arch_class(),
+                    "generation reported no KV-cache byte count (store sequence did not advance); \
+                 omitting kv_cache_bytes from this run rather than recording an earlier \
+                 generation's figure"
+                );
+                0
+            }
+            rmlx_models::KvBytesVerdict::ReportedZero => {
+                tracing::warn!(
+                    arch = model.arch_class(),
+                    "generation reported a KV cache of 0 bytes after a real prefill — the byte \
+                 accounting is wrong, not the cache; omitting kv_cache_bytes from this run"
+                );
+                0
+            }
+        };
     // Drop the span guard explicitly so the span closes (and its elapsed_ms is
     // emitted to the JSONL log) right here — before the summary println below.
     drop(_decode_span_guard);

--- a/crates/rmlx-cli/src/commands/bench.rs
+++ b/crates/rmlx-cli/src/commands/bench.rs
@@ -17,9 +17,13 @@
 //!    not a time-to-first-token), are hard errors — not a fast-looking number.
 //! 2. **It never reports a bare central value.** Every metric carries its
 //!    observed min/max across the measured runs, and `--runs` is rejected below
-//!    2 so there is always a spread to report. A metric that *trends* across
-//!    those runs has no central value at all, and is refused rather than
-//!    summarised — see [`detect_drift`].
+//!    2 so there is always a spread to report. A metric that never settled
+//!    across those runs has no central value at all, and is refused rather than
+//!    summarised — whether it settled is decided by two independent gates, one
+//!    per shape a cell fails to settle in: a *trend* (see [`detect_drift`]) and
+//!    a *range* too wide to call noise around a centre (see
+//!    [`SETTLED_MAX_RANGE_PCT`]). Which metrics are gated is enumerated on
+//!    [`Metric::gate`], not left to which call sites happen to check.
 //!
 //! `bench` is read-only with respect to the metrics database: it prints, it
 //! does not record. Use `rmlx baseline --record` for the append-only store.
@@ -49,13 +53,15 @@ pub(crate) const MIN_RUNS: u32 = 2;
 /// instead of a measurement that was never taken.
 ///
 /// What prevents that is [`arch::Architecture::clear_prompt_cache`], called
-/// before every generation: the cache is emptied, so the next request is a
-/// guaranteed miss and a real prefill. Asking for *zero* slots would not do it
-/// — capacity is clamped to a minimum of one, so a "zero-slot" cache still
-/// stores and can still serve a snapshot.
+/// before every generation: the RAM slots are emptied, so the next request
+/// misses. Asking for *zero* slots would not do it — capacity is clamped to a
+/// minimum of one, so a "zero-slot" cache still stores and can still serve a
+/// snapshot.
 ///
-/// `assert_prefill_measured` re-checks the outcome per run rather than trusting
-/// either the constant or the clear.
+/// A RAM miss is not the same as a prefill: the clear does not detach an SSD KV
+/// source, which can serve the miss from a `.kvb` instead. So
+/// `assert_prefill_measured` checks the outcome of every run rather than
+/// trusting either the constant or the clear.
 const BENCH_PROMPT_CACHE_SLOTS: usize = 1;
 
 /// Largest run-to-run trend a metric may show and still be summarised, as a
@@ -67,7 +73,66 @@ const BENCH_PROMPT_CACHE_SLOTS: usize = 1;
 /// line across its own runs cannot support either comparison, whichever way it
 /// moves — an improving ramp means the cell had not converged just as much as a
 /// degrading one does.
+///
+/// This is a floor, not the whole test: clearing it says the fitted change is
+/// *large*, not that it is a trend. See [`TREND_MIN_RESID_MULTIPLE`].
 const TREND_MAX_DRIFT_PCT: f64 = 10.0;
+
+/// How far the fitted change must exceed the cell's own residual scatter before
+/// it is called a trend.
+///
+/// The percentage floor alone has no noise anchoring, and at the default
+/// `--runs 3` the fit is thin enough for that to matter: with three runs the
+/// least-squares change reduces exactly to `last − first`, so the middle run
+/// contributes nothing but its share of the median and a single zig-zag reads
+/// as a slope. `[100, 118, 88]` fits to −12% and would be refused as a decline
+/// it plainly is not.
+///
+/// Requiring the fitted change to also dominate the scatter *about* the fitted
+/// line separates the two: on a real ramp the residuals are small next to the
+/// change (a measured 17.8 s → 25.5 s TTFT ramp fits 6831 ms against a 2×RMS of
+/// 1479), while on a zig-zag they are the same size as it (2×RMS 22.6 against a
+/// fitted 12). Two is the multiple because at three runs a zig-zag has the fixed
+/// residual pattern `(−k, +2k, −k)`, whose RMS is `k√2` — so its scatter is
+/// always the same order as the step that produced it, and a multiple of two
+/// puts the `[100, 118, 88]` case (2×RMS 22.6 vs fitted 12) on the refuse side
+/// with margin, while leaving real ramps — whose residuals are a small fraction
+/// of the change — several times clear of it.
+///
+/// Both conditions must hold. Refusing on scatter alone would abort settled
+/// cells (a tight cell has tiny residuals *and* a tiny change), and refusing on
+/// percentage alone is the noise-driven abort whose documented remedy — raise
+/// `--warmup` and re-measure — is measure-until-it-passes.
+const TREND_MIN_RESID_MULTIPLE: f64 = 2.0;
+
+/// Largest observed range a gated metric may show and still be summarised, as a
+/// percentage of its median. See [`Spread::range_pct`].
+///
+/// The trend gate only refuses movement that goes *one way*. A cell can fail to
+/// settle without trending — a single-run spike has slope zero at any
+/// magnitude, and a late-onset step fits to a smaller and smaller slope as
+/// `--runs` grows (a last-run jump of `d` fits to `1.33d` at three runs but only
+/// `0.29d` at twenty), so the operator's natural response to a noisy abort would
+/// otherwise make the guard weaker. The range gate closes both: it is
+/// order-blind on purpose, and refuses "did not settle" whichever shape it takes.
+///
+/// Fifteen percent, from this instrument's own measured settled cells — ten
+/// cells across gemma-4-e2b and Ternary-Bonsai-8B at 4k, 32k and 64k, all
+/// pinned in `a_settled_cell_clears_the_range_gate`. Most gated metrics of a
+/// settled cell range under 2% (tightest: 0.17%), but two settled cells on that
+/// same host produced a 7.56% TTFT range and a 7.09% decode-TPS range, and the
+/// widest *accepted* wobble on record is the 8.35% TTFT range pinned in
+/// `the_threshold_separates_warmup_wobble_from_a_ramp`. So the settled
+/// population is not 2%-wide, it has a ~8% tail, and a ceiling near 10% would
+/// leave that tail about 1.2× of margin — it would abort settled cells on a bad
+/// day. Fifteen sits at 1.8× the worst accepted case while still refusing a
+/// spike or a late step, which run to tens of percent.
+///
+/// Only [`Gate::Settled`] metrics are checked. `itl_p99_ms` in particular
+/// ranged 58.6% on a cell whose every other metric ranged under 2% — an
+/// extreme-order statistic has no settled range to speak of, which is why it is
+/// reported rather than gated.
+const SETTLED_MAX_RANGE_PCT: f64 = 15.0;
 
 // ---------------------------------------------------------------------------
 // Spread — a central value that carries its observed range
@@ -94,13 +159,14 @@ impl Spread {
     /// nothing, and returning a zero would be indistinguishable from a real
     /// measurement of zero.
     ///
-    /// Takes the sample by value and sorts it in place: the caller has already
-    /// built the vector, and a borrowing signature would only copy it again.
-    pub(crate) fn of(values: Vec<f64>) -> Option<Self> {
+    /// Borrows: every caller also needs the values in collection order for the
+    /// settle gates, so a by-value signature would have them clone first and
+    /// allocate exactly as often.
+    pub(crate) fn of(values: &[f64]) -> Option<Self> {
         if values.is_empty() {
             return None;
         }
-        let mut sorted = values;
+        let mut sorted = values.to_vec();
         sorted.sort_by(f64::total_cmp);
         let n = sorted.len();
         // Bounds: `sorted` is non-empty (checked above), so `first`/`last` are
@@ -167,20 +233,34 @@ pub(crate) fn percentile_sorted(sorted: &[f64], q: f64) -> Option<f64> {
 /// The test is the least-squares slope over the run index, scaled to the whole
 /// run sequence and expressed against the median. Ordinary regression rather
 /// than a monotonicity test on purpose: a real ramp with one noisy step is
-/// still a ramp, and would escape a strict-monotonic check the moment `--runs`
-/// grew past three.
+/// still a ramp, and would escape a strict-monotonic check once `--runs` grows
+/// past three. At exactly three runs that robustness is not there to be had —
+/// `mean_x` is 1 and the `ȳ` terms cancel, so the fitted change reduces
+/// *exactly* to `last − first` and the middle run contributes nothing but its
+/// share of the median. That degeneracy is why the percentage test is not the
+/// whole test.
 ///
-/// At the default three runs, a sample whose spread is very wide fits a slope
-/// in *whatever* order it arrives — with a 40%-wide sample, every permutation
-/// clears the threshold. That is not a flaw to tune away: three runs cannot
-/// separate a ramp from that much noise, and a cell that noisy has no
-/// trustworthy median either. Both are refused, which is the safe direction;
-/// the error prints the values in run order so the operator can see which it
-/// was.
+/// Two conditions, both necessary. The fitted change must clear
+/// [`TREND_MAX_DRIFT_PCT`] of the median — it has to be *large* — and it must
+/// also exceed [`TREND_MIN_RESID_MULTIPLE`] times the RMS of the residuals about
+/// the fitted line — it has to be large *relative to the cell's own scatter*. A
+/// percentage alone cannot tell a ramp from a zig-zag at three runs, where the
+/// fit degenerates to `last − first`; the residual test is what supplies the
+/// missing noise anchoring.
+///
+/// The residual RMS divides by `n`, not by the regression's `n − 2` degrees of
+/// freedom. With the default three runs `n − 2` is one, and the resulting
+/// estimate swings by a factor of `√3` for no gain: the quantity wanted here is
+/// "how far do these points sit off the line", not an unbiased variance.
+///
+/// At the two-run minimum the line passes through both points, so the residual
+/// RMS is exactly zero and the percentage floor governs alone. That is the right
+/// answer rather than a gap: with two points there is no scatter to measure, and
+/// anything else would be inventing one.
 ///
 /// `None` when there is no trend worth refusing over: fewer than two runs (no
 /// order to speak of), a zero median (no scale to express the change against),
-/// or a fitted change within [`TREND_MAX_DRIFT_PCT`].
+/// or a fitted change that fails either condition.
 pub(crate) fn detect_drift(values_in_order: &[f64], median: f64) -> Option<f64> {
     let n = values_in_order.len();
     if n < 2 || median == 0.0 {
@@ -206,26 +286,59 @@ pub(crate) fn detect_drift(values_in_order: &[f64], median: f64) -> Option<f64> 
     if sxx == 0.0 {
         return None;
     }
-    // Slope per run, scaled across the whole sequence: first run to last.
-    let pct_of_median = sxy / sxx * (n_f - 1.0) / median.abs() * 100.0;
-    (pct_of_median.abs() > TREND_MAX_DRIFT_PCT).then_some(pct_of_median)
+    let slope = sxy / sxx;
+    // Change across the whole sequence: first measured run to last.
+    let fitted_change = slope * (n_f - 1.0);
+    let pct_of_median = fitted_change / median.abs() * 100.0;
+    if pct_of_median.abs() <= TREND_MAX_DRIFT_PCT {
+        return None;
+    }
+    // Scatter about the fitted line. A change that does not dominate this is a
+    // sample that happens to end higher than it started, not a trend.
+    let mut sq_resid = 0.0_f64;
+    for (i, y) in values_in_order.iter().enumerate() {
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "i indexes the run count — single digits in every real invocation"
+        )]
+        let dx = i as f64 - mean_x;
+        let resid = y - (mean_y + slope * dx);
+        sq_resid += resid * resid;
+    }
+    let resid_rms = (sq_resid / n_f).sqrt();
+    (fitted_change.abs() > TREND_MIN_RESID_MULTIPLE * resid_rms).then_some(pct_of_median)
 }
 
-/// Refuse to summarise a metric that trended across its own runs.
-fn assert_no_drift(name: &str, values_in_order: &[f64], median: f64) -> anyhow::Result<()> {
-    let Some(pct) = detect_drift(values_in_order, median) else {
-        return Ok(());
-    };
-    let direction = if pct > 0.0 { "rose" } else { "fell" };
+/// Why a metric cannot be summarised as one cell, or `None` when it settled.
+///
+/// Two shapes of not-settling, checked in order of how specific the diagnosis
+/// is. A trend names *which way* the cell was moving and has a remedy (more
+/// warmup); a wide range only says the runs never converged, and its remedy is
+/// the host, not the run count. Reported as a string rather than raised here so
+/// the caller can name every metric that failed instead of only the first.
+fn settle_refusal(name: &str, values_in_order: &[f64], spread: &Spread) -> Option<String> {
     let ordered: Vec<String> = values_in_order.iter().map(|v| format!("{v:.3}")).collect();
-    Err(anyhow::anyhow!(
-        "{name} {direction} {:.1}% from the first measured run to the last ({}, in run order): \
-         this is a trend, not a spread, and its median is not a measurement. The cell had not \
-         reached a steady state — raise --warmup until consecutive runs agree, or measure a \
-         cell that settles",
-        pct.abs(),
-        ordered.join(" → ")
-    ))
+    let ordered = ordered.join(" → ");
+    if let Some(pct) = detect_drift(values_in_order, spread.median) {
+        let direction = if pct > 0.0 { "rose" } else { "fell" };
+        return Some(format!(
+            "{name} {direction} {:.1}% from the first measured run to the last ({ordered}, in \
+             run order): this is a trend, not a spread, and its median is not a measurement. \
+             The cell had not reached a steady state — raise --warmup until consecutive runs \
+             agree, or measure a cell that settles",
+            pct.abs(),
+        ));
+    }
+    let range_pct = spread.range_pct();
+    if range_pct > SETTLED_MAX_RANGE_PCT {
+        return Some(format!(
+            "{name} spanned {range_pct:.1}% of its median across the measured runs ({ordered}, \
+             in run order), over the {SETTLED_MAX_RANGE_PCT:.0}% ceiling: the runs never \
+             converged on a value, so the median is the middle of a scatter rather than a \
+             measurement. Quiet the host, or measure a cell that settles"
+        ));
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -262,11 +375,18 @@ fn kv_bytes_or_reason(verdict: KvBytesVerdict, arch_class: &str) -> anyhow::Resu
 /// the two at the call site type-checks, passes every test that builds tuples
 /// directly, and silently inverts the guard.
 ///
-/// Two conditions, both necessary:
+/// Three conditions, all necessary:
 ///
 /// - **`hits == 0`.** A hit means the post-prefill KV snapshot was replayed, so
 ///   the run's TTFT is a cache-replay time, not a time-to-first-token — a
 ///   number that is small, stable, and wrong.
+/// - **`ssd_hits == 0`.** A RAM miss that the SSD tier served is *also* a
+///   skipped prefill, and it does not show up in `hits`: `hydrate_from_ssd`
+///   bumps its own counter after `find_best_prefix` has already recorded the
+///   miss. Clearing the RAM slots does not detach the SSD source, so the
+///   emptied-cache guarantee that makes `hits == 0, misses == 1` mean "a real
+///   prefill ran" holds only while nothing hydrates. Reading the run's TTFT off
+///   a `.kvb` reconstruction is the same defect wearing a different counter.
 /// - **`misses >= 1`.** The cache was consulted and did not serve this run, so
 ///   a prefill genuinely happened. Counters that report nothing certify
 ///   nothing.
@@ -277,7 +397,13 @@ fn kv_bytes_or_reason(verdict: KvBytesVerdict, arch_class: &str) -> anyhow::Resu
 /// under stable counters a repeat that was served shows `hits > 0`, and after a
 /// clear the run shows `hits == 0, misses == 1`.
 pub(crate) fn assert_prefill_measured(stats: Option<&CacheStats>) -> anyhow::Result<()> {
-    let Some(&CacheStats { hits, misses, .. }) = stats else {
+    let Some(&CacheStats {
+        hits,
+        misses,
+        ssd_hits,
+        ..
+    }) = stats
+    else {
         return Err(anyhow::anyhow!(
             "measured run reported no prompt-cache stats, so nothing certifies that it \
              performed a prefill rather than replaying a snapshot. Refusing to report its \
@@ -289,6 +415,14 @@ pub(crate) fn assert_prefill_measured(stats: Option<&CacheStats>) -> anyhow::Res
             "measured run was served from the prompt cache ({hits} hit(s), {misses} miss(es)): \
              prefill was skipped, so its TTFT and prefill throughput are cache-replay times, \
              not measurements. Refusing to report them"
+        ));
+    }
+    if ssd_hits > 0 {
+        return Err(anyhow::anyhow!(
+            "measured run was served from the SSD KV tier ({ssd_hits} hydrate(s)): the RAM \
+             cache missed, but the blocks were reconstructed from a .kvb file instead of \
+             being prefilled, so its TTFT is a hydrate time. Emptying the RAM slots does not \
+             detach the SSD source. Refusing to report it"
         ));
     }
     if misses == 0 {
@@ -569,7 +703,117 @@ fn measure_one(
     )
 }
 
+// ---------------------------------------------------------------------------
+// Metrics — one enumeration, one gate decision each
+// ---------------------------------------------------------------------------
+
+/// What the summary requires of a metric before it will report it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Gate {
+    /// The cell must have settled in this metric: no run-to-run trend, and a
+    /// range narrow enough to be noise around a centre.
+    Settled,
+    /// Reported with its spread, never gated. Each metric that opts out states
+    /// why on [`Metric::gate`].
+    Ungated,
+}
+
+/// Every metric one bench cell reports.
+///
+/// The point of the enum is [`Metric::gate`]: whether a metric is checked for
+/// settling used to be positional — a call that was made for some metrics and
+/// simply absent for others — so a metric added later inherited whichever
+/// treatment its author happened to copy. Here the exhaustive match makes the
+/// choice mandatory: a new variant does not compile until it names its gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Metric {
+    TtftMs,
+    DecodeTps,
+    PrefillTps,
+    ItlP50Ms,
+    ItlP99Ms,
+    KvCacheBytes,
+}
+
+impl Metric {
+    /// Reporting order, which is also summary-row order.
+    pub(crate) const ALL: [Self; 6] = [
+        Self::TtftMs,
+        Self::ItlP50Ms,
+        Self::ItlP99Ms,
+        Self::DecodeTps,
+        Self::PrefillTps,
+        Self::KvCacheBytes,
+    ];
+
+    /// Label used in the summary and in every refusal message.
+    pub(crate) const fn name(self) -> &'static str {
+        match self {
+            Self::TtftMs => "ttft_ms",
+            Self::DecodeTps => "decode_tps",
+            Self::PrefillTps => "prefill_tps",
+            Self::ItlP50Ms => "itl_p50_ms",
+            Self::ItlP99Ms => "itl_p99_ms",
+            Self::KvCacheBytes => "kv_cache_bytes",
+        }
+    }
+
+    /// Whether the cell has to have settled in this metric.
+    #[allow(
+        clippy::match_same_arms,
+        reason = "the two ungated metrics opt out for unrelated reasons and each states its own; \
+                  merging the arms would drop one of the two justifications and leave the next \
+                  metric added inheriting whichever it landed beside"
+    )]
+    pub(crate) const fn gate(self) -> Gate {
+        match self {
+            // The three robust per-run quantities plus the byte total. These
+            // are what a decision gets made on, so a cell that has not settled
+            // in any of them cannot support one.
+            Self::TtftMs | Self::DecodeTps | Self::ItlP50Ms | Self::KvCacheBytes => Gate::Settled,
+
+            // Nearest-rank p99 over a 128-token run is the second-largest
+            // inter-token gap: an extreme-order statistic whose run-to-run
+            // movement is dominated by whether that one run happened to hit a
+            // stall, not by whether the cell has settled. Measured gemma-4-e2b
+            // at 4k: ttft, decode TPS and ITL p50 all moved 5-6% across three
+            // runs while p99 moved 26%. Gating it would abort cells whose
+            // measurements are fine; its spread is still printed, so the tail
+            // stays visible.
+            Self::ItlP99Ms => Gate::Ungated,
+
+            // An exact deterministic reciprocal of `ttft_ms` — the prompt is
+            // identical in every run of a cell, so `prompt_tokens / ttft` adds
+            // no independent evidence. Gating it would test `ttft_ms` twice
+            // under a nonlinear transform, and the two could disagree purely on
+            // where the middle run landed. `ttft_ms` carries the gate.
+            Self::PrefillTps => Gate::Ungated,
+        }
+    }
+
+    /// This metric's per-run values in collection order.
+    ///
+    /// `None` when a run could not produce the quantity at all — only
+    /// [`Metric::PrefillTps`] can be absent, and a cell where only some runs
+    /// have one is not a cell.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "KV byte totals are far below 2^53; f64 is exact over the whole range"
+    )]
+    fn values(self, samples: &[RunSample]) -> Option<Vec<f64>> {
+        match self {
+            Self::TtftMs => Some(samples.iter().map(|s| s.ttft_ms).collect()),
+            Self::DecodeTps => Some(samples.iter().map(|s| s.decode_tps).collect()),
+            Self::PrefillTps => samples.iter().map(|s| s.prefill_tps).collect(),
+            Self::ItlP50Ms => Some(samples.iter().map(|s| s.itl_p50_ms).collect()),
+            Self::ItlP99Ms => Some(samples.iter().map(|s| s.itl_p99_ms).collect()),
+            Self::KvCacheBytes => Some(samples.iter().map(|s| s.kv_cache_bytes as f64).collect()),
+        }
+    }
+}
+
 /// Summary of one bench cell.
+#[derive(Debug)]
 struct BenchSummary {
     ttft_ms: Spread,
     decode_tps: Spread,
@@ -583,65 +827,54 @@ struct BenchSummary {
     token_digest: u64,
 }
 
-/// Fold the measured runs into per-metric spreads, refusing any metric that
-/// trended across the runs instead of settling.
+/// Fold the measured runs into per-metric spreads, refusing any metric in which
+/// the cell did not settle.
 ///
-/// Errors when `samples` is empty, and when any checked metric drifted. Every
-/// metric is summarised from the same runs, so either all of them exist or none
-/// do — there is no partial summary.
+/// Errors when `samples` is empty, and when any [`Gate::Settled`] metric
+/// trended or scattered. Every metric is summarised from the same runs, so
+/// either all of them exist or none do — there is no partial summary.
+///
+/// Every gated metric is checked before anything is refused, so the error names
+/// *all* of them. Refusing at the first one hides how much of the cell moved,
+/// which is the difference between "one metric wobbled" and "the whole run was
+/// contended".
 fn summarize(samples: &[RunSample]) -> anyhow::Result<BenchSummary> {
     let missing = || anyhow::anyhow!("no measured runs completed — nothing to summarise");
 
-    // Each metric is checked for a trend *in collection order* before its
-    // order-blind spread is accepted.
-    let checked = |name: &str, f: fn(&RunSample) -> f64| -> anyhow::Result<Spread> {
-        let in_order: Vec<f64> = samples.iter().map(f).collect();
-        let spread = Spread::of(in_order.clone()).ok_or_else(missing)?;
-        assert_no_drift(name, &in_order, spread.median)?;
-        Ok(spread)
-    };
-
-    let ttft_ms = checked("ttft_ms", |s| s.ttft_ms)?;
-    let decode_tps = checked("decode_tps", |s| s.decode_tps)?;
-    let itl_p50_ms = checked("itl_p50_ms", |s| s.itl_p50_ms)?;
-    #[allow(
-        clippy::cast_precision_loss,
-        reason = "KV byte totals are far below 2^53; f64 is exact over the whole range"
-    )]
-    let kv_bytes = checked("kv_cache_bytes", |s| s.kv_cache_bytes as f64)?;
-
-    // `itl_p99_ms` is deliberately NOT drift-checked. Nearest-rank p99 over a
-    // 128-token run is the second-largest inter-token gap: an extreme-order
-    // statistic whose run-to-run movement is dominated by whether that one run
-    // happened to hit a stall, not by whether the cell has settled. Measured
-    // gemma-4-e2b at 4k: ttft, decode TPS and ITL p50 all moved 5-6% across
-    // three runs while p99 moved 26% — checking it would abort cells whose
-    // measurements are fine. Its spread is still printed, so the tail stays
-    // visible; it is just not evidence of a trend.
-    let itl_p99_ms =
-        Spread::of(samples.iter().map(|s| s.itl_p99_ms).collect()).ok_or_else(missing)?;
-
-    // Prefill throughput is present only if every run produced one.
-    let prefill_in_order: Option<Vec<f64>> = samples.iter().map(|s| s.prefill_tps).collect();
-    let prefill_tps = match prefill_in_order {
-        Some(v) => {
-            let spread = Spread::of(v.clone()).ok_or_else(missing)?;
-            assert_no_drift("prefill_tps", &v, spread.median)?;
-            Some(spread)
+    let mut spreads: Vec<(Metric, Spread)> = Vec::with_capacity(Metric::ALL.len());
+    let mut refusals: Vec<String> = Vec::new();
+    for metric in Metric::ALL {
+        let Some(in_order) = metric.values(samples) else {
+            continue;
+        };
+        let spread = Spread::of(&in_order).ok_or_else(missing)?;
+        if metric.gate() == Gate::Settled {
+            refusals.extend(settle_refusal(metric.name(), &in_order, &spread));
         }
-        None => None,
-    };
+        spreads.push((metric, spread));
+    }
+    if !refusals.is_empty() {
+        return Err(anyhow::anyhow!(
+            "this cell did not settle in {} of its {} gated metric(s), so it has no median to \
+             report:\n  - {}",
+            refusals.len(),
+            Metric::ALL
+                .iter()
+                .filter(|m| m.gate() == Gate::Settled)
+                .count(),
+            refusals.join("\n  - ")
+        ));
+    }
 
-    let token_digest = samples.first().ok_or_else(missing)?.token_digest;
-
+    let get = |metric: Metric| spreads.iter().find(|(m, _)| *m == metric).map(|&(_, s)| s);
     Ok(BenchSummary {
-        ttft_ms,
-        decode_tps,
-        prefill_tps,
-        itl_p50_ms,
-        itl_p99_ms,
-        kv_bytes,
-        token_digest,
+        ttft_ms: get(Metric::TtftMs).ok_or_else(missing)?,
+        decode_tps: get(Metric::DecodeTps).ok_or_else(missing)?,
+        prefill_tps: get(Metric::PrefillTps),
+        itl_p50_ms: get(Metric::ItlP50Ms).ok_or_else(missing)?,
+        itl_p99_ms: get(Metric::ItlP99Ms).ok_or_else(missing)?,
+        kv_bytes: get(Metric::KvCacheBytes).ok_or_else(missing)?,
+        token_digest: samples.first().ok_or_else(missing)?.token_digest,
     })
 }
 
@@ -673,7 +906,7 @@ fn prepare_prompt(args: &BenchArgs, tokenizer: &tokenizers::Tokenizer) -> anyhow
     Ok(prompt_ids)
 }
 
-/// Check that a run decoded the same tokens as the cell's first run.
+/// Check that every run of the cell decoded the same tokens.
 ///
 /// Every run in a cell feeds the same prompt to the same model at temperature 0
 /// with a fixed seed, so every run must emit a byte-identical token stream. A
@@ -684,16 +917,44 @@ fn prepare_prompt(args: &BenchArgs, tokenizer: &tokenizers::Tokenizer) -> anyhow
 /// beyond reproducibility: a KV cache that silently stops being written decodes
 /// *faster* while producing wrong tokens, so a timing-only instrument is biased
 /// toward accepting exactly that defect.
-fn assert_same_token_stream(label: &str, expected: u64, got: u64) -> anyhow::Result<()> {
-    if expected == got {
+///
+/// The reference is the **most common** digest, not the first run's. Anchoring
+/// on run 1 makes a cold-start defect — the case a repeated-run instrument is
+/// most likely to meet — report every *later* run as the deviant one, pointing
+/// the operator away from the run that actually misbehaved. The message lists
+/// every run with its digest either way, so a two-run cell with no majority is
+/// still fully described.
+fn assert_one_token_stream(runs: &[(String, u64)]) -> anyhow::Result<()> {
+    let mut counts: std::collections::HashMap<u64, usize> = std::collections::HashMap::new();
+    for &(_, digest) in runs {
+        *counts.entry(digest).or_insert(0) += 1;
+    }
+    if counts.len() <= 1 {
         return Ok(());
     }
+    // Ties broken by the smaller digest, so the message is deterministic.
+    let (majority, majority_n) = counts
+        .into_iter()
+        .max_by_key(|&(digest, n)| (n, std::cmp::Reverse(digest)))
+        .ok_or_else(|| anyhow::anyhow!("no runs to compare token streams across"))?;
+    let listing: Vec<String> = runs
+        .iter()
+        .map(|(label, digest)| {
+            let mark = if *digest == majority {
+                ""
+            } else {
+                "  <-- differs"
+            };
+            format!("{label}: {digest:#018x}{mark}")
+        })
+        .collect();
     Err(anyhow::anyhow!(
-        "{label} decoded a different token stream than the first run of this cell \
-         (digest {got:#018x} vs {expected:#018x}). Every run here decodes the same prompt at \
-         temperature 0, so the runs are not repeats of one measurement — and a cache that \
-         stops being written decodes faster while producing wrong tokens. Refusing to \
-         summarise them as one cell"
+        "the runs of this cell decoded different token streams, so they are not repeats of one \
+         measurement — and a cache that stops being written decodes faster while producing \
+         wrong tokens. Most common digest {majority:#018x} ({majority_n} of {} run(s)):\n  {}\n\
+         Refusing to summarise them as one cell",
+        runs.len(),
+        listing.join("\n  ")
     ))
 }
 
@@ -710,35 +971,32 @@ fn collect_samples(
 ) -> anyhow::Result<Vec<RunSample>> {
     // The warmup runs are discarded as measurements, but their tokens are still
     // evidence: a warmup that decodes something else than the measured runs is
-    // the same defect and costs nothing to catch.
-    let mut expected_digest: Option<u64> = None;
-    let mut check_digest = |label: &str, s: &RunSample| -> anyhow::Result<()> {
-        match expected_digest {
-            None => {
-                expected_digest = Some(s.token_digest);
-                Ok(())
-            }
-            Some(e) => assert_same_token_stream(label, e, s.token_digest),
-        }
-    };
+    // the same defect and costs nothing to catch. Digests are compared once, at
+    // the end, over every run — see `assert_one_token_stream`.
+    let mut digests: Vec<(String, u64)> = Vec::with_capacity((args.warmup + args.runs) as usize);
 
     for i in 0..args.warmup {
         info!(run = i + 1, of = args.warmup, "bench: warmup run");
         let s = measure_one(model, tokenizer, prompt_ids, args)
             .map_err(|e| anyhow::anyhow!("warmup run {} failed: {e}", i + 1))?;
-        check_digest(&format!("warmup run {}", i + 1), &s)?;
+        digests.push((format!("warmup run {}", i + 1), s.token_digest));
     }
 
     let mut samples: Vec<RunSample> = Vec::with_capacity(args.runs as usize);
     for i in 0..args.runs {
         let s = measure_one(model, tokenizer, prompt_ids, args)
             .map_err(|e| anyhow::anyhow!("measured run {} failed: {e}", i + 1))?;
-        check_digest(&format!("measured run {}", i + 1), &s)?;
+        digests.push((format!("measured run {}", i + 1), s.token_digest));
+        // Every reported metric appears here, so a run that the summary later
+        // refuses is still recoverable from the log — including `prefill_tps`,
+        // which is otherwise only ever printed as part of a summary that a
+        // refusal discards.
         info!(
             run = i + 1,
             of = args.runs,
             ttft_ms = s.ttft_ms,
             decode_tps = s.decode_tps,
+            prefill_tps = s.prefill_tps,
             itl_p50_ms = s.itl_p50_ms,
             itl_p99_ms = s.itl_p99_ms,
             kv_cache_bytes = s.kv_cache_bytes,
@@ -747,6 +1005,7 @@ fn collect_samples(
         );
         samples.push(s);
     }
+    assert_one_token_stream(&digests)?;
     Ok(samples)
 }
 

--- a/crates/rmlx-cli/src/commands/bench.rs
+++ b/crates/rmlx-cli/src/commands/bench.rs
@@ -17,18 +17,18 @@
 //!    not a time-to-first-token), are hard errors — not a fast-looking number.
 //! 2. **It never reports a bare central value.** Every metric carries its
 //!    observed min/max across the measured runs, and `--runs` is rejected below
-//!    2 so there is always a spread to report.
+//!    2 so there is always a spread to report. A metric that *trends* across
+//!    those runs has no central value at all, and is refused rather than
+//!    summarised — see [`detect_drift`].
 //!
 //! `bench` is read-only with respect to the metrics database: it prints, it
 //! does not record. Use `rmlx baseline --record` for the append-only store.
-
-#![allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
 
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use rmlx_mlx::Device;
-use rmlx_models::arch;
+use rmlx_models::{arch, classify_kv_bytes, CacheStats, KvBytesVerdict};
 use tracing::{info, warn};
 
 use super::baseline::tokenize_prompt_text;
@@ -42,14 +42,32 @@ pub(crate) const MIN_RUNS: u32 = 2;
 
 /// Prompt-cache slots used for every bench generation.
 ///
-/// Zero, deliberately. `bench` runs N generations of the *same* prompt in one
-/// process; with any slots at all, run 2 onwards would be served from the
-/// prompt cache, skip prefill entirely, and report a TTFT of a few milliseconds
-/// that looks like a very fast prefill instead of a measurement that was never
-/// taken. Zero slots makes every run a cache miss and therefore a real prefill.
-/// `assert_prefill_measured` re-checks that per run rather than trusting this
-/// constant.
-const BENCH_PROMPT_CACHE_SLOTS: usize = 0;
+/// One — an ordinary single-slot cache, the same shape `rmlx baseline` serves
+/// under. `bench` runs N generations of the *same* prompt in one process, so
+/// run 2 onwards would be served from the prompt cache, skip prefill entirely,
+/// and report a TTFT of a few milliseconds that looks like a very fast prefill
+/// instead of a measurement that was never taken.
+///
+/// What prevents that is [`arch::Architecture::clear_prompt_cache`], called
+/// before every generation: the cache is emptied, so the next request is a
+/// guaranteed miss and a real prefill. Asking for *zero* slots would not do it
+/// — capacity is clamped to a minimum of one, so a "zero-slot" cache still
+/// stores and can still serve a snapshot.
+///
+/// `assert_prefill_measured` re-checks the outcome per run rather than trusting
+/// either the constant or the clear.
+const BENCH_PROMPT_CACHE_SLOTS: usize = 1;
+
+/// Largest run-to-run trend a metric may show and still be summarised, as a
+/// percentage of its median. See [`detect_drift`].
+///
+/// Ten percent, calibrated against what this instrument is used for: it accepts
+/// or rejects changes at the repo's ±1% decode-TPS band and its >5%
+/// regression-stop line. A cell whose own metric moves more than twice that
+/// line across its own runs cannot support either comparison, whichever way it
+/// moves — an improving ramp means the cell had not converged just as much as a
+/// degrading one does.
+const TREND_MAX_DRIFT_PCT: f64 = 10.0;
 
 // ---------------------------------------------------------------------------
 // Spread — a central value that carries its observed range
@@ -75,11 +93,14 @@ impl Spread {
     /// Summarise a sample. `None` for an empty sample — there is no median of
     /// nothing, and returning a zero would be indistinguishable from a real
     /// measurement of zero.
-    pub(crate) fn of(values: &[f64]) -> Option<Self> {
+    ///
+    /// Takes the sample by value and sorts it in place: the caller has already
+    /// built the vector, and a borrowing signature would only copy it again.
+    pub(crate) fn of(values: Vec<f64>) -> Option<Self> {
         if values.is_empty() {
             return None;
         }
-        let mut sorted = values.to_vec();
+        let mut sorted = values;
         sorted.sort_by(f64::total_cmp);
         let n = sorted.len();
         // Bounds: `sorted` is non-empty (checked above), so `first`/`last` are
@@ -129,45 +150,87 @@ pub(crate) fn percentile_sorted(sorted: &[f64], q: f64) -> Option<f64> {
 }
 
 // ---------------------------------------------------------------------------
-// KV-byte reading — three states, not two
+// Drift — a trend is not a spread
 // ---------------------------------------------------------------------------
 
-/// What a pair of `kv_cache_bytes_sample()` reads around one generation says
-/// about the byte count that generation produced.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum KvBytesVerdict {
-    /// The generation reported a non-zero byte count. Usable.
-    Reported(u64),
-    /// The generation reported nothing: the readable value belongs to an
-    /// earlier generation, or is the never-written initialiser. This is the
-    /// state that a bare `-> u64` accessor collapses into "0" or, worse, into
-    /// the previous run's plausible-looking figure.
-    Unreported,
-    /// The generation did report, and reported zero bytes. Distinct from
-    /// `Unreported`: the plumbing works and the answer is still not usable as a
-    /// resident-KV measurement after a real prefill.
-    ReportedZero,
+/// Detect a run-to-run trend in `values`, **in collection order**.
+///
+/// Returns the fitted change from the first measured run to the last as a
+/// signed percentage of the median — positive means the metric rose.
+///
+/// [`Spread`] is order-blind by construction: it sorts. A metric that climbs
+/// monotonically from run to run therefore reports as a wide *spread*, and a
+/// wide spread is read as noise around a central value. It is not — a drifting
+/// cell has no central value, and its median is a point on a ramp that depends
+/// on where the operator stopped measuring.
+///
+/// The test is the least-squares slope over the run index, scaled to the whole
+/// run sequence and expressed against the median. Ordinary regression rather
+/// than a monotonicity test on purpose: a real ramp with one noisy step is
+/// still a ramp, and would escape a strict-monotonic check the moment `--runs`
+/// grew past three.
+///
+/// At the default three runs, a sample whose spread is very wide fits a slope
+/// in *whatever* order it arrives — with a 40%-wide sample, every permutation
+/// clears the threshold. That is not a flaw to tune away: three runs cannot
+/// separate a ramp from that much noise, and a cell that noisy has no
+/// trustworthy median either. Both are refused, which is the safe direction;
+/// the error prints the values in run order so the operator can see which it
+/// was.
+///
+/// `None` when there is no trend worth refusing over: fewer than two runs (no
+/// order to speak of), a zero median (no scale to express the change against),
+/// or a fitted change within [`TREND_MAX_DRIFT_PCT`].
+pub(crate) fn detect_drift(values_in_order: &[f64], median: f64) -> Option<f64> {
+    let n = values_in_order.len();
+    if n < 2 || median == 0.0 {
+        return None;
+    }
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "n is the run count — single digits in every real invocation"
+    )]
+    let n_f = n as f64;
+    let mean_x = (n_f - 1.0) / 2.0;
+    let mean_y = values_in_order.iter().sum::<f64>() / n_f;
+    let (mut sxy, mut sxx) = (0.0_f64, 0.0_f64);
+    for (i, y) in values_in_order.iter().enumerate() {
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "i indexes the run count — single digits in every real invocation"
+        )]
+        let dx = i as f64 - mean_x;
+        sxy += dx * (y - mean_y);
+        sxx += dx * dx;
+    }
+    if sxx == 0.0 {
+        return None;
+    }
+    // Slope per run, scaled across the whole sequence: first run to last.
+    let pct_of_median = sxy / sxx * (n_f - 1.0) / median.abs() * 100.0;
+    (pct_of_median.abs() > TREND_MAX_DRIFT_PCT).then_some(pct_of_median)
 }
 
-/// Classify the byte count a generation produced from the store sequence
-/// observed before and after it.
-///
-/// Detection ("did this generation report?") is decided by the sequence, and
-/// only then is the value interpreted. Collapsing the two — treating a zero, or
-/// an unchanged sequence, as "no KV" — is what silently records one run's
-/// number under another run's label.
-pub(crate) const fn classify_kv_bytes(
-    before: rmlx_models::KvBytesSample,
-    after: rmlx_models::KvBytesSample,
-) -> KvBytesVerdict {
-    if after.seq <= before.seq {
-        return KvBytesVerdict::Unreported;
-    }
-    if after.bytes == 0 {
-        return KvBytesVerdict::ReportedZero;
-    }
-    KvBytesVerdict::Reported(after.bytes)
+/// Refuse to summarise a metric that trended across its own runs.
+fn assert_no_drift(name: &str, values_in_order: &[f64], median: f64) -> anyhow::Result<()> {
+    let Some(pct) = detect_drift(values_in_order, median) else {
+        return Ok(());
+    };
+    let direction = if pct > 0.0 { "rose" } else { "fell" };
+    let ordered: Vec<String> = values_in_order.iter().map(|v| format!("{v:.3}")).collect();
+    Err(anyhow::anyhow!(
+        "{name} {direction} {:.1}% from the first measured run to the last ({}, in run order): \
+         this is a trend, not a spread, and its median is not a measurement. The cell had not \
+         reached a steady state — raise --warmup until consecutive runs agree, or measure a \
+         cell that settles",
+        pct.abs(),
+        ordered.join(" → ")
+    ))
 }
+
+// ---------------------------------------------------------------------------
+// KV-byte reading — three states, not two
+// ---------------------------------------------------------------------------
 
 /// Turn a verdict into a usable byte count or the reason there is none.
 fn kv_bytes_or_reason(verdict: KvBytesVerdict, arch_class: &str) -> anyhow::Result<u64> {
@@ -194,7 +257,12 @@ fn kv_bytes_or_reason(verdict: KvBytesVerdict, arch_class: &str) -> anyhow::Resu
 /// Check that one measured generation actually ran prefill.
 ///
 /// `stats` is the arch's prompt-cache counters read *after* the generation, or
-/// `None` when the arch has no cache to report. Two conditions, both necessary:
+/// `None` when the arch has no cache to report. Taken as the named
+/// [`CacheStats`] rather than a `(hits, misses)` pair: with a tuple, swapping
+/// the two at the call site type-checks, passes every test that builds tuples
+/// directly, and silently inverts the guard.
+///
+/// Two conditions, both necessary:
 ///
 /// - **`hits == 0`.** A hit means the post-prefill KV snapshot was replayed, so
 ///   the run's TTFT is a cache-replay time, not a time-to-first-token — a
@@ -203,14 +271,13 @@ fn kv_bytes_or_reason(verdict: KvBytesVerdict, arch_class: &str) -> anyhow::Resu
 ///   a prefill genuinely happened. Counters that report nothing certify
 ///   nothing.
 ///
-/// Absolute counters rather than a before/after delta, deliberately: a cache
-/// configured with zero slots is rebuilt on each generation, which resets the
-/// counters, and a delta across a reset reads as "no activity". The rule holds
-/// either way — under stable counters a repeat that was served shows `hits > 0`,
-/// and under reset counters the freshly-built cache shows `hits == 0,
-/// misses == 1`.
-pub(crate) fn assert_prefill_measured(stats: Option<(u64, u64)>) -> anyhow::Result<()> {
-    let Some((hits, misses)) = stats else {
+/// Absolute counters rather than a before/after delta, deliberately: the
+/// per-run `clear_prompt_cache` resets the counters along with the slots, and a
+/// delta across a reset reads as "no activity". The rule holds either way —
+/// under stable counters a repeat that was served shows `hits > 0`, and after a
+/// clear the run shows `hits == 0, misses == 1`.
+pub(crate) fn assert_prefill_measured(stats: Option<&CacheStats>) -> anyhow::Result<()> {
+    let Some(&CacheStats { hits, misses, .. }) = stats else {
         return Err(anyhow::anyhow!(
             "measured run reported no prompt-cache stats, so nothing certifies that it \
              performed a prefill rather than replaying a snapshot. Refusing to report its \
@@ -285,6 +352,22 @@ pub(crate) fn load_is_contended(load_1m: f64, cpus: usize) -> bool {
 // One measured run
 // ---------------------------------------------------------------------------
 
+/// FNV-1a-64 over a run's token ids.
+///
+/// Stable across processes and releases (unlike `DefaultHasher`), so two
+/// invocations of `bench` on the same cell can be compared by eye from the
+/// printed digest.
+pub(crate) fn token_stream_digest(token_ids: impl IntoIterator<Item = u32>) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for id in token_ids {
+        for b in id.to_le_bytes() {
+            h ^= u64::from(b);
+            h = h.wrapping_mul(0x1000_0000_01b3);
+        }
+    }
+    h
+}
+
 /// Everything one generation contributes to the summary.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RunSample {
@@ -292,8 +375,9 @@ pub(crate) struct RunSample {
     pub ttft_ms: f64,
     /// Steady-state decode rate over tokens 2..N, tokens/second.
     pub decode_tps: f64,
-    /// Prefill throughput, prompt tokens/second.
-    pub prefill_tps: f64,
+    /// Prefill throughput, prompt tokens/second. `None` when the run produced
+    /// nothing to divide by — never a zero standing in for one.
+    pub prefill_tps: Option<f64>,
     /// Median inter-token latency within the run, milliseconds.
     pub itl_p50_ms: f64,
     /// 99th-percentile inter-token latency within the run, milliseconds.
@@ -302,6 +386,9 @@ pub(crate) struct RunSample {
     pub kv_cache_bytes: u64,
     /// Tokens actually generated.
     pub n_generated: usize,
+    /// FNV-1a-64 over the run's token ids. Every run in a cell decodes the same
+    /// prompt at temperature 0, so every run must produce the same digest.
+    pub token_digest: u64,
 }
 
 /// Derive a run's metrics from the per-token arrival times.
@@ -319,6 +406,7 @@ pub(crate) fn sample_from_arrivals(
     arrivals_s: &[f64],
     prompt_tokens: usize,
     kv_cache_bytes: u64,
+    token_digest: u64,
 ) -> Option<RunSample> {
     if arrivals_s.len() < 2 {
         return None;
@@ -338,11 +426,14 @@ pub(crate) fn sample_from_arrivals(
     } else {
         return None;
     };
-    let prefill_tps = if first > 0.0 && prompt_tokens > 0 {
-        prompt_tokens as f64 / first
-    } else {
-        0.0
-    };
+    // `None`, not `0.0`: a zero here would be summarised and printed exactly
+    // like a measured throughput of zero — the one thing this file exists to
+    // prevent.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "prompt lengths are far below 2^53; f64 is exact over the whole range"
+    )]
+    let prefill_tps = (first > 0.0 && prompt_tokens > 0).then(|| prompt_tokens as f64 / first);
 
     Some(RunSample {
         ttft_ms: first * 1000.0,
@@ -352,6 +443,7 @@ pub(crate) fn sample_from_arrivals(
         itl_p99_ms: percentile_sorted(&itl_ms, 0.99)?,
         kv_cache_bytes,
         n_generated: arrivals_s.len(),
+        token_digest,
     })
 }
 
@@ -409,6 +501,11 @@ fn measure_one(
     let penalty_cfg = rmlx_models::PenaltyConfig::default();
     let mut token_history: Vec<u32> = Vec::new();
 
+    // Empty the prompt cache so this generation is a guaranteed miss and runs a
+    // real prefill. Done here, before the clock starts, so the clearing is not
+    // charged to the TTFT it protects.
+    model.clear_prompt_cache();
+
     let kv_before = model.kv_cache_bytes_sample();
 
     // Per-token arrival stamps. Reserved once, so the callback never allocates
@@ -439,7 +536,7 @@ fn measure_one(
         )
         .map_err(|e| anyhow::anyhow!("generate_greedy: {e}"))?;
 
-    assert_prefill_measured(model.cache_stats().map(|s| (s.hits, s.misses)))?;
+    assert_prefill_measured(model.cache_stats().as_ref())?;
 
     let kv_cache_bytes = kv_bytes_or_reason(
         classify_kv_bytes(kv_before, model.kv_cache_bytes_sample()),
@@ -459,42 +556,92 @@ fn measure_one(
         ));
     }
 
-    sample_from_arrivals(&arrivals_s, prompt_ids.len(), kv_cache_bytes).ok_or_else(|| {
-        anyhow::anyhow!(
-            "run generated {} token(s); at least 2 are needed for an inter-token latency \
+    let token_digest = token_stream_digest(steps.iter().map(|s| s.token_id));
+
+    sample_from_arrivals(&arrivals_s, prompt_ids.len(), kv_cache_bytes, token_digest).ok_or_else(
+        || {
+            anyhow::anyhow!(
+                "run generated {} token(s); at least 2 are needed for an inter-token latency \
              and a steady-state decode rate. Raise --max-tokens",
-            arrivals_s.len()
-        )
-    })
+                arrivals_s.len()
+            )
+        },
+    )
 }
 
 /// Summary of one bench cell.
 struct BenchSummary {
     ttft_ms: Spread,
     decode_tps: Spread,
-    prefill_tps: Spread,
+    /// `None` when any run could not produce a prefill throughput. A cell where
+    /// only some runs have one is not a cell.
+    prefill_tps: Option<Spread>,
     itl_p50_ms: Spread,
     itl_p99_ms: Spread,
     kv_bytes: Spread,
+    /// The one token-stream digest every run agreed on.
+    token_digest: u64,
 }
 
-/// Fold the measured runs into per-metric spreads.
+/// Fold the measured runs into per-metric spreads, refusing any metric that
+/// trended across the runs instead of settling.
 ///
-/// `None` when `samples` is empty; every metric is summarised from the same
-/// runs, so either all of them exist or none do.
-fn summarize(samples: &[RunSample]) -> Option<BenchSummary> {
-    let pick = |f: fn(&RunSample) -> f64| Spread::of(&samples.iter().map(f).collect::<Vec<_>>());
-    Some(BenchSummary {
-        ttft_ms: pick(|s| s.ttft_ms)?,
-        decode_tps: pick(|s| s.decode_tps)?,
-        prefill_tps: pick(|s| s.prefill_tps)?,
-        itl_p50_ms: pick(|s| s.itl_p50_ms)?,
-        itl_p99_ms: pick(|s| s.itl_p99_ms)?,
-        #[allow(
-            clippy::cast_precision_loss,
-            reason = "KV byte totals are far below 2^53; f64 is exact over the whole range"
-        )]
-        kv_bytes: pick(|s| s.kv_cache_bytes as f64)?,
+/// Errors when `samples` is empty, and when any checked metric drifted. Every
+/// metric is summarised from the same runs, so either all of them exist or none
+/// do — there is no partial summary.
+fn summarize(samples: &[RunSample]) -> anyhow::Result<BenchSummary> {
+    let missing = || anyhow::anyhow!("no measured runs completed — nothing to summarise");
+
+    // Each metric is checked for a trend *in collection order* before its
+    // order-blind spread is accepted.
+    let checked = |name: &str, f: fn(&RunSample) -> f64| -> anyhow::Result<Spread> {
+        let in_order: Vec<f64> = samples.iter().map(f).collect();
+        let spread = Spread::of(in_order.clone()).ok_or_else(missing)?;
+        assert_no_drift(name, &in_order, spread.median)?;
+        Ok(spread)
+    };
+
+    let ttft_ms = checked("ttft_ms", |s| s.ttft_ms)?;
+    let decode_tps = checked("decode_tps", |s| s.decode_tps)?;
+    let itl_p50_ms = checked("itl_p50_ms", |s| s.itl_p50_ms)?;
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "KV byte totals are far below 2^53; f64 is exact over the whole range"
+    )]
+    let kv_bytes = checked("kv_cache_bytes", |s| s.kv_cache_bytes as f64)?;
+
+    // `itl_p99_ms` is deliberately NOT drift-checked. Nearest-rank p99 over a
+    // 128-token run is the second-largest inter-token gap: an extreme-order
+    // statistic whose run-to-run movement is dominated by whether that one run
+    // happened to hit a stall, not by whether the cell has settled. Measured
+    // gemma-4-e2b at 4k: ttft, decode TPS and ITL p50 all moved 5-6% across
+    // three runs while p99 moved 26% — checking it would abort cells whose
+    // measurements are fine. Its spread is still printed, so the tail stays
+    // visible; it is just not evidence of a trend.
+    let itl_p99_ms =
+        Spread::of(samples.iter().map(|s| s.itl_p99_ms).collect()).ok_or_else(missing)?;
+
+    // Prefill throughput is present only if every run produced one.
+    let prefill_in_order: Option<Vec<f64>> = samples.iter().map(|s| s.prefill_tps).collect();
+    let prefill_tps = match prefill_in_order {
+        Some(v) => {
+            let spread = Spread::of(v.clone()).ok_or_else(missing)?;
+            assert_no_drift("prefill_tps", &v, spread.median)?;
+            Some(spread)
+        }
+        None => None,
+    };
+
+    let token_digest = samples.first().ok_or_else(missing)?.token_digest;
+
+    Ok(BenchSummary {
+        ttft_ms,
+        decode_tps,
+        prefill_tps,
+        itl_p50_ms,
+        itl_p99_ms,
+        kv_bytes,
+        token_digest,
     })
 }
 
@@ -526,6 +673,30 @@ fn prepare_prompt(args: &BenchArgs, tokenizer: &tokenizers::Tokenizer) -> anyhow
     Ok(prompt_ids)
 }
 
+/// Check that a run decoded the same tokens as the cell's first run.
+///
+/// Every run in a cell feeds the same prompt to the same model at temperature 0
+/// with a fixed seed, so every run must emit a byte-identical token stream. A
+/// cell whose runs disagree is not measuring one thing N times, and its timings
+/// describe N different generations.
+///
+/// This is also the only output check `bench` performs, and it is load-bearing
+/// beyond reproducibility: a KV cache that silently stops being written decodes
+/// *faster* while producing wrong tokens, so a timing-only instrument is biased
+/// toward accepting exactly that defect.
+fn assert_same_token_stream(label: &str, expected: u64, got: u64) -> anyhow::Result<()> {
+    if expected == got {
+        return Ok(());
+    }
+    Err(anyhow::anyhow!(
+        "{label} decoded a different token stream than the first run of this cell \
+         (digest {got:#018x} vs {expected:#018x}). Every run here decodes the same prompt at \
+         temperature 0, so the runs are not repeats of one measurement — and a cache that \
+         stops being written decodes faster while producing wrong tokens. Refusing to \
+         summarise them as one cell"
+    ))
+}
+
 /// Run the warmup runs (discarded) then the measured ones.
 ///
 /// A failure in any run aborts the whole invocation: a summary built from the
@@ -537,16 +708,32 @@ fn collect_samples(
     prompt_ids: &[u32],
     args: &BenchArgs,
 ) -> anyhow::Result<Vec<RunSample>> {
+    // The warmup runs are discarded as measurements, but their tokens are still
+    // evidence: a warmup that decodes something else than the measured runs is
+    // the same defect and costs nothing to catch.
+    let mut expected_digest: Option<u64> = None;
+    let mut check_digest = |label: &str, s: &RunSample| -> anyhow::Result<()> {
+        match expected_digest {
+            None => {
+                expected_digest = Some(s.token_digest);
+                Ok(())
+            }
+            Some(e) => assert_same_token_stream(label, e, s.token_digest),
+        }
+    };
+
     for i in 0..args.warmup {
         info!(run = i + 1, of = args.warmup, "bench: warmup run");
-        measure_one(model, tokenizer, prompt_ids, args)
+        let s = measure_one(model, tokenizer, prompt_ids, args)
             .map_err(|e| anyhow::anyhow!("warmup run {} failed: {e}", i + 1))?;
+        check_digest(&format!("warmup run {}", i + 1), &s)?;
     }
 
     let mut samples: Vec<RunSample> = Vec::with_capacity(args.runs as usize);
     for i in 0..args.runs {
         let s = measure_one(model, tokenizer, prompt_ids, args)
             .map_err(|e| anyhow::anyhow!("measured run {} failed: {e}", i + 1))?;
+        check_digest(&format!("measured run {}", i + 1), &s)?;
         info!(
             run = i + 1,
             of = args.runs,
@@ -555,6 +742,7 @@ fn collect_samples(
             itl_p50_ms = s.itl_p50_ms,
             itl_p99_ms = s.itl_p99_ms,
             kv_cache_bytes = s.kv_cache_bytes,
+            token_digest = format!("{:#018x}", s.token_digest),
             "bench: measured run"
         );
         samples.push(s);
@@ -563,6 +751,10 @@ fn collect_samples(
 }
 
 /// Execute `rmlx bench`.
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "owns the argument bundle for the whole invocation; main.rs builds it and hands it over"
+)]
 pub(crate) fn run_bench(args: BenchArgs) -> anyhow::Result<()> {
     if args.runs < MIN_RUNS {
         return Err(anyhow::anyhow!(
@@ -591,8 +783,7 @@ pub(crate) fn run_bench(args: BenchArgs) -> anyhow::Result<()> {
     info!(load_ms, arch = model.arch_class(), "bench: model loaded");
 
     let samples = collect_samples(&model, &tokenizer, &prompt_ids, &args)?;
-    let summary = summarize(&samples)
-        .ok_or_else(|| anyhow::anyhow!("no measured runs completed — nothing to summarise"))?;
+    let summary = summarize(&samples)?;
 
     let load_after = load_average_1m();
     let ctx = ReportCtx {
@@ -665,10 +856,11 @@ fn emit_json(ctx: &ReportCtx<'_>, s: &BenchSummary, samples: &[RunSample]) -> an
         "load_1m_after": ctx.load_after,
         "cpus": ctx.cpus,
         "contended": ctx.contended,
+        "token_digest": format!("{:#018x}", s.token_digest),
         "metrics": {
             "ttft_ms": spread_json(&s.ttft_ms),
             "decode_tps": spread_json(&s.decode_tps),
-            "prefill_tps": spread_json(&s.prefill_tps),
+            "prefill_tps": s.prefill_tps.as_ref().map(spread_json),
             "itl_p50_ms": spread_json(&s.itl_p50_ms),
             "itl_p99_ms": spread_json(&s.itl_p99_ms),
             "kv_cache_bytes": spread_json(&s.kv_bytes),
@@ -680,6 +872,7 @@ fn emit_json(ctx: &ReportCtx<'_>, s: &BenchSummary, samples: &[RunSample]) -> an
             "itl_p50_ms": r.itl_p50_ms,
             "itl_p99_ms": r.itl_p99_ms,
             "kv_cache_bytes": r.kv_cache_bytes,
+            "token_digest": format!("{:#018x}", r.token_digest),
         })).collect::<Vec<_>>(),
     });
     println!("{}", serde_json::to_string_pretty(&doc)?);
@@ -720,8 +913,17 @@ fn emit_table(ctx: &ReportCtx<'_>, s: &BenchSummary) {
     row("itl_p50_ms", &s.itl_p50_ms, 3);
     row("itl_p99_ms", &s.itl_p99_ms, 3);
     row("decode_tps", &s.decode_tps, 3);
-    row("prefill_tps", &s.prefill_tps, 1);
+    match s.prefill_tps.as_ref() {
+        Some(v) => row("prefill_tps", v, 1),
+        // No run produced a prefill throughput. Say so rather than print a
+        // zero that reads as a measured throughput of zero.
+        None => println!("{:<16} {:>14}", "prefill_tps", "n/a"),
+    }
     row("kv_cache_bytes", &s.kv_bytes, 0);
+    println!(
+        "tokens: digest={:#018x} (identical across every run)",
+        s.token_digest
+    );
 
     let fmt_load = |l: Option<f64>| l.map_or_else(|| "n/a".to_owned(), |v| format!("{v:.2}"));
     println!(

--- a/crates/rmlx-cli/src/commands/bench.rs
+++ b/crates/rmlx-cli/src/commands/bench.rs
@@ -1,0 +1,759 @@
+//! `rmlx bench` command implementation.
+//!
+//! A repeated-run decode instrument. One invocation serves the same
+//! (model, KV codec, context, generation length) cell `--warmup` + `--runs`
+//! times in-process and reports TTFT, inter-token latency (ITL p50/p99),
+//! steady-state decode TPS and filled-prefix KV bytes as a median plus the
+//! observed run-to-run range.
+//!
+//! Two properties matter more than the feature list, because the numbers this
+//! prints are used to accept or reject other work:
+//!
+//! 1. **It refuses to print a number it cannot stand behind.** Every quantity
+//!    it reports is checked against the condition that makes it meaningful, and
+//!    a failed check aborts the run with the reason. In particular a KV-byte
+//!    figure that the just-finished generation did not itself report, and a
+//!    generation whose prefill was served from the prompt cache (so its TTFT is
+//!    not a time-to-first-token), are hard errors — not a fast-looking number.
+//! 2. **It never reports a bare central value.** Every metric carries its
+//!    observed min/max across the measured runs, and `--runs` is rejected below
+//!    2 so there is always a spread to report.
+//!
+//! `bench` is read-only with respect to the metrics database: it prints, it
+//! does not record. Use `rmlx baseline --record` for the append-only store.
+
+#![allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use rmlx_mlx::Device;
+use rmlx_models::arch;
+use tracing::{info, warn};
+
+use super::baseline::tokenize_prompt_text;
+
+/// Minimum number of measured runs.
+///
+/// A single measurement has no observable spread, and a decode-TPS figure with
+/// no spread has repeatedly supported conclusions that a second run overturned.
+/// The instrument therefore has no single-run mode.
+pub(crate) const MIN_RUNS: u32 = 2;
+
+/// Prompt-cache slots used for every bench generation.
+///
+/// Zero, deliberately. `bench` runs N generations of the *same* prompt in one
+/// process; with any slots at all, run 2 onwards would be served from the
+/// prompt cache, skip prefill entirely, and report a TTFT of a few milliseconds
+/// that looks like a very fast prefill instead of a measurement that was never
+/// taken. Zero slots makes every run a cache miss and therefore a real prefill.
+/// `assert_prefill_measured` re-checks that per run rather than trusting this
+/// constant.
+const BENCH_PROMPT_CACHE_SLOTS: usize = 0;
+
+// ---------------------------------------------------------------------------
+// Spread — a central value that carries its observed range
+// ---------------------------------------------------------------------------
+
+/// Median of a sample together with the range actually observed.
+///
+/// There is no constructor that drops `min`/`max`: a caller cannot obtain the
+/// median of a bench metric without also obtaining its spread.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct Spread {
+    /// Median over the measured runs.
+    pub median: f64,
+    /// Smallest value observed.
+    pub min: f64,
+    /// Largest value observed.
+    pub max: f64,
+    /// Number of measured runs behind the figures.
+    pub n: usize,
+}
+
+impl Spread {
+    /// Summarise a sample. `None` for an empty sample — there is no median of
+    /// nothing, and returning a zero would be indistinguishable from a real
+    /// measurement of zero.
+    pub(crate) fn of(values: &[f64]) -> Option<Self> {
+        if values.is_empty() {
+            return None;
+        }
+        let mut sorted = values.to_vec();
+        sorted.sort_by(f64::total_cmp);
+        let n = sorted.len();
+        // Bounds: `sorted` is non-empty (checked above), so `first`/`last` are
+        // `Some` and the median indices are in range.
+        let median = if n % 2 == 1 {
+            *sorted.get(n / 2)?
+        } else {
+            f64::midpoint(*sorted.get(n / 2 - 1)?, *sorted.get(n / 2)?)
+        };
+        Some(Self {
+            median,
+            min: *sorted.first()?,
+            max: *sorted.last()?,
+            n,
+        })
+    }
+
+    /// Observed range as a percentage of the median — the one number that says
+    /// how much to trust the median. `0.0` when the median is zero (no scale to
+    /// express the range against).
+    pub(crate) fn range_pct(&self) -> f64 {
+        if self.median == 0.0 {
+            0.0
+        } else {
+            (self.max - self.min) / self.median.abs() * 100.0
+        }
+    }
+}
+
+/// Nearest-rank percentile of an already-sorted sample, `q` in `0.0..=1.0`.
+///
+/// `None` for an empty sample, for the same reason `Spread::of` returns `None`:
+/// a percentile of nothing is not zero.
+pub(crate) fn percentile_sorted(sorted: &[f64], q: f64) -> Option<f64> {
+    if sorted.is_empty() || !(0.0..=1.0).contains(&q) {
+        return None;
+    }
+    let n = sorted.len();
+    // Nearest-rank: rank = ceil(q * n), clamped to 1..=n, then 0-based.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "q is in 0..=1 and n is a slice length, so q*n is a small non-negative float"
+    )]
+    let rank = (q * n as f64).ceil() as usize;
+    sorted.get(rank.clamp(1, n) - 1).copied()
+}
+
+// ---------------------------------------------------------------------------
+// KV-byte reading — three states, not two
+// ---------------------------------------------------------------------------
+
+/// What a pair of `kv_cache_bytes_sample()` reads around one generation says
+/// about the byte count that generation produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KvBytesVerdict {
+    /// The generation reported a non-zero byte count. Usable.
+    Reported(u64),
+    /// The generation reported nothing: the readable value belongs to an
+    /// earlier generation, or is the never-written initialiser. This is the
+    /// state that a bare `-> u64` accessor collapses into "0" or, worse, into
+    /// the previous run's plausible-looking figure.
+    Unreported,
+    /// The generation did report, and reported zero bytes. Distinct from
+    /// `Unreported`: the plumbing works and the answer is still not usable as a
+    /// resident-KV measurement after a real prefill.
+    ReportedZero,
+}
+
+/// Classify the byte count a generation produced from the store sequence
+/// observed before and after it.
+///
+/// Detection ("did this generation report?") is decided by the sequence, and
+/// only then is the value interpreted. Collapsing the two — treating a zero, or
+/// an unchanged sequence, as "no KV" — is what silently records one run's
+/// number under another run's label.
+pub(crate) const fn classify_kv_bytes(
+    before: rmlx_models::KvBytesSample,
+    after: rmlx_models::KvBytesSample,
+) -> KvBytesVerdict {
+    if after.seq <= before.seq {
+        return KvBytesVerdict::Unreported;
+    }
+    if after.bytes == 0 {
+        return KvBytesVerdict::ReportedZero;
+    }
+    KvBytesVerdict::Reported(after.bytes)
+}
+
+/// Turn a verdict into a usable byte count or the reason there is none.
+fn kv_bytes_or_reason(verdict: KvBytesVerdict, arch_class: &str) -> anyhow::Result<u64> {
+    match verdict {
+        KvBytesVerdict::Reported(n) => Ok(n),
+        KvBytesVerdict::Unreported => Err(anyhow::anyhow!(
+            "generation produced no KV-cache byte count on arch {arch_class}: the store \
+             sequence did not advance, so the readable figure belongs to an earlier \
+             generation or is the unset initialiser. Refusing to report it as this run's \
+             measurement"
+        )),
+        KvBytesVerdict::ReportedZero => Err(anyhow::anyhow!(
+            "generation on arch {arch_class} reported a KV cache of 0 bytes after a real \
+             prefill — the byte accounting is wrong, not the cache. Refusing to report a \
+             zero-byte KV measurement"
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt-cache guard — a TTFT is only a TTFT when prefill actually ran
+// ---------------------------------------------------------------------------
+
+/// Check that one measured generation actually ran prefill.
+///
+/// `stats` is the arch's prompt-cache counters read *after* the generation, or
+/// `None` when the arch has no cache to report. Two conditions, both necessary:
+///
+/// - **`hits == 0`.** A hit means the post-prefill KV snapshot was replayed, so
+///   the run's TTFT is a cache-replay time, not a time-to-first-token — a
+///   number that is small, stable, and wrong.
+/// - **`misses >= 1`.** The cache was consulted and did not serve this run, so
+///   a prefill genuinely happened. Counters that report nothing certify
+///   nothing.
+///
+/// Absolute counters rather than a before/after delta, deliberately: a cache
+/// configured with zero slots is rebuilt on each generation, which resets the
+/// counters, and a delta across a reset reads as "no activity". The rule holds
+/// either way — under stable counters a repeat that was served shows `hits > 0`,
+/// and under reset counters the freshly-built cache shows `hits == 0,
+/// misses == 1`.
+pub(crate) fn assert_prefill_measured(stats: Option<(u64, u64)>) -> anyhow::Result<()> {
+    let Some((hits, misses)) = stats else {
+        return Err(anyhow::anyhow!(
+            "measured run reported no prompt-cache stats, so nothing certifies that it \
+             performed a prefill rather than replaying a snapshot. Refusing to report its \
+             TTFT"
+        ));
+    };
+    if hits > 0 {
+        return Err(anyhow::anyhow!(
+            "measured run was served from the prompt cache ({hits} hit(s), {misses} miss(es)): \
+             prefill was skipped, so its TTFT and prefill throughput are cache-replay times, \
+             not measurements. Refusing to report them"
+        ));
+    }
+    if misses == 0 {
+        return Err(anyhow::anyhow!(
+            "measured run recorded no prompt-cache miss: the cache was never consulted, so \
+             the counters do not certify that this run performed a fresh prefill and its \
+             TTFT cannot be attributed to it"
+        ));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Machine load — a contended host is not a measurement condition
+// ---------------------------------------------------------------------------
+
+/// Parse the 1-minute figure out of `sysctl -n vm.loadavg` output, which is
+/// `{ <1m> <5m> <15m> }`.
+///
+/// `None` when the text does not have that shape — an unparseable reading is
+/// reported as "no reading", never as a load of zero, which would silently
+/// certify a busy host as quiet.
+pub(crate) fn parse_loadavg_1m(sysctl_out: &str) -> Option<f64> {
+    sysctl_out
+        .trim()
+        .trim_start_matches('{')
+        .trim_end_matches('}')
+        .split_whitespace()
+        .next()?
+        .parse::<f64>()
+        .ok()
+}
+
+/// 1-minute load average, or `None` when the OS declines to report one.
+///
+/// Shells out rather than calling `getloadavg`: this crate denies `unsafe`, and
+/// the CLI already reads process figures through `ps` the same way.
+fn load_average_1m() -> Option<f64> {
+    let out = std::process::Command::new("sysctl")
+        .args(["-n", "vm.loadavg"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_loadavg_1m(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Whether the host looked busy enough for the measurement to be suspect.
+///
+/// The threshold is the CPU count: at or above it, runnable work outnumbers
+/// cores and the decode loop is competing for them. This does not abort the
+/// run — the operator may knowingly be measuring under load — but it is
+/// reported next to the numbers so a contended figure is never mistaken for a
+/// quiet-machine one.
+pub(crate) fn load_is_contended(load_1m: f64, cpus: usize) -> bool {
+    load_1m >= cpus as f64
+}
+
+// ---------------------------------------------------------------------------
+// One measured run
+// ---------------------------------------------------------------------------
+
+/// Everything one generation contributes to the summary.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RunSample {
+    /// Prefill through first token, milliseconds.
+    pub ttft_ms: f64,
+    /// Steady-state decode rate over tokens 2..N, tokens/second.
+    pub decode_tps: f64,
+    /// Prefill throughput, prompt tokens/second.
+    pub prefill_tps: f64,
+    /// Median inter-token latency within the run, milliseconds.
+    pub itl_p50_ms: f64,
+    /// 99th-percentile inter-token latency within the run, milliseconds.
+    pub itl_p99_ms: f64,
+    /// Filled-prefix KV cache bytes after decode.
+    pub kv_cache_bytes: u64,
+    /// Tokens actually generated.
+    pub n_generated: usize,
+}
+
+/// Derive a run's metrics from the per-token arrival times.
+///
+/// `arrivals_s` are the elapsed seconds, relative to generation start, at which
+/// each token became available — one entry per generated token, in order. The
+/// first entry is the TTFT; the gaps between consecutive entries are the
+/// inter-token latencies.
+///
+/// `None` when fewer than two tokens arrived: with one token there is no
+/// inter-token interval and no steady-state rate, and reporting the combined
+/// prefill+decode number in their place would label a prefill-dominated figure
+/// as a decode rate.
+pub(crate) fn sample_from_arrivals(
+    arrivals_s: &[f64],
+    prompt_tokens: usize,
+    kv_cache_bytes: u64,
+) -> Option<RunSample> {
+    if arrivals_s.len() < 2 {
+        return None;
+    }
+    let first = *arrivals_s.first()?;
+    let last = *arrivals_s.last()?;
+
+    let mut itl_ms: Vec<f64> = arrivals_s
+        .windows(2)
+        .filter_map(|w| Some((w.get(1)? - w.first()?) * 1000.0))
+        .collect();
+    itl_ms.sort_by(f64::total_cmp);
+
+    let decode_window_s = last - first;
+    let decode_tps = if decode_window_s > 0.0 {
+        (arrivals_s.len() as f64 - 1.0) / decode_window_s
+    } else {
+        return None;
+    };
+    let prefill_tps = if first > 0.0 && prompt_tokens > 0 {
+        prompt_tokens as f64 / first
+    } else {
+        0.0
+    };
+
+    Some(RunSample {
+        ttft_ms: first * 1000.0,
+        decode_tps,
+        prefill_tps,
+        itl_p50_ms: percentile_sorted(&itl_ms, 0.50)?,
+        itl_p99_ms: percentile_sorted(&itl_ms, 0.99)?,
+        kv_cache_bytes,
+        n_generated: arrivals_s.len(),
+    })
+}
+
+/// Arguments for one `rmlx bench` invocation.
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "internal closed struct — the argument bundle main.rs builds for the single call site"
+)]
+#[derive(Debug)]
+pub(crate) struct BenchArgs {
+    /// Model snapshot directory.
+    pub model: PathBuf,
+    /// Prompt file (plain text or chat-JSON fixture).
+    pub prompt: PathBuf,
+    /// Short label for the prompt in the summary.
+    pub prompt_label: String,
+    /// Inference device.
+    pub device: Device,
+    /// Tokens to generate per run.
+    pub max_tokens: u32,
+    /// Measured runs (>= `MIN_RUNS`).
+    pub runs: u32,
+    /// Discarded warmup runs before the measured ones.
+    pub warmup: u32,
+    /// Resolved KV-cache codec.
+    pub kv_quant: rmlx_kv_quant::KvQuant,
+    /// KV ring capacity override, when given.
+    pub max_ctx: Option<i32>,
+    /// Cap on tokenized prompt length.
+    pub max_prompt_tokens: usize,
+    /// Whether `--max-prompt-tokens` was passed explicitly.
+    pub cap_is_explicit: bool,
+    /// Opt into truncating an over-cap prompt on GPU.
+    pub allow_truncate: bool,
+    /// Emit the summary as one JSON object instead of a table.
+    pub json: bool,
+}
+
+/// Run one generation and return its sample, or the reason there is none.
+fn measure_one(
+    model: &arch::Architecture,
+    tokenizer: &tokenizers::Tokenizer,
+    prompt_ids: &[u32],
+    args: &BenchArgs,
+) -> anyhow::Result<RunSample> {
+    let sampler_cfg = rmlx_models::SamplerConfig {
+        temperature: 0.0,
+        top_p: 1.0,
+        top_k: 0,
+        min_p: 0.0,
+        seed: None,
+        top_logprobs_k: 0,
+    };
+    let mut rng = rmlx_models::Pcg32::new(sampler_cfg.seed_or_default());
+    let penalty_cfg = rmlx_models::PenaltyConfig::default();
+    let mut token_history: Vec<u32> = Vec::new();
+
+    let kv_before = model.kv_cache_bytes_sample();
+
+    // Per-token arrival stamps. Reserved once, so the callback never allocates
+    // and the timing it records is not the timing of its own bookkeeping.
+    let mut arrivals_s: Vec<f64> = Vec::with_capacity(args.max_tokens as usize);
+    let t0 = Instant::now();
+    let mut on_token = |_step: &rmlx_models::ProbeStep| -> Option<u32> {
+        arrivals_s.push(t0.elapsed().as_secs_f64());
+        None
+    };
+
+    let steps = model
+        .generate_greedy(
+            tokenizer,
+            prompt_ids,
+            args.max_tokens as usize,
+            args.device,
+            Some(args.kv_quant),
+            args.max_ctx,
+            BENCH_PROMPT_CACHE_SLOTS,
+            &[], // no EOS stop: every run must decode the same token count
+            &mut on_token,
+            None,
+            &sampler_cfg,
+            &mut rng,
+            &penalty_cfg,
+            &mut token_history,
+        )
+        .map_err(|e| anyhow::anyhow!("generate_greedy: {e}"))?;
+
+    assert_prefill_measured(model.cache_stats().map(|s| (s.hits, s.misses)))?;
+
+    let kv_cache_bytes = kv_bytes_or_reason(
+        classify_kv_bytes(kv_before, model.kv_cache_bytes_sample()),
+        model.arch_class(),
+    )?;
+
+    // The callback fires once per emitted token, so a mismatch means the two
+    // disagree about how many tokens the run produced — the arrival stamps
+    // could not then be attributed to the returned tokens.
+    if arrivals_s.len() != steps.len() {
+        return Err(anyhow::anyhow!(
+            "per-token callback fired {} time(s) but the run returned {} token(s): the \
+             arrival timestamps cannot be matched to the generated tokens, so the \
+             inter-token latencies are not this run's",
+            arrivals_s.len(),
+            steps.len()
+        ));
+    }
+
+    sample_from_arrivals(&arrivals_s, prompt_ids.len(), kv_cache_bytes).ok_or_else(|| {
+        anyhow::anyhow!(
+            "run generated {} token(s); at least 2 are needed for an inter-token latency \
+             and a steady-state decode rate. Raise --max-tokens",
+            arrivals_s.len()
+        )
+    })
+}
+
+/// Summary of one bench cell.
+struct BenchSummary {
+    ttft_ms: Spread,
+    decode_tps: Spread,
+    prefill_tps: Spread,
+    itl_p50_ms: Spread,
+    itl_p99_ms: Spread,
+    kv_bytes: Spread,
+}
+
+/// Fold the measured runs into per-metric spreads.
+///
+/// `None` when `samples` is empty; every metric is summarised from the same
+/// runs, so either all of them exist or none do.
+fn summarize(samples: &[RunSample]) -> Option<BenchSummary> {
+    let pick = |f: fn(&RunSample) -> f64| Spread::of(&samples.iter().map(f).collect::<Vec<_>>());
+    Some(BenchSummary {
+        ttft_ms: pick(|s| s.ttft_ms)?,
+        decode_tps: pick(|s| s.decode_tps)?,
+        prefill_tps: pick(|s| s.prefill_tps)?,
+        itl_p50_ms: pick(|s| s.itl_p50_ms)?,
+        itl_p99_ms: pick(|s| s.itl_p99_ms)?,
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "KV byte totals are far below 2^53; f64 is exact over the whole range"
+        )]
+        kv_bytes: pick(|s| s.kv_cache_bytes as f64)?,
+    })
+}
+
+/// Tokenize the prompt and apply the length cap.
+fn prepare_prompt(args: &BenchArgs, tokenizer: &tokenizers::Tokenizer) -> anyhow::Result<Vec<u32>> {
+    let prompt_text = std::fs::read_to_string(&args.prompt)
+        .map_err(|e| anyhow::anyhow!("cannot read prompt file {}: {e}", args.prompt.display()))?;
+    let (mut prompt_ids, template_used) =
+        tokenize_prompt_text(&args.model, tokenizer, &prompt_text)?;
+    let effective_len = super::baseline::resolve_prompt_truncation(
+        prompt_ids.len(),
+        args.max_prompt_tokens,
+        args.device,
+        args.cap_is_explicit,
+        args.allow_truncate,
+    )?;
+    prompt_ids.truncate(effective_len);
+    info!(
+        model = %args.model.display(),
+        device = ?args.device,
+        kv_quant = %args.kv_quant,
+        prompt_tokens = prompt_ids.len(),
+        max_tokens = args.max_tokens,
+        runs = args.runs,
+        warmup = args.warmup,
+        template_used,
+        "bench: starting"
+    );
+    Ok(prompt_ids)
+}
+
+/// Run the warmup runs (discarded) then the measured ones.
+///
+/// A failure in any run aborts the whole invocation: a summary built from the
+/// runs that happened to succeed would be a different measurement than the one
+/// requested, reported under the requested one's label.
+fn collect_samples(
+    model: &arch::Architecture,
+    tokenizer: &tokenizers::Tokenizer,
+    prompt_ids: &[u32],
+    args: &BenchArgs,
+) -> anyhow::Result<Vec<RunSample>> {
+    for i in 0..args.warmup {
+        info!(run = i + 1, of = args.warmup, "bench: warmup run");
+        measure_one(model, tokenizer, prompt_ids, args)
+            .map_err(|e| anyhow::anyhow!("warmup run {} failed: {e}", i + 1))?;
+    }
+
+    let mut samples: Vec<RunSample> = Vec::with_capacity(args.runs as usize);
+    for i in 0..args.runs {
+        let s = measure_one(model, tokenizer, prompt_ids, args)
+            .map_err(|e| anyhow::anyhow!("measured run {} failed: {e}", i + 1))?;
+        info!(
+            run = i + 1,
+            of = args.runs,
+            ttft_ms = s.ttft_ms,
+            decode_tps = s.decode_tps,
+            itl_p50_ms = s.itl_p50_ms,
+            itl_p99_ms = s.itl_p99_ms,
+            kv_cache_bytes = s.kv_cache_bytes,
+            "bench: measured run"
+        );
+        samples.push(s);
+    }
+    Ok(samples)
+}
+
+/// Execute `rmlx bench`.
+pub(crate) fn run_bench(args: BenchArgs) -> anyhow::Result<()> {
+    if args.runs < MIN_RUNS {
+        return Err(anyhow::anyhow!(
+            "--runs must be at least {MIN_RUNS}: a single measurement has no observable \
+             run-to-run spread, and this instrument does not report a central value without one"
+        ));
+    }
+
+    let tokenizer = tokenizers::Tokenizer::from_file(args.model.join("tokenizer.json"))
+        .map_err(|e| anyhow::anyhow!("cannot load tokenizer.json: {e}"))?;
+    let prompt_ids = prepare_prompt(&args, &tokenizer)?;
+
+    let cpus = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
+    let load_before = load_average_1m();
+    if load_before.is_some_and(|l| load_is_contended(l, cpus)) {
+        warn!(
+            load_1m = load_before,
+            cpus, "host is busy — bench numbers are contended, not quiet-machine figures"
+        );
+    }
+
+    let load_start = Instant::now();
+    let model = arch::load_model(&args.model, args.device, &arch::LoadOpts::default())
+        .map_err(|e| anyhow::anyhow!("arch::load_model: {e}"))?;
+    let load_ms = load_start.elapsed().as_secs_f64() * 1000.0;
+    info!(load_ms, arch = model.arch_class(), "bench: model loaded");
+
+    let samples = collect_samples(&model, &tokenizer, &prompt_ids, &args)?;
+    let summary = summarize(&samples)
+        .ok_or_else(|| anyhow::anyhow!("no measured runs completed — nothing to summarise"))?;
+
+    let load_after = load_average_1m();
+    let ctx = ReportCtx {
+        model_name: args
+            .model
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("(unknown)"),
+        arch_class: model.arch_class(),
+        args: &args,
+        prompt_tokens: prompt_ids.len(),
+        gen_tokens: samples.first().map_or(0, |s| s.n_generated),
+        load_ms,
+        load_before,
+        load_after,
+        cpus,
+        contended: [load_before, load_after]
+            .into_iter()
+            .flatten()
+            .any(|l| load_is_contended(l, cpus)),
+    };
+
+    if args.json {
+        emit_json(&ctx, &summary, &samples)?;
+    } else {
+        emit_table(&ctx, &summary);
+    }
+    Ok(())
+}
+
+/// Run context the summary needs alongside the metrics themselves.
+struct ReportCtx<'a> {
+    model_name: &'a str,
+    arch_class: &'a str,
+    args: &'a BenchArgs,
+    prompt_tokens: usize,
+    gen_tokens: usize,
+    load_ms: f64,
+    load_before: Option<f64>,
+    load_after: Option<f64>,
+    cpus: usize,
+    contended: bool,
+}
+
+fn spread_json(s: &Spread) -> serde_json::Value {
+    serde_json::json!({
+        "median": s.median,
+        "min": s.min,
+        "max": s.max,
+        "range_pct": s.range_pct(),
+        "n": s.n,
+    })
+}
+
+/// Machine-readable summary. Carries every individual run alongside the
+/// per-metric spreads, so a consumer can re-derive the spread rather than
+/// having to trust the summary.
+fn emit_json(ctx: &ReportCtx<'_>, s: &BenchSummary, samples: &[RunSample]) -> anyhow::Result<()> {
+    let doc = serde_json::json!({
+        "model": ctx.model_name,
+        "arch": ctx.arch_class,
+        "kv_quant": ctx.args.kv_quant.to_string(),
+        "prompt": ctx.args.prompt_label,
+        "prompt_tokens": ctx.prompt_tokens,
+        "gen_tokens": ctx.gen_tokens,
+        "runs": ctx.args.runs,
+        "warmup": ctx.args.warmup,
+        "load_ms": ctx.load_ms,
+        "load_1m_before": ctx.load_before,
+        "load_1m_after": ctx.load_after,
+        "cpus": ctx.cpus,
+        "contended": ctx.contended,
+        "metrics": {
+            "ttft_ms": spread_json(&s.ttft_ms),
+            "decode_tps": spread_json(&s.decode_tps),
+            "prefill_tps": spread_json(&s.prefill_tps),
+            "itl_p50_ms": spread_json(&s.itl_p50_ms),
+            "itl_p99_ms": spread_json(&s.itl_p99_ms),
+            "kv_cache_bytes": spread_json(&s.kv_bytes),
+        },
+        "runs_detail": samples.iter().map(|r| serde_json::json!({
+            "ttft_ms": r.ttft_ms,
+            "decode_tps": r.decode_tps,
+            "prefill_tps": r.prefill_tps,
+            "itl_p50_ms": r.itl_p50_ms,
+            "itl_p99_ms": r.itl_p99_ms,
+            "kv_cache_bytes": r.kv_cache_bytes,
+        })).collect::<Vec<_>>(),
+    });
+    println!("{}", serde_json::to_string_pretty(&doc)?);
+    Ok(())
+}
+
+/// Human-readable summary. Every row carries min/max so no reader sees a
+/// central value without its spread.
+fn emit_table(ctx: &ReportCtx<'_>, s: &BenchSummary) {
+    println!(
+        "bench: model={} arch={} kv_quant={} prompt={} prompt_tokens={} gen_tokens={} \
+         runs={} warmup={} load={:.0}ms",
+        ctx.model_name,
+        ctx.arch_class,
+        ctx.args.kv_quant,
+        ctx.args.prompt_label,
+        ctx.prompt_tokens,
+        ctx.gen_tokens,
+        ctx.args.runs,
+        ctx.args.warmup,
+        ctx.load_ms
+    );
+    println!(
+        "{:<16} {:>14} {:>14} {:>14} {:>9}",
+        "metric", "median", "min", "max", "range%"
+    );
+    let row = |name: &str, v: &Spread, prec: usize| {
+        println!(
+            "{name:<16} {:>14.prec$} {:>14.prec$} {:>14.prec$} {:>8.1}%",
+            v.median,
+            v.min,
+            v.max,
+            v.range_pct(),
+            prec = prec
+        );
+    };
+    row("ttft_ms", &s.ttft_ms, 2);
+    row("itl_p50_ms", &s.itl_p50_ms, 3);
+    row("itl_p99_ms", &s.itl_p99_ms, 3);
+    row("decode_tps", &s.decode_tps, 3);
+    row("prefill_tps", &s.prefill_tps, 1);
+    row("kv_cache_bytes", &s.kv_bytes, 0);
+
+    let fmt_load = |l: Option<f64>| l.map_or_else(|| "n/a".to_owned(), |v| format!("{v:.2}"));
+    println!(
+        "host: cpus={} load_1m={}→{}{}",
+        ctx.cpus,
+        fmt_load(ctx.load_before),
+        fmt_load(ctx.load_after),
+        if ctx.contended {
+            "  CONTENDED — measured while the host was busy, treat as a lower bound"
+        } else {
+            ""
+        }
+    );
+}
+
+/// Resolve a prompt path the same way `rmlx baseline` does.
+pub(crate) fn resolve_prompt(
+    prompts_root: &Path,
+    prompt: PathBuf,
+    prompt_tokens: Option<u32>,
+) -> anyhow::Result<(PathBuf, String)> {
+    if let Some(n) = prompt_tokens {
+        return super::baseline::resolve_prompt_tokens_file(prompts_root, n);
+    }
+    let label = prompt
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("unknown")
+        .to_owned();
+    Ok((prompt, label))
+}
+
+#[cfg(test)]
+#[path = "bench_tests.rs"]
+mod bench_tests;

--- a/crates/rmlx-cli/src/commands/bench_tests.rs
+++ b/crates/rmlx-cli/src/commands/bench_tests.rs
@@ -17,6 +17,18 @@ fn sample(bytes: u64, seq: u64) -> KvBytesSample {
     s
 }
 
+/// Prompt-cache counters as the guard sees them. Named fields, so a
+/// hits/misses transposition cannot slip through the way it could with a
+/// positional tuple.
+fn cache_stats(hits: u64, misses: u64) -> CacheStats {
+    // `CacheStats` is `#[non_exhaustive]` outside its crate, so build it from
+    // the `Default` and assign — the same way any downstream consumer would.
+    let mut s = CacheStats::default();
+    s.hits = hits;
+    s.misses = misses;
+    s
+}
+
 // ── KV bytes: three states, not two ─────────────────────────────────
 
 /// The load-bearing case. A generation that never reached its KV-byte store
@@ -104,7 +116,7 @@ fn unusable_kv_verdicts_are_errors_with_distinct_reasons() {
 /// "TTFT" is a few milliseconds of cache replay.
 #[test]
 fn prompt_cache_hit_is_refused() {
-    let err = assert_prefill_measured(Some((1, 1)))
+    let err = assert_prefill_measured(Some(&cache_stats(1, 1)))
         .expect_err("a cache-served run must not pass as a prefill measurement");
     let msg = err.to_string();
     assert!(msg.contains("served from the prompt cache"), "got: {msg}");
@@ -114,7 +126,8 @@ fn prompt_cache_hit_is_refused() {
 /// evidence that a fresh prefill happened.
 #[test]
 fn no_prompt_cache_activity_is_refused() {
-    let err = assert_prefill_measured(Some((0, 0))).expect_err("zero activity certifies nothing");
+    let err = assert_prefill_measured(Some(&cache_stats(0, 0)))
+        .expect_err("zero activity certifies nothing");
     assert!(err.to_string().contains("never consulted"));
 }
 
@@ -131,28 +144,32 @@ fn absent_prompt_cache_stats_are_refused() {
 /// them was a hit.
 #[test]
 fn repeated_misses_with_no_hits_pass() {
-    assert!(assert_prefill_measured(Some((0, 1))).is_ok());
-    assert!(assert_prefill_measured(Some((0, 3))).is_ok());
+    assert!(assert_prefill_measured(Some(&cache_stats(0, 1))).is_ok());
+    assert!(assert_prefill_measured(Some(&cache_stats(0, 3))).is_ok());
 }
 
 /// A hit is refused however many misses accompany it — a run that was served
 /// is a run whose prefill did not happen.
 #[test]
 fn a_hit_is_refused_regardless_of_miss_count() {
-    assert!(assert_prefill_measured(Some((1, 5))).is_err());
-    assert!(assert_prefill_measured(Some((7, 0))).is_err());
+    assert!(assert_prefill_measured(Some(&cache_stats(1, 5))).is_err());
+    assert!(assert_prefill_measured(Some(&cache_stats(7, 0))).is_err());
 }
 
 // ── Spread: no central value without its range ─────────────────────
 
 #[test]
 fn spread_of_empty_sample_is_none() {
-    assert_eq!(Spread::of(&[]), None, "a median of nothing is not zero");
+    assert_eq!(
+        Spread::of(Vec::new()),
+        None,
+        "a median of nothing is not zero"
+    );
 }
 
 #[test]
 fn spread_reports_median_and_observed_range() {
-    let s = Spread::of(&[110.0, 100.0, 105.0]).expect("non-empty");
+    let s = Spread::of(vec![110.0, 100.0, 105.0]).expect("non-empty");
     assert!((s.median - 105.0).abs() < 1e-9);
     assert!((s.min - 100.0).abs() < 1e-9);
     assert!((s.max - 110.0).abs() < 1e-9);
@@ -167,7 +184,7 @@ fn spread_reports_median_and_observed_range() {
 
 #[test]
 fn spread_median_of_even_sample_averages_the_middle_two() {
-    let s = Spread::of(&[1.0, 2.0, 3.0, 4.0]).expect("non-empty");
+    let s = Spread::of(vec![1.0, 2.0, 3.0, 4.0]).expect("non-empty");
     assert!((s.median - 2.5).abs() < 1e-9);
 }
 
@@ -175,8 +192,8 @@ fn spread_median_of_even_sample_averages_the_middle_two() {
 /// same thing — that collapse is what made single-run numbers look conclusive.
 #[test]
 fn equal_medians_with_different_stability_are_distinguishable() {
-    let tight = Spread::of(&[99.9, 100.0, 100.1]).expect("non-empty");
-    let loose = Spread::of(&[70.0, 100.0, 130.0]).expect("non-empty");
+    let tight = Spread::of(vec![99.9, 100.0, 100.1]).expect("non-empty");
+    let loose = Spread::of(vec![70.0, 100.0, 130.0]).expect("non-empty");
     assert!((tight.median - loose.median).abs() < 1e-9);
     assert!(
         loose.range_pct() > tight.range_pct() * 10.0,
@@ -263,14 +280,14 @@ fn percentile_rejects_out_of_range_quantile() {
 fn sample_from_arrivals_derives_ttft_itl_and_decode_rate() {
     // TTFT 0.5 s, then 4 more tokens at 100 ms each.
     let arrivals = [0.5, 0.6, 0.7, 0.8, 0.9];
-    let s = sample_from_arrivals(&arrivals, 1000, 4096).expect("5 tokens is enough");
+    let s = sample_from_arrivals(&arrivals, 1000, 4096, 0xabc).expect("5 tokens is enough");
     assert!((s.ttft_ms - 500.0).abs() < 1e-6);
     assert!((s.itl_p50_ms - 100.0).abs() < 1e-6);
     assert!((s.itl_p99_ms - 100.0).abs() < 1e-6);
     // 4 inter-token intervals over 0.4 s.
     assert!((s.decode_tps - 10.0).abs() < 1e-6, "{}", s.decode_tps);
     // 1000 prompt tokens in 0.5 s.
-    assert!((s.prefill_tps - 2000.0).abs() < 1e-6);
+    assert!((s.prefill_tps.expect("first arrival is non-zero") - 2000.0).abs() < 1e-6);
     assert_eq!(s.kv_cache_bytes, 4096);
     assert_eq!(s.n_generated, 5);
 }
@@ -279,7 +296,8 @@ fn sample_from_arrivals_derives_ttft_itl_and_decode_rate() {
 /// this run would report ~5.5 tok/s instead of 10.
 #[test]
 fn decode_rate_excludes_prefill() {
-    let s = sample_from_arrivals(&[0.5, 0.6, 0.7, 0.8, 0.9], 1000, 1).expect("enough tokens");
+    let s =
+        sample_from_arrivals(&[0.5, 0.6, 0.7, 0.8, 0.9], 1000, 1, 0xabc).expect("enough tokens");
     let with_prefill_included = 5.0 / 0.9;
     assert!(
         s.decode_tps > with_prefill_included * 1.5,
@@ -293,15 +311,15 @@ fn decode_rate_excludes_prefill() {
 /// decode-rate label.
 #[test]
 fn single_token_run_yields_no_sample() {
-    assert!(sample_from_arrivals(&[0.5], 100, 4096).is_none());
-    assert!(sample_from_arrivals(&[], 100, 4096).is_none());
+    assert!(sample_from_arrivals(&[0.5], 100, 4096, 0).is_none());
+    assert!(sample_from_arrivals(&[], 100, 4096, 0).is_none());
 }
 
 /// Arrivals with no elapsed time between first and last cannot produce a rate;
 /// a divide-by-zero here would surface as `inf` tok/s.
 #[test]
 fn zero_width_decode_window_yields_no_sample() {
-    assert!(sample_from_arrivals(&[0.5, 0.5], 100, 4096).is_none());
+    assert!(sample_from_arrivals(&[0.5, 0.5], 100, 4096, 0).is_none());
 }
 
 /// ITL percentiles are computed over the gaps, so a stall in the middle of a
@@ -315,7 +333,7 @@ fn itl_p99_catches_a_mid_run_stall() {
         let prev = *arrivals.last().expect("non-empty");
         arrivals.push(prev + step);
     }
-    let s = sample_from_arrivals(&arrivals, 100, 4096).expect("enough tokens");
+    let s = sample_from_arrivals(&arrivals, 100, 4096, 0xabc).expect("enough tokens");
     assert!((s.itl_p50_ms - 10.0).abs() < 1e-6, "p50={}", s.itl_p50_ms);
     assert!(
         s.itl_p99_ms > 400.0,
@@ -346,4 +364,191 @@ fn unparseable_loadavg_is_absent_not_zero() {
     assert_eq!(parse_loadavg_1m(""), None);
     assert_eq!(parse_loadavg_1m("{ }"), None);
     assert_eq!(parse_loadavg_1m("sysctl: unknown oid"), None);
+}
+
+// ── Drift: a trend is not a spread ──────────────────────────────────
+
+/// The measured case this guard was built for: gemma-4-e2b at 64k, three
+/// consecutive in-process generations, TTFT in milliseconds. `Spread` sorts,
+/// so it reports this as a wide range around a median; in collection order it
+/// is a ramp, and the median is a point on it.
+#[test]
+fn measured_ttft_ramp_is_detected_as_drift() {
+    let in_order = [17_769.4, 22_764.3, 25_475.1];
+    let spread = Spread::of(in_order.to_vec()).expect("non-empty");
+    let pct = detect_drift(&in_order, spread.median).expect("a 43% ramp is a trend");
+    assert!(
+        pct > 30.0,
+        "fitted drift {pct:.1}% understates a 17.8s → 25.5s ramp"
+    );
+    let err = assert_no_drift("ttft_ms", &in_order, spread.median)
+        .expect_err("a drifting metric must not be summarised");
+    let msg = err.to_string();
+    assert!(msg.contains("trend, not a spread"), "got: {msg}");
+    assert!(msg.contains("rose"), "must name the direction: {msg}");
+}
+
+/// Order is the whole point: a one-run spike that starts and ends at the same
+/// place is spread, while the same magnitude of movement spent going one way is
+/// a trend. `Spread` cannot tell them apart, because it sorts before it looks —
+/// both of these produce an identical median and an identical range.
+#[test]
+fn a_spike_is_spread_but_a_ramp_is_drift() {
+    let spike = [100.0, 130.0, 100.0];
+    let ramp = [100.0, 115.0, 130.0];
+    let spike_spread = Spread::of(spike.to_vec()).expect("non-empty");
+    let ramp_spread = Spread::of(ramp.to_vec()).expect("non-empty");
+    assert!(
+        (spike_spread.max - ramp_spread.max).abs() < 1e-9
+            && (spike_spread.min - ramp_spread.min).abs() < 1e-9,
+        "both samples must look identical to the order-blind summary"
+    );
+    assert_eq!(
+        detect_drift(&spike, spike_spread.median),
+        None,
+        "a run that returned to where it started did not trend"
+    );
+    assert!(
+        detect_drift(&ramp, ramp_spread.median).is_some(),
+        "the same movement spent going one way is a trend"
+    );
+}
+
+/// Decode TPS falling across runs is the same defect with the opposite sign —
+/// the measured Bonsai case, 129.24 → 126.74 → 115.59.
+#[test]
+fn a_falling_metric_drifts_too() {
+    let in_order = [129.24, 126.74, 115.59];
+    let spread = Spread::of(in_order.to_vec()).expect("non-empty");
+    let pct = detect_drift(&in_order, spread.median).expect("a 10.6% decline is a trend");
+    assert!(pct < 0.0, "direction must be signed");
+    let msg = assert_no_drift("decode_tps", &in_order, spread.median)
+        .expect_err("a falling metric is still drifting")
+        .to_string();
+    assert!(msg.contains("fell"), "got: {msg}");
+}
+
+/// A settled cell must pass. These are the measured gemma-4-e2b ITL p50 values
+/// from the same run that produced the TTFT ramp above: the run-to-run noise is
+/// under 1%, and refusing it would make the instrument useless.
+#[test]
+fn a_settled_metric_is_not_drift() {
+    let in_order = [9.455, 9.840, 9.538];
+    let spread = Spread::of(in_order.to_vec()).expect("non-empty");
+    assert_eq!(detect_drift(&in_order, spread.median), None);
+    assert!(assert_no_drift("itl_p50_ms", &in_order, spread.median).is_ok());
+}
+
+/// A constant metric has no trend and no scale problem. Measured KV bytes are
+/// bit-identical across runs of a cell, so this is the common case.
+#[test]
+fn a_constant_metric_is_not_drift() {
+    let in_order = [649_353_216.0, 649_353_216.0, 649_353_216.0];
+    assert_eq!(detect_drift(&in_order, 649_353_216.0), None);
+}
+
+/// Measured gemma-4-e2b at 4k, three runs: the robust metrics move 5-6% and the
+/// tail statistic moves 26%. The threshold has to sit above the first group and
+/// below a real ramp, or the guard is either useless or unusable. This pins
+/// that separation, so a later threshold change has to face it.
+#[test]
+fn the_threshold_separates_warmup_wobble_from_a_ramp() {
+    // Settled-enough: measured ttft, decode TPS and ITL p50 from one cell.
+    for (name, v, med) in [
+        ("ttft_ms", [209.207, 215.761, 198.285], 209.207),
+        ("decode_tps", [119.178, 121.846, 126.562], 121.846),
+        ("itl_p50_ms", [8.368, 8.098, 7.889], 8.098),
+    ] {
+        assert_eq!(
+            detect_drift(&v, med),
+            None,
+            "{name} is ordinary warmup wobble and must not abort the cell"
+        );
+    }
+    // A real ramp from the same model at 64k must still be caught.
+    assert!(detect_drift(&[17_065.0, 22_768.2, 24_684.6], 22_768.2).is_some());
+}
+
+/// Mutation check: the guard must key on the run-to-run *trend*, not on the
+/// magnitude of the values. A cell an order of magnitude larger, equally
+/// settled, must still pass.
+#[test]
+fn drift_is_scale_free() {
+    let small = [100.0, 101.0, 100.5];
+    let large = [100_000.0, 101_000.0, 100_500.0];
+    assert_eq!(detect_drift(&small, 100.5), None);
+    assert_eq!(detect_drift(&large, 100_500.0), None);
+    // And a proportionally identical ramp is caught at either scale.
+    assert!(detect_drift(&[100.0, 120.0, 140.0], 120.0).is_some());
+    assert!(detect_drift(&[100_000.0, 120_000.0, 140_000.0], 120_000.0).is_some());
+}
+
+/// Degenerate inputs must not manufacture a verdict: one run has no order, and
+/// a zero median has no scale to express a change against.
+#[test]
+fn drift_needs_order_and_a_scale() {
+    assert_eq!(detect_drift(&[100.0], 100.0), None);
+    assert_eq!(detect_drift(&[], 0.0), None);
+    assert_eq!(detect_drift(&[0.0, 5.0], 0.0), None);
+}
+
+// ── Token stream: same prompt, temperature 0, same tokens ───────────
+
+/// A frozen KV cache decodes *faster* while producing wrong tokens, so a
+/// timing-only instrument is biased toward accepting it. The digest is what
+/// makes that visible.
+#[test]
+fn a_differing_token_stream_is_refused() {
+    let a = token_stream_digest([1_u32, 2, 3, 4]);
+    let b = token_stream_digest([1_u32, 2, 3, 5]);
+    assert_ne!(a, b, "one differing token must change the digest");
+    let msg = assert_same_token_stream("measured run 2", a, b)
+        .expect_err("runs of one cell must decode the same tokens")
+        .to_string();
+    assert!(msg.contains("different token stream"), "got: {msg}");
+    assert!(assert_same_token_stream("measured run 2", a, a).is_ok());
+}
+
+/// Order matters: a digest that ignored it would pass a run that emitted the
+/// right tokens in the wrong sequence.
+#[test]
+fn the_digest_is_order_sensitive() {
+    assert_ne!(
+        token_stream_digest([1_u32, 2, 3]),
+        token_stream_digest([3_u32, 2, 1])
+    );
+}
+
+/// Length matters too — a truncated stream must not collide with a full one.
+#[test]
+fn the_digest_distinguishes_a_truncated_stream() {
+    assert_ne!(
+        token_stream_digest([1_u32, 2, 3]),
+        token_stream_digest([1_u32, 2])
+    );
+    assert_ne!(token_stream_digest([0_u32]), token_stream_digest([]));
+}
+
+// ── prefill_tps: absent, never zero ─────────────────────────────────
+
+/// The one place in the file that used to substitute a literal `0.0` for a
+/// quantity it could not compute, and then feed it to `Spread` and print it as
+/// a measurement.
+#[test]
+fn prefill_throughput_is_absent_not_zero_when_undefined() {
+    // Prompt of zero tokens: nothing was prefilled, so there is no throughput.
+    let s = sample_from_arrivals(&[0.5, 0.6, 0.7], 0, 4096, 0xabc).expect("enough tokens");
+    assert_eq!(
+        s.prefill_tps, None,
+        "a zero here is printed exactly like a measured throughput of zero"
+    );
+    // The rest of the run is still a valid measurement.
+    assert!((s.ttft_ms - 500.0).abs() < 1e-6);
+}
+
+/// A run whose first token arrived at t=0 has no prefill interval to divide by.
+#[test]
+fn prefill_throughput_is_absent_when_the_first_token_is_instant() {
+    let s = sample_from_arrivals(&[0.0, 0.1, 0.2], 1000, 4096, 0xabc).expect("enough tokens");
+    assert_eq!(s.prefill_tps, None);
 }

--- a/crates/rmlx-cli/src/commands/bench_tests.rs
+++ b/crates/rmlx-cli/src/commands/bench_tests.rs
@@ -1,0 +1,349 @@
+//! Unit tests for the `rmlx bench` instrument.
+//!
+//! The subject here is the instrument's refusal behaviour, not its arithmetic:
+//! every test that matters feeds it a condition under which its numbers would
+//! be wrong and asserts that it says so instead of returning one.
+
+use super::*;
+use rmlx_models::KvBytesSample;
+
+fn sample(bytes: u64, seq: u64) -> KvBytesSample {
+    // `KvBytesSample` is `#[non_exhaustive]` outside its crate, so build it
+    // from the `Default` and assign — the same way any downstream consumer
+    // would have to.
+    let mut s = KvBytesSample::default();
+    s.bytes = bytes;
+    s.seq = seq;
+    s
+}
+
+// ── KV bytes: three states, not two ─────────────────────────────────
+
+/// The load-bearing case. A generation that never reached its KV-byte store
+/// leaves the previous generation's figure readable. A classifier that looked
+/// only at the value would hand back `9_000_000` — a number from a different
+/// run, indistinguishable from a fresh one.
+#[test]
+fn kv_bytes_unreported_when_sequence_did_not_advance() {
+    let before = sample(9_000_000, 7);
+    let after = sample(9_000_000, 7);
+    assert_eq!(
+        classify_kv_bytes(before, after),
+        KvBytesVerdict::Unreported,
+        "an unchanged store sequence means this generation reported nothing; the \
+         readable byte count belongs to an earlier one"
+    );
+}
+
+/// "Never stored" is the same failure with a zero value: the byte count is the
+/// initialiser, not a measurement of an empty cache.
+#[test]
+fn kv_bytes_unreported_when_nothing_was_ever_stored() {
+    assert_eq!(
+        classify_kv_bytes(sample(0, 0), sample(0, 0)),
+        KvBytesVerdict::Unreported
+    );
+}
+
+/// A genuine store of zero is a *different* state from "nothing was stored" —
+/// the plumbing worked and the answer is zero. It is still not usable, but it
+/// points at the byte accounting rather than at the reporting path.
+#[test]
+fn kv_bytes_reported_zero_is_distinct_from_unreported() {
+    assert_eq!(
+        classify_kv_bytes(sample(0, 0), sample(0, 1)),
+        KvBytesVerdict::ReportedZero
+    );
+    assert_ne!(
+        classify_kv_bytes(sample(0, 0), sample(0, 1)),
+        classify_kv_bytes(sample(0, 0), sample(0, 0)),
+        "collapsing 'reported zero' into 'never reported' is the bug this \
+         classifier exists to prevent"
+    );
+}
+
+#[test]
+fn kv_bytes_reported_when_sequence_advanced_with_a_value() {
+    assert_eq!(
+        classify_kv_bytes(sample(9_000_000, 7), sample(4_242, 8)),
+        KvBytesVerdict::Reported(4_242)
+    );
+}
+
+/// Both unusable verdicts must produce an error, and the two errors must not
+/// read the same — the operator needs to know which of the two happened.
+#[test]
+fn unusable_kv_verdicts_are_errors_with_distinct_reasons() {
+    let unreported = kv_bytes_or_reason(KvBytesVerdict::Unreported, "TestArch");
+    let zero = kv_bytes_or_reason(KvBytesVerdict::ReportedZero, "TestArch");
+    let unreported_msg = unreported
+        .expect_err("Unreported must not yield a number")
+        .to_string();
+    let zero_msg = zero
+        .expect_err("ReportedZero must not yield a number")
+        .to_string();
+    assert!(
+        unreported_msg.contains("store sequence did not advance"),
+        "unreported error must name the cause, got: {unreported_msg}"
+    );
+    assert!(
+        zero_msg.contains("0 bytes"),
+        "reported-zero error must name the cause, got: {zero_msg}"
+    );
+    assert_ne!(unreported_msg, zero_msg);
+    assert_eq!(
+        kv_bytes_or_reason(KvBytesVerdict::Reported(512), "TestArch").ok(),
+        Some(512)
+    );
+}
+
+// ── Prompt-cache guard: a TTFT is only a TTFT when prefill ran ──────
+
+/// The condition an in-process repeated-run bench walks straight into: with
+/// reusing prompt-cache slots, run 2 replays the post-prefill snapshot and its
+/// "TTFT" is a few milliseconds of cache replay.
+#[test]
+fn prompt_cache_hit_is_refused() {
+    let err = assert_prefill_measured(Some((1, 1)))
+        .expect_err("a cache-served run must not pass as a prefill measurement");
+    let msg = err.to_string();
+    assert!(msg.contains("served from the prompt cache"), "got: {msg}");
+}
+
+/// A cache that was never consulted certifies nothing either — silence is not
+/// evidence that a fresh prefill happened.
+#[test]
+fn no_prompt_cache_activity_is_refused() {
+    let err = assert_prefill_measured(Some((0, 0))).expect_err("zero activity certifies nothing");
+    assert!(err.to_string().contains("never consulted"));
+}
+
+/// An arch with no cache stats at all is the same failure: nothing observable
+/// says a prefill happened.
+#[test]
+fn absent_prompt_cache_stats_are_refused() {
+    let err = assert_prefill_measured(None).expect_err("absent stats certify nothing");
+    assert!(err.to_string().contains("no prompt-cache stats"));
+}
+
+/// Repeated misses are fine — under counters that are not reset between runs,
+/// run 3 legitimately shows 3 cumulative misses. What matters is that none of
+/// them was a hit.
+#[test]
+fn repeated_misses_with_no_hits_pass() {
+    assert!(assert_prefill_measured(Some((0, 1))).is_ok());
+    assert!(assert_prefill_measured(Some((0, 3))).is_ok());
+}
+
+/// A hit is refused however many misses accompany it — a run that was served
+/// is a run whose prefill did not happen.
+#[test]
+fn a_hit_is_refused_regardless_of_miss_count() {
+    assert!(assert_prefill_measured(Some((1, 5))).is_err());
+    assert!(assert_prefill_measured(Some((7, 0))).is_err());
+}
+
+// ── Spread: no central value without its range ─────────────────────
+
+#[test]
+fn spread_of_empty_sample_is_none() {
+    assert_eq!(Spread::of(&[]), None, "a median of nothing is not zero");
+}
+
+#[test]
+fn spread_reports_median_and_observed_range() {
+    let s = Spread::of(&[110.0, 100.0, 105.0]).expect("non-empty");
+    assert!((s.median - 105.0).abs() < 1e-9);
+    assert!((s.min - 100.0).abs() < 1e-9);
+    assert!((s.max - 110.0).abs() < 1e-9);
+    assert_eq!(s.n, 3);
+    // 10/105 → ~9.52%
+    assert!(
+        (s.range_pct() - 9.523_809_5).abs() < 1e-4,
+        "{}",
+        s.range_pct()
+    );
+}
+
+#[test]
+fn spread_median_of_even_sample_averages_the_middle_two() {
+    let s = Spread::of(&[1.0, 2.0, 3.0, 4.0]).expect("non-empty");
+    assert!((s.median - 2.5).abs() < 1e-9);
+}
+
+/// Two samples with the same median but different stability must not print the
+/// same thing — that collapse is what made single-run numbers look conclusive.
+#[test]
+fn equal_medians_with_different_stability_are_distinguishable() {
+    let tight = Spread::of(&[99.9, 100.0, 100.1]).expect("non-empty");
+    let loose = Spread::of(&[70.0, 100.0, 130.0]).expect("non-empty");
+    assert!((tight.median - loose.median).abs() < 1e-9);
+    assert!(
+        loose.range_pct() > tight.range_pct() * 10.0,
+        "tight={} loose={}",
+        tight.range_pct(),
+        loose.range_pct()
+    );
+}
+
+/// The instrument has no single-run mode. The check fires before any file is
+/// read, so a bogus model path cannot be what produced the error.
+#[test]
+fn single_run_invocation_is_refused_before_any_io() {
+    let args = BenchArgs {
+        model: PathBuf::from("/nonexistent/model"),
+        prompt: PathBuf::from("/nonexistent/prompt.txt"),
+        prompt_label: "x".to_owned(),
+        device: Device::Cpu,
+        max_tokens: 8,
+        runs: 1,
+        warmup: 0,
+        kv_quant: rmlx_kv_quant::KvQuant::None,
+        max_ctx: None,
+        max_prompt_tokens: 4096,
+        cap_is_explicit: false,
+        allow_truncate: false,
+        json: false,
+    };
+    let msg = run_bench(args)
+        .expect_err("--runs 1 must be refused")
+        .to_string();
+    assert!(
+        msg.contains("--runs must be at least"),
+        "must refuse for lack of spread, not for the missing paths: {msg}"
+    );
+}
+
+// ── Percentiles ─────────────────────────────────────────────────────
+
+#[test]
+fn percentile_of_empty_sample_is_none() {
+    assert_eq!(percentile_sorted(&[], 0.5), None);
+}
+
+#[test]
+fn percentile_nearest_rank() {
+    let v = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+    assert_eq!(percentile_sorted(&v, 0.5), Some(5.0));
+    assert_eq!(percentile_sorted(&v, 0.99), Some(10.0));
+    assert_eq!(percentile_sorted(&v, 0.0), Some(1.0));
+    assert_eq!(percentile_sorted(&v, 1.0), Some(10.0));
+}
+
+/// p99 must track the tail, not the bulk. A 2%-of-samples stall is exactly what
+/// a mean hides and what the instrument exists to surface.
+///
+/// Nearest-rank p99 of 100 samples is the 99th smallest, so it reports the
+/// stall once the tail is at least 2 samples wide — a single 1-in-100 outlier
+/// legitimately sits above p99 and is p100's business.
+#[test]
+fn p99_surfaces_a_tail_a_mean_would_hide() {
+    let mut v: Vec<f64> = std::iter::repeat_n(10.0, 98).collect();
+    v.push(200.0);
+    v.push(200.0);
+    v.sort_by(f64::total_cmp);
+    let mean = v.iter().sum::<f64>() / v.len() as f64;
+    assert_eq!(percentile_sorted(&v, 0.50), Some(10.0));
+    assert_eq!(percentile_sorted(&v, 0.99), Some(200.0));
+    assert!(
+        mean < 15.0,
+        "the mean stays near the bulk ({mean}) — only p99 shows the stall"
+    );
+}
+
+#[test]
+fn percentile_rejects_out_of_range_quantile() {
+    assert_eq!(percentile_sorted(&[1.0], 1.5), None);
+    assert_eq!(percentile_sorted(&[1.0], -0.1), None);
+}
+
+// ── Per-run derivation from token arrival times ─────────────────────
+
+#[test]
+fn sample_from_arrivals_derives_ttft_itl_and_decode_rate() {
+    // TTFT 0.5 s, then 4 more tokens at 100 ms each.
+    let arrivals = [0.5, 0.6, 0.7, 0.8, 0.9];
+    let s = sample_from_arrivals(&arrivals, 1000, 4096).expect("5 tokens is enough");
+    assert!((s.ttft_ms - 500.0).abs() < 1e-6);
+    assert!((s.itl_p50_ms - 100.0).abs() < 1e-6);
+    assert!((s.itl_p99_ms - 100.0).abs() < 1e-6);
+    // 4 inter-token intervals over 0.4 s.
+    assert!((s.decode_tps - 10.0).abs() < 1e-6, "{}", s.decode_tps);
+    // 1000 prompt tokens in 0.5 s.
+    assert!((s.prefill_tps - 2000.0).abs() < 1e-6);
+    assert_eq!(s.kv_cache_bytes, 4096);
+    assert_eq!(s.n_generated, 5);
+}
+
+/// The decode rate must exclude prefill. If TTFT leaked into the denominator
+/// this run would report ~5.5 tok/s instead of 10.
+#[test]
+fn decode_rate_excludes_prefill() {
+    let s = sample_from_arrivals(&[0.5, 0.6, 0.7, 0.8, 0.9], 1000, 1).expect("enough tokens");
+    let with_prefill_included = 5.0 / 0.9;
+    assert!(
+        s.decode_tps > with_prefill_included * 1.5,
+        "decode_tps {} looks like it still carries the prefill cost ({with_prefill_included})",
+        s.decode_tps
+    );
+}
+
+/// One token gives no inter-token interval. Falling back to the combined
+/// prefill+decode rate here would print a prefill-dominated figure under a
+/// decode-rate label.
+#[test]
+fn single_token_run_yields_no_sample() {
+    assert!(sample_from_arrivals(&[0.5], 100, 4096).is_none());
+    assert!(sample_from_arrivals(&[], 100, 4096).is_none());
+}
+
+/// Arrivals with no elapsed time between first and last cannot produce a rate;
+/// a divide-by-zero here would surface as `inf` tok/s.
+#[test]
+fn zero_width_decode_window_yields_no_sample() {
+    assert!(sample_from_arrivals(&[0.5, 0.5], 100, 4096).is_none());
+}
+
+/// ITL percentiles are computed over the gaps, so a stall in the middle of a
+/// run shows up in p99 while p50 stays at the healthy cadence.
+#[test]
+fn itl_p99_catches_a_mid_run_stall() {
+    let mut arrivals = vec![0.1];
+    for i in 1..100 {
+        // 10 ms cadence, with one 500 ms stall at step 50.
+        let step = if i == 50 { 0.5 } else { 0.01 };
+        let prev = *arrivals.last().expect("non-empty");
+        arrivals.push(prev + step);
+    }
+    let s = sample_from_arrivals(&arrivals, 100, 4096).expect("enough tokens");
+    assert!((s.itl_p50_ms - 10.0).abs() < 1e-6, "p50={}", s.itl_p50_ms);
+    assert!(
+        s.itl_p99_ms > 400.0,
+        "p99={} must expose the stall",
+        s.itl_p99_ms
+    );
+}
+
+// ── Load guard ──────────────────────────────────────────────────────
+
+#[test]
+fn load_guard_flags_a_busy_host() {
+    assert!(load_is_contended(16.0, 16));
+    assert!(load_is_contended(20.0, 16));
+    assert!(!load_is_contended(1.5, 16));
+}
+
+#[test]
+fn loadavg_parses_the_sysctl_shape() {
+    assert_eq!(parse_loadavg_1m("{ 3.03 4.53 5.24 }\n"), Some(3.03));
+    assert_eq!(parse_loadavg_1m("{ 0.00 0.00 0.00 }"), Some(0.0));
+}
+
+/// An unreadable load must read as "no reading", not as an idle host — the
+/// latter would stamp a contended measurement as quiet-machine.
+#[test]
+fn unparseable_loadavg_is_absent_not_zero() {
+    assert_eq!(parse_loadavg_1m(""), None);
+    assert_eq!(parse_loadavg_1m("{ }"), None);
+    assert_eq!(parse_loadavg_1m("sysctl: unknown oid"), None);
+}

--- a/crates/rmlx-cli/src/commands/bench_tests.rs
+++ b/crates/rmlx-cli/src/commands/bench_tests.rs
@@ -29,6 +29,13 @@ fn cache_stats(hits: u64, misses: u64) -> CacheStats {
     s
 }
 
+/// The same counters, plus the SSD-tier hydrate count.
+fn cache_stats_ssd(hits: u64, misses: u64, ssd_hits: u64) -> CacheStats {
+    let mut s = cache_stats(hits, misses);
+    s.ssd_hits = ssd_hits;
+    s
+}
+
 // ── KV bytes: three states, not two ─────────────────────────────────
 
 /// The load-bearing case. A generation that never reached its KV-byte store
@@ -156,20 +163,39 @@ fn a_hit_is_refused_regardless_of_miss_count() {
     assert!(assert_prefill_measured(Some(&cache_stats(7, 0))).is_err());
 }
 
+/// The shape that gets past a hits/misses-only guard: emptying the RAM slots
+/// does not detach the SSD source, so the run misses in RAM (`hits == 0`,
+/// `misses == 1` — a clean bill of health) and is then served by hydrating a
+/// `.kvb`. Its "TTFT" is a reconstruction time.
+#[test]
+fn an_ssd_hydrate_is_refused_even_though_it_looks_like_a_clean_miss() {
+    let hydrated = cache_stats_ssd(0, 1, 1);
+    assert!(
+        assert_prefill_measured(Some(&cache_stats(0, 1))).is_ok(),
+        "the same counters without the hydrate are a genuine prefill"
+    );
+    let msg = assert_prefill_measured(Some(&hydrated))
+        .expect_err("a hydrated run did not prefill")
+        .to_string();
+    assert!(msg.contains("SSD KV tier"), "got: {msg}");
+    // And it is a distinct diagnosis from a RAM hit — the operator needs to
+    // know which tier served it.
+    let ram_hit = assert_prefill_measured(Some(&cache_stats(1, 1)))
+        .expect_err("a RAM hit did not prefill either")
+        .to_string();
+    assert_ne!(msg, ram_hit);
+}
+
 // ── Spread: no central value without its range ─────────────────────
 
 #[test]
 fn spread_of_empty_sample_is_none() {
-    assert_eq!(
-        Spread::of(Vec::new()),
-        None,
-        "a median of nothing is not zero"
-    );
+    assert_eq!(Spread::of(&[]), None, "a median of nothing is not zero");
 }
 
 #[test]
 fn spread_reports_median_and_observed_range() {
-    let s = Spread::of(vec![110.0, 100.0, 105.0]).expect("non-empty");
+    let s = Spread::of(&[110.0, 100.0, 105.0]).expect("non-empty");
     assert!((s.median - 105.0).abs() < 1e-9);
     assert!((s.min - 100.0).abs() < 1e-9);
     assert!((s.max - 110.0).abs() < 1e-9);
@@ -184,7 +210,7 @@ fn spread_reports_median_and_observed_range() {
 
 #[test]
 fn spread_median_of_even_sample_averages_the_middle_two() {
-    let s = Spread::of(vec![1.0, 2.0, 3.0, 4.0]).expect("non-empty");
+    let s = Spread::of(&[1.0, 2.0, 3.0, 4.0]).expect("non-empty");
     assert!((s.median - 2.5).abs() < 1e-9);
 }
 
@@ -192,8 +218,8 @@ fn spread_median_of_even_sample_averages_the_middle_two() {
 /// same thing — that collapse is what made single-run numbers look conclusive.
 #[test]
 fn equal_medians_with_different_stability_are_distinguishable() {
-    let tight = Spread::of(vec![99.9, 100.0, 100.1]).expect("non-empty");
-    let loose = Spread::of(vec![70.0, 100.0, 130.0]).expect("non-empty");
+    let tight = Spread::of(&[99.9, 100.0, 100.1]).expect("non-empty");
+    let loose = Spread::of(&[70.0, 100.0, 130.0]).expect("non-empty");
     assert!((tight.median - loose.median).abs() < 1e-9);
     assert!(
         loose.range_pct() > tight.range_pct() * 10.0,
@@ -368,6 +394,13 @@ fn unparseable_loadavg_is_absent_not_zero() {
 
 // ── Drift: a trend is not a spread ──────────────────────────────────
 
+/// Settle a metric the way `summarize` does, so the tests exercise both gates
+/// together rather than either one in isolation.
+fn settle(name: &str, values_in_order: &[f64]) -> Option<String> {
+    let spread = Spread::of(values_in_order).expect("non-empty sample");
+    settle_refusal(name, values_in_order, &spread)
+}
+
 /// The measured case this guard was built for: gemma-4-e2b at 64k, three
 /// consecutive in-process generations, TTFT in milliseconds. `Spread` sorts,
 /// so it reports this as a wide range around a median; in collection order it
@@ -375,29 +408,31 @@ fn unparseable_loadavg_is_absent_not_zero() {
 #[test]
 fn measured_ttft_ramp_is_detected_as_drift() {
     let in_order = [17_769.4, 22_764.3, 25_475.1];
-    let spread = Spread::of(in_order.to_vec()).expect("non-empty");
+    let spread = Spread::of(&in_order).expect("non-empty");
     let pct = detect_drift(&in_order, spread.median).expect("a 43% ramp is a trend");
     assert!(
         pct > 30.0,
         "fitted drift {pct:.1}% understates a 17.8s → 25.5s ramp"
     );
-    let err = assert_no_drift("ttft_ms", &in_order, spread.median)
-        .expect_err("a drifting metric must not be summarised");
-    let msg = err.to_string();
+    let msg = settle("ttft_ms", &in_order).expect("a drifting metric must not be summarised");
     assert!(msg.contains("trend, not a spread"), "got: {msg}");
     assert!(msg.contains("rose"), "must name the direction: {msg}");
 }
 
-/// Order is the whole point: a one-run spike that starts and ends at the same
-/// place is spread, while the same magnitude of movement spent going one way is
-/// a trend. `Spread` cannot tell them apart, because it sorts before it looks —
-/// both of these produce an identical median and an identical range.
+/// Order is the whole point for the *trend* gate: a one-run spike that starts
+/// and ends at the same place has slope zero, while the same magnitude of
+/// movement spent going one way is a trend.
+///
+/// A spike is still not a settled cell, though, and at 30% of the median it is
+/// nowhere near one — so it is the range gate, not the trend gate, that refuses
+/// it. Both must be present: the trend gate alone would pass a spike of any
+/// magnitude whatsoever.
 #[test]
 fn a_spike_is_spread_but_a_ramp_is_drift() {
     let spike = [100.0, 130.0, 100.0];
     let ramp = [100.0, 115.0, 130.0];
-    let spike_spread = Spread::of(spike.to_vec()).expect("non-empty");
-    let ramp_spread = Spread::of(ramp.to_vec()).expect("non-empty");
+    let spike_spread = Spread::of(&spike).expect("non-empty");
+    let ramp_spread = Spread::of(&ramp).expect("non-empty");
     assert!(
         (spike_spread.max - ramp_spread.max).abs() < 1e-9
             && (spike_spread.min - ramp_spread.min).abs() < 1e-9,
@@ -412,6 +447,46 @@ fn a_spike_is_spread_but_a_ramp_is_drift() {
         detect_drift(&ramp, ramp_spread.median).is_some(),
         "the same movement spent going one way is a trend"
     );
+    let spike_msg = settle("ttft_ms", &spike).expect("a 30% spike is not a settled cell");
+    assert!(
+        spike_msg.contains("never converged"),
+        "a spike must be refused by the range gate, not the trend gate: {spike_msg}"
+    );
+}
+
+/// An unbounded spike is the shape the trend gate cannot see at all: slope
+/// stays zero however large it gets, so without a range gate a 40%-wide cell
+/// would be summarised as if its median meant something.
+#[test]
+fn an_arbitrarily_large_spike_is_still_refused() {
+    for magnitude in [140.0, 300.0, 10_000.0] {
+        let spike = [100.0, magnitude, 100.0];
+        assert_eq!(
+            detect_drift(&spike, 100.0),
+            None,
+            "a spike has no slope at any magnitude — {magnitude} must not read as a trend"
+        );
+        assert!(
+            settle("ttft_ms", &spike).is_some(),
+            "spike of {magnitude} must still be refused as unsettled"
+        );
+    }
+}
+
+/// Late-onset drift: the fitted change of a single last-run jump shrinks as
+/// `--runs` grows (`6d(n−1)/n²` — `1.33d` at 3 runs, `0.29d` at 20), so raising
+/// `--runs` in response to a noisy abort would otherwise make the guard weaker.
+/// The range gate does not care how many runs the jump is diluted across.
+#[test]
+fn a_late_onset_step_is_refused_however_many_runs_dilute_it() {
+    for n in [3_usize, 10, 20] {
+        let mut values: Vec<f64> = std::iter::repeat_n(100.0, n - 1).collect();
+        values.push(130.0); // a +30% jump on the final run
+        assert!(
+            settle("decode_tps", &values).is_some(),
+            "a +30% final-run step over {n} runs must be refused"
+        );
+    }
 }
 
 /// Decode TPS falling across runs is the same defect with the opposite sign —
@@ -419,13 +494,35 @@ fn a_spike_is_spread_but_a_ramp_is_drift() {
 #[test]
 fn a_falling_metric_drifts_too() {
     let in_order = [129.24, 126.74, 115.59];
-    let spread = Spread::of(in_order.to_vec()).expect("non-empty");
+    let spread = Spread::of(&in_order).expect("non-empty");
     let pct = detect_drift(&in_order, spread.median).expect("a 10.6% decline is a trend");
     assert!(pct < 0.0, "direction must be signed");
-    let msg = assert_no_drift("decode_tps", &in_order, spread.median)
-        .expect_err("a falling metric is still drifting")
-        .to_string();
+    let msg = settle("decode_tps", &in_order).expect("a falling metric is still drifting");
     assert!(msg.contains("fell"), "got: {msg}");
+}
+
+/// A zig-zag is scatter, not a trend. With three runs the fitted change reduces
+/// to `last − first`, so the middle run contributes nothing and this sample
+/// fits a −12% "decline" it plainly does not have. Its residuals about the
+/// fitted line are twice the size of the change (2×RMS 22.6 vs 12), which is
+/// what the noise anchoring exists to notice.
+#[test]
+fn a_zig_zag_is_scatter_not_a_trend() {
+    let in_order = [100.0, 118.0, 88.0];
+    assert_eq!(
+        detect_drift(&in_order, 100.0),
+        None,
+        "a sample that jumped up and then further down is not a ramp, however far the \
+         endpoints happen to sit apart"
+    );
+    // It is still not a settled cell — the *range* gate is what refuses it, and
+    // it says so as scatter rather than as a decline.
+    let msg = settle("decode_tps", &in_order).expect("30% of the median is not settled");
+    assert!(msg.contains("never converged"), "got: {msg}");
+    assert!(
+        !msg.contains("fell"),
+        "a zig-zag must not be reported as a direction: {msg}"
+    );
 }
 
 /// A settled cell must pass. These are the measured gemma-4-e2b ITL p50 values
@@ -434,9 +531,9 @@ fn a_falling_metric_drifts_too() {
 #[test]
 fn a_settled_metric_is_not_drift() {
     let in_order = [9.455, 9.840, 9.538];
-    let spread = Spread::of(in_order.to_vec()).expect("non-empty");
+    let spread = Spread::of(&in_order).expect("non-empty");
     assert_eq!(detect_drift(&in_order, spread.median), None);
-    assert!(assert_no_drift("itl_p50_ms", &in_order, spread.median).is_ok());
+    assert_eq!(settle("itl_p50_ms", &in_order), None);
 }
 
 /// A constant metric has no trend and no scale problem. Measured KV bytes are
@@ -454,6 +551,8 @@ fn a_constant_metric_is_not_drift() {
 #[test]
 fn the_threshold_separates_warmup_wobble_from_a_ramp() {
     // Settled-enough: measured ttft, decode TPS and ITL p50 from one cell.
+    // Checked through the whole settle decision, not just the trend half — a
+    // range gate tightened past these would abort cells that are fine.
     for (name, v, med) in [
         ("ttft_ms", [209.207, 215.761, 198.285], 209.207),
         ("decode_tps", [119.178, 121.846, 126.562], 121.846),
@@ -464,9 +563,105 @@ fn the_threshold_separates_warmup_wobble_from_a_ramp() {
             None,
             "{name} is ordinary warmup wobble and must not abort the cell"
         );
+        assert_eq!(
+            settle(name, &v),
+            None,
+            "{name} is ordinary warmup wobble and must clear both gates"
+        );
     }
     // A real ramp from the same model at 64k must still be caught.
     assert!(detect_drift(&[17_065.0, 22_768.2, 24_684.6], 22_768.2).is_some());
+    assert!(settle("ttft_ms", &[17_065.0, 22_768.2, 24_684.6]).is_some());
+}
+
+/// The range ceiling is calibrated against cells this instrument itself
+/// measured as settled: gemma-4-e2b at 64k and Ternary-Bonsai-8B at 4k, 32k and
+/// 64k, all `--kv-quant none --runs 3` on an 18-core host carrying a 1-minute
+/// load of 3.4-16.3. Every gated metric of a settled cell must clear the
+/// ceiling, or the ceiling is refusing measurements rather than protecting them.
+///
+/// Both groups matter. The tight group is what the instrument looks like when
+/// nothing goes wrong; the wide group is the same instrument, same models, on a
+/// host that hiccupped once mid-cell — still a settled cell, and the reason the
+/// ceiling is not set near the tight group.
+#[test]
+fn a_settled_cell_clears_the_range_gate() {
+    // Tight: most gated metrics of a settled cell live here.
+    for (cell, name, v) in [
+        (
+            "e2b-64k w3",
+            "ttft_ms",
+            [22_562.683, 22_632.198, 22_776.669],
+        ),
+        ("e2b-64k w3", "itl_p50_ms", [9.855, 9.942, 9.998]),
+        ("bonsai-4k w0", "decode_tps", [137.677, 138.533, 136.919]),
+        ("bonsai-4k w1", "itl_p50_ms", [7.122, 6.980, 7.128]),
+        (
+            "bonsai-32k w2",
+            "ttft_ms",
+            [19_510.139, 19_522.153, 19_543.872],
+        ),
+        ("bonsai-32k w2", "decode_tps", [66.474, 65.434, 65.330]),
+        (
+            "bonsai-64k w0",
+            "ttft_ms",
+            [58_050.704, 59_936.437, 59_895.033],
+        ),
+        ("bonsai-64k w0", "decode_tps", [39.640, 38.301, 39.072]),
+    ] {
+        let spread = Spread::of(&v).expect("non-empty");
+        assert!(
+            spread.range_pct() < SETTLED_MAX_RANGE_PCT / 4.0,
+            "{cell} {name} is a tight settled cell and must clear the \
+             {SETTLED_MAX_RANGE_PCT}% ceiling with at least 4x margin, observed range {:.2}%",
+            spread.range_pct()
+        );
+        assert_eq!(settle(name, &v), None, "{cell} {name} must not be refused");
+    }
+
+    // Wide but still settled: one run of the cell caught a host hiccup. These
+    // are what stops the ceiling from being set near the tight group — at 10%
+    // they would have had ~1.2x of margin.
+    for (cell, name, v) in [
+        ("bonsai-4k w1", "ttft_ms", [1204.071, 1300.797, 1279.021]),
+        ("e2b-64k w3", "decode_tps", [99.327, 99.607, 92.561]),
+    ] {
+        let spread = Spread::of(&v).expect("non-empty");
+        assert!(
+            spread.range_pct() > 7.0 && spread.range_pct() < SETTLED_MAX_RANGE_PCT,
+            "{cell} {name} is the wide tail of the settled population, observed range {:.2}%",
+            spread.range_pct()
+        );
+        assert_eq!(
+            settle(name, &v),
+            None,
+            "{cell} {name} settled and must not be refused"
+        );
+    }
+}
+
+/// A settled cell's `itl_p99_ms`: 58.6% of range on a gemma-4-e2b 64k cell
+/// whose every gated metric ranged under 2%. This is the measurement behind
+/// [`Gate::Ungated`] for p99 — gating it would abort settled cells, and no
+/// plausible ceiling separates it from a real defect.
+#[test]
+fn the_tail_statistic_would_abort_settled_cells_if_it_were_gated() {
+    let p99 = [16.337, 10.261, 10.370]; // e2b-64k --warmup 3
+    let spread = Spread::of(&p99).expect("non-empty");
+    assert!(
+        spread.range_pct() > SETTLED_MAX_RANGE_PCT,
+        "p99 ranged {:.1}% on a settled cell — the reason it is not gated",
+        spread.range_pct()
+    );
+    assert_eq!(Metric::ItlP99Ms.gate(), Gate::Ungated);
+}
+
+/// KV bytes are bit-identical across the runs of a cell, so a range gate that
+/// keyed off anything but the observed values would show up here first.
+#[test]
+fn a_constant_metric_clears_both_gates() {
+    let in_order = [649_353_216.0, 649_353_216.0, 649_353_216.0];
+    assert_eq!(settle("kv_cache_bytes", &in_order), None);
 }
 
 /// Mutation check: the guard must key on the run-to-run *trend*, not on the
@@ -502,11 +697,71 @@ fn a_differing_token_stream_is_refused() {
     let a = token_stream_digest([1_u32, 2, 3, 4]);
     let b = token_stream_digest([1_u32, 2, 3, 5]);
     assert_ne!(a, b, "one differing token must change the digest");
-    let msg = assert_same_token_stream("measured run 2", a, b)
-        .expect_err("runs of one cell must decode the same tokens")
-        .to_string();
-    assert!(msg.contains("different token stream"), "got: {msg}");
-    assert!(assert_same_token_stream("measured run 2", a, a).is_ok());
+    let msg = assert_one_token_stream(&[
+        ("measured run 1".to_owned(), a),
+        ("measured run 2".to_owned(), b),
+    ])
+    .expect_err("runs of one cell must decode the same tokens")
+    .to_string();
+    assert!(msg.contains("different token streams"), "got: {msg}");
+    assert!(assert_one_token_stream(&[
+        ("measured run 1".to_owned(), a),
+        ("measured run 2".to_owned(), a),
+    ])
+    .is_ok());
+}
+
+/// A cold-start defect corrupts run 1, not runs 2-N. Anchoring on the first run
+/// would report every later run as the deviant one and send the operator after
+/// the wrong runs; the majority is what identifies the outlier.
+#[test]
+fn the_outlier_run_is_named_not_the_majority() {
+    let good = token_stream_digest([1_u32, 2, 3]);
+    let cold = token_stream_digest([9_u32, 9, 9]);
+    let msg = assert_one_token_stream(&[
+        ("warmup run 1".to_owned(), cold),
+        ("measured run 1".to_owned(), good),
+        ("measured run 2".to_owned(), good),
+        ("measured run 3".to_owned(), good),
+    ])
+    .expect_err("a cell with two different streams is not one cell")
+    .to_string();
+    assert!(
+        msg.contains(&format!("Most common digest {good:#018x} (3 of 4 run(s))")),
+        "the majority stream must be named as the reference: {msg}"
+    );
+    // Every run is listed, and only the cold one is marked.
+    assert_eq!(
+        msg.matches("<-- differs").count(),
+        1,
+        "exactly the outlier is marked: {msg}"
+    );
+    assert!(
+        msg.contains("warmup run 1")
+            && msg.contains("measured run 1")
+            && msg.contains("measured run 3"),
+        "every run must be listed with its digest: {msg}"
+    );
+}
+
+/// With two runs and two digests there is no majority. The instrument must
+/// still name both rather than silently picking one as correct.
+#[test]
+fn a_two_run_disagreement_names_both() {
+    let a = token_stream_digest([1_u32]);
+    let b = token_stream_digest([2_u32]);
+    let msg = assert_one_token_stream(&[
+        ("measured run 1".to_owned(), a),
+        ("measured run 2".to_owned(), b),
+    ])
+    .expect_err("two different streams are not one cell")
+    .to_string();
+    assert!(msg.contains(&format!("{a:#018x}")), "got: {msg}");
+    assert!(msg.contains(&format!("{b:#018x}")), "got: {msg}");
+    assert!(
+        msg.contains("1 of 2 run(s)"),
+        "no majority is stated: {msg}"
+    );
 }
 
 /// Order matters: a digest that ignored it would pass a run that emitted the
@@ -551,4 +806,105 @@ fn prefill_throughput_is_absent_not_zero_when_undefined() {
 fn prefill_throughput_is_absent_when_the_first_token_is_instant() {
     let s = sample_from_arrivals(&[0.0, 0.1, 0.2], 1000, 4096, 0xabc).expect("enough tokens");
     assert_eq!(s.prefill_tps, None);
+}
+
+// ── Which metrics are gated is enumerated, not positional ───────────
+
+/// One run's worth of sample, with every metric settable.
+fn run_sample(ttft_ms: f64, decode_tps: f64, kv: u64) -> RunSample {
+    RunSample {
+        ttft_ms,
+        decode_tps,
+        prefill_tps: Some(1000.0 / ttft_ms),
+        itl_p50_ms: 10.0,
+        itl_p99_ms: 12.0,
+        kv_cache_bytes: kv,
+        n_generated: 128,
+        token_digest: 0xabc,
+    }
+}
+
+/// The gate decision is a total function of the metric. This does not merely
+/// re-state the match — it pins that both lists are non-empty, so a change that
+/// gated everything (aborting settled cells on p99 noise) or gated nothing
+/// (the state this guard replaced) fails here.
+#[test]
+fn every_metric_names_a_gate_and_both_lists_are_populated() {
+    let gated: Vec<&str> = Metric::ALL
+        .iter()
+        .filter(|m| m.gate() == Gate::Settled)
+        .map(|m| m.name())
+        .collect();
+    let ungated: Vec<&str> = Metric::ALL
+        .iter()
+        .filter(|m| m.gate() == Gate::Ungated)
+        .map(|m| m.name())
+        .collect();
+    assert_eq!(
+        gated,
+        vec!["ttft_ms", "itl_p50_ms", "decode_tps", "kv_cache_bytes"],
+        "the metrics a decision is made on must all be gated"
+    );
+    assert_eq!(
+        ungated,
+        vec!["itl_p99_ms", "prefill_tps"],
+        "p99 is an extreme-order statistic and prefill_tps is a reciprocal of ttft_ms; \
+         both are reported, neither is evidence"
+    );
+    assert_eq!(
+        gated.len() + ungated.len(),
+        Metric::ALL.len(),
+        "every metric is in exactly one list"
+    );
+}
+
+/// `prefill_tps` is `prompt_tokens / ttft`, with `prompt_tokens` identical in
+/// every run of a cell — so gating it would test `ttft_ms` twice under a
+/// nonlinear transform, and the transform is what decides whether they agree.
+/// Its verdict must not be able to abort a cell, whatever it says on its own.
+#[test]
+fn prefill_tps_cannot_abort_a_cell() {
+    assert_eq!(Metric::PrefillTps.gate(), Gate::Ungated);
+    // A blatant ramp in prefill_tps, on runs whose gated metrics all settled.
+    let mut samples = [
+        run_sample(1000.0, 100.0, 4096),
+        run_sample(1000.0, 100.0, 4096),
+        run_sample(1000.0, 100.0, 4096),
+    ];
+    samples[0].prefill_tps = Some(500.0);
+    samples[1].prefill_tps = Some(750.0);
+    samples[2].prefill_tps = Some(1000.0);
+    let prefill = [500.0, 750.0, 1000.0];
+    assert!(
+        settle("prefill_tps", &prefill).is_some(),
+        "the values themselves are a ramp — the point is that nothing asks"
+    );
+    let summary = summarize(&samples).expect("gated metrics settled, so the cell stands");
+    let reported = summary
+        .prefill_tps
+        .expect("dropping the gate must not drop the reporting");
+    assert!((reported.median - 750.0).abs() < 1e-9);
+    assert!(reported.range_pct() > 60.0, "its spread is still visible");
+}
+
+/// A contended run moves more than one metric. Refusing at the first hides how
+/// much of the cell moved, which is the difference between "one metric wobbled"
+/// and "the whole run was contended".
+#[test]
+fn every_unsettled_metric_is_named_not_just_the_first() {
+    // ttft ramps, decode TPS falls, kv bytes stay put.
+    let samples = [
+        run_sample(1000.0, 130.0, 4096),
+        run_sample(1400.0, 126.0, 4096),
+        run_sample(1800.0, 112.0, 4096),
+    ];
+    let msg = summarize(&samples)
+        .expect_err("a cell that moved in two metrics is not summarisable")
+        .to_string();
+    assert!(msg.contains("ttft_ms"), "got: {msg}");
+    assert!(msg.contains("decode_tps"), "got: {msg}");
+    assert!(
+        msg.contains("2 of its 4 gated metric(s)"),
+        "the count of moved metrics is what says how bad it was: {msg}"
+    );
 }

--- a/crates/rmlx-cli/src/commands/mod.rs
+++ b/crates/rmlx-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! CLI command implementations.
 
 pub(crate) mod baseline;
+pub(crate) mod bench;
 pub(crate) mod calibration_softmax;
 pub(crate) mod eval;
 pub(crate) mod healthcheck;
@@ -14,6 +15,7 @@ pub(crate) mod serve;
 pub(crate) mod transcribe;
 
 pub(crate) use baseline::run_baseline;
+pub(crate) use bench::run_bench;
 pub(crate) use eval::run_ppl;
 pub(crate) use healthcheck::run_healthcheck;
 pub(crate) use info::run_info;

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -106,7 +106,7 @@ use commands::serve::{FusedQkMode, PlanarFlashDecodeMode, SparseAttnMode, TurboF
 use commands::{
     acquire_claim_for_device, build_cache_type_spec, parse_device, parse_kv_bits_combo,
     parse_kv_bits_fractional, parse_kv_preset, parse_kv_quant, parse_max_ctx,
-    parse_max_prompt_tokens, resolve_model_flags, resolve_preset_arg, run_baseline,
+    parse_max_prompt_tokens, resolve_model_flags, resolve_preset_arg, run_baseline, run_bench,
     run_healthcheck, run_info, run_kv_calibrate, run_ppl, run_serve,
 };
 
@@ -1070,6 +1070,110 @@ enum Cmd {
         #[arg(long, env = "RMLX_YARN_ORIGINAL_MAX", value_name = "U32")]
         yarn_original_max: Option<u32>,
     },
+    /// Repeated-run decode instrument: TTFT, ITL p50/p99, decode TPS and
+    /// filled-prefix KV bytes for one (model, KV codec, context, generation)
+    /// cell, as a median plus the observed run-to-run range.
+    ///
+    /// Unlike `baseline` (one run, one row appended to the metrics store),
+    /// `bench` runs the cell `--warmup` + `--runs` times in one process,
+    /// prints the spread, and writes nothing. It aborts rather than print a
+    /// number whose measurement conditions did not hold — a run served from
+    /// the prompt cache (so its TTFT is a replay time) and a KV-byte figure
+    /// the run did not itself report are both hard errors.
+    Bench {
+        /// Path to the model snapshot directory.
+        #[arg(long)]
+        model: PathBuf,
+        /// Path to the prompt file. Defaults to the bundled fixture. Mutually
+        /// exclusive with `--prompt-tokens`.
+        #[arg(
+            long,
+            default_value = "crates/rmlx-cli/tests/fixtures/baseline_prompt.txt",
+            conflicts_with = "prompt_tokens"
+        )]
+        prompt: PathBuf,
+        /// Select a canonical bench prompt from `prompts/longctx_<N/1024>k.json`
+        /// (e.g. `--prompt-tokens 4096` → `prompts/longctx_4k.json`). Mutually
+        /// exclusive with `--prompt`.
+        #[arg(long, value_name = "N")]
+        prompt_tokens: Option<u32>,
+        /// Device: "cpu" or "gpu".
+        #[arg(long, default_value = "gpu")]
+        device: String,
+        /// Tokens to generate per run. Visible alias `--gen-tokens`.
+        #[arg(long, visible_alias = "gen-tokens", default_value_t = 128)]
+        max_tokens: u32,
+        /// Measured runs. Must be >= 2 — a single run has no observable spread.
+        #[arg(long, default_value_t = 3)]
+        runs: u32,
+        /// Discarded warmup runs before the measured ones.
+        #[arg(long, default_value_t = 1)]
+        warmup: u32,
+        /// KV cache quantization: "auto" (arch default), "bf16" (unquantised
+        /// cache; alias "none"), "k8v4", "k8v8", "planar", ...
+        #[arg(long, default_value = "auto")]
+        kv_quant: String,
+        /// Named KV-cache preset (see `rmlx baseline --help` long-help).
+        /// Mutually exclusive with `--kv-quant`, `--cache-type-k`,
+        /// `--cache-type-v` and `--kv-bits`.
+        #[arg(
+            long,
+            value_name = "NAME",
+            conflicts_with_all = &["kv_quant", "cache_type_k", "cache_type_v", "kv_bits"],
+            value_parser = parse_kv_preset,
+            long_help = KV_PRESET_LONG_HELP,
+        )]
+        kv_preset: Option<KvPresetArg>,
+        /// Per-side KV cache codec for K (see long-help).
+        #[arg(
+            long = "cache-type-k",
+            visible_alias = "ctk",
+            value_name = "TAG",
+            conflicts_with = "kv_quant",
+            long_help = CACHE_TYPE_K_LONG_HELP,
+        )]
+        cache_type_k: Option<String>,
+        /// Per-side KV cache codec for V (see long-help).
+        #[arg(
+            long = "cache-type-v",
+            visible_alias = "ctv",
+            value_name = "TAG",
+            conflicts_with = "kv_quant",
+            long_help = CACHE_TYPE_V_LONG_HELP,
+        )]
+        cache_type_v: Option<String>,
+        /// Integer bit-width KV quantization alias. See long-help.
+        #[arg(
+            long,
+            value_name = "BITS",
+            conflicts_with_all = &["kv_quant", "cache_type_k", "cache_type_v"],
+            long_help = KV_BITS_LONG_HELP,
+        )]
+        kv_bits: Option<f32>,
+        /// Group size for --kv-bits (default 64). See --kv-bits long-help.
+        #[arg(long, value_name = "N", requires = "kv_bits")]
+        kv_group_size: Option<usize>,
+        /// Maximum context length (tokens) for the KV cache buffer. Visible
+        /// alias `--ctx-max`. Must be >= 256 when set.
+        #[arg(long, visible_alias = "ctx-max")]
+        max_ctx: Option<u32>,
+        /// Truncate the tokenized prompt to at most this many tokens. Defaults
+        /// to the built-in cap (65536). Same device-dependent semantics as
+        /// `rmlx baseline --max-prompt-tokens`.
+        #[arg(long, value_name = "N")]
+        max_prompt_tokens: Option<usize>,
+        /// Opt into silently truncating a too-long prompt on `--device gpu`
+        /// instead of erroring.
+        #[arg(long, default_value_t = false)]
+        allow_truncate: bool,
+        /// Emit the summary as one JSON object instead of the text table.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+        /// Root directory to search for canonical bench prompt files
+        /// (`longctx_<N>k.json`). Env: `RMLX_PROMPTS_DIR`.
+        #[arg(long, env = "RMLX_PROMPTS_DIR", value_name = "PATH")]
+        prompts_dir: Option<PathBuf>,
+    },
     /// Manage named server profiles in `<RMLX_HOME>/profiles.toml`.
     Profile {
         #[command(subcommand)]
@@ -1205,6 +1309,30 @@ const DEFAULT_MAX_TOKENS_CAP: u32 = u32::MAX;
 const DEFAULT_MAX_TIMEOUT_SECS: u64 = 600;
 const DEFAULT_MAX_LOADED_MODELS: usize = 1;
 const DEFAULT_MAX_QUEUE_DEPTH: usize = 64;
+
+/// Locate the canonical bench-prompt directory (`prompts/longctx_<N>k.json`).
+///
+/// An explicit `--prompts-dir` wins; otherwise walk up from cwd looking for a
+/// `prompts/` subdirectory that contains `longctx_4k.json` (the workspace-root
+/// convention the bench harnesses use), falling back to `prompts/` relative to
+/// cwd. Shared by `baseline` and `bench` so both resolve `--prompt-tokens N`
+/// against the same directory.
+fn resolve_prompts_root(prompts_dir: Option<PathBuf>) -> PathBuf {
+    prompts_dir
+        .or_else(|| {
+            let mut cur = std::env::current_dir().ok()?;
+            loop {
+                let p = cur.join("prompts");
+                if p.join("longctx_4k.json").exists() {
+                    return Some(p);
+                }
+                if !cur.pop() {
+                    return None;
+                }
+            }
+        })
+        .unwrap_or_else(|| PathBuf::from("prompts"))
+}
 
 #[allow(
     clippy::expect_used,
@@ -1961,22 +2089,7 @@ fn main() -> Result<()> {
             // Resolve --prompt-tokens → canonical longctx file when present.
             // The prompts/ dir lives at the workspace root; locate it via the
             // --prompts-dir flag (env: RMLX_PROMPTS_DIR) or a cwd-walk.
-            let prompts_root = prompts_dir
-                .or_else(|| {
-                    // Walk up from cwd for `prompts/longctx_4k.json` (mirrors
-                    // the workspace-root convention used by the bench harness).
-                    let mut cur = std::env::current_dir().ok()?;
-                    loop {
-                        let p = cur.join("prompts");
-                        if p.join("longctx_4k.json").exists() {
-                            return Some(p);
-                        }
-                        if !cur.pop() {
-                            return None;
-                        }
-                    }
-                })
-                .unwrap_or_else(|| PathBuf::from("prompts"));
+            let prompts_root = resolve_prompts_root(prompts_dir);
 
             let (effective_prompt_path, prompt_id_opt, prompt_body_opt): (
                 PathBuf,
@@ -2061,6 +2174,76 @@ fn main() -> Result<()> {
                 &sink,
                 record_args,
             )?;
+        }
+        Cmd::Bench {
+            model,
+            prompt,
+            prompt_tokens,
+            device,
+            max_tokens,
+            runs,
+            warmup,
+            kv_quant,
+            kv_preset,
+            cache_type_k,
+            cache_type_v,
+            kv_bits,
+            kv_group_size,
+            max_ctx,
+            max_prompt_tokens,
+            allow_truncate,
+            json,
+            prompts_dir,
+        } => {
+            let cap_is_explicit = max_prompt_tokens.is_some();
+            let max_prompt_tokens = parse_max_prompt_tokens(
+                max_prompt_tokens.unwrap_or(commands::baseline::MAX_PROMPT_TOKENS),
+            )?;
+            // Same KV resolution ladder as `baseline`, so a cell benched here
+            // and a cell recorded there name the same codec.
+            let (dev, kv_quant_resolved, max_ctx_override) = if let Some(preset_arg) = kv_preset {
+                let max_ctx_override = parse_max_ctx(max_ctx)?;
+                let dev = parse_device(&device)?;
+                let cfg = rmlx_loader::load_config(&model)
+                    .map_err(|e| anyhow::anyhow!("load_config: {e}"))?;
+                let preset_kq = resolve_preset_arg(preset_arg, &cfg, max_ctx_override);
+                info!(kv_quant = ?preset_kq, "--kv-preset resolved");
+                let kq = commands::parse::resolve_kv_quant(&cfg, Some(preset_kq), None);
+                (dev, kq, max_ctx_override)
+            } else {
+                resolve_model_flags(
+                    &model,
+                    &kv_quant,
+                    cache_type_k.as_deref(),
+                    cache_type_v.as_deref(),
+                    max_ctx,
+                    &device,
+                    "rmlx bench",
+                    kv_bits,
+                    kv_group_size,
+                )?
+            };
+            let _claim = acquire_claim_for_device(dev, SENTINEL_PORT)?;
+
+            let prompts_root = resolve_prompts_root(prompts_dir);
+            let (prompt_path, prompt_label) =
+                commands::bench::resolve_prompt(&prompts_root, prompt, prompt_tokens)?;
+
+            run_bench(commands::bench::BenchArgs {
+                model,
+                prompt: prompt_path,
+                prompt_label,
+                device: dev,
+                max_tokens,
+                runs,
+                warmup,
+                kv_quant: kv_quant_resolved,
+                max_ctx: max_ctx_override,
+                max_prompt_tokens,
+                cap_is_explicit,
+                allow_truncate,
+                json,
+            })?;
         }
         Cmd::Eval { cmd } => match cmd {
             EvalCmd::Ppl {

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -1245,6 +1245,27 @@ impl Architecture {
         }
     }
 
+    /// Drop every snapshot held by this arch's prompt cache and reset its
+    /// hit/miss counters, so the next generation is a guaranteed miss and
+    /// performs a real prefill.
+    ///
+    /// The measurement commands use this to make repeated generations of the
+    /// same prompt comparable. Requesting a zero-slot cache does not achieve
+    /// that: slot capacity is clamped to a minimum of one, so a "zero-slot"
+    /// cache still stores and can still serve a snapshot.
+    pub fn clear_prompt_cache(&self) {
+        match self {
+            Architecture::Gemma4(_) => crate::gemma4::prompt_cache::PROMPT_CACHE.clear(),
+            Architecture::Gemma3(_) => crate::gemma3::prompt_cache::PROMPT_CACHE.clear(),
+            Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::prompt_cache::PROMPT_CACHE.clear(),
+            Architecture::Qwen3(_) => crate::qwen3::QWEN3_PROMPT_CACHE.clear(),
+            Architecture::Qwen2(_) => crate::qwen2::prompt_cache::PROMPT_CACHE.clear(),
+            Architecture::BitNet(_) => crate::bitnet::prompt_cache::PROMPT_CACHE.clear(),
+            Architecture::Qwen3VlMoe(_) => crate::qwen3_vl_moe::prompt_cache::PROMPT_CACHE.clear(),
+            Architecture::Laguna(_) => crate::laguna::prompt_cache::PROMPT_CACHE.clear(),
+        }
+    }
+
     /// Actual on-device KV-cache bytes used by the most recent `generate_greedy`
     /// call on this architecture, paired with the store sequence they were
     /// written at.
@@ -1253,8 +1274,9 @@ impl Architecture {
     /// via `store_kv_cache_bytes` at the end of every generate call.
     ///
     /// Callers that *record* the byte count as a measurement must sample this
-    /// before and after the generation and require [`KvBytesSample::seq`] to
-    /// have advanced. Without that check, a generation that returns before
+    /// before and after the generation and require
+    /// [`crate::prompt_cache::KvBytesSample::seq`] to have advanced. Without
+    /// that check, a generation that returns before
     /// reaching the store (an early-out prefill path, or an arch that does not
     /// maintain the static) yields the previous call's byte count — or the `0`
     /// initialiser — with nothing to distinguish it from a fresh reading.

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -1246,21 +1246,39 @@ impl Architecture {
     }
 
     /// Actual on-device KV-cache bytes used by the most recent `generate_greedy`
-    /// call on this architecture.
+    /// call on this architecture, paired with the store sequence they were
+    /// written at.
     ///
     /// Reads the arch-specific prompt-cache static that `generate_greedy` writes
     /// via `store_kv_cache_bytes` at the end of every generate call.
-    pub fn kv_cache_bytes(&self) -> u64 {
+    ///
+    /// Callers that *record* the byte count as a measurement must sample this
+    /// before and after the generation and require [`KvBytesSample::seq`] to
+    /// have advanced. Without that check, a generation that returns before
+    /// reaching the store (an early-out prefill path, or an arch that does not
+    /// maintain the static) yields the previous call's byte count — or the `0`
+    /// initialiser — with nothing to distinguish it from a fresh reading.
+    pub fn kv_cache_bytes_sample(&self) -> crate::prompt_cache::KvBytesSample {
         match self {
-            Architecture::Gemma4(_) => crate::gemma4::gemma4_kv_cache_bytes(),
-            Architecture::Gemma3(_) => crate::gemma3::gemma3_kv_cache_bytes(),
-            Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::qwen3_5_moe_kv_cache_bytes(),
-            Architecture::Qwen3(_) => crate::qwen3::read_kv_cache_bytes(),
-            Architecture::Qwen2(_) => crate::qwen2::qwen2_kv_cache_bytes(),
-            Architecture::BitNet(_) => crate::bitnet::bitnet_kv_cache_bytes(),
-            Architecture::Qwen3VlMoe(_) => crate::qwen3_vl_moe::qwen3_vl_moe_kv_cache_bytes(),
-            Architecture::Laguna(_) => crate::laguna::laguna_kv_cache_bytes(),
+            Architecture::Gemma4(_) => crate::gemma4::gemma4_kv_cache_bytes_sample(),
+            Architecture::Gemma3(_) => crate::gemma3::gemma3_kv_cache_bytes_sample(),
+            Architecture::Qwen3_5Moe(_) => crate::qwen3_5_moe::qwen3_5_moe_kv_cache_bytes_sample(),
+            Architecture::Qwen3(_) => crate::qwen3::read_kv_cache_bytes_sample(),
+            Architecture::Qwen2(_) => crate::qwen2::qwen2_kv_cache_bytes_sample(),
+            Architecture::BitNet(_) => crate::bitnet::bitnet_kv_cache_bytes_sample(),
+            Architecture::Qwen3VlMoe(_) => {
+                crate::qwen3_vl_moe::qwen3_vl_moe_kv_cache_bytes_sample()
+            }
+            Architecture::Laguna(_) => crate::laguna::laguna_kv_cache_bytes_sample(),
         }
+    }
+
+    /// Bare byte count from [`Self::kv_cache_bytes_sample`], for the reporting
+    /// surfaces (`/metrics/cache`, the server's per-request gauge) that display
+    /// the last-known figure and have no generation boundary to check it
+    /// against.
+    pub fn kv_cache_bytes(&self) -> u64 {
+        self.kv_cache_bytes_sample().bytes
     }
 
     /// Arch-pinned auto-KV default, when the arch must not take the

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -1246,13 +1246,20 @@ impl Architecture {
     }
 
     /// Drop every snapshot held by this arch's prompt cache and reset its
-    /// hit/miss counters, so the next generation is a guaranteed miss and
-    /// performs a real prefill.
+    /// hit/miss counters, so the next generation misses in RAM.
     ///
     /// The measurement commands use this to make repeated generations of the
     /// same prompt comparable. Requesting a zero-slot cache does not achieve
     /// that: slot capacity is clamped to a minimum of one, so a "zero-slot"
     /// cache still stores and can still serve a snapshot.
+    ///
+    /// **A RAM miss is not the same as a prefill.** This clears RAM slots only;
+    /// an attached SSD KV tier keeps its source, and the next request can still
+    /// be served by hydrating a `.kvb` — recorded as `ssd_hits`, never as
+    /// `hits`. A caller that needs the next generation to *prefill* must check
+    /// the outcome (`hits == 0 && ssd_hits == 0`) rather than trust this call.
+    /// The SSD tier is attached only from the server today, so the measurement
+    /// commands do not meet it in practice; they check anyway.
     pub fn clear_prompt_cache(&self) {
         match self {
             Architecture::Gemma4(_) => crate::gemma4::prompt_cache::PROMPT_CACHE.clear(),
@@ -1292,6 +1299,39 @@ impl Architecture {
                 crate::qwen3_vl_moe::qwen3_vl_moe_kv_cache_bytes_sample()
             }
             Architecture::Laguna(_) => crate::laguna::laguna_kv_cache_bytes_sample(),
+        }
+    }
+
+    /// Record the KV-cache byte total the generation that just finished on this
+    /// architecture produced.
+    ///
+    /// The write counterpart of [`Self::kv_cache_bytes_sample`], dispatching to
+    /// the same per-arch static. Generation paths that own their caches
+    /// directly — the speculative round loops, which never call
+    /// `generate_greedy` and so never reach an arch's own store site — report
+    /// through here, so a caller that samples around the call can attribute the
+    /// figure to it. Without the store, every such caller reads
+    /// [`crate::prompt_cache::KvBytesVerdict::Unreported`] forever: correct, but
+    /// no measurement.
+    ///
+    /// `post` is the witness minted by the decode phase, which pins the sample
+    /// to after decode — see [`crate::decode_loop::PostDecode`].
+    pub(crate) fn store_kv_cache_bytes(&self, n: u64, post: crate::decode_loop::PostDecode) {
+        match self {
+            Architecture::Gemma4(_) => crate::gemma4::prompt_cache::store_kv_cache_bytes(n, post),
+            Architecture::Gemma3(_) => crate::gemma3::prompt_cache::store_kv_cache_bytes(n, post),
+            Architecture::Qwen3_5Moe(_) => {
+                crate::qwen3_5_moe::prompt_cache::store_kv_cache_bytes(n, post);
+            }
+            Architecture::Qwen3(_) => {
+                crate::qwen3::QWEN3_PROMPT_CACHE.store_kv_cache_bytes(n, post);
+            }
+            Architecture::Qwen2(_) => crate::qwen2::prompt_cache::store_kv_cache_bytes(n, post),
+            Architecture::BitNet(_) => crate::bitnet::prompt_cache::store_kv_cache_bytes(n, post),
+            Architecture::Qwen3VlMoe(_) => {
+                crate::qwen3_vl_moe::prompt_cache::store_kv_cache_bytes(n, post);
+            }
+            Architecture::Laguna(_) => crate::laguna::prompt_cache::store_kv_cache_bytes(n, post),
         }
     }
 

--- a/crates/rmlx-models/src/bitnet/mod.rs
+++ b/crates/rmlx-models/src/bitnet/mod.rs
@@ -42,7 +42,7 @@ pub use generate::generate_greedy;
 pub use loader::load_from_path;
 pub use model::BitNetText;
 pub use prompt_cache::read_cache_stats as bitnet_cache_stats;
-pub use prompt_cache::read_kv_cache_bytes as bitnet_kv_cache_bytes;
+pub use prompt_cache::read_kv_cache_bytes_sample as bitnet_kv_cache_bytes_sample;
 
 #[cfg(test)]
 #[path = "tests.rs"]

--- a/crates/rmlx-models/src/bitnet/prompt_cache.rs
+++ b/crates/rmlx-models/src/bitnet/prompt_cache.rs
@@ -33,7 +33,9 @@
 #![allow(clippy::redundant_closure_for_method_calls)]
 use rmlx_core::error::Result;
 
-use crate::prompt_cache::{ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate};
+use crate::prompt_cache::{
+    ArchPromptCache, CacheStats, KvBytesSample, PromptCacheEntry, ReusePolicy, SsdHydrate,
+};
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
 
@@ -193,8 +195,8 @@ pub fn read_cache_stats() -> Option<CacheStats> {
 }
 
 /// Read the KV-cache bytes from the last completed BitNet request.
-pub fn read_kv_cache_bytes() -> u64 {
-    PROMPT_CACHE.read_kv_cache_bytes()
+pub fn read_kv_cache_bytes_sample() -> KvBytesSample {
+    PROMPT_CACHE.read_kv_cache_bytes_sample()
 }
 
 /// Record the KV-cache byte total for the just-completed request.

--- a/crates/rmlx-models/src/gemma3/mod.rs
+++ b/crates/rmlx-models/src/gemma3/mod.rs
@@ -52,7 +52,7 @@ pub use generate::{generate_greedy, probe_forward};
 pub use loader::load_from_path;
 pub use model::Gemma3Text;
 pub use prompt_cache::read_cache_stats as gemma3_cache_stats;
-pub use prompt_cache::read_kv_cache_bytes as gemma3_kv_cache_bytes;
+pub use prompt_cache::read_kv_cache_bytes_sample as gemma3_kv_cache_bytes_sample;
 pub use vision::{
     build_inputs_embeds, load_vision_tower, Gemma3ImageProcessor, Gemma3PixelValues,
     MultiModalProjector, VisionModel, BOI_TOKEN_ID, EOI_TOKEN_ID, IMAGE_TOKEN_ID,

--- a/crates/rmlx-models/src/gemma3/prompt_cache.rs
+++ b/crates/rmlx-models/src/gemma3/prompt_cache.rs
@@ -50,7 +50,9 @@
 #![allow(clippy::redundant_closure_for_method_calls)]
 use rmlx_core::error::Result;
 
-use crate::prompt_cache::{ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate};
+use crate::prompt_cache::{
+    ArchPromptCache, CacheStats, KvBytesSample, PromptCacheEntry, ReusePolicy, SsdHydrate,
+};
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
 
@@ -250,8 +252,8 @@ pub fn read_cache_stats() -> Option<CacheStats> {
 }
 
 /// Read the KV-cache bytes from the last completed Gemma3 request.
-pub fn read_kv_cache_bytes() -> u64 {
-    PROMPT_CACHE.read_kv_cache_bytes()
+pub fn read_kv_cache_bytes_sample() -> KvBytesSample {
+    PROMPT_CACHE.read_kv_cache_bytes_sample()
 }
 
 /// Record the KV-cache byte total for the just-completed request.

--- a/crates/rmlx-models/src/gemma4/mod.rs
+++ b/crates/rmlx-models/src/gemma4/mod.rs
@@ -55,7 +55,7 @@ pub use preprocessor::{
     Gemma4ImageProcessorConfig, Gemma4PixelValues, MAX_SUPPORTED_SOFT_TOKENS,
 };
 pub use prompt_cache::read_cache_stats as gemma4_cache_stats;
-pub use prompt_cache::read_kv_cache_bytes as gemma4_kv_cache_bytes;
+pub use prompt_cache::read_kv_cache_bytes_sample as gemma4_kv_cache_bytes_sample;
 pub use vision::unified::{
     build_unified_inputs_embeds, is_unified_arch, load_unified_vision_embedder,
     unified_image_processor_config, unified_num_soft_tokens, UnifiedVisionConfig,

--- a/crates/rmlx-models/src/gemma4/prompt_cache.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache.rs
@@ -30,7 +30,8 @@
 use rmlx_core::error::Result;
 
 use crate::prompt_cache::{
-    ArchPromptCache, CacheStats, PromptCacheEntry, ReuseKind, ReusePolicy, SsdHydrate, BLOCK_TOKENS,
+    ArchPromptCache, CacheStats, KvBytesSample, PromptCacheEntry, ReuseKind, ReusePolicy,
+    SsdHydrate, BLOCK_TOKENS,
 };
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
@@ -348,8 +349,8 @@ pub fn read_cache_stats() -> Option<CacheStats> {
 }
 
 /// Read the KV-cache bytes from the last completed Gemma4 request.
-pub fn read_kv_cache_bytes() -> u64 {
-    PROMPT_CACHE.read_kv_cache_bytes()
+pub fn read_kv_cache_bytes_sample() -> KvBytesSample {
+    PROMPT_CACHE.read_kv_cache_bytes_sample()
 }
 
 /// Record the KV-cache byte total for the just-completed request. Called by

--- a/crates/rmlx-models/src/laguna/mod.rs
+++ b/crates/rmlx-models/src/laguna/mod.rs
@@ -34,4 +34,4 @@ pub use generate::generate_greedy;
 pub use loader::load_from_path;
 pub use model::LagunaText;
 pub use prompt_cache::read_cache_stats as laguna_cache_stats;
-pub use prompt_cache::read_kv_cache_bytes as laguna_kv_cache_bytes;
+pub use prompt_cache::read_kv_cache_bytes_sample as laguna_kv_cache_bytes_sample;

--- a/crates/rmlx-models/src/laguna/prompt_cache.rs
+++ b/crates/rmlx-models/src/laguna/prompt_cache.rs
@@ -33,7 +33,9 @@
 #![allow(clippy::redundant_closure_for_method_calls)]
 use rmlx_core::error::Result;
 
-use crate::prompt_cache::{ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate};
+use crate::prompt_cache::{
+    ArchPromptCache, CacheStats, KvBytesSample, PromptCacheEntry, ReusePolicy, SsdHydrate,
+};
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
 
@@ -193,8 +195,8 @@ pub fn read_cache_stats() -> Option<CacheStats> {
 }
 
 /// Read the KV-cache bytes from the last completed Laguna request.
-pub fn read_kv_cache_bytes() -> u64 {
-    PROMPT_CACHE.read_kv_cache_bytes()
+pub fn read_kv_cache_bytes_sample() -> KvBytesSample {
+    PROMPT_CACHE.read_kv_cache_bytes_sample()
 }
 
 /// Record the KV-cache byte total for the just-completed request.

--- a/crates/rmlx-models/src/lib.rs
+++ b/crates/rmlx-models/src/lib.rs
@@ -77,6 +77,6 @@ pub use decode_loop::{ProbeStep, SmokeVerdict};
 // per-arch `attach_at_load` switch and calls `rmlx_kv_ssd::prepare_attach`.
 // The `pub use rmlx_kv_ssd as kv_ssd;` convenience alias was dropped —
 // there were zero callers. Import directly from `rmlx_kv_ssd`.
-pub use prompt_cache::CacheStats;
+pub use prompt_cache::{CacheStats, KvBytesSample};
 pub use sampler::{Pcg32, PenaltyConfig, SamplerConfig, TokenLogprobs};
 pub use speculative::{DraftKind, SpeculativeDispatcher};

--- a/crates/rmlx-models/src/lib.rs
+++ b/crates/rmlx-models/src/lib.rs
@@ -77,6 +77,6 @@ pub use decode_loop::{ProbeStep, SmokeVerdict};
 // per-arch `attach_at_load` switch and calls `rmlx_kv_ssd::prepare_attach`.
 // The `pub use rmlx_kv_ssd as kv_ssd;` convenience alias was dropped —
 // there were zero callers. Import directly from `rmlx_kv_ssd`.
-pub use prompt_cache::{CacheStats, KvBytesSample};
+pub use prompt_cache::{classify_kv_bytes, CacheStats, KvBytesSample, KvBytesVerdict};
 pub use sampler::{Pcg32, PenaltyConfig, SamplerConfig, TokenLogprobs};
 pub use speculative::{DraftKind, SpeculativeDispatcher};

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -709,8 +709,13 @@ impl<E: PromptCacheEntry> PromptCache<E> {
         }
     }
 
-    /// Clear all slots and reset stats.
+    /// Clear all RAM slots and reset stats.
     /// Called when model is unloaded or capacity changes.
+    ///
+    /// RAM only. An attached SSD source ([`Self::set_ssd_source`]) survives, so
+    /// the next lookup can still miss in RAM and be served by
+    /// [`Self::hydrate_from_ssd`] — which bumps `stats.ssd_hits`, not
+    /// `stats.hits`. This is not a guarantee that the next request prefills.
     pub(crate) fn clear(&mut self) {
         self.slots.clear();
         self.stats = CacheStats::default();

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -178,6 +178,30 @@ pub struct CacheStats {
 }
 
 // ---------------------------------------------------------------------------
+// KvBytesSample
+// ---------------------------------------------------------------------------
+
+/// A read of an arch's last-request KV-cache byte total, tagged with the store
+/// sequence it was written at.
+///
+/// The bare byte count is ambiguous: `0` is both the never-written initialiser
+/// and a legal (if suspicious) reading, and a non-zero value read after a
+/// generation that never reported one is the *previous* generation's figure.
+/// Callers that record the number as a measurement need to tell those apart, so
+/// they sample the pair before and after the generation and require `seq` to
+/// have advanced. See [`crate::arch::Architecture::kv_cache_bytes_sample`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct KvBytesSample {
+    /// Byte total recorded by the most recent `store_kv_cache_bytes` call.
+    /// Meaningless unless `seq > 0`.
+    pub bytes: u64,
+    /// Number of `store_kv_cache_bytes` calls on this arch since process start.
+    /// `0` means no generation has reported a figure.
+    pub seq: u64,
+}
+
+// ---------------------------------------------------------------------------
 // PromptCacheEntry trait
 // ---------------------------------------------------------------------------
 
@@ -1017,6 +1041,16 @@ pub(crate) struct ArchPromptCache<E: PromptCacheEntry> {
     attach: std::sync::Mutex<Option<AttachParams>>,
     /// Last-request KV-cache byte total, surfaced via `/metrics/cache`.
     last_kv_bytes: std::sync::atomic::AtomicU64,
+    /// Number of `store_kv_cache_bytes` calls on this arch since process start.
+    ///
+    /// `last_kv_bytes` alone cannot tell "no generation has reported a figure
+    /// yet" from "a generation reported zero", nor "this generation reported"
+    /// from "you are reading the previous generation's figure". Both collapse
+    /// to a plausible-looking number a caller would record as a measurement.
+    /// The sequence makes the distinction observable: a caller that samples it
+    /// before and after a generation knows whether the byte count it reads
+    /// belongs to that generation.
+    kv_bytes_seq: std::sync::atomic::AtomicU64,
 }
 
 impl<E: PromptCacheEntry> ArchPromptCache<E> {
@@ -1029,6 +1063,7 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
             inner: std::sync::Mutex::new(None),
             attach: std::sync::Mutex::new(None),
             last_kv_bytes: std::sync::atomic::AtomicU64::new(0),
+            kv_bytes_seq: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -1365,10 +1400,22 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
             .map(PromptCache::stats)
     }
 
-    /// Read the KV-cache bytes from the last completed request (0 if none).
-    pub(crate) fn read_kv_cache_bytes(&self) -> u64 {
-        self.last_kv_bytes
-            .load(std::sync::atomic::Ordering::Relaxed)
+    /// Read the KV-cache bytes from the last completed request, paired with the
+    /// store sequence they were written at.
+    ///
+    /// `seq == 0` means no generation on this arch has reported a figure yet,
+    /// so `bytes` is the `0` initialiser and not a measurement.
+    pub(crate) fn read_kv_cache_bytes_sample(&self) -> KvBytesSample {
+        // Load the sequence LAST: a concurrent store bumps `last_kv_bytes`
+        // before the sequence, so a sequence read after the byte read can only
+        // under-report progress. A caller comparing sequences then sees "no new
+        // reading" and refuses, rather than pairing a fresh byte count with a
+        // stale sequence and reporting it as its own.
+        let bytes = self
+            .last_kv_bytes
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let seq = self.kv_bytes_seq.load(std::sync::atomic::Ordering::Acquire);
+        KvBytesSample { bytes, seq }
     }
 
     /// Store the KV-cache bytes for the just-finished request. Called by
@@ -1390,6 +1437,10 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
         tracing::debug!(kv_bytes = n, "kv cache bytes");
         self.last_kv_bytes
             .store(n, std::sync::atomic::Ordering::Relaxed);
+        // Release-ordered so a reader that observes the bumped sequence also
+        // observes the byte count that goes with it.
+        self.kv_bytes_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -201,6 +201,51 @@ pub struct KvBytesSample {
     pub seq: u64,
 }
 
+/// What a pair of [`KvBytesSample`] reads taken around one generation says
+/// about the byte count that generation produced.
+#[allow(
+    clippy::exhaustive_enums,
+    reason = "closed by construction: the sequence either advanced or it did not, and if it \
+              did the byte count is either zero or not. There is no fourth state, and a \
+              wildcard arm at the call sites would defeat the purpose of the distinction"
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KvBytesVerdict {
+    /// The generation reported a non-zero byte count. Usable.
+    Reported(u64),
+    /// The generation reported nothing: the readable value belongs to an
+    /// earlier generation, or is the never-written initialiser. This is the
+    /// state that a bare `-> u64` accessor collapses into "0" or, worse, into
+    /// the previous run's plausible-looking figure.
+    Unreported,
+    /// The generation did report, and reported zero bytes. Distinct from
+    /// [`KvBytesVerdict::Unreported`]: the plumbing works and the answer is
+    /// still not usable as a resident-KV measurement after a real prefill.
+    ReportedZero,
+}
+
+/// Classify the byte count a generation produced, from the store sequence
+/// observed before and after it.
+///
+/// Detection ("did this generation report?") is decided by the sequence, and
+/// only then is the value interpreted. Collapsing the two — treating a zero, or
+/// an unchanged sequence, as "no KV" — is what silently records one run's
+/// number under another run's label.
+///
+/// Every caller that *records* or *reports* a KV-byte figure as a measurement
+/// goes through this. A caller that only displays the last-known value
+/// (`/metrics/cache`) may read the bare count.
+#[must_use]
+pub const fn classify_kv_bytes(before: KvBytesSample, after: KvBytesSample) -> KvBytesVerdict {
+    if after.seq <= before.seq {
+        return KvBytesVerdict::Unreported;
+    }
+    if after.bytes == 0 {
+        return KvBytesVerdict::ReportedZero;
+    }
+    KvBytesVerdict::Reported(after.bytes)
+}
+
 // ---------------------------------------------------------------------------
 // PromptCacheEntry trait
 // ---------------------------------------------------------------------------
@@ -666,7 +711,6 @@ impl<E: PromptCacheEntry> PromptCache<E> {
 
     /// Clear all slots and reset stats.
     /// Called when model is unloaded or capacity changes.
-    #[allow(dead_code)]
     pub(crate) fn clear(&mut self) {
         self.slots.clear();
         self.stats = CacheStats::default();
@@ -1131,6 +1175,22 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
         }
     }
 
+    /// Drop every cached snapshot and reset the hit/miss counters, keeping the
+    /// cache object itself — its capacity and its installed SSD sinks — in
+    /// place. A no-op when no generation has built the cache yet.
+    ///
+    /// This is the supported way to make the next request a guaranteed miss.
+    /// Asking for a zero-slot cache is not: capacity is clamped to a minimum of
+    /// one slot, so a "zero-slot" cache still stores and can still serve a
+    /// snapshot.
+    pub(crate) fn clear(&self) {
+        self.with_inner_mut(|slot| {
+            if let Some(cache) = slot.as_mut() {
+                cache.clear();
+            }
+        });
+    }
+
     /// Wire the spiller + hydrator onto this arch's prompt cache
     /// for `namespace` at `kv_quant` (/ ). Records the attach params
     /// so they survive a later cache re-creation, then installs the sinks on
@@ -1406,15 +1466,27 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
     /// `seq == 0` means no generation on this arch has reported a figure yet,
     /// so `bytes` is the `0` initialiser and not a measurement.
     pub(crate) fn read_kv_cache_bytes_sample(&self) -> KvBytesSample {
-        // Load the sequence LAST: a concurrent store bumps `last_kv_bytes`
-        // before the sequence, so a sequence read after the byte read can only
-        // under-report progress. A caller comparing sequences then sees "no new
-        // reading" and refuses, rather than pairing a fresh byte count with a
-        // stale sequence and reporting it as its own.
+        // Load the sequence FIRST, and with Acquire. The writer stores
+        // `last_kv_bytes` before releasing the sequence, so observing sequence
+        // `k` guarantees the byte count for generation `k` is already visible:
+        // the byte load that follows returns generation `k`'s figure or a later
+        // one. The pairing invariant is therefore "bytes is never *older* than
+        // seq", which is the direction that matters — a caller comparing
+        // sequences can refuse a reading that was in fact valid, but can never
+        // accept a stale byte count as a fresh generation's measurement.
+        //
+        // The opposite order does not hold: an Acquire load only orders the
+        // accesses that follow it, so reading bytes first leaves that load
+        // outside the release/acquire edge (and free to sink below it on
+        // aarch64). The reader could then pair generation `k-1`'s bytes with
+        // sequence `k` — exactly the stale-value-under-a-fresh-label failure
+        // `KvBytesSample` exists to make impossible.
+        //
+        // No seqlock needed: the payload is a single `u64`, which cannot tear.
+        let seq = self.kv_bytes_seq.load(std::sync::atomic::Ordering::Acquire);
         let bytes = self
             .last_kv_bytes
             .load(std::sync::atomic::Ordering::Relaxed);
-        let seq = self.kv_bytes_seq.load(std::sync::atomic::Ordering::Acquire);
         KvBytesSample { bytes, seq }
     }
 

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -1412,17 +1412,56 @@ fn arch_cache_with_inner_mut_round_trip() {
     });
 }
 
-/// unit test #4: `store_kv_cache_bytes` + `read_kv_cache_bytes`
+/// unit test #4: `store_kv_cache_bytes` + `read_kv_cache_bytes_sample`
 /// round-trip. Mirrors the per-request /metrics/cache wire path.
 #[test]
 fn arch_cache_kv_bytes_round_trip() {
     let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test-bytes", ReusePolicy::Partial);
     let post = crate::decode_loop::PostDecode::for_test();
-    assert_eq!(arch.read_kv_cache_bytes(), 0, "fresh cache reports zero");
+    assert_eq!(
+        arch.read_kv_cache_bytes_sample().bytes,
+        0,
+        "fresh cache reports zero"
+    );
     arch.store_kv_cache_bytes(424_242, post);
-    assert_eq!(arch.read_kv_cache_bytes(), 424_242);
+    assert_eq!(arch.read_kv_cache_bytes_sample().bytes, 424_242);
     arch.store_kv_cache_bytes(0, post);
-    assert_eq!(arch.read_kv_cache_bytes(), 0);
+    assert_eq!(arch.read_kv_cache_bytes_sample().bytes, 0);
+}
+
+/// The store sequence separates "no generation has reported a byte count" from
+/// "a generation reported zero" — two states the bare byte value collapses into
+/// the same `0`. A caller that records the figure as a measurement reads the
+/// sequence, not the value, to decide whether it has one.
+#[test]
+fn arch_cache_kv_bytes_seq_distinguishes_unreported_from_zero() {
+    let arch: ArchPromptCache<TestEntry> = ArchPromptCache::new("test-seq", ReusePolicy::Partial);
+    let post = crate::decode_loop::PostDecode::for_test();
+
+    let fresh = arch.read_kv_cache_bytes_sample();
+    assert_eq!(fresh.seq, 0, "no store yet — sequence must still be zero");
+
+    // A genuine store of zero bytes is NOT the same state as "never stored",
+    // even though both report `bytes == 0`.
+    arch.store_kv_cache_bytes(0, post);
+    let reported_zero = arch.read_kv_cache_bytes_sample();
+    assert_eq!(reported_zero.bytes, 0);
+    assert_eq!(
+        reported_zero.seq, 1,
+        "a store of zero must still advance the sequence — otherwise it is \
+         indistinguishable from never having stored"
+    );
+
+    // Every store advances it, so a caller can tell "this generation reported"
+    // from "I am reading the previous generation's figure".
+    arch.store_kv_cache_bytes(4096, post);
+    assert_eq!(
+        arch.read_kv_cache_bytes_sample(),
+        KvBytesSample {
+            bytes: 4096,
+            seq: 2
+        }
+    );
 }
 
 /// unit test #5: `read_cache_stats` returns `None` for an

--- a/crates/rmlx-models/src/qwen2/mod.rs
+++ b/crates/rmlx-models/src/qwen2/mod.rs
@@ -31,4 +31,4 @@ pub use generate::generate_greedy;
 pub use loader::load_from_path;
 pub use model::Qwen2Text;
 pub use prompt_cache::read_cache_stats as qwen2_cache_stats;
-pub use prompt_cache::read_kv_cache_bytes as qwen2_kv_cache_bytes;
+pub use prompt_cache::read_kv_cache_bytes_sample as qwen2_kv_cache_bytes_sample;

--- a/crates/rmlx-models/src/qwen2/prompt_cache.rs
+++ b/crates/rmlx-models/src/qwen2/prompt_cache.rs
@@ -33,7 +33,9 @@
 #![allow(clippy::redundant_closure_for_method_calls)]
 use rmlx_core::error::Result;
 
-use crate::prompt_cache::{ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate};
+use crate::prompt_cache::{
+    ArchPromptCache, CacheStats, KvBytesSample, PromptCacheEntry, ReusePolicy, SsdHydrate,
+};
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
 
@@ -193,8 +195,8 @@ pub fn read_cache_stats() -> Option<CacheStats> {
 }
 
 /// Read the KV-cache bytes from the last completed Qwen2 request.
-pub fn read_kv_cache_bytes() -> u64 {
-    PROMPT_CACHE.read_kv_cache_bytes()
+pub fn read_kv_cache_bytes_sample() -> KvBytesSample {
+    PROMPT_CACHE.read_kv_cache_bytes_sample()
 }
 
 /// Record the KV-cache byte total for the just-completed request.

--- a/crates/rmlx-models/src/qwen3.rs
+++ b/crates/rmlx-models/src/qwen3.rs
@@ -75,8 +75,8 @@ use crate::kv_cache::{
 use crate::layers::{resolve_quant, QuantParams};
 use crate::load_util::{bf16_param, bf16_scales, Weights};
 use crate::prompt_cache::{
-    chained_block_hashes_seeded, ArchPromptCache, Consumed, PromptCacheEntry, ReusePolicy,
-    SsdHydrate, FNV_OFFSET,
+    chained_block_hashes_seeded, ArchPromptCache, Consumed, KvBytesSample, PromptCacheEntry,
+    ReusePolicy, SsdHydrate, FNV_OFFSET,
 };
 use crate::sampler::TokenLogprobs;
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
@@ -261,8 +261,8 @@ pub fn read_cache_stats() -> Option<crate::prompt_cache::CacheStats> {
 }
 
 /// Read the KV-cache bytes from the last completed Qwen3 request.
-pub fn read_kv_cache_bytes() -> u64 {
-    QWEN3_PROMPT_CACHE.read_kv_cache_bytes()
+pub fn read_kv_cache_bytes_sample() -> KvBytesSample {
+    QWEN3_PROMPT_CACHE.read_kv_cache_bytes_sample()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rmlx-models/src/qwen3_5_moe/mod.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/mod.rs
@@ -33,7 +33,7 @@ pub use loader::{load_from_path, load_from_path_paro};
 pub use model::Qwen3_5MoeText;
 pub(crate) use mtp_layer::{MtpLayer, MtpLayerDims};
 pub use prompt_cache::read_cache_stats as qwen3_5_moe_cache_stats;
-pub use prompt_cache::read_kv_cache_bytes as qwen3_5_moe_kv_cache_bytes;
+pub use prompt_cache::read_kv_cache_bytes_sample as qwen3_5_moe_kv_cache_bytes_sample;
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/prompt_cache.rs
@@ -32,7 +32,8 @@
 use rmlx_core::error::Result;
 
 use crate::prompt_cache::{
-    ArchPromptCache, CacheStats, PromptCacheEntry, ReuseKind, ReusePolicy, SsdHydrate,
+    ArchPromptCache, CacheStats, KvBytesSample, PromptCacheEntry, ReuseKind, ReusePolicy,
+    SsdHydrate,
 };
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
@@ -231,8 +232,8 @@ pub fn read_cache_stats() -> Option<CacheStats> {
 
 /// Read the KV-cache bytes (KV + linear-attn) from the last completed Qwen3.5
 /// MoE request.
-pub fn read_kv_cache_bytes() -> u64 {
-    PROMPT_CACHE.read_kv_cache_bytes()
+pub fn read_kv_cache_bytes_sample() -> KvBytesSample {
+    PROMPT_CACHE.read_kv_cache_bytes_sample()
 }
 
 /// Record the KV-cache byte total for the just-completed request.

--- a/crates/rmlx-models/src/qwen3_tests.rs
+++ b/crates/rmlx-models/src/qwen3_tests.rs
@@ -337,18 +337,18 @@ fn qwen3_kv_bytes_store_read_roundtrip() {
     let sentinel_miss: u64 = 123_456_789;
     QWEN3_PROMPT_CACHE.store_kv_cache_bytes(sentinel_miss, post);
     assert_eq!(
-        read_kv_cache_bytes(),
+        read_kv_cache_bytes_sample().bytes,
         sentinel_miss,
-        "read_kv_cache_bytes() must return the value stored on the Miss path"
+        "read_kv_cache_bytes_sample() must return the value stored on the Miss path"
     );
 
     // Simulate the Exact-hit path store (same atomic, same semantics).
     let sentinel_hit: u64 = 987_654_321;
     QWEN3_PROMPT_CACHE.store_kv_cache_bytes(sentinel_hit, post);
     assert_eq!(
-        read_kv_cache_bytes(),
+        read_kv_cache_bytes_sample().bytes,
         sentinel_hit,
-        "read_kv_cache_bytes() must return the value stored on the Exact-hit path"
+        "read_kv_cache_bytes_sample() must return the value stored on the Exact-hit path"
     );
 
     // Reset to 0 so parallel tests see a clean state.

--- a/crates/rmlx-models/src/qwen3_vl_moe/mod.rs
+++ b/crates/rmlx-models/src/qwen3_vl_moe/mod.rs
@@ -62,5 +62,5 @@ pub use loader::{load_config_qwen3_vl, load_from_path, load_text_from_path};
 pub use model::Qwen3VlMoe;
 pub use model::Qwen3VlMoeText;
 pub use prompt_cache::read_cache_stats as qwen3_vl_moe_cache_stats;
-pub use prompt_cache::read_kv_cache_bytes as qwen3_vl_moe_kv_cache_bytes;
+pub use prompt_cache::read_kv_cache_bytes_sample as qwen3_vl_moe_kv_cache_bytes_sample;
 pub use vision::{load_vision_tower, Qwen3VlMoeVision, VisionOutput};

--- a/crates/rmlx-models/src/qwen3_vl_moe/prompt_cache.rs
+++ b/crates/rmlx-models/src/qwen3_vl_moe/prompt_cache.rs
@@ -36,7 +36,9 @@
 #![allow(clippy::redundant_closure_for_method_calls)]
 use rmlx_core::error::Result;
 
-use crate::prompt_cache::{ArchPromptCache, CacheStats, PromptCacheEntry, ReusePolicy, SsdHydrate};
+use crate::prompt_cache::{
+    ArchPromptCache, CacheStats, KvBytesSample, PromptCacheEntry, ReusePolicy, SsdHydrate,
+};
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 use rmlx_kv_ssd::{HydratedBlock, SsdHydrator};
 
@@ -197,8 +199,8 @@ pub fn read_cache_stats() -> Option<CacheStats> {
 }
 
 /// Read the KV-cache bytes from the last completed Qwen3-VL-MoE request.
-pub fn read_kv_cache_bytes() -> u64 {
-    PROMPT_CACHE.read_kv_cache_bytes()
+pub fn read_kv_cache_bytes_sample() -> KvBytesSample {
+    PROMPT_CACHE.read_kv_cache_bytes_sample()
 }
 
 /// Record the KV-cache byte total for the just-completed request.

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -958,6 +958,15 @@ pub fn dflash_generate_greedy(
         elapsed_ms,
         "[dflash] debug summary"
     );
+
+    // Report the verifier's resident KV, so a caller that sampled the verifier
+    // arch around this call can attribute the figure to it. This round loop
+    // never goes through `Architecture::generate_greedy`, so nothing else
+    // writes it.
+    verifier.store_kv_cache_bytes(
+        crate::speculative::verifier_kv_bytes(&v_caches, Some(&v_lin)),
+        crate::decode_loop::PostDecode::seal(),
+    );
     Ok(emitted)
 }
 

--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -1232,6 +1232,15 @@ pub fn eagle3_generate_greedy(
         block_size = block_total,
         "eagle3_generate_greedy: done"
     );
+
+    // Report the verifier's resident KV, so a caller that sampled the verifier
+    // arch around this call can attribute the figure to it. This round loop
+    // never goes through `Architecture::generate_greedy`, so nothing else
+    // writes it.
+    verifier.store_kv_cache_bytes(
+        crate::speculative::verifier_kv_bytes(&v_caches, Some(&v_lin)),
+        crate::decode_loop::PostDecode::seal(),
+    );
     Ok(emitted)
 }
 

--- a/crates/rmlx-models/src/speculative/gemma4_assistant.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant.rs
@@ -960,6 +960,15 @@ pub fn mtp_assistant_generate_greedy(
         block_size,
         "mtp_assistant_generate_greedy: done"
     );
+
+    // Report the verifier's resident KV, so a caller that sampled the verifier
+    // arch around this call can attribute the figure to it. This round loop
+    // never goes through `Architecture::generate_greedy`, so nothing else
+    // writes it. Gemma4 is full-attention only — no recurrent state to add.
+    verifier.store_kv_cache_bytes(
+        crate::speculative::verifier_kv_bytes(&caches, None),
+        crate::decode_loop::PostDecode::seal(),
+    );
     Ok(emitted)
 }
 

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -46,6 +46,18 @@ use crate::kv_cache::KvCacheBuilder;
 pub use draft_kind::DraftKind;
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache, KV_MAX_SEQ_DEFAULT};
 
+/// Resident KV bytes held by a verifier's own caches.
+///
+/// Same basis as the per-arch `generate_greedy` byte total: the attention
+/// caches plus, on hybrid archs, the recurrent linear-attention state. Only the
+/// verifier's caches count — the draft's are an implementation detail of the
+/// accelerator, and including them would make a speculative row incomparable
+/// with the ordinary row for the same model and context.
+pub(crate) fn verifier_kv_bytes(kv: &[KvCache], lin: Option<&[LinearAttnCache]>) -> u64 {
+    kv.iter().map(KvCache::resident_bytes).sum::<u64>()
+        + lin.map_or(0, |l| l.iter().map(LinearAttnCache::resident_bytes).sum())
+}
+
 /// Holds a (verifier, draft) pair for speculative decoding.
 ///
 /// Phase 1 invariants:
@@ -923,6 +935,15 @@ impl SpeculativeDispatcher {
             "spec_generate_greedy_cached: done"
         );
 
+        // Report the verifier's resident KV, so a caller that sampled the
+        // verifier arch around this call can attribute the figure to it. This
+        // path never goes through `Architecture::generate_greedy`, so nothing
+        // else writes it.
+        self.verifier.store_kv_cache_bytes(
+            verifier_kv_bytes(&verifier_caches, verifier_lin.as_deref()),
+            crate::decode_loop::PostDecode::seal(),
+        );
+
         Ok(emitted)
     }
 
@@ -1321,6 +1342,13 @@ impl SpeculativeDispatcher {
             verifier_ms = (verifier_ns as f64) / 1.0e6,
             k,
             "spec_generate_stochastic_cached: done"
+        );
+
+        // See the greedy path: the verifier's own resident KV, reported so the
+        // caller can attribute it to this call.
+        self.verifier.store_kv_cache_bytes(
+            verifier_kv_bytes(&verifier_caches, verifier_lin.as_deref()),
+            crate::decode_loop::PostDecode::seal(),
         );
 
         Ok(emitted)

--- a/crates/rmlx-models/src/speculative/mtp.rs
+++ b/crates/rmlx-models/src/speculative/mtp.rs
@@ -888,6 +888,15 @@ pub fn mtp_generate_greedy(
         block_size = block_total,
         "mtp_generate_greedy: done"
     );
+
+    // Report the verifier's resident KV, so a caller that sampled the verifier
+    // arch around this call can attribute the figure to it. This round loop
+    // never goes through `Architecture::generate_greedy`, so nothing else
+    // writes it.
+    verifier.store_kv_cache_bytes(
+        crate::speculative::verifier_kv_bytes(&v_caches, Some(&v_lin)),
+        crate::decode_loop::PostDecode::seal(),
+    );
     Ok(emitted)
 }
 

--- a/crates/rmlx-server/src/engine/speculative.rs
+++ b/crates/rmlx-server/src/engine/speculative.rs
@@ -503,7 +503,7 @@ impl Generator for SpeculativeGenerator {
 
     fn kv_cache_bytes(&self) -> u64 {
         // SpeculativeDispatcher wraps a Gemma4 verifier — reads its static.
-        rmlx_models::gemma4::gemma4_kv_cache_bytes()
+        rmlx_models::gemma4::gemma4_kv_cache_bytes_sample().bytes
     }
 
     fn load_phases(&self) -> Option<rmlx_models::LoadPhases> {
@@ -1011,7 +1011,7 @@ impl Generator for SpeculativeGenerator {
                     // F6/L18: emit KV-cache bytes to SPSC drainer (SpeculativeGenerator
                     // always wraps a Gemma4 verifier, so the global static applies).
                     {
-                        let kv_bytes = rmlx_models::gemma4::gemma4_kv_cache_bytes();
+                        let kv_bytes = rmlx_models::gemma4::gemma4_kv_cache_bytes_sample().bytes;
                         if kv_bytes > 0 {
                             if let Some(ref drainer) = metrics_drainer {
                                 use crate::metrics_drainer::{MetricEvent, MetricKind};

--- a/crates/rmlx-server/src/engine/speculative.rs
+++ b/crates/rmlx-server/src/engine/speculative.rs
@@ -824,7 +824,14 @@ impl Generator for SpeculativeGenerator {
             // across the call, or the readable figure belongs to an earlier
             // generation. The rows below land in the append-only events table,
             // where a wrong value cannot be taken back.
-            let kv_before = rmlx_models::gemma4::gemma4_kv_cache_bytes_sample();
+            //
+            // Read off the **verifier's own** architecture. The byte statics are
+            // per arch, and the drafter branches below run against a
+            // Qwen3.5/3.6-MoE verifier, not a Gemma4 one — sampling a fixed
+            // arch's static here would compare a reading of some other model's
+            // cache before and after, and hand back that model's bytes as this
+            // request's whenever it happened to generate in between.
+            let kv_before = dispatcher.verifier.kv_cache_bytes_sample();
 
             let result = if let Some(drafter_arc) = eagle3_drafter.as_ref() {
                 // EAGLE-3 round-loop (greedy). Autoregressive draft +
@@ -1015,8 +1022,8 @@ impl Generator for SpeculativeGenerator {
                     } else {
                         "length".to_owned()
                     };
-                    // F6/L18: emit KV-cache bytes to SPSC drainer (SpeculativeGenerator
-                    // always wraps a Gemma4 verifier, so the global static applies).
+                    // F6/L18: emit KV-cache bytes to the SPSC drainer, read off
+                    // the verifier's own arch static (see `kv_before`).
                     {
                         // Attribute the byte count to this generation before
                         // recording it: an unchanged store sequence means the
@@ -1025,16 +1032,21 @@ impl Generator for SpeculativeGenerator {
                         // is recordable — skip the row and say why.
                         let kv_bytes = match rmlx_models::classify_kv_bytes(
                             kv_before,
-                            rmlx_models::gemma4::gemma4_kv_cache_bytes_sample(),
+                            dispatcher.verifier.kv_cache_bytes_sample(),
                         ) {
                             rmlx_models::KvBytesVerdict::Reported(n) => n,
                             rmlx_models::KvBytesVerdict::Unreported => {
+                                // Every round loop reports at the end of its
+                                // decode phase, so this is now reachable only
+                                // for a generation that returned before one —
+                                // an immediate EOS on the prefill bonus token.
                                 tracing::warn!(
                                     model_id = %model_id_for_log,
+                                    arch = dispatcher.verifier.arch_class(),
                                     "speculative generation reported no KV-cache byte count \
-                                     (store sequence did not advance); skipping the \
-                                     kv_cache_bytes row rather than recording an earlier \
-                                     generation's figure"
+                                     (store sequence did not advance, so it ended before its \
+                                     decode phase); skipping the kv_cache_bytes row rather \
+                                     than recording an earlier generation's figure"
                                 );
                                 0
                             }

--- a/crates/rmlx-server/src/engine/speculative.rs
+++ b/crates/rmlx-server/src/engine/speculative.rs
@@ -819,6 +819,13 @@ impl Generator for SpeculativeGenerator {
                 None
             };
 
+            // Sampled before the generation so the byte count emitted below can
+            // be attributed to *this* one: the store sequence must advance
+            // across the call, or the readable figure belongs to an earlier
+            // generation. The rows below land in the append-only events table,
+            // where a wrong value cannot be taken back.
+            let kv_before = rmlx_models::gemma4::gemma4_kv_cache_bytes_sample();
+
             let result = if let Some(drafter_arc) = eagle3_drafter.as_ref() {
                 // EAGLE-3 round-loop (greedy). Autoregressive draft +
                 // multi-layer hidden capture + d2t remap + GDN snapshot/restore
@@ -1011,7 +1018,36 @@ impl Generator for SpeculativeGenerator {
                     // F6/L18: emit KV-cache bytes to SPSC drainer (SpeculativeGenerator
                     // always wraps a Gemma4 verifier, so the global static applies).
                     {
-                        let kv_bytes = rmlx_models::gemma4::gemma4_kv_cache_bytes_sample().bytes;
+                        // Attribute the byte count to this generation before
+                        // recording it: an unchanged store sequence means the
+                        // readable figure is an earlier generation's, and a
+                        // reported zero means the accounting is wrong. Neither
+                        // is recordable — skip the row and say why.
+                        let kv_bytes = match rmlx_models::classify_kv_bytes(
+                            kv_before,
+                            rmlx_models::gemma4::gemma4_kv_cache_bytes_sample(),
+                        ) {
+                            rmlx_models::KvBytesVerdict::Reported(n) => n,
+                            rmlx_models::KvBytesVerdict::Unreported => {
+                                tracing::warn!(
+                                    model_id = %model_id_for_log,
+                                    "speculative generation reported no KV-cache byte count \
+                                     (store sequence did not advance); skipping the \
+                                     kv_cache_bytes row rather than recording an earlier \
+                                     generation's figure"
+                                );
+                                0
+                            }
+                            rmlx_models::KvBytesVerdict::ReportedZero => {
+                                tracing::warn!(
+                                    model_id = %model_id_for_log,
+                                    "speculative generation reported a KV cache of 0 bytes \
+                                     after a real prefill — the byte accounting is wrong, not \
+                                     the cache; skipping the kv_cache_bytes row"
+                                );
+                                0
+                            }
+                        };
                         if kv_bytes > 0 {
                             if let Some(ref drainer) = metrics_drainer {
                                 use crate::metrics_drainer::{MetricEvent, MetricKind};

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,7 +18,8 @@ Subcommands:
 | `serve` | OpenAI + Anthropic-compatible HTTP inference server |
 | `chat` | Interactive REPL for ad-hoc model testing |
 | `info` | Print arch + quant metadata for a snapshot; no inference |
-| `baseline` | Measure load time, TTFT, decode TPS, peak RSS |
+| `baseline` | Measure load time, TTFT, decode TPS, peak RSS — one run, one metrics row |
+| `bench` | Repeated-run decode instrument: TTFT, ITL p50/p99, decode TPS, KV bytes with run-to-run spread; prints only |
 | `healthcheck` | Shell-able readiness probe; JSON or plain text output |
 | `metrics` | Metrics database management (schema, query, export) |
 | `eval ppl` | Offline perplexity evaluation over a text corpus |
@@ -377,6 +378,112 @@ rmlx baseline --model /path/to/snapshot --prompt-tokens 131072 \
 # recording a 65536-token run under a 128k label.
 rmlx baseline --model /path/to/snapshot --prompt-tokens 131072 --device gpu
 ```
+
+---
+
+### `bench`
+
+Repeated-run decode instrument for one (model, KV codec, context, generation
+length) cell. Serves the cell `--warmup` + `--runs` times **in one process**
+and reports four quantities as a median with the observed run-to-run range:
+
+| Metric | Meaning |
+|---|---|
+| `ttft_ms` | Prefill through first token. |
+| `itl_p50_ms` / `itl_p99_ms` | Inter-token latency percentiles **within** a run (nearest-rank over the gaps between consecutive token arrivals). |
+| `decode_tps` | Steady-state decode rate over tokens 2..N — prefill excluded. |
+| `prefill_tps` | Prompt tokens / TTFT. |
+| `kv_cache_bytes` | Filled-prefix KV cache bytes, sampled post-decode. |
+
+```bash
+rmlx bench --model /path/to/snapshot --prompt-tokens 4096 --max-tokens 128
+rmlx bench --model /path/to/snapshot --prompt-tokens 32768 --max-ctx 40960 \
+  --kv-quant k8v4 --runs 5 --warmup 1 --json
+```
+
+```text
+bench: model=… arch=Qwen3ForCausalLM kv_quant=… prompt=longctx_4k prompt_tokens=4096 …
+metric                   median            min            max    range%
+ttft_ms                  512.30         509.11         514.90       1.1%
+itl_p50_ms                 9.012          8.998          9.031       0.4%
+itl_p99_ms                 9.877          9.640         10.204       6.3%
+decode_tps               110.914        110.612        111.083       0.4%
+kv_cache_bytes         134217728      134217728      134217728       0.0%
+host: cpus=16 load_1m=1.20→1.35
+```
+
+#### `bench` vs `baseline`
+
+| | `baseline` | `bench` |
+|---|---|---|
+| Runs per invocation | 1 | `--warmup` + `--runs` (min 2 measured) |
+| Output | one-line summary | median + min/max + range% per metric |
+| ITL percentiles | no | yes (p50, p99) |
+| Writes to `runs.db` | with `--record` | never — prints only |
+| Prompt-cache slots | 1 | 0 (every run is a fresh prefill) |
+
+Use `baseline --record` when a row must land in the append-only store; use
+`bench` when the question is "what is this cell's number, and how much do I
+trust it".
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--model` | path | required | Path to the model snapshot directory. |
+| `--prompt` | path | bundled fixture | Prompt file. Same plain-text / chat-JSON handling as `baseline`. Mutually exclusive with `--prompt-tokens`. |
+| `--prompt-tokens` | u32 | — | Canonical bench prompt from `prompts/longctx_<N/1024>k.json`. Mutually exclusive with `--prompt`. |
+| `--device` | `cpu \| gpu` | `gpu` | Inference device. |
+| `--max-tokens` / `--gen-tokens` | u32 | 128 | Tokens generated per run. |
+| `--runs` | u32 | 3 | Measured runs. **Must be ≥ 2** — see "Refusals" below. |
+| `--warmup` | u32 | 1 | Discarded runs before the measured ones. |
+| `--kv-quant` | string | `auto` | KV cache quantization preset. |
+| `--kv-preset` | string | — | Named KV-cache preset. Same values and exclusions as `baseline`. |
+| `--cache-type-k` / `--ctk`, `--cache-type-v` / `--ctv` | string | — | Per-side KV codec. Mutually exclusive with `--kv-quant`. |
+| `--kv-bits` | float | — | Bit-width alias. Mutually exclusive with `--kv-quant` and `--cache-type-*`. |
+| `--kv-group-size` | usize | 64 | Group size for `--kv-bits`. |
+| `--max-ctx` / `--ctx-max` | u32 | (from model) | KV cache buffer token capacity. Must be ≥ 256 when set. |
+| `--max-prompt-tokens` | usize | 65536 | Cap on the tokenized prompt length. Same device-dependent semantics as `baseline`. |
+| `--allow-truncate` | bool flag | off | Opt into truncating an over-cap prompt on `--device gpu`. |
+| `--json` | bool flag | off | Emit one JSON object (per-metric spreads plus every individual run) instead of the table. |
+| `--prompts-dir` | path | (cwd walk) | Root to search for `longctx_<N>k.json`. Env: `RMLX_PROMPTS_DIR`. |
+
+#### Refusals
+
+The numbers `bench` prints are used to accept or reject work, so it aborts
+rather than print one whose measurement conditions did not hold. Each of these
+is a hard error naming the cause, never a silent zero or a plausible default:
+
+- **`--runs 1`.** A single measurement has no observable spread, and this
+  instrument does not report a central value without one. Checked before any
+  file is opened.
+- **A run served from the prompt cache.** `bench` uses zero prompt-cache slots
+  so every run performs a real prefill, and then *verifies* it from the arch's
+  cache counters: no hits, and at least one miss. A hit means the post-prefill
+  KV snapshot was replayed, so the run's TTFT is a cache-replay time — small,
+  stable, and not a time-to-first-token. Absent counters are refused too:
+  nothing observable would then say a prefill happened.
+- **A KV-byte figure the run did not report.** The arch's byte count is read as
+  a `(bytes, seq)` pair (`Architecture::kv_cache_bytes_sample`), sampled before
+  and after each generation. If `seq` did not advance, the readable value
+  belongs to an *earlier* generation (or is the unset initialiser) and is
+  refused. A reported-but-zero count is a separate, differently-worded error:
+  the reporting path worked and the byte accounting is what is wrong.
+- **A callback/token count mismatch**, which would mean the arrival timestamps
+  cannot be attributed to the returned tokens.
+- **Fewer than 2 tokens generated**, which yields no inter-token interval and
+  no steady-state rate. `bench` does not substitute the combined
+  prefill+decode number in their place.
+
+#### Host contention
+
+`bench` reads the 1-minute load average before and after the measured runs and
+prints both. When either sample is at or above the CPU count, the summary is
+marked `CONTENDED` (and a `warn!` is emitted): the numbers are a lower bound
+taken on a busy host, not quiet-machine figures. An unreadable load average is
+reported as `n/a`, never as `0.00`.
+
+`bench` does not abort on contention — measuring under known load is a
+legitimate thing to do deliberately — it just makes it impossible to mistake
+the result for a quiet-machine one afterwards.
 
 ---
 
@@ -1077,6 +1184,26 @@ rmlx baseline \
   --kv-quant k8v8 \
   --label "phase-3-gate" \
   --record
+```
+
+### Bench a KV-codec cell with its spread
+
+```bash
+# Three measured runs after one warmup; median + range per metric.
+rmlx bench \
+  --model /path/to/snapshot \
+  --prompt-tokens 4096 \
+  --max-tokens 128 \
+  --kv-quant k8v4
+
+# Long context, machine-readable, five runs for a tighter range.
+rmlx bench \
+  --model /path/to/snapshot \
+  --prompt-tokens 32768 \
+  --max-ctx 40960 \
+  --max-tokens 128 \
+  --runs 5 \
+  --json
 ```
 
 ### Metrics database operations

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -392,8 +392,9 @@ and reports four quantities as a median with the observed run-to-run range:
 | `ttft_ms` | Prefill through first token. |
 | `itl_p50_ms` / `itl_p99_ms` | Inter-token latency percentiles **within** a run (nearest-rank over the gaps between consecutive token arrivals). |
 | `decode_tps` | Steady-state decode rate over tokens 2..N — prefill excluded. |
-| `prefill_tps` | Prompt tokens / TTFT. |
+| `prefill_tps` | Prompt tokens / TTFT. Reported as `n/a` when undefined, never as `0`. |
 | `kv_cache_bytes` | Filled-prefix KV cache bytes, sampled post-decode. |
+| `token_digest` | FNV-1a-64 over the run's token ids. Identical across every run of a cell, or the run aborts. |
 
 ```bash
 rmlx bench --model /path/to/snapshot --prompt-tokens 4096 --max-tokens 128
@@ -409,6 +410,7 @@ itl_p50_ms                 9.012          8.998          9.031       0.4%
 itl_p99_ms                 9.877          9.640         10.204       6.3%
 decode_tps               110.914        110.612        111.083       0.4%
 kv_cache_bytes         134217728      134217728      134217728       0.0%
+tokens: digest=0x8f2a1c47bd9e0356 (identical across every run)
 host: cpus=16 load_1m=1.20→1.35
 ```
 
@@ -420,11 +422,34 @@ host: cpus=16 load_1m=1.20→1.35
 | Output | one-line summary | median + min/max + range% per metric |
 | ITL percentiles | no | yes (p50, p99) |
 | Writes to `runs.db` | with `--record` | never — prints only |
-| Prompt-cache slots | 1 | 0 (every run is a fresh prefill) |
+| Prompt-cache slots | 1 | 1, cleared before every run (so every run is a fresh prefill) |
+| Output check | prints a decoded preview | token-stream digest, required identical across runs |
 
 Use `baseline --record` when a row must land in the append-only store; use
 `bench` when the question is "what is this cell's number, and how much do I
 trust it".
+
+**Their TTFTs are not the same quantity, and should not be compared directly.**
+`baseline` measures the *first* generation in a fresh process. `bench` discards
+`--warmup` generations first, so it measures a *warmed, repeated* generation.
+In-process TTFT genuinely moves between the two, and the direction depends on
+the context length. Measured on gemma-4-e2b and Ternary-Bonsai-8B (`--kv-quant
+none`, 4096-token prompt, 128 generated):
+
+| | gemma-4-e2b | Ternary-Bonsai-8B |
+|---|---|---|
+| `baseline` (median of 3 invocations) | 257 ms | 1272 ms |
+| `bench` generation 1 (`--warmup 0`) | 250 ms (**−2.6%**) | 1297 ms (**+2.0%**) |
+| `bench` median (`--warmup 1`) | 207 ms (−19%) | 1345 ms (+5.8%) |
+
+Generation 1 agrees with `baseline` on both architectures; the divergence is the
+warmup, not a disagreement about what a TTFT is. Compare `bench` TTFTs to other
+`bench` TTFTs at the same `--warmup`, and `baseline` TTFTs to other `baseline`
+TTFTs. Decode TPS does not have this problem — it averages the steady-state
+gaps *within* a generation, so it is robust in both tools.
+
+At long context the movement is large enough that `bench` refuses to report a
+median at all until the cell settles — see the drift refusal below.
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
@@ -455,12 +480,33 @@ is a hard error naming the cause, never a silent zero or a plausible default:
 - **`--runs 1`.** A single measurement has no observable spread, and this
   instrument does not report a central value without one. Checked before any
   file is opened.
-- **A run served from the prompt cache.** `bench` uses zero prompt-cache slots
-  so every run performs a real prefill, and then *verifies* it from the arch's
-  cache counters: no hits, and at least one miss. A hit means the post-prefill
-  KV snapshot was replayed, so the run's TTFT is a cache-replay time — small,
-  stable, and not a time-to-first-token. Absent counters are refused too:
-  nothing observable would then say a prefill happened.
+- **A run served from the prompt cache.** `bench` clears the arch's prompt cache
+  before every generation so each run performs a real prefill, and then
+  *verifies* it from the arch's cache counters: no hits, and at least one miss.
+  A hit means the post-prefill KV snapshot was replayed, so the run's TTFT is a
+  cache-replay time — small, stable, and not a time-to-first-token. Absent
+  counters are refused too: nothing observable would then say a prefill
+  happened. (Requesting a zero-slot cache would *not* achieve this: slot
+  capacity is clamped to a minimum of one.)
+- **A metric that trended across the runs.** `Spread` sorts, so a value that
+  climbs from run to run is reported as a wide *range* around a median — and a
+  wide range reads as noise. It is not: a drifting cell has no central value,
+  and its median is a point on a ramp that depends on where the operator
+  stopped. `bench` fits a line to `ttft_ms`, `decode_tps`, `itl_p50_ms`,
+  `prefill_tps` and `kv_cache_bytes` **in collection order** and aborts when the
+  first-to-last change exceeds 10% of the median, in either direction, naming
+  the values in run order. Raise `--warmup` until consecutive runs agree.
+  `itl_p99_ms` is exempt: nearest-rank p99 over a 128-token run is the
+  second-largest inter-token gap, so its run-to-run movement tracks whether one
+  run hit a stall rather than whether the cell settled. Its spread is still
+  printed.
+- **Runs that decoded different tokens.** Every run in a cell feeds the same
+  prompt to the same model at temperature 0, so every run must emit a
+  byte-identical token stream. `bench` digests each run's token ids (FNV-1a-64,
+  warmup runs included) and aborts when they disagree. This is not only a
+  reproducibility check: a KV cache that silently stops being written decodes
+  *faster* while producing wrong tokens, so a timing-only instrument is biased
+  toward accepting exactly that defect.
 - **A KV-byte figure the run did not report.** The arch's byte count is read as
   a `(bytes, seq)` pair (`Architecture::kv_cache_bytes_sample`), sampled before
   and after each generation. If `seq` did not advance, the readable value

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -403,7 +403,7 @@ Source of truth for `observations.metric`, `.unit`, `.direction`. Add to this ta
 | `model_load_ms`       | `ms`    | `lower_better`  | Wall time from `serve` start to "ready" log line.                       |
 | `peak_rss_mb`         | `mb`    | `lower_better`  | Peak resident set during the run.                                       |
 | `metal_peak_alloc_mb` | `mb`    | `lower_better`  | Peak Metal device allocation (from `mx.metal.get_peak_memory()`).       |
-| `kv_cache_bytes`      | `bytes` | `lower_better`  | Live-inference KV resident bytes at end of generation: the *filled* prefix of the cache that actually serves decode (packed codes + scales + rotation/residual buffers, plus the per-position bf16/f32 decode buffers scaled to the filled length). Reads real Array shapes × dtype via `KvCache::resident_bytes`, but counts only `offset` positions of the seq-scaled buffers — the bf16/f32 decode mirrors are pre-allocated to the `--max-ctx` ceiling, so counting the whole allocation would inflate the figure and make bytes-per-KV-token depend on the ceiling rather than the prompt. Excludes any prompt-cache snapshot clone (held separately, never summed). Sampled at ONE lifecycle point on every arch — **after the decode loop**, when the decode-time GPU ring of a ring-backed codec is resident — so the figure is comparable across archs and across prompt-cache hit/miss. "One lifecycle point" means post-decode *and only when a decode ran*: an immediate-EOS or NaN-prefill run (no decode loop) does not refresh this metric and keeps the prior value — uniform across archs, and lossless since with no decode there is no ring. The requirement is gated by a witness: `store_kv_cache_bytes` takes a `PostDecode` minted only by a completed decode loop, so re-co-locating the store at the prefill snapshot fails to compile (the loop's witness is not in scope there). It is a raised bar + review convention backed by a manual-GPU re-drift test, not an unforgeable compile guarantee — `seal()` is `pub(crate)`. |
+| `kv_cache_bytes`      | `bytes` | `lower_better`  | Live-inference KV resident bytes at end of generation: the *filled* prefix of the cache that actually serves decode (packed codes + scales + rotation/residual buffers, plus the per-position bf16/f32 decode buffers scaled to the filled length). Reads real Array shapes × dtype via `KvCache::resident_bytes`, but counts only `offset` positions of the seq-scaled buffers — the bf16/f32 decode mirrors are pre-allocated to the `--max-ctx` ceiling, so counting the whole allocation would inflate the figure and make bytes-per-KV-token depend on the ceiling rather than the prompt. Excludes any prompt-cache snapshot clone (held separately, never summed). Sampled at ONE lifecycle point on every arch — **after the decode loop**, when the decode-time GPU ring of a ring-backed codec is resident — so the figure is comparable across archs and across prompt-cache hit/miss. "One lifecycle point" means post-decode *and only when a decode ran*: an immediate-EOS or NaN-prefill run (no decode loop) does not refresh this metric and keeps the prior value — uniform across archs, and lossless since with no decode there is no ring. The requirement is gated by a witness: `store_kv_cache_bytes` takes a `PostDecode` minted only by a completed decode loop, so re-co-locating the store at the prefill snapshot fails to compile (the loop's witness is not in scope there). It is a raised bar + review convention backed by a manual-GPU re-drift test, not an unforgeable compile guarantee — `seal()` is `pub(crate)`. **Reading it back:** the "keeps the prior value" case above means a bare byte count cannot be attributed to a particular generation. `Architecture::kv_cache_bytes_sample()` therefore returns `(bytes, seq)`, where `seq` counts `store_kv_cache_bytes` calls on that arch. A caller that *records* the figure samples the pair before and after the generation and requires `seq` to have advanced; if it did not, the readable count belongs to an earlier generation (or is the unset `0` initialiser) and must be refused, not written. `Architecture::kv_cache_bytes()` returns the bare count and is for display surfaces (`/metrics/cache`) that have no generation boundary to check against — do not record from it. |
 | `tps_per_gb_ram`      | `ratio` | `higher_better` | `decode_tps_warm / peak_rss_gb` — runtime efficiency.                   |
 | `task_pass_at_1`      | `ratio` | `higher_better` | Quality probe pass rate (CBB-style). 0.0–1.0.                           |
 | `prompt_cache_block_hits`        | `count` | `higher_better` | Cumulative 256-tok blocks served from a cached prefix.   |
@@ -739,6 +739,25 @@ Crate plan:
 - `crates/rmlx-metrics/` — new lib crate. Owns DB connection, schema migrations, canonicalization (§5), metric registry (§4), prompt registry, ingest API.
 - `crates/rmlx-cli` — adds `metrics` subcommand wrapping the lib.
 - Deps: `rusqlite` (bundled feature for static SQLite), `serde` for JSONL row deserialization.
+
+### 8.1.1 What is NOT a recording path: `rmlx bench`
+
+`rmlx bench` (see [`docs/CLI.md`](CLI.md#bench)) measures the same quantities —
+TTFT, ITL p50/p99, decode TPS, `kv_cache_bytes` — over N repeated runs of one
+cell and prints medians with the observed range. It **writes nothing**: no
+buffer file, no `observations` row, no `bests` entry. Looking for its numbers in
+`runs.db` will find nothing, by design.
+
+The split is deliberate. `runs.db` is append-only, so a row recorded under the
+wrong conditions is permanent; `bench` exists to *establish* a number and its
+spread interactively, including the runs that get thrown away. When a figure is
+worth keeping, `rmlx baseline --record` is the path that writes it.
+
+`bench` is also where the refusal rules live in executable form — a
+prompt-cache-served run, a KV-byte figure the run did not itself report, and a
+`--runs 1` invocation are all hard errors there. Any future recording path that
+measures the same quantities should refuse on the same conditions rather than
+record a plausible-looking value.
 
 ### 8.2 Subcommands
 

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -754,10 +754,19 @@ spread interactively, including the runs that get thrown away. When a figure is
 worth keeping, `rmlx baseline --record` is the path that writes it.
 
 `bench` is also where the refusal rules live in executable form — a
-prompt-cache-served run, a KV-byte figure the run did not itself report, and a
-`--runs 1` invocation are all hard errors there. Any future recording path that
-measures the same quantities should refuse on the same conditions rather than
-record a plausible-looking value.
+prompt-cache-served run, a KV-byte figure the run did not itself report, a
+metric that trended across the runs instead of settling, runs that decoded
+different tokens, and a `--runs 1` invocation are all hard errors there. Any
+recording path that measures the same quantities refuses on the same conditions
+rather than record a plausible-looking value.
+
+The `kv_cache_bytes` rule is already carried by the two paths that *write*:
+`rmlx baseline --record` and the server's speculative-decode request boundary
+both sample `kv_cache_bytes_sample()` before and after the generation and
+require the store sequence to have advanced. When it has not, the figure
+readable belongs to an earlier generation, and both paths `warn!` and omit the
+row rather than append it — the refusal matters more here than in `bench`,
+because `bench` can be re-run and an `observations` row cannot be taken back.
 
 ### 8.2 Subcommands
 


### PR DESCRIPTION
Closes #303.

Adds `rmlx bench` — a repeated-run decode instrument reporting TTFT, inter-token latency p50/p99, decode TPS, prefill TPS and filled-prefix KV bytes, each with median/min/max spread, plus `--json` carrying every individual run.

The design constraint that shaped it: **it must refuse to print a number it cannot stand behind.** A silently wrong measurement is worse than an error, because it gets quoted.

### What already existed

The issue's framing overstated the gap, and that is worth recording. `baseline` already computed TTFT and decode TPS with prefill correctly excluded; `Architecture::kv_cache_bytes()` already existed; `decode_profile` already carried per-request timings on all seven arches; `scripts/perf_canary.sh` already did median-of-3. Genuinely missing were ITL percentiles, a first-party repeated-run command, and any way to tell a valid KV-byte reading from a stale one.

The issue also asked for a running ITL accumulator in the engine. That was unnecessary — `generate_greedy`'s `step_fn` already fires per emitted token, so ITL is computed exactly, model-agnostically, in the CLI callback. **`git diff` against the decode loop, runtime, codecs and FFI is empty.**

### Refusals

Detection is split from interpretation, and the ambiguous middle case is a loud error rather than a fallback:

- **KV bytes** — `kv_cache_bytes()` collapsed "no value reported" with "zero reported". Now `KvBytesSample { bytes, seq }` with a sequence witness bumped at the store, classified into `Unreported` / `ReportedZero` / `Reported(n)`, the first two being differently-worded errors.
- **Prefill actually ran** — a run served from the prompt cache has no prefill, so its TTFT is meaningless. Caught on a real model: with the guard disabled, runs 2–3 reported TTFT `0.0` and `prefill_tps` of **85,038,233** (Bonsai) / **74,124,086** (gemma-4-e2b).
- **Hydrate is not prefill** — an SSD-tier hydrate increments `ssd_hits`, never `hits`, so it slipped past the cache check and reported a hydrate time as TTFT. Now refused.
- **Token stream identical** — every run in a cell uses the same prompt at temperature 0, so all runs must emit byte-identical tokens. A digest is compared across warmup and measured runs. This closes a real blind spot: the documented silent-KV-corruption class makes a frozen cache decode *faster*, so a throughput-only instrument is biased toward accepting it.
- **The cell settled** — see below.
- `--runs 1`, `<2` generated tokens, and a zero-width decode window are all refused before anything is printed. `prefill_tps` returns absent rather than `0.0`.

### The drift guard — why this exists

Validation found `bench` reporting **27,885 ms TTFT for a quantity whose true single-shot value is ~17,400 ms: +60%, as a median with a spread, no error.** TTFT degrades monotonically across in-process generations, and the default `--warmup 1` discards generation 1 — the only one that agrees with an independent measurement.

Both candidate mechanisms were falsified by measurement, not argued away:

| mechanism | test | result |
|---|---|---|
| over-provisioned `--max-ctx` | interleaved A/B/A/B, 131072 vs 69120 | ratio 1.431 vs 1.430 — **falsified** |
| prompt-cache slots=0 rebuild path | re-run after decoupling | 1.411 / 1.388 / 1.446 — **falsified** |

The drift is intrinsic to in-process repetition, so reconciling was not available and refusing was the only correct route. `Spread` is order-blind by construction, so a monotonic ramp reads as spread; the guard fits a trend over run order and refuses to print a median for a cell that did not settle.

It is anchored in the cell's own scatter rather than a bare percentage — at `--runs 3` a least-squares fit degenerates to exactly `(y₃ − y₁)`, so a percentage floor alone rejects no noise. A fitted change must also exceed 2× the residual RMS. Verified against every must-detect case (the 17.8→25.5 s ramp: 2·rms 1077 vs Δfit 7706) while `[100, 118, 88]` now correctly reads as scatter. A range gate catches the shapes a trend gate cannot — an unbounded spike has slope zero, and a late-onset step *dilutes* as `--runs` grows (`1.33d` at n=3 → `0.285d` at n=20), so raising `--runs` must not weaken the guard. Threshold 15%, derived from 10 measured settled cells whose worst accepted wobble was 8.35%.

`itl_p99_ms` is exempt, structurally rather than by omission: at `--max-tokens 128` nearest-rank p99 is the 2nd-largest of 127 gaps, an extreme-order statistic that ranged 58.6% on a cell whose gated metrics were all under 2%.

The root cause of the underlying drift is **not** identified — filed as #320. This ships the guard, not the explanation.

### Cross-checks

KV bytes byte-for-byte identical to an independent read in **4/4 cells** including both at 64k. Decode TPS agrees within −0.55%..+3.14% across both arches at 4k and 64k, inside the comparison's own spread. TTFT generation-1 agrees within 2.0% (Bonsai) / 2.6% (gemma-4-e2b); the remaining gap against `baseline`'s median is the warmup semantics — bench measures a warmed repeat, baseline a first generation — and is documented rather than papered over.

### Instrumentation cost

Settled structurally, because no wall-clock A/B can resolve it: the engine-side addition is one `AtomicU64::fetch_add` per *request* (1.65 ns), and the per-token callback is a clock read `baseline` already performed (marginal cost 4.1 ns, **0.00005%** of an 8.13 ms token). An A/A null control of the binary against *itself* produced −2.10%, so a wall-clock design would need >10⁷ invocations to resolve a 2.7×10⁻⁶ effect. Recorded because the first attempt to prove this by A/B could just as easily have "confirmed" a 2% regression.

### Review rounds

Three rounds — a Rust review, an independent performance validation, and a re-review of the fixes — produced:

- an **inverted atomic load order** where a bumped `seq` could pair with stale `bytes`, the exact failure the type exists to prevent (reader now loads `seq` first, Acquire, then `bytes`)
- the recording paths (`baseline --record`, the speculative events row) were the ones left *unguarded* while the printing path got the refusals — inverted, since only the recording paths write permanently
- the speculative row read a **hard-coded foreign arch's** static: the server read gemma4's while eagle3/dflash/mtp structurally require a Qwen3.5-MoE verifier. Now routed through the verifier's own arch, wired end-to-end, and proven on a live run (before: 0 stores / 0 rows / 1 warn per request; after: 1 store, 1 row equal to the round loop's own caches)
- `bench`'s measurement integrity depended on a **bug in another crate** (#319) — decoupled via the already-existing, previously-dead `PromptCache::clear()`

### Gates

`make ci` green. 1572 workspace tests. Mutation checks on both new thresholds. Drift guard verified red on the genuinely drifting cell and green on settled cells, on both architectures, with load average recorded alongside every number (the host was contended throughout — 4–16 on 18 cores).

Model runs used a scratch `RMLX_HOME` with `--metrics off`; the real `metrics/runs.db` was verified untouched.

Follow-ups filed and scoped out: #319 (prompt-cache capacity), #320 (in-process TTFT drift root cause), #321 (per-arch byte statics can cross-attribute between two same-arch models).
