### PR TITLE
docs(kv): the K-only decode cap was the dispatcher eval, not a host restage (#295)

### DIFF
--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -677,8 +677,9 @@ impl KvQuant {
     ///   so the GPU iso/rotor branch is shadowed and the codec encode that does
     ///   run (at prefill) is CPU → `Some(reason)`.
     /// - **K-only iso** (`IsoKOnly3/4`): NO bf16 early-return — the iso K MSL
-    ///   kernel dispatches every decode step on GPU → `None` (Metal, hybrid:
-    ///   dequant restages host-side each step, but a Metal kernel runs).
+    ///   kernel dispatches every decode step on GPU → `None` (Metal, and
+    ///   GPU-resident end to end: the flash-decode kernel reads the packed ring
+    ///   in place, so the growing prefix never crosses to the host).
     /// - **K-only rotor** (`RotorKOnly3/4`): NO bf16 early-return; the runtime
     ///   dispatcher (`update_rotor_k_only_{3,4}` and the sdpa fast path) gates
     ///   the GPU K encode on the store's sticky `use_qjl()` flag. QJL off
@@ -700,7 +701,7 @@ impl KvQuant {
     /// Exhaustive on purpose (no wildcard) so a new variant must be classified.
     #[allow(
         clippy::match_same_arms,
-        reason = "the K-only iso arm returns None like the Metal arm but is kept separate to document the per-codec Metal-vs-CPU verdict this fn exists for: a Metal kernel dispatches for the K-only iso codec, distinct from the genuinely-Metal q8/turbo codecs and from the QJL-gated rotor arm. Merging the arms would erase that distinction."
+        reason = "the K-only iso arm returns None like the Metal arm but is kept separate to document the per-codec Metal-vs-CPU verdict this fn exists for: the K-only iso codec reaches Metal by its own encode + flash-decode kernels rather than the shared q8/turbo path, and unlike the rotor arm it carries no QJL gate that could flip the verdict. Merging the arms would erase that per-codec record."
     )]
     pub fn cpu_hot_path_reason(&self) -> Option<&'static str> {
         match self {
@@ -722,9 +723,11 @@ impl KvQuant {
             // K-only iso variants: NO bf16 decode-seed early-return — the iso K
             // codec fires every decode step. On GPU, `update_iso_k_only_{3,4}`
             // dispatches the real iso{3,4} MSL encode kernel; IsoKOnly3 also runs
-            // the iso3 MSL dequant kernel. This is a Metal hot path (a hybrid —
-            // the dequant restages the growing prefix host-side each step — but a
-            // Metal kernel demonstrably dispatches, so it is NOT a CPU-only codec).
+            // the iso3 MSL dequant kernel. Decode reads the packed ring through
+            // the iso flash-decode kernel, so the growing prefix stays on device;
+            // the only host readback (`packed_view_cpu`) is reached from
+            // `dequant()` / `dequant_gpu()` at a block-rebuild or SSD-spill
+            // boundary, never from a decode step. Metal hot path, no host stage.
             KvQuant::IsoKOnly3 | KvQuant::IsoKOnly4 => None,
             // V-only rotor variants and the rotor-K-asym variants early-return to
             // the bf16 decode seed at decode (`decode_fp16_k.is_some()`), so the
@@ -762,9 +765,9 @@ impl KvQuant {
             // at first append), matching the sdpa fast path:
             //   - QJL on (opt-in `--rotor-qjl on`): K append runs on CPU → CPU hot path.
             //   - QJL off (default): `rotor{3,4}_gpu_append_into_k_blocks`
-            //     dispatches the per-codec rotor MSL encode kernel → Metal hot
-            //     path (hybrid: the dequant restages host-side each step, but a
-            //     Metal kernel dispatches), so it is NOT a CPU-only codec.
+            //     dispatches the per-codec rotor MSL encode kernel, and decode
+            //     reads the packed ring through the rotor flash-decode kernel →
+            //     Metal hot path, GPU-resident end to end, no host stage.
             KvQuant::RotorKOnly3 | KvQuant::RotorKOnly4 => {
                 if crate::rotor_qjl::rotor_qjl_enabled() {
                     Some(

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -244,6 +244,52 @@ never smaller than bf16 (see `docs/KV_QUANT.md` "Memory truth"), and its
 decode is several times `none`'s. Bench them for kernel work and quality
 study, not as memory or throughput candidates.
 
+#### K-only family, re-recorded after the dispatcher fix
+
+The table above left the K-only family incomplete: `k_iso4` / `k_rotor4` were
+never re-recorded, and the Bonsai `k_iso3` 4k cell was refused pre-fix. These
+are the completed cells on the post-fix tree, `rmlx bench` n=3 + 1 warmup,
+`release-perf`, scratch `RMLX_HOME`, `--metrics off`. Prompt lengths are the
+tokenized fixtures: Bonsai 3770 / 15629 / 31553, e2b 4117 / 17148 / 34355.
+Run-to-run range was ≤2.1% in every cell and the token digest was identical
+across the runs of a cell.
+
+| model | codec | 4k | 16k | 32k | KV bytes @32k | × `none` |
+|---|---|---|---|---|---|---|
+| Bonsai-8B | `none` (control) | 140.32 | 95.74 | 67.40 | 5,341,839,360 | 1.000 |
+| Bonsai-8B | `k_iso3` | **60.28** | 26.17 | 14.36 | 5,371,658,240 | 1.006 |
+| Bonsai-8B | `k_iso4` | **60.56** | — | — | — | — |
+| Bonsai-8B | `k_rotor3` | **54.24** | 22.41 | 12.33 | 5,952,718,304 | 1.114 |
+| Bonsai-8B | `k_rotor4` | **54.10** | — | — | — | — |
+| gemma-4-e2b | `none` (control) | 126.82 | 119.29 | 112.55 | 218,148,864 | 1.000 |
+| gemma-4-e2b | `k_iso3` | **107.15** | 66.74 | 44.44 | 218,803,200 | 1.003 |
+| gemma-4-e2b | `k_iso4` | **107.97** | — | — | — | — |
+| gemma-4-e2b | `k_rotor3` | **101.58** | 58.34 | 37.12 | 254,477,328 | 1.167 |
+| gemma-4-e2b | `k_rotor4` | **100.73** | — | — | — | — |
+
+The KV-bytes column is the reason to stop optimizing this family for
+throughput: `k_iso3/4` measures **1.003–1.006×** `none` and `k_rotor3/4`
+**1.11–1.17×**. A codec that is not smaller than bf16 has no bandwidth prize
+to collect, so parity with `none` is the ceiling, not a milestone on the way
+past it.
+
+Marginal cost over the replicated 16k→32k segment (`itl_p50` ms per 1k KV
+tokens) is unchanged by the dispatcher fix, as predicted — the fix moved the
+intercept, not the slope:
+
+| model | `none` | `k_iso3` | `k_rotor3` |
+|---|---|---|---|
+| Bonsai-8B | 0.261 | 1.799 (6.9×) | 2.178 (8.3×) |
+| gemma-4-e2b | 0.025 | 0.432 | 0.567 |
+
+Read e2b's ratio-to-`none` with care: only its 7 global layers grow, so the
+`none` denominator is near zero and the ratio inflates. Compare the absolute
+ms/1k across models instead. Counted from the per-dispatch `trace!` under
+`--log verbose`, the flash-decode kernel fires once per *growing* attention
+layer per decode step and is handed the full prefix — 26 of 36 layers on
+Bonsai (the first 2 and last 8 are forced to K8V8), 7 of 35 on e2b. What
+remains is per-KV-token work inside the kernel, not data movement.
+
 Each new codec: invoke `scripts/bench_codec_cell.sh --kv-quant <codec> --model <model>` per cell (3 cells per codec, A.y-excluded skipped), then append to this table.
 
 **Champions regen**: regenerate `BENCHMARK_CHAMPIONS.md` via `rmlx metrics export --markdown` after each cell lands. If that command is unavailable, manual fallback: hand-edit `BENCHMARK_CHAMPIONS.md` with cell + recorded TPS, cite source CSV row.


### PR DESCRIPTION
Closes #295.

**The cap does not reproduce.** #292 removed it — the "~23–25 TPS ceiling" was the per-step dispatcher `eval()` intercept, not a property of these codecs.

Criterion stated before measuring: **C1** (reproduces) = 20.7–27.5 TPS; **C2** (gone) = ≥35.0. On current `main`, C2 is met on all four codecs and C1 fails on all four.

| model | codec | 4k | 16k | 32k | KV @32k | × `none` |
|---|---|---|---|---|---|---|
| Bonsai-8B | `none` (control) | 140.32 | 95.74 | 67.40 | 5,341,839,360 | 1.000 |
| Bonsai-8B | `k_iso3` | **60.28** (was ~25.3) | 26.17 | 14.36 | 5,371,658,240 | 1.006 |
| Bonsai-8B | `k_iso4` | **60.56** (was ~25.2) | — | — | — | — |
| Bonsai-8B | `k_rotor3` | **54.24** (was ~22.9) | 22.41 | 12.33 | 5,952,718,304 | 1.114 |
| Bonsai-8B | `k_rotor4` | **54.10** (was ~23.6) | — | — | — | — |
| gemma-4-e2b | `none` (control) | 126.82 | 119.29 | 112.55 | 218,148,864 | 1.000 |
| gemma-4-e2b | `k_iso3` | 107.15 | 66.74 | 44.44 | 218,803,200 | 1.003 |
| gemma-4-e2b | `k_rotor3` | 101.58 | 58.34 | 37.12 | 254,477,328 | 1.167 |

`rmlx bench`, n=3 + warmup, range ≤2.1% every cell, token digest identical across runs, load 1.9–5.7 recorded per cell. The `none` null control moved +5.3%, so the 2.4× on `k_iso3` is far outside it.

### Three things the issue got wrong

**The root cause does not exist.** "The dequant of the growing prefix is staged through the host each step" has no code path. Established two independent ways rather than by trusting the comments that assert it: `packed_view_cpu` — the only host readback — has exactly three callers, all inside `dequant()`/`dequant_gpu()`, none on the decode path; and a `--log verbose` dispatch trace shows the kernel receiving the full growing prefix directly (`kv_seq` 3771→3801, monotonic).

**Those stale comments were the one real defect here, and they are what this PR fixes.** Three claims in `quant.rs` asserted the hybrid/restage behaviour — including the `reason` on an `#[allow]`, which justified a separate match arm on grounds that were themselves false. This issue cited them as its root cause, so they had already misled one investigation.

**"Closing it should lift them toward the plain-codec range" is unreachable.** `k_iso3` measures 1.003–1.006× `none`'s bytes and `k_rotor3` 1.11–1.17×. A codec that is not smaller than bf16 has no bandwidth prize to collect, so parity is the ceiling — #310's conclusion, confirmed here by independent KV-byte measurement. No kernel work was done, because none could win.

Also: the issue's hard-rule-10 framing is misapplied — these codecs decode on GPU, they are not "the last codecs with a CPU hot path". And its item (c), the rotor block leak predicted at 1.18× against a recorded 1.54×, is already fixed: measured 1.114×/1.167×, at the prediction.

### What remains real

The kernel-side **per-KV-token** cost — the P1 thread-0 softmax between 2–3 threadgroup barriers per KV token. Marginal cost over 16k→32k: Bonsai `none` 0.261 ms/1k, `k_iso3` 1.799 (6.9×), `k_rotor3` 2.178 (8.3×). It is the slope, it is present on both architectures, and it is bounded above by the format ceiling — so it is not worth building against while the store is not smaller than bf16.

### Changes

Comments and docs only — **2 non-comment changed lines**, both the `reason` string inside an `#[allow]` attribute, so zero behaviour change.

- `crates/rmlx-kv-quant/src/quant.rs:679-682, :704, :722-728, :765-768` — the three falsified restage claims corrected, and the `#[allow]` reason replaced with the honest one.
- `docs/PERF_BASELINE.md:241-286` — new "K-only family, re-recorded after the dispatcher fix" subsection carrying the matrix above, with KV-bytes and marginal-cost columns.

`make ci` green.

Follow-up filed: #335 (a pre-existing unlocked read of `rotor_qjl_enabled()` in `precompile_tests.rs`, unrelated to this work).
