### PR TITLE
feat(profiling): capture a bounded decode window as a replayable Metal GPU trace (#307)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,10 @@ target-size-report: ## advisory: print target/ size + hint when over threshold (
 build-capture: ## build the debug-only GPU-capture binary (release-debug + metal-capture)
 	cargo build --profile release-debug --features rmlx-cli/metal-capture
 
-test-capture: ## run the GPU-capture unit tests (feature-gated, so plain `make test` skips them)
+# `make test` is `cargo test --workspace` without --all-features, so it compiles
+# these out entirely. Run from `ci` as well, or an off-by-one in the window
+# policy passes the gate green.
+test-capture: ## run the GPU-capture unit tests (feature-gated, so plain `make test` skips them; also a `make ci` step)
 	cargo test -p rmlx-mlx --features metal-capture --lib metal_capture
 	cargo test -p rmlx-cli --features metal-capture --bin rmlx gpu_capture
 
@@ -218,7 +221,7 @@ check-metal-format: ## CI gate: every KV .metal kernel is clang-format clean (sk
 	@bash scripts/check_metal_format.sh $(METAL_STRICT)
 
 # ---- one-shot CI gate -------------------------------------------------
-ci: fmt-check lint test deny audit ci-metrics ## full pre-merge gate: fmt + clippy + test + deny + audit + metrics-sanity + inline-test + MSL gates
+ci: fmt-check lint test test-capture deny audit ci-metrics ## full pre-merge gate: fmt + clippy + test + feature-gated capture tests + deny + audit + metrics-sanity + inline-test + MSL gates
 	@bash scripts/check_no_inline_tests.sh
 	@bash scripts/check_no_scalar_f32_leak.sh
 	@bash scripts/check_no_decode_swallow.sh

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         profile-samply profile-samply-debug profile-instruments bench asm perf-iter \
         canary canary-gate \
         mlx-preflight mlx-restore-pin target-gc target-size-report profile-gputrace \
+        build-capture test-capture \
         ssd-canary ssd-canary-gate \
         bench-codec-cell \
         smoke-codec-matrix \
@@ -82,13 +83,24 @@ target-gc:       ## report stale target/ profiles (APPLY=1 to prune; target/ has
 target-size-report: ## advisory: print target/ size + hint when over threshold (non-failing; also runs at the end of `make ci`)
 	@bash scripts/target_size_report.sh
 
+build-capture: ## build the debug-only GPU-capture binary (release-debug + metal-capture)
+	cargo build --profile release-debug --features rmlx-cli/metal-capture
+
+test-capture: ## run the GPU-capture unit tests (feature-gated, so plain `make test` skips them)
+	cargo test -p rmlx-mlx --features metal-capture --lib metal_capture
+	cargo test -p rmlx-cli --features metal-capture --bin rmlx gpu_capture
+
 profile-gputrace: ## capture a decode-window Metal GPU trace for Xcode (CODEC= MODEL= required)
 	@if [ -z "$(CODEC)" ] || [ -z "$(MODEL)" ]; then \
-		echo "Usage: make profile-gputrace CODEC=<codec> MODEL=<snapshot-abs-path> [PROMPT_TOKENS=4096] [GEN=16]"; \
+		echo "Usage: make profile-gputrace CODEC=<codec> MODEL=<snapshot-abs-path> \
+[PROMPT_TOKENS=4096] [SKIP=4] [STEPS=8] [GEN=N]"; \
+		echo "Needs a binary from \`make build-capture\`."; \
 		exit 2; \
 	fi
 	bash scripts/gpu_capture.sh --kv-quant $(CODEC) --model $(MODEL) \
-		$(if $(PROMPT_TOKENS),--prompt-tokens $(PROMPT_TOKENS),) $(if $(GEN),--gen $(GEN),)
+		$(if $(PROMPT_TOKENS),--prompt-tokens $(PROMPT_TOKENS),) \
+		$(if $(SKIP),--skip $(SKIP),) $(if $(STEPS),--steps $(STEPS),) \
+		$(if $(GEN),--gen $(GEN),)
 
 mlx-restore-pin: ## restore mlx 0.31.2 + mlx-c 0.6.0_2 (nax-capable pair) and relink
 	bash scripts/mlx_restore_pin.sh

--- a/crates/rmlx-cli/Cargo.toml
+++ b/crates/rmlx-cli/Cargo.toml
@@ -54,6 +54,10 @@ tikv-jemallocator = { workspace = true }
 # Then: ./target/debug/rmlx baseline ...  (writes dhat-heap.json on exit)
 [features]
 dhat-heap = ["dep:dhat"]
+# Debug-only Metal GPU trace capture. Adds the `--gpu-capture*` flags to
+# `rmlx baseline` and the per-step hook in the shared decode loop. Off, neither
+# the flags nor the hook exist, so a release binary cannot capture at all.
+metal-capture = ["rmlx-mlx/metal-capture", "rmlx-models/metal-capture"]
 
 [dev-dependencies]
 tempfile     = { workspace = true }

--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -671,54 +671,64 @@ pub(crate) fn run_baseline(
     }
 
     // -- Append to metrics/baseline.csv ---------------------------------------
-    let ts_utc = chrono::Utc::now()
-        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
-        .to_string();
+    // Gated on the same kill switch as the DB. `--metrics off` means this run
+    // records nothing, and baseline.csv is a metrics surface under
+    // <RMLX_HOME>/metrics/ exactly like runs.db is — an append here is as
+    // permanent as a row there. Left ungated, a run with the DB shut off (a GPU
+    // capture, say, whose timings are meaningless by construction) still left a
+    // row behind.
+    if rmlx_metrics::mode::current() == rmlx_metrics::mode::MetricsMode::Off {
+        info!("baseline: --metrics off, no baseline.csv row written");
+    } else {
+        let ts_utc = chrono::Utc::now()
+            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+            .to_string();
 
-    // Truncate first-50 to 200 chars then CSV-escape.
-    let output_cell = baseline_csv_escape(&notes_truncated);
+        // Truncate first-50 to 200 chars then CSV-escape.
+        let output_cell = baseline_csv_escape(&notes_truncated);
 
-    let csv_path = rmlx_core::paths::metrics_dir().join("baseline.csv");
+        let csv_path = rmlx_core::paths::metrics_dir().join("baseline.csv");
 
-    // Header written only when the file is absent or zero-length.
-    let write_header =
-        !csv_path.exists() || std::fs::metadata(&csv_path).map_or(true, |m| m.len() == 0);
+        // Header written only when the file is absent or zero-length.
+        let write_header =
+            !csv_path.exists() || std::fs::metadata(&csv_path).map_or(true, |m| m.len() == 0);
 
-    let mut csv_file = std::fs::OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(&csv_path)
-        .map_err(|e| anyhow::anyhow!("open {}: {e}", csv_path.display()))?;
+        let mut csv_file = std::fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&csv_path)
+            .map_err(|e| anyhow::anyhow!("open {}: {e}", csv_path.display()))?;
 
-    if write_header {
-        csv_file.write_all(
-            b"run_id,timestamp_utc,backend,model_basename,quantization_type,context_size,\
-              prompt,device,prompt_tokens,load_ms,ttft_ms,tps,peak_rss_mb,output_first_50\n",
-        )?;
+        if write_header {
+            csv_file.write_all(
+                b"run_id,timestamp_utc,backend,model_basename,quantization_type,context_size,\
+                  prompt,device,prompt_tokens,load_ms,ttft_ms,tps,peak_rss_mb,output_first_50\n",
+            )?;
+        }
+
+        let row = format!(
+            "{},{},rMLX,{},{},{},{},{},{},{:.0},{:.0},{:.3},{:.1},{}\n",
+            baseline_csv_escape(run_id),
+            ts_utc,
+            baseline_csv_escape(model_basename),
+            baseline_csv_escape(&quantization_type),
+            context_size,
+            baseline_csv_escape(prompt_label),
+            baseline_csv_escape(device_str),
+            prompt_token_count,
+            load_ms,
+            ttft_ms,
+            tps,
+            rss_mb,
+            output_cell,
+        );
+        csv_file
+            .write_all(row.as_bytes())
+            .map_err(|e| anyhow::anyhow!("write baseline.csv row: {e}"))?;
+        csv_file
+            .flush()
+            .map_err(|e| anyhow::anyhow!("flush baseline.csv: {e}"))?;
     }
-
-    let row = format!(
-        "{},{},rMLX,{},{},{},{},{},{},{:.0},{:.0},{:.3},{:.1},{}\n",
-        baseline_csv_escape(run_id),
-        ts_utc,
-        baseline_csv_escape(model_basename),
-        baseline_csv_escape(&quantization_type),
-        context_size,
-        baseline_csv_escape(prompt_label),
-        baseline_csv_escape(device_str),
-        prompt_token_count,
-        load_ms,
-        ttft_ms,
-        tps,
-        rss_mb,
-        output_cell,
-    );
-    csv_file
-        .write_all(row.as_bytes())
-        .map_err(|e| anyhow::anyhow!("write baseline.csv row: {e}"))?;
-    csv_file
-        .flush()
-        .map_err(|e| anyhow::anyhow!("flush baseline.csv: {e}"))?;
 
     info!(
         load_ms,

--- a/crates/rmlx-cli/src/commands/gpu_capture.rs
+++ b/crates/rmlx-cli/src/commands/gpu_capture.rs
@@ -1,0 +1,137 @@
+// CLI binary: user-facing output. tracing carries the structured record; the
+// operator needs the trace path on stdout to open it.
+#![allow(clippy::print_stdout)]
+//! Driver for `rmlx baseline --gpu-capture` — the debug-only Metal GPU trace of
+//! a bounded window of steady-state decode.
+//!
+//! Compiled only under the `metal-capture` feature; without it neither this
+//! module nor the flags that reach it exist, so a release binary cannot capture.
+//!
+//! The whole point of this file is that failure is loud. Every way a capture can
+//! fail to happen — no capture layer, occupied destination, a generation too
+//! short to reach the window, a window that opened but wrote nothing — ends in a
+//! non-zero exit with the reason, never in a run that quietly produced no trace.
+
+use std::path::Path;
+
+use anyhow::{bail, Result};
+use rmlx_mlx::metal_capture::{self, Outcome};
+
+/// Validate and arm the capture window. Returns whether a capture was requested,
+/// which [`report`] needs to decide whether silence is acceptable.
+///
+/// Called before the model loads so a bad request costs seconds rather than a
+/// full weight load.
+pub(crate) fn arm(path: Option<&Path>, skip: u32, steps: u32, max_tokens: u32) -> Result<bool> {
+    let Some(path) = path else {
+        return Ok(false);
+    };
+    // The decode loop drives one window tick per token after the prefill token,
+    // so a generation shorter than this can never close the window. Catching it
+    // here is the difference between a clear message and a trace that silently
+    // holds fewer steps than asked for.
+    let need = metal_capture::min_tokens_for_window(skip, steps);
+    if max_tokens < need {
+        bail!(
+            "--gpu-capture needs at least {need} generated tokens to open, fill and close a \
+             {skip}-skip / {steps}-step window, but --max-tokens is {max_tokens}. \
+             Raise --max-tokens to {need} or shrink the window."
+        );
+    }
+    metal_capture::arm(path.to_path_buf(), skip, steps)?;
+    Ok(true)
+}
+
+/// Stop any live capture and turn the outcome into an exit status plus an
+/// operator-facing summary. Call once, after generation, whether it succeeded
+/// or not.
+pub(crate) fn report(requested: bool) -> Result<()> {
+    describe(metal_capture::finish()?, requested)
+}
+
+/// Turn a finished capture into an exit status and an operator summary.
+/// Separate from [`report`] so every outcome — including the ones that need a
+/// real generation to reach — is reachable from a test.
+fn describe(outcome: Outcome, requested: bool) -> Result<()> {
+    match outcome {
+        Outcome::Disabled => {
+            if requested {
+                bail!(
+                    "GPU capture was armed for this run but the driver was already disarmed \
+                     when the run ended. Nothing was written. This is an internal \
+                     inconsistency — a second capture driver ran in the same process."
+                );
+            }
+            Ok(())
+        }
+        // Zero steps means the decode loop was never entered at all, which is a
+        // different fault from a generation that was merely too short: the arch
+        // does not route through the shared loop the hook lives in. Saying
+        // "raise --max-tokens" there would send the operator down a dead end.
+        Outcome::NeverOpened { seen: 0, .. } => bail!(
+            "GPU capture window never opened: the run produced no decode steps at all. \
+             Either generation stopped at the prefill token, or this architecture does not \
+             decode through the shared loop the capture hook lives in \
+             (rmlx_models::decode_loop::pipelined_decode)."
+        ),
+        Outcome::NeverOpened { seen, needed } => bail!(
+            "GPU capture window never opened: generation produced {seen} decode steps but the \
+             window opens at step {needed}. Lower --gpu-capture-skip or raise --max-tokens."
+        ),
+        Outcome::Captured {
+            path,
+            steps,
+            complete,
+        } => {
+            let bytes = bundle_bytes(&path);
+            if !complete {
+                tracing::warn!(
+                    path = %path.display(),
+                    captured_steps = steps,
+                    "GPU capture window closed early — generation stopped before the step budget was spent"
+                );
+            }
+            tracing::info!(
+                path = %path.display(),
+                captured_steps = steps,
+                bytes,
+                complete,
+                "GPU capture written"
+            );
+            println!(
+                "gpu-capture: {} ({steps} decode steps, {bytes} bytes{})",
+                path.display(),
+                if complete { "" } else { ", SHORT" }
+            );
+            println!("gpu-capture: open with  open '{}'", path.display());
+            Ok(())
+        }
+    }
+}
+
+/// Total size of a `.gputrace` bundle. Bundles are directories; a read error
+/// contributes nothing rather than aborting a successful capture.
+fn bundle_bytes(path: &Path) -> u64 {
+    fn walk(dir: &Path) -> u64 {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return 0;
+        };
+        entries
+            .flatten()
+            .map(|e| match e.file_type() {
+                Ok(t) if t.is_dir() => walk(&e.path()),
+                Ok(_) => e.metadata().map_or(0, |m| m.len()),
+                Err(_) => 0,
+            })
+            .sum()
+    }
+    match std::fs::metadata(path) {
+        Ok(m) if m.is_dir() => walk(path),
+        Ok(m) => m.len(),
+        Err(_) => 0,
+    }
+}
+
+#[cfg(test)]
+#[path = "gpu_capture_tests.rs"]
+mod gpu_capture_tests;

--- a/crates/rmlx-cli/src/commands/gpu_capture.rs
+++ b/crates/rmlx-cli/src/commands/gpu_capture.rs
@@ -1,6 +1,3 @@
-// CLI binary: user-facing output. tracing carries the structured record; the
-// operator needs the trace path on stdout to open it.
-#![allow(clippy::print_stdout)]
 //! Driver for `rmlx baseline --gpu-capture` — the debug-only Metal GPU trace of
 //! a bounded window of steady-state decode.
 //!

--- a/crates/rmlx-cli/src/commands/gpu_capture_tests.rs
+++ b/crates/rmlx-cli/src/commands/gpu_capture_tests.rs
@@ -7,8 +7,14 @@
 //! cargo test -p rmlx-cli --features metal-capture gpu_capture
 //! ```
 //!
-//! None of them arms the process-global capture driver — every case here is
-//! rejected, or observed, before any Metal state is touched.
+//! None of them arms the process-global capture driver, and none may: the
+//! driver is a `static`, so a test that leaves it armed changes what its
+//! siblings observe, order- and thread-dependently. Every case here is either
+//! rejected before the driver is set, or observes a driver that was never
+//! armed. Any case that reaches the real `arm` must be rejected on a branch
+//! that does not depend on the environment the test happens to run in —
+//! `MTL_CAPTURE_ENABLED=1` is exported in exactly the shell someone developing
+//! this feature uses, and it flips the capture-layer branch.
 
 use std::path::Path;
 
@@ -38,12 +44,20 @@ fn rejects_a_generation_too_short_to_close_the_window() {
 #[test]
 fn accepts_the_exact_minimum_token_count() {
     // The boundary case must NOT be rejected, or the driver is overstating the
-    // requirement. It fails later (no capture layer in a test process), but the
-    // token-count gate is what is under test here.
-    let err = arm(Some(Path::new("/tmp/rmlx-exact.gputrace")), 4, 8, 14)
+    // requirement. The destination sits in a directory that does not exist, so
+    // whatever the environment says about the capture layer, `validate` rejects
+    // the request before the driver is armed — the assertion is about the token
+    // gate alone, and this test cannot leave state behind for its siblings.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("no-such-dir").join("exact.gputrace");
+    let err = arm(Some(&path), 4, 8, 14)
         .err()
         .map(|e| e.to_string())
         .unwrap_or_default();
+    assert!(
+        !err.is_empty(),
+        "the request must still be rejected — on the destination, not the token count"
+    );
     assert!(
         !err.contains("--max-tokens"),
         "14 tokens is exactly enough and must clear the token gate, got: {err}"

--- a/crates/rmlx-cli/src/commands/gpu_capture_tests.rs
+++ b/crates/rmlx-cli/src/commands/gpu_capture_tests.rs
@@ -1,0 +1,144 @@
+//! Tests for the `--gpu-capture` driver's loud-failure paths.
+//!
+//! These compile only under the `metal-capture` feature, like the module they
+//! cover:
+//!
+//! ```sh
+//! cargo test -p rmlx-cli --features metal-capture gpu_capture
+//! ```
+//!
+//! None of them arms the process-global capture driver — every case here is
+//! rejected, or observed, before any Metal state is touched.
+
+use std::path::Path;
+
+use rmlx_mlx::metal_capture::Outcome;
+
+use super::{arm, bundle_bytes, describe, report};
+
+#[test]
+fn no_flag_means_no_capture_and_no_error() {
+    let requested = arm(None, 4, 8, 32);
+    assert!(matches!(requested, Ok(false)), "got {requested:?}");
+}
+
+#[test]
+fn rejects_a_generation_too_short_to_close_the_window() {
+    // skip 4 + steps 8 needs 14 tokens; 12 cannot close the window.
+    let err = arm(Some(Path::new("/tmp/rmlx-short.gputrace")), 4, 8, 12)
+        .err()
+        .map(|e| e.to_string())
+        .unwrap_or_default();
+    assert!(
+        err.contains("--max-tokens is 12") && err.contains("at least 14"),
+        "the error must name both the requirement and what was passed, got: {err}"
+    );
+}
+
+#[test]
+fn accepts_the_exact_minimum_token_count() {
+    // The boundary case must NOT be rejected, or the driver is overstating the
+    // requirement. It fails later (no capture layer in a test process), but the
+    // token-count gate is what is under test here.
+    let err = arm(Some(Path::new("/tmp/rmlx-exact.gputrace")), 4, 8, 14)
+        .err()
+        .map(|e| e.to_string())
+        .unwrap_or_default();
+    assert!(
+        !err.contains("--max-tokens"),
+        "14 tokens is exactly enough and must clear the token gate, got: {err}"
+    );
+}
+
+#[test]
+fn report_is_silent_when_nothing_was_requested() {
+    assert!(report(false).is_ok());
+}
+
+#[test]
+fn report_fails_loudly_when_an_armed_capture_produced_nothing() {
+    let err = report(true)
+        .err()
+        .map(|e| e.to_string())
+        .unwrap_or_default();
+    assert!(
+        err.contains("already disarmed"),
+        "an armed capture that produced nothing must be an error, got: {err}"
+    );
+}
+
+#[test]
+fn zero_decode_steps_names_the_uncovered_arch_not_the_token_count() {
+    // An arch that does not decode through the shared loop reaches the window
+    // zero times. Telling the operator to raise --max-tokens there is a dead
+    // end, so this case must point at the hook instead.
+    let err = describe(Outcome::NeverOpened { seen: 0, needed: 5 }, true)
+        .err()
+        .map(|e| e.to_string())
+        .unwrap_or_default();
+    assert!(
+        err.contains("pipelined_decode"),
+        "zero steps must name the shared decode loop, got: {err}"
+    );
+    assert!(
+        !err.contains("--max-tokens"),
+        "zero steps must NOT send the operator after the token count, got: {err}"
+    );
+}
+
+#[test]
+fn a_window_that_never_opened_is_an_error_naming_what_it_needed() {
+    // Reached when generation stops (EOS) before the window's first step. The
+    // run "succeeded" and wrote no trace — exactly the silent-failure mode this
+    // driver exists to prevent, so it must exit non-zero.
+    let err = describe(
+        Outcome::NeverOpened {
+            seen: 6,
+            needed: 31,
+        },
+        true,
+    )
+    .err()
+    .map(|e| e.to_string())
+    .unwrap_or_default();
+    assert!(
+        err.contains("6 decode steps") && err.contains("step 31"),
+        "the error must report both what the run reached and what the window needed, got: {err}"
+    );
+}
+
+#[test]
+fn a_short_but_real_capture_is_reported_not_rejected() {
+    // Fewer steps than asked for is still a usable trace; it must warn, not fail.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("short.gputrace");
+    std::fs::create_dir(&path).expect("mkdir");
+    let res = describe(
+        Outcome::Captured {
+            path,
+            steps: 3,
+            complete: false,
+        },
+        true,
+    );
+    assert!(
+        res.is_ok(),
+        "a short capture must not fail the run: {res:?}"
+    );
+}
+
+#[test]
+fn bundle_bytes_sums_a_directory_and_tolerates_a_missing_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let nested = dir.path().join("store0");
+    std::fs::create_dir(&nested).expect("mkdir");
+    std::fs::write(dir.path().join("index"), b"0123456789").expect("write");
+    std::fs::write(nested.join("blob"), b"01234").expect("write");
+
+    assert_eq!(bundle_bytes(dir.path()), 15, "bundle size is recursive");
+    assert_eq!(
+        bundle_bytes(&dir.path().join("nope")),
+        0,
+        "a missing bundle must report zero, not panic"
+    );
+}

--- a/crates/rmlx-cli/src/commands/mod.rs
+++ b/crates/rmlx-cli/src/commands/mod.rs
@@ -4,6 +4,8 @@ pub(crate) mod baseline;
 pub(crate) mod bench;
 pub(crate) mod calibration_softmax;
 pub(crate) mod eval;
+#[cfg(feature = "metal-capture")]
+pub(crate) mod gpu_capture;
 pub(crate) mod healthcheck;
 pub(crate) mod info;
 pub(crate) mod kv_calibrate;

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -1359,6 +1359,28 @@ fn resolve_prompts_root(prompts_dir: Option<PathBuf>) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("prompts"))
 }
 
+/// Whether this invocation asks for a GPU trace capture.
+///
+/// Read before the metrics kill switch is resolved: a captured run's numbers are
+/// instrumentation artefacts, not measurements, and must not reach any metrics
+/// surface. See the call site in [`main`].
+#[cfg(feature = "metal-capture")]
+fn gpu_capture_requested(cmd: &Cmd) -> bool {
+    matches!(
+        cmd,
+        Cmd::Baseline {
+            gpu_capture: Some(_),
+            ..
+        }
+    )
+}
+
+/// Without the capture feature there is no flag to ask with.
+#[cfg(not(feature = "metal-capture"))]
+const fn gpu_capture_requested(_cmd: &Cmd) -> bool {
+    false
+}
+
 #[allow(
     clippy::expect_used,
     reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
@@ -1387,7 +1409,20 @@ fn main() -> Result<()> {
     // Resolve the metrics kill switch exactly once, before anything can open
     // the DB or spawn the drainer. Every writer reads it from here; no call
     // site carries its own toggle.
-    rmlx_metrics::mode::init(cli.metrics_mode.mode());
+    //
+    // A GPU-capture run is instrumentation, not measurement: the capture layer
+    // serialises every dispatch and collapses decode to single-digit TPS, so
+    // every number the run produces is false. Force the switch off for it. The
+    // clap conflict with `--record` covers the §8.5 observations row only —
+    // the `events` rows and the `metrics/baseline.csv` append happen outside
+    // it, so without this a hand-run capture still wrote a ~2.5 TPS row into
+    // append-only surfaces.
+    let capture_forces_metrics_off = gpu_capture_requested(&cli.cmd);
+    rmlx_metrics::mode::init(if capture_forces_metrics_off {
+        rmlx_metrics::mode::MetricsMode::Off
+    } else {
+        cli.metrics_mode.mode()
+    });
 
     // Record the MLX nax-GEMM-kernel capability this binary was built with,
     // before the first `RunIdentity::get()` / `EventRecorder::record`.
@@ -1414,6 +1449,14 @@ fn main() -> Result<()> {
         }
     }
     let _guard = init_tracing(&run_id, cli.log, cli.log_cap_mb)?;
+
+    // Reported after tracing is up, since the decision above predates it.
+    if capture_forces_metrics_off {
+        info!(
+            "--gpu-capture: metrics forced off — a capture-distorted run writes no events \
+             row, no baseline.csv row and no observation"
+        );
+    }
 
     // Install the rotor-QJL toggle before any cache construction.
     // This is a process-wide one-shot OnceLock; safe to call once at startup.

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -1069,6 +1069,31 @@ enum Cmd {
         /// Env: `RMLX_YARN_ORIGINAL_MAX`.
         #[arg(long, env = "RMLX_YARN_ORIGINAL_MAX", value_name = "U32")]
         yarn_original_max: Option<u32>,
+        /// Write a Metal GPU trace of a bounded window of steady-state decode
+        /// to PATH (a `.gputrace` bundle, opened in Xcode). Debug builds only —
+        /// this flag exists only when the binary is built with
+        /// `--features rmlx-cli/metal-capture`.
+        ///
+        /// The process must have been launched with `MTL_CAPTURE_ENABLED=1`;
+        /// Metal inserts the capture layer at launch and cannot do so later.
+        /// `scripts/gpu_capture.sh` handles both.
+        ///
+        /// Capture perturbs every timing this command measures, so it cannot be
+        /// combined with `--record`.
+        #[cfg(feature = "metal-capture")]
+        #[arg(long, value_name = "PATH", conflicts_with = "record")]
+        gpu_capture: Option<PathBuf>,
+        /// Decode steps to run before the GPU-capture window opens. Skipping the
+        /// first steps keeps first-touch kernel compilation and pipeline warm-up
+        /// out of the trace.
+        #[cfg(feature = "metal-capture")]
+        #[arg(long, value_name = "N", default_value_t = 4, requires = "gpu_capture")]
+        gpu_capture_skip: u32,
+        /// Decode steps inside the GPU-capture window. Keep it small — every
+        /// captured dispatch is serialised into the bundle.
+        #[cfg(feature = "metal-capture")]
+        #[arg(long, value_name = "N", default_value_t = 8, requires = "gpu_capture")]
+        gpu_capture_steps: u32,
     },
     /// Repeated-run decode instrument: TTFT, ITL p50/p99, decode TPS and
     /// filled-prefix KV bytes for one (model, KV codec, context, generation)
@@ -2055,7 +2080,24 @@ fn main() -> Result<()> {
             prompts_dir,
             yarn_factor,
             yarn_original_max,
+            #[cfg(feature = "metal-capture")]
+            gpu_capture,
+            #[cfg(feature = "metal-capture")]
+            gpu_capture_skip,
+            #[cfg(feature = "metal-capture")]
+            gpu_capture_steps,
         } => {
+            // Arm the GPU-capture window before anything expensive happens: a
+            // request that cannot be honoured must cost seconds, not a full
+            // weight load followed by a failure at the first decode step.
+            #[cfg(feature = "metal-capture")]
+            let capture_requested = commands::gpu_capture::arm(
+                gpu_capture.as_deref(),
+                gpu_capture_skip,
+                gpu_capture_steps,
+                max_tokens,
+            )?;
+
             let cap_is_explicit = max_prompt_tokens.is_some();
             let max_prompt_tokens = parse_max_prompt_tokens(
                 max_prompt_tokens.unwrap_or(commands::baseline::MAX_PROMPT_TOKENS),
@@ -2158,7 +2200,7 @@ fn main() -> Result<()> {
                 factor,
                 original_max: yarn_original_max.map_or(0.0, |v| v as f32),
             });
-            run_baseline(
+            let baseline_result = run_baseline(
                 &model,
                 &effective_prompt_path,
                 &device,
@@ -2173,7 +2215,15 @@ fn main() -> Result<()> {
                 yarn_override,
                 &sink,
                 record_args,
-            )?;
+            );
+            // Always stop and report the capture, including when the run failed —
+            // otherwise a live scope leaks and the trace is never finalised. The
+            // run's own error still wins, since it is the root cause.
+            #[cfg(feature = "metal-capture")]
+            let capture_result = commands::gpu_capture::report(capture_requested);
+            baseline_result?;
+            #[cfg(feature = "metal-capture")]
+            capture_result?;
         }
         Cmd::Bench {
             model,

--- a/crates/rmlx-mlx/Cargo.toml
+++ b/crates/rmlx-mlx/Cargo.toml
@@ -20,8 +20,8 @@ safetensors = { workspace = true }
 
 [features]
 # Feature-gated GPU trace capture via MTLCaptureManager (debug only).
-# Enables `rmlx_mlx::metal_capture::CaptureScope` — a drop-guard RAII wrapper
-# around mlx_metal_start_capture / mlx_metal_stop_capture.
+# Enables `rmlx_mlx::metal_capture` — the arm / step / finish driver over
+# mlx_metal_start_capture / mlx_metal_stop_capture, plus the pure window policy.
 # Do NOT enable in release builds; the feature tag keeps binaries clean.
 metal-capture = []
 

--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -1,3 +1,10 @@
+// LOC-exempt: crate root of the mlx-c wrapper. `Array` — the owned handle every
+// other module in the workspace passes around — is inseparable from the
+// crate-private FFI plumbing it calls on every op: the thread-local error
+// capture behind `check_status`, the process-global default-stream helper, the
+// quant-mode CString cache, and the null-handle sentinel for optional
+// arguments. Splitting `Array` out would export that plumbing across a module
+// boundary purely to move lines, with no reader benefit.
 //! Safe Rust wrapper around the brew-prebuilt `mlx-c` library.
 //!
 //! # Quick start

--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -30,6 +30,11 @@
 )]
 
 pub mod compile;
+/// Bounded-window Metal GPU trace capture. Debug-only: compiled out entirely
+/// unless the `metal-capture` feature is enabled, so a release build carries no
+/// state, no decode-path branch, and no route to `MTLCaptureManager`.
+#[cfg(feature = "metal-capture")]
+pub mod metal_capture;
 pub mod metal_kernel;
 mod sys;
 
@@ -1178,88 +1183,6 @@ pub mod metal {
         let recommended = device_info_size("max_recommended_working_set_size")?;
         let old = set_wired_limit(recommended)?;
         Ok(Some((recommended, old)))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Metal capture (debug feature only)
-// ---------------------------------------------------------------------------
-//
-// `CaptureScope` is a RAII drop-guard around `mlx_metal_start_capture` /
-// `mlx_metal_stop_capture`. Guarded by the `metal-capture` feature flag so
-// release builds pay exactly zero overhead.
-//
-// # Usage (Instruments GPU trace)
-//
-// 1. Build with `--features rmlx-mlx/metal-capture`.
-// 2. Construct `CaptureScope::start("/tmp/rmlx.gputrace").unwrap()` before the
-// hot path; drop (or call `.stop()`) after.
-// 3. Open the `.gputrace` bundle in Xcode Instruments → Metal System Trace.
-//
-// # mlx-c API
-//
-// `mlx_metal_start_capture(path: *const c_char) -> int` — 0 = ok, non-0 = error.
-// `mlx_metal_stop_capture() -> int` — 0 = ok, non-0 = error.
-// Both are in `mlx/c/metal.h` (mlx-c 0.6.0).
-
-/// RAII Metal GPU trace capture scope (enabled by the `metal-capture` feature).
-#[cfg(feature = "metal-capture")]
-pub mod metal_capture {
-    use std::ffi::CString;
-
-    use crate::{check_status, install_error_handler, sys, Result};
-
-    /// RAII guard that starts a Metal GPU trace on construction and stops it
-    /// on drop (or when `stop()` is called explicitly).
-    ///
-    /// # Safety
-    /// Only one `CaptureScope` should be active at a time — the Metal capture
-    /// manager is process-global. Constructing two overlapping scopes is
-    /// defined behaviour (the second `start_capture` is a no-op per mlx-c
-    /// docs), but the resulting trace will be incomplete.
-    #[allow(missing_debug_implementations)]
-    pub struct CaptureScope {
-        stopped: bool,
-    }
-
-    impl CaptureScope {
-        /// Start a Metal capture writing to `path` (e.g. `"/tmp/rmlx.gputrace"`).
-        ///
-        /// Returns `Err` if Metal is unavailable or the capture backend returns
-        /// a non-zero status.
-        pub fn start(path: &str) -> Result<Self> {
-            install_error_handler();
-            let path_c = CString::new(path).map_err(|e| {
-                crate::Error::Mlx(format!("CaptureScope::start: path contains NUL: {e}"))
-            })?;
-            // SAFETY: path_c is a valid NUL-terminated string.
-            let status = unsafe { sys::mlx_metal_start_capture(path_c.as_ptr()) };
-            // SAFETY: called immediately after the C function on the same thread.
-            unsafe { check_status(status, "metal_capture::start") }?;
-            Ok(CaptureScope { stopped: false })
-        }
-
-        /// Stop the capture explicitly. A no-op if already stopped.
-        ///
-        /// Returns `Err` if the stop call returns non-zero.
-        pub fn stop(&mut self) -> Result<()> {
-            if self.stopped {
-                return Ok(());
-            }
-            self.stopped = true;
-            install_error_handler();
-            // SAFETY: no preconditions; mlx_metal_stop_capture is idempotent per docs.
-            let status = unsafe { sys::mlx_metal_stop_capture() };
-            // SAFETY: called immediately after the C function on the same thread.
-            unsafe { check_status(status, "metal_capture::stop") }
-        }
-    }
-
-    impl Drop for CaptureScope {
-        fn drop(&mut self) {
-            // Best-effort: ignore errors on drop (can't propagate from Drop).
-            let _ = self.stop();
-        }
     }
 }
 

--- a/crates/rmlx-mlx/src/metal_capture.rs
+++ b/crates/rmlx-mlx/src/metal_capture.rs
@@ -19,6 +19,16 @@
 //! [`step`] once per step and knows nothing about paths, counts, or Metal, so
 //! the hook is model- and codec-agnostic.
 //!
+//! # Precondition: one decode stream
+//!
+//! The driver is process-global but the hook lives in the shared decode loop,
+//! which the server drives once per in-flight request. With two generations
+//! decoding at once the window would count their steps as one sum and the trace
+//! would bracket an arbitrary interleaving of both. Only `rmlx baseline` arms a
+//! capture today and it decodes a single stream on one thread, so this holds;
+//! [`step`] warns once if it is ever ticked from another thread rather than
+//! quietly producing a trace that means something else.
+//!
 //! # Prerequisite outside our control
 //!
 //! Apple only inserts the Metal capture layer into a process when the
@@ -48,10 +58,13 @@ use rmlx_core::error::Error;
 /// drop (or when [`CaptureScope::stop`] is called explicitly).
 ///
 /// Only one scope may be active at a time — the Metal capture manager is
-/// process-global. The driver in this module owns the single scope; construct
-/// one directly only in tests.
-#[allow(missing_debug_implementations)]
-pub struct CaptureScope {
+/// process-global, and starting a second capture while one is live raises an
+/// Objective-C exception, which crosses the FFI boundary as a foreign exception
+/// and aborts the process instead of returning an `Err` we could report. So the
+/// type is crate-private: the driver below is the only constructor and the
+/// compiler, not a comment, enforces the single-scope invariant.
+#[derive(Debug)]
+pub(crate) struct CaptureScope {
     stopped: bool,
 }
 
@@ -60,7 +73,7 @@ impl CaptureScope {
     ///
     /// Returns `Err` if the capture layer is not inserted, the path already
     /// exists, or Metal is unavailable.
-    pub fn start(path: &Path) -> Result<Self> {
+    pub(crate) fn start(path: &Path) -> Result<Self> {
         install_error_handler();
         let path_str = path.to_str().ok_or_else(|| {
             Error::Mlx(format!(
@@ -78,7 +91,7 @@ impl CaptureScope {
     }
 
     /// Stop the capture explicitly. A no-op if already stopped.
-    pub fn stop(&mut self) -> Result<()> {
+    pub(crate) fn stop(&mut self) -> Result<()> {
         if self.stopped {
             return Ok(());
         }
@@ -93,8 +106,19 @@ impl CaptureScope {
 
 impl Drop for CaptureScope {
     fn drop(&mut self) {
-        // Best-effort: Drop cannot propagate. `finish` is the path that reports
-        // a failing stop; this only covers an early unwind.
+        // Best-effort: Drop cannot propagate, so `finish` stays the path that
+        // reports a failing stop. What this actually covers is the local
+        // bindings below that `take()` the scope out of the driver and then
+        // fail in `stop()` — there the value is dropped on the `?` and stopping
+        // twice is a no-op, because `stop` latches `stopped` before the call.
+        //
+        // What it does NOT cover is an unwind through the decode loop: the live
+        // scope is owned by the process-global `DRIVER` static, and statics are
+        // never dropped. A panic mid-window therefore skips `finish`, leaves
+        // `mlx_metal_stop_capture` uncalled, and exits with an unfinalised
+        // bundle. That failure is loud on its own — the process dies with the
+        // panic — unlike the silent successful-run-with-no-trace this module
+        // exists to remove, so it is documented here rather than papered over.
         if let Err(e) = self.stop() {
             tracing::error!(error = %e, "metal capture failed to stop on drop");
         }
@@ -149,13 +173,19 @@ impl Window {
     }
 
     /// Observe one decode-step boundary and report the action it triggers.
+    ///
+    /// `skip` and `steps` come straight from CLI flags, so their sum is
+    /// saturating: this module ships under `release-debug`, which has
+    /// `overflow-checks` off, and a wrapped bound would silently open the
+    /// window at the wrong step and report nonsense — the opposite of the
+    /// diagnostic's purpose.
     pub const fn tick(&mut self) -> Action {
         self.seen += 1;
         if !self.opened && self.seen > self.skip {
             self.opened = true;
             return Action::Open;
         }
-        if self.opened && !self.closed && self.seen > self.skip + self.steps {
+        if self.opened && !self.closed && self.seen > self.skip.saturating_add(self.steps) {
             self.closed = true;
             return Action::Close;
         }
@@ -171,7 +201,7 @@ impl Window {
     /// Boundaries the generation must reach for the window to open at all.
     #[must_use]
     pub const fn steps_needed_to_open(&self) -> u32 {
-        self.skip + 1
+        self.skip.saturating_add(1)
     }
 
     /// Whether the window ever opened.
@@ -249,9 +279,13 @@ pub fn validate(path: &Path, layer_inserted: bool, steps: u32) -> Result<()> {
 ///
 /// The loop drives one boundary per token after the prefill token, and the
 /// closing boundary is itself a step that has to exist — hence the `+ 2`.
+///
+/// Saturating for the same reason as [`Window::tick`]: both operands are
+/// CLI-supplied and `release-debug` does not check overflow, so a wrapped
+/// minimum would wave through a generation far too short to hold the window.
 #[must_use]
 pub const fn min_tokens_for_window(skip: u32, steps: u32) -> u32 {
-    skip + steps + 2
+    skip.saturating_add(steps).saturating_add(2)
 }
 
 /// Whether Apple's Metal capture layer is present in this process.
@@ -299,13 +333,21 @@ struct Driver {
     path: PathBuf,
     window: Window,
     scope: Option<CaptureScope>,
+    /// Thread that armed the capture. The window counts decode steps, not
+    /// per-request decode steps, so a tick from anywhere else means the trace
+    /// no longer brackets one generation — see the module's single-stream
+    /// precondition.
+    armed_on: std::thread::ThreadId,
+    /// Latch so the cross-thread warning is emitted once, not once per step.
+    foreign_tick_warned: bool,
 }
 
 static DRIVER: Mutex<Option<Driver>> = Mutex::new(None);
 
 /// A poisoned driver lock means a panic unwound through a capture step. The
-/// state behind it is a counter plus an `Option<CaptureScope>`, both of which
-/// stay meaningful after an unwind, so recovering beats aborting the process.
+/// state behind it is counters, latches and an `Option<CaptureScope>`, all of
+/// which stay meaningful after an unwind, so recovering beats aborting the
+/// process.
 fn driver() -> MutexGuard<'static, Option<Driver>> {
     DRIVER.lock().unwrap_or_else(|poisoned| {
         tracing::warn!("metal capture driver lock was poisoned; recovering");
@@ -333,6 +375,8 @@ pub fn arm(path: PathBuf, skip: u32, steps: u32) -> Result<()> {
         path,
         window: Window::new(skip, steps),
         scope: None,
+        armed_on: std::thread::current().id(),
+        foreign_tick_warned: false,
     });
     Ok(())
 }
@@ -347,6 +391,14 @@ pub fn step() -> Result<()> {
     let Some(d) = guard.as_mut() else {
         return Ok(());
     };
+    if !d.foreign_tick_warned && std::thread::current().id() != d.armed_on {
+        d.foreign_tick_warned = true;
+        tracing::warn!(
+            "GPU capture window ticked from a thread other than the one that armed it. \
+             If more than one generation is decoding, the window counts their steps as \
+             one sum and the trace brackets an interleaving of both."
+        );
+    }
     match d.window.tick() {
         Action::Idle => Ok(()),
         Action::Open => {

--- a/crates/rmlx-mlx/src/metal_capture.rs
+++ b/crates/rmlx-mlx/src/metal_capture.rs
@@ -1,0 +1,405 @@
+//! Metal GPU trace capture over a bounded window of steady-state decode.
+//!
+//! Compiled only under the `metal-capture` feature. An ordinary build contains
+//! none of this — no state, no branch on the decode path, and no way to reach
+//! `MTLCaptureManager` at all.
+//!
+//! # Why a window
+//!
+//! A whole-run capture is dominated by weight load and prefill and is unusably
+//! large. Kernel work studies steady-state decode, so the driver skips the first
+//! `skip` decode steps (pipeline warm-up, first-touch kernel compilation) and
+//! captures the next `steps`.
+//!
+//! # Shape
+//!
+//! [`Window`] is the pure policy: fed one tick per decode-step boundary, it says
+//! when to open and when to close. [`arm`] / [`step`] / [`finish`] wrap it in a
+//! process-global driver that owns the [`CaptureScope`]. The decode loop calls
+//! [`step`] once per step and knows nothing about paths, counts, or Metal, so
+//! the hook is model- and codec-agnostic.
+//!
+//! # Prerequisite outside our control
+//!
+//! Apple only inserts the Metal capture layer into a process when the
+//! `MTL_CAPTURE_ENABLED` environment variable is set at launch — a framework
+//! toggle, not an rMLX configuration knob. rMLX never keys behaviour off it; it
+//! is read once, purely so a missing capture layer reports the fix instead of
+//! mlx-c's bare "Capture layer is not inserted".
+//!
+//! # mlx-c API
+//!
+//! `mlx_metal_start_capture(path: *const c_char) -> int` — 0 = ok, non-0 = error.
+//! `mlx_metal_stop_capture() -> int` — 0 = ok, non-0 = error.
+//! Both live in `mlx/c/metal.h` (mlx-c 0.6.0).
+
+use std::ffi::CString;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+use crate::{check_status, install_error_handler, sys, Result};
+use rmlx_core::error::Error;
+
+// ---------------------------------------------------------------------------
+// RAII scope
+// ---------------------------------------------------------------------------
+
+/// RAII guard that starts a Metal GPU trace on construction and stops it on
+/// drop (or when [`CaptureScope::stop`] is called explicitly).
+///
+/// Only one scope may be active at a time — the Metal capture manager is
+/// process-global. The driver in this module owns the single scope; construct
+/// one directly only in tests.
+#[allow(missing_debug_implementations)]
+pub struct CaptureScope {
+    stopped: bool,
+}
+
+impl CaptureScope {
+    /// Start a Metal capture writing to `path`.
+    ///
+    /// Returns `Err` if the capture layer is not inserted, the path already
+    /// exists, or Metal is unavailable.
+    pub fn start(path: &Path) -> Result<Self> {
+        install_error_handler();
+        let path_str = path.to_str().ok_or_else(|| {
+            Error::Mlx(format!(
+                "CaptureScope::start: trace path is not valid UTF-8: {}",
+                path.display()
+            ))
+        })?;
+        let path_c = CString::new(path_str)
+            .map_err(|e| Error::Mlx(format!("CaptureScope::start: path contains NUL: {e}")))?;
+        // SAFETY: path_c is a valid NUL-terminated string that outlives the call.
+        let status = unsafe { sys::mlx_metal_start_capture(path_c.as_ptr()) };
+        // SAFETY: called immediately after the C function on the same thread.
+        unsafe { check_status(status, "metal_capture::start") }?;
+        Ok(Self { stopped: false })
+    }
+
+    /// Stop the capture explicitly. A no-op if already stopped.
+    pub fn stop(&mut self) -> Result<()> {
+        if self.stopped {
+            return Ok(());
+        }
+        self.stopped = true;
+        install_error_handler();
+        // SAFETY: no preconditions; mlx_metal_stop_capture is idempotent per docs.
+        let status = unsafe { sys::mlx_metal_stop_capture() };
+        // SAFETY: called immediately after the C function on the same thread.
+        unsafe { check_status(status, "metal_capture::stop") }
+    }
+}
+
+impl Drop for CaptureScope {
+    fn drop(&mut self) {
+        // Best-effort: Drop cannot propagate. `finish` is the path that reports
+        // a failing stop; this only covers an early unwind.
+        if let Err(e) = self.stop() {
+            tracing::error!(error = %e, "metal capture failed to stop on drop");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Window policy (pure)
+// ---------------------------------------------------------------------------
+
+/// What the driver must do at the decode-step boundary just observed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(
+    clippy::exhaustive_enums,
+    reason = "closed three-state instruction from Window::tick to its single driver"
+)]
+pub enum Action {
+    /// Nothing to do at this boundary.
+    Idle,
+    /// Open the capture scope before the step that is about to run.
+    Open,
+    /// Close the capture scope; the requested step budget is spent.
+    Close,
+}
+
+/// Pure window policy: ticked once per decode-step boundary, it decides when the
+/// capture opens and closes. Holds no Metal state, so it is unit-testable.
+///
+/// A tick is observed *before* the step it precedes runs. With `skip = 4` and
+/// `steps = 8` the scope opens before step 5 and closes before step 13, so
+/// steps 5..=12 — eight whole steps — are inside the trace.
+#[derive(Debug, Clone, Copy)]
+pub struct Window {
+    skip: u32,
+    steps: u32,
+    seen: u32,
+    opened: bool,
+    closed: bool,
+}
+
+impl Window {
+    /// Build a window that skips `skip` decode steps and then captures `steps`.
+    #[must_use]
+    pub const fn new(skip: u32, steps: u32) -> Self {
+        Self {
+            skip,
+            steps,
+            seen: 0,
+            opened: false,
+            closed: false,
+        }
+    }
+
+    /// Observe one decode-step boundary and report the action it triggers.
+    pub const fn tick(&mut self) -> Action {
+        self.seen += 1;
+        if !self.opened && self.seen > self.skip {
+            self.opened = true;
+            return Action::Open;
+        }
+        if self.opened && !self.closed && self.seen > self.skip + self.steps {
+            self.closed = true;
+            return Action::Close;
+        }
+        Action::Idle
+    }
+
+    /// Decode-step boundaries observed so far.
+    #[must_use]
+    pub const fn seen(&self) -> u32 {
+        self.seen
+    }
+
+    /// Boundaries the generation must reach for the window to open at all.
+    #[must_use]
+    pub const fn steps_needed_to_open(&self) -> u32 {
+        self.skip + 1
+    }
+
+    /// Whether the window ever opened.
+    #[must_use]
+    pub const fn opened(&self) -> bool {
+        self.opened
+    }
+
+    /// Whether the requested step budget was spent (the window closed on its
+    /// own rather than at the end of a short generation).
+    #[must_use]
+    pub const fn closed(&self) -> bool {
+        self.closed
+    }
+
+    /// Whole decode steps inside the window once generation has ended.
+    ///
+    /// Call only after the decode loop returns: it assumes the step following
+    /// the last observed boundary has run to completion, which is true at the
+    /// end of the loop and false mid-loop.
+    #[must_use]
+    pub const fn captured_steps_at_end(&self) -> u32 {
+        if !self.opened {
+            return 0;
+        }
+        if self.closed {
+            return self.steps;
+        }
+        self.seen - self.skip
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Request validation
+// ---------------------------------------------------------------------------
+
+/// Validate a capture request. Pure — takes the capture-layer state rather than
+/// reading the environment, so it is testable outside a Metal process.
+///
+/// Runs before the model loads: a rejected request must cost seconds, not a full
+/// weight load followed by a failure at the first decode step.
+pub fn validate(path: &Path, layer_inserted: bool, steps: u32) -> Result<()> {
+    if !layer_inserted {
+        return Err(Error::Mlx(
+            "GPU capture requested but Apple's Metal capture layer is not inserted in \
+             this process. Relaunch with MTL_CAPTURE_ENABLED=1 in the environment \
+             (Metal reads it at launch and it cannot be inserted afterwards), or use \
+             scripts/gpu_capture.sh, which sets it."
+                .to_owned(),
+        ));
+    }
+    if steps == 0 {
+        return Err(Error::Mlx(
+            "GPU capture window is zero steps wide; ask for at least one decode step".to_owned(),
+        ));
+    }
+    if path.exists() {
+        return Err(Error::Mlx(format!(
+            "GPU capture destination already exists: {}. Metal refuses to overwrite a \
+             trace bundle; remove it or pick another path.",
+            path.display()
+        )));
+    }
+    match path.parent() {
+        Some(dir) if !dir.as_os_str().is_empty() && !dir.is_dir() => Err(Error::Mlx(format!(
+            "GPU capture destination directory does not exist: {}",
+            dir.display()
+        ))),
+        _ => Ok(()),
+    }
+}
+
+/// Decode steps a generation must produce for a `skip`/`steps` window to open,
+/// fill, and close inside the decode loop.
+///
+/// The loop drives one boundary per token after the prefill token, and the
+/// closing boundary is itself a step that has to exist — hence the `+ 2`.
+#[must_use]
+pub const fn min_tokens_for_window(skip: u32, steps: u32) -> u32 {
+    skip + steps + 2
+}
+
+/// Whether Apple's Metal capture layer is present in this process.
+///
+/// The layer is inserted at launch when `MTL_CAPTURE_ENABLED` is set; there is
+/// no in-process way to insert it afterwards.
+#[must_use]
+pub fn capture_layer_inserted() -> bool {
+    std::env::var_os("MTL_CAPTURE_ENABLED").is_some_and(|v| v != "0")
+}
+
+// ---------------------------------------------------------------------------
+// Process-global driver
+// ---------------------------------------------------------------------------
+
+/// Result of [`finish`] — what the run actually produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(
+    clippy::exhaustive_enums,
+    reason = "closed outcome set reported once per run by the CLI capture driver"
+)]
+pub enum Outcome {
+    /// No capture was requested.
+    Disabled,
+    /// A trace was written. `complete` is false when generation stopped (EOS,
+    /// token cap) before the requested step budget was spent.
+    Captured {
+        /// Path of the `.gputrace` bundle.
+        path: PathBuf,
+        /// Whole decode steps inside the trace.
+        steps: u32,
+        /// Whether the full requested budget was captured.
+        complete: bool,
+    },
+    /// Capture was armed but generation never reached the window's first step.
+    NeverOpened {
+        /// Decode-step boundaries the generation did reach.
+        seen: u32,
+        /// Boundaries it needed to reach for the window to open.
+        needed: u32,
+    },
+}
+
+struct Driver {
+    path: PathBuf,
+    window: Window,
+    scope: Option<CaptureScope>,
+}
+
+static DRIVER: Mutex<Option<Driver>> = Mutex::new(None);
+
+/// A poisoned driver lock means a panic unwound through a capture step. The
+/// state behind it is a counter plus an `Option<CaptureScope>`, both of which
+/// stay meaningful after an unwind, so recovering beats aborting the process.
+fn driver() -> MutexGuard<'static, Option<Driver>> {
+    DRIVER.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!("metal capture driver lock was poisoned; recovering");
+        poisoned.into_inner()
+    })
+}
+
+/// Arm the decode-window capture for this process. A second arm while one is
+/// live is an error, not a silent replacement.
+pub fn arm(path: PathBuf, skip: u32, steps: u32) -> Result<()> {
+    validate(&path, capture_layer_inserted(), steps)?;
+    let mut guard = driver();
+    if guard.is_some() {
+        return Err(Error::Mlx(
+            "GPU capture is already armed for this process".to_owned(),
+        ));
+    }
+    tracing::info!(
+        path = %path.display(),
+        skip_steps = skip,
+        capture_steps = steps,
+        "GPU capture armed; window opens after the skipped decode steps"
+    );
+    *guard = Some(Driver {
+        path,
+        window: Window::new(skip, steps),
+        scope: None,
+    });
+    Ok(())
+}
+
+/// Observe one decode-step boundary. Called by the shared decode loop, once per
+/// step, before the step's forward pass.
+///
+/// A capture that cannot start is an error, not a warning: a run that quietly
+/// produces no trace is the failure mode this path exists to remove.
+pub fn step() -> Result<()> {
+    let mut guard = driver();
+    let Some(d) = guard.as_mut() else {
+        return Ok(());
+    };
+    match d.window.tick() {
+        Action::Idle => Ok(()),
+        Action::Open => {
+            d.scope = Some(CaptureScope::start(&d.path)?);
+            tracing::info!(
+                path = %d.path.display(),
+                after_steps = d.window.seen() - 1,
+                "GPU capture window open"
+            );
+            Ok(())
+        }
+        Action::Close => {
+            if let Some(mut scope) = d.scope.take() {
+                scope.stop()?;
+            }
+            tracing::info!(
+                path = %d.path.display(),
+                captured_steps = d.window.captured_steps_at_end(),
+                "GPU capture window closed"
+            );
+            Ok(())
+        }
+    }
+}
+
+/// Stop any live capture and report what the run produced. Disarms the driver.
+pub fn finish() -> Result<Outcome> {
+    let mut guard = driver();
+    let Some(mut d) = guard.take() else {
+        return Ok(Outcome::Disabled);
+    };
+    if let Some(mut scope) = d.scope.take() {
+        scope.stop()?;
+    }
+    if !d.window.opened() {
+        return Ok(Outcome::NeverOpened {
+            seen: d.window.seen(),
+            needed: d.window.steps_needed_to_open(),
+        });
+    }
+    if !d.path.exists() {
+        return Err(Error::Mlx(format!(
+            "GPU capture window opened and closed but no trace bundle exists at {}",
+            d.path.display()
+        )));
+    }
+    Ok(Outcome::Captured {
+        path: d.path,
+        steps: d.window.captured_steps_at_end(),
+        complete: d.window.closed(),
+    })
+}
+
+#[cfg(test)]
+#[path = "metal_capture_tests.rs"]
+mod metal_capture_tests;

--- a/crates/rmlx-mlx/src/metal_capture_tests.rs
+++ b/crates/rmlx-mlx/src/metal_capture_tests.rs
@@ -1,0 +1,186 @@
+//! Unit tests for the GPU-capture window policy and request validation.
+//!
+//! Both surfaces under test are pure: [`Window`] holds no Metal state and
+//! [`validate`] takes the capture-layer flag as an argument instead of reading
+//! the environment, so nothing here touches a GPU or the process env.
+//!
+//! Run them with the feature on — an ordinary `cargo test` compiles none of
+//! this out (`make test-capture`):
+//!
+//! ```sh
+//! cargo test -p rmlx-mlx --features metal-capture metal_capture
+//! ```
+
+use super::{min_tokens_for_window, validate, Action, Window};
+
+/// Drive `n` boundaries through a window, returning the action at each.
+fn drive(w: &mut Window, n: u32) -> Vec<Action> {
+    (0..n).map(|_| w.tick()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Window policy
+// ---------------------------------------------------------------------------
+
+#[test]
+fn window_opens_after_the_skipped_steps() {
+    let mut w = Window::new(4, 8);
+    let acts = drive(&mut w, 5);
+    assert_eq!(
+        acts,
+        vec![
+            Action::Idle,
+            Action::Idle,
+            Action::Idle,
+            Action::Idle,
+            Action::Open
+        ],
+        "skip=4 must open at the 5th boundary, not earlier and not later"
+    );
+    assert!(w.opened());
+    assert!(!w.closed());
+}
+
+#[test]
+fn window_closes_after_the_step_budget() {
+    let mut w = Window::new(4, 8);
+    let acts = drive(&mut w, 13);
+    // Open at boundary 5, close at boundary 13 → steps 5..=12 inside = 8.
+    assert_eq!(acts.iter().filter(|a| **a == Action::Open).count(), 1);
+    assert_eq!(acts.get(12), Some(&Action::Close), "closes at boundary 13");
+    assert!(w.closed());
+    assert_eq!(w.captured_steps_at_end(), 8);
+}
+
+#[test]
+fn window_opens_and_closes_exactly_once() {
+    let mut w = Window::new(2, 3);
+    let acts = drive(&mut w, 40);
+    assert_eq!(acts.iter().filter(|a| **a == Action::Open).count(), 1);
+    assert_eq!(acts.iter().filter(|a| **a == Action::Close).count(), 1);
+    assert_eq!(w.captured_steps_at_end(), 3, "budget is not exceeded");
+}
+
+#[test]
+fn zero_skip_opens_at_the_first_boundary() {
+    // Boundary 1 opens (step 1 runs inside), boundary 2 is step 2, boundary 3
+    // closes — two whole steps captured.
+    let mut w = Window::new(0, 2);
+    assert_eq!(w.tick(), Action::Open);
+    assert_eq!(w.tick(), Action::Idle);
+    assert_eq!(w.tick(), Action::Close);
+    assert_eq!(w.captured_steps_at_end(), 2);
+}
+
+#[test]
+fn short_generation_reports_the_steps_it_actually_got() {
+    // Opens at boundary 5; generation ends after boundary 9, so steps 5..=9 ran.
+    let mut w = Window::new(4, 8);
+    drive(&mut w, 9);
+    assert!(w.opened());
+    assert!(!w.closed(), "budget was not spent");
+    assert_eq!(w.captured_steps_at_end(), 5);
+}
+
+#[test]
+fn window_that_never_opens_reports_zero_and_what_it_needed() {
+    let mut w = Window::new(10, 4);
+    drive(&mut w, 6);
+    assert!(!w.opened());
+    assert_eq!(w.captured_steps_at_end(), 0);
+    assert_eq!(w.seen(), 6);
+    assert_eq!(w.steps_needed_to_open(), 11);
+}
+
+#[test]
+fn min_tokens_covers_open_fill_and_close() {
+    // The boundary count a generation reaches is what the loop drives; the
+    // window needs one boundary past the closing one to exist.
+    let (skip, steps) = (4, 8);
+    let need = min_tokens_for_window(skip, steps);
+    let mut w = Window::new(skip, steps);
+    drive(&mut w, need - 1);
+    assert!(
+        w.closed(),
+        "min_tokens_for_window must be enough boundaries for a clean close"
+    );
+
+    let mut short = Window::new(skip, steps);
+    drive(&mut short, need - 2);
+    assert!(
+        !short.closed(),
+        "one boundary fewer must NOT close — otherwise the minimum is overstated"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Request validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_rejects_a_missing_capture_layer_with_the_fix() {
+    let dir = std::env::temp_dir();
+    let err = validate(&dir.join("rmlx-vcl.gputrace"), false, 8)
+        .err()
+        .map(|e| e.to_string())
+        .unwrap_or_default();
+    assert!(
+        err.contains("MTL_CAPTURE_ENABLED"),
+        "the error must name the env var Metal needs at launch, got: {err}"
+    );
+}
+
+#[test]
+fn validate_accepts_a_fresh_path_when_the_layer_is_inserted() {
+    let dir = std::env::temp_dir();
+    let res = validate(
+        &dir.join("rmlx-fresh-path-that-does-not-exist.gputrace"),
+        true,
+        8,
+    );
+    assert!(res.is_ok(), "fresh path must validate: {res:?}");
+}
+
+#[test]
+fn validate_rejects_a_zero_step_window() {
+    let dir = std::env::temp_dir();
+    let err = validate(&dir.join("rmlx-zero.gputrace"), true, 0)
+        .err()
+        .map(|e| e.to_string())
+        .unwrap_or_default();
+    assert!(
+        err.contains("zero steps"),
+        "a zero-wide window must be rejected, got: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_an_existing_destination() {
+    // Metal refuses to overwrite a bundle; catching it here costs seconds
+    // instead of a full model load. Any existing path proves the branch.
+    let existing = std::env::temp_dir();
+    assert!(existing.is_dir(), "test fixture: temp dir must exist");
+    let err = validate(&existing, true, 8)
+        .err()
+        .map(|e| e.to_string())
+        .unwrap_or_default();
+    assert!(
+        err.contains("already exists"),
+        "an occupied destination must be rejected, got: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_a_missing_parent_directory() {
+    let missing = std::env::temp_dir()
+        .join("rmlx-no-such-dir-8f3a1c")
+        .join("t.gputrace");
+    let err = validate(&missing, true, 8)
+        .err()
+        .map(|e| e.to_string())
+        .unwrap_or_default();
+    assert!(
+        err.contains("does not exist"),
+        "a missing parent dir must be rejected, got: {err}"
+    );
+}

--- a/crates/rmlx-models/Cargo.toml
+++ b/crates/rmlx-models/Cargo.toml
@@ -33,6 +33,12 @@ image        = { workspace = true }
 symphonia = { workspace = true }
 rustfft   = { workspace = true }
 
+[features]
+# Debug-only Metal GPU trace capture over a bounded decode window. Adds the
+# per-step hook in the shared decode loop; off, that hook does not exist.
+# Never enable in a release build.
+metal-capture = ["rmlx-mlx/metal-capture"]
+
 [dev-dependencies]
 tempfile = { workspace = true }
 # Criterion micro-benchmarks for prefix-index strategies. Pulled

--- a/crates/rmlx-models/src/decode_loop.rs
+++ b/crates/rmlx-models/src/decode_loop.rs
@@ -332,6 +332,15 @@ pub(crate) fn pipelined_decode(
     let mut forced_next: Option<u32> = None;
 
     for step_idx in 1..ctx.n_tokens {
+        // Debug-only GPU-trace window. Compiled out entirely without the
+        // `metal-capture` feature, so an ordinary build has no branch here.
+        // Ticked before the step's work so the trace brackets whole steps, and
+        // driven from the shared loop so the window is model- and
+        // codec-agnostic. A capture that cannot start aborts the run rather
+        // than leaving it silently uncaptured.
+        #[cfg(feature = "metal-capture")]
+        rmlx_mlx::metal_capture::step()?;
+
         let step_t0 = Instant::now();
         let fwd_t0 = Instant::now();
         // A failed forward aborts the request. Returning the tokens produced so

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -324,6 +324,34 @@ rmlx baseline --model /path/to/snapshot --prompt-tokens 4096 --label "8k-bench"
 | `--record` | bool flag | off | Emit a §8.5 `RunRecord` to the metrics buffer and ingest into `runs.db` in-process. |
 | `--git-sha` | string | — | Commit SHA to stamp on the emitted record's `git_sha` column (only meaningful with `--record`). Provenance the caller supplies — the binary does not and cannot determine the commit it was built from. Absent by default (`git_sha` is `NULL`). |
 
+#### GPU-capture flags (debug builds only)
+
+Three further flags exist **only** when the binary is built with
+`--features rmlx-cli/metal-capture`. A release binary does not have them —
+`--gpu-capture` there is an "unexpected argument" error, and neither the flag
+nor the per-step hook it drives is linked in. See
+[`docs/PROFILING.md` §5](PROFILING.md) for the workflow.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--gpu-capture` | path | — | Write a Metal GPU trace of a bounded window of steady-state decode to this path (a `.gputrace` bundle). Mutually exclusive with `--record`. |
+| `--gpu-capture-skip` | u32 | 4 | Decode steps to run before the window opens, so first-touch kernel compilation and pipeline warm-up stay out of the trace. Requires `--gpu-capture`. |
+| `--gpu-capture-steps` | u32 | 8 | Decode steps inside the window. Requires `--gpu-capture`. |
+
+The process must be launched with `MTL_CAPTURE_ENABLED=1`. That is Apple's —
+Metal inserts the capture layer at launch and cannot do so afterwards — not an
+rMLX knob: the trace path and the window come from the flags above.
+`scripts/gpu_capture.sh` (`make profile-gputrace`) sets it and runs the
+toolchain preflight.
+
+Every way a capture can fail to happen is a non-zero exit, checked **before the
+model loads** where possible: no capture layer, an occupied destination, a
+missing parent directory, a zero-wide window, or a `--max-tokens` too small to
+open, fill and close the window (it needs `skip + steps + 2`). A generation that
+stops early and never reaches the window is an error at the end of the run.
+`--record` is rejected outright because capture perturbs every timing `baseline`
+measures.
+
 #### Chat-JSON prompt tokenization
 
 The canonical `prompts/longctx_<N/1024>k.json` fixtures (and any `--prompt`

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -334,9 +334,9 @@ nor the per-step hook it drives is linked in. See
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--gpu-capture` | path | — | Write a Metal GPU trace of a bounded window of steady-state decode to this path (a `.gputrace` bundle). Mutually exclusive with `--record`. |
+| `--gpu-capture` | path | — | Write a Metal GPU trace of a bounded window of steady-state decode to this path (a `.gputrace` bundle). Mutually exclusive with `--record`, and forces `--metrics off`. |
 | `--gpu-capture-skip` | u32 | 4 | Decode steps to run before the window opens, so first-touch kernel compilation and pipeline warm-up stay out of the trace. Requires `--gpu-capture`. |
-| `--gpu-capture-steps` | u32 | 8 | Decode steps inside the window. Requires `--gpu-capture`. |
+| `--gpu-capture-steps` | u32 | 8 | Decode steps inside the window. Keep it at 8 or more — the decode loop is pipelined, so a narrower window holds a strict subset of the kernels a step actually runs. Requires `--gpu-capture`. |
 
 The process must be launched with `MTL_CAPTURE_ENABLED=1`. That is Apple's —
 Metal inserts the capture layer at launch and cannot do so afterwards — not an
@@ -349,8 +349,14 @@ model loads** where possible: no capture layer, an occupied destination, a
 missing parent directory, a zero-wide window, or a `--max-tokens` too small to
 open, fill and close the window (it needs `skip + steps + 2`). A generation that
 stops early and never reaches the window is an error at the end of the run.
-`--record` is rejected outright because capture perturbs every timing `baseline`
-measures.
+
+Capture perturbs every timing `baseline` measures — decode collapses to
+single-digit TPS inside the window — so none of a capture run's numbers may
+reach a metrics surface. `--record` is rejected outright, and `--gpu-capture`
+additionally forces the process metrics mode to `off` whatever `--metrics` says,
+which is what actually keeps the `events` table and
+`<RMLX_HOME>/metrics/baseline.csv` clean; the flag conflict alone only covered
+the `observations` row.
 
 #### Chat-JSON prompt tokenization
 

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -144,29 +144,89 @@ On M5 the Neural Accelerator is **part of the GPU**, so profiling nax needs no
 special tooling — the ordinary Metal capture path covers it
 ([ml-explore/mlx#3182](https://github.com/ml-explore/mlx/issues/3182)).
 
-`rmlx_mlx::metal_capture::CaptureScope` is an RAII guard over
-`mlx_metal_start_capture` / `mlx_metal_stop_capture`, behind the
-`metal-capture` feature so release builds pay nothing.
+### How the window works
+
+The capture is a **bounded window of decode steps**, not a whole run: a run is
+dominated by weight load and prefill, which is not what kernel work studies, and
+a full-run trace is unusably large.
+
+`rmlx_mlx::metal_capture` owns the whole mechanism behind the `metal-capture`
+feature. `CaptureScope` is the RAII guard over `mlx_metal_start_capture` /
+`mlx_metal_stop_capture`; `Window` is the pure policy that decides when the
+scope opens and closes. The one hook is a `step()` call at the top of the
+**shared** decode loop (`rmlx_models::decode_loop::pipelined_decode`), so the
+window is model- and codec-agnostic — every arch that uses that loop (gemma4,
+gemma3, qwen3, qwen3.5-MoE) is covered with no per-arch wiring.
+
+With `--gpu-capture-skip 4 --gpu-capture-steps 8` the scope opens before decode
+step 5 and closes before step 13: eight whole steps, no load, no prefill.
+
+**Off, none of it exists.** Without the feature there is no flag, no hook, no
+`Window`, and no undefined reference to `mlx_metal_start_capture` — verifiable
+with `nm -u target/release/rmlx | grep mlx_metal_start_capture` (empty).
 
 ### Prerequisites
 
-Full **Xcode**, not just Command Line Tools — traces cannot be replayed without
-it:
+1. Full **Xcode**, not just Command Line Tools — traces cannot be replayed
+   without it:
 
-```sh
-sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-```
+   ```sh
+   sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+   ```
+
+2. A binary built with the feature:
+
+   ```sh
+   make build-capture     # cargo build --profile release-debug --features rmlx-cli/metal-capture
+   ```
+
+3. `MTL_CAPTURE_ENABLED=1` in the process environment. This is **Apple's** —
+   Metal inserts the capture layer at launch and there is no in-process way to
+   add it later — not an rMLX configuration knob. The wrapper script sets it;
+   without it the run aborts before loading the model and says so.
 
 ### Capture
 
 ```sh
-cargo build --profile release-debug --features rmlx-mlx/metal-capture
 make profile-gputrace CODEC=iso3_sym MODEL=/path/to/snapshot
+# or, with the window spelled out:
+bash scripts/gpu_capture.sh --kv-quant iso3_sym --model /path/to/snapshot \
+  --prompt-tokens 4096 --skip 4 --steps 8
 ```
 
-The window is a short generation, deliberately: a whole run is unusably large
-and dominated by model load and prefill, which is not what kernel work studies.
-Traces land in `.rmlx/traces/`; `open` them in Xcode.
+Traces land in `.rmlx/traces/`; `open` them in Xcode. The script runs the MLX
+preflight, refuses a binary built without the feature, sizes `--max-ctx` for the
+prompt, and passes `--metrics off` — a capture run's timings are worthless (see
+below) and must never reach `runs.db`.
+
+Driving it directly is the same thing without the guard rails:
+
+```sh
+MTL_CAPTURE_ENABLED=1 ./target/release-debug/rmlx --metrics off baseline \
+  --model /path/to/snapshot --kv-quant none \
+  --prompt-tokens 4096 --max-tokens 18 --max-ctx 4700 \
+  --gpu-capture .rmlx/traces/run.gputrace --gpu-capture-skip 4 --gpu-capture-steps 8
+```
+
+### What it costs
+
+Capture serialises and records every dispatch and snapshots every resident GPU
+buffer. Two consequences worth planning for:
+
+- **Decode collapses** to single-digit TPS during the window (measured: ~2.5 TPS
+  on gemma-4-e2b against ~127 TPS for the same cell uncaptured). Timings from a
+  capture run are meaningless — `--gpu-capture` is rejected with `--record` for
+  exactly this reason.
+- **Bundles are large** — the resource snapshot dominates, so the floor is
+  roughly the model's resident footprint. ~6 GB for an e2b-class model at 4k
+  context, near-identical for an 8-step and a 16-step window. Delete traces when
+  you are done with them; `.rmlx/traces/` has no size cap.
+
+The *command stream* (`<trace>/capture`) is the part that scales with the
+window — measured at ~2.2–2.6 MB per decode step with a fixed floor under 0.2%
+of an 8-step stream. That near-zero intercept is the check that a trace really
+holds only the decode window: model load or prefill inside it would show up as a
+large constant term.
 
 ### What to read in the trace
 
@@ -178,6 +238,16 @@ Traces land in `.rmlx/traces/`; `open` them in Xcode.
 
 See also [Analyzing Apple GPU performance using counter
 statistics](https://developer.apple.com/documentation/xcode/analyzing-apple-gpu-performance-using-counter-statistics).
+
+### Tests
+
+The window policy and the request validation are pure and unit-tested, but the
+tests are behind the same feature, so a plain `cargo test` does not compile
+them. Run them with:
+
+```sh
+make test-capture
+```
 
 ## 6. Ad-hoc cardinality counting with the `counts` crate
 

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -135,10 +135,13 @@ Note: the global allocator is replaced when this feature is active, so jemalloc 
 
 ## 5. Metal GPU capture (the tool for kernel work)
 
-**This is the right profiler for MSL kernel questions**, not samply. Kernel cost
-lives on the GPU: occupancy, ALU-vs-memory limiter, achieved bandwidth, and the
-gaps between dispatches (a large gap means a host round-trip). Host stack
-sampling cannot see any of it.
+**This is the entry point for MSL kernel questions**, not samply — kernel cost
+lives on the GPU, where host stack sampling cannot see it. But a `.gputrace` is
+a *frame capture*, not a timeline, and it answers far less on its own than the
+Xcode marketing implies. [What a `.gputrace` actually
+answers](#what-a-gputrace-actually-answers) below splits the three questions
+people conflate; read it before planning a session, because one of the three is
+not answerable from a capture at all.
 
 On M5 the Neural Accelerator is **part of the GPU**, so profiling nax needs no
 special tooling — the ordinary Metal capture path covers it
@@ -160,6 +163,12 @@ gemma3, qwen3, qwen3.5-MoE) is covered with no per-arch wiring.
 
 With `--gpu-capture-skip 4 --gpu-capture-steps 8` the scope opens before decode
 step 5 and closes before step 13: eight whole steps, no load, no prefill.
+
+**Use at least 8 steps.** `pipelined_decode` is pipelined — a step's work
+straddles the boundary — so a 1-step window's kernel set is a strict *subset* of
+an 8-step window's (measured: it misses the `gather_front*` embedding lookups).
+A narrow window does not just capture less; it misrepresents which kernels
+decode runs.
 
 **Off, none of it exists.** Without the feature there is no flag, no hook, no
 `Window`, and no undefined reference to `mlx_metal_start_capture` — verifiable
@@ -194,10 +203,16 @@ bash scripts/gpu_capture.sh --kv-quant iso3_sym --model /path/to/snapshot \
   --prompt-tokens 4096 --skip 4 --steps 8
 ```
 
-Traces land in `.rmlx/traces/`; `open` them in Xcode. The script runs the MLX
-preflight, refuses a binary built without the feature, sizes `--max-ctx` for the
-prompt, and passes `--metrics off` — a capture run's timings are worthless (see
-below) and must never reach `runs.db`.
+Traces land in `.rmlx/traces/` named
+`<model>-<codec>-<prompt>tok-<timestamp>.gputrace`; `open` them in Xcode. The
+script runs the MLX preflight, refuses a binary built without the feature, and
+sizes `--max-ctx` for the prompt.
+
+A capture run's timings are worthless (see below), so `--gpu-capture` forces the
+metrics kill switch to `off` for the whole process — no `events` row, no
+`observations` row, no `metrics/baseline.csv` append — whatever `--metrics` says.
+It also conflicts with `--record`, so asking for a recorded capture is an error
+rather than a silent downgrade.
 
 Driving it directly is the same thing without the guard rails:
 
@@ -215,8 +230,9 @@ buffer. Two consequences worth planning for:
 
 - **Decode collapses** to single-digit TPS during the window (measured: ~2.5 TPS
   on gemma-4-e2b against ~127 TPS for the same cell uncaptured). Timings from a
-  capture run are meaningless — `--gpu-capture` is rejected with `--record` for
-  exactly this reason.
+  capture run are meaningless, which is why `--gpu-capture` conflicts with
+  `--record` *and* forces `--metrics off` — the flag conflict alone would still
+  have let the run write an `events` row and a `baseline.csv` line.
 - **Bundles are large** — the resource snapshot dominates, so the floor is
   roughly the model's resident footprint. ~6 GB for an e2b-class model at 4k
   context, near-identical for an 8-step and a 16-step window. Delete traces when
@@ -228,16 +244,57 @@ of an 8-step stream. That near-zero intercept is the check that a trace really
 holds only the decode window: model load or prefill inside it would show up as a
 large constant term.
 
-### What to read in the trace
+### What a `.gputrace` actually answers
 
-| Question | Where |
-|---|---|
-| Is the kernel itself slow, or is time lost between dispatches? | per-dispatch duration vs inter-dispatch gap — a large gap is a host round-trip (e.g. a per-step prefix restage) |
-| Compute-bound or bandwidth-bound? | limiter / ALU utilisation vs achieved bandwidth counters |
-| Is the codec's own kernel even running? | dispatch list — a codec that decodes via the bf16 mirror shows no flash-decode dispatch at all |
+Three questions people run this for. They need three different things, and only
+the first is in the bundle you just wrote. Measured across five bundles from
+this path: **no `.gpuprofiler_raw`, and zero timestamp, duration or counter
+payloads anywhere** — the only `counter`-ish string in a whole 6 GB bundle is
+one empty `counterSampleBuffers` category label.
 
-See also [Analyzing Apple GPU performance using counter
+**1. Kernel identity — in the bundle, offline, no Xcode.**
+
+`<trace>/device-resources-0x<addr>` names every pipeline and function the window
+referenced, by mangled MSL name, and `<trace>/metadata` counts how many of them
+went unused:
+
+```sh
+strings <trace>/device-resources-0x* | grep -oE 'gather_front[a-z0-9_]*' | sort -u
+plutil -p <trace>/metadata | grep unused   # unusedComputePipelineStateCount, ...
+```
+
+That is enough to answer "is the codec's own kernel running at all, or is it
+decoding through the bf16 mirror?" — the question that motivated the capture
+window in the first place.
+
+**2. Per-dispatch time, limiter counters, occupancy, achieved bandwidth — GUI
+only, and they do not exist until you ask for them.**
+
+Open the bundle in Xcode and press **Profile**. That *replays* the capture
+on-device with counters enabled, and the replay is what creates
+`.gpuprofiler_raw`. There is no headless replay tool: on Xcode 26.6 `xctrace`
+offers `record` / `import` / `export` / `symbolicate` and nothing that replays a
+capture, so this step cannot be scripted or run over ssh. Background: [Analyzing
+Apple GPU performance using
+counter
 statistics](https://developer.apple.com/documentation/xcode/analyzing-apple-gpu-performance-using-counter-statistics).
+
+**3. Gaps between dispatches as they occurred in your run — not in a frame
+capture. Ever.**
+
+A replay has the replay's schedule, not the schedule of the run you captured.
+Host round-trips — the blocking `Array::eval()` per layer per step, a per-step
+prefix restage — will **not** show up in a `.gputrace`, no matter how it is
+replayed. That needs a timeline instrument over the live process:
+
+```sh
+xcrun xctrace record --template 'Metal System Trace' --launch -- \
+  ./target/release-debug/rmlx --metrics off baseline --model /path/to/snapshot ...
+```
+
+Budget the session accordingly: if the hypothesis is "the GPU is idle waiting on
+the host", a GPU capture is the wrong artifact and will cost a day proving
+nothing.
 
 ### Tests
 
@@ -248,6 +305,9 @@ them. Run them with:
 ```sh
 make test-capture
 ```
+
+`make ci` runs that target too — without it, an off-by-one in the window policy
+would pass the gate green, since `make test` compiles these tests out entirely.
 
 ## 6. Ad-hoc cardinality counting with the `counts` crate
 

--- a/scripts/gpu_capture.sh
+++ b/scripts/gpu_capture.sh
@@ -4,14 +4,19 @@
 #
 # Why this exists: on M5 the Neural Accelerator is part of the GPU, so profiling
 # nax needs no special tooling — the ordinary Metal capture path covers it
-# (ml-explore/mlx#3182). For MSL kernel questions we need GPU-side counters
-# (occupancy, ALU vs memory bound, achieved bandwidth, dispatch gaps), which
-# host stack sampling (samply) cannot show.
+# (ml-explore/mlx#3182). MSL kernel questions are answered GPU-side, which host
+# stack sampling (samply) cannot show: the bundle names the pipelines the window
+# ran, and replaying it in Xcode with Profile produces the counters.
 #
 # The capture window matters: a whole run is unusably large and dominated by
 # load + prefill, which is not what we are studying. The engine opens the scope
 # after --skip decode steps and closes it --steps later, so the trace holds
 # steady-state decode and nothing else.
+#
+# Keep --steps at 8 or more. The decode loop is pipelined, so a step's work
+# straddles the window boundary: a 1-step window's kernel set is a strict subset
+# of an 8-step one (it misses the gather_front* embedding lookups), and reading
+# it as "the kernels decode runs" is wrong.
 #
 # Prerequisites (checked below, each with the fix):
 #   - Xcode (not just Command Line Tools) selected via xcode-select
@@ -125,7 +130,11 @@ fi
 
 mkdir -p "$OUT_DIR"
 stamp=$(date +%Y%m%d-%H%M%S)
-trace="$OUT_DIR/${KV_QUANT}-${PROMPT_TOKENS}tok-${stamp}.gputrace"
+# The model goes in the name: bundles are multi-GB and land side by side, and
+# without it two runs of the same codec and prompt size are indistinguishable
+# short of reverse-engineering kernel names out of the archive.
+model_tag=$(basename "${MODEL%/}")
+trace="$OUT_DIR/${model_tag}-${KV_QUANT}-${PROMPT_TOKENS}tok-${stamp}.gputrace"
 
 # Give the KV ring room for the prompt plus the generation, so the run is not
 # rejected for context before it ever decodes.
@@ -167,8 +176,12 @@ echo ""
 echo "done: $trace"
 echo "open with:  open '$trace'"
 echo ""
-echo "In Xcode, the questions this trace should answer:"
-echo "  - per-dispatch kernel time for the flash-decode kernel vs the gaps between dispatches"
-echo "    (a large gap = host round-trip, e.g. the k_iso*/k_rotor* prefix restage)"
-echo "  - limiter counters: ALU vs memory bound, occupancy, achieved bandwidth"
-echo "    (tells whether a quant decode kernel is compute- or bandwidth-limited)"
+echo "What this bundle holds, and what it does not:"
+echo "  - kernel identity is in the bundle already: which pipelines the window"
+echo "    referenced, and which of them were actually used. No Xcode needed."
+echo "  - per-dispatch time, ALU-vs-memory limiter, occupancy and achieved"
+echo "    bandwidth are NOT in it. Open it in Xcode and press Profile: that"
+echo "    replays the capture on-device with counters enabled and writes them."
+echo "  - the gaps between dispatches as they happened in THIS run are not"
+echo "    recoverable at all — a replay has the replay's schedule. For host"
+echo "    round-trips use:  xcrun xctrace record --template 'Metal System Trace'"

--- a/scripts/gpu_capture.sh
+++ b/scripts/gpu_capture.sh
@@ -9,16 +9,21 @@
 # host stack sampling (samply) cannot show.
 #
 # The capture window matters: a whole run is unusably large and dominated by
-# load + prefill, which is not what we are studying. This drives a short
-# generation so the trace is mostly steady-state decode.
+# load + prefill, which is not what we are studying. The engine opens the scope
+# after --skip decode steps and closes it --steps later, so the trace holds
+# steady-state decode and nothing else.
 #
-# Prerequisites (checked below):
+# Prerequisites (checked below, each with the fix):
 #   - Xcode (not just Command Line Tools) selected via xcode-select
-#   - a binary built with the metal-capture feature
+#   - a binary built with the metal-capture feature (the flags do not exist
+#     otherwise — a release build cannot capture at all)
+#   - MTL_CAPTURE_ENABLED=1 in the child environment; Metal inserts the capture
+#     layer at launch and cannot do so afterwards. This script sets it.
 #
 # Usage:
 #   bash scripts/gpu_capture.sh --kv-quant iso3_sym --model /path/to/snapshot
-#   bash scripts/gpu_capture.sh --kv-quant none --model ... --prompt-tokens 4096 --gen 16
+#   bash scripts/gpu_capture.sh --kv-quant none --model ... --prompt-tokens 4096 \
+#       --skip 4 --steps 8
 #
 # Output: a .gputrace bundle under .rmlx/traces/, ready to open in Xcode.
 
@@ -27,7 +32,9 @@ set -uo pipefail
 KV_QUANT=""
 MODEL=""
 PROMPT_TOKENS=4096
-GEN=16
+SKIP=4
+STEPS=8
+GEN=""
 OUT_DIR=".rmlx/traces"
 
 while [ $# -gt 0 ]; do
@@ -42,6 +49,14 @@ while [ $# -gt 0 ]; do
 		;;
 	--prompt-tokens)
 		PROMPT_TOKENS="$2"
+		shift 2
+		;;
+	--skip)
+		SKIP="$2"
+		shift 2
+		;;
+	--steps)
+		STEPS="$2"
 		shift 2
 		;;
 	--gen)
@@ -60,11 +75,23 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$KV_QUANT" ] || [ -z "$MODEL" ]; then
-	echo "usage: $0 --kv-quant <codec> --model <snapshot-abs-path> [--prompt-tokens N] [--gen N]" >&2
+	echo "usage: $0 --kv-quant <codec> --model <snapshot-abs-path>" >&2
+	echo "       [--prompt-tokens N] [--skip N] [--steps N] [--gen N] [--out-dir DIR]" >&2
 	exit 2
 fi
 
 cd "$(dirname "$0")/.." || exit 1
+
+# The engine needs skip + steps + 2 decode steps to open, fill and close the
+# window; a couple more keeps a short EOS from truncating it.
+min_gen=$((SKIP + STEPS + 2))
+if [ -z "$GEN" ]; then
+	GEN=$((min_gen + 4))
+elif [ "$GEN" -lt "$min_gen" ]; then
+	echo "ERROR: --gen $GEN cannot hold a $SKIP-skip / $STEPS-step window." >&2
+	echo "  Raise it to at least $min_gen, or shrink --skip / --steps." >&2
+	exit 2
+fi
 
 # --- 1. Xcode must be selected; Command Line Tools alone cannot replay traces --
 dev_dir=$(xcode-select -p 2>/dev/null)
@@ -79,13 +106,20 @@ fi
 bash scripts/mlx_preflight.sh || exit 1
 
 # --- 3. binary must carry the capture feature ------------------------------
-# CaptureScope is behind `metal-capture` so release builds pay nothing; a binary
-# built without it silently produces no trace.
+# The --gpu-capture flags are compiled out without it, so their absence from
+# --help is the authoritative check: a release binary cannot capture at all.
 BIN="target/release-debug/rmlx"
+BUILD_HINT="cargo build --profile release-debug --features rmlx-cli/metal-capture"
 if [ ! -x "$BIN" ]; then
 	echo "ERROR: $BIN not found." >&2
 	echo "  Build it with the capture feature and full debug info:" >&2
-	echo "    cargo build --profile release-debug --features rmlx-mlx/metal-capture" >&2
+	echo "    $BUILD_HINT" >&2
+	exit 1
+fi
+if ! "$BIN" baseline --help 2>/dev/null | grep -q -- '--gpu-capture'; then
+	echo "ERROR: $BIN was built WITHOUT the metal-capture feature." >&2
+	echo "  It has no --gpu-capture flag and cannot write a trace. Rebuild with:" >&2
+	echo "    $BUILD_HINT" >&2
 	exit 1
 fi
 
@@ -93,29 +127,39 @@ mkdir -p "$OUT_DIR"
 stamp=$(date +%Y%m%d-%H%M%S)
 trace="$OUT_DIR/${KV_QUANT}-${PROMPT_TOKENS}tok-${stamp}.gputrace"
 
-echo "capturing: codec=$KV_QUANT prompt=$PROMPT_TOKENS gen=$GEN"
+# Give the KV ring room for the prompt plus the generation, so the run is not
+# rejected for context before it ever decodes.
+max_ctx=$((PROMPT_TOKENS + GEN + 512))
+
+echo "capturing: codec=$KV_QUANT prompt=$PROMPT_TOKENS skip=$SKIP steps=$STEPS gen=$GEN"
 echo "trace:     $trace"
 
-# RMLX_METAL_CAPTURE_PATH is read by the engine's capture hook; the window is
-# opened after prefill so the trace is steady-state decode, not model load.
-RMLX_METAL_CAPTURE_PATH="$trace" \
-	"$BIN" baseline \
+# MTL_CAPTURE_ENABLED is Apple's — Metal reads it at launch to insert the
+# capture layer, and there is no in-process way to add it later. It is not an
+# rMLX configuration knob: the trace path and the window come from CLI flags.
+# --metrics off keeps a capture-distorted run out of runs.db.
+MTL_CAPTURE_ENABLED=1 \
+	"$BIN" --metrics off baseline \
 	--model "$MODEL" \
 	--kv-quant "$KV_QUANT" \
 	--prompt-tokens "$PROMPT_TOKENS" \
 	--max-tokens "$GEN" \
-	--max-ctx 65536 \
-	--max-prompt-tokens 65528
+	--max-ctx "$max_ctx" \
+	--max-prompt-tokens "$((PROMPT_TOKENS + 64))" \
+	--gpu-capture "$trace" \
+	--gpu-capture-skip "$SKIP" \
+	--gpu-capture-steps "$STEPS"
 rc=$?
 
+# The engine already fails loudly on every way a capture can not happen, so a
+# zero exit here means the bundle exists. Re-check anyway: this script is the
+# thing an operator runs, and a missing bundle must never read as success.
 if [ $rc -ne 0 ]; then
 	echo "capture run failed (exit $rc)" >&2
 	exit $rc
 fi
-
 if [ ! -e "$trace" ]; then
-	echo "ERROR: no trace written to $trace" >&2
-	echo "  Was the binary built with --features rmlx-mlx/metal-capture?" >&2
+	echo "ERROR: run reported success but no trace exists at $trace" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
Closes #307.

`CaptureScope` existed with **zero callers**; `scripts/gpu_capture.sh` passed `RMLX_METAL_CAPTURE_PATH`, which nothing read; and the script's only failure signal was noticing a missing file after a full run. This wires an actual capture over a bounded window of steady-state decode.

Two prerequisites nobody had documented, both found by experiment:

- **`MTL_CAPTURE_ENABLED=1` is mandatory.** Without it `mlx_metal_start_capture` fails with *"Capture layer is not inserted."* Metal reads it at launch; there is no in-process way to insert the layer later. The old script would have failed even with a working engine hook. This is Apple's framework variable, read once to produce a better error than mlx-c's — rMLX keys no behaviour off it, so it is not a new config knob.
- **Metal refuses to overwrite an existing destination.** Worth catching before a 60-second model load, not after.

### Design

**Gated by cargo feature**, threaded `rmlx-mlx` → `rmlx-models` → `rmlx-cli`, with `#[cfg]` on the clap fields themselves — so a release binary has no flag, no module, and no branch in the decode loop.

**One hook in the shared `pipelined_decode`**, not per-arch, so gemma4 / gemma3 / qwen3 / qwen3.5-MoE are covered with no per-arch wiring and no codec coupling. Window *policy* (`Window`/`Action`) is split from the *effect* (`CaptureScope`), which makes the timing rules unit-testable without a GPU.

**CLI flags, no new environment variable**: `--gpu-capture <PATH>`, `--gpu-capture-skip` (4), `--gpu-capture-steps` (8) on `baseline`.

**Every refusal happens before the model loads** — no capture layer, occupied destination, missing parent dir, zero-width window, `--max-tokens < skip + steps + 2`. A window that never opened is an error, and `seen == 0` reports the uncovered-arch case rather than sending the operator after `--max-tokens`.

### Evidence the window is decode, not load

"The file exists" proves nothing, so three independent lines:

**Linearity with a near-zero intercept.** An 8× lever (1 step vs 8 steps) on Bonsai-8B: 2.19 MB vs 17.70 MB. Zero-intercept prediction 2.2125 MB, measured −1.0%; implied fixed floor **−0.15%**. Load issues thousands of dequant dispatches and a 4117-token prefill is ~64 chunks × 35 layers — either inside the window would show as a large constant term. There is none.

**Kernel identity from the bundle contents.** The window contains `affine_qmv_*` (matrix-**vector**, the `q_seq = 1` signature; prefill uses `qmm`), `argmax_bfloat16` (once per generated token, never during prefill), and `sdpa_vector_2pass_2_bfloat16_t_128`. It contains **zero `steel_attention` / `bq64`** — while those prefill pipelines demonstrably exist elsewhere in the same bundle. A prefill-created pipeline present in the process and absent from the window is direct content-level proof.

**Timestamps.** Load completes 12:50:25.237, window opens 12:50:25.537, closes 12:50:32.378; TTFT was 270 ms.

Traces produced on both architectures — gemma-4-e2b (`kv_h=1`, shared-KV) and Ternary-Bonsai-8B (`kv_h=8`, `head_dim=128`) — and both open in Xcode.

### Evidence the gating is total

Beyond the symbol check (0 `metal_capture` strings, no `mlx_metal_start_capture` import, no `MTL_CAPTURE_ENABLED`, flag absent from `--help` in a plain build): **every change in the diff is either inside `#[cfg(feature = "metal-capture")]` or in a non-code file.** For a plain build, base and head compile from identical effective source, so the feature *cannot* cost decode throughput. That is conclusive and makes a throughput A/B unnecessary.

### Review rounds

A Rust review and an independent performance validation produced:

- **The `--record` conflict did not protect the append-only DB.** It blocked only the `observations` row while `baseline.csv` was appended unconditionally — not even gated by `--metrics off` — so every capture run at ~2.5 TPS left a row. `--gpu-capture` now forces the metrics kill switch off, proven by a scratch-`RMLX_HOME` capture run that left **no `metrics/` directory at all** against a control that wrote 8 events rows plus a CSV row.
- **A test left the process-global driver armed** whenever `MTL_CAPTURE_ENABLED=1` was exported — i.e. it flaked precisely in the shell where this feature is developed, and the module doc claimed the opposite. Reproduced (3/6 red), fixed (8/8 green under the same env).
- **`make ci` compiled out all 21 new tests.** `test-capture` is now a `ci` prerequisite.
- `CaptureScope` was `pub`, so a second capture from any downstream crate would raise an Objective-C exception across FFI and abort the process. Now `pub(crate)`.
- Saturating arithmetic on the window bounds (`release-debug` has `overflow-checks` off, so wrapping produced a nonsense diagnostic); a false `Drop` comment corrected; the single-decode-stream precondition stated and a foreign-thread tick made observable.

### `docs/PROFILING.md` §5 was overselling the artifact

Measured across four bundles: **no `.gpuprofiler_raw`, zero timestamp/duration/counter payloads.** §5 now splits three genuinely different things:

- **Kernel identity** — available offline from the bundle.
- **Per-dispatch time, limiter counters, occupancy, bandwidth** — require opening in Xcode and pressing **Profile**, which replays on-device with counters enabled. GUI-only; no headless replay exists in Xcode 26.6.
- **Gaps between dispatches as they occurred** — **not in a frame capture at all.** Replay timing is the replay's schedule. These need `xcrun xctrace record --template 'Metal System Trace'`. This matters because the host round-trip people are hunting will *not* appear in a `.gputrace`.

Also documented: **use ≥8 steps** — a 1-step window's kernel set is a strict subset of the 8-step set, because `pipelined_decode` is pipelined and a step's work straddles the boundary.

### Already paying for itself

The first captures produced two results that were previously unobtainable, both filed rather than folded in here:

- **NAX appears in no decode dispatch list** on either architecture or codec — empirically settling the standing question on #309.
- **`iso3_sym`'s decode window is a strict superset of `none`'s**, with `sdpa_vector` present *and used* alongside the hand-written iso kernels at 1.74× command volume, for 7.25× slower decode and 1.043× *more* memory than bf16. Filed as #323 with a numeric discriminator, since `device-resources` proves *referenced*, not *counted*.

`make ci` green (now including the 21 capture tests). Bundle naming gained the model basename — two 6 GB `none-4096tok-*` traces had been distinguishable only by reverse-engineering kernel names.
