### PR TITLE
docs(mlx): NAX attention is prefill-only and head-dim gated (#309)

### DIFF
--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -109,6 +109,41 @@ This is a **Homebrew bottle regression, not an MLX regression**: the upstream
 0.32.0 PyPI wheel ships the kernels and is fine. Tracked in
 [#216](https://github.com/Pushkinist/rMLX/issues/216).
 
+#### Where NAX can appear, and where it cannot
+
+The pin buys the NAX **GEMM** path (`steel_gemm_fused_nax_*`), which every
+model's matmuls go through. NAX **attention** is a far narrower thing, and the
+two are easy to conflate:
+
+| Path | NAX? | Why |
+|---|---|---|
+| Prefill attention, `head_dim` 64 or 128, Q not f32 | **yes**, `steel_attention_<dtype>_bq64_…` | MLX's `sdpa_full` takes the NAX branch unless `head_dim == 80` or Q is f32 without TF32 |
+| Prefill attention, `head_dim` 256 | no | MLX ships `steel_attention` for `bd` 64 / 80 / 128 only — a 256-wide head has no fused prefill kernel at all and runs the composite matmul+softmax fallback |
+| Decode attention, any `head_dim`, any codec | no | `bq64` is a query tile of 64; decode is `q_seq = 1`, and MLX routes `q_seq <= 8` to `sdpa_vector`, which has no NAX variant |
+| Our own `.metal` kernels | no | all of them are `q_seq = 1` decode kernels. NAX's one matmul tile shape has an M floor of 16; at `q_seq = 1` the only M available is `heads_per_kv` (4–8 on our models), so the tile can never be more than half filled |
+
+So the bf16 mirror's decode advantage over a quantized codec is bandwidth and
+kernel quality, **not** NAX — no decode path on any codec reaches it, and a
+hand-written decode kernel could not either. Only prefill is in play, and only
+for a 64- or 128-wide head.
+
+Measured on this host (M5 Max, mlx 0.31.2), from the per-pipeline binary
+archives inside a GPU capture — the whole `mlx.metallib` is also embedded in a
+bundle, so only the small per-pipeline archives are evidence of a *created*
+pipeline:
+
+- Ternary-Bonsai-8B (`head_dim` 128) creates three
+  `steel_attention_bfloat16_bq64_bk32_bd128_wm4_wn1_mask*` pipelines — the
+  causal, aligned-masked and unaligned-masked prefill permutations. NAX is
+  engaged and Q is already bf16, so there is no f32 gate to fix.
+- gemma-4-e2b (`head_dim` 256) creates none, on the same tooling and prompt
+  size. It does create `steel_gemm_fused_nax_*`, i.e. NAX GEMM is live for a
+  model whose attention can never use NAX.
+- Both decode through `sdpa_vector`.
+
+Of the test targets only Bonsai-8B is `head_dim` 128; the gemma-4 family, the
+Qwen3.6 / Qwen3.5 family (Bonsai-27B included) and medgemma are all 256.
+
 #### What the build checks
 
 `build.rs` warns — never fails — on two independent things:

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -143,9 +143,15 @@ answers](#what-a-gputrace-actually-answers) below splits the three questions
 people conflate; read it before planning a session, because one of the three is
 not answerable from a capture at all.
 
-On M5 the Neural Accelerator is **part of the GPU**, so profiling nax needs no
-special tooling — the ordinary Metal capture path covers it
-([ml-explore/mlx#3182](https://github.com/ml-explore/mlx/issues/3182)).
+On M5 the Neural Accelerator is part of the GPU, so there is no separate NAX
+tool and none is needed
+([ml-explore/mlx#3182](https://github.com/ml-explore/mlx/issues/3182)): a
+capture *names* NAX pipelines like any other — `steel_gemm_fused_nax_*` for
+matmul, `steel_attention_*_bq64_*` for attention, where **`bq64` means the NAX
+attention branch was taken and `bq32` means it was not**. It does not *time*
+them, on this hardware or any other; see [What a `.gputrace` actually
+answers](#what-a-gputrace-actually-answers). Which paths can reach NAX at all
+is in [`docs/FFI.md`](FFI.md#where-nax-can-appear-and-where-it-cannot).
 
 ### How the window works
 


### PR DESCRIPTION
Closes #309. Docs-only — the investigation found nothing to switch on.

### Decode: NAX is unreachable, structurally

Measured from captured decode windows on both architectures and both codecs: **zero `bq64`, zero `steel_attention`**. The control that makes it conclusive is that prefill's `steel_attention_bfloat16_bq64_bk32_bd128_*` pipelines *are* present in the same bundle — so the absence is a property of the decode path, not of the capture.

This matches the mechanism rather than merely coinciding with it: `bq64` is a query tile of 64, decode is `q_seq = 1`, and MLX routes `q_seq <= 8` to `sdpa_vector`, which has no NAX variant. So the bf16 mirror's decode advantage is bandwidth and kernel quality — **not** NAX.

### Prefill: already correct, and the f32 suspicion is falsified

The issue's live concern was that MLX silently drops NAX when Q is f32, and this repo has a documented history of f32 leaking into otherwise-bf16 paths. Checked rather than assumed:

**Ternary-Bonsai-8B already dispatches NAX prefill in bf16.** The capture creates three `steel_attention_bfloat16_bq64_bk32_bd128_wm4_wn1_mask*` pipelines (causal, aligned-masked, unaligned-masked). `bq64` means NAX engaged; `bfloat16` means Q is not f32. Nothing in rMLX prevents it — the additive mask is already cast to `q_dtype` before SDPA (`qwen3.rs:1073-1078`), so there is no dtype promotion, and both mask modes satisfy MLX's `sdpa_full_supported_mask`.

Every other test target is `head_dim 256` and therefore ineligible regardless of dtype — MLX's `sdpa_full` supports `head_dim ∈ {64, 80, 128}` only (`scaled_dot_product_attention.cpp:622-623`), and `metal-nm` on the pinned metallib confirms `steel_attention` exists only at bd 64/80/128, with `bq64` only at bd64/bd128 (bd80 is `bq32`-only, matching the source's `!= 80` guard).

Paired control, same tooling and prompt: gemma-4-e2b creates **zero** `steel_attention` archives while still creating `steel_gemm_fused_nax_*` — NAX GEMM live, attention never.

### A methodological trap worth recording

A `.gputrace` bundle embeds the **entire** `mlx.metallib` — an identical 157 MB blob in both captures, carrying 168 `steel_attention` strings. String-matching a bundle therefore proves nothing about what ran. Only the small per-pipeline binary archives, one function name each, prove a pipeline was created. Both results above rest on those.

### Doc corrections

- `docs/PROFILING.md:146-154` claimed "profiling nax needs no special tooling — the ordinary Metal capture path covers it". A capture gives **identity**, never timing. Rewritten to say what it does give, plus the `bq64` (NAX taken) vs `bq32` (not taken) discriminator.
- `docs/FFI.md:112-146` — new section under the MLX pin covering where NAX can and cannot appear: prefill at 64/128 yes, prefill at 256 no, decode never, and our own `.metal` kernels never (MLX instantiates one descriptor shape metallib-wide with an M floor of 16, while every rMLX kernel is `q_seq = 1` so the largest achievable M is `heads_per_kv`, 4–8).

Nothing stale needed removing — no doc claimed NAX at decode. `README.md`, `docs/PERF_BASELINE.md` and `docs/METRICS_DB.md` were checked and are already correctly scoped to the GEMM bottle regression and to prefill.

### Closing without overclaiming

Three residuals, stated so this does not close on more than was shown:

1. The other `head_dim 64/128` models in the tree (jina ×3, ReaderLM-v2, Qwen3-VL-30B-A3B, the DFlash drafter) share Bonsai's code path and bf16 stream, so eligibility is **expected, not proven**. Notably the jina models are pure-prefill workloads — the most NAX-relevant in the tree — and the capture tool cannot reach them, because its window hooks the decode loop.
2. Whether MLX's runtime compiler would accept an injected `MetalPerformancePrimitives` header through `MetalKernel::new` remains untested. Moot for the "do not port the decode kernels" decision, which the M-floor argument settles independently.
3. The M1–M4 host-class caveat is untested here (no such hardware), but it is now much less consequential: since no decode path reaches NAX on M5 either, codec-vs-bf16-mirror decode comparisons are on level ground on every host class. The caveat survives for prefill only.

`make ci` green.

Follow-up filed: **#337** — `head_dim 256` has no fused attention kernel in MLX *at all*, so gemma-4 and Qwen3.6/3.5 run prefill attention as composite matmul+softmax with a materialised `[L_q, L_k]` score matrix. Unrelated to NAX, and the natural fix is upstream.
