### PR TITLE
perf(kv): kernel dispatchers stop blocking the host per layer — up to 3.06x decode (#292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: GPU-touching tests carry the Metal-context #[ignore]
         run: make check-gpu-tests-ignored
+      # A flash-decode dispatcher that blocks on Array::eval() produces exactly
+      # the right tokens, so no test can see it — it only shows up as a decode
+      # rate several times below what the codec should reach. Static gate.
+      - name: flash-decode dispatchers keep their inputs lazy
+        run: make check-no-kernel-input-eval
 
   msl:
     name: msl kernels (compile + format)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: GPU-touching tests carry the Metal-context #[ignore]
         run: make check-gpu-tests-ignored
-      # A flash-decode dispatcher that blocks on Array::eval() produces exactly
+      # A Metal-kernel dispatcher that blocks on Array::eval() produces exactly
       # the right tokens, so no test can see it — it only shows up as a decode
       # rate several times below what the codec should reach. Static gate.
-      - name: flash-decode dispatchers keep their inputs lazy
+      - name: kernel dispatchers keep their inputs lazy
         run: make check-no-kernel-input-eval
+      # ...and the gate above is only worth its runtime if it still fires when
+      # the eval is spelled differently, moved to a sub-directory, or hidden one
+      # call deep in a shared scaffold. Fixture trees pin that recall.
+      - name: the lazy-inputs gate still catches what it is for
+        run: make check-no-kernel-input-eval-fixtures
 
   msl:
     name: msl kernels (compile + format)

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         e2e \
         file-size-report check-no-inline-tests check-no-scalar-f32-leak \
         check-no-decode-swallow check-gpu-tests-ignored \
+        check-no-kernel-input-eval \
         check-metal-compiles check-metal-format
 
 help:
@@ -227,6 +228,9 @@ check-no-decode-swallow: ## CI gate: fail if a decode-step failure breaks instea
 check-gpu-tests-ignored: ## CI gate: fail if a GPU-touching test in ANY workspace member lacks #[ignore] (would abort the whole test binary under parallel cargo test)
 	@bash scripts/check_gpu_tests_ignored.sh
 
+check-no-kernel-input-eval: ## CI gate: fail if a flash-decode dispatcher blocks on Array::eval() (serialises host vs GPU once per layer per decode step)
+	@bash scripts/check_no_kernel_input_eval.sh
+
 # METAL_STRICT=--strict turns a missing toolchain into a hard failure instead of
 # a skip. CI sets it (the macOS runner ships the toolchain, so a skip there would
 # mean the gate protected nothing); local runs leave it empty and skip.
@@ -244,6 +248,7 @@ ci: fmt-check lint test test-capture deny audit ci-metrics ## full pre-merge gat
 	@bash scripts/check_no_scalar_f32_leak.sh
 	@bash scripts/check_no_decode_swallow.sh
 	@bash scripts/check_gpu_tests_ignored.sh
+	@bash scripts/check_no_kernel_input_eval.sh
 	@bash scripts/check_metal_format.sh
 	@bash scripts/check_metal_compiles.sh
 	@bash scripts/file_size_report.sh || true

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         e2e \
         file-size-report check-no-inline-tests check-no-scalar-f32-leak \
         check-no-decode-swallow check-gpu-tests-ignored \
-        check-no-kernel-input-eval \
+        check-no-kernel-input-eval check-no-kernel-input-eval-fixtures \
         check-metal-compiles check-metal-format
 
 help:
@@ -228,8 +228,11 @@ check-no-decode-swallow: ## CI gate: fail if a decode-step failure breaks instea
 check-gpu-tests-ignored: ## CI gate: fail if a GPU-touching test in ANY workspace member lacks #[ignore] (would abort the whole test binary under parallel cargo test)
 	@bash scripts/check_gpu_tests_ignored.sh
 
-check-no-kernel-input-eval: ## CI gate: fail if a flash-decode dispatcher blocks on Array::eval() (serialises host vs GPU once per layer per decode step)
+check-no-kernel-input-eval: ## CI gate: fail if a Metal-kernel dispatcher blocks on Array::eval() (serialises host vs GPU once per layer per decode step)
 	@bash scripts/check_no_kernel_input_eval.sh
+
+check-no-kernel-input-eval-fixtures: ## CI gate: the eval gate still fires on renamed/relocated/differently-spelled evals
+	@bash scripts/check_no_kernel_input_eval_fixtures.sh
 
 # METAL_STRICT=--strict turns a missing toolchain into a hard failure instead of
 # a skip. CI sets it (the macOS runner ships the toolchain, so a skip there would
@@ -249,6 +252,7 @@ ci: fmt-check lint test test-capture deny audit ci-metrics ## full pre-merge gat
 	@bash scripts/check_no_decode_swallow.sh
 	@bash scripts/check_gpu_tests_ignored.sh
 	@bash scripts/check_no_kernel_input_eval.sh
+	@bash scripts/check_no_kernel_input_eval_fixtures.sh
 	@bash scripts/check_metal_format.sh
 	@bash scripts/check_metal_compiles.sh
 	@bash scripts/file_size_report.sh || true

--- a/crates/rmlx-kv-quant/src/flash_decode_common.rs
+++ b/crates/rmlx-kv-quant/src/flash_decode_common.rs
@@ -29,6 +29,43 @@
 //! chat prompt against a single-KV-head model (Gemma4 global layers are
 //! `kv_h == 1`), where a 2-token prompt reaches `kv_seq == 2` on the first
 //! decode step, well below the compile floor.
+//!
+//! # Why a kernel dispatcher must not `eval()` its inputs
+//!
+//! This is the canonical statement of the rule; the MSL dispatchers point here
+//! rather than repeating it, so the argument cannot drift between copies. The
+//! CI gate `make check-no-kernel-input-eval` enforces it.
+//!
+//! These kernels read their buffers by raw linear offset, so they need
+//! row-contiguous inputs. Historically every dispatcher forced
+//! `Array::eval()` on each input immediately before dispatch, on the reasoning
+//! that a pending lazy transpose would otherwise be read with the wrong
+//! strides. **Both halves of that reasoning are wrong:**
+//!
+//! * **Ordering.** `rmlx_mlx::metal_kernel::MetalKernel::apply` enqueues an
+//!   MLX `fast::CustomKernel` **graph node**; it does not dispatch.
+//!   MLX runs that node's `eval_gpu` only once every input edge is itself
+//!   materialised, and the `ensure_row_contiguous` copy — requested by
+//!   `MetalKernel::new` — is applied inside that same `eval_gpu`. The kernel
+//!   therefore cannot observe an uncomputed or strided buffer. A caller-side
+//!   `eval()` buys no ordering the graph does not already provide; it only
+//!   moves *when* the host blocks.
+//! * **Layout.** `Array::eval()` materialises but does **not** relayout. MLX's
+//!   `Transpose` is a strided view over a shared buffer, so an evaluated
+//!   transpose is still non-row-contiguous — evaluating it would not have
+//!   fixed the stride problem the comment claimed to be guarding. The layout
+//!   guarantee comes from `reshape` plus `ensure_row_contiguous`, and always
+//!   did.
+//!
+//! The cost of the eval was not small: it blocks the calling thread on the GPU
+//! once per attention layer per decode step, so the forward pass advances one
+//! layer at a time with nothing queued ahead. Removing it is a fixed
+//! per-step saving (it collapses the per-step intercept, not the per-KV-token
+//! slope) worth multiples of the decode rate at short context.
+//!
+//! An eval that is genuinely load-bearing — a host readback before
+//! `to_bytes()`, say — stays, and says so at the call site with an
+//! `// eval-ok: <reason>` marker.
 
 use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{pad, Array, Device};

--- a/crates/rmlx-kv-quant/src/fused_qk_common.rs
+++ b/crates/rmlx-kv-quant/src/fused_qk_common.rs
@@ -107,10 +107,10 @@ pub(crate) fn build_fused_qk_setup(
     }
     let dims_arr = Array::from_bytes(&dims_bytes, &[5], Dtype::U32)?;
 
-    q_f32.eval()?;
-    mask_flat.eval()?;
-    scale_arr.eval()?;
-    dims_arr.eval()?;
+    // Inputs stay lazy: `MetalKernel::apply` enqueues a graph node, so MLX
+    // materialises them — and applies `ensure_row_contiguous` — inside the
+    // kernel's own `eval_gpu`. A blocking eval here would only stall the host
+    // once per layer per decode step. See `crate::flash_decode_common` docs.
 
     let out_total: i64 = i64::from(b) * i64::from(n_q_heads) * i64::from(kv_seq);
     let grid_x: i64 = i64::from(kv_seq) * i64::from(head_dim);

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
@@ -623,11 +623,11 @@ pub fn iso_flash_decode_sdpa<const BITS: u8>(
             .map_err(|e| Error::Mlx(format!("iso_flash_decode dims: {e}")))?
     };
 
-    // Inputs stay lazy — do NOT force-evaluate them here. The raw-linear read
-    // needs row-contiguous buffers, and `MetalKernel::new` already asks MLX for
-    // that (`ensure_row_contiguous`), which copies a strided input before
-    // dispatch. A blocking `Array::eval` adds nothing to that guarantee and
-    // serialises the caller against the GPU once per layer per decode step.
+    // Inputs stay lazy — do NOT force-evaluate them here. `MetalKernel::apply`
+    // enqueues a graph node, so MLX materialises every input, and applies the
+    // `ensure_row_contiguous` copy, inside the kernel's own `eval_gpu`; a
+    // blocking eval buys no ordering and stalls the host once per layer per
+    // decode step. Full argument: `crate::flash_decode_common` module docs.
 
     // ── P1 dispatch ───────────────────────────────────────────────────────
     let kern_p1 = p1_kernel(BITS)?;

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
@@ -623,19 +623,11 @@ pub fn iso_flash_decode_sdpa<const BITS: u8>(
             .map_err(|e| Error::Mlx(format!("iso_flash_decode dims: {e}")))?
     };
 
-    // Materialise inputs to flush any pending lazy ops before kernel dispatch.
-    // The MSL kernels read by raw linear offset and ignore MLX lazy-transpose
-    // strides, so a pending permutation must be resolved here.
-    q_f32.eval()?;
-    codes_flat.eval()?;
-    scales_flat.eval()?;
-    norms_flat.eval()?;
-    v_flat.eval()?;
-    if has_mask == 1 {
-        mask_flat.eval()?;
-    }
-    scale_arr.eval()?;
-    dims_arr.eval()?;
+    // Inputs stay lazy — do NOT force-evaluate them here. The raw-linear read
+    // needs row-contiguous buffers, and `MetalKernel::new` already asks MLX for
+    // that (`ensure_row_contiguous`), which copies a strided input before
+    // dispatch. A blocking `Array::eval` adds nothing to that guarantee and
+    // serialises the caller against the GPU once per layer per decode step.
 
     // ── P1 dispatch ───────────────────────────────────────────────────────
     let kern_p1 = p1_kernel(BITS)?;

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
@@ -456,6 +456,196 @@ fn iso4_flash_decode_matches_reference_with_mask_across_tiles() {
     run_oracle_masked(4, 2, 4, (TILE_SIZE as usize) * 2 + 22, 128, true);
 }
 
+// ── Lazy, non-row-contiguous mask ─────────────────────────────────────────────
+//
+// The dispatcher no longer calls `mask_flat.eval()`. The mask is the one input
+// built by `astype` + `reshape` rather than `reshape` alone, and it is the only
+// input a caller can hand over as a strided view (`additive_mask` is a
+// pass-through parameter from `sdpa.rs`). Every other test in this file feeds a
+// freshly-built contiguous mask, so none of them would notice if dropping the
+// eval had cost the mask path something.
+//
+// This one feeds a transposed (non-row-contiguous) mask three ways and requires
+// all three to agree:
+//
+//   lazy      — strided view, never evaluated by the caller
+//   evaluated — same strided view, `eval()`ed first: what the removed call did.
+//               `eval()` materialises but does not relayout, so this array is
+//               still non-row-contiguous — which is why the removed call was
+//               never the source of the layout guarantee.
+//   contiguous — explicitly relaid out, the layout the kernel actually needs.
+//
+// Agreement proves the row-contiguous copy is applied by MLX inside the
+// kernel's `eval_gpu` (via `ensure_row_contiguous`), independent of when — or
+// whether — the caller materialises the input.
+
+/// How the transposed mask is handed to the dispatcher.
+#[derive(Clone, Copy)]
+enum MaskPrep {
+    /// Strided view, never evaluated by the caller — the post-fix path.
+    Lazy,
+    /// Strided view, `eval()`ed first — what the removed call did.
+    Evaluated,
+    /// Explicitly relaid out row-contiguous.
+    Contiguous,
+}
+
+/// Dispatch iso flash-decode with a mask supplied as a **transposed** view.
+///
+/// `prep` selects how that view is materialised before the dispatch, so the
+/// caller varies only the mask's materialisation/layout while holding
+/// everything else identical. Returns `None` when the GPU is unavailable.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn iso_decode_with_transposed_mask(bits: u8, mask_bf16: bool, prep: MaskPrep) -> Option<Vec<f32>> {
+    if skip_if_no_gpu_env() {
+        return None;
+    }
+    let (b, kv_h, heads_per_kv, kv_seq, head_dim) =
+        (1_usize, 2_usize, 4_usize, 40_usize, 128_usize);
+    let n_q_heads = kv_h * heads_per_kv;
+    let n_tokens = kv_seq * kv_h;
+
+    let q = lcg_data(n_q_heads * head_dim, 0xA11CE);
+    let k = lcg_data(n_tokens * head_dim, 0xB0B);
+    let v = lcg_data(n_tokens * head_dim, 0xC0FFEE);
+    let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+    let (codes, scales, norms, _k_deq) = iso_encode_for_test(&k, head_dim, bits);
+    let q_arr = make_f32_array(&q, &[b as i32, n_q_heads as i32, 1, head_dim as i32]);
+    let v_arr = make_f32_array(&v, &[b as i32, kv_h as i32, kv_seq as i32, head_dim as i32]);
+
+    // Build the mask in key-major order `[b, kv_seq, n_q_heads]`, then transpose
+    // to the `[b, n_q_heads, kv_seq]` the dispatcher expects. The result is a
+    // strided view over the key-major buffer, not a row-contiguous array.
+    let mask_km: Vec<f32> = (0..kv_seq * n_q_heads)
+        .map(|i| {
+            let s = i / n_q_heads;
+            let hq = i % n_q_heads;
+            if hq == 0 && s == kv_seq / 2 {
+                -1.0e30
+            } else {
+                (hq as f32) * 0.25 - (s as f32) * 0.03125
+            }
+        })
+        .collect();
+    let mask_src = make_f32_array(&mask_km, &[b as i32, kv_seq as i32, n_q_heads as i32]);
+    let mask_src = if mask_bf16 {
+        mask_src
+            .astype(Dtype::Bf16, Device::Gpu)
+            .expect("mask astype bf16")
+    } else {
+        mask_src
+    };
+    let mask_t = mask_src
+        .transpose(&[0, 2, 1], Device::Gpu)
+        .expect("mask transpose");
+    let mask = match prep {
+        MaskPrep::Lazy => mask_t,
+        MaskPrep::Evaluated => {
+            mask_t.eval().expect("mask eval");
+            mask_t
+        }
+        MaskPrep::Contiguous => mask_t.contiguous(Device::Gpu).expect("mask contiguous"),
+    };
+
+    let out = match bits {
+        3 => iso_flash_decode_sdpa::<3>(
+            &q_arr,
+            &codes,
+            &scales,
+            &norms,
+            &v_arr,
+            Some(&mask),
+            b as i32,
+            kv_h as i32,
+            kv_seq as i32,
+            head_dim as i32,
+            heads_per_kv as i32,
+            scale,
+            Device::Gpu,
+        ),
+        4 => iso_flash_decode_sdpa::<4>(
+            &q_arr,
+            &codes,
+            &scales,
+            &norms,
+            &v_arr,
+            Some(&mask),
+            b as i32,
+            kv_h as i32,
+            kv_seq as i32,
+            head_dim as i32,
+            heads_per_kv as i32,
+            scale,
+            Device::Gpu,
+        ),
+        other => panic!("iso_decode_with_transposed_mask: unsupported bits={other}"),
+    }
+    .expect("iso_flash_decode_sdpa");
+
+    Some(array_to_f32(&out))
+}
+
+/// Assert the three mask materialisation/layout variants agree elementwise.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn assert_lazy_mask_matches_evaluated(bits: u8, mask_bf16: bool) {
+    let Some(lazy) = iso_decode_with_transposed_mask(bits, mask_bf16, MaskPrep::Lazy) else {
+        return;
+    };
+    let evaluated = iso_decode_with_transposed_mask(bits, mask_bf16, MaskPrep::Evaluated)
+        .expect("gpu available on first call");
+    let contiguous = iso_decode_with_transposed_mask(bits, mask_bf16, MaskPrep::Contiguous)
+        .expect("gpu available on first call");
+
+    assert_eq!(lazy.len(), evaluated.len(), "bits={bits}: output length");
+    assert_eq!(lazy.len(), contiguous.len(), "bits={bits}: output length");
+    assert!(!lazy.is_empty(), "bits={bits}: empty output");
+
+    let mut max_eval_err = 0.0_f32;
+    let mut max_contig_err = 0.0_f32;
+    for ((l, e), c) in lazy.iter().zip(evaluated.iter()).zip(contiguous.iter()) {
+        assert!(l.is_finite(), "bits={bits}: non-finite output {l}");
+        max_eval_err = max_eval_err.max((l - e).abs());
+        max_contig_err = max_contig_err.max((l - c).abs());
+    }
+    assert!(
+        max_eval_err < 1e-5,
+        "bits={bits} bf16={mask_bf16}: lazy mask diverges from the pre-fix \
+         evaluated mask by {max_eval_err}"
+    );
+    assert!(
+        max_contig_err < 1e-5,
+        "bits={bits} bf16={mask_bf16}: lazy mask diverges from an explicitly \
+         row-contiguous mask by {max_contig_err}"
+    );
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
+fn iso3_flash_decode_lazy_noncontiguous_f32_mask_matches_evaluated() {
+    assert_lazy_mask_matches_evaluated(3, false);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
+fn iso4_flash_decode_lazy_noncontiguous_f32_mask_matches_evaluated() {
+    assert_lazy_mask_matches_evaluated(4, false);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
+fn iso3_flash_decode_lazy_noncontiguous_bf16_mask_matches_evaluated() {
+    // bf16 source exercises the dispatcher's `astype` + `reshape` mask branch,
+    // the one the removed `mask_flat.eval()` sat directly behind.
+    assert_lazy_mask_matches_evaluated(3, true);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run in isolation: cargo test iso_flash_decode -- --ignored --test-threads=1"]
+fn iso4_flash_decode_lazy_noncontiguous_bf16_mask_matches_evaluated() {
+    assert_lazy_mask_matches_evaluated(4, true);
+}
+
 // ── GQA ───────────────────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_symv_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_symv_msl.rs
@@ -450,11 +450,11 @@ pub fn iso_flash_decode_symv_sdpa<const BITS: u8>(
             .map_err(|e| Error::Mlx(format!("iso_flash_decode_symv dims: {e}")))?
     };
 
-    // Inputs stay lazy — do NOT force-evaluate them here. The raw-linear read
-    // needs row-contiguous buffers, and `MetalKernel::new` already asks MLX for
-    // that (`ensure_row_contiguous`), which copies a strided input before
-    // dispatch. A blocking `Array::eval` adds nothing to that guarantee and
-    // serialises the caller against the GPU once per layer per decode step.
+    // Inputs stay lazy — do NOT force-evaluate them here. `MetalKernel::apply`
+    // enqueues a graph node, so MLX materialises every input, and applies the
+    // `ensure_row_contiguous` copy, inside the kernel's own `eval_gpu`; a
+    // blocking eval buys no ordering and stalls the host once per layer per
+    // decode step. Full argument: `crate::flash_decode_common` module docs.
 
     // ── P1 dispatch ───────────────────────────────────────────────────────
     let kern_p1 = p1_kernel(BITS)?;

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_symv_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_symv_msl.rs
@@ -450,18 +450,11 @@ pub fn iso_flash_decode_symv_sdpa<const BITS: u8>(
             .map_err(|e| Error::Mlx(format!("iso_flash_decode_symv dims: {e}")))?
     };
 
-    // Materialise inputs to flush any pending lazy ops before kernel dispatch.
-    // The MSL kernels read by raw linear offset and ignore MLX lazy-transpose
-    // strides, so a pending permutation must be resolved here.
-    q_f32.eval()?;
-    for arr in [&k_codes, &k_scales, &k_norms, &v_codes, &v_scales, &v_norms] {
-        arr.eval()?;
-    }
-    if has_mask == 1 {
-        mask_flat.eval()?;
-    }
-    scale_arr.eval()?;
-    dims_arr.eval()?;
+    // Inputs stay lazy — do NOT force-evaluate them here. The raw-linear read
+    // needs row-contiguous buffers, and `MetalKernel::new` already asks MLX for
+    // that (`ensure_row_contiguous`), which copies a strided input before
+    // dispatch. A blocking `Array::eval` adds nothing to that guarantee and
+    // serialises the caller against the GPU once per layer per decode step.
 
     // ── P1 dispatch ───────────────────────────────────────────────────────
     let kern_p1 = p1_kernel(BITS)?;

--- a/crates/rmlx-kv-quant/src/iso_fused_qk_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_fused_qk_msl.rs
@@ -317,9 +317,10 @@ pub fn iso_fused_qk_sdpa<const BITS: u8>(
     let codes_flat = k_codes.reshape(&[codes_total as i32], device)?;
     let scales_flat = k_scales.reshape(&[scales_total as i32], device)?;
     let norms_flat = k_norms.reshape(&[norms_total as i32], device)?;
-    codes_flat.eval()?;
-    scales_flat.eval()?;
-    norms_flat.eval()?;
+    // Inputs stay lazy: `MetalKernel::apply` enqueues a graph node, so MLX
+    // materialises them — and applies `ensure_row_contiguous` — inside the
+    // kernel's own `eval_gpu`. A blocking eval here would only stall the host
+    // once per layer per decode step. See `crate::flash_decode_common` docs.
 
     let kernel = iso_qk_kernel(BITS)?;
     let mut invoke = MetalKernelInvoke::new();

--- a/crates/rmlx-kv-quant/src/isoquant_msl.rs
+++ b/crates/rmlx-kv-quant/src/isoquant_msl.rs
@@ -486,6 +486,9 @@ pub fn iso3_gpu_outputs_to_cpu(
         ));
     }
 
+    // eval-ok: host readback — the `to_bytes()` below copies this array to
+    // CPU, so it has to be materialised first. Not a kernel-input barrier: this
+    // runs once per quantize call, off the per-decode-step path.
     codes_gpu.eval()?;
     #[allow(
         clippy::expect_used,
@@ -496,6 +499,9 @@ pub fn iso3_gpu_outputs_to_cpu(
         .chunks_exact(4)
         .map(|b| u32::from_le_bytes(b.try_into().expect("len 4 by chunks_exact contract")))
         .collect();
+    // eval-ok: host readback — the `to_bytes()` below copies this array to
+    // CPU, so it has to be materialised first. Not a kernel-input barrier: this
+    // runs once per quantize call, off the per-decode-step path.
     scales_gpu.eval()?;
     #[allow(
         clippy::expect_used,
@@ -506,6 +512,9 @@ pub fn iso3_gpu_outputs_to_cpu(
         .chunks_exact(4)
         .map(|b| f32::from_le_bytes(b.try_into().expect("len 4 by chunks_exact contract")))
         .collect();
+    // eval-ok: host readback — the `to_bytes()` below copies this array to
+    // CPU, so it has to be materialised first. Not a kernel-input barrier: this
+    // runs once per quantize call, off the per-decode-step path.
     norms_gpu.eval()?;
     #[allow(
         clippy::expect_used,

--- a/crates/rmlx-kv-quant/src/isoquant_msl_v4.rs
+++ b/crates/rmlx-kv-quant/src/isoquant_msl_v4.rs
@@ -556,6 +556,9 @@ pub fn iso4_gpu_outputs_to_cpu(
 
     // chunks_exact(4) yields slices of exactly 4 bytes by contract, so the
     // try_into never fails; expect documents the invariant for the type check.
+    // eval-ok: host readback — the `to_bytes()` below copies this array to
+    // CPU, so it has to be materialised first. Not a kernel-input barrier: this
+    // runs once per quantize call, off the per-decode-step path.
     codes_gpu.eval()?;
     #[allow(
         clippy::expect_used,
@@ -566,6 +569,9 @@ pub fn iso4_gpu_outputs_to_cpu(
         .chunks_exact(4)
         .map(|b| u32::from_le_bytes(b.try_into().expect("len 4 by chunks_exact contract")))
         .collect();
+    // eval-ok: host readback — the `to_bytes()` below copies this array to
+    // CPU, so it has to be materialised first. Not a kernel-input barrier: this
+    // runs once per quantize call, off the per-decode-step path.
     scales_gpu.eval()?;
     #[allow(
         clippy::expect_used,
@@ -576,6 +582,9 @@ pub fn iso4_gpu_outputs_to_cpu(
         .chunks_exact(4)
         .map(|b| f32::from_le_bytes(b.try_into().expect("len 4 by chunks_exact contract")))
         .collect();
+    // eval-ok: host readback — the `to_bytes()` below copies this array to
+    // CPU, so it has to be materialised first. Not a kernel-input barrier: this
+    // runs once per quantize call, off the per-decode-step path.
     norms_gpu.eval()?;
     #[allow(
         clippy::expect_used,

--- a/crates/rmlx-kv-quant/src/planar_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/planar_flash_decode_msl.rs
@@ -472,24 +472,20 @@ pub fn planar_flash_decode_sdpa(
             .map_err(|e| Error::Mlx(format!("planar_flash_decode dims: {e}")))?
     };
 
-    // eval-ok: kept as an ordering barrier for the planar_quantize atomic-OR
-    // race found during fused-QK development — a different reason from the
-    // row-contiguous precaution the iso/rotor dispatchers carried, which was
-    // redundant against `ensure_row_contiguous` and has been removed. The
-    // barrier costs the same per-layer host stall those did, so if the race is
-    // real it belongs in the quantize kernel rather than here; that has not
-    // been re-verified, and this path is off by default
-    // (`--planar-flash-decode auto` = OFF), so the barrier stays for now.
-    q_f32.eval()?;
-    codes_flat.eval()?;
-    scales_flat.eval()?;
-    rot_flat.eval()?;
-    v_flat.eval()?;
-    if has_mask == 1 {
-        mask_flat.eval()?;
-    }
-    scale_arr.eval()?;
-    dims_arr.eval()?;
+    // Inputs stay lazy — do NOT force-evaluate them here. `MetalKernel::apply`
+    // enqueues a graph node, so MLX materialises every input, and applies the
+    // `ensure_row_contiguous` copy, inside the kernel's own `eval_gpu`; a
+    // blocking eval buys no ordering and stalls the host once per layer per
+    // decode step. Full argument: `crate::flash_decode_common` module docs.
+    //
+    // These calls also used to be justified as a barrier against a
+    // `planar_quantize` atomic-OR race. That hazard is handled where it
+    // arises: `planar_quantize_v4_gpu` zero-initialises its atomically-ORed
+    // outputs (`set_init_value(0.0)`), same as the iso and rotor quantize
+    // kernels. A blocking eval on the *decode* kernel's inputs could not have
+    // repaired a corrupted *quantize* output in any case — it only shifts
+    // timing, which is what a barrier masking a race looks like rather than a
+    // fix for one.
 
     // ── P1 dispatch ───────────────────────────────────────────────────────
     let kern_p1 = p1_kernel_v4()?;

--- a/crates/rmlx-kv-quant/src/planar_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/planar_flash_decode_msl.rs
@@ -472,9 +472,14 @@ pub fn planar_flash_decode_sdpa(
             .map_err(|e| Error::Mlx(format!("planar_flash_decode dims: {e}")))?
     };
 
-    // Materialise inputs to flush any pending lazy ops before kernel dispatch
-    // (guards against the planar_quantize atomic-OR race discovered during
-    // fused-QK development).
+    // eval-ok: kept as an ordering barrier for the planar_quantize atomic-OR
+    // race found during fused-QK development — a different reason from the
+    // row-contiguous precaution the iso/rotor dispatchers carried, which was
+    // redundant against `ensure_row_contiguous` and has been removed. The
+    // barrier costs the same per-layer host stall those did, so if the race is
+    // real it belongs in the quantize kernel rather than here; that has not
+    // been re-verified, and this path is off by default
+    // (`--planar-flash-decode auto` = OFF), so the barrier stays for now.
     q_f32.eval()?;
     codes_flat.eval()?;
     scales_flat.eval()?;

--- a/crates/rmlx-kv-quant/src/planar_fused_qk_msl.rs
+++ b/crates/rmlx-kv-quant/src/planar_fused_qk_msl.rs
@@ -368,16 +368,15 @@ pub fn planar_fused_qk(
     .collect();
     let dims_arr = Array::from_bytes(&dims_bytes, &[4], Dtype::U32)?;
 
-    // Materialise all inputs before dispatch — upstream lazy ops (e.g. the
-    // planar quantize atomic-OR accumulation) may still be pending, which
-    // would let the fused-QK kernel read partially-populated buffers and
-    // produce garbage (~1e38 magnitudes seen in early development).
-    q_f32.eval()?;
-    codes_flat.eval()?;
-    scales_flat.eval()?;
-    rot32_flat.eval()?;
-    scale_arr.eval()?;
-    dims_arr.eval()?;
+    // Inputs stay lazy: `MetalKernel::apply` enqueues a graph node, so MLX
+    // materialises them — and applies `ensure_row_contiguous` — inside the
+    // kernel's own `eval_gpu`. A blocking eval here would only stall the host
+    // once per layer per decode step. See `crate::flash_decode_common` docs.
+    //
+    // The former justification here — a barrier against pending
+    // `planar_quantize` atomic-OR accumulation — described a hazard that is
+    // handled where it arises: `planar_quantize_v4_gpu` zero-initialises its
+    // atomically-ORed outputs (`set_init_value(0.0)`).
 
     let kernel = qk_kernel(bits)?;
     PLANAR_FUSED_QK_DISPATCHES.fetch_add(1, Ordering::Relaxed);

--- a/crates/rmlx-kv-quant/src/q8_fused_qk_msl.rs
+++ b/crates/rmlx-kv-quant/src/q8_fused_qk_msl.rs
@@ -196,8 +196,10 @@ pub fn q8_fused_qk_sdpa(
     let scales_total: i64 = tok_count * i64::from(head_dim) / (Q8_GROUP_SIZE as i64);
     let codes_flat = k_codes.reshape(&[codes_total as i32], device)?;
     let scales_flat = k_scales.reshape(&[scales_total as i32], device)?;
-    codes_flat.eval()?;
-    scales_flat.eval()?;
+    // Inputs stay lazy: `MetalKernel::apply` enqueues a graph node, so MLX
+    // materialises them — and applies `ensure_row_contiguous` — inside the
+    // kernel's own `eval_gpu`. A blocking eval here would only stall the host
+    // once per layer per decode step. See `crate::flash_decode_common` docs.
 
     let kernel = qk_kernel()?;
     let mut invoke = MetalKernelInvoke::new();

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_msl.rs
@@ -691,20 +691,11 @@ pub fn rotor_flash_decode_sdpa<const BITS: u8>(
             .map_err(|e| Error::Mlx(format!("rotor_flash_decode dims: {e}")))?
     };
 
-    // Materialise inputs to flush any pending lazy ops before kernel dispatch.
-    // The MSL kernels read by raw linear offset and ignore MLX lazy-transpose
-    // strides, so a pending permutation must be resolved here.
-    q_f32.eval()?;
-    codes_flat.eval()?;
-    scales_flat.eval()?;
-    norms_flat.eval()?;
-    rotors_flat.eval()?;
-    v_flat.eval()?;
-    if has_mask == 1 {
-        mask_flat.eval()?;
-    }
-    scale_arr.eval()?;
-    dims_arr.eval()?;
+    // Inputs stay lazy — do NOT force-evaluate them here. The raw-linear read
+    // needs row-contiguous buffers, and `MetalKernel::new` already asks MLX for
+    // that (`ensure_row_contiguous`), which copies a strided input before
+    // dispatch. A blocking `Array::eval` adds nothing to that guarantee and
+    // serialises the caller against the GPU once per layer per decode step.
 
     // ── P1 dispatch ───────────────────────────────────────────────────────
     let kern_p1 = p1_kernel(BITS)?;

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_msl.rs
@@ -691,11 +691,11 @@ pub fn rotor_flash_decode_sdpa<const BITS: u8>(
             .map_err(|e| Error::Mlx(format!("rotor_flash_decode dims: {e}")))?
     };
 
-    // Inputs stay lazy — do NOT force-evaluate them here. The raw-linear read
-    // needs row-contiguous buffers, and `MetalKernel::new` already asks MLX for
-    // that (`ensure_row_contiguous`), which copies a strided input before
-    // dispatch. A blocking `Array::eval` adds nothing to that guarantee and
-    // serialises the caller against the GPU once per layer per decode step.
+    // Inputs stay lazy — do NOT force-evaluate them here. `MetalKernel::apply`
+    // enqueues a graph node, so MLX materialises every input, and applies the
+    // `ensure_row_contiguous` copy, inside the kernel's own `eval_gpu`; a
+    // blocking eval buys no ordering and stalls the host once per layer per
+    // decode step. Full argument: `crate::flash_decode_common` module docs.
 
     // ── P1 dispatch ───────────────────────────────────────────────────────
     let kern_p1 = p1_kernel(BITS)?;

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl.rs
@@ -469,11 +469,11 @@ pub fn rotor_flash_decode_symv_sdpa<const BITS: u8>(
             .map_err(|e| Error::Mlx(format!("rotor_flash_decode_symv dims: {e}")))?
     };
 
-    // Inputs stay lazy — do NOT force-evaluate them here. The raw-linear read
-    // needs row-contiguous buffers, and `MetalKernel::new` already asks MLX for
-    // that (`ensure_row_contiguous`), which copies a strided input before
-    // dispatch. A blocking `Array::eval` adds nothing to that guarantee and
-    // serialises the caller against the GPU once per layer per decode step.
+    // Inputs stay lazy — do NOT force-evaluate them here. `MetalKernel::apply`
+    // enqueues a graph node, so MLX materialises every input, and applies the
+    // `ensure_row_contiguous` copy, inside the kernel's own `eval_gpu`; a
+    // blocking eval buys no ordering and stalls the host once per layer per
+    // decode step. Full argument: `crate::flash_decode_common` module docs.
 
     // ── P1 dispatch ───────────────────────────────────────────────────────
     let kern_p1 = p1_kernel(BITS)?;

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_symv_msl.rs
@@ -469,20 +469,11 @@ pub fn rotor_flash_decode_symv_sdpa<const BITS: u8>(
             .map_err(|e| Error::Mlx(format!("rotor_flash_decode_symv dims: {e}")))?
     };
 
-    // Materialise inputs to flush any pending lazy ops before kernel dispatch.
-    // The MSL kernels read by raw linear offset and ignore MLX lazy-transpose
-    // strides, so a pending permutation must be resolved here.
-    q_f32.eval()?;
-    for arr in [
-        &k_codes, &k_scales, &k_norms, &k_rotors, &v_codes, &v_scales, &v_norms, &v_rotors,
-    ] {
-        arr.eval()?;
-    }
-    if has_mask == 1 {
-        mask_flat.eval()?;
-    }
-    scale_arr.eval()?;
-    dims_arr.eval()?;
+    // Inputs stay lazy — do NOT force-evaluate them here. The raw-linear read
+    // needs row-contiguous buffers, and `MetalKernel::new` already asks MLX for
+    // that (`ensure_row_contiguous`), which copies a strided input before
+    // dispatch. A blocking `Array::eval` adds nothing to that guarantee and
+    // serialises the caller against the GPU once per layer per decode step.
 
     // ── P1 dispatch ───────────────────────────────────────────────────────
     let kern_p1 = p1_kernel(BITS)?;

--- a/crates/rmlx-kv-quant/src/rotor_fused_qk_msl.rs
+++ b/crates/rmlx-kv-quant/src/rotor_fused_qk_msl.rs
@@ -496,14 +496,10 @@ pub fn rotor_fused_qk_sdpa_generic<const BITS: u8>(
         Array::from_bytes(bytes, &[6], Dtype::U32)?
     };
 
-    q_f32.eval()?;
-    codes_flat.eval()?;
-    scales_flat.eval()?;
-    norms_flat.eval()?;
-    rotors_flat.eval()?;
-    mask_flat.eval()?;
-    scale_arr.eval()?;
-    dims_arr.eval()?;
+    // Inputs stay lazy: `MetalKernel::apply` enqueues a graph node, so MLX
+    // materialises them — and applies `ensure_row_contiguous` — inside the
+    // kernel's own `eval_gpu`. A blocking eval here would only stall the host
+    // once per layer per decode step. See `crate::flash_decode_common` docs.
 
     let kernel = rotor_qk_kernel(BITS)?;
     let mut invoke = MetalKernelInvoke::new();

--- a/crates/rmlx-kv-quant/src/rotorquant_msl.rs
+++ b/crates/rmlx-kv-quant/src/rotorquant_msl.rs
@@ -782,6 +782,9 @@ pub fn rotor_gpu_outputs_to_cpu(
         ));
     }
 
+    // eval-ok: host readback — the `to_bytes()` below copies this array to
+    // CPU, so it has to be materialised first. Not a kernel-input barrier: this
+    // runs once per quantize call, off the per-decode-step path.
     codes_gpu.eval()?;
     #[allow(
         clippy::expect_used,
@@ -792,6 +795,9 @@ pub fn rotor_gpu_outputs_to_cpu(
         .chunks_exact(4)
         .map(|b| u32::from_le_bytes(b.try_into().expect("len 4 by chunks_exact contract")))
         .collect();
+    // eval-ok: host readback — the `to_bytes()` below copies this array to
+    // CPU, so it has to be materialised first. Not a kernel-input barrier: this
+    // runs once per quantize call, off the per-decode-step path.
     scales_gpu.eval()?;
     #[allow(
         clippy::expect_used,
@@ -802,6 +808,9 @@ pub fn rotor_gpu_outputs_to_cpu(
         .chunks_exact(4)
         .map(|b| f32::from_le_bytes(b.try_into().expect("len 4 by chunks_exact contract")))
         .collect();
+    // eval-ok: host readback — the `to_bytes()` below copies this array to
+    // CPU, so it has to be materialised first. Not a kernel-input barrier: this
+    // runs once per quantize call, off the per-decode-step path.
     norms_gpu.eval()?;
     #[allow(
         clippy::expect_used,

--- a/crates/rmlx-kv-quant/src/sparse_attn/phase1_score_msl.rs
+++ b/crates/rmlx-kv-quant/src/sparse_attn/phase1_score_msl.rs
@@ -292,12 +292,10 @@ pub fn phase1_score(
             .map_err(|e| Error::Mlx(format!("phase1_score dims: {e}")))?
     };
 
-    q_f32.eval()?;
-    codes_flat.eval()?;
-    scales_flat.eval()?;
-    rot_flat.eval()?;
-    scale_arr.eval()?;
-    dims_arr.eval()?;
+    // Inputs stay lazy: `MetalKernel::apply` enqueues a graph node, so MLX
+    // materialises them — and applies `ensure_row_contiguous` — inside the
+    // kernel's own `eval_gpu`. A blocking eval here would only stall the host
+    // once per layer per decode step. See `crate::flash_decode_common` docs.
 
     let kern = p1_kernel()?;
     let mut inv = MetalKernelInvoke::new();

--- a/crates/rmlx-kv-quant/src/sparse_attn/phase2_sparse_attend_msl.rs
+++ b/crates/rmlx-kv-quant/src/sparse_attn/phase2_sparse_attend_msl.rs
@@ -330,15 +330,15 @@ pub fn phase2_sparse_attend(
             .map_err(|e| Error::Mlx(format!("phase2_sparse_attend dims: {e}")))?
     };
 
-    q_f32.eval()?;
-    codes_flat.eval()?;
-    scales_flat.eval()?;
-    rot_flat.eval()?;
-    v_flat.eval()?;
-    all_scores_flat.eval()?;
-    head_threshold_flat.eval()?;
-    scale_arr.eval()?;
-    dims_arr.eval()?;
+    // Inputs stay lazy: `MetalKernel::apply` enqueues a graph node, so MLX
+    // materialises them — and applies `ensure_row_contiguous` — inside the
+    // kernel's own `eval_gpu`. A blocking eval here would only stall the host
+    // once per layer per decode step. See `crate::flash_decode_common` docs.
+    //
+    // `head_threshold` is built host-side between Phase 1 and Phase 2, but the
+    // host sync that implies already happened in the caller, which reads
+    // Phase-1's `tile_top_scores` back to CPU to compute it. Re-evaluating the
+    // reshaped result here adds nothing.
 
     let kern = p2_kernel()?;
     let mut inv = MetalKernelInvoke::new();
@@ -424,9 +424,10 @@ pub fn phase2_lse_merge(
             .map_err(|e| Error::Mlx(format!("phase2_lse_merge dims_p2: {e}")))?
     };
 
-    partial_flat.eval()?;
-    lse_flat.eval()?;
-    dims_p2_arr.eval()?;
+    // Inputs stay lazy: `MetalKernel::apply` enqueues a graph node, so MLX
+    // materialises them — and applies `ensure_row_contiguous` — inside the
+    // kernel's own `eval_gpu`. A blocking eval here would only stall the host
+    // once per layer per decode step. See `crate::flash_decode_common` docs.
 
     let kern = merge_kernel()?;
     let mut inv = MetalKernelInvoke::new();

--- a/crates/rmlx-kv-quant/src/turbo_k3_fused_qk_msl.rs
+++ b/crates/rmlx-kv-quant/src/turbo_k3_fused_qk_msl.rs
@@ -190,8 +190,10 @@ pub fn turbo_k3_fused_qk_sdpa(
     let scales_total: i64 = tok_count * i64::from(head_dim) / (GROUP_SIZE as i64);
     let codes_flat = k_codes.reshape(&[codes_total as i32], device)?;
     let scales_flat = k_scales.reshape(&[scales_total as i32], device)?;
-    codes_flat.eval()?;
-    scales_flat.eval()?;
+    // Inputs stay lazy: `MetalKernel::apply` enqueues a graph node, so MLX
+    // materialises them — and applies `ensure_row_contiguous` — inside the
+    // kernel's own `eval_gpu`. A blocking eval here would only stall the host
+    // once per layer per decode step. See `crate::flash_decode_common` docs.
 
     let kernel = qk_kernel()?;
     let mut invoke = MetalKernelInvoke::new();

--- a/crates/rmlx-kv-quant/src/turbo_k4_fused_qk_msl.rs
+++ b/crates/rmlx-kv-quant/src/turbo_k4_fused_qk_msl.rs
@@ -195,8 +195,10 @@ pub fn turbo_k4_fused_qk_sdpa(
     let scales_total: i64 = tok_count * i64::from(head_dim) / (GROUP_SIZE as i64);
     let codes_flat = k_codes.reshape(&[codes_total as i32], device)?;
     let scales_flat = k_scales.reshape(&[scales_total as i32], device)?;
-    codes_flat.eval()?;
-    scales_flat.eval()?;
+    // Inputs stay lazy: `MetalKernel::apply` enqueues a graph node, so MLX
+    // materialises them — and applies `ensure_row_contiguous` — inside the
+    // kernel's own `eval_gpu`. A blocking eval here would only stall the host
+    // once per layer per decode step. See `crate::flash_decode_common` docs.
 
     let kernel = qk_kernel()?;
     let mut invoke = MetalKernelInvoke::new();

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -460,6 +460,21 @@ methods trigger execution:
   current step's argmax is still being read back to the CPU, mirroring
   mlx-lm's `mx.async_eval` pattern in `generate.py`.
 
+**Never `eval()` a kernel's inputs before dispatching it.** `Array::eval()`
+blocks the calling thread until the GPU has produced the array, so an `eval()`
+inside a per-layer dispatcher runs the forward pass one layer at a time with
+nothing queued ahead — the host and the GPU stop overlapping. It produces
+byte-identical output, which is why the cost hides: it shows up only as a
+decode rate several times below what the kernel can reach. A KV flash-decode
+dispatcher paying this on every attention layer measured **2.7× below** its own
+rate on Ternary-Bonsai-8B once the `eval()` calls were dropped, with the token
+digest unchanged. Pass lazy arrays to `MetalKernel::apply` and let MLX schedule
+the graph; the row-contiguous guarantee a raw-linear kernel needs comes from
+`ensure_row_contiguous` (below), not from forcing evaluation. The CI gate
+`make check-no-kernel-input-eval` enforces this for the flash-decode
+dispatchers, with an `// eval-ok: <reason>` marker for a genuinely load-bearing
+barrier.
+
 ### Data readback
 
 `Array::to_bytes()` forces evaluation (`eval()`) before reading, then calls
@@ -685,6 +700,15 @@ mlx-c copies them internally.
 `ensure_row_contiguous = true` is always set — the safer default for custom
 kernels. `atomic_outputs = false` unless the kernel requires read-modify-write
 atomics (e.g. `atomic_fetch_or_explicit`).
+
+`ensure_row_contiguous` is what makes it safe for a kernel body to index its
+buffers by raw linear offset: MLX copies any input that is not row-contiguous
+(a lazy transpose, a strided view) before the dispatch. Callers therefore do
+**not** need to materialise inputs themselves — see "Never `eval()` a kernel's
+inputs" under Evaluation. It does not fix a *semantic* layout disagreement: an
+array whose logical axis order is not the one the kernel indexes is still wrong
+after the copy, and that is what the canonical seq-major KV store layout is
+for.
 
 `MetalKernel::apply` takes a `MetalKernelInvoke` by value (consumed), builds
 input/output `mlx_vector_array` handles, dispatches via

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -468,12 +468,34 @@ byte-identical output, which is why the cost hides: it shows up only as a
 decode rate several times below what the kernel can reach. A KV flash-decode
 dispatcher paying this on every attention layer measured **2.7× below** its own
 rate on Ternary-Bonsai-8B once the `eval()` calls were dropped, with the token
-digest unchanged. Pass lazy arrays to `MetalKernel::apply` and let MLX schedule
-the graph; the row-contiguous guarantee a raw-linear kernel needs comes from
-`ensure_row_contiguous` (below), not from forcing evaluation. The CI gate
-`make check-no-kernel-input-eval` enforces this for the flash-decode
-dispatchers, with an `// eval-ok: <reason>` marker for a genuinely load-bearing
-barrier.
+digest unchanged.
+
+Pass lazy arrays to `MetalKernel::apply` and let MLX schedule the graph. Two
+facts make that safe, and both are worth stating because the comment this rule
+replaced got each of them wrong:
+
+* **Ordering.** `MetalKernel::apply` enqueues an MLX `fast::CustomKernel` graph
+  node; it does not dispatch. MLX runs that node's `eval_gpu` only once every
+  input edge is materialised, and applies the `ensure_row_contiguous` copy
+  (below) inside that same `eval_gpu`. A kernel cannot read an uncomputed or
+  strided buffer, so a caller-side `eval()` buys no ordering — it only changes
+  *when* the host blocks.
+* **Layout.** `Array::eval()` materialises but does **not** relayout. MLX's
+  `Transpose` is a strided view over a shared buffer, so an evaluated transpose
+  is still non-row-contiguous. The layout guarantee for a raw-linear kernel
+  always came from `reshape` plus `ensure_row_contiguous`, never from forcing
+  evaluation.
+
+The CI gate `make check-no-kernel-input-eval` enforces this across every
+custom-Metal-kernel dispatcher and shared dispatcher scaffold in the KV codec
+layer (keyed on the file constructing a `MetalKernelInvoke`, or being a
+`*_common.rs` scaffold — not on a codec name), with an `// eval-ok: <reason>`
+marker for a genuinely load-bearing call such as a host readback before
+`to_bytes()`. One marker exempts one call.
+`make check-no-kernel-input-eval-fixtures` is the gate's own recall test: a
+fixture tree per evasion (UFCS `Array::eval(&x)`, an eval moved into a shared
+`_common.rs` helper, a dispatcher relocated into a sub-directory, a marker
+leaking onto a following loop) pinned to the exit code the gate must produce.
 
 ### Data readback
 

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2909,10 +2909,22 @@ before dispatch, which blocked the host on the GPU once per attention layer per
 decode step. That alone was worth 1.2–2.9× decode across iso and rotor, K-only
 and `_sym`, on both `kv_h = 8` and `kv_h = 1` architectures — the `_sym` pair at
 a 4k prompt on Ternary-Bonsai-8B went 19.1 → 55.1 TPS with an unchanged token
-digest. Any per-codec marginal-cost figure recorded before that (including the
-tables in `docs/models/bonsai/8B/rMLX.md` §2 and issue #292) is measuring the
-dispatcher, not the kernel. `make check-no-kernel-input-eval` keeps it from
-coming back.
+digest.
+
+**What that invalidates, and what it does not.** The eval was a *fixed* cost per
+decode step — one host↔GPU round trip per attention layer, the same count
+whatever the KV length. It therefore moves the **intercept** of per-step decode
+time and leaves the **slope** alone. Fitting `ms/step = a + b × (KV tokens/1000)`
+across the binary pair: `a` 41.14 → **7.01 ms/step (−83%)**, `b` 2.437 → **2.449
+ms/1k KV tokens (+0.5%)** — ≈34 ms/step recovered, which over the layer count is
+≈0.16 ms per eval, a textbook round trip.
+
+So: every **absolute decode-TPS** cell for these codecs recorded before this
+change measures the dispatcher and must be re-recorded — including the tables in
+`docs/models/bonsai/8B/rMLX.md` §2 and issue #292. **Marginal-cost figures
+(ms/1k KV tokens) survive**: a slope cancels a fixed per-step cost by
+construction, so a published ms/1k table is still valid and should not be
+discarded. `make check-no-kernel-input-eval` keeps the defect from coming back.
 
 So these codecs remain opt-in (`--kv-quant rotor3_sym` / `rotor4_sym`, and the
 iso pair), and remain research codecs for quality experiments and kernel work —

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2893,14 +2893,33 @@ same two predicates — it cannot drift from what is materialised.
 
 ### Speed vs. the mirror (honest)
 
-Dropping the mirror is a **memory** win, not a decode-speed win on the current
-two-pass shell. Against the MLX bf16 flash attention the dormant mirror used, the
-fused quant-K + quant-V path is materially slower at long context — the dominant
-gap is the two-pass flash-decode shell, not the V unpack. So `rotor*_sym` remains
-opt-in (`--kv-quant rotor3_sym` / `rotor4_sym`); it is the right pick when
-resident KV is the binding constraint, not when peak decode TPS is. Closing the
-speed gap needs a single-pass simdgroup flash-decode that beats MLX bf16 flash
-(tracked with `#45`).
+Dropping the mirror is **neither** a memory win nor a decode-speed win. It is
+not a memory win because the store is not smaller than bf16 to begin with (see
+"Memory truth" above — 21.75 bits/value for rotor, 16.25 for iso), so there is
+no bandwidth prize to collect and no context at which a crossover exists. It is
+not a speed win because the two-pass flash-decode shell — a per-token
+threadgroup barrier pair with a thread-0-only softmax section, one threadgroup
+per *query* head (so `heads_per_kv` threadgroups re-read the same KV stream),
+and an f32 `partial_o` round trip between P1 and P2 — costs more per token than
+MLX's bf16 flash attention over the same bytes.
+
+What is **no longer** part of that gap: until the dispatchers were made lazy,
+every one of these kernels forced `Array::eval()` on its inputs immediately
+before dispatch, which blocked the host on the GPU once per attention layer per
+decode step. That alone was worth 1.2–2.9× decode across iso and rotor, K-only
+and `_sym`, on both `kv_h = 8` and `kv_h = 1` architectures — the `_sym` pair at
+a 4k prompt on Ternary-Bonsai-8B went 19.1 → 55.1 TPS with an unchanged token
+digest. Any per-codec marginal-cost figure recorded before that (including the
+tables in `docs/models/bonsai/8B/rMLX.md` §2 and issue #292) is measuring the
+dispatcher, not the kernel. `make check-no-kernel-input-eval` keeps it from
+coming back.
+
+So these codecs remain opt-in (`--kv-quant rotor3_sym` / `rotor4_sym`, and the
+iso pair), and remain research codecs for quality experiments and kernel work —
+not memory or throughput candidates. Closing the remaining speed gap needs a
+single-pass simdgroup flash-decode that beats MLX bf16 flash (tracked with
+`#45`); closing the memory gap needs a repacked store, which is a redesign, not
+a kernel change.
 
 ### Short-prompt abort at `kv_h == 1` — small-`norms`-buffer device floor
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -193,13 +193,41 @@ were recorded before the flash-decode-over-quant kernels
 before `--rotor-qjl` flipped to default `off`, and they encode a causal story
 that no longer holds. The paragraph they carried claimed the K-only variants
 trail their `*_sym` siblings because the K side had no GPU-resident code mirror
-and paid a CPU `dequant()` of the whole prefix per step. Both halves are now
-false: the K-only stores keep a GPU ring the kernel reads directly, and the
-measured relation is **inverted** — on Bonsai-8B at a 4k prompt `k_iso3`
-decodes at ≈19 TPS against `iso3_sym`'s ≈14, and the gap widens with context.
-Symmetric codecs are now the slower tier, because quantizing V puts a second
-dequant inside the decode kernel. Live numbers per (codec, context) live in
-`docs/models/bonsai/8B/rMLX.md` §2; re-record these cells before using them.
+and paid a CPU `dequant()` of the whole prefix per step. Both halves are false:
+the K-only stores keep a GPU ring the kernel reads directly, and neither the
+K-only nor the `_sym` tier is CPU-bound at decode.
+
+The successor claim — that the `_sym` tier is the slower one *because
+quantizing V puts a second dequant inside the decode kernel* — is also wrong,
+and the reason it read that way was a dispatcher defect, not the V axis. Every
+iso / rotor flash-decode dispatcher forced `Array::eval()` on its kernel inputs
+immediately before dispatch, blocking the host on the GPU once per attention
+layer per decode step. Removing it (the graph is left lazy; MLX's
+`ensure_row_contiguous` already supplies the layout guarantee the raw-linear
+kernels need) is worth **1.17–2.89×** decode across the family, with the token
+digest, the KV bytes and TTFT all unchanged. Measured `rmlx bench`, n=3 per
+cell, `release-perf`, one binary pair:
+
+| model | ctx | `iso3_sym` | `k_iso3` | `rotor3_sym` | `k_rotor3` | `none` (control) |
+|---|---|---|---|---|---|---|
+| Bonsai-8B | 4k | 19.09 → **55.15** | — → 56.98 | — | — | 138.5 → 139.2 (+0.5%) |
+| Bonsai-8B | 16k | 11.00 → **19.01** | 14.90 → **24.37** | 10.13 → **16.03** | 13.73 → **21.59** | 93.7 → 93.3 (−0.5%) |
+| Bonsai-8B | 32k | 7.67 → **10.44** | 9.81 → **13.53** | — | — | 65.1 → 63.9 (−1.9%) |
+| gemma-4-e2b | 4k | 65.57 → **100.20** | 76.33 → **107.09** | — | — | 129.1 → 128.1 (−0.7%) |
+| gemma-4-e2b | 16k | 42.42 → **57.04** | 53.73 → **66.64** | 35.15 → **44.52** | 47.70 → **58.07** | 119.4 → 120.8 (+1.2%) |
+| gemma-4-e2b | 32k | 29.56 → **35.58** | 37.76 → **44.34** | — | — | 112.9 → 113.9 (+0.9%) |
+
+`none` is the null control: it reaches none of the four changed dispatchers, and
+its six cells bound the session's measurement noise at ±1.9%. The Bonsai
+`k_iso3` 4k base cell is absent because `rmlx bench` refused it — the pre-fix
+binary scattered 19.65 / 24.71 / 19.76 TPS (25.6% of median) at that cell, over
+the 15% settle ceiling. Narrower run-to-run spread after the fix is a
+consistent second-order effect: a host-side GPU wait per layer makes the cell
+sensitive to host scheduling (e2b `iso3_sym` @4k: 7.41% range → 0.77%).
+
+**Every number in the family recorded before this change measures the
+dispatcher, not the kernel** — re-record before use. Live numbers per (codec,
+context) live in `docs/models/bonsai/8B/rMLX.md` §2.
 
 **Neither tier competes with `none` on either axis.** The whole iso/rotor
 family stores one `u32` code word plus one `f32` scale per group, so it is

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -225,9 +225,18 @@ the 15% settle ceiling. Narrower run-to-run spread after the fix is a
 consistent second-order effect: a host-side GPU wait per layer makes the cell
 sensitive to host scheduling (e2b `iso3_sym` @4k: 7.41% range → 0.77%).
 
-**Every number in the family recorded before this change measures the
-dispatcher, not the kernel** — re-record before use. Live numbers per (codec,
-context) live in `docs/models/bonsai/8B/rMLX.md` §2.
+**Every absolute decode-TPS number in the family recorded before this change
+measures the dispatcher, not the kernel** — re-record before use. Live numbers
+per (codec, context) live in `docs/models/bonsai/8B/rMLX.md` §2.
+
+**Marginal-cost figures (ms per 1k KV tokens) are not invalidated.** The eval was
+a fixed cost per decode step — one host↔GPU round trip per attention layer,
+independent of KV length — so it lands entirely in the intercept of
+`ms/step = a + b × (KV tokens/1000)` and a slope cancels it by construction.
+Fitted across this binary pair: `a` 41.14 → **7.01 ms/step (−83%)**, `b` 2.437 →
+**2.449 ms/1k KV tokens (+0.5%)**. The ≈34 ms/step recovered is ≈0.16 ms per
+eval over the layer count, a textbook round trip. A published ms/1k table stays
+valid; do not discard one on the strength of this fix.
 
 **Neither tier competes with `none` on either axis.** The whole iso/rotor
 family stores one `u32` code word plus one `f32` scale per group, so it is

--- a/docs/models/bonsai/8B/rMLX.md
+++ b/docs/models/bonsai/8B/rMLX.md
@@ -24,6 +24,27 @@ discarded. Bar (§3): WIN / TIE-on-noise / LOSS.
 > because they were CPU-bound; that cap is gone — both families now run the
 > complete 4k–64k range on the new flash-decode-over-quant kernels (§0, §4).
 
+> ⚠️ **Superseded for the iso / rotor rows (2026-08-15).** Every `iso*` / `rotor*`
+> / `k_iso*` / `k_rotor*` decode cell in this document — the §2 matrix, the §2.2
+> marginal-cost fits, and the §0 root-cause bullets that rest on them — was
+> measured against a dispatcher that forced `Array::eval()` on its kernel inputs
+> once per attention layer per decode step, blocking the host on the GPU. With
+> that removed, a paired `rmlx bench` A/B (n=3, one binary pair, `none` as the
+> null control) reads **+17% to +189%** on those codecs at unchanged token
+> digest, KV bytes and TTFT: Bonsai `iso3_sym` 19.09 → **55.15** @4k,
+> 11.00 → **19.01** @16k, 7.67 → **10.44** @32k; `k_iso3` 14.90 → **24.37**
+> @16k; `rotor3_sym` 10.13 → **16.03** @16k; `k_rotor3` 13.73 → **21.59** @16k.
+> The `none` control moved −1.9…+1.2% across six cells. Full table in
+> `docs/PERF_BASELINE.md` § "The iso / rotor Bonsai anchors above are stale".
+>
+> Two conclusions in §0 and §2.2 are therefore **withdrawn**: that the `_sym`
+> penalty is a V-side dequant cost inside the symv kernel, and that the K-only /
+> `_sym` marginal-cost split measures the kernels. Both were measuring the
+> dispatcher. What is **not** withdrawn: `none` is still the fastest and the
+> smallest at every context, and no member of this family beats it after the
+> fix either — the format is not smaller than bf16 (#310), so there is no
+> crossover to reach. Re-record these rows before citing them.
+
 ---
 
 ## 0. TL;DR
@@ -57,14 +78,18 @@ discarded. Bar (§3): WIN / TIE-on-noise / LOSS.
   worse than the 0.2.5 CPU path it was built to replace. The symv
   flash-decode kernel provably dispatches on GPU at every size (confirmed via
   `iso_flash_decode_symv_sdpa` / `rotor_flash_decode_symv_sdpa` probes,
-  including at 64k) — this is a genuine marginal-cost defect in the new
-  kernel, not a dispatch failure. Root-caused to the V-side dequant **inside
-  the symv kernel specifically** — *not* to quantized-V in general
-  (`rot_k_tq4v` quantizes V on the generic path and is cheap at 1.16 ms/1k),
-  and *not* to the flash-decode scaffolding in general (the K-only kernels are
-  costly but stable): marginal cost **6.25–9.42 ms per 1k KV tokens** vs the
-  K-only (quantized-K-only, bf16-V) family's **2.25–3.49 ms/1k** and `none`'s
-  **0.33 ms/1k** (§2.2) — filed as issue #292. KV memory did improve sharply
+  including at 64k) — this is a genuine marginal-cost defect, not a dispatch
+  failure. **The root cause originally recorded here — a V-side dequant inside
+  the symv kernel — is withdrawn (2026-08-15).** The dominant term was the
+  dispatcher, which blocked the host on `Array::eval()` once per attention layer
+  per decode step; that cost is paid identically by the K-only kernels and is
+  not V-specific at all. Removing it lifts `iso3_sym` 19.09 → 55.15 TPS @4k and
+  `k_iso3` 14.90 → 24.37 @16k, and closes most of the `_sym` vs K-only gap this
+  bullet was built on (at 4k the two are now 55.15 vs 56.98, 3% apart). The
+  marginal-cost numbers below — **6.25–9.42 ms per 1k KV tokens** for `_sym`,
+  **2.25–3.49 ms/1k** K-only, `none`'s **0.33 ms/1k** (§2.2) — therefore measure
+  the dispatcher and must be re-recorded. Filed as issue #292. KV memory did
+  improve sharply
   (30608→10640 MB @64k, 2.91×→1.01× `none`, essentially free now) — the
   codec got cheap on memory and expensive on compute at exactly the context
   length it exists to serve.

--- a/docs/models/bonsai/8B/rMLX.md
+++ b/docs/models/bonsai/8B/rMLX.md
@@ -25,8 +25,8 @@ discarded. Bar (§3): WIN / TIE-on-noise / LOSS.
 > complete 4k–64k range on the new flash-decode-over-quant kernels (§0, §4).
 
 > ⚠️ **Superseded for the iso / rotor rows (2026-08-15).** Every `iso*` / `rotor*`
-> / `k_iso*` / `k_rotor*` decode cell in this document — the §2 matrix, the §2.2
-> marginal-cost fits, and the §0 root-cause bullets that rest on them — was
+> / `k_iso*` / `k_rotor*` **absolute decode-TPS** cell in this document — the §2
+> matrix and the §0 root-cause bullets that rest on it — was
 > measured against a dispatcher that forced `Array::eval()` on its kernel inputs
 > once per attention layer per decode step, blocking the host on the GPU. With
 > that removed, a paired `rmlx bench` A/B (n=3, one binary pair, `none` as the
@@ -37,13 +37,22 @@ discarded. Bar (§3): WIN / TIE-on-noise / LOSS.
 > The `none` control moved −1.9…+1.2% across six cells. Full table in
 > `docs/PERF_BASELINE.md` § "The iso / rotor Bonsai anchors above are stale".
 >
-> Two conclusions in §0 and §2.2 are therefore **withdrawn**: that the `_sym`
-> penalty is a V-side dequant cost inside the symv kernel, and that the K-only /
-> `_sym` marginal-cost split measures the kernels. Both were measuring the
-> dispatcher. What is **not** withdrawn: `none` is still the fastest and the
+> One conclusion in §0 is therefore **withdrawn**: that the `_sym` penalty is a
+> V-side dequant cost inside the symv kernel. It was the dispatcher, and the
+> K-only kernels paid it identically.
+>
+> **§2.2's marginal-cost fits (ms per 1k KV tokens) are NOT withdrawn.** The eval
+> was a fixed cost per decode step — one host↔GPU round trip per attention layer,
+> whatever the KV length — so it moves the intercept of
+> `ms/step = a + b × (KV tokens/1000)` and a slope cancels it by construction.
+> Measured across the binary pair: `a` 41.14 → **7.01 ms/step (−83%)**,
+> `b` 2.437 → **2.449 ms/1k (+0.5%)**. Cite the ms/1k table; re-record the TPS
+> cells.
+>
+> What is **not** withdrawn either: `none` is still the fastest and the
 > smallest at every context, and no member of this family beats it after the
-> fix either — the format is not smaller than bf16 (#310), so there is no
-> crossover to reach. Re-record these rows before citing them.
+> fix — the format is not smaller than bf16 (#310), so there is no
+> crossover to reach.
 
 ---
 
@@ -85,11 +94,15 @@ discarded. Bar (§3): WIN / TIE-on-noise / LOSS.
   per decode step; that cost is paid identically by the K-only kernels and is
   not V-specific at all. Removing it lifts `iso3_sym` 19.09 → 55.15 TPS @4k and
   `k_iso3` 14.90 → 24.37 @16k, and closes most of the `_sym` vs K-only gap this
-  bullet was built on (at 4k the two are now 55.15 vs 56.98, 3% apart). The
-  marginal-cost numbers below — **6.25–9.42 ms per 1k KV tokens** for `_sym`,
-  **2.25–3.49 ms/1k** K-only, `none`'s **0.33 ms/1k** (§2.2) — therefore measure
-  the dispatcher and must be re-recorded. Filed as issue #292. KV memory did
-  improve sharply
+  bullet was built on (at 4k the two are now 55.15 vs 56.98, 3% apart). Every
+  **absolute TPS** figure in this bullet and in §2 therefore measures the
+  dispatcher and must be re-recorded. The **marginal-cost** numbers below —
+  **6.25–9.42 ms per 1k KV tokens** for `_sym`, **2.25–3.49 ms/1k** K-only,
+  `none`'s **0.33 ms/1k** (§2.2) — **stand**: the eval was a fixed per-step cost
+  (one host round trip per attention layer, whatever the KV length), so it lands
+  in the intercept and a slope cancels it. Measured across the binary pair, the
+  intercept fell 41.14 → 7.01 ms/step (−83%) while the slope moved 2.437 → 2.449
+  ms/1k (+0.5%). Filed as issue #292. KV memory did improve sharply
   (30608→10640 MB @64k, 2.91×→1.01× `none`, essentially free now) — the
   codec got cheap on memory and expensive on compute at exactly the context
   length it exists to serve.

--- a/scripts/check_no_kernel_input_eval.sh
+++ b/scripts/check_no_kernel_input_eval.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # scripts/check_no_kernel_input_eval.sh — CI gate: flag blocking Array::eval()
-# on a flash-decode kernel's inputs.
+# in a custom-Metal-kernel dispatcher.
+#
+# usage: check_no_kernel_input_eval.sh [SRC_DIR] [MIN_FILES]
 #
 # PROBLEM
 # -------
 # `Array::eval()` is a synchronous graph evaluation: it blocks the calling
-# thread until the GPU has produced the array. A flash-decode dispatcher runs
+# thread until the GPU has produced the array. A decode-path dispatcher runs
 # once per attention layer per decode step, so an `eval()` on its inputs
 # serialises the host against the GPU that many times per token — the forward
 # pass then advances one layer at a time with nothing queued ahead, and the
@@ -15,65 +17,104 @@
 #
 # WHY THE PRECAUTION IS NOT NEEDED
 # --------------------------------
-# These kernels read their buffers by raw linear offset, so they need
-# row-contiguous inputs. That guarantee already comes from the custom-kernel
-# builder: `MetalKernel::new` passes `ensure_row_contiguous`, and MLX copies any
-# non-row-contiguous input before the dispatch. A blocking `eval()` adds nothing
-# to it.
+# `MetalKernel::apply` enqueues an MLX `fast::CustomKernel` graph node; it does
+# not dispatch. MLX runs that node's `eval_gpu` only once every input edge is
+# materialised, and the row-contiguous copy (`ensure_row_contiguous`, passed by
+# `MetalKernel::new`) happens inside that same `eval_gpu`. A kernel therefore
+# cannot read an uncomputed or strided buffer, and a caller-side `eval()` adds
+# no ordering the graph does not already give. The long-form version of this
+# argument lives in one place — the `flash_decode_common` module docs.
 #
-# WHAT THIS GATE CHECKS
-# ---------------------
-# Every non-test `*flash_decode*_msl.rs` under crates/rmlx-kv-quant/src/ is
-# scanned for `.eval()` calls. A hit is a violation unless it carries an
-# `// eval-ok: <reason>` marker, either on the same line or in the contiguous
-# block of comments / `eval()` calls / block delimiters directly above it.
+# WHAT THIS GATE SCANS
+# --------------------
+# Recursively under SRC_DIR (default `crates/rmlx-kv-quant/src`), every
+# non-test `.rs` file that is either
 #
-# Keyed on shape (a flash-decode dispatcher forcing evaluation), never on a
-# codec or architecture name.
+#   * a custom-Metal-kernel dispatcher — it constructs a `MetalKernelInvoke`, or
+#   * a shared dispatcher scaffold — its name ends in `_common.rs`.
 #
-# Exit 0 = clean. Exit 1 = violation found.
+# Keyed on shape, never on a codec or architecture name, so a dispatcher that
+# is renamed, or moved into a sub-directory, stays in scope. The `_common.rs`
+# arm is what keeps an eval from being hidden one call deep in a helper that
+# every dispatcher already imports.
+#
+# A `.eval(` / `::eval(` call is a violation unless the *same* call carries an
+# `// eval-ok: <reason>` marker — on its own line, or on the contiguous comment
+# lines directly above it. One marker exempts exactly one call.
+#
+# Exit 0 = clean. Exit 1 = violation, or fewer dispatchers found than expected.
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SRC_DIR="$ROOT/crates/rmlx-kv-quant/src"
+SRC_DIR="${1:-$ROOT/crates/rmlx-kv-quant/src}"
 
-shopt -s nullglob
+# Vacuity floor. A rename or a relocation that drops a dispatcher out of the
+# scan must fail the gate, not silently shrink its coverage — so the expected
+# file count is pinned, not merely required to be non-zero. Raise it when a
+# dispatcher is added; a drop below it means coverage was lost.
+MIN_FILES="${2:-${CHECK_EVAL_MIN_FILES:-27}}"
+
+if [ ! -d "$SRC_DIR" ]; then
+    echo "check-no-kernel-input-eval: scan root does not exist: $SRC_DIR" >&2
+    exit 1
+fi
+
 FILES=()
-for f in "$SRC_DIR"/*flash_decode*_msl.rs; do
-    case "$f" in
-        *_tests.rs) continue ;;
-    esac
+while IFS= read -r f; do
     FILES+=("$f")
-done
-shopt -u nullglob
+done < <(
+    find "$SRC_DIR" -type f -name '*.rs' \
+        ! -name '*_tests.rs' ! -name 'tests.rs' \
+        \( -name '*_common.rs' -o -exec grep -lq 'MetalKernelInvoke' {} \; \) \
+        -print | sort
+)
 
-if [ ${#FILES[@]} -eq 0 ]; then
-    echo "check-no-kernel-input-eval: no flash-decode dispatcher found under $SRC_DIR" >&2
-    echo "the gate would pass vacuously — fix the scan path" >&2
+if [ "${#FILES[@]}" -lt "$MIN_FILES" ]; then
+    echo "check-no-kernel-input-eval: found ${#FILES[@]} dispatcher/scaffold files under" >&2
+    echo "  $SRC_DIR" >&2
+    echo "but expected at least $MIN_FILES." >&2
+    echo "A dispatcher was renamed, moved or deleted and the scan lost coverage." >&2
+    echo "Fix the scan (or lower the pinned floor deliberately) — do not ignore this." >&2
     exit 1
 fi
 
 VIOLATIONS=0
 for f in "${FILES[@]}"; do
     out=$(awk '
-        # Track the contiguous run of lines that may carry the marker for the
-        # eval below: comments, other eval() calls, and bare block delimiters.
         {
             line = $0
             stripped = line
             gsub(/^[ \t]+|[ \t]+$/, "", stripped)
+
+            # Strip a trailing line comment before looking for a call, so a
+            # comment that merely mentions eval() is not a violation.
+            code = line
+            sub(/\/\/.*$/, "", code)
+
+            is_full_comment = (stripped ~ /^\/\//)
+            has_marker      = (stripped ~ /\/\/.*eval-ok:/)
+            is_eval         = (code ~ /(\.|::)eval[[:space:]]*\(/)
         }
-        stripped ~ /eval-ok:/ { marked = 1 }
-        {
-            is_comment = (stripped ~ /^\/\//)
-            is_eval     = (index(line, ".eval()") > 0)
-            is_delim    = (stripped == "}" || stripped ~ /^(if|for)[ (].*\{$/ || stripped == "")
-            has_eval    = is_eval && !is_comment
+
+        # Same-line marker: exempts this call and nothing else.
+        has_marker && is_eval { armed = 0; next }
+
+        # Comment-line marker: arms exactly one following call.
+        has_marker { armed = 1; next }
+
+        is_eval {
+            if (armed) { armed = 0; next }
+            printf "%s:%d: %s\n", FILENAME, FNR, stripped
+            bad = 1
+            next
         }
-        has_eval && !marked { printf "%s:%d: %s\n", FILENAME, FNR, stripped; bad = 1 }
-        # A line that is none of the above ends the marker run.
-        !(is_comment || is_eval || is_delim) { marked = 0 }
+
+        # Further comment lines keep the marker armed; anything else disarms it,
+        # so a marker cannot leak across an intervening statement or block.
+        is_full_comment { next }
+        { armed = 0 }
+
         END { exit bad ? 1 : 0 }
     ' "$f") || VIOLATIONS=1
     if [ -n "$out" ]; then
@@ -86,22 +127,25 @@ if [ "$VIOLATIONS" -ne 0 ]; then
 
 check-no-kernel-input-eval: FAIL
 
-A flash-decode dispatcher force-evaluates an array. `Array::eval()` blocks the
-calling thread on the GPU; called once per layer per decode step it serialises
-the whole forward pass and costs multiples of the decode rate, with no change
-to the produced tokens.
+A custom-Metal-kernel dispatcher force-evaluates an array. `Array::eval()`
+blocks the calling thread on the GPU; called once per layer per decode step it
+serialises the whole forward pass and costs multiples of the decode rate, with
+no change to the produced tokens.
 
-The row-contiguous guarantee these raw-linear kernels need already comes from
-`MetalKernel::new`, which passes `ensure_row_contiguous` — drop the eval and
-leave the graph lazy.
+`MetalKernel::apply` enqueues a graph node, not a dispatch: MLX materialises
+every input — and applies the `ensure_row_contiguous` copy — inside the
+kernel's own `eval_gpu`. Drop the eval and leave the graph lazy.
 
-If a specific eval really is load-bearing, say why at the call site:
+If a specific eval really is load-bearing (a host readback, or an ordering
+constraint the graph genuinely cannot express), say why at the call site:
 
-    // eval-ok: <reason this dispatch cannot be lazy>
+    // eval-ok: <reason this one call cannot be lazy>
     some_array.eval()?;
+
+One marker exempts one call.
 
 EOF
     exit 1
 fi
 
-echo "check-no-kernel-input-eval: ok (${#FILES[@]} flash-decode dispatchers scanned)"
+echo "check-no-kernel-input-eval: ok (${#FILES[@]} dispatcher/scaffold files scanned)"

--- a/scripts/check_no_kernel_input_eval.sh
+++ b/scripts/check_no_kernel_input_eval.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# scripts/check_no_kernel_input_eval.sh — CI gate: flag blocking Array::eval()
+# on a flash-decode kernel's inputs.
+#
+# PROBLEM
+# -------
+# `Array::eval()` is a synchronous graph evaluation: it blocks the calling
+# thread until the GPU has produced the array. A flash-decode dispatcher runs
+# once per attention layer per decode step, so an `eval()` on its inputs
+# serialises the host against the GPU that many times per token — the forward
+# pass then advances one layer at a time with nothing queued ahead, and the
+# codec measures far slower than the bf16 path it was written to beat. This is
+# invisible at review: the call looks like a correctness precaution and the
+# output is bit-identical either way.
+#
+# WHY THE PRECAUTION IS NOT NEEDED
+# --------------------------------
+# These kernels read their buffers by raw linear offset, so they need
+# row-contiguous inputs. That guarantee already comes from the custom-kernel
+# builder: `MetalKernel::new` passes `ensure_row_contiguous`, and MLX copies any
+# non-row-contiguous input before the dispatch. A blocking `eval()` adds nothing
+# to it.
+#
+# WHAT THIS GATE CHECKS
+# ---------------------
+# Every non-test `*flash_decode*_msl.rs` under crates/rmlx-kv-quant/src/ is
+# scanned for `.eval()` calls. A hit is a violation unless it carries an
+# `// eval-ok: <reason>` marker, either on the same line or in the contiguous
+# block of comments / `eval()` calls / block delimiters directly above it.
+#
+# Keyed on shape (a flash-decode dispatcher forcing evaluation), never on a
+# codec or architecture name.
+#
+# Exit 0 = clean. Exit 1 = violation found.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="$ROOT/crates/rmlx-kv-quant/src"
+
+shopt -s nullglob
+FILES=()
+for f in "$SRC_DIR"/*flash_decode*_msl.rs; do
+    case "$f" in
+        *_tests.rs) continue ;;
+    esac
+    FILES+=("$f")
+done
+shopt -u nullglob
+
+if [ ${#FILES[@]} -eq 0 ]; then
+    echo "check-no-kernel-input-eval: no flash-decode dispatcher found under $SRC_DIR" >&2
+    echo "the gate would pass vacuously — fix the scan path" >&2
+    exit 1
+fi
+
+VIOLATIONS=0
+for f in "${FILES[@]}"; do
+    out=$(awk '
+        # Track the contiguous run of lines that may carry the marker for the
+        # eval below: comments, other eval() calls, and bare block delimiters.
+        {
+            line = $0
+            stripped = line
+            gsub(/^[ \t]+|[ \t]+$/, "", stripped)
+        }
+        stripped ~ /eval-ok:/ { marked = 1 }
+        {
+            is_comment = (stripped ~ /^\/\//)
+            is_eval     = (index(line, ".eval()") > 0)
+            is_delim    = (stripped == "}" || stripped ~ /^(if|for)[ (].*\{$/ || stripped == "")
+            has_eval    = is_eval && !is_comment
+        }
+        has_eval && !marked { printf "%s:%d: %s\n", FILENAME, FNR, stripped; bad = 1 }
+        # A line that is none of the above ends the marker run.
+        !(is_comment || is_eval || is_delim) { marked = 0 }
+        END { exit bad ? 1 : 0 }
+    ' "$f") || VIOLATIONS=1
+    if [ -n "$out" ]; then
+        printf '%s\n' "$out"
+    fi
+done
+
+if [ "$VIOLATIONS" -ne 0 ]; then
+    cat >&2 <<'EOF'
+
+check-no-kernel-input-eval: FAIL
+
+A flash-decode dispatcher force-evaluates an array. `Array::eval()` blocks the
+calling thread on the GPU; called once per layer per decode step it serialises
+the whole forward pass and costs multiples of the decode rate, with no change
+to the produced tokens.
+
+The row-contiguous guarantee these raw-linear kernels need already comes from
+`MetalKernel::new`, which passes `ensure_row_contiguous` — drop the eval and
+leave the graph lazy.
+
+If a specific eval really is load-bearing, say why at the call site:
+
+    // eval-ok: <reason this dispatch cannot be lazy>
+    some_array.eval()?;
+
+EOF
+    exit 1
+fi
+
+echo "check-no-kernel-input-eval: ok (${#FILES[@]} flash-decode dispatchers scanned)"

--- a/scripts/check_no_kernel_input_eval_fixtures.sh
+++ b/scripts/check_no_kernel_input_eval_fixtures.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/check_no_kernel_input_eval_fixtures.sh — recall test for the
+# `check_no_kernel_input_eval.sh` gate.
+#
+# A source gate is only worth its runtime if it still fires when the thing it
+# looks for is spelled differently, moved, or hidden one call deep. Each
+# fixture under `scripts/fixtures/no_kernel_input_eval/` is a synthetic scan
+# root paired with the exit code the gate must produce for it. A gate change
+# that loses recall fails here instead of passing silently on the real tree.
+#
+# Exit 0 = every fixture produced its expected exit code.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE="$ROOT/scripts/check_no_kernel_input_eval.sh"
+FIX="$ROOT/scripts/fixtures/no_kernel_input_eval"
+
+# fixture | min-files | expected-exit | what it proves
+CASES=(
+    "clean|1|0|a dispatcher with no eval passes"
+    "plain_eval|1|1|the plain x.eval() spelling is caught"
+    "ufcs_eval|1|1|the UFCS Array::eval(&x) spelling is caught"
+    "common_helper|2|1|an eval hidden in a shared _common.rs scaffold is caught"
+    "nested_dir|1|1|a dispatcher in a sub-directory is still scanned"
+    "marker_same_line|1|0|a same-line eval-ok marker exempts its own call"
+    "marker_above|1|0|an eval-ok marker on the lines above exempts one call"
+    "marker_leaks_to_loop|1|1|one marker exempts one call, not a following loop"
+    "trailing_comment|1|0|a comment naming .eval() is not itself a call"
+    "empty_tree|1|1|an empty scan root fails instead of passing vacuously"
+    "clean|2|1|fewer dispatchers than the pinned floor fails"
+)
+
+FAILED=0
+PASSED=0
+
+for case in "${CASES[@]}"; do
+    IFS='|' read -r name min want what <<<"$case"
+    out=$("$GATE" "$FIX/$name" "$min" 2>&1)
+    got=$?
+    if [ "$got" -eq "$want" ]; then
+        PASSED=$((PASSED + 1))
+        printf '  ok   %-22s min=%s exit=%s — %s\n' "$name" "$min" "$got" "$what"
+    else
+        FAILED=$((FAILED + 1))
+        printf '  FAIL %-22s min=%s exit=%s (want %s) — %s\n' \
+            "$name" "$min" "$got" "$want" "$what"
+        printf '%s\n' "$out" | sed 's/^/       | /'
+    fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "check-no-kernel-input-eval fixtures: FAIL ($FAILED of $((PASSED + FAILED)))" >&2
+    exit 1
+fi
+
+echo "check-no-kernel-input-eval fixtures: ok ($PASSED cases)"

--- a/scripts/fixtures/no_kernel_input_eval/clean/alpha_msl.rs
+++ b/scripts/fixtures/no_kernel_input_eval/clean/alpha_msl.rs
@@ -1,0 +1,6 @@
+// Fixture: a dispatcher with no eval at all. Expected exit 0.
+fn dispatch(q: &Array) -> Result<Vec<Array>> {
+    let mut invoke = MetalKernelInvoke::new();
+    invoke.add_input(q)?;
+    kernel().apply(invoke, device)
+}

--- a/scripts/fixtures/no_kernel_input_eval/common_helper/alpha_msl.rs
+++ b/scripts/fixtures/no_kernel_input_eval/common_helper/alpha_msl.rs
@@ -1,0 +1,8 @@
+// Fixture: the dispatcher itself is clean; the eval hides in the shared
+// scaffold next to it. Expected exit 1 (reported against the scaffold).
+fn dispatch(q: &Array) -> Result<Vec<Array>> {
+    materialise(q)?;
+    let mut invoke = MetalKernelInvoke::new();
+    invoke.add_input(q)?;
+    kernel().apply(invoke, device)
+}

--- a/scripts/fixtures/no_kernel_input_eval/common_helper/flash_decode_common.rs
+++ b/scripts/fixtures/no_kernel_input_eval/common_helper/flash_decode_common.rs
@@ -1,0 +1,5 @@
+// Fixture: shared scaffold with no MetalKernelInvoke of its own — in scope
+// because its name ends in `_common.rs`.
+pub(crate) fn materialise(a: &Array) -> Result<()> {
+    a.eval()
+}

--- a/scripts/fixtures/no_kernel_input_eval/empty_tree/README.md
+++ b/scripts/fixtures/no_kernel_input_eval/empty_tree/README.md
@@ -1,0 +1,2 @@
+Fixture: a scan root with no dispatcher in it. The gate must fail rather than
+report a vacuous pass.

--- a/scripts/fixtures/no_kernel_input_eval/marker_above/alpha_msl.rs
+++ b/scripts/fixtures/no_kernel_input_eval/marker_above/alpha_msl.rs
@@ -1,0 +1,10 @@
+// Fixture: marker on the comment lines directly above the call. Expected
+// exit 0.
+fn dispatch(q: &Array) -> Result<Vec<Array>> {
+    // eval-ok: host readback follows — `to_bytes` copies to CPU, so the
+    // array has to be materialised first.
+    q.eval()?;
+    let mut invoke = MetalKernelInvoke::new();
+    invoke.add_input(q)?;
+    kernel().apply(invoke, device)
+}

--- a/scripts/fixtures/no_kernel_input_eval/marker_leaks_to_loop/alpha_msl.rs
+++ b/scripts/fixtures/no_kernel_input_eval/marker_leaks_to_loop/alpha_msl.rs
@@ -1,0 +1,12 @@
+// Fixture: one marker must exempt exactly one call — the loop below it is
+// still a violation. Expected exit 1.
+fn dispatch(q: &Array, b: &Array, c: &Array) -> Result<Vec<Array>> {
+    // eval-ok: host readback follows
+    q.eval()?;
+    for arr in [b, c] {
+        arr.eval()?;
+    }
+    let mut invoke = MetalKernelInvoke::new();
+    invoke.add_input(q)?;
+    kernel().apply(invoke, device)
+}

--- a/scripts/fixtures/no_kernel_input_eval/marker_same_line/alpha_msl.rs
+++ b/scripts/fixtures/no_kernel_input_eval/marker_same_line/alpha_msl.rs
@@ -1,0 +1,7 @@
+// Fixture: marker on the call's own line. Expected exit 0.
+fn dispatch(q: &Array) -> Result<Vec<Array>> {
+    q.eval()?; // eval-ok: host readback follows
+    let mut invoke = MetalKernelInvoke::new();
+    invoke.add_input(q)?;
+    kernel().apply(invoke, device)
+}

--- a/scripts/fixtures/no_kernel_input_eval/nested_dir/sub/alpha_msl.rs
+++ b/scripts/fixtures/no_kernel_input_eval/nested_dir/sub/alpha_msl.rs
@@ -1,0 +1,8 @@
+// Fixture: a dispatcher one directory down. Expected exit 1 (the scan must
+// recurse).
+fn dispatch(q: &Array) -> Result<Vec<Array>> {
+    q.eval()?;
+    let mut invoke = MetalKernelInvoke::new();
+    invoke.add_input(q)?;
+    kernel().apply(invoke, device)
+}

--- a/scripts/fixtures/no_kernel_input_eval/plain_eval/alpha_msl.rs
+++ b/scripts/fixtures/no_kernel_input_eval/plain_eval/alpha_msl.rs
@@ -1,0 +1,7 @@
+// Fixture: the plain `x.eval()?;` spelling. Expected exit 1.
+fn dispatch(q: &Array) -> Result<Vec<Array>> {
+    q.eval()?;
+    let mut invoke = MetalKernelInvoke::new();
+    invoke.add_input(q)?;
+    kernel().apply(invoke, device)
+}

--- a/scripts/fixtures/no_kernel_input_eval/trailing_comment/alpha_msl.rs
+++ b/scripts/fixtures/no_kernel_input_eval/trailing_comment/alpha_msl.rs
@@ -1,0 +1,8 @@
+// Fixture: a trailing comment that merely names the call is not a call.
+// Expected exit 0.
+fn dispatch(q: &Array) -> Result<Vec<Array>> {
+    let k = 1; // never call .eval() on kernel inputs
+    let mut invoke = MetalKernelInvoke::new();
+    invoke.add_input(q)?;
+    kernel().apply(invoke, device)
+}

--- a/scripts/fixtures/no_kernel_input_eval/ufcs_eval/alpha_msl.rs
+++ b/scripts/fixtures/no_kernel_input_eval/ufcs_eval/alpha_msl.rs
@@ -1,0 +1,7 @@
+// Fixture: the UFCS spelling `Array::eval(&q)?;`. Expected exit 1.
+fn dispatch(q: &Array) -> Result<Vec<Array>> {
+    Array::eval(q)?;
+    let mut invoke = MetalKernelInvoke::new();
+    invoke.add_input(q)?;
+    kernel().apply(invoke, device)
+}


### PR DESCRIPTION
Closes #292. The issue's diagnosis was wrong: the cost was in the **dispatchers**, not the kernels.

Every iso/rotor flash-decode dispatcher called `Array::eval()` on 8–9 of its kernel inputs immediately before dispatch. `Array::eval()` is a blocking full-graph flush — it stops the host until the GPU drains. At 26 dispatching layers × ~8 evals × ~0.16 ms, that is **~34 ms of pure host↔GPU serialization per decode step**, independent of context length.

The stated justification — that a pending permutation had to be resolved — never described what `eval()` does. `eval()` materialises; it does **not** relayout. MLX's `Transpose` is a strided view over a shared buffer, so an evaluated transpose is still non-row-contiguous. The layout guarantee always came from `reshape` plus `ensure_row_contiguous`, which `MetalKernel::new` passes unconditionally.

Ordering is likewise not lost. `MetalKernel::apply` enqueues a `fast::CustomKernel` **graph node**, not a dispatch: MLX runs its `eval_gpu` only once every input edge is materialised, and `ensure_row_contiguous` is evaluated inside that same `eval_gpu`. Several removed evals were on `from_bytes` arrays that carry no primitive at all — literal no-ops.

### Measured

| model | cell | base | fix | Δ |
|---|---|---|---|---|
| Bonsai-8B | `iso3_sym` @4k | 19.75 (15.5% — **bench refused**) | 60.42 (<0.1%) | **3.06×** |
| Bonsai-8B | `rotor3_sym` @4k | 18.25 (15.2% — **refused**) | 50.50 (0.6%) | **2.77×** |
| Bonsai-8B | `iso3_sym` @32k | 8.45 | 11.82 | 1.40× |
| gemma-4-e2b | `iso3_sym` @4k | 64.39 | 100.98 | 1.57× |
| Qwen3.6-35B-A3B | `k8v8` +fused-qk @4k | 46.39 | 69.29 | **+49.4%** |
| Bonsai-8B | `k8v4` +fused-qk @16k | 9.73 | 12.71 | +30.6% |

Every digest and every `kv_cache_bytes` byte-identical, base↔fix, in every cell. Null control `none` spans −0.7%…+1.6% across six cells on two models.

**The frozen-cache hypothesis is refuted by dispatch count, not by digest**: 26.00 symv dispatches per decode step, *identical in both binaries*. The kernel fires exactly as often after the fix.

The cost is a per-step intercept, not a per-token slope — which is why it masqueraded as a codec problem:

| | base | fix |
|---|---|---|
| intercept (ms/step) | 41.14 | **7.01 (−83%)** |
| slope (ms/1k KV tok) | 2.437 | 2.449 (+0.5%) |

So **absolute decode-TPS cells** for this family must be re-recorded; **marginal-cost (ms/1k) figures survive** — a slope cancels a fixed per-step cost by construction. The docs now say exactly that, rather than the blanket claim the first revision made.

### The format ceiling still stands

Post-fix @32k, `iso3_sym` is 11.82 vs `none` 66.39 — **5.62× slower** (was 7.91×) and 8.63× `none` per KV token, while storing 1.1516× true bf16. #310's conclusion is unchanged: a codec that is not smaller than bf16 has no bandwidth prize to collect, and this fix does not make the family competitive. It removes a cost that was never the codec's.

### Scope grew, because the same bug was everywhere

Review found the first gate keyed on a **filename substring** and so scanned only the five touched files, while 8 sibling decode-path dispatchers kept 41 identical evals. A 9th site was then found in `fused_qk_common.rs`. **53 evals removed across 10 files.**

Ten are proven at serve level (the fused-QK cells above). The other 43 are removed on correctness evidence only, because their paths are **unreachable from a shipped binary** — verified by dispatch tally rather than assumed: `iso_fused_qk` routes to `iso_flash_decode_symv` instead; `planar_*` is dormant behind a warm-TTFT bypass; `sparse_attn` needs calibration artefacts no test-target model has; `rotor_fused_qk` never dispatches at all (filed as #333). They are backed by the GPU parity suites, all green. Deliberately **not** marked `eval-ok` — marking a non-load-bearing eval to make a gate green is the rubber stamp that would defeat the gate.

Nine genuine host-readback evals in the quantize paths keep an `// eval-ok:` with a real reason.

### The gate now gates

Rewritten to key on **shape** (a file constructing a `MetalKernelInvoke`, plus `*_common.rs` scaffolding), recursive, 27 files. Three false-green paths and one false-red, each reproduced against the pre-fix script and fixed:

| fixture | old gate | new gate |
|---|---|---|
| `Array::eval(&q)` (UFCS) | **0** — missed | 1 |
| eval behind a `_common.rs` helper | **0** — missed | 1 |
| dispatcher in a subdirectory | **0** — missed | 1 |
| one marker leaking into a following loop | **0** — missed | 1 |
| trailing comment naming `.eval()` | **1** — false red | 0 |

`// eval-ok:` now binds to a single call rather than a block, a vacuity floor fails when coverage silently drops, and an 11-case fixture suite makes the gate's own recall testable. Both gates run in `make ci` and the Linux CI job.

### Planar exemption dropped

Its cited `planar_quantize` atomic-OR hazard is already guarded at the right place — `planarquant_msl.rs:283-286` calls `set_init_value(0.0)` with exactly that rationale, and the iso/rotor quantize kernels carry the identical guard. Mechanically, a blocking eval on the **decode** kernel's inputs cannot repair a corrupted **quantize** output; it only shifts timing, which is the signature of a barrier masking a race rather than fixing one.

### The path the digests did not cover

All observed dispatches carry `has_mask = 0`, so the removed `mask_flat.eval()` was reachable but untested. Four `#[ignore]` GPU tests now feed a **transposed** (non-row-contiguous) mask three ways — lazy, eval'd, explicitly contiguous — for f32 and bf16, asserting max abs error < 1e-5. Mutation-checked: under a mutant feeding an untransposed mask all four fail by 0.179.

### Also corrected

`--kv-quant none` is **not** bf16 on Qwen3: `kv_quant_for_layer` forces K8V8 on the first 2 and last 8 layers under every codec, so 26 of 36 layers are bf16 and 10 are K8V8, making `none` itself 1.1439× true bf16. That is why `iso3_sym`'s decode window contains `sdpa_vector` — closed #323 as not-a-defect — and it means every "vs `none`" ratio compares two mixtures. Filed as #331.

`make ci` green — 2605 workspace tests, 217 ignored GPU tests, 11/11 gate fixtures.

Follow-ups filed: #331 (the `none` baseline), #332 (two GPU tests stale since #310), #333 (rotor fused-QK never dispatches).
