### PR TITLE
docs(kv): fused quantized decode does not clear break-even — #45 answered negative

### DIFF
--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2619,6 +2619,112 @@ sensitive — see `.rmlx/bench/perf_canary.csv` rows tagged
 
 ---
 
+## Fused flash-decode over a quant store — the break-even condition
+
+The four sections that follow — plus TurboFlash, whose posture and measured
+cells live on `rmlx_cli::commands::serve::TurboFlashMode` — each describe a
+hand-written MSL kernel that reads a packed KV store directly at decode instead
+of a bf16 mirror. They all exist for one reason: a smaller store means fewer
+bytes moved per decode step. This section states the condition under which that
+trade actually pays, and records what it measures on this tree. Read it before
+concluding that a new fused kernel — or a denser store — will make some codec
+win.
+
+### The condition
+
+Two quantities, both measurable with `rmlx bench`:
+
+* **ρ** — bytes the fused kernel reads, over bytes MLX `sdpa_vector` reads from
+  the bf16 mirror for the same cell. Measured as the codec's resident KV in
+  excess of `none`'s.
+* **ε** — the fraction of MLX `sdpa_vector`'s per-byte throughput the
+  hand-written kernel achieves: `ε = ρ / (marginal-slope ratio vs none)`, where
+  the slope is `b` in `ms/step = a + b·(KV tokens/1000)`.
+
+A fused decode beats bf16 iff **ρ < ε**. Note that ε is a property of the
+*kernel shell*, not of the codec, and ρ is a property of the *store*, not of the
+kernel — so a codec and a kernel can each be reasonable and the pair still lose.
+
+### Measured (`d8a6169`, release-perf, M5 Max, n=3, contended host)
+
+| kernel | arch | `heads_per_kv` | ρ | slope ratio | ε |
+|---|---|---|---|---|---|
+| TurboFlash (`k8v4`) | Bonsai-8B | 4 | 0.262 | 6.37× | **0.041** |
+| `iso_flash_decode_symv` (`iso3_sym`) | Bonsai-8B | 4 | 1.013 | 7.51× | **0.135** |
+| `iso_flash_decode_symv` (`iso3_sym`) | gemma-4-e2b | 8 | ~1.01 | 19.2× | **0.052** |
+
+The TurboFlash row is the sharpest statement available: at 32k on Bonsai-8B the
+fused path reads **3.8× fewer bytes** and costs **6.4× more time per KV token**.
+Decode through these kernels is **not bandwidth-bound**, so a smaller store does
+not buy time.
+
+Dispatch was witnessed, not inferred. `--turbo-flash on` at a 4k prompt (below
+the kernel's own `kv_seq > 4096` gate) is bit-identical to `off` in resident
+bytes and within noise on TPS; dropping the gate at the *same* prompt moves
+resident KV by +180 MB and decode 129.8 → 65.9 TPS. The 16k/32k byte deltas
+(+722 MB / +1445 MB, exactly linear in `kv_seq`) are the kernel engaging.
+
+### Why ε is small — grid geometry
+
+Every P1 kernel here indexes its grid by **query** head (`n_bh = b · n_q_heads`)
+and addresses KV with `kv_h_idx = hq / heads_per_kv`. So `heads_per_kv`
+threadgroups each stream the identical KV bytes. That caps the shell at
+**ε ≤ 1/heads_per_kv** before any kernel-body cost:
+
+| arch | `heads_per_kv` | geometric ceiling | measured ε |
+|---|---|---|---|
+| Bonsai-8B | 4 | 0.250 | 0.135 (54% of ceiling) |
+| gemma-4-e2b | 8 | 0.125 | 0.052 (42% of ceiling) |
+
+Measured ε differs between the two archs by 2.6×; `heads_per_kv` alone predicts
+2.0×. The geometry is the dominant term. The residual ≈2× is the f32
+`partial_o` P1→P2 DRAM round trip plus the thread-0-serial online-softmax
+section, where all but one lane idle twice per KV token.
+
+**Corollary for `kv_h == 1` architectures.** e2b's geometric ceiling (0.125) is
+*below* the densest store in the tree (`tsym3`, ρ = 0.158). On such an arch no
+fused decode over any store that exists or has been proposed can beat bf16 **even
+with a perfect kernel body**, until the grid stops re-reading KV per query head.
+
+### What ρ would have to be
+
+| kernel efficiency | break-even store (bf16 = 32 bits per K+V pair) |
+|---|---|
+| ε = 0.135 (best measured) | 4.3 bits/pair = **2.2 bits per value per axis** |
+| ε = 0.052 (e2b) | 1.7 bits/pair = **0.83 bits per value per axis** |
+| ε = 0.041 (TurboFlash) | 1.3 bits/pair = **0.66 bits per value per axis** |
+
+Against what exists or has been specced:
+
+| store | bits/value | ρ | clears ε = 0.135? |
+|---|---|---|---|
+| `tsym3` — densest store in the tree | 2.5 | 0.158 | no, 1.2× over |
+| the repacked iso/rotor store specced in "Memory truth" | 3.75 | 0.234 | no, 1.7× over |
+| rotor with its structurally-zero components dropped | 14.0 | 0.876 | no, 6.5× over |
+| iso / rotor as stored today | 16.25 / 21.75 | 1.02 / 1.36 | no |
+
+**The binding constraint is ε, not ρ.** Repacking a store is necessary for some
+of these codecs to stop costing memory, but it is not sufficient to make a fused
+decode win, and on `kv_h == 1` it is not even close. Order kernel-shell work
+first; judge a store repack on its memory merits, not on an expected decode win.
+
+### The honest read on the mirror-fed codecs
+
+`k8v4` and `tsym3` still produce a token digest **bit-identical to `none`** at
+4k / 16k / 32k on both architectures. A q8/q4/turbo3 store cannot reproduce bf16
+output bit-exactly over 64 greedy steps at 32k, so this is direct evidence that
+their quant store is not on the decode read path — the mirror is. They pay for
+the store in resident bytes (+26% and +16% at 32k on Bonsai) and in prefill
+(`tsym3` TTFT 23.1 s vs `none` 19.2 s at 32k) and get nothing back at decode.
+
+That remains a real defect. What the table above rules out is the *specific*
+remedy of pointing a hand-written flash-decode kernel at those stores: it has
+been built twice — TurboFlash for `k8v4`, the iso/rotor flash-decode pair for the
+eight `_sym` / K-only codecs — and both lose, for a reason that is structural and
+now quantified.
+
+---
+
 ## `rotor_flash_decode` — fused MSL flash-decode over rotor-quant K
 
 Fused flash-decode for `KvStorage::RotorKOnly3` / `RotorKOnly4`: QK over the
@@ -2929,9 +3035,12 @@ discarded. `make check-no-kernel-input-eval` keeps the defect from coming back.
 So these codecs remain opt-in (`--kv-quant rotor3_sym` / `rotor4_sym`, and the
 iso pair), and remain research codecs for quality experiments and kernel work —
 not memory or throughput candidates. Closing the remaining speed gap needs a
-single-pass simdgroup flash-decode that beats MLX bf16 flash (tracked with
-`#45`); closing the memory gap needs a repacked store, which is a redesign, not
-a kernel change.
+flash-decode shell that stops re-reading KV once per query head, drops the f32
+P1→P2 partial round trip, and stops serialising the online softmax on one lane;
+closing the memory gap needs a repacked store, which is a redesign, not a kernel
+change. Neither alone is enough — see "Fused flash-decode over a quant store —
+the break-even condition" above for the measured `ρ < ε` arithmetic and why the
+shell, not the store, is the binding constraint.
 
 ### Short-prompt abort at `kv_h == 1` — small-`norms`-buffer device floor
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -244,6 +244,15 @@ never smaller than bf16 (see `docs/KV_QUANT.md` "Memory truth"), and its
 decode is several times `none`'s. Bench them for kernel work and quality
 study, not as memory or throughput candidates.
 
+**A denser store would not rescue them either.** Post-fix marginal cost puts the
+hand-written flash-decode shell at 4–14% of MLX `sdpa_vector`'s per-byte
+throughput, measured on both `kv_h = 8` and `kv_h = 1`, so break-even needs a
+store of 0.7–2.2 bits per value per axis — denser than anything in the tree or
+on the roadmap. The arithmetic, the two-architecture measurement and the grid
+geometry that causes it are in `docs/KV_QUANT.md` § "Fused flash-decode over a
+quant store — the break-even condition". Do not spend kernel effort on this
+family expecting a decode win without first moving that number.
+
 #### K-only family, re-recorded after the dispatcher fix
 
 The table above left the K-only family incomplete: `k_iso4` / `k_rotor4` were

--- a/docs/models/bonsai/27B/rMLX.md
+++ b/docs/models/bonsai/27B/rMLX.md
@@ -375,17 +375,34 @@ The small long-context residual is a minor follow-up (§4), no longer the headli
 Ranked by impact:
 
 1. **Fused MSL flash-decode-over-quant kernels for the Tier-2 (`*_sym`) and
-   Tier-3 (`k_*`) families — the headline.** The matrix proves the ROI: the iso /
-   rotor codecs are the **fastest in the whole sweep when they have a GPU decode
-   kernel** (`rotor3/4` +7…+13 % vs `none`; `iso3` +13 % at 16k). Their sub-8-bit
-   and symmetric variants have **no Metal kernel**, so they fall back to a CPU
-   dequant seed (Tier 3) or a dormant bf16-mirror (Tier 2). A real fused
-   flash-decode-over-quant kernel for these would convert **8 currently
-   useless / mirror cells** (4 `*_sym` + 4 `k_*`) into viable ones. This is the
-   known blocker: *per-step `quantized_matmul` can't beat MLX bf16 flash at long
-   ctx — it needs an MSL flash-decode-over-quant kernel*. The 27B is the best
-   argument yet for building it, because the GPU-kerneled members of the same
-   families already win.
+   Tier-3 (`k_*`) families — built, and the ROI argument did not survive it.**
+   The original text here read: *the iso / rotor codecs are the fastest in the
+   whole sweep when they have a GPU decode kernel (`rotor3/4` +7…+13 % vs `none`;
+   `iso3` +13 % at 16k), their sub-8-bit and symmetric variants have no Metal
+   kernel, so a real fused flash-decode-over-quant kernel would convert 8
+   currently useless / mirror cells (4 `*_sym` + 4 `k_*`) into viable ones.*
+
+   Those kernels were then written — `iso_flash_decode`, `rotor_flash_decode` and
+   the `_symv` pair — and all 8 cells now decode straight off the packed store
+   with no mirror. **They did not become viable.** Two independent reasons, both
+   measured after the fact:
+
+   * The stores are not smaller than bf16 (16.25 bits/value for iso, 21.75 for
+     rotor, against bf16's 16.0), so there was never a bandwidth prize to
+     collect — see "Memory truth" in `docs/KV_QUANT.md`.
+   * The kernel shell itself achieves only 4–14 % of MLX `sdpa_vector`'s
+     per-byte throughput, chiefly because its P1 grid is indexed by *query* head
+     and so re-reads the whole KV stream `heads_per_kv` times. Even the densest
+     store in the tree is too fat to clear that bar. The `ρ < ε` arithmetic,
+     the two-architecture measurement and the corollary for `kv_h == 1` are in
+     `docs/KV_QUANT.md` § "Fused flash-decode over a quant store — the break-even
+     condition".
+
+   The premise that misled this item was *"the GPU-kerneled members of the same
+   families already win, so a kernel is the missing piece"*. `rotor3/4` and
+   `iso3` win because they decode through the **bf16 mirror**, i.e. through MLX's
+   own SDPA — not because their codec math is fast at decode. They were never
+   evidence about a hand-written kernel.
 2. **rMLX prefill — corrected to near-parity (was misdiagnosed as a 2.6–3.4× GDN
    loss).** The original text here concluded prefill was 2.6–3.4× slower than the
    siblings and pinned the blame on the GDN recurrence kernel


### PR DESCRIPTION
Closes #45 — as **answered-negative**. Docs-only; no kernel was built, because the measurement says one cannot win.

The mechanism #45 asks for already exists in two independent implementations — TurboFlash for `k8v4`, and `{iso,rotor}_flash_decode{,_symv}` for the eight `_sym`/K-only codecs — and both are **slower** than the bf16 mirror they replace.

### The break-even condition

A fused decode beats the mirror iff **ρ < ε**, where ρ = bytes the fused kernel reads relative to MLX's `sdpa_vector`, and ε = the fraction of MLX's per-byte throughput it achieves.

| kernel | arch | `heads_per_kv` | ρ | slope ratio | ε |
|---|---|---|---|---|---|
| TurboFlash (`k8v4`) | Bonsai-8B | 4 | 0.262 | 6.37× | **0.041** |
| `iso_flash_decode_symv` (`iso3_sym`) | Bonsai-8B | 4 | 1.013 | 7.51× | **0.135** |
| `iso_flash_decode_symv` (`iso3_sym`) | gemma-4-e2b | 8 | ~1.01 | 19.2× | **0.052** |

Best ε anywhere is **0.135**; smallest ρ anywhere is **0.158**. Nothing clears, on either architecture. The fused path reads **3.8× fewer bytes and costs 6.4× more time per KV token** — decode through these kernels is not bandwidth-bound, so the prize never converts.

Controlled A/B: `--turbo-flash off`/`on` — same codec, store, model and context, only the decode kernel differs. Dispatch proven rather than inferred: the flag alone is inert (4k arms bit-identical at 815,628,288 B), while removing the `kv_seq` gate at the *same* prompt moves resident KV +180,617,216 B and decode 129.8 → 65.9 TPS. Byte deltas at 16k/32k are exactly linear in `kv_seq`.

### Why — geometric, not a tuning miss

Every P1 kernel indexes its grid by **query** head, so `heads_per_kv` threadgroups stream identical KV bytes, capping **ε ≤ 1/heads_per_kv**. Measured ε differs between architectures by 2.6×; `heads_per_kv` alone predicts 2.0×, with the residual ~2× being the f32 `partial_o` P1→P2 round trip and the thread-0-serial softmax.

The sharpest consequence: on `kv_h == 1` the ceiling is 0.125, **below the densest store in the tree (0.158)** — so on that shape no fused decode over any store, present or proposed, beats bf16 even with a perfect kernel body.

Filed as **#340**, correctly placed in #304 **Phase 2** (kernel shell), not Phase 3.

### #317 is not a prerequisite

It takes rotor 21.75 → 14.02 bits/value (ρ 1.36 → 0.876) — **6.5× above** the best measured ε. Even #310's most aggressive repack (3.75 bits/value, ρ 0.234) is **1.7× above**. Break-even needs 0.66–2.2 bits per value *per axis*. Format work is necessary but nowhere near sufficient; #45 should not have been sequenced behind it, and #317 should not be justified by an expected decode win.

### Corrections landed in the docs

- **The 2026-07-16 ROI argument was falsified at its premise.** It reasoned that `iso3`/`rotor3/4` win because they "have a GPU decode kernel". They win because they decode through the **bf16 mirror** — MLX's own SDPA. `cpu_hot_path_reason()` says so directly: the GPU iso branch "is shadowed by the bf16 decode seed". Those codecs were never evidence about a hand-written kernel, and that misreading drove the plan in `docs/models/bonsai/27B/rMLX.md`, now corrected with the premise that misled it.
- "Up to ~4× less KV-read → faster decode" — falsified.
- "780 MB → ~200–390 MB" — the one measured fused path *added* 722 MB–1.4 GB; flash buffers sit on top of both mirror and store.
- "18 of 25 codecs inert at decode" — stale, and re-confirmed for the rest with a stronger oracle than dispatch counting: `k8v4`/`tsym3` digests are **bit-identical to `none`** at 4k/16k/32k on both architectures.

`docs/KV_QUANT.md` gains the break-even condition framing all four flash-decode families; `docs/PERF_BASELINE.md` records that a denser store would not rescue them.

### Methodology note

ρ is measured as resident bytes *in excess of* `none`. Two effects make that read smaller than the true store fraction — #331 (`none` is not pure bf16 on Qwen3) and any store displacing mirror bytes. Both are generous to the fused kernel, so the negative conclusion is conservative in the right direction.

`make ci` green.

**Needs a human decision, deliberately not changed here:** `CLAUDE.md` hard rule 10 states codecs "MUST decode on-GPU, reading the quant store directly (fused flash-decode-over-quant …; see #45)". The measurement says doing so is slower than the bf16 mirror on every current format, so the rule mandates a technique the evidence contradicts and cites a closed issue as justification.
