### PR TITLE
feat(mlx): warn at runtime when an NA-class host loads a nax-less MLX (#305)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,23 @@ regression that costs ~3.8× GPU matmul throughput), the build prints a warning
 naming the fix. It is a warning, not an error — the build still succeeds. See
 [`docs/FFI.md`](docs/FFI.md#pinned-mlx--mlx-c-pair).
 
-### On M5 and later: check for the Neural Accelerator kernels
+### On M5 and later: the Neural Accelerator kernels
 
 M5 introduced the Neural Accelerator (NAX). Some Homebrew MLX bottles are built
-in a way that silently omits the NAX kernels, which costs roughly **2–3.8× on
-prefill** while leaving decode largely untouched — so the loss is easy to miss.
-On M1–M4 there is no NAX and nothing to check: those bottles legitimately
-contain no NAX kernels.
+in a way that silently omits the NAX kernels, which costs roughly **2–3.7× on
+prefill / time-to-first-token** while leaving decode untouched — output stays
+correct and only TTFT regresses, so the loss is easy to misread as a model-code
+problem. On M1–M4 there is no NAX and nothing to check: those bottles
+legitimately contain no NAX kernels, at every MLX version.
+
+**rMLX checks this for you.** On startup it scans the `mlx.metallib` of the MLX
+it actually loaded, and warns only when the host has a Neural Accelerator *and*
+the kernels are absent. That is the honest check for an installed binary: a
+prebuilt bottle links MLX through a package-manager symlink, so the MLX it runs
+against is yours, not the one it was built with. Pre-M5 hosts never see the
+warning and never pay for the scan.
+
+To check by hand — or to confirm a fix took:
 
 ```sh
 strings "$(brew --prefix mlx)/lib/mlx.metallib" | grep -c steel_gemm_fused_nax
@@ -170,8 +180,10 @@ strings "$(brew --prefix mlx)/lib/mlx.metallib" | grep -c steel_gemm_fused_nax
 # M1-M4: 0 is normal and expected.
 ```
 
-Contributors can run this (and the rest of the toolchain checks) with
-`make mlx-preflight`.
+Published rMLX **prefill** numbers assume the kernels are present; TTFT measured
+on a stack without them is not comparable to them. Decode numbers are unaffected
+either way. Contributors can run this (and the rest of the toolchain checks)
+with `make mlx-preflight`.
 
 ### Extra tooling for kernel work (contributors only)
 

--- a/crates/rmlx-mlx/build.rs
+++ b/crates/rmlx-mlx/build.rs
@@ -24,10 +24,6 @@ include!("build_support.rs");
 /// Declares the MLX / mlx-c pair this build is validated against.
 const PIN_FILE: &str = "mlx-pin.txt";
 
-/// The GEMM kernel family whose presence in `mlx.metallib` is the capability
-/// the pin exists to guarantee. Missing entirely in some bottles.
-const NAX_GEMM_KERNEL: &str = "steel_gemm_fused_nax";
-
 /// Read size for the metallib scan.
 const SCAN_CHUNK: usize = 1 << 20;
 

--- a/crates/rmlx-mlx/build_support.rs
+++ b/crates/rmlx-mlx/build_support.rs
@@ -9,6 +9,16 @@
 // Paths and traits are fully qualified: an `include!`d file cannot own imports
 // without colliding with whichever file pulled it in.
 
+/// The GEMM kernel family whose presence in `mlx.metallib` is the capability
+/// the pin exists to guarantee. Missing entirely in some bottles.
+///
+/// Lives here rather than in `build.rs` so the build script, its tests and the
+/// runtime probe do not each carry their own copy of the string. The runtime
+/// probe (`src/nax.rs`) still needs its own — a build script cannot be imported
+/// from the crate it builds — and `build_side_names_the_same_kernel_family`
+/// pins that one to this one.
+const NAX_GEMM_KERNEL: &str = "steel_gemm_fused_nax";
+
 /// The MLX / mlx-c pair declared by `mlx-pin.txt`.
 #[derive(Debug, PartialEq, Eq)]
 struct MlxPin {

--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -43,6 +43,7 @@ pub mod compile;
 #[cfg(feature = "metal-capture")]
 pub mod metal_capture;
 pub mod metal_kernel;
+mod nax;
 mod sys;
 
 use std::cell::Cell;
@@ -96,6 +97,7 @@ pub(crate) fn install_error_handler() {
             sys::mlx_set_error_handler(Some(handler), ptr::null_mut(), None);
         }
         warn_on_mlx_version_skew();
+        nax::warn_if_nax_kernels_missing();
     });
 }
 
@@ -119,6 +121,13 @@ const MLX_BUILD_VERSION: &str = env!("RMLX_MLX_BUILD_VERSION");
 /// links both — reads this constant and calls
 /// `rmlx_metrics::identity::set_mlx_nax` with it once at startup, before any
 /// metrics recording. See `docs/METRICS_DB.md`.
+///
+/// This describes the machine that **built** the binary — the right answer for
+/// a source install, the wrong one for a prebuilt bottle or release tarball,
+/// which link MLX through a package-manager symlink and load whatever the
+/// installing user has. The operator-facing answer therefore comes from the
+/// crate-private `nax` module's runtime probe of the library actually loaded,
+/// not from here.
 pub const NAX_CAPABILITY: &str = env!("RMLX_MLX_NAX");
 
 /// Read the MLX version of the dylib actually loaded into this process.

--- a/crates/rmlx-mlx/src/nax.rs
+++ b/crates/rmlx-mlx/src/nax.rs
@@ -17,8 +17,9 @@
 //! majority of Macs. Warning there would be noise on hardware that cannot use
 //! the kernels either way, and a warning most people learn to ignore is worse
 //! than no warning at all — it would bury the one host where the absence
-//! costs something. So the host-class gate runs first, and when it says no,
-//! nothing else runs: no file is opened and nothing is logged above `debug`.
+//! costs something. So the host-class gate runs ahead of every other step: on
+//! a host with no Neural Accelerator neither the dyld image walk nor the
+//! metallib open happens, and nothing is logged above `debug`.
 //!
 //! # What the absence costs
 //!
@@ -32,10 +33,11 @@ use std::path::{Path, PathBuf};
 
 /// The GEMM kernel family only Neural-Accelerator hardware can run.
 ///
-/// Spelled here as well as in `build.rs`: a build script cannot import from
-/// the crate it builds, so the two copies are structural rather than an
+/// Spelled here as well as in `build_support.rs`: a build script cannot import
+/// from the crate it builds, so the two copies are structural rather than an
 /// oversight. Both must name the same family, or the build-time and runtime
-/// answers describe different things.
+/// answers describe different things — `build_side_names_the_same_kernel_family`
+/// pins them together, because nothing in the compiler does.
 const NAX_GEMM_KERNEL: &str = "steel_gemm_fused_nax";
 
 /// Apple GPU family that introduced the per-core Neural Accelerator.
@@ -85,22 +87,38 @@ pub(crate) enum NaxFinding {
     Scanned {
         /// Whether the scan found the nax GEMM kernel family.
         kernels_present: bool,
+        /// The metallib that answered. Carried in the variant rather than
+        /// re-derived at the warning site: the warning has to name the file it
+        /// read, and a second, independently-obtained path could disagree with
+        /// this one — which would silently demote a confirmed absence to a
+        /// `debug!` instead of failing.
+        metallib: PathBuf,
     },
 }
 
 impl NaxFinding {
-    /// Whether this finding is worth saying out loud.
+    /// The metallib to name out loud, or `None` when there is nothing to say.
     ///
     /// Loud only for a confirmed absence on hardware that can use the kernels.
     /// Present is silent, a non-NA host is silent even when they are absent,
     /// and an uninspectable metallib is silent because it establishes nothing.
-    pub(crate) const fn warrants_warning(&self) -> bool {
-        matches!(
-            self,
+    ///
+    /// Returning the path rather than a bool is what keeps the decision and the
+    /// thing the warning talks about a single observation: both come out of the
+    /// same match arm.
+    pub(crate) fn warning_target(&self) -> Option<&Path> {
+        match self {
             Self::Scanned {
-                kernels_present: false
-            }
-        )
+                kernels_present: false,
+                metallib,
+            } => Some(metallib),
+            Self::NotNaClass
+            | Self::Unverified
+            | Self::Scanned {
+                kernels_present: true,
+                ..
+            } => None,
+        }
     }
 }
 
@@ -133,7 +151,10 @@ fn evaluate(gpu_family: Option<u8>, metallib: Option<&Path>) -> NaxFinding {
         return NaxFinding::Unverified;
     };
     match metallib_has_nax_kernels(path) {
-        Ok(kernels_present) => NaxFinding::Scanned { kernels_present },
+        Ok(kernels_present) => NaxFinding::Scanned {
+            kernels_present,
+            metallib: path.to_path_buf(),
+        },
         Err(e) => {
             tracing::debug!(
                 metallib = %path.display(),
@@ -154,13 +175,14 @@ fn evaluate(gpu_family: Option<u8>, metallib: Option<&Path>) -> NaxFinding {
 /// is the expected one but was built without the kernels.
 pub(crate) fn warn_if_nax_kernels_missing() {
     let gpu_family = rmlx_core::apple_gpu::apple_silicon_generation();
-    let metallib = loaded_metallib_path();
+    let metallib = metallib_to_scan(gpu_family);
+    // `evaluate` applies the host-class gate again. That is not redundant
+    // bookkeeping: it has to stay a total function of its inputs, which is what
+    // makes the host-class x kernel-presence matrix testable on a machine that
+    // is only ever one of those hosts.
     let finding = evaluate(gpu_family, metallib.as_deref());
 
-    // A confirmed absence always has a path to name — `warrants_warning` needs
-    // a scan result, and only a readable path produces one. Binding both keeps
-    // that an observation rather than an assumption with a fallback.
-    if let (true, Some(path)) = (finding.warrants_warning(), metallib.as_deref()) {
+    if let Some(path) = finding.warning_target() {
         tracing::warn!(
             gpu_family = ?gpu_family,
             metallib = %path.display(),
@@ -188,6 +210,21 @@ pub(crate) fn warn_if_nax_kernels_missing() {
     }
 }
 
+/// The metallib worth scanning on this host, or `None` when there is none.
+///
+/// The host-class gate sits here, ahead of the dyld image walk, so a host with
+/// no Neural Accelerator skips the walk as well as the metallib open. Walking
+/// every loaded image is not "nothing runs", which is what the module claims
+/// pre-M5 hosts pay.
+///
+/// Named rather than folded into its one caller so that skip is observable:
+/// the caller does I/O and emits tracing, but this is a total function of the
+/// host class, and in a process that has MLX loaded a `None` here can only mean
+/// the walk did not happen.
+fn metallib_to_scan(gpu_family: Option<u8>) -> Option<PathBuf> {
+    is_na_class(gpu_family).then(loaded_metallib_path).flatten()
+}
+
 /// Path of the `mlx.metallib` belonging to the `libmlx.dylib` dyld loaded.
 fn loaded_metallib_path() -> Option<PathBuf> {
     Some(loaded_libmlx_path()?.parent()?.join(METALLIB_FILE))
@@ -201,12 +238,24 @@ fn loaded_libmlx_path() -> Option<PathBuf> {
     use std::os::unix::ffi::OsStrExt as _;
 
     // SAFETY: both functions are libSystem's read-only accessors over dyld's
-    // loaded-image list. `index` is bounded by the count read immediately
-    // before it, and `_dyld_get_image_name` returns either null or a
-    // NUL-terminated string dyld owns for the image's lifetime; the bytes are
-    // copied out before this returns. The list is mutated only by dlopen /
-    // dlclose, and this runs from the crate's one-shot MLX init, which does
-    // neither.
+    // loaded-image list, which is process-wide state — so the invariant that
+    // has to hold is process-wide too, not a property of this thread. Other
+    // threads are already running by this point (the tracing appender, and
+    // tokio workers under `serve`), so assume the list can move underneath the
+    // loop and check what that can do:
+    //
+    // - The count is a snapshot. A concurrent load only appends, so a stale
+    //   count under-reports and the walk misses a newly added image — it never
+    //   reads out of range. A concurrent unload would make `index` stale in the
+    //   other direction, and `_dyld_get_image_name` answers an out-of-range
+    //   index with null, which the null check skips. Either way this degrades
+    //   to a missed image, never to a bad read.
+    // - The name pointer belongs to dyld and stays valid for as long as the
+    //   image is loaded; the bytes are copied into an owned `PathBuf` before
+    //   this returns. Only unloading that image could free it, and nothing in
+    //   this process unloads one: the workspace calls neither `dlopen` nor
+    //   `dlclose`, and MLX and Metal load images without ever unloading them.
+    //   So there is no window in which the copy could race a free.
     unsafe {
         for index in 0.._dyld_image_count() {
             let raw = _dyld_get_image_name(index);
@@ -229,15 +278,38 @@ fn metallib_has_nax_kernels(path: &Path) -> std::io::Result<bool> {
     contains_nax_kernel(std::fs::File::open(path)?, SCAN_CHUNK)
 }
 
+/// Whether `hay` contains `needle`, skipping ahead on `first` — the needle's
+/// first byte — rather than comparing at every offset.
+///
+/// That skip is the difference between this and the equivalent scan in
+/// `build_support.rs`, and it is why this one can sit on a startup path: a
+/// per-offset comparison over a ~150 MB metallib takes seconds.
+fn has_needle(hay: &[u8], needle: &[u8], first: u8) -> bool {
+    let mut from = 0_usize;
+    while let Some(offset) = hay
+        .get(from..)
+        .and_then(|tail| tail.iter().position(|&b| b == first))
+    {
+        let start = from + offset;
+        if hay
+            .get(start..)
+            .is_some_and(|tail| tail.starts_with(needle))
+        {
+            return true;
+        }
+        from = start + 1;
+    }
+    false
+}
+
 /// Whether `reader` yields [`NAX_GEMM_KERNEL`] anywhere, scanning in
 /// `chunk`-sized reads.
 ///
-/// Skips ahead on the needle's first byte rather than comparing at every
-/// offset. That is the difference between this and the equivalent scan in
-/// `build_support.rs`, and it is why this one can sit on a startup path: a
-/// per-offset comparison over ~124 MB takes seconds, this takes ~47 ms for a
-/// full pass and ~2 ms in the common case, where the first match arrives a
-/// couple of MB in and ends the scan early.
+/// Each read is searched where it lands. Only the last needle-1 bytes are
+/// carried forward, and only they are ever copied — a match that begins any
+/// earlier was already either found or ruled out in the read it began in. The
+/// file is ~124-158 MB and the buffer this needs is 19 bytes, so nothing
+/// between those two sizes should be memcpy'd on a startup path.
 ///
 /// `chunk` is a parameter so the carry path — a match straddling two reads —
 /// is testable without a 124 MB fixture.
@@ -246,8 +318,20 @@ fn contains_nax_kernel<R: Read>(mut reader: R, chunk: usize) -> std::io::Result<
     let Some(&first) = needle.first() else {
         return Ok(false);
     };
+    if chunk == 0 {
+        // A zero-length buffer makes `read` answer `Ok(0)` without touching the
+        // stream, which the loop below would take for end-of-file and report as
+        // a confirmed absence — established by reading nothing. Refuse, so the
+        // caller lands in `Unverified` instead.
+        return Err(std::io::Error::other(
+            "metallib scan needs a non-zero read size",
+        ));
+    }
+    // The most a match starting in one read can extend into the next.
+    let tail_len = needle.len().saturating_sub(1);
     let mut buf = vec![0_u8; chunk];
-    let mut window: Vec<u8> = Vec::new();
+    let mut carry: Vec<u8> = Vec::with_capacity(tail_len);
+    let mut bridge: Vec<u8> = Vec::with_capacity(tail_len.saturating_mul(2));
     loop {
         let n = match reader.read(&mut buf) {
             Ok(0) => return Ok(false),
@@ -259,33 +343,44 @@ fn contains_nax_kernel<R: Read>(mut reader: R, chunk: usize) -> std::io::Result<
             Err(e) => return Err(e),
         };
         // `Read` guarantees n <= buf.len(); `get` states that without a panic
-        // path and keeps the copy a memcpy.
+        // path.
         let Some(filled) = buf.get(..n) else {
             return Err(std::io::Error::other(
                 "reader reported more bytes than the buffer holds",
             ));
         };
-        window.extend_from_slice(filled);
 
-        let mut from = 0_usize;
-        while let Some(offset) = window
-            .get(from..)
-            .and_then(|tail| tail.iter().position(|&b| b == first))
-        {
-            let start = from + offset;
-            if window
-                .get(start..)
-                .is_some_and(|tail| tail.starts_with(needle))
-            {
+        // Matches that *start* in the carried tail. They run at most needle-1
+        // bytes past it, so joining that much of this read is enough — the read
+        // is never copied wholesale.
+        if !carry.is_empty() {
+            bridge.clear();
+            bridge.extend_from_slice(&carry);
+            if let Some(head) = filled.get(..tail_len.min(filled.len())) {
+                bridge.extend_from_slice(head);
+            }
+            if has_needle(&bridge, needle, first) {
                 return Ok(true);
             }
-            from = start + 1;
+        }
+        // Matches that start in this read are found in it directly, in place.
+        if has_needle(filled, needle, first) {
+            return Ok(true);
         }
 
-        // Keep the last needle-1 bytes: a match straddling this read and the
-        // next one lives entirely inside that tail plus what comes after.
-        let consumed = window.len().saturating_sub(needle.len().saturating_sub(1));
-        window.drain(..consumed);
+        // Carry the last needle-1 bytes of the stream so far. A match beginning
+        // inside them is exactly the one neither search above could have
+        // settled, and it is all the next read needs.
+        let keep_from = filled.len().saturating_sub(tail_len);
+        if keep_from > 0 {
+            // This read alone supplies the whole tail; nothing older survives.
+            carry.clear();
+        }
+        if let Some(tail) = filled.get(keep_from..) {
+            carry.extend_from_slice(tail);
+        }
+        let excess = carry.len().saturating_sub(tail_len);
+        carry.drain(..excess);
     }
 }
 

--- a/crates/rmlx-mlx/src/nax.rs
+++ b/crates/rmlx-mlx/src/nax.rs
@@ -1,0 +1,294 @@
+//! Runtime check: does the MLX **actually loaded** into this process carry the
+//! Neural-Accelerator GEMM kernels?
+//!
+//! `build.rs` scans the metallib it compiled against and bakes the answer into
+//! `crate::NAX_CAPABILITY`. That constant describes the machine that *built*
+//! the binary, which is the wrong machine for anything shipped: a prebuilt
+//! Homebrew bottle or release tarball links `libmlx.dylib` through a
+//! package-manager `opt` symlink, so it loads whatever MLX the installing user
+//! happens to have — a different version, a different bottle, a different
+//! capability. This module answers the question for the library dyld actually
+//! resolved, which is the only answer that survives distribution.
+//!
+//! # Only Neural-Accelerator-class hosts hear anything
+//!
+//! Apple Silicon before M5 has no GPU Neural Accelerator, so its MLX
+//! legitimately ships zero of these kernels at every version. That is the
+//! majority of Macs. Warning there would be noise on hardware that cannot use
+//! the kernels either way, and a warning most people learn to ignore is worse
+//! than no warning at all — it would bury the one host where the absence
+//! costs something. So the host-class gate runs first, and when it says no,
+//! nothing else runs: no file is opened and nothing is logged above `debug`.
+//!
+//! # What the absence costs
+//!
+//! These are the GEMM kernels, so the loss is confined to GEMM-bound work:
+//! prefill / time-to-first-token measured 2.2-3.7x slower without them.
+//! Decode is bandwidth-bound, never reaches this path, and stays flat — which
+//! is exactly why the loss hides. Output remains correct.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+/// The GEMM kernel family only Neural-Accelerator hardware can run.
+///
+/// Spelled here as well as in `build.rs`: a build script cannot import from
+/// the crate it builds, so the two copies are structural rather than an
+/// oversight. Both must name the same family, or the build-time and runtime
+/// answers describe different things.
+const NAX_GEMM_KERNEL: &str = "steel_gemm_fused_nax";
+
+/// Apple GPU family that introduced the per-core Neural Accelerator.
+///
+/// [`rmlx_core::apple_gpu`] maps M1 -> 7, M2 -> 8, M3 / M4 -> 9, M5 -> 10, and
+/// one family per generation after that, so `>= 10` is "M5 or later". Do not
+/// confuse the Neural Accelerator with the Neural *Engine* (ANE): every Mac
+/// since M1 has an ANE, it is unrelated to this GEMM path, and keying off it
+/// would make every Mac NA-class.
+const NA_CLASS_GPU_FAMILY: u8 = 10;
+
+/// Read size for the metallib scan. The file is ~124-158 MB, which no startup
+/// path should hold in memory at once.
+const SCAN_CHUNK: usize = 1 << 20;
+
+/// The Metal library MLX colocates with `libmlx.dylib` and loads kernels from.
+const METALLIB_FILE: &str = "mlx.metallib";
+
+/// The dylib file name dyld reports for MLX itself.
+const LIBMLX_FILE: &str = "libmlx.dylib";
+
+// dyld's read-only accessors over the loaded-image list, from libSystem. Used
+// instead of a prefix baked in at build time because a baked prefix describes
+// the build machine's package layout, and the point of this module is to
+// describe the library that was really loaded.
+unsafe extern "C" {
+    fn _dyld_image_count() -> u32;
+    fn _dyld_get_image_name(image_index: u32) -> *const std::ffi::c_char;
+}
+
+/// What the probe established, kept separate from what it should say about it.
+///
+/// Three states, not a host-class flag beside a tri-state scan result: the two
+/// are not independent, because a host with no Neural Accelerator is never
+/// scanned at all. Spelling that as a variant means "did not look" cannot be
+/// mistaken for "looked and found nothing" — and reporting a capability that
+/// was never observed is how a probe starts lying.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum NaxFinding {
+    /// This host has no GPU Neural Accelerator, or its chip could not be
+    /// identified. The kernels cannot matter here, so nothing was scanned.
+    NotNaClass,
+    /// Neural-Accelerator-class host, but the metallib could not be inspected
+    /// — no path to it, or it would not read. Establishes nothing.
+    Unverified,
+    /// Neural-Accelerator-class host, and the metallib answered.
+    Scanned {
+        /// Whether the scan found the nax GEMM kernel family.
+        kernels_present: bool,
+    },
+}
+
+impl NaxFinding {
+    /// Whether this finding is worth saying out loud.
+    ///
+    /// Loud only for a confirmed absence on hardware that can use the kernels.
+    /// Present is silent, a non-NA host is silent even when they are absent,
+    /// and an uninspectable metallib is silent because it establishes nothing.
+    pub(crate) const fn warrants_warning(&self) -> bool {
+        matches!(
+            self,
+            Self::Scanned {
+                kernels_present: false
+            }
+        )
+    }
+}
+
+/// Whether an Apple GPU family number is Neural-Accelerator-class.
+///
+/// `None` — an unidentifiable chip, a non-Apple-Silicon host, a failed sysctl
+/// — is treated as "not NA-class": a probe that cannot identify the hardware
+/// has nothing to assert and must stay quiet rather than guess.
+const fn is_na_class(gpu_family: Option<u8>) -> bool {
+    matches!(gpu_family, Some(family) if family >= NA_CLASS_GPU_FAMILY)
+}
+
+/// Probe the host class, then — only if it matters — the metallib.
+///
+/// Both inputs are injected rather than read here so the full host-class x
+/// kernel-presence matrix is testable on one machine: this crate only ever
+/// runs on one Mac at a time, and the case that must never regress (a pre-M5
+/// host staying silent about a metallib with no nax kernels) is unreachable on
+/// the hardware that would run the tests.
+fn evaluate(gpu_family: Option<u8>, metallib: Option<&Path>) -> NaxFinding {
+    if !is_na_class(gpu_family) {
+        // Returns before touching the filesystem, not merely before deciding
+        // to speak: on a host with no Neural Accelerator the answer cannot
+        // change any outcome, so the scan must not cost anything either. The
+        // variant is what proves it — a scan that had run would have produced
+        // `Scanned`.
+        return NaxFinding::NotNaClass;
+    }
+    let Some(path) = metallib else {
+        return NaxFinding::Unverified;
+    };
+    match metallib_has_nax_kernels(path) {
+        Ok(kernels_present) => NaxFinding::Scanned { kernels_present },
+        Err(e) => {
+            tracing::debug!(
+                metallib = %path.display(),
+                error = %e,
+                "MLX nax-kernel probe could not read the metallib; capability unverified"
+            );
+            NaxFinding::Unverified
+        }
+    }
+}
+
+/// Warn once when this host has a Neural Accelerator and the MLX it loaded
+/// cannot reach it.
+///
+/// Called from the crate's one-shot MLX init alongside the build/runtime
+/// version-skew warning. The two are complementary: the skew warning catches a
+/// library that changed underneath a built binary, this catches a library that
+/// is the expected one but was built without the kernels.
+pub(crate) fn warn_if_nax_kernels_missing() {
+    let gpu_family = rmlx_core::apple_gpu::apple_silicon_generation();
+    let metallib = loaded_metallib_path();
+    let finding = evaluate(gpu_family, metallib.as_deref());
+
+    // A confirmed absence always has a path to name — `warrants_warning` needs
+    // a scan result, and only a readable path produces one. Binding both keeps
+    // that an observation rather than an assumption with a fallback.
+    if let (true, Some(path)) = (finding.warrants_warning(), metallib.as_deref()) {
+        tracing::warn!(
+            gpu_family = ?gpu_family,
+            metallib = %path.display(),
+            kernel = NAX_GEMM_KERNEL,
+            "this Mac has a GPU Neural Accelerator, but the MLX it loaded ships no \
+             Neural-Accelerator GEMM kernels. Prefill / time-to-first-token measured \
+             2.2-3.7x slower without them. Decode is bandwidth-bound, never reaches \
+             this path, and is unaffected — so output stays correct and only TTFT \
+             regresses, which is why the loss reads as a model-code defect rather than \
+             a toolchain one. Published rMLX prefill numbers assume these kernels are \
+             present; TTFT measured here is not comparable to them. Verify with \
+             `strings {} | grep -c {NAX_GEMM_KERNEL}` (want non-zero). Some package \
+             bottles omit the family entirely while a build of the same MLX version \
+             from another source carries it, so this is about the build, not the \
+             version number.",
+            path.display(),
+        );
+    } else {
+        tracing::debug!(
+            gpu_family = ?gpu_family,
+            finding = ?finding,
+            metallib = ?metallib,
+            "MLX nax-kernel probe: nothing to report"
+        );
+    }
+}
+
+/// Path of the `mlx.metallib` belonging to the `libmlx.dylib` dyld loaded.
+fn loaded_metallib_path() -> Option<PathBuf> {
+    Some(loaded_libmlx_path()?.parent()?.join(METALLIB_FILE))
+}
+
+/// Walk dyld's loaded-image list for `libmlx.dylib`.
+///
+/// `None` when no such image is loaded, which on a build that links MLX means
+/// the list could not be read — the caller treats that as "cannot verify".
+fn loaded_libmlx_path() -> Option<PathBuf> {
+    use std::os::unix::ffi::OsStrExt as _;
+
+    // SAFETY: both functions are libSystem's read-only accessors over dyld's
+    // loaded-image list. `index` is bounded by the count read immediately
+    // before it, and `_dyld_get_image_name` returns either null or a
+    // NUL-terminated string dyld owns for the image's lifetime; the bytes are
+    // copied out before this returns. The list is mutated only by dlopen /
+    // dlclose, and this runs from the crate's one-shot MLX init, which does
+    // neither.
+    unsafe {
+        for index in 0.._dyld_image_count() {
+            let raw = _dyld_get_image_name(index);
+            if raw.is_null() {
+                continue;
+            }
+            let path = Path::new(std::ffi::OsStr::from_bytes(
+                std::ffi::CStr::from_ptr(raw).to_bytes(),
+            ));
+            if path.file_name() == Some(std::ffi::OsStr::new(LIBMLX_FILE)) {
+                return Some(path.to_path_buf());
+            }
+        }
+    }
+    None
+}
+
+/// Whether `path` carries the nax GEMM kernel family.
+fn metallib_has_nax_kernels(path: &Path) -> std::io::Result<bool> {
+    contains_nax_kernel(std::fs::File::open(path)?, SCAN_CHUNK)
+}
+
+/// Whether `reader` yields [`NAX_GEMM_KERNEL`] anywhere, scanning in
+/// `chunk`-sized reads.
+///
+/// Skips ahead on the needle's first byte rather than comparing at every
+/// offset. That is the difference between this and the equivalent scan in
+/// `build_support.rs`, and it is why this one can sit on a startup path: a
+/// per-offset comparison over ~124 MB takes seconds, this takes ~47 ms for a
+/// full pass and ~2 ms in the common case, where the first match arrives a
+/// couple of MB in and ends the scan early.
+///
+/// `chunk` is a parameter so the carry path — a match straddling two reads —
+/// is testable without a 124 MB fixture.
+fn contains_nax_kernel<R: Read>(mut reader: R, chunk: usize) -> std::io::Result<bool> {
+    let needle = NAX_GEMM_KERNEL.as_bytes();
+    let Some(&first) = needle.first() else {
+        return Ok(false);
+    };
+    let mut buf = vec![0_u8; chunk];
+    let mut window: Vec<u8> = Vec::new();
+    loop {
+        let n = match reader.read(&mut buf) {
+            Ok(0) => return Ok(false),
+            Ok(n) => n,
+            // An interrupted read is not a failed probe: the caller reads an
+            // error as "cannot inspect" and goes quiet, which is the outcome
+            // this scan exists to prevent.
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        };
+        // `Read` guarantees n <= buf.len(); `get` states that without a panic
+        // path and keeps the copy a memcpy.
+        let Some(filled) = buf.get(..n) else {
+            return Err(std::io::Error::other(
+                "reader reported more bytes than the buffer holds",
+            ));
+        };
+        window.extend_from_slice(filled);
+
+        let mut from = 0_usize;
+        while let Some(offset) = window
+            .get(from..)
+            .and_then(|tail| tail.iter().position(|&b| b == first))
+        {
+            let start = from + offset;
+            if window
+                .get(start..)
+                .is_some_and(|tail| tail.starts_with(needle))
+            {
+                return Ok(true);
+            }
+            from = start + 1;
+        }
+
+        // Keep the last needle-1 bytes: a match straddling this read and the
+        // next one lives entirely inside that tail plus what comes after.
+        let consumed = window.len().saturating_sub(needle.len().saturating_sub(1));
+        window.drain(..consumed);
+    }
+}
+
+#[cfg(test)]
+#[path = "nax_tests.rs"]
+mod nax_tests;

--- a/crates/rmlx-mlx/src/nax_tests.rs
+++ b/crates/rmlx-mlx/src/nax_tests.rs
@@ -1,0 +1,372 @@
+//! Tests for the runtime Neural-Accelerator GEMM-kernel probe.
+//!
+//! The load-bearing property is the **host-class gate**, and it cannot be
+//! covered by running on this machine: only one class of hardware is available
+//! at a time, and the case that must never regress is a pre-M5 host staying
+//! silent about a metallib with no nax kernels. So the chip is stubbed as a
+//! brand string through the same parser the runtime path uses, and the
+//! metallib as a small file with or without the kernel name in it. Both halves
+//! of the matrix are asserted in both directions: a guard never observed
+//! firing, and never observed staying quiet when it should, is not known to
+//! work.
+
+use std::path::{Path, PathBuf};
+
+use rmlx_core::apple_gpu::parse_apple_generation;
+
+use super::{
+    contains_nax_kernel, evaluate, is_na_class, loaded_libmlx_path, loaded_metallib_path,
+    NaxFinding, LIBMLX_FILE, METALLIB_FILE, NAX_GEMM_KERNEL,
+};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// A file in the temp dir holding `body`, removed when the guard drops.
+struct Fixture {
+    path: PathBuf,
+}
+
+impl Fixture {
+    fn new(name: &str, body: &[u8]) -> Self {
+        let path = std::env::temp_dir().join(format!("rmlx-nax-{}-{name}", std::process::id()));
+        std::fs::write(&path, body).expect("write nax fixture");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Stand-in for a metallib that carries the kernels, with enough filler that
+/// the needle is not the only thing in the file.
+fn with_nax() -> Vec<u8> {
+    let mut body = vec![b'\x00'; 4096];
+    body.extend_from_slice(NAX_GEMM_KERNEL.as_bytes());
+    body.extend_from_slice(b"_nn_bfloat16_bfloat16_bm64");
+    body.extend_from_slice(&vec![b'\x00'; 4096]);
+    body
+}
+
+/// Stand-in for a metallib built with the kernel family compiled out. Carries
+/// the *neighbouring* kernel names so the scan has to distinguish them rather
+/// than just noticing the file is different.
+fn without_nax() -> Vec<u8> {
+    let mut body = vec![b'\x00'; 4096];
+    body.extend_from_slice(b"steel_gemm_fused_nn_bfloat16_bfloat16_bm64");
+    body.extend_from_slice(b"steel_attention_bfloat16_bq64_bk32_bd128");
+    body.extend_from_slice(&vec![b'\x00'; 4096]);
+    body
+}
+
+// ---------------------------------------------------------------------------
+// Host class — stubbed brand strings
+// ---------------------------------------------------------------------------
+
+/// Every Apple Silicon generation before M5 lacks a Neural Accelerator, so its
+/// zero-nax MLX is correct and must never be treated as NA-class. This is the
+/// majority of Macs and the case a false warning would ruin.
+#[test]
+fn pre_m5_brand_strings_are_not_na_class() {
+    for brand in [
+        "Apple M1",
+        "Apple M1 Pro",
+        "Apple M1 Ultra",
+        "Apple M2 Pro",
+        "Apple M3 Max",
+        "Apple M4",
+        "Apple M4 Pro",
+    ] {
+        assert!(
+            !is_na_class(parse_apple_generation(brand)),
+            "{brand} has no Neural Accelerator and must not be NA-class"
+        );
+    }
+}
+
+/// M5 is where the Neural Accelerator arrives; later generations keep it.
+#[test]
+fn m5_and_later_brand_strings_are_na_class() {
+    for brand in ["Apple M5", "Apple M5 Pro", "Apple M5 Max", "Apple M6 Ultra"] {
+        assert!(
+            is_na_class(parse_apple_generation(brand)),
+            "{brand} has a Neural Accelerator and must be NA-class"
+        );
+    }
+}
+
+/// A chip the parser cannot identify asserts nothing, so it is not NA-class —
+/// the probe stays quiet rather than guessing.
+#[test]
+fn unidentifiable_hosts_are_not_na_class() {
+    for brand in [
+        "Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz",
+        "Apple",
+        "Apple M",
+        "",
+        "   ",
+    ] {
+        assert!(
+            !is_na_class(parse_apple_generation(brand)),
+            "{brand:?} cannot be identified and must not be NA-class"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The host-class x kernel-presence matrix
+// ---------------------------------------------------------------------------
+
+/// The one cell that speaks: Neural-Accelerator hardware running an MLX whose
+/// metallib has no nax kernels.
+#[test]
+fn na_class_host_with_no_kernels_warns() {
+    let fixture = Fixture::new("na-absent", &without_nax());
+    for brand in ["Apple M5", "Apple M5 Max", "Apple M6 Ultra"] {
+        let finding = evaluate(parse_apple_generation(brand), Some(fixture.path()));
+        assert_eq!(
+            finding,
+            NaxFinding::Scanned {
+                kernels_present: false
+            },
+            "{brand} must scan and confirm the absence"
+        );
+        assert!(
+            finding.warrants_warning(),
+            "{brand} on a nax-less metallib is the whole point of the probe: {finding:?}"
+        );
+    }
+}
+
+/// Same hardware, a metallib that carries the kernels: nothing to say.
+#[test]
+fn na_class_host_with_kernels_is_silent() {
+    let fixture = Fixture::new("na-present", &with_nax());
+    let finding = evaluate(parse_apple_generation("Apple M5 Max"), Some(fixture.path()));
+
+    assert_eq!(
+        finding,
+        NaxFinding::Scanned {
+            kernels_present: true
+        },
+        "the scan must confirm the kernels it was pointed at"
+    );
+    assert!(
+        !finding.warrants_warning(),
+        "a working stack must not warn: {finding:?}"
+    );
+}
+
+/// The regression that would be worse than shipping nothing: the identical
+/// nax-less metallib on a pre-M5 host, where it is correct, must stay silent.
+///
+/// M4 is in the list on purpose — it is the generation immediately below the
+/// Neural Accelerator, so it is the one that flips if the host-class threshold
+/// ever slips by one.
+#[test]
+fn pre_m5_host_with_no_kernels_is_silent() {
+    let fixture = Fixture::new("pre-m5-absent", &without_nax());
+    for brand in ["Apple M1", "Apple M2 Pro", "Apple M3 Max", "Apple M4 Pro"] {
+        let finding = evaluate(parse_apple_generation(brand), Some(fixture.path()));
+        assert!(
+            !finding.warrants_warning(),
+            "{brand} legitimately ships zero nax kernels and must never be warned: {finding:?}"
+        );
+    }
+}
+
+/// A pre-M5 host does not merely ignore the metallib — it never opens it. The
+/// fixture here *does* carry the kernels, so a scan that had run would have
+/// produced `Scanned`; `NotNaClass` is the proof that the host-class gate
+/// short-circuits ahead of the file access, which is what makes the probe free
+/// on the hardware it has nothing to say about.
+#[test]
+fn pre_m5_host_never_scans_the_metallib() {
+    let fixture = Fixture::new("pre-m5-present", &with_nax());
+    for brand in ["Apple M1", "Apple M2 Pro", "Apple M3 Max", "Apple M4 Pro"] {
+        assert_eq!(
+            evaluate(parse_apple_generation(brand), Some(fixture.path())),
+            NaxFinding::NotNaClass,
+            "{brand} must not read the metallib at all"
+        );
+    }
+}
+
+/// An unidentifiable chip is handled as not-NA-class end to end, not just in
+/// the predicate: no scan, no warning.
+#[test]
+fn unidentified_host_neither_scans_nor_warns() {
+    let fixture = Fixture::new("unknown-host", &without_nax());
+    let finding = evaluate(
+        parse_apple_generation("Intel(R) Xeon(R) W-2191B"),
+        Some(fixture.path()),
+    );
+
+    assert_eq!(finding, NaxFinding::NotNaClass);
+    assert!(!finding.warrants_warning(), "{finding:?}");
+}
+
+/// "Could not look" is not "absent". An NA-class host whose metallib is
+/// missing or unreadable establishes nothing, so it must stay silent rather
+/// than report a capability it never observed.
+#[test]
+fn na_class_host_with_unreadable_metallib_is_silent() {
+    let missing = std::env::temp_dir().join(format!(
+        "rmlx-nax-{}-does-not-exist/{METALLIB_FILE}",
+        std::process::id()
+    ));
+    let finding = evaluate(parse_apple_generation("Apple M5 Max"), Some(&missing));
+
+    assert_eq!(
+        finding,
+        NaxFinding::Unverified,
+        "an unreadable metallib is unverified, not confirmed absent"
+    );
+    assert!(!finding.warrants_warning(), "{finding:?}");
+}
+
+/// No metallib path at all (dyld had no `libmlx.dylib` to point at) is the
+/// same "cannot verify" state.
+#[test]
+fn na_class_host_with_no_metallib_path_is_silent() {
+    let finding = evaluate(parse_apple_generation("Apple M5 Max"), None);
+
+    assert_eq!(finding, NaxFinding::Unverified);
+    assert!(!finding.warrants_warning(), "{finding:?}");
+}
+
+// ---------------------------------------------------------------------------
+// The scan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scan_finds_the_kernel_family_anywhere_in_the_stream() {
+    let needle = NAX_GEMM_KERNEL.as_bytes();
+    let filler = vec![b'q'; 300];
+
+    let at_start = [needle, &filler].concat();
+    let at_end = [&filler[..], needle].concat();
+    let in_middle = [&filler[..], needle, &filler].concat();
+
+    for (label, body) in [
+        ("start", at_start),
+        ("end", at_end),
+        ("middle", in_middle),
+        ("whole stream", needle.to_vec()),
+    ] {
+        assert!(
+            contains_nax_kernel(body.as_slice(), 64).expect("scan"),
+            "needle at {label} must be found"
+        );
+    }
+}
+
+#[test]
+fn scan_reports_absence_rather_than_near_misses() {
+    for (label, body) in [
+        ("empty stream", Vec::new()),
+        ("no kernels at all", vec![b'\x00'; 4096]),
+        // Shares the whole prefix but not the `_nax` suffix — the classic
+        // false positive if the scan stopped comparing early.
+        ("prefix only", b"steel_gemm_fused_nn_bfloat16".to_vec()),
+        // Many first-byte hits, no match: exercises the skip loop's advance.
+        (
+            "first-byte hits",
+            b"ssssssteel_ssteel_gemm_fused_na".to_vec(),
+        ),
+        // Truncated one byte short of the needle.
+        ("truncated needle", b"steel_gemm_fused_na".to_vec()),
+    ] {
+        assert!(
+            !contains_nax_kernel(body.as_slice(), 8).expect("scan"),
+            "{label} must not read as a match"
+        );
+    }
+}
+
+/// The carry path: a needle split across two reads still matches. Chunk sizes
+/// are chosen so the split lands at every offset inside the needle.
+#[test]
+fn scan_matches_a_needle_straddling_two_reads() {
+    let needle = NAX_GEMM_KERNEL.as_bytes();
+    for split in 1..needle.len() {
+        let body = [&vec![b'z'; split][..], needle].concat();
+        assert!(
+            contains_nax_kernel(body.as_slice(), split).expect("scan"),
+            "needle split after {split} byte(s) must still be found"
+        );
+    }
+}
+
+/// A chunk far smaller than the needle still works — the retained tail grows
+/// the window until a full needle fits.
+#[test]
+fn scan_works_with_a_chunk_smaller_than_the_needle() {
+    let body = [&vec![b'z'; 40][..], NAX_GEMM_KERNEL.as_bytes(), b"tail"].concat();
+    assert!(contains_nax_kernel(body.as_slice(), 1).expect("scan"));
+}
+
+/// The scan reads a real file through the same entry point `evaluate` uses.
+#[test]
+fn scan_reads_a_file_on_disk() {
+    let present = Fixture::new("disk-present", &with_nax());
+    let absent = Fixture::new("disk-absent", &without_nax());
+
+    assert_eq!(
+        super::metallib_has_nax_kernels(present.path()).ok(),
+        Some(true)
+    );
+    assert_eq!(
+        super::metallib_has_nax_kernels(absent.path()).ok(),
+        Some(false)
+    );
+    assert!(
+        super::metallib_has_nax_kernels(Path::new("/nonexistent/mlx.metallib")).is_err(),
+        "a missing file must surface as an error, not as a confirmed absence"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// dyld image lookup
+// ---------------------------------------------------------------------------
+
+/// This test binary links `libmlx.dylib` (`build.rs` emits the link directive
+/// and asserts the dylib exists), so dyld must be able to name it. That is
+/// what makes the runtime probe possible at all on a distributed binary, where
+/// the build machine's prefix is the wrong answer.
+#[test]
+fn dyld_names_the_loaded_libmlx() {
+    let path = loaded_libmlx_path().expect("libmlx.dylib is linked, so dyld must list it");
+
+    assert_eq!(
+        path.file_name().and_then(|n| n.to_str()),
+        Some(LIBMLX_FILE),
+        "the image found must be libmlx itself, not something merely nearby: {path:?}"
+    );
+    assert!(
+        path.is_absolute(),
+        "dyld reports absolute image paths: {path:?}"
+    );
+}
+
+/// The metallib is derived as libmlx's sibling, which is where MLX colocates
+/// it and therefore where MLX itself will load kernels from.
+#[test]
+fn metallib_path_is_the_sibling_of_the_loaded_libmlx() {
+    let libmlx = loaded_libmlx_path().expect("libmlx.dylib is linked");
+    let metallib = loaded_metallib_path().expect("a located libmlx always yields a metallib path");
+
+    assert_eq!(metallib.parent(), libmlx.parent());
+    assert_eq!(
+        metallib.file_name().and_then(|n| n.to_str()),
+        Some(METALLIB_FILE)
+    );
+}

--- a/crates/rmlx-mlx/src/nax_tests.rs
+++ b/crates/rmlx-mlx/src/nax_tests.rs
@@ -16,7 +16,7 @@ use rmlx_core::apple_gpu::parse_apple_generation;
 
 use super::{
     contains_nax_kernel, evaluate, is_na_class, loaded_libmlx_path, loaded_metallib_path,
-    NaxFinding, LIBMLX_FILE, METALLIB_FILE, NAX_GEMM_KERNEL,
+    metallib_to_scan, NaxFinding, LIBMLX_FILE, METALLIB_FILE, NAX_GEMM_KERNEL,
 };
 
 // ---------------------------------------------------------------------------
@@ -135,12 +135,16 @@ fn na_class_host_with_no_kernels_warns() {
         assert_eq!(
             finding,
             NaxFinding::Scanned {
-                kernels_present: false
+                kernels_present: false,
+                metallib: fixture.path().to_path_buf(),
             },
             "{brand} must scan and confirm the absence"
         );
-        assert!(
-            finding.warrants_warning(),
+        // The warning names the file the scan actually read, out of the same
+        // variant that decided to warn — not a path re-derived beside it.
+        assert_eq!(
+            finding.warning_target(),
+            Some(fixture.path()),
             "{brand} on a nax-less metallib is the whole point of the probe: {finding:?}"
         );
     }
@@ -155,12 +159,14 @@ fn na_class_host_with_kernels_is_silent() {
     assert_eq!(
         finding,
         NaxFinding::Scanned {
-            kernels_present: true
+            kernels_present: true,
+            metallib: fixture.path().to_path_buf(),
         },
         "the scan must confirm the kernels it was pointed at"
     );
-    assert!(
-        !finding.warrants_warning(),
+    assert_eq!(
+        finding.warning_target(),
+        None,
         "a working stack must not warn: {finding:?}"
     );
 }
@@ -176,8 +182,9 @@ fn pre_m5_host_with_no_kernels_is_silent() {
     let fixture = Fixture::new("pre-m5-absent", &without_nax());
     for brand in ["Apple M1", "Apple M2 Pro", "Apple M3 Max", "Apple M4 Pro"] {
         let finding = evaluate(parse_apple_generation(brand), Some(fixture.path()));
-        assert!(
-            !finding.warrants_warning(),
+        assert_eq!(
+            finding.warning_target(),
+            None,
             "{brand} legitimately ships zero nax kernels and must never be warned: {finding:?}"
         );
     }
@@ -200,6 +207,32 @@ fn pre_m5_host_never_scans_the_metallib() {
     }
 }
 
+/// …and the gate sits ahead of the dyld image walk as well, not only ahead of
+/// the metallib open. Walking every loaded image is real work, and the module
+/// claims a pre-M5 host pays none.
+///
+/// This test binary links `libmlx.dylib`, so the walk *can* find it — the
+/// precondition below states that outright. A `None` for a pre-M5 host can
+/// therefore only mean the walk never ran.
+#[test]
+fn pre_m5_host_never_walks_the_image_list() {
+    assert!(
+        loaded_metallib_path().is_some(),
+        "precondition: this binary links libmlx, so the walk must be able to name it"
+    );
+    for brand in ["Apple M1", "Apple M2 Pro", "Apple M3 Max", "Apple M4 Pro"] {
+        assert_eq!(
+            metallib_to_scan(parse_apple_generation(brand)),
+            None,
+            "{brand} must not pay for the image walk either"
+        );
+    }
+    assert!(
+        metallib_to_scan(parse_apple_generation("Apple M5 Max")).is_some(),
+        "an NA-class host must still get the path it has to scan"
+    );
+}
+
 /// An unidentifiable chip is handled as not-NA-class end to end, not just in
 /// the predicate: no scan, no warning.
 #[test]
@@ -211,7 +244,7 @@ fn unidentified_host_neither_scans_nor_warns() {
     );
 
     assert_eq!(finding, NaxFinding::NotNaClass);
-    assert!(!finding.warrants_warning(), "{finding:?}");
+    assert_eq!(finding.warning_target(), None, "{finding:?}");
 }
 
 /// "Could not look" is not "absent". An NA-class host whose metallib is
@@ -230,7 +263,7 @@ fn na_class_host_with_unreadable_metallib_is_silent() {
         NaxFinding::Unverified,
         "an unreadable metallib is unverified, not confirmed absent"
     );
-    assert!(!finding.warrants_warning(), "{finding:?}");
+    assert_eq!(finding.warning_target(), None, "{finding:?}");
 }
 
 /// No metallib path at all (dyld had no `libmlx.dylib` to point at) is the
@@ -240,7 +273,7 @@ fn na_class_host_with_no_metallib_path_is_silent() {
     let finding = evaluate(parse_apple_generation("Apple M5 Max"), None);
 
     assert_eq!(finding, NaxFinding::Unverified);
-    assert!(!finding.warrants_warning(), "{finding:?}");
+    assert_eq!(finding.warning_target(), None, "{finding:?}");
 }
 
 // ---------------------------------------------------------------------------
@@ -306,12 +339,52 @@ fn scan_matches_a_needle_straddling_two_reads() {
     }
 }
 
+/// The same carry path with reads far larger than the needle, which is the
+/// shape the real 1 MB scan has: the tail is taken from the end of a full
+/// buffer rather than accumulated out of scraps, and the sweep above — whose
+/// chunks are all smaller than the needle — never reaches that branch.
+#[test]
+fn scan_matches_a_needle_straddling_two_full_size_reads() {
+    let needle = NAX_GEMM_KERNEL.as_bytes();
+    for chunk in [needle.len() + 1, 64, 4096] {
+        for in_first_read in 1..needle.len() {
+            let mut body = vec![b'z'; chunk - in_first_read];
+            body.extend_from_slice(needle);
+            body.extend_from_slice(&[b'z'; 7]);
+            assert!(
+                contains_nax_kernel(body.as_slice(), chunk).expect("scan"),
+                "needle with {in_first_read} byte(s) in a {chunk}-byte read must still be found"
+            );
+        }
+    }
+}
+
 /// A chunk far smaller than the needle still works — the retained tail grows
 /// the window until a full needle fits.
 #[test]
 fn scan_works_with_a_chunk_smaller_than_the_needle() {
     let body = [&vec![b'z'; 40][..], NAX_GEMM_KERNEL.as_bytes(), b"tail"].concat();
     assert!(contains_nax_kernel(body.as_slice(), 1).expect("scan"));
+}
+
+/// A zero read size cannot establish anything, so it must not answer "absent".
+///
+/// `read` into a zero-length buffer returns `Ok(0)` without touching the
+/// stream, which is indistinguishable from end-of-file — so a scan that
+/// accepted it would report a confirmed absence having read no bytes, and
+/// `evaluate` would turn that into a warning. Production always passes
+/// `SCAN_CHUNK`; the parameter exists so tests can vary it, which is exactly
+/// how a zero would get here.
+#[test]
+fn scan_refuses_a_zero_read_size() {
+    let body = [&vec![b'z'; 8][..], NAX_GEMM_KERNEL.as_bytes()].concat();
+    assert!(
+        contains_nax_kernel(body.as_slice(), 0).is_err(),
+        "a zero read size must surface as an error, not as a confirmed absence"
+    );
+    // Including when the kernels really are absent — the error is about not
+    // having looked, not about what was there.
+    assert!(contains_nax_kernel(without_nax().as_slice(), 0).is_err());
 }
 
 /// The scan reads a real file through the same entry point `evaluate` uses.
@@ -331,6 +404,30 @@ fn scan_reads_a_file_on_disk() {
     assert!(
         super::metallib_has_nax_kernels(Path::new("/nonexistent/mlx.metallib")).is_err(),
         "a missing file must surface as an error, not as a confirmed absence"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Kernel-family name drift
+// ---------------------------------------------------------------------------
+
+/// The kernel family is spelled twice — here for the runtime probe, and in
+/// `build_support.rs` for the build-time scan — because a build script cannot
+/// import from the crate it builds. Nothing in the compiler couples the two.
+///
+/// Renaming one copy alone leaves the runtime probe scanning for a string no
+/// metallib ever contained, so it would report a confirmed absence on every
+/// host: a permanent false warning on exactly the M5 machines this exists for,
+/// with everything still compiling and every other test still passing. Pin them.
+#[test]
+fn build_side_names_the_same_kernel_family() {
+    const BUILD_SUPPORT: &str = include_str!("../build_support.rs");
+
+    let declaration = format!("const NAX_GEMM_KERNEL: &str = \"{NAX_GEMM_KERNEL}\";");
+    assert!(
+        BUILD_SUPPORT.contains(&declaration),
+        "build_support.rs must declare `{declaration}`: the build-time scan and this \
+         runtime probe have to name one family, or their answers describe different things"
     );
 }
 

--- a/crates/rmlx-mlx/tests/mlx_pin.rs
+++ b/crates/rmlx-mlx/tests/mlx_pin.rs
@@ -146,7 +146,7 @@ fn mlx_version_degrades_to_unknown() {
     reason = "reads from an in-memory slice, which cannot fail"
 )]
 fn needle_is_found_across_a_chunk_boundary() {
-    let needle = b"steel_gemm_fused_nax";
+    let needle = NAX_GEMM_KERNEL.as_bytes();
     // Straddle a read boundary: the match exists only if the tail is carried.
     let mut haystack = vec![b'.'; 7];
     haystack.extend_from_slice(needle);
@@ -165,7 +165,7 @@ fn needle_is_found_across_a_chunk_boundary() {
     reason = "reads from an in-memory slice, which cannot fail"
 )]
 fn needle_absent_reports_false() {
-    let needle = b"steel_gemm_fused_nax";
+    let needle = NAX_GEMM_KERNEL.as_bytes();
     assert!(!contains_needle(b"".as_slice(), needle, 8).unwrap());
     assert!(!contains_needle(b"steel_gemm_fused_na".as_slice(), needle, 8).unwrap());
     // A near-miss must not count: this is the 0-vs-360 distinction itself.
@@ -288,13 +288,13 @@ fn loud_message_reports_the_absence_without_the_ships_them_contradiction() {
         "0.32.0",
         "0.6.0_3",
         &pin,
-        "steel_gemm_fused_nax",
+        NAX_GEMM_KERNEL,
         "crates/rmlx-mlx/mlx-pin.txt",
     );
     let joined = lines.join("\n");
 
     // States the finding plainly.
-    assert!(joined.contains("ships no steel_gemm_fused_nax kernels"));
+    assert!(joined.contains(&format!("ships no {NAX_GEMM_KERNEL} kernels")));
 
     // Must not restate the fixed self-contradiction: claiming, in the same
     // breath as reporting an absence, that the pinned pair's metallib ships
@@ -322,7 +322,7 @@ fn loud_message_never_hard_fails() {
         "unknown",
         "unknown",
         &pin,
-        "steel_gemm_fused_nax",
+        NAX_GEMM_KERNEL,
         "crates/rmlx-mlx/mlx-pin.txt",
     );
     assert!(!lines.is_empty());

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -246,6 +246,42 @@ existing one-shot init, and warns on mismatch. Together the two checks cover
 both halves: the pin catches a bad stack at compile time, the skew warning
 catches a stack that changed underneath a built binary.
 
+### Runtime NAX capability (`src/nax.rs`)
+
+A version match is not a capability match, and neither survives distribution.
+`RMLX_MLX_NAX` describes the machine that *built* the binary; a Homebrew bottle
+or release tarball links `libmlx.dylib` through the moving `opt` symlink, so it
+runs against the installing user's MLX, which may be a different bottle of the
+same version. `src/nax.rs` therefore repeats the metallib scan at run time, on
+the same one-shot init as the skew warning, against the library **dyld actually
+loaded** (found by walking dyld's image list for `libmlx.dylib`, then reading
+its colocated `mlx.metallib`).
+
+**Host-class gated, and that gate is the point.** The kernels only exist for
+the GPU Neural Accelerator, which arrives with M5 — Apple GPU family 10 in
+`rmlx_core::apple_gpu`. Every earlier generation legitimately ships zero of
+them at every MLX version, so a warning there would be noise on the majority
+of Macs and would train people to ignore the one host where the absence costs
+something. The gate runs first, and when it says "no Neural Accelerator"
+nothing else runs: the metallib is never opened.
+
+| Host | Kernels | Result |
+|---|---|---|
+| M5+ | absent (confirmed) | `warn!` — names prefill/TTFT, the metallib, and the check command |
+| M5+ | present | `debug!` only |
+| M5+ | metallib unreadable / not found | `debug!` only — "could not look" is not "absent" |
+| M1–M4, or chip unidentifiable | either | `debug!` only; **no scan at all** |
+
+Measured cost on the release binary (M5 Max): **~1.2 ms** when the kernels are
+present (the first match lands a couple of MB in and ends the scan), ~49 ms for
+a full pass over a 124 MB metallib with none, and **~0** on a pre-M5 host,
+which never opens the file. It runs once per process, on the init that already
+precedes a multi-second model load.
+
+The wording is scoped to **prefill / TTFT** deliberately: NAX is unreachable at
+decode by construction (see "Where NAX can appear, and where it cannot"), so a
+warning implying a general slowdown would be wrong.
+
 ### Build pipeline (`build.rs`)
 
 1. Target guard: `aarch64-apple-darwin` only. The assertion fires at compile

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -262,8 +262,8 @@ the GPU Neural Accelerator, which arrives with M5 — Apple GPU family 10 in
 `rmlx_core::apple_gpu`. Every earlier generation legitimately ships zero of
 them at every MLX version, so a warning there would be noise on the majority
 of Macs and would train people to ignore the one host where the absence costs
-something. The gate runs first, and when it says "no Neural Accelerator"
-nothing else runs: the metallib is never opened.
+something. The gate runs ahead of every other step, and when it says "no Neural
+Accelerator" neither the dyld image walk nor the metallib open happens.
 
 | Host | Kernels | Result |
 |---|---|---|
@@ -272,11 +272,13 @@ nothing else runs: the metallib is never opened.
 | M5+ | metallib unreadable / not found | `debug!` only — "could not look" is not "absent" |
 | M1–M4, or chip unidentifiable | either | `debug!` only; **no scan at all** |
 
-Measured cost on the release binary (M5 Max): **~1.2 ms** when the kernels are
-present (the first match lands a couple of MB in and ends the scan), ~49 ms for
-a full pass over a 124 MB metallib with none, and **~0** on a pre-M5 host,
-which never opens the file. It runs once per process, on the init that already
-precedes a multi-second model load.
+Measured cost on the release binary (M5 Max, warm page cache, best of 5):
+**~0.7 ms** when the kernels are present — the first match lands a couple of MB
+into the 158 MB metallib and ends the scan — and **~49 ms** for a full pass over
+a metallib of the same size with none. On a pre-M5 host it is **~1.3 µs**, which
+is the `sysctl` chip query and nothing else: the dyld image walk (~220 ns) and
+the file open are both behind the gate. It runs once per process, on the init
+that already precedes a multi-second model load.
 
 The wording is scoped to **prefill / TTFT** deliberately: NAX is unreachable at
 decode by construction (see "Where NAX can appear, and where it cannot"), so a

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,6 +17,27 @@ crates are `publish = false`). There is no separate `VERSION` file.
   the binary links.
 - A published tap repo `Pushkinist/homebrew-rmlx` for `brew tap`.
 
+> **What the shipped artifacts resolve MLX to.** Both the bottle and the
+> release tarball link `libmlx.dylib` / `libmlxc.dylib` through the moving
+> `/opt/homebrew/opt/...` symlinks, so **neither carries the MLX it was built
+> against** — each runs against whatever the installing user has, which
+> `depends_on "mlx-c"` resolves to the current release. Two consequences worth
+> holding onto when reading a user report:
+>
+> - The `RMLX_MLX_NAX` baked into the artifact describes the **release
+>   machine**, not the user's. `events.mlx_nax` from a distributed binary is
+>   the builder's answer. The user-facing answer is the runtime probe in
+>   `crates/rmlx-mlx/src/nax.rs`, which reads the metallib actually loaded and
+>   warns only on Neural-Accelerator hosts (see `docs/FFI.md`).
+> - Run `make mlx-preflight` on the release machine before step 8's keg build.
+>   It does not change what users get, but it keeps the release machine's own
+>   published prefill numbers honest.
+>
+> The formula deliberately does **not** pin an MLX version — that would force a
+> downgrade on M1–M4 users for a benefit their hardware has no use for. The
+> rationale is in `packaging/homebrew/rmlx.rb`; do not "fix" it by adding a
+> version constraint.
+
 ## Cut a release
 
 1. **Bump** `version` in `Cargo.toml` `[workspace.package]`.

--- a/packaging/homebrew/rmlx.rb
+++ b/packaging/homebrew/rmlx.rb
@@ -18,6 +18,24 @@
 #
 # Builds from source (depends_on "rust" => :build) and links the Homebrew MLX
 # (depends_on "mlx-c"), so the mlx-c rpath always matches the user's MLX install.
+#
+# The `mlx-c` dependency is deliberately unversioned, and must stay that way.
+# rMLX pins one validated mlx / mlx-c pair for development
+# (crates/rmlx-mlx/mlx-pin.txt), but that pin exists for a bottle regression
+# that only costs anything on M5-and-later hardware — the generation that has a
+# GPU Neural Accelerator. On M1-M4 the same MLX is entirely correct, and
+# requiring an older release there would force a downgrade for a benefit that
+# hardware cannot use. The pin is a this-machine, this-generation workaround,
+# not a product requirement.
+#
+# What ships to users instead is a runtime check: rmlx probes the mlx.metallib
+# of the library it actually loaded and warns on startup only when the host has
+# a Neural Accelerator and the kernels are missing. That stays true after a
+# `brew upgrade mlx` moves the symlink underneath an already-installed rmlx,
+# which no version constraint here could. See crates/rmlx-mlx/src/nax.rs and
+# docs/FFI.md. There is no `caveats` block for the same reason: it would print
+# for every user on every Mac, and the runtime warning reaches exactly the
+# hosts the finding applies to.
 class Rmlx < Formula
   desc "Rust-native, single-binary MLX inference + conversion backend for Apple Silicon"
   homepage "https://github.com/Pushkinist/rMLX"


### PR DESCRIPTION
Closes #305.

A user who installs rMLX gets whatever MLX their package manager resolves, with no check and no signal. On an M5+ host that can silently be the nax-less mlx 0.32.0 bottle — zero `steel_gemm_fused_nax` kernels where 0.31.2 ships 288, costing **2.2–3.7× on prefill**. Benches still run and still look plausible.

### What the install paths actually resolve to, verified

| path | builds against | **runs** against | signal before |
|---|---|---|---|
| `brew install rmlx` (bottle) | release machine's pinned 0.31.2 | **user's** — `depends_on "mlx-c"` → mlx-c 0.6.0_3 → **mlx 0.32.0, 0 nax** | none |
| source / `install.sh` / `cargo install` | user's | same | a `cargo:warning`, buried |
| release tarball | release machine's 0.31.2 | **user's** | none |

`otool -L` shows install names of `/opt/homebrew/opt/{mlx,mlx-c}/lib/…` — moving symlinks. **No shipped artifact carries the MLX it was built against**, and `brew upgrade mlx` retargets an already-installed rmlx with no rebuild.

### Runtime signal, not a pin

A pin cannot be right for both audiences: it buys nothing on M1–M4 (no Neural Accelerator, zero nax kernels is correct at every version) and would force a downgrade there. And it cannot bind anyway, because the install names are `opt` symlinks that no formula constraint reaches after installation.

So the probe reads ground truth at startup: walk dyld's image list for the `libmlx.dylib` **actually loaded**, scan its colocated `mlx.metallib`, and emit one `tracing::warn!` **only** when the host has a Neural Accelerator (GPU family ≥ 10 / M5+) **and** the kernels are confirmed absent. It keeps working once a fixed bottle ships, and stays true after distribution.

The formula stays unversioned, with the reasoning written into it so nobody "fixes" it later. No `caveats` block — that prints for every user on every Mac, whereas the runtime warning reaches exactly the hosts the finding applies to.

### Host-class correctness is the point

M1–M4 must never be warned, and are not. Verified at three independent levels, with the guard observed both firing and staying silent:

| host | metallib | finding | warns |
|---|---|---|---|
| M5 Max (real) | real 0.32.0 bottle, 0 nax | `Scanned{false}` | **yes** |
| M5 Max (real) | real 0.31.2, 288 nax | `Scanned{true}` | no |
| M4 Pro (stubbed) | 0 nax | `NotNaClass` | **no** |
| M4 Pro (stubbed) | 288 nax | `NotNaClass` | no |

Plus live `rmlx info` runs on two architectures. The boundary is pinned from **both** sides at the real M4/M5 line — a slip to `>= 9` fails the pre-M5 tests, `>= 11` fails the M5 test.

### "Could not look" is not "absent"

A three-state finding — `NotNaClass` / `Unverified` / `Scanned{kernels_present, metallib}` — so a failure to read can never present as a confirmed absence. Every `Err` path (missing file, permissions, mid-scan read error, over-long read, and now a zero read size) lands in `Unverified` and stays silent. The only `Ok(false)` producer is a genuine EOF after a full scan.

This matters because **the issue's own proposed condition would have misfired**: warning when `NAX_CAPABILITY != "present"` folds "unknown" into "absent", so a host where nothing was established gets warned. The issue also proposed reading the build-time constant — which describes the *builder's* machine, not the user's.

### Review round

- The SAFETY comment discharged the dyld race with the **wrong invariant** (a claim about the calling thread, where the requirement is process-wide). The code was correct; the justification was not, and a SAFETY comment that proves the wrong thing is worse than a terse one. Restated, and verified that `dlopen`/`dlclose` appear nowhere in the workspace.
- The warning decision was reconstructed from two independently-derived values, so a fall-through would have silently downgraded a confirmed absence to `debug!`. The path now lives **in the variant**, and the compiler enforces the pairing.
- The module doc claimed pre-M5 hosts run nothing, while the dyld walk ran *before* the gate. Gate hoisted; the claim is now true as written.
- The kernel-family name was spelled in 6 places with no drift guard — drift would mean scanning for a string the metallib never contained, i.e. **a permanent false warning on exactly the M5 hosts this targets**. Consolidated to 2, pinned by a test.

### Measurement notes

The first-round figures did not survive scrutiny and were re-measured: 84 ns is below even the dyld walk alone (219 ns), so it cannot have covered the function it was attributed to. Current, measured: pre-M5 **1.3 µs** (now entirely the `sysctlbyname` chip query), present case **687 µs**, full pass over a 158 MB nax-less metallib **49.4 ms** — startup only, on a gated path.

A reviewer estimate that the intermediate copy cost "roughly a fifth" of the scan was **refuted by A/B measurement at 7%**; the fix landed anyway because it is correct and simpler, and the docs quote the measured 6.8%.

Also worth recording: the first full-pass fixture was 124 MB of a single repeated byte, which gives the first-byte skip zero hits and measured unrealistically fast. It was rebuilt from the real metallib with the kernel names rewritten to same-length strings, preserving size and byte statistics.

### Coverage gap, stated

The MLX-version axis is exercised with a **real** nax-less metallib extracted from the brew cache, so the scan is proven on genuine bytes — but the brew symlinks were not physically repointed to 0.32.0, since that needs a paired mlx/mlx-c repoint plus a rebuild and would break this machine's pin. The fully end-to-end "user has 0.32.0 linked" case is therefore untested.

`make ci` green. 77 crate tests, 8 mutation checks all killed, zero `unwrap`/`expect` in shipped code.

Known follow-up: `events.mlx_nax` still records the **build** machine's answer, so rows from a distributed binary describe the builder's MLX. Feeding the runtime finding in would change the meaning of an append-only column mid-stream — documented in `docs/RELEASING.md` rather than changed unilaterally.
