### PR TITLE
feat(profiling): entitle the capture binary, refuse before the multi-GB write, and tool the bundle (#325)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         profile-samply profile-samply-debug profile-instruments bench asm perf-iter \
         canary canary-gate \
         mlx-preflight mlx-restore-pin target-gc target-size-report profile-gputrace \
-        build-capture test-capture \
+        build-capture test-capture gputrace-preflight traces-gc \
         ssd-canary ssd-canary-gate \
         bench-codec-cell \
         smoke-codec-matrix \
@@ -83,8 +83,26 @@ target-gc:       ## report stale target/ profiles (APPLY=1 to prune; target/ has
 target-size-report: ## advisory: print target/ size + hint when over threshold (non-failing; also runs at the end of `make ci`)
 	@bash scripts/target_size_report.sh
 
-build-capture: ## build the debug-only GPU-capture binary (release-debug + metal-capture)
+# The re-sign is not optional decoration. Cargo emits an ad-hoc *linker-signed*
+# binary with no entitlements at all; com.apple.security.get-task-allow is what
+# marks the process attachable by Apple's developer tools, which is a
+# prerequisite for the GPU debugger to work with what it captured.
+# `codesign --force` is idempotent, so this also repairs a binary that a plain
+# `cargo build` re-created without it.
+build-capture: ## build + entitle the debug-only GPU-capture binary (release-debug + metal-capture, signed so Apple's GPU tools can attach)
 	cargo build --profile release-debug --features rmlx-cli/metal-capture
+	codesign --force --sign - --entitlements scripts/rmlx-capture.entitlements \
+		target/release-debug/rmlx
+	@bash scripts/gputrace_preflight.sh --binary target/release-debug/rmlx
+
+gputrace-preflight: ## check the GPU-tools prerequisites (developer mode, get-task-allow, Xcode selected, Metal toolchain)
+	@bash scripts/gputrace_preflight.sh $(if $(BIN),--binary $(BIN),)
+
+traces-gc:       ## report .rmlx/traces against the retention caps (APPLY=1 to prune; MAX_COUNT=/MAX_TOTAL_GB=/MAX_AGE_DAYS= to retune)
+	bash scripts/traces_gc.sh $(if $(APPLY),--apply,) $(if $(ALL),--all,) \
+		$(if $(MAX_COUNT),--max-count $(MAX_COUNT),) \
+		$(if $(MAX_TOTAL_GB),--max-total-gb $(MAX_TOTAL_GB),) \
+		$(if $(MAX_AGE_DAYS),--max-age-days $(MAX_AGE_DAYS),)
 
 # `make test` is `cargo test --workspace` without --all-features, so it compiles
 # these out entirely. Run from `ci` as well, or an off-by-one in the window
@@ -93,17 +111,17 @@ test-capture: ## run the GPU-capture unit tests (feature-gated, so plain `make t
 	cargo test -p rmlx-mlx --features metal-capture --lib metal_capture
 	cargo test -p rmlx-cli --features metal-capture --bin rmlx gpu_capture
 
-profile-gputrace: ## capture a decode-window Metal GPU trace for Xcode (CODEC= MODEL= required)
+profile-gputrace: ## capture a decode-window Metal GPU trace (CODEC= MODEL= required; enforces the .rmlx/traces cap unless KEEP_ALL=1)
 	@if [ -z "$(CODEC)" ] || [ -z "$(MODEL)" ]; then \
 		echo "Usage: make profile-gputrace CODEC=<codec> MODEL=<snapshot-abs-path> \
-[PROMPT_TOKENS=4096] [SKIP=4] [STEPS=8] [GEN=N]"; \
+[PROMPT_TOKENS=4096] [SKIP=4] [STEPS=8] [GEN=N] [KEEP_ALL=1]"; \
 		echo "Needs a binary from \`make build-capture\`."; \
 		exit 2; \
 	fi
 	bash scripts/gpu_capture.sh --kv-quant $(CODEC) --model $(MODEL) \
 		$(if $(PROMPT_TOKENS),--prompt-tokens $(PROMPT_TOKENS),) \
 		$(if $(SKIP),--skip $(SKIP),) $(if $(STEPS),--steps $(STEPS),) \
-		$(if $(GEN),--gen $(GEN),)
+		$(if $(GEN),--gen $(GEN),) $(if $(KEEP_ALL),--keep-all,)
 
 mlx-restore-pin: ## restore mlx 0.31.2 + mlx-c 0.6.0_2 (nax-capable pair) and relink
 	bash scripts/mlx_restore_pin.sh

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -354,6 +354,21 @@ rMLX knob: the trace path and the window come from the flags above.
 `scripts/gpu_capture.sh` (`make profile-gputrace`) sets it and runs the
 toolchain preflight.
 
+Two host-side prerequisites are **not** about this binary's flags but decide
+whether Apple's GPU tools can attach to the process at all: developer mode
+(`sudo DevToolsSecurity -enable`) and the `com.apple.security.get-task-allow`
+entitlement on the binary. Cargo's linker-signed ad-hoc signature carries no
+entitlements, so `make build-capture` re-signs the binary with
+`scripts/rmlx-capture.entitlements` as part of the build. Both are checked by
+`scripts/gputrace_preflight.sh` (`make gputrace-preflight`), which
+`scripts/gpu_capture.sh` runs *before* the capture rather than after several GB
+have been written. See [`docs/PROFILING.md` §5](PROFILING.md).
+
+Bundles are ~6 GB. After a successful capture `scripts/gpu_capture.sh` bounds
+`.rmlx/traces/` to the newest 6 bundles / 40 GB, evicting oldest-first and
+printing every removal; `--keep-all` (`make profile-gputrace … KEEP_ALL=1`)
+skips that, and `make traces-gc` reports or enforces the caps on demand.
+
 Every way a capture can fail to happen is a non-zero exit, checked **before the
 model loads** where possible: no capture layer, an occupied destination, a
 missing parent directory, a zero-wide window, or a `--max-tokens` too small to

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -176,23 +176,60 @@ with `nm -u target/release/rmlx | grep mlx_metal_start_capture` (empty).
 
 ### Prerequisites
 
-1. Full **Xcode**, not just Command Line Tools — traces cannot be replayed
-   without it:
+Capture and *replay* need different things, and the split is why a trace can be
+written successfully and still show nothing when opened. All of them are checked
+before a run writes anything — `scripts/gpu_capture.sh` refuses up front rather
+than after several GB.
+
+**To capture:**
+
+1. A binary built with the feature:
+
+   ```sh
+   make build-capture     # cargo build --profile release-debug --features rmlx-cli/metal-capture, then signs it
+   ```
+
+2. `MTL_CAPTURE_ENABLED=1` in the process environment. This is **Apple's** —
+   Metal inserts the capture layer at launch and there is no in-process way to
+   add it later — not an rMLX configuration knob. The wrapper script sets it;
+   without it the run aborts before loading the model and says so.
+
+**For Apple's GPU tools to attach to the process** (developer mode plus the
+debuggable entitlement are what let them attach at all — a capture taken by a
+process they may not attach to is not usable in the Xcode GPU debugger),
+checked by `scripts/gputrace_preflight.sh` / `make gputrace-preflight`:
+
+3. Full **Xcode**, not just Command Line Tools:
 
    ```sh
    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
    ```
 
-2. A binary built with the feature:
+4. **Developer mode** enabled — Xcode's GPU tools cannot attach without it:
 
    ```sh
-   make build-capture     # cargo build --profile release-debug --features rmlx-cli/metal-capture
+   sudo DevToolsSecurity -enable
    ```
 
-3. `MTL_CAPTURE_ENABLED=1` in the process environment. This is **Apple's** —
-   Metal inserts the capture layer at launch and there is no in-process way to
-   add it later — not an rMLX configuration knob. The wrapper script sets it;
-   without it the run aborts before loading the model and says so.
+5. The capture binary signed with **`com.apple.security.get-task-allow`** —
+   Apple's "this process may be attached to" marker. Cargo emits an ad-hoc
+   *linker-signed* binary that carries no entitlements at all, so a plain
+   `cargo build` fails this. `make build-capture` re-signs with
+   `scripts/rmlx-capture.entitlements` as part of the build; `codesign --force`
+   is idempotent, so it also repairs a binary a bare `cargo build` re-created.
+   The re-sign is inert for throughput — measured on gemma-4-e2b at 4k, decode
+   128.5 TPS signed against 128.4 unsigned (+0.10%, inside a 2.2% run-to-run
+   range), identical token digest.
+
+   Verify by hand with:
+
+   ```sh
+   codesign -d --entitlements - target/release-debug/rmlx
+   ```
+
+6. The Metal toolchain, for the shader recompilation a replay does
+   (`xcodebuild -downloadComponent MetalToolchain`). Advisory — the preflight
+   warns rather than failing, since capture itself does not need it.
 
 ### Capture
 
@@ -204,9 +241,11 @@ bash scripts/gpu_capture.sh --kv-quant iso3_sym --model /path/to/snapshot \
 ```
 
 Traces land in `.rmlx/traces/` named
-`<model>-<codec>-<prompt>tok-<timestamp>.gputrace`; `open` them in Xcode. The
-script runs the MLX preflight, refuses a binary built without the feature, and
-sizes `--max-ctx` for the prompt.
+`<model>-<codec>-<prompt>tok-<timestamp>.gputrace`. The script runs the MLX
+preflight, refuses a binary built without the feature, refuses a host that
+cannot attach (developer mode, entitlement — *before* the multi-GB write), sizes
+`--max-ctx` for the prompt, and enforces the trace-directory cap afterwards
+(see [Keeping `.rmlx/traces` bounded](#keeping-rmlxtraces-bounded)).
 
 A capture run's timings are worthless (see below), so `--gpu-capture` forces the
 metrics kill switch to `off` for the whole process — no `events` row, no
@@ -247,54 +286,140 @@ large constant term.
 ### What a `.gputrace` actually answers
 
 Three questions people run this for. They need three different things, and only
-the first is in the bundle you just wrote. Measured across five bundles from
-this path: **no `.gpuprofiler_raw`, and zero timestamp, duration or counter
-payloads anywhere** — the only `counter`-ish string in a whole 6 GB bundle is
-one empty `counterSampleBuffers` category label.
+the first is in the bundle you just wrote. Measured across six bundles from this
+path — including ones captured with developer mode on and an entitled binary:
+**no `.gpuprofiler_raw`, and zero timestamp, duration or counter payloads
+anywhere** — the only `counter`-ish string in a whole 6 GB bundle is one empty
+`counterSampleBuffers` category label.
 
-**1. Kernel identity — in the bundle, offline, no Xcode.**
+**1. Kernel identity — in the bundle, offline, no Xcode. This is the reason to
+capture.**
 
 `<trace>/device-resources-0x<addr>` names every pipeline and function the window
-referenced, by mangled MSL name, and `<trace>/metadata` counts how many of them
-went unused:
-
-```sh
-strings <trace>/device-resources-0x* | grep -oE 'gather_front[a-z0-9_]*' | sort -u
-plutil -p <trace>/metadata | grep unused   # unusedComputePipelineStateCount, ...
-```
+referenced, by mangled MSL name; `unused-device-resources-0x<addr>` holds the
+ones the capture layer recorded as unused. Read them with the bundle tools
+below, not by hand — the record layout has traps (see
+[Working with a bundle](#working-with-a-bundle)).
 
 That is enough to answer "is the codec's own kernel running at all, or is it
 decoding through the bf16 mirror?" — the question that motivated the capture
-window in the first place.
+window in the first place, and the one that produced the `iso3_sym` ⊃ `none`
+finding.
 
-**2. Per-dispatch time, limiter counters, occupancy, achieved bandwidth — GUI
-only, and they do not exist until you ask for them.**
+**2. Per-dispatch time, limiter counters, occupancy, achieved bandwidth — do
+not plan a session around these. Most of them do not exist on this hardware.**
 
-Open the bundle in Xcode and press **Profile**. That *replays* the capture
-on-device with counters enabled, and the replay is what creates
-`.gpuprofiler_raw`. There is no headless replay tool: on Xcode 26.6 `xctrace`
-offers `record` / `import` / `export` / `symbolicate` and nothing that replays a
-capture, so this step cannot be scripted or run over ssh. Background: [Analyzing
-Apple GPU performance using
-counter
-statistics](https://developer.apple.com/documentation/xcode/analyzing-apple-gpu-performance-using-counter-statistics).
+- Timing appears only in `.gpuprofiler_raw`, and only Xcode's **GUI** Profile
+  replay writes it. There is no scriptable equivalent: `xctrace` has no replay
+  verb (Xcode 26.6 offers `record` / `import` / `export` / `remodel` /
+  `symbolicate`), `/System/Library/CoreServices/MTLReplayer.app` has hidden
+  `--replay` / `--counters` flags but hangs and is killed without Xcode's XPC
+  session, and Xcode 26's MCP server exposes nothing that touches a gputrace.
+- The counters people actually want are **unsupported on M5 Max**:
+  `supportsCounterSampling(atDispatchBoundary)` is false, `device.counterSets`
+  returns exactly one set (`GPUTimestamp`), and the *Metal GPU Counters*
+  template refuses with "Selected counter profile is not supported on target
+  device".
 
-**3. Gaps between dispatches as they occurred in your run — not in a frame
-capture. Ever.**
+So an empty timeline in Xcode is the expected state of these bundles, not a
+misconfiguration to chase.
+
+**3. Wall-clock GPU timing and the gaps between submissions — use Metal System
+Trace, not a capture. Ever.**
 
 A replay has the replay's schedule, not the schedule of the run you captured.
 Host round-trips — the blocking `Array::eval()` per layer per step, a per-step
 prefix restage — will **not** show up in a `.gputrace`, no matter how it is
-replayed. That needs a timeline instrument over the live process:
+replayed. A timeline instrument over the live process does show them, headlessly
+and with nanosecond resolution:
 
 ```sh
-xcrun xctrace record --template 'Metal System Trace' --launch -- \
+xcrun xctrace record --template 'Metal System Trace' --no-prompt \
+  --output run.trace --time-limit 8s --launch -- \
   ./target/release-debug/rmlx --metrics off baseline --model /path/to/snapshot ...
+
+xcrun xctrace export --input run.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="metal-gpu-intervals"]' \
+  --output gpu.xml
 ```
 
-Budget the session accordingly: if the hypothesis is "the GPU is idle waiting on
-the host", a GPU capture is the wrong artifact and will cost a day proving
-nothing.
+That table gives per-GPU-submission `start` and `duration` in nanoseconds,
+`gpu-channel-name`, `start-latency` (the CPU→GPU gap), and `cmdbuffer-id` /
+`encoder-id`, per process; `metal-application-encoders-list` and
+`metal-command-buffer-completed` join on those ids. Measured run-to-run spread:
+0.06%. Three things to know before using it:
+
+- **`--attach <pid>` does not work** for this template — it reports "No
+  configuration information received, will have to guess" and exports zero rows.
+  Metal instrumentation has to be present at launch: use `--launch --` (or
+  `--all-processes`, which does pick up a running process).
+- The export XML uses an **`id`/`ref` back-reference encoding** with positional
+  columns and `<sentinel/>` for NULL. A naive parser silently misaligns columns,
+  which reads as plausible-but-wrong numbers rather than an error.
+- **Volume**: an 8 s trace is a ~145 MB bundle and ~44 MB of XML for one table.
+  Bound it with `--time-limit`.
+
+Pipeline and function names do **not** survive the export (only encoder,
+command-buffer, buffer and queue labels), and the driver coalesces consecutive
+compute encoders into one GPU kick — so one row can cover several encoders. Pair
+it with the identity list from a capture when you need to know *which* kernel.
+
+### Working with a bundle
+
+A 6 GB bundle is opaque, and its layout is Apple's — not a stable contract. Four
+scripts cover the operations that have actually been needed. Each one checks the
+structure it depends on and fails loudly, by name, when the layout moves: an
+empty list is never printed in place of "could not read this".
+
+| Command | What it answers |
+|---|---|
+| `bash scripts/gputrace_summary.sh <bundle>` | What was captured (model, codec, prompt size, when — read back from the harness naming convention), total and command-stream size, and whether a `.gpuprofiler_raw` is present. |
+| `bash scripts/gputrace_kernels.sh <bundle>` | Which Metal functions the window referenced, and which the capture layer recorded as unused. `--set used\|unused\|all`, `--names-only` for piping. |
+| `bash scripts/gputrace_diff.sh <a> <b>` | What A's window referenced that B's did not, and vice versa — the codec-vs-codec or commit-vs-commit A/B. |
+| `bash scripts/gputrace_preflight.sh` | The host-side prerequisites above, each with its fix. Also `make gputrace-preflight`. |
+
+Worked example — the same comparison that first had to be done by hand, on two
+captures of gemma-4-e2b at 4k taken minutes apart:
+
+```console
+$ bash scripts/gputrace_diff.sh <none>.gputrace <iso3_sym>.gputrace
+shared: 37
+only in A (0):
+only in B (9):
+  custom_kernel_rmlx_iso_flash_decode_symv_p1_b3
+  custom_kernel_rmlx_iso_flash_decode_symv_p2
+  custom_kernel_rmlx_iso3_quantize
+  ...
+```
+
+Two limits worth knowing. Some function records store their name by object id
+rather than inline; those are counted and reported (`… 46 named, 12 stored by
+object id`) instead of silently dropped, so the named list is a subset, not the
+whole set. And a `.gputrace` holds no dispatch *counts* — the command stream
+references pipelines by object id, so "which kernels ran" is answerable offline
+but "how many times" is not.
+
+### Keeping `.rmlx/traces` bounded
+
+Bundles are ~6 GB each — roughly the model's resident footprint — and a single
+A/B session produces several. Unlike `target/`, they are not cheap to
+regenerate: each is a model load plus a capture run. So the directory is
+**capped**, not expired on a timer:
+
+- keep the newest **6** bundles, and at most **40 GB** total;
+- eviction is oldest-first, never the bundle just written, and every removal is
+  printed with its reason and the space reclaimed;
+- `scripts/gpu_capture.sh` enforces the cap after a successful capture — the
+  point of a cap is to stop a session filling the disk, and an advisory the
+  operator runs afterwards does not do that. Pass `--keep-all`
+  (`make profile-gputrace … KEEP_ALL=1`) for a session that wants more.
+
+```sh
+make traces-gc                                   # report: what is over the caps
+make traces-gc APPLY=1                           # enforce them
+make traces-gc APPLY=1 MAX_COUNT=12 MAX_TOTAL_GB=80
+bash scripts/traces_gc.sh --apply --max-age-days 7   # optional extra age rule
+```
 
 ### Tests
 

--- a/scripts/gpu_capture.sh
+++ b/scripts/gpu_capture.sh
@@ -19,9 +19,12 @@
 # it as "the kernels decode runs" is wrong.
 #
 # Prerequisites (checked below, each with the fix):
-#   - Xcode (not just Command Line Tools) selected via xcode-select
 #   - a binary built with the metal-capture feature (the flags do not exist
 #     otherwise — a release build cannot capture at all)
+#   - the replay prerequisites, via scripts/gputrace_preflight.sh: Xcode (not
+#     just Command Line Tools) selected, developer mode enabled, and the binary
+#     signed with com.apple.security.get-task-allow. A capture written without
+#     those is several GB that Xcode opens and shows nothing for.
 #   - MTL_CAPTURE_ENABLED=1 in the child environment; Metal inserts the capture
 #     layer at launch and cannot do so afterwards. This script sets it.
 #
@@ -29,8 +32,12 @@
 #   bash scripts/gpu_capture.sh --kv-quant iso3_sym --model /path/to/snapshot
 #   bash scripts/gpu_capture.sh --kv-quant none --model ... --prompt-tokens 4096 \
 #       --skip 4 --steps 8
+#   bash scripts/gpu_capture.sh ... --keep-all     # do not enforce the trace cap
 #
-# Output: a .gputrace bundle under .rmlx/traces/, ready to open in Xcode.
+# Output: a .gputrace bundle under .rmlx/traces/, ready to open in Xcode. After
+# a successful capture the trace directory is bounded by scripts/traces_gc.sh
+# (oldest-first, never the new bundle, every removal printed); --keep-all skips
+# that for a session that wants to keep more than the cap.
 
 set -uo pipefail
 
@@ -41,6 +48,7 @@ SKIP=4
 STEPS=8
 GEN=""
 OUT_DIR=".rmlx/traces"
+KEEP_ALL=0
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -72,6 +80,10 @@ while [ $# -gt 0 ]; do
 		OUT_DIR="$2"
 		shift 2
 		;;
+	--keep-all)
+		KEEP_ALL=1
+		shift
+		;;
 	*)
 		echo "unknown argument: $1" >&2
 		exit 2
@@ -81,7 +93,7 @@ done
 
 if [ -z "$KV_QUANT" ] || [ -z "$MODEL" ]; then
 	echo "usage: $0 --kv-quant <codec> --model <snapshot-abs-path>" >&2
-	echo "       [--prompt-tokens N] [--skip N] [--steps N] [--gen N] [--out-dir DIR]" >&2
+	echo "       [--prompt-tokens N] [--skip N] [--steps N] [--gen N] [--out-dir DIR] [--keep-all]" >&2
 	exit 2
 fi
 
@@ -98,23 +110,11 @@ elif [ "$GEN" -lt "$min_gen" ]; then
 	exit 2
 fi
 
-# --- 1. Xcode must be selected; Command Line Tools alone cannot replay traces --
-dev_dir=$(xcode-select -p 2>/dev/null)
-if [ "${dev_dir##*/}" = "CommandLineTools" ]; then
-	echo "ERROR: xcode-select points at Command Line Tools, not Xcode." >&2
-	echo "  GPU traces need the full Xcode toolchain. Select it with:" >&2
-	echo "    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer" >&2
-	exit 1
-fi
-
-# --- 2. toolchain sanity: same gate the bench path uses ---------------------
-bash scripts/mlx_preflight.sh || exit 1
-
-# --- 3. binary must carry the capture feature ------------------------------
+# --- 1. binary must carry the capture feature ------------------------------
 # The --gpu-capture flags are compiled out without it, so their absence from
 # --help is the authoritative check: a release binary cannot capture at all.
 BIN="target/release-debug/rmlx"
-BUILD_HINT="cargo build --profile release-debug --features rmlx-cli/metal-capture"
+BUILD_HINT="make build-capture     # cargo build --profile release-debug --features rmlx-cli/metal-capture, then sign it"
 if [ ! -x "$BIN" ]; then
 	echo "ERROR: $BIN not found." >&2
 	echo "  Build it with the capture feature and full debug info:" >&2
@@ -127,6 +127,16 @@ if ! "$BIN" baseline --help 2>/dev/null | grep -q -- '--gpu-capture'; then
 	echo "    $BUILD_HINT" >&2
 	exit 1
 fi
+
+# --- 2. host must be able to REPLAY what we are about to write --------------
+# Xcode selected, developer mode on, and the binary signed with
+# com.apple.security.get-task-allow. Checked here, before the run, because a
+# capture from an unentitled process or a host without developer mode still
+# writes several GB and only reveals the problem as an empty Xcode timeline.
+bash scripts/gputrace_preflight.sh --binary "$BIN" || exit 1
+
+# --- 3. toolchain sanity: same gate the bench path uses ---------------------
+bash scripts/mlx_preflight.sh || exit 1
 
 mkdir -p "$OUT_DIR"
 stamp=$(date +%Y%m%d-%H%M%S)
@@ -176,12 +186,31 @@ echo ""
 echo "done: $trace"
 echo "open with:  open '$trace'"
 echo ""
+
+# Bound the collection, right after a successful capture. Bundles are ~6 GB and
+# a session of A/B captures fills a disk long before anything "ages out", so the
+# cap is enforced here rather than left as an advisory the operator runs later —
+# by the time a disk is full the run in flight has already failed. Eviction is
+# oldest-first, never the bundle just written, and every removal is printed.
+# --keep-all skips it for a session that genuinely wants more than the cap.
+if [ "$KEEP_ALL" = "1" ]; then
+	echo "retention: --keep-all, cap not enforced ($(ls -d "$OUT_DIR"/*.gputrace 2>/dev/null | wc -l | tr -d ' ') bundles in $OUT_DIR)"
+else
+	bash scripts/traces_gc.sh --apply --dir "$OUT_DIR"
+fi
+echo ""
+echo "Offline, no Xcode:"
+echo "  bash scripts/gputrace_summary.sh '$trace'"
+echo "  bash scripts/gputrace_kernels.sh '$trace'"
+echo "  bash scripts/gputrace_diff.sh <other.gputrace> '$trace'"
+echo ""
 echo "What this bundle holds, and what it does not:"
 echo "  - kernel identity is in the bundle already: which pipelines the window"
 echo "    referenced, and which of them were actually used. No Xcode needed."
-echo "  - per-dispatch time, ALU-vs-memory limiter, occupancy and achieved"
-echo "    bandwidth are NOT in it. Open it in Xcode and press Profile: that"
-echo "    replays the capture on-device with counters enabled and writes them."
-echo "  - the gaps between dispatches as they happened in THIS run are not"
-echo "    recoverable at all — a replay has the replay's schedule. For host"
-echo "    round-trips use:  xcrun xctrace record --template 'Metal System Trace'"
+echo "  - no timing of any kind. Only Xcode's GUI Profile replay writes a"
+echo "    .gpuprofiler_raw, and the per-dispatch counters people want are not"
+echo "    supported on this GPU. An empty Xcode timeline is expected here."
+echo "  - for wall-clock GPU time and CPU->GPU gaps, record the live process:"
+echo "      xcrun xctrace record --template 'Metal System Trace' --no-prompt \\"
+echo "        --output run.trace --time-limit 8s --launch -- <rmlx ...>"
+echo "    See docs/PROFILING.md §5 for the export and its parsing traps."

--- a/scripts/gputrace_diff.sh
+++ b/scripts/gputrace_diff.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Diff the function sets of two .gputrace bundles: what did A's window reference
+# that B's did not, and the other way round.
+#
+# This is the A/B that motivates capturing at all — "what does iso3_sym dispatch
+# that none does not", one codec against another, or one commit against another.
+# It was first done by hand, reverse-engineering names out of the archive; this
+# is the same operation with the parser and its layout checks in
+# scripts/gputrace_kernels.sh, so a bundle it cannot read is an error rather
+# than an empty diff that reads like "no difference".
+#
+# Usage:
+#   bash scripts/gputrace_diff.sh <a.gputrace> <b.gputrace>
+#   bash scripts/gputrace_diff.sh <a.gputrace> <b.gputrace> --set unused
+#
+# Exit: 0 = compared (whether or not they differ), 2 = usage, 3 = a bundle could
+#       not be parsed (the reason comes from gputrace_kernels.sh)
+
+set -uo pipefail
+
+A=""
+B=""
+SET="used"
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--set)
+		if [ $# -lt 2 ]; then
+			echo "--set needs used|unused" >&2
+			exit 2
+		fi
+		SET="$2"
+		shift 2
+		;;
+	-h | --help)
+		echo "usage: $0 <a.gputrace> <b.gputrace> [--set used|unused]"
+		exit 0
+		;;
+	-*)
+		echo "unknown argument: $1" >&2
+		exit 2
+		;;
+	*)
+		if [ -z "$A" ]; then
+			A="$1"
+		elif [ -z "$B" ]; then
+			B="$1"
+		else
+			echo "expected exactly two bundles (got a third: $1)" >&2
+			exit 2
+		fi
+		shift
+		;;
+	esac
+done
+
+if [ -z "$A" ] || [ -z "$B" ]; then
+	echo "usage: $0 <a.gputrace> <b.gputrace> [--set used|unused]" >&2
+	exit 2
+fi
+case "$SET" in
+used | unused) ;;
+*)
+	echo "--set must be used or unused (got '$SET')" >&2
+	exit 2
+	;;
+esac
+
+cd "$(dirname "$0")/.." || exit 1
+here="$(pwd)"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/gputrace-diff.XXXXXX") || exit 1
+trap 'rm -rf "$tmp"' EXIT
+
+# The kernel lister does the parsing and owns every layout check. Its failures
+# are ours: a diff computed from a half-read bundle is worse than no diff.
+list() {
+	local bundle="$1" out="$2"
+	if ! bash "$here/scripts/gputrace_kernels.sh" "$bundle" --set "$SET" --names-only >"$out"; then
+		echo "ERROR: could not list functions for $bundle (see above) — no diff produced." >&2
+		return 1
+	fi
+	sort -u "$out" -o "$out"
+}
+
+list "$A" "$tmp/a" || exit 3
+list "$B" "$tmp/b" || exit 3
+
+only_a=$(comm -23 "$tmp/a" "$tmp/b")
+only_b=$(comm -13 "$tmp/a" "$tmp/b")
+shared=$(comm -12 "$tmp/a" "$tmp/b" | wc -l | tr -d ' ')
+
+count() {
+	if [ -z "$1" ]; then echo 0; else printf '%s\n' "$1" | wc -l | tr -d ' '; fi
+}
+
+echo "set:    $SET functions"
+echo "A:      $A ($(wc -l <"$tmp/a" | tr -d ' ') named)"
+echo "B:      $B ($(wc -l <"$tmp/b" | tr -d ' ') named)"
+echo "shared: $shared"
+echo ""
+echo "only in A ($(count "$only_a")):"
+[ -n "$only_a" ] && printf '%s\n' "$only_a" | sed 's/^/  /'
+echo ""
+echo "only in B ($(count "$only_b")):"
+[ -n "$only_b" ] && printf '%s\n' "$only_b" | sed 's/^/  /'
+
+if [ -z "$only_a" ] && [ -z "$only_b" ]; then
+	echo ""
+	echo "identical named function sets"
+fi
+
+# Names the parser could not read are per-bundle and not part of either list;
+# gputrace_kernels.sh reports their count for each bundle.
+exit 0

--- a/scripts/gputrace_kernels.sh
+++ b/scripts/gputrace_kernels.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# List the Metal functions a captured window referenced, straight out of the
+# bundle — no Xcode, no replay.
+#
+# This is the one thing a .gputrace answers offline (docs/PROFILING.md §5): it
+# proves a kernel *fired* instead of inferring it from timing, which is what
+# every "is the codec's own kernel running, or is it decoding through the bf16
+# mirror?" question needs.
+#
+# Where the names come from. A bundle holds two function/pipeline archives, both
+# in Apple's "MTSP" container:
+#
+#   device-resources-0x<addr>         referenced by the captured window
+#   unused-device-resources-0x<addr>  recorded by the capture layer as unused
+#
+# Inside, each function record is the literal string `function` followed by its
+# name, so a `function`-marker scan recovers the list. Some records carry an
+# opaque 16-hex object id instead of a name (the container stores that name by
+# reference) — those are counted and reported separately rather than dropped,
+# because "33 functions, 6 of which this parser could not name" and "33
+# functions" are different facts.
+#
+# The layout is Apple's and is NOT a stable contract, so every structural
+# assumption is checked and a violation is a hard error naming what broke — an
+# empty list must never be mistaken for "no kernels ran". The checks:
+#
+#   - the container magic is MTSP;
+#   - the referenced set holds at least one `function` record;
+#   - at most half the records are unreadable (past that the record shape has
+#     moved, and any list would be a guess);
+#   - at least one record yields a readable name.
+#
+# Individual unreadable records are not fatal — they are counted and printed.
+#
+# Usage:
+#   bash scripts/gputrace_kernels.sh <bundle.gputrace>
+#   bash scripts/gputrace_kernels.sh <bundle.gputrace> --set unused
+#   bash scripts/gputrace_kernels.sh <bundle.gputrace> --set used --names-only
+#
+# Exit: 0 = parsed, 2 = usage / no such bundle, 3 = bundle layout not understood
+
+set -uo pipefail
+
+BUNDLE=""
+SET="all"
+NAMES_ONLY=0
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--set)
+		if [ $# -lt 2 ]; then
+			echo "--set needs used|unused|all" >&2
+			exit 2
+		fi
+		SET="$2"
+		shift 2
+		;;
+	--names-only)
+		NAMES_ONLY=1
+		shift
+		;;
+	-h | --help)
+		echo "usage: $0 <bundle.gputrace> [--set used|unused|all] [--names-only]"
+		exit 0
+		;;
+	-*)
+		echo "unknown argument: $1" >&2
+		exit 2
+		;;
+	*)
+		if [ -n "$BUNDLE" ]; then
+			echo "only one bundle at a time (got '$BUNDLE' and '$1')" >&2
+			exit 2
+		fi
+		BUNDLE="$1"
+		shift
+		;;
+	esac
+done
+
+if [ -z "$BUNDLE" ]; then
+	echo "usage: $0 <bundle.gputrace> [--set used|unused|all] [--names-only]" >&2
+	exit 2
+fi
+case "$SET" in
+used | unused | all) ;;
+*)
+	echo "--set must be used, unused or all (got '$SET')" >&2
+	exit 2
+	;;
+esac
+if [ "$NAMES_ONLY" = "1" ] && [ "$SET" = "all" ]; then
+	echo "--names-only needs --set used or --set unused (a merged list is ambiguous)" >&2
+	exit 2
+fi
+if [ ! -d "$BUNDLE" ]; then
+	echo "ERROR: $BUNDLE is not a .gputrace bundle directory" >&2
+	exit 2
+fi
+
+BUNDLE="${BUNDLE%/}"
+
+# Resolve the two archives. `delta-device-resources-*` is skipped: it holds the
+# incremental resource updates, not the function table.
+used_file=""
+unused_file=""
+for f in "$BUNDLE"/device-resources-0x*; do
+	[ -e "$f" ] || continue
+	used_file="$f"
+done
+for f in "$BUNDLE"/unused-device-resources-0x*; do
+	[ -e "$f" ] || continue
+	unused_file="$f"
+done
+
+if [ -z "$used_file" ]; then
+	echo "ERROR: no device-resources-0x* file in $BUNDLE." >&2
+	echo "  Either this is not a Metal GPU trace, or the bundle layout changed." >&2
+	echo "  Check what it holds:  ls '$BUNDLE' | grep -v '^MTL'" >&2
+	exit 3
+fi
+
+# check_magic <file> — the archives start with the four bytes "MTSP".
+check_magic() {
+	local magic
+	magic=$(head -c 4 "$1" 2>/dev/null)
+	if [ "$magic" != "MTSP" ]; then
+		echo "ERROR: $(basename "$1") does not start with the expected MTSP magic (got '${magic}')." >&2
+		echo "  The capture container changed format; this parser is out of date." >&2
+		return 1
+	fi
+	return 0
+}
+
+# parse_functions <file> <label> <require-nonempty:0|1>
+# Writes names to $names_out, object ids to $opaque_out, and the number of
+# records whose value could not be read to $unresolved_out. Returns 1 on a
+# structural violation, having said which one.
+#
+# A record is `CSuwuw` / `function` / <value>, but the container also emits raw
+# pointer bytes that sometimes decode as a short printable run, so the value is
+# not always the very next string:
+#
+#     CSuwuw · function · @!Ac · vn_copybfloat16bfloat16 · @!Ac · CiulSl
+#
+# The scan therefore looks ahead a few strings, skipping anything not shaped
+# like a name or an object id, and stops at the next record (`CSuwuw` or
+# `function`). A record the scan cannot resolve is counted, never silently
+# dropped: "39 records, 33 named" and "39 records, 33 named, 6 unreadable" are
+# different facts about the same window.
+names_out=""
+opaque_out=""
+marker_count=0
+unresolved_out=0
+parse_functions() {
+	local file="$1" label="$2" require="$3"
+	local raw values markers
+
+	check_magic "$file" || return 1
+
+	raw=$(strings -n 4 "$file" | awk '
+		$0 == "function" {
+			if (pend > 0) unresolved++
+			pend = 4
+			next
+		}
+		pend > 0 {
+			# Container type tags ("CSuwuw", "CiulSl", "Ciuli", ...) are a C
+			# followed by field codes; hitting one means this record had no
+			# readable value, so stop rather than adopt the next record"s name.
+			if ($0 ~ /^C[iulwSbtU@<>3]+$/) { unresolved++; pend = 0; next }
+			if ($0 ~ /^([0-9A-F]{12,}|[A-Za-z_][A-Za-z0-9_]*)$/) { print; pend = 0; next }
+			pend--
+			if (pend == 0) unresolved++
+			next
+		}
+		END { if (pend > 0) unresolved++; print "#unresolved " unresolved + 0 }
+	')
+
+	markers=$(strings -n 4 "$file" | grep -cx 'function')
+	marker_count="$markers"
+	unresolved_out=$(printf '%s\n' "$raw" | sed -n 's/^#unresolved //p')
+	unresolved_out=${unresolved_out:-0}
+	values=$(printf '%s\n' "$raw" | grep -v '^#unresolved ')
+
+	if [ "$markers" -eq 0 ]; then
+		if [ "$require" = "1" ]; then
+			echo "ERROR: $(basename "$file") holds no 'function' records at all." >&2
+			echo "  A captured decode window always references functions, so this is a" >&2
+			echo "  layout change, not an empty result. Inspect it with:" >&2
+			echo "    strings -n 4 '$file' | sort | uniq -c | sort -rn | head" >&2
+			return 1
+		fi
+		names_out=""
+		opaque_out=""
+		return 0
+	fi
+
+	# Most records unreadable means the record shape moved, not that this
+	# window happened to use anonymous functions.
+	if [ "$unresolved_out" -gt $((markers / 2)) ]; then
+		echo "ERROR: $(basename "$file"): $unresolved_out of $markers function records unreadable." >&2
+		echo "  That is most of them — the record layout changed. Inspect it with:" >&2
+		echo "    strings -n 4 '$file' | grep -A3 -x function | head -30" >&2
+		return 1
+	fi
+
+	opaque_out=$(printf '%s\n' "$values" | grep -E '^[0-9A-F]{12,}$' | sort -u)
+	names_out=$(printf '%s\n' "$values" | grep -vE '^[0-9A-F]{12,}$' | sort -u)
+
+	if [ -z "$names_out" ]; then
+		echo "ERROR: $(basename "$file"): $markers function records, none with a readable name." >&2
+		echo "  Names are no longer stored inline; this parser cannot report the set." >&2
+		return 1
+	fi
+	return 0
+}
+
+count_lines() {
+	if [ -z "$1" ]; then echo 0; else printf '%s\n' "$1" | wc -l | tr -d ' '; fi
+}
+
+emit_set() {
+	local label="$1" names="$2" opaque="$3" markers="$4" file="$5" unresolved="$6"
+	if [ "$NAMES_ONLY" = "1" ]; then
+		[ -n "$names" ] && printf '%s\n' "$names"
+		return 0
+	fi
+	local tail=""
+	[ "$unresolved" -gt 0 ] && tail=", $unresolved unreadable"
+	echo ""
+	echo "$label ($(basename "$file")): $markers function records — $(count_lines "$names") named, $(count_lines "$opaque") stored by object id$tail"
+	[ -n "$names" ] && printf '%s\n' "$names" | sed 's/^/  /'
+	return 0
+}
+
+rc=0
+
+if [ "$SET" = "used" ] || [ "$SET" = "all" ]; then
+	parse_functions "$used_file" "used" 1 || exit 3
+	used_names="$names_out"
+	used_opaque="$opaque_out"
+	used_markers="$marker_count"
+	used_unresolved="$unresolved_out"
+fi
+if [ "$SET" = "unused" ] || [ "$SET" = "all" ]; then
+	if [ -z "$unused_file" ]; then
+		if [ "$NAMES_ONLY" = "1" ]; then
+			echo "ERROR: $BUNDLE has no unused-device-resources-0x* file." >&2
+			echo "  Nothing to list; a silent empty list would read as 'nothing unused'." >&2
+			exit 3
+		fi
+		unused_absent=1
+	else
+		# Zero unused functions is a legitimate outcome here (unlike the
+		# referenced set), so an empty parse is reported, not rejected.
+		parse_functions "$unused_file" "unused" 0 || exit 3
+		unused_absent=0
+		unused_names="$names_out"
+		unused_opaque="$opaque_out"
+		unused_markers="$marker_count"
+		unused_unresolved="$unresolved_out"
+	fi
+fi
+
+if [ "$NAMES_ONLY" = "0" ]; then
+	echo "bundle: $BUNDLE"
+fi
+
+if [ "$SET" = "used" ] || [ "$SET" = "all" ]; then
+	emit_set "referenced by the window" "$used_names" "$used_opaque" "$used_markers" \
+		"$used_file" "$used_unresolved"
+fi
+if [ "$SET" = "unused" ] || [ "$SET" = "all" ]; then
+	if [ "$unused_absent" = "1" ]; then
+		echo ""
+		echo "recorded unused: no unused-device-resources-0x* file in this bundle"
+	else
+		emit_set "recorded unused by the capture layer" "$unused_names" "$unused_opaque" \
+			"$unused_markers" "$unused_file" "$unused_unresolved"
+	fi
+fi
+
+exit $rc

--- a/scripts/gputrace_preflight.sh
+++ b/scripts/gputrace_preflight.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
-# Check the host-side prerequisites for capturing a Metal GPU trace AND for
-# replaying it in Xcode.
+# Check the host-side prerequisites for Apple's GPU tools to work with a Metal
+# capture of this binary.
 #
-# Capture and replay have different requirements, and the split is why a trace
-# can be written successfully and still show nothing when opened:
+# Two different things gate a session, and confusing them is why a trace can be
+# written successfully and still be useless:
 #
 #   - capture needs the Metal capture layer (MTL_CAPTURE_ENABLED at launch) and
 #     a binary built with the metal-capture feature. scripts/gpu_capture.sh owns
 #     both; they are build-side, not host-side, so they are not checked here.
-#   - replay (Xcode -> Profile, the step that produces per-dispatch timings and
-#     writes .gpuprofiler_raw into the bundle) needs the host to be in developer
-#     mode, full Xcode selected, and the captured process to have been
-#     debuggable — i.e. signed with com.apple.security.get-task-allow. Cargo's
-#     linker-signed ad-hoc signature carries no entitlements at all, so a
-#     freshly built binary fails that last one by default.
+#   - the GPU tools attaching to the process needs the host in developer mode,
+#     full Xcode selected, and the process marked debuggable — i.e. signed with
+#     com.apple.security.get-task-allow. Cargo's linker-signed ad-hoc signature
+#     carries no entitlements at all, so a freshly built binary fails that one
+#     by default.
+#
+# What this does NOT promise: per-dispatch timings. Only Xcode's GUI Profile
+# replay writes .gpuprofiler_raw, it cannot be driven headlessly, and the
+# counters behind it are unsupported on this GPU — see docs/PROFILING.md §5,
+# which points at Metal System Trace for wall-clock GPU time.
 #
 # Every failure names its exact fix. Run it standalone before a session, or let
 # scripts/gpu_capture.sh run it — it refuses there before the multi-GB write.
@@ -22,7 +26,7 @@
 #   bash scripts/gputrace_preflight.sh
 #   bash scripts/gputrace_preflight.sh --binary target/release-debug/rmlx
 #
-# Exit: 0 = every replay prerequisite met (warnings may still print)
+# Exit: 0 = every prerequisite met (warnings may still print)
 #       1 = at least one prerequisite unmet (each printed with its fix)
 #       2 = usage error
 
@@ -81,14 +85,14 @@ else
 fi
 
 # --- 2. developer mode ------------------------------------------------------
-# Without it the GPU tools cannot attach or replay. Note the third branch: an
+# Without it the GPU tools cannot attach at all. Note the third branch: an
 # unrecognised DevToolsSecurity output is reported as unreadable rather than
 # quietly treated as "disabled" or "fine".
 dts=$(DevToolsSecurity -status 2>&1)
 case "$dts" in
 *"currently enabled"*) pass "developer mode enabled" ;;
 *"currently disabled"*)
-	bad "developer mode is disabled — Xcode's GPU tools cannot replay a trace." \
+	bad "developer mode is disabled — Apple's GPU tools cannot attach at all." \
 		"sudo DevToolsSecurity -enable"
 	;;
 *)
@@ -118,8 +122,8 @@ else
 	elif [ -z "$ents" ]; then
 		# A cargo binary is linker-signed: signed, but with an empty entitlement set.
 		bad "$BIN carries no entitlements at all (cargo's linker-signed ad-hoc signature)." \
-			"Xcode's GPU tools cannot replay a capture taken from a process" \
-			"they were not allowed to attach to. Re-sign it:" \
+			"Apple's GPU tools may not attach to a process that is not marked" \
+			"debuggable, so a capture from it is not usable in them. Re-sign it:" \
 			"$SIGN_HINT_A" \
 			"$SIGN_HINT_B"
 	elif ! printf '%s' "$ents" | plutil -lint - >/dev/null 2>&1; then
@@ -136,8 +140,8 @@ else
 				"$SIGN_HINT_A"
 		else
 			bad "$BIN carries no com.apple.security.get-task-allow entitlement." \
-				"Xcode's GPU tools cannot replay a capture taken from a process" \
-				"they were not allowed to attach to. Re-sign it:" \
+				"Apple's GPU tools may not attach to a process that is not marked" \
+				"debuggable, so a capture from it is not usable in them. Re-sign it:" \
 				"$SIGN_HINT_A" \
 				"$SIGN_HINT_B"
 		fi
@@ -145,13 +149,13 @@ else
 fi
 
 # --- 4. Metal toolchain (advisory) ------------------------------------------
-# A replay recompiles the captured pipelines, so a missing Metal toolchain
+# Anything that recompiles the captured pipelines needs it, so its absence
 # turns into a confusing Xcode-side failure. Advisory, not fatal: capture
 # itself does not need it.
 if xcrun -sdk macosx metal --version >/dev/null 2>&1; then
 	pass "Metal toolchain present: $(xcrun -sdk macosx metal --version 2>&1 | head -1)"
 else
-	warn "Metal toolchain not installed — a replay that recompiles shaders will fail."
+	warn "Metal toolchain not installed — anything recompiling captured shaders will fail."
 	warn "Install it with:  xcodebuild -downloadComponent MetalToolchain"
 fi
 
@@ -159,5 +163,5 @@ if [ "$fail" -ne 0 ]; then
 	echo "preflight FAILED — fix the items above before capturing." >&2
 	exit 1
 fi
-echo "preflight ok — capture and Xcode replay prerequisites are met"
+echo "preflight ok — Apple's GPU tools can attach to this binary on this host"
 exit 0

--- a/scripts/gputrace_preflight.sh
+++ b/scripts/gputrace_preflight.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Check the host-side prerequisites for capturing a Metal GPU trace AND for
+# replaying it in Xcode.
+#
+# Capture and replay have different requirements, and the split is why a trace
+# can be written successfully and still show nothing when opened:
+#
+#   - capture needs the Metal capture layer (MTL_CAPTURE_ENABLED at launch) and
+#     a binary built with the metal-capture feature. scripts/gpu_capture.sh owns
+#     both; they are build-side, not host-side, so they are not checked here.
+#   - replay (Xcode -> Profile, the step that produces per-dispatch timings and
+#     writes .gpuprofiler_raw into the bundle) needs the host to be in developer
+#     mode, full Xcode selected, and the captured process to have been
+#     debuggable — i.e. signed with com.apple.security.get-task-allow. Cargo's
+#     linker-signed ad-hoc signature carries no entitlements at all, so a
+#     freshly built binary fails that last one by default.
+#
+# Every failure names its exact fix. Run it standalone before a session, or let
+# scripts/gpu_capture.sh run it — it refuses there before the multi-GB write.
+#
+# Usage:
+#   bash scripts/gputrace_preflight.sh
+#   bash scripts/gputrace_preflight.sh --binary target/release-debug/rmlx
+#
+# Exit: 0 = every replay prerequisite met (warnings may still print)
+#       1 = at least one prerequisite unmet (each printed with its fix)
+#       2 = usage error
+
+set -uo pipefail
+
+BIN="target/release-debug/rmlx"
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--binary)
+		if [ $# -lt 2 ]; then
+			echo "--binary needs a path" >&2
+			exit 2
+		fi
+		BIN="$2"
+		shift 2
+		;;
+	-h | --help)
+		echo "usage: $0 [--binary <path>]"
+		exit 0
+		;;
+	*)
+		echo "unknown argument: $1" >&2
+		echo "usage: $0 [--binary <path>]" >&2
+		exit 2
+		;;
+	esac
+done
+
+cd "$(dirname "$0")/.." || exit 1
+
+fail=0
+
+pass() { echo "  ok    $1"; }
+warn() { echo "  warn  $1"; }
+bad() {
+	echo "  FAIL  $1" >&2
+	shift
+	for line in "$@"; do echo "        $line" >&2; done
+	fail=1
+}
+
+echo "gputrace preflight (binary: $BIN)"
+
+# --- 1. full Xcode selected -------------------------------------------------
+# Command Line Tools ship no GPU tools, so a trace cannot be opened at all.
+dev_dir=$(xcode-select -p 2>/dev/null)
+if [ -z "$dev_dir" ]; then
+	bad "xcode-select has no developer directory selected." \
+		"sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"
+elif [ "${dev_dir##*/}" = "CommandLineTools" ]; then
+	bad "xcode-select points at Command Line Tools, not Xcode ($dev_dir)." \
+		"sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"
+else
+	pass "Xcode selected: $dev_dir"
+fi
+
+# --- 2. developer mode ------------------------------------------------------
+# Without it the GPU tools cannot attach or replay. Note the third branch: an
+# unrecognised DevToolsSecurity output is reported as unreadable rather than
+# quietly treated as "disabled" or "fine".
+dts=$(DevToolsSecurity -status 2>&1)
+case "$dts" in
+*"currently enabled"*) pass "developer mode enabled" ;;
+*"currently disabled"*)
+	bad "developer mode is disabled — Xcode's GPU tools cannot replay a trace." \
+		"sudo DevToolsSecurity -enable"
+	;;
+*)
+	bad "could not read developer-mode status; DevToolsSecurity said: ${dts:-<no output>}" \
+		"Check it by hand:  DevToolsSecurity -status" \
+		"Enable it with:    sudo DevToolsSecurity -enable"
+	;;
+esac
+
+# --- 3. the capture binary is debuggable ------------------------------------
+# `codesign -d --entitlements -` prints the entitlement plist on stdout. A
+# cargo-built binary is ad-hoc *linker-signed* and has none, which is the
+# default state of a fresh `cargo build` — `make build-capture` re-signs it.
+SIGN_HINT_A="make build-capture     # builds and re-signs with the entitlement"
+SIGN_HINT_B="or: codesign --force --sign - --entitlements scripts/rmlx-capture.entitlements $BIN"
+if [ ! -x "$BIN" ]; then
+	bad "capture binary not found at $BIN." "$SIGN_HINT_A"
+else
+	ents=$(codesign -d --entitlements - --xml "$BIN" 2>/dev/null)
+	cs_rc=$?
+	# The key is dotted and plutil reads dots as key-path separators, so it has
+	# to be escaped — unescaped, plutil reports "no value at that key path" for
+	# a binary that does carry the entitlement, i.e. a silent false negative.
+	gta_key='com\.apple\.security\.get-task-allow'
+	if [ $cs_rc -ne 0 ]; then
+		bad "codesign could not read $BIN (exit $cs_rc) — is it a signed Mach-O?" "$SIGN_HINT_A"
+	elif [ -z "$ents" ]; then
+		# A cargo binary is linker-signed: signed, but with an empty entitlement set.
+		bad "$BIN carries no entitlements at all (cargo's linker-signed ad-hoc signature)." \
+			"Xcode's GPU tools cannot replay a capture taken from a process" \
+			"they were not allowed to attach to. Re-sign it:" \
+			"$SIGN_HINT_A" \
+			"$SIGN_HINT_B"
+	elif ! printf '%s' "$ents" | plutil -lint - >/dev/null 2>&1; then
+		# Neither "entitled" nor "not entitled": codesign printed something this
+		# check cannot read. Say so instead of guessing an answer.
+		bad "codesign printed an entitlement blob that is not a readable plist." \
+			"Inspect it by hand:  codesign -d --entitlements - $BIN"
+	else
+		gta=$(printf '%s' "$ents" | plutil -extract "$gta_key" raw - 2>/dev/null)
+		if [ "$gta" = "true" ]; then
+			pass "get-task-allow entitlement present"
+		elif [ -n "$gta" ]; then
+			bad "$BIN has com.apple.security.get-task-allow set to '$gta', not true." \
+				"$SIGN_HINT_A"
+		else
+			bad "$BIN carries no com.apple.security.get-task-allow entitlement." \
+				"Xcode's GPU tools cannot replay a capture taken from a process" \
+				"they were not allowed to attach to. Re-sign it:" \
+				"$SIGN_HINT_A" \
+				"$SIGN_HINT_B"
+		fi
+	fi
+fi
+
+# --- 4. Metal toolchain (advisory) ------------------------------------------
+# A replay recompiles the captured pipelines, so a missing Metal toolchain
+# turns into a confusing Xcode-side failure. Advisory, not fatal: capture
+# itself does not need it.
+if xcrun -sdk macosx metal --version >/dev/null 2>&1; then
+	pass "Metal toolchain present: $(xcrun -sdk macosx metal --version 2>&1 | head -1)"
+else
+	warn "Metal toolchain not installed — a replay that recompiles shaders will fail."
+	warn "Install it with:  xcodebuild -downloadComponent MetalToolchain"
+fi
+
+if [ "$fail" -ne 0 ]; then
+	echo "preflight FAILED — fix the items above before capturing." >&2
+	exit 1
+fi
+echo "preflight ok — capture and Xcode replay prerequisites are met"
+exit 0

--- a/scripts/gputrace_summary.sh
+++ b/scripts/gputrace_summary.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Summarise a .gputrace bundle: what it is, how big it is, and — the part that
+# is otherwise invisible — whether it has been profiled in Xcode yet.
+#
+# A bundle is several GB of opaque blobs. Two facts are worth having before
+# opening one:
+#
+#   1. what it captured. The harness encodes that in the name
+#      (<model>-<codec>-<prompt>tok-<timestamp>.gputrace), so this reads it back
+#      rather than guessing from the contents.
+#   2. whether a .gpuprofiler_raw is present. A capture holds no timing at all;
+#      only Xcode's GUI Profile replay ever writes that file, and it cannot be
+#      driven headlessly. Reported because its absence is the normal state and
+#      people mistake it for a broken capture — for wall-clock GPU timing use
+#      Metal System Trace instead (docs/PROFILING.md §5).
+#
+# The bundle layout is Apple's and is not a stable contract, so the structural
+# reads (metadata plist, capture stream, resource archive) are checked and a
+# violation is a hard error naming what broke — never a summary with silently
+# missing fields.
+#
+# Usage:
+#   bash scripts/gputrace_summary.sh <bundle.gputrace> [<bundle.gputrace> ...]
+#   bash scripts/gputrace_summary.sh .rmlx/traces/*.gputrace
+#
+# Exit: 0 = summarised, 2 = usage / no such bundle, 3 = bundle layout not understood
+
+set -uo pipefail
+
+if [ $# -eq 0 ]; then
+	echo "usage: $0 <bundle.gputrace> [<bundle.gputrace> ...]" >&2
+	exit 2
+fi
+case "${1:-}" in
+-h | --help)
+	echo "usage: $0 <bundle.gputrace> [<bundle.gputrace> ...]"
+	exit 0
+	;;
+esac
+
+rc=0
+
+# Shape checks are pure parameter expansion on purpose: `printf ... | grep -q`
+# under `set -o pipefail` reports failure when grep exits before the writer
+# finishes, which would turn a well-formed name into "does not follow the
+# convention".
+is_digits() {
+	case "$1" in
+	"") return 1 ;;
+	*[!0-9]*) return 1 ;;
+	*) return 0 ;;
+	esac
+}
+
+for raw in "$@"; do
+	bundle="${raw%/}"
+	if [ ! -d "$bundle" ]; then
+		echo "ERROR: $bundle is not a .gputrace bundle directory" >&2
+		rc=2
+		continue
+	fi
+
+	base=$(basename "$bundle")
+	echo "bundle:   $bundle"
+
+	# --- name fields --------------------------------------------------------
+	# Parsed right-anchored: <model>-<codec>-<N>tok-<YYYYMMDD>-<HHMMSS>. The
+	# model tag may be absent in bundles captured before the harness added it,
+	# which is reported as such — an empty model field is never printed as if
+	# it had been read.
+	stem="${base%.gputrace}"
+	if [ "$stem" = "$base" ]; then
+		echo "  name:   '$base' does not end in .gputrace — not a trace bundle name"
+	fi
+	name_rest="$stem"
+	hms="${name_rest##*-}"
+	name_rest="${name_rest%-*}"
+	ymd="${name_rest##*-}"
+	name_rest="${name_rest%-*}"
+	toks="${name_rest##*-}"
+	name_rest="${name_rest%-*}"
+	codec="${name_rest##*-}"
+	model="${name_rest%-*}"
+	[ "$model" = "$codec" ] && model=""
+
+	tok_count="${toks%tok}"
+	if is_digits "$hms" && [ "${#hms}" -eq 6 ] &&
+		is_digits "$ymd" && [ "${#ymd}" -eq 8 ] &&
+		[ "$tok_count" != "$toks" ] && is_digits "$tok_count"; then
+		echo "  model:  ${model:-<not in name — captured before the harness stamped it>}"
+		echo "  codec:  $codec"
+		echo "  prompt: $tok_count tokens"
+		echo "  when:   $ymd $hms"
+	else
+		echo "  name:   '$base' does not follow the harness convention"
+		echo "          (<model>-<codec>-<prompt>tok-<YYYYMMDD>-<HHMMSS>.gputrace);"
+		echo "          model, codec and prompt size are unknown for this bundle."
+	fi
+
+	# --- structure ----------------------------------------------------------
+	missing=""
+	[ -f "$bundle/capture" ] || missing="$missing capture"
+	[ -f "$bundle/metadata" ] || missing="$missing metadata"
+	dev_res=""
+	for f in "$bundle"/device-resources-0x*; do
+		[ -e "$f" ] && dev_res="$f"
+	done
+	[ -n "$dev_res" ] || missing="$missing device-resources-0x*"
+	if [ -n "$missing" ]; then
+		echo "ERROR: $bundle is missing:$missing" >&2
+		echo "  Either this is not a Metal GPU trace, or the bundle layout changed." >&2
+		rc=3
+		echo ""
+		continue
+	fi
+
+	total=$(du -sh "$bundle" 2>/dev/null | awk '{print $1}')
+	cap=$(du -h "$bundle/capture" 2>/dev/null | awk '{print $1}')
+	entries=$(find "$bundle" -maxdepth 1 -mindepth 1 | wc -l | tr -d ' ')
+	echo "  size:   ${total:-unknown} total, ${cap:-unknown} command stream, $entries entries"
+
+	# --- profiled yet? ------------------------------------------------------
+	prof=$(find "$bundle" -maxdepth 2 -name '*gpuprofiler_raw*' -print -quit 2>/dev/null)
+	if [ -n "$prof" ]; then
+		prof_h=$(du -h "$prof" 2>/dev/null | awk '{print $1}')
+		echo "  timing: PROFILED — $(basename "$prof") (${prof_h:-size unknown}) holds a replay's counters"
+	else
+		echo "  timing: NOT PROFILED — no .gpuprofiler_raw (the normal state: only"
+		echo "          Xcode's GUI Profile replay writes one). What this bundle does"
+		echo "          answer, offline:"
+		echo "            bash scripts/gputrace_kernels.sh '$bundle'"
+		echo "          For wall-clock GPU timing use Metal System Trace instead —"
+		echo "          docs/PROFILING.md §5."
+	fi
+
+	# --- metadata -----------------------------------------------------------
+	meta=$(plutil -p "$bundle/metadata" 2>&1)
+	if [ $? -ne 0 ] || [ -z "$meta" ]; then
+		echo "ERROR: $bundle/metadata is not a readable property list:" >&2
+		printf '%s\n' "$meta" | head -3 | sed 's/^/    /' >&2
+		rc=3
+		echo ""
+		continue
+	fi
+	frames=$(printf '%s\n' "$meta" | awk -F'=> ' '/captured_frames_count/ {print $2}')
+	echo "  frames: ${frames:-<no captured_frames_count key — metadata layout changed>}"
+	unused=$(printf '%s\n' "$meta" | awk -F'=> ' '/unused[A-Za-z]*Count/ && $2+0 > 0 {
+		gsub(/[" ]/, "", $1); sub(/.*\./, "", $1); printf "%s=%s ", $1, $2 }')
+	[ -n "$unused" ] && echo "  unused: $unused"
+
+	echo ""
+done
+
+exit $rc

--- a/scripts/rmlx-capture.entitlements
+++ b/scripts/rmlx-capture.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Debug-only entitlement for the GPU-capture binary (`make build-capture`).
+
+  com.apple.security.get-task-allow marks the process debuggable, which is what
+  lets Apple's developer tools attach to it. Without it a capture is written but
+  cannot be replayed in Xcode, so no per-dispatch timings ever exist.
+
+  This is never part of a release artifact: only the release-debug capture
+  binary is signed with it, and a release build is signed by nothing here.
+-->
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/traces_gc.sh
+++ b/scripts/traces_gc.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Bound how much disk .rmlx/traces holds, and say exactly what was removed.
+#
+# A .gputrace is roughly the model's resident footprint — ~6 GB for an e2b-class
+# model — because capture snapshots every resident GPU buffer. Four of them
+# arrive in one afternoon of A/B work. Unlike target/, a trace is *not* cheap to
+# regenerate: each one costs a model load plus a capture run, so the policy is
+# to bound the collection, not to expire individual bundles on a timer.
+#
+# Retention, in the order applied. The newest bundle is never a candidate (it is
+# the one being looked at right now) unless --all is passed:
+#
+#   1. --max-count N     keep the N newest bundles           (default 6)
+#   2. --max-total-gb N  then evict oldest-first until the directory fits (40)
+#   3. --max-age-days N  optional extra rule; off unless the flag is given
+#
+# Eviction is always oldest-first and always printed with its reason and the
+# space reclaimed. A capture that disappears without a line of output is worse
+# than a full disk — the operator re-runs a 6 GB capture wondering where it went.
+#
+# Deliberately flag-driven, not env-driven: the project treats a new environment
+# variable as a support burden (see CLAUDE.md, simplicity rules).
+#
+# Usage:
+#   bash scripts/traces_gc.sh                        # report only, nothing deleted
+#   bash scripts/traces_gc.sh --apply                # enforce the caps
+#   bash scripts/traces_gc.sh --apply --max-count 12 --max-total-gb 80
+#   bash scripts/traces_gc.sh --apply --max-age-days 7
+#   bash scripts/traces_gc.sh --apply --all          # newest is evictable too
+#   bash scripts/traces_gc.sh --dir /path/to/traces
+#
+# Exit: 0 on every advisory path (nothing to do, report only, caps enforced),
+#       2 on usage.
+
+set -uo pipefail
+
+MAX_COUNT=6
+MAX_TOTAL_GB=40
+MAX_AGE_DAYS="" # optional; empty = no age rule
+APPLY=0
+ALL=0
+DIR=".rmlx/traces"
+
+need_arg() {
+	if [ "$2" -lt 2 ]; then
+		echo "$1 needs a value" >&2
+		exit 2
+	fi
+}
+need_number() {
+	case "$2" in
+	"" | *[!0-9]*)
+		echo "$1 must be a whole number (got '$2')" >&2
+		exit 2
+		;;
+	esac
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--apply)
+		APPLY=1
+		shift
+		;;
+	--all)
+		ALL=1
+		shift
+		;;
+	--max-count)
+		need_arg "$1" $#
+		need_number "$1" "$2"
+		MAX_COUNT="$2"
+		shift 2
+		;;
+	--max-total-gb)
+		need_arg "$1" $#
+		need_number "$1" "$2"
+		MAX_TOTAL_GB="$2"
+		shift 2
+		;;
+	--max-age-days)
+		need_arg "$1" $#
+		need_number "$1" "$2"
+		MAX_AGE_DAYS="$2"
+		shift 2
+		;;
+	--dir)
+		need_arg "$1" $#
+		DIR="$2"
+		shift 2
+		;;
+	-h | --help)
+		echo "usage: $0 [--apply] [--all] [--max-count N] [--max-total-gb N] [--max-age-days N] [--dir DIR]"
+		exit 0
+		;;
+	*)
+		echo "unknown argument: $1" >&2
+		echo "usage: $0 [--apply] [--all] [--max-count N] [--max-total-gb N] [--max-age-days N] [--dir DIR]" >&2
+		exit 2
+		;;
+	esac
+done
+
+cd "$(dirname "$0")/.." || exit 1
+
+if [ ! -d "$DIR" ]; then
+	echo "no $DIR — nothing to do"
+	exit 0
+fi
+
+# Oldest first, so eviction order is simply list order and "newest" is the tail.
+listing=$(
+	for b in "$DIR"/*.gputrace; do
+		[ -d "$b" ] || continue
+		m=$(stat -f %m "$b" 2>/dev/null) || continue
+		[ -n "$m" ] && printf '%s\t%s\n' "$m" "$b"
+	done | sort -n
+)
+if [ -z "$listing" ]; then
+	echo "$DIR holds no .gputrace bundles — nothing to do"
+	exit 0
+fi
+
+bundles=()
+while IFS=$'\t' read -r _ path; do
+	[ -n "$path" ] && bundles+=("$path")
+done <<<"$listing"
+
+n=${#bundles[@]}
+total_before=$(du -sk "$DIR" 2>/dev/null | awk '{print $1}')
+total_before=${total_before:-0}
+
+kb_of() { du -sk "$1" 2>/dev/null | awk '{print $1}'; }
+h_of() { du -sh "$1" 2>/dev/null | awk '{print $1}'; }
+
+# Decide first, act second: the plan is printed whether or not --apply is set,
+# so a dry run shows exactly what an apply would remove.
+declare -a reason
+running_total=0
+sizes=()
+for i in $(seq 0 $((n - 1))); do
+	k=$(kb_of "${bundles[$i]}")
+	k=${k:-0}
+	sizes+=("$k")
+	running_total=$((running_total + k))
+	reason[i]=""
+done
+
+max_total_kb=$((MAX_TOTAL_GB * 1024 * 1024))
+
+# Rule 3 (optional): age.
+if [ -n "$MAX_AGE_DAYS" ]; then
+	for i in $(seq 0 $((n - 1))); do
+		fresh=$(find "${bundles[$i]}" -maxdepth 0 -newermt "-${MAX_AGE_DAYS} days" -print -quit 2>/dev/null)
+		[ -z "$fresh" ] && reason[i]="stale >${MAX_AGE_DAYS}d"
+	done
+fi
+
+# Rule 1: count. Everything but the newest MAX_COUNT goes, oldest first.
+if [ "$n" -gt "$MAX_COUNT" ]; then
+	over=$((n - MAX_COUNT))
+	for i in $(seq 0 $((over - 1))); do
+		[ -z "${reason[$i]}" ] && reason[i]="beyond the newest $MAX_COUNT"
+	done
+fi
+
+# Rule 2: total size. Oldest first until what remains fits.
+projected=0
+for i in $(seq 0 $((n - 1))); do
+	[ -z "${reason[$i]}" ] && projected=$((projected + sizes[i]))
+done
+if [ "$projected" -gt "$max_total_kb" ]; then
+	for i in $(seq 0 $((n - 1))); do
+		[ "$projected" -le "$max_total_kb" ] && break
+		[ -n "${reason[$i]}" ] && continue
+		reason[i]="over the ${MAX_TOTAL_GB}G cap"
+		projected=$((projected - sizes[i]))
+	done
+fi
+
+# The newest bundle is what an operator is looking at right now.
+if [ "$ALL" != "1" ]; then
+	reason[$((n - 1))]=""
+fi
+
+reclaimed=0
+evicted=0
+for i in $(seq 0 $((n - 1))); do
+	name=$(basename "${bundles[$i]}")
+	size_h=$(h_of "${bundles[$i]}")
+	if [ -z "${reason[$i]}" ]; then
+		if [ "$i" -eq $((n - 1)) ] && [ "$ALL" != "1" ]; then
+			echo "keep    $name ($size_h) — newest bundle (use --all to override)"
+		else
+			echo "keep    $name ($size_h)"
+		fi
+		continue
+	fi
+	if [ "$APPLY" = "1" ]; then
+		echo "prune   $name ($size_h) — ${reason[$i]}"
+		rm -rf "${bundles[$i]:?}"
+		reclaimed=$((reclaimed + sizes[i]))
+	else
+		echo "would   $name ($size_h) — ${reason[$i]}"
+	fi
+	evicted=$((evicted + 1))
+done
+
+gb() { echo $(($1 / 1024 / 1024)); }
+
+echo ""
+if [ "$APPLY" = "1" ]; then
+	total_after=$(du -sk "$DIR" 2>/dev/null | awk '{print $1}')
+	total_after=${total_after:-0}
+	echo "$DIR: $(gb "$total_before")G -> $(gb "$total_after")G, $evicted pruned (reclaimed $(gb "$reclaimed")G); caps: $MAX_COUNT bundles / ${MAX_TOTAL_GB}G"
+else
+	if [ "$evicted" -eq 0 ]; then
+		echo "$DIR: $n bundles, $(gb "$total_before")G — within caps ($MAX_COUNT bundles / ${MAX_TOTAL_GB}G), nothing to prune"
+	else
+		echo "report only — re-run with --apply to prune $evicted bundle(s). $DIR: $n bundles, $(gb "$total_before")G (caps: $MAX_COUNT bundles / ${MAX_TOTAL_GB}G)"
+	fi
+fi
+
+exit 0


### PR DESCRIPTION
Addresses #325. Lands the capture-side half and the bundle tooling; **replay is not achieved and is not achievable on this hardware** — documented rather than claimed.

### What was blocking

A `.gputrace` opened in Xcode and showed nothing. Two host prerequisites were unmet and neither was checked, so the run completed, wrote several GB, and the operator discovered the problem only in the GUI.

- **Developer mode** was disabled (cleared out-of-band).
- **The capture binary carried no `com.apple.security.get-task-allow`** — cargo's linker-signed ad-hoc signature has an empty entitlement set. Confirmed independently: `flags=0x20002(adhoc,linker-signed)`, no entitlements.

`make build-capture` now signs the binary as part of the build, so the artifact is usable rather than needing an undocumented manual step, and `scripts/gpu_capture.sh` refuses **before** the multi-GB write, naming the exact fix.

### Replay: what actually happens

Not achievable, and the reason is a ceiling rather than a misconfiguration:

- `xctrace` has `record/import/export/remodel/symbolicate` — **no replay verb**. Only `GPUToolsReplay.framework`, with no CLI or XPC helper.
- Driving Xcode's **Replay** button spawned `GPUToolsReplayService`, which exited within seconds producing nothing. Log: `Unable to connect to the device. (6)`.
- `.gpuprofiler_raw` is absent from all 6 bundles, **including two captured with developer mode on and an entitled binary**. Entitled and unentitled bundles' `metadata` differ only by UUID.

Independently verified on this device, which is why this is a ceiling and not a setup problem: `supportsCounterSampling(atDispatchBoundary)` is **false**; `device.counterSets` returns exactly one set (`GPUTimestamp`); `Metal GPU Counters` fails with *"Selected counter profile is not supported on target device"*; and the driver **coalesces consecutive compute encoders into one GPU kick**, so per-kernel attribution is not recoverable even where timing exists.

`.gpuprofiler_raw` was therefore **not** implemented as a pass criterion, and no claim is made that replay works.

### Bundle tooling — what the capture genuinely gives

Kernel **identity** is available offline, and it is what produced #323. Now tooled rather than hand-derived:

- `gputrace_summary.sh` — model/codec/prompt from the name, sizes, frame count, and whether the bundle has been profiled yet.
- `gputrace_kernels.sh` — Metal function names, used vs recorded-unused.
- `gputrace_diff.sh` — A-only / B-only / shared.
- `gputrace_preflight.sh` — Xcode selected, developer mode, entitlement, Metal toolchain.
- `traces_gc.sh` — retention.

Proven on a freshly captured, matched `none` vs `iso3_sym` pair: **37 shared, 9 only in `iso3_sym`**, including `custom_kernel_rmlx_iso_flash_decode_symv_p1_b3`, `…_p2` and `…iso3_quantize` — #323's hand-derived result, reproduced by tooling.

The bundle layout is an Apple-defined format and not a stable contract, so every parser distinguishes **"nothing matched"** from **"the layout changed and I could not read it"**. A single unreadable record is counted and reported (`46 named, 12 by object id, 1 unreadable`), never silently dropped; a majority-unreadable container is exit 3, not an empty list. The `metadata` plist's `unusedComputePipelineStateCount` reads 0 even when `unused-device-resources` holds entries, so nothing is built on it.

### Retention

Bundles are ~6 GB and are **not** cheaply regenerable — each costs a model load plus a capture run. Enforced **at capture time** (newest 6 bundles, 40 GB), because an advisory the operator runs afterwards cannot stop the session that fills the disk. Oldest-first, newest never evicted, every removal printed with its reason and the space reclaimed. Override is `--keep-all` / `KEEP_ALL=1`. No new environment variables.

### Evidence

**25/25 mutation checks, all red-first.** Parsers: truncated archive, truncation right after a marker, corrupted name, majority-unreadable container, corrupted magic, emptied archive, missing entries. Guards: entitlement stripped → refusal with **no bundle written** (4 bundles → 4); `DevToolsSecurity` stubbed disabled / garbage / silent → three distinct refusals; `xcode-select` stubbed to CLT → refusal. Retention: count cap, size cap (2.3 GB → 800 MB under a 1 GB cap), newest survives `--max-count 0`, and both enforcement and `--keep-all` proven against **real** captures.

Two real bugs surfaced by those checks, both fixed: **`plutil -extract` treats dots as key-path separators**, so the unescaped entitlement key reported "absent" for an entitled binary — a silent false negative in the guard itself; and `cmd | grep -q` under `set -o pipefail` can fail on SIGPIPE.

**Signing is inert — measured, not assumed:** gemma-4-e2b 4k, 3 runs + warmup, signed 128.509 TPS vs unsigned 128.375 (**+0.10%**, inside the 2.2% run-to-run range), token digest identical.

### The path that does work, documented not built

`docs/PROFILING.md` now carries the headless timing recipe rather than implying the GUI is reachable:

```
xcrun xctrace record --template 'Metal System Trace' --no-prompt \
  --output run.trace --time-limit 8s --launch -- ./rmlx <args>
xcrun xctrace export --input run.trace \
  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="metal-gpu-intervals"]' --output gpu.xml
```

with its three verified traps: `--attach <pid>` yields **0 rows** for this template (instrumentation must exist at launch — use `--launch` or `--all-processes`); the XML uses `id`/`ref` back-references with positional columns and `<sentinel/>` NULLs, so naive parsing silently misaligns; and 8 s is ~44 MB of XML.

Deliberately not half-built — it needs a real parser, which is a follow-up branch.

`make ci` green. Only the trace captured during this work was deleted; the four pre-existing bundles are untouched.
