### PR TITLE
fix(kv-ssd): enforce the namespace budget at runtime, not only at attach (#30, closes #342)

### DIFF
--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -522,9 +522,10 @@ enum Cmd {
         /// `<RMLX_HOME>/cache/kv/<namespace>/` and a RAM miss is served from the
         /// longest cached block-aligned prefix on disk. The namespace is the
         /// model id unless `--project` overrides it. Eviction within the
-        /// namespace is LRU-by-size, kept under this ceiling; budgets persist
-        /// across restarts (the on-disk index is pruned + evicted-to-budget at
-        /// startup). Because `rmlx serve` runs a single MLX process, one
+        /// namespace is LRU-by-size: the ceiling is enforced at model load
+        /// (index pruned + evicted-to-budget) and again after every block the
+        /// spill thread writes, so it holds for the life of the process and not
+        /// only at startup. Because `rmlx serve` runs a single MLX process, one
         /// namespace is active at a time, so this per-namespace ceiling is also
         /// the global ceiling.
         #[arg(long, value_name = "GIB", default_value_t = 0.0)]

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -517,8 +517,11 @@ enum Cmd {
         /// SSD prompt-cache tier budget, in GiB. GLOBAL ceiling over the
         /// active cache namespace's on-disk KV blocks.
         ///
-        /// Default 0 = tier OFF (RAM-only prompt cache, unchanged behaviour).
-        /// When > 0, RAM-evicted prompt-cache snapshots spill to
+        /// Default 0 = no per-namespace ceiling. With `--kv-ssd-global-gb` also
+        /// 0 that means the tier is OFF (RAM-only prompt cache, unchanged
+        /// behaviour); with a global pool set, the tier is on and the pool
+        /// ceiling governs this namespace on its own.
+        /// When the tier is on, RAM-evicted prompt-cache snapshots spill to
         /// `<RMLX_HOME>/cache/kv/<namespace>/` and a RAM miss is served from the
         /// longest cached block-aligned prefix on disk. The namespace is the
         /// model id unless `--project` overrides it. Eviction within the
@@ -551,9 +554,10 @@ enum Cmd {
         /// exceeds the global budget, the per-namespace ceiling is implicitly
         /// clamped (`min(per_ns, global)`), and a warning is emitted.
         ///
-        /// Precedence (per-namespace ceiling effective value):
-        /// `min(--kv-ssd-cache-gb, --kv-ssd-global-gb)` when global > 0,
-        /// else `--kv-ssd-cache-gb`.
+        /// Precedence (per-namespace ceiling effective value): the tighter of
+        /// the two when both are > 0; whichever one is set when only one is;
+        /// and no ceiling at all when neither is (the tier is off). A zero on
+        /// either flag is "unconfigured", never "a ceiling of zero bytes".
         #[arg(long, value_name = "GIB", default_value_t = 0.0)]
         kv_ssd_global_gb: f64,
         /// RAM cap for the in-process prompt cache, in GiB.

--- a/crates/rmlx-kv-ssd/src/block_io.rs
+++ b/crates/rmlx-kv-ssd/src/block_io.rs
@@ -385,9 +385,14 @@ pub(crate) fn read_caches(
     model_id: &str,
     kv_quant: KvQuant,
 ) -> Result<(Vec<KvCache>, Vec<LinearAttnCache>)> {
-    let (kv_caches, lin_caches, _, _, _, _) = read_caches_inner(path, device, model_id, kv_quant)?;
+    let (kv_caches, lin_caches, _, _, _, _) = read_caches_inner(path, device, model_id, kv_quant)?
+        .ok_or_else(|| Error::Mlx(format!("KV block read: {} not found", path.display())))?;
     Ok((kv_caches, lin_caches))
 }
+
+/// Reconstructed caches plus the hydrate phase timings:
+/// `(kv_caches, lin_caches, bytes_read, dur_read_us, dur_dequant_us, dur_finalize_us)`.
+type TimedCaches = (Vec<KvCache>, Vec<LinearAttnCache>, u64, u64, u64, u64);
 
 /// Timed variant of [`read_caches`] for SSD-tier hydrate observability.
 ///
@@ -400,31 +405,38 @@ pub(crate) fn read_caches(
 ///   reconstruction / dequant).
 /// - `dur_finalize_us` — time to wrap each reconstructed [`KvStorage`] into a
 ///   decode-ready [`KvCache`]; CPU-only struct construction, not a GPU upload.
+///
+/// `Ok(None)` means the file is no longer on disk — the routine outcome of an
+/// LRU eviction landing between the index lookup and the read. The caller
+/// distinguishes it from `Err` (a genuinely bad block) on the type.
 pub(crate) fn read_caches_timed(
     path: &Path,
     device: Device,
     model_id: &str,
     kv_quant: KvQuant,
-) -> Result<(Vec<KvCache>, Vec<LinearAttnCache>, u64, u64, u64, u64)> {
+) -> Result<Option<TimedCaches>> {
     read_caches_inner(path, device, model_id, kv_quant)
 }
 
 /// Shared core for [`read_caches`] and [`read_caches_timed`].
 ///
-/// Returns `(kv_caches, lin_caches, bytes_read, dur_read_us, dur_dequant_us, dur_finalize_us)`.
+/// Returns `(kv_caches, lin_caches, bytes_read, dur_read_us, dur_dequant_us, dur_finalize_us)`,
+/// or `Ok(None)` when the block file does not exist.
 /// Mirrors the write-side `serialize_block_refs` pattern.
 fn read_caches_inner(
     path: &Path,
     device: Device,
     model_id: &str,
     kv_quant: KvQuant,
-) -> Result<(Vec<KvCache>, Vec<LinearAttnCache>, u64, u64, u64, u64)> {
+) -> Result<Option<TimedCaches>> {
     use std::time::Instant;
 
     let bytes_read = std::fs::metadata(path).map_or(0, |m| m.len());
 
     let t_read = Instant::now();
-    let reader = KvBlockReader::open(path)?;
+    let Some(reader) = KvBlockReader::open_existing(path)? else {
+        return Ok(None);
+    };
     let dur_read_us = t_read.elapsed().as_micros() as u64;
 
     let t_dequant = Instant::now();
@@ -451,14 +463,14 @@ fn read_caches_inner(
         .collect();
     let dur_finalize_us = t_finalize.elapsed().as_micros() as u64;
 
-    Ok((
+    Ok(Some((
         kv_caches,
         lin_caches,
         bytes_read,
         dur_read_us,
         dur_dequant_us,
         dur_finalize_us,
-    ))
+    )))
 }
 
 /// Shared serialization core over an owned-slice of storages.
@@ -2009,8 +2021,24 @@ pub struct KvBlockReader {
 impl KvBlockReader {
     /// Load the file into memory. Header verification happens in [`Self::hydrate`].
     pub fn open(path: &Path) -> Result<Self> {
-        let bytes = std::fs::read(path).map_err(|e| Error::Mlx(format!("KV block read: {e}")))?;
-        Ok(Self { bytes })
+        Self::open_existing(path)?
+            .ok_or_else(|| Error::Mlx(format!("KV block read: {} not found", path.display())))
+    }
+
+    /// Like [`Self::open`], but reports a file that is not there as `Ok(None)`
+    /// rather than an error.
+    ///
+    /// LRU eviction unlinks blocks whose rows it has already deleted, so a
+    /// hydrate that read the row a moment earlier finds the file gone as a
+    /// matter of routine. That is a miss, not corruption, and the single
+    /// `fs::read` classifies it without a second `stat` (and without the
+    /// window one would open).
+    pub fn open_existing(path: &Path) -> Result<Option<Self>> {
+        match std::fs::read(path) {
+            Ok(bytes) => Ok(Some(Self { bytes })),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(Error::Mlx(format!("KV block read: {e}"))),
+        }
     }
 
     /// Read the `model_id` header without hydrating.

--- a/crates/rmlx-kv-ssd/src/hydrate.rs
+++ b/crates/rmlx-kv-ssd/src/hydrate.rs
@@ -46,7 +46,7 @@ use rmlx_kv_quant::KvQuant;
 use crate::block_io::read_caches_timed;
 use crate::hashing::{chained_block_hashes_seeded, BLOCK_TOKENS, FNV_OFFSET};
 use crate::hooks::{call_ssd_hydrate_prom_hook, ssd_event_recorder};
-use crate::ssd_index::SsdKvIndex;
+use crate::ssd_index::{KvBlockRow, SsdKvIndex};
 
 /// A reconstructed SSD block ready to be wrapped as an arch prompt-cache entry.
 ///
@@ -247,14 +247,14 @@ impl SsdHydrator {
 
         // ── Phases 2–4: file read + dequant + GPU upload (timed inside block_io) ──
         match read_caches_timed(&row.path, self.device, &self.model_id, self.kv_quant) {
-            Ok((
+            Ok(Some((
                 kv_caches,
                 lin_caches,
                 bytes_read,
                 dur_read_us,
                 dur_dequant_us,
                 dur_finalize_us,
-            )) => {
+            ))) => {
                 // ── Phase 5: SQLite touch (LRU update) ────────────────────────
                 let t_touch = Instant::now();
                 if let Err(e) = self.index.touch(&row.hash, row.layout_key) {
@@ -326,26 +326,48 @@ impl SsdHydrator {
                     lin_caches,
                 }))
             }
+            Ok(None) => {
+                // The block was evicted between this lookup and the read. LRU
+                // eviction deletes the row first, so the row is normally gone
+                // already; dropping it here covers an evictor that did not get
+                // to unlink. Nothing to remove from disk, and nothing wrong.
+                tracing::debug!(
+                    hash = %row.hash,
+                    path = %row.path.display(),
+                    "ssd-hydrate: block evicted under the read, falling back to prefill"
+                );
+                self.drop_row(&row);
+                Ok(None)
+            }
             Err(e) => {
-                // Corrupt / metadata-mismatch / read error: delete file + row,
-                // fall through to prefill.
+                // Genuinely bad block (truncated, wrong header, unreadable):
+                // delete row + file, fall through to prefill.
                 tracing::warn!(
                     hash = %row.hash,
                     path = %row.path.display(),
                     error = %e,
-                    "ssd-hydrate: corrupt block, deleting file + index row, falling back to prefill"
+                    "ssd-hydrate: corrupt block, deleting index row + file, falling back to prefill"
                 );
+                // Row before file, the same order LRU eviction uses: it makes an
+                // interrupted cleanup leave an unreferenced row, which
+                // `prune_missing` reclaims, instead of an unreferenced file,
+                // which nothing does.
+                self.drop_row(&row);
                 let _ = std::fs::remove_file(&row.path);
-                if let Err(de) = self.index.delete(&row.hash, row.layout_key) {
-                    tracing::warn!(
-                        hash = %row.hash,
-                        layout_key = row.layout_key,
-                        error = %de,
-                        "ssd-hydrate: index row delete failed"
-                    );
-                }
                 Ok(None)
             }
+        }
+    }
+
+    /// Drop `row`'s index entry after a read that could not be served.
+    fn drop_row(&self, row: &KvBlockRow) {
+        if let Err(e) = self.index.delete(&row.hash, row.layout_key) {
+            tracing::warn!(
+                hash = %row.hash,
+                layout_key = row.layout_key,
+                error = %e,
+                "ssd-hydrate: index row delete failed"
+            );
         }
     }
 }

--- a/crates/rmlx-kv-ssd/src/hydrate_tests.rs
+++ b/crates/rmlx-kv-ssd/src/hydrate_tests.rs
@@ -537,6 +537,376 @@ fn ssd_hit_lookup_emits_hydrate_event() {
     assert_eq!(block_count, 1, "one block reconstructed");
 }
 
+// ── Budget enforcement racing in-flight hydrates ──────────────────────────
+
+/// Enforcing the on-disk budget while requests are hydrating is the shape this
+/// repo has been bitten by before: a cache write that quietly does the wrong
+/// thing reports no error, and the run just produces different output. So the
+/// property under test is not "it did not crash" — it is that **every block a
+/// racing hydrate is handed is the block it asked for**, checked against the
+/// K-dequant of the exact cache that was spilled under that prompt.
+///
+/// Why the invariant holds, and what would break it: a block is only reachable
+/// through its own `(hash, layout_key)` row, `evict_lru_until` deletes that row
+/// before the `.kvb` is unlinked, and a read of a vanished or half-written file
+/// fails the header check and takes the existing corrupt-block path (drop the
+/// row, `warn!`, miss). Every racing outcome therefore collapses to a miss and
+/// a full prefill. A regression that reused a row's path after its own row was
+/// gone, or that shared one file across two hashes, would surface here as a
+/// content mismatch rather than as a crash.
+///
+/// Three threads model the production tier: the spill drain thread growing the
+/// namespace, the budget pass shrinking it, and a request thread hydrating. The
+/// pre-race pass pins that the content check can pass on real data, so a run in
+/// which the race produced only misses cannot pass vacuously.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn budget_enforcement_racing_hydrates_never_serves_a_foreign_block() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Barrier};
+
+    const RACE_PASSES: usize = 40;
+    const NS: &str = "race-ns";
+
+    let device = Device::Cpu;
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().to_path_buf();
+    let db = dir.join("index.db");
+    let fx = Arc::new(seed_race_fixture(&dir, &db, device));
+    // Room for half the prompts, so the filler the writer thread adds keeps
+    // pushing the namespace over and the budget pass keeps having work.
+    let budget = fx.block_bytes * (RACE_PROMPTS as u64 / 2);
+
+    // Pre-race pass on quiet state: every prompt hits and its content is its
+    // own. This is what stops the racing assertions below from passing on a run
+    // that only ever saw misses.
+    {
+        let hydrator = SsdHydrator::with_index(
+            MODEL_ID,
+            QUANT,
+            RACE_LK,
+            device,
+            dir.clone(),
+            SsdKvIndex::open_at(&db).unwrap(),
+        );
+        for i in 0..RACE_PROMPTS {
+            let block = hydrator
+                .lookup(&fx.prompts[i])
+                .unwrap()
+                .expect("quiet-state lookup must hit");
+            assert_own_block(&block, &fx, i, device, "quiet-state");
+        }
+    }
+
+    let barrier = Arc::new(Barrier::new(3));
+    let stop = Arc::new(AtomicU64::new(0));
+    let evicted_total = Arc::new(AtomicU64::new(0));
+
+    // Thread 1 — the budget pass, standing in for the spill drain thread's
+    // post-write enforcement.
+    let evictor = {
+        let (db, barrier, stop, evicted_total) = (
+            db.clone(),
+            Arc::clone(&barrier),
+            Arc::clone(&stop),
+            Arc::clone(&evicted_total),
+        );
+        std::thread::spawn(move || {
+            let idx = SsdKvIndex::open_at(&db).unwrap();
+            barrier.wait();
+            while stop.load(Ordering::Acquire) == 0 {
+                let n = crate::ssd_tier::enforce_namespace_budget(&idx, NS, budget);
+                evicted_total.fetch_add(n, Ordering::AcqRel);
+                std::thread::yield_now();
+            }
+        })
+    };
+
+    // Thread 2 — namespace growth. Fresh keys every time, exactly as a spiller
+    // records a block it has just written.
+    let writer = {
+        let (db, dir, barrier, stop, block_bytes) = (
+            db.clone(),
+            dir.clone(),
+            Arc::clone(&barrier),
+            Arc::clone(&stop),
+            fx.block_bytes,
+        );
+        std::thread::spawn(move || {
+            let idx = SsdKvIndex::open_at(&db).unwrap();
+            barrier.wait();
+            let mut n = 0u64;
+            while stop.load(Ordering::Acquire) == 0 {
+                let key = format!("filler{n:012x}");
+                let p = dir.join(format!("{key}.kvb"));
+                if std::fs::write(&p, vec![0u8; block_bytes as usize]).is_ok() {
+                    let _ =
+                        idx.record(&key, RACE_LK, &p, MODEL_ID, &QUANT.to_string(), block_bytes);
+                }
+                n += 1;
+                std::thread::yield_now();
+            }
+        })
+    };
+
+    // Thread 3 — the request thread. Re-records its own block after a miss,
+    // which is what a real miss leads to (prefill, then spill on eviction).
+    let hydrator_thread = {
+        let (barrier, fx) = (Arc::clone(&barrier), Arc::clone(&fx));
+        std::thread::spawn(move || {
+            let re_index = SsdKvIndex::open_at(&db).unwrap();
+            let hydrator = SsdHydrator::with_index(
+                MODEL_ID,
+                QUANT,
+                RACE_LK,
+                device,
+                dir.clone(),
+                SsdKvIndex::open_at(&db).unwrap(),
+            );
+            barrier.wait();
+            let (mut hits, mut misses) = (0u64, 0u64);
+            for _ in 0..RACE_PASSES {
+                for i in 0..RACE_PROMPTS {
+                    match hydrator.lookup(&fx.prompts[i]) {
+                        Ok(Some(block)) => {
+                            hits += 1;
+                            assert_own_block(&block, &fx, i, device, "racing");
+                        }
+                        Ok(None) => {
+                            misses += 1;
+                            // Re-record from the bytes captured at seed time —
+                            // no MLX work off the seeding thread.
+                            let p = dir.join(format!("{}.kvb", fx.keys[i]));
+                            if std::fs::write(&p, &fx.kvb_bytes[i]).is_ok() {
+                                let _ = re_index.record(
+                                    &fx.keys[i],
+                                    RACE_LK,
+                                    &p,
+                                    MODEL_ID,
+                                    &QUANT.to_string(),
+                                    fx.kvb_bytes[i].len() as u64,
+                                );
+                            }
+                        }
+                        Err(e) => panic!("hydrate must never surface an error, got {e}"),
+                    }
+                }
+            }
+            (hits, misses)
+        })
+    };
+
+    let (hits, misses) = hydrator_thread.join().expect("hydrator thread panicked");
+    stop.store(1, Ordering::Release);
+    evictor.join().expect("evictor thread panicked");
+    writer.join().expect("writer thread panicked");
+
+    assert_eq!(
+        hits + misses,
+        (RACE_PASSES * RACE_PROMPTS) as u64,
+        "every racing lookup must resolve to a hit or a miss"
+    );
+    assert!(
+        evicted_total.load(Ordering::Acquire) > 0,
+        "the budget pass must have actually evicted during the race, \
+         otherwise nothing was raced"
+    );
+}
+
+/// Prompts (and therefore indexed blocks) in the racing-budget fixture.
+const RACE_PROMPTS: usize = 6;
+/// Layout key the racing-budget fixture spills and probes under.
+const RACE_LK: u64 = 0x00c0_ffee_0000_0001;
+
+/// One indexed block per prompt, plus everything a checker needs to tell those
+/// blocks apart after a round trip through the tier.
+struct RaceFixture {
+    /// Token ids per prompt; one full block each.
+    prompts: Vec<Vec<u32>>,
+    /// Index/`.kvb` key per prompt (the salted chained digest).
+    keys: Vec<String>,
+    /// K dequant of the cache that was spilled under each prompt.
+    expected_k: Vec<Vec<f32>>,
+    /// Raw `.kvb` bytes per prompt, so a miss can be re-recorded without doing
+    /// MLX work off the thread that built the caches.
+    kvb_bytes: Vec<Vec<u8>>,
+    /// On-disk size of one block, the unit the budget is expressed in.
+    block_bytes: u64,
+}
+
+/// Seed `dir`'s index with one block per prompt. Each prompt gets its own token
+/// ids *and* its own KV content, which is what makes "served the wrong block"
+/// observable in the data rather than only in the token ids.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn seed_race_fixture(dir: &std::path::Path, db: &std::path::Path, device: Device) -> RaceFixture {
+    let index = SsdKvIndex::open_at(db).unwrap();
+    let prompts: Vec<Vec<u32>> = (0..RACE_PROMPTS)
+        .map(|i| {
+            let base = (i as u32 + 1) * 100_000;
+            (base..base + BLOCK_TOKENS as u32).collect()
+        })
+        .collect();
+    let mut keys = Vec::with_capacity(RACE_PROMPTS);
+    let mut expected_k = Vec::with_capacity(RACE_PROMPTS);
+    let mut kvb_bytes = Vec::with_capacity(RACE_PROMPTS);
+    for (i, ids) in prompts.iter().enumerate() {
+        let chained =
+            chained_block_hashes_seeded(ids, FNV_OFFSET ^ RACE_LK ^ QUANT.cache_key_salt());
+        assert_eq!(chained.len(), 1);
+        let key = hash_to_hex_local(chained[0]);
+        let cache = build_kvcache(BLOCK_TOKENS as i32, 0x9E11 + i as u64 * 977);
+        expected_k.push(probe_k(&cache, device));
+        let path = dir.join(format!("{key}.kvb"));
+        write_caches(&path, device, MODEL_ID, QUANT, &[cache], &[]).unwrap();
+        let size = std::fs::metadata(&path).unwrap().len();
+        index
+            .record(&key, RACE_LK, &path, MODEL_ID, &QUANT.to_string(), size)
+            .unwrap();
+        kvb_bytes.push(std::fs::read(&path).unwrap());
+        keys.push(key);
+    }
+    let block_bytes = index.total_bytes().unwrap() / RACE_PROMPTS as u64;
+    RaceFixture {
+        prompts,
+        keys,
+        expected_k,
+        kvb_bytes,
+        block_bytes,
+    }
+}
+
+/// Assert `block` is the block that was spilled under `fx.prompts[i]` — both
+/// its token ids and its K content. Content is what catches a block served
+/// under the wrong key; token ids alone would not, since they are recomputed
+/// from the caller's own prompt.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+fn assert_own_block(
+    block: &HydratedBlock,
+    fx: &RaceFixture,
+    i: usize,
+    device: Device,
+    whence: &str,
+) {
+    assert_eq!(
+        &block.prompt_ids, &fx.prompts[i],
+        "{whence}: hydrate served prompt {i} foreign token ids"
+    );
+    let got = probe_k(&block.kv_caches[0], device);
+    assert_eq!(got.len(), fx.expected_k[i].len());
+    let err = fx.expected_k[i]
+        .iter()
+        .zip(&got)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    assert!(
+        err < 1e-3,
+        "{whence}: hydrate served prompt {i} a block whose K content is not its own \
+         (max err {err})"
+    );
+}
+
+/// A row whose `.kvb` is gone — what a budget pass interrupted between its row
+/// delete and its file unlink leaves behind, and what an operator's `rm` leaves
+/// behind — must read as a clean miss that also repairs the row, and the
+/// namespace must stay usable afterwards. Half-applied maintenance leaves a
+/// working tier, not a poisoned one.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: single full block yields exactly one chained digest, asserted before index"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn hydrate_of_a_row_whose_file_vanished_is_a_miss_and_leaves_the_tier_usable() {
+    const LK: u64 = 0x00c0_ffee_0000_0002;
+
+    let device = Device::Cpu;
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().to_path_buf();
+    let db = dir.join("index.db");
+    let index = SsdKvIndex::open_at(&db).unwrap();
+
+    let prompt_ids: Vec<u32> = (0..BLOCK_TOKENS as u32).collect();
+    let chained =
+        chained_block_hashes_seeded(&prompt_ids, FNV_OFFSET ^ LK ^ QUANT.cache_key_salt());
+    assert_eq!(chained.len(), 1);
+    let key = hash_to_hex_local(chained[0]);
+    let path = dir.join(format!("{key}.kvb"));
+
+    let cache = build_kvcache(BLOCK_TOKENS as i32, 0x7E57);
+    let expected = probe_k(&cache, device);
+    write_caches(&path, device, MODEL_ID, QUANT, &[cache], &[]).unwrap();
+    let size = std::fs::metadata(&path).unwrap().len();
+    let kvb = std::fs::read(&path).unwrap();
+    index
+        .record(&key, LK, &path, MODEL_ID, &QUANT.to_string(), size)
+        .unwrap();
+
+    // Row survives, file does not — the half-applied state.
+    std::fs::remove_file(&path).unwrap();
+
+    let hydrator = SsdHydrator::with_index(
+        MODEL_ID,
+        QUANT,
+        LK,
+        device,
+        dir,
+        SsdKvIndex::open_at(&db).unwrap(),
+    );
+    assert!(
+        hydrator.lookup(&prompt_ids).unwrap().is_none(),
+        "a row pointing at a vanished file must read as a miss"
+    );
+    assert!(
+        index.lookup(&key, LK).unwrap().is_none(),
+        "the dangling row must be dropped, not left to miss forever"
+    );
+
+    // The namespace is still usable: re-spill the same block and hydrate it.
+    std::fs::write(&path, &kvb).unwrap();
+    index
+        .record(&key, LK, &path, MODEL_ID, &QUANT.to_string(), size)
+        .unwrap();
+    let block = hydrator
+        .lookup(&prompt_ids)
+        .unwrap()
+        .expect("re-spilled block must hydrate");
+    let got = probe_k(&block.kv_caches[0], device);
+    let err = expected
+        .iter()
+        .zip(&got)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    assert!(err < 1e-3, "re-spilled block round-trip error {err}");
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────
 
 fn hash_to_hex_local(d: u64) -> String {

--- a/crates/rmlx-kv-ssd/src/hydrate_tests.rs
+++ b/crates/rmlx-kv-ssd/src/hydrate_tests.rs
@@ -584,9 +584,16 @@ fn budget_enforcement_racing_hydrates_never_serves_a_foreign_block() {
     let dir = tmp.path().to_path_buf();
     let db = dir.join("index.db");
     let fx = Arc::new(seed_race_fixture(&dir, &db, device));
-    // Room for half the prompts, so the filler the writer thread adds keeps
-    // pushing the namespace over and the budget pass keeps having work.
-    let budget = fx.block_bytes * (RACE_PROMPTS as u64 / 2);
+    // Sized so both arms of the race stay well populated: the writer's filler
+    // keeps the namespace over the ceiling (so the budget pass always has work
+    // and lookups keep missing), while the prompt blocks are not crowded down to
+    // a survival rate that would let a slow box reach zero hits and skip the
+    // content check entirely. `last_used` is unix *seconds* (`unix_now`) and the
+    // race finishes well inside one, so every row ties and `ORDER BY last_used
+    // ASC` has no tiebreak — which block gets evicted is arbitrary, and headroom
+    // is what keeps `hits > 0` robust rather than lucky. Measured: ~31% hits,
+    // ~69% misses over 240 lookups.
+    let budget = fx.block_bytes * (RACE_PROMPTS as u64 * 4);
 
     // Pre-race pass on quiet state: every prompt hits and its content is its
     // own. This is what stops the racing assertions below from passing on a run
@@ -712,6 +719,16 @@ fn budget_enforcement_racing_hydrates_never_serves_a_foreign_block() {
     evictor.join().expect("evictor thread panicked");
     writer.join().expect("writer thread panicked");
 
+    // `assert_own_block` — the whole point of the test — only runs on a hit, so
+    // a run that raced its way to zero hits would pass without ever checking a
+    // block's content. Nothing else here catches that: `hits + misses` is
+    // tautological, and `evicted_total` only shows the evictor ran.
+    assert!(
+        hits > 0,
+        "no racing lookup hit ({hits} hits / {misses} misses), so the content \
+         check never ran; the run proves nothing about which block a racing \
+         hydrate is served"
+    );
     assert_eq!(
         hits + misses,
         (RACE_PASSES * RACE_PROMPTS) as u64,

--- a/crates/rmlx-kv-ssd/src/spill.rs
+++ b/crates/rmlx-kv-ssd/src/spill.rs
@@ -152,7 +152,7 @@ impl SsdSpiller {
                 tracing::info!(namespace = %ns, dir = %dir.display(), budget_bytes, "kv-spill: drain thread started");
                 for job in rx {
                     if drain_one(&index, &dir, device, job) {
-                        crate::ssd_tier::enforce_budget_after_spill(&index, &ns, budget_bytes);
+                        crate::ssd_tier::enforce_namespace_budget(&index, &ns, budget_bytes);
                     }
                 }
                 tracing::debug!(namespace = %ns, "kv-spill: drain thread exiting (all senders dropped)");
@@ -193,7 +193,7 @@ impl SsdSpiller {
             .spawn(move || {
                 for job in rx {
                     if drain_one_inner(&index, &dir, device, job, None) {
-                        crate::ssd_tier::enforce_budget_after_spill(&index, &ns, budget_bytes);
+                        crate::ssd_tier::enforce_namespace_budget(&index, &ns, budget_bytes);
                     }
                 }
             })

--- a/crates/rmlx-kv-ssd/src/spill.rs
+++ b/crates/rmlx-kv-ssd/src/spill.rs
@@ -92,6 +92,13 @@ pub struct SpillJob {
 /// The drain thread owns the [`SsdKvIndex`] and the destination directory, and
 /// lives for the process lifetime (the join handle is dropped — the thread
 /// exits when all senders are dropped).
+///
+/// It is also where the namespace's on-disk budget is enforced. The drain
+/// thread is the only writer that grows the tier, it already holds an index
+/// handle, and it runs off the inference path — so it evicts to budget after
+/// every block it records. Nothing else evicts between model loads, so without
+/// that pass a long-lived `serve` would exceed `--kv-ssd-cache-gb` for its
+/// whole lifetime and only come back under the ceiling at the next attach.
 #[allow(missing_debug_implementations)]
 pub struct SsdSpiller {
     tx: SyncSender<SpillJob>,
@@ -116,10 +123,18 @@ impl SsdSpiller {
     /// On index-open failure the drain thread logs `warn!` and exits; the
     /// sender side still accepts (and silently drops) jobs, so the cache keeps
     /// working with spill effectively disabled.
+    ///
+    /// The namespace byte ceiling is resolved once here from the installed
+    /// SSD-tier config, so it is the same figure the attach-time maintenance
+    /// pass evicted to. `0` (tier unconfigured) leaves the drain thread with no
+    /// ceiling to enforce, exactly as before.
     pub fn spawn(model_id: impl Into<String>, layout_key: u64, device: Device) -> Self {
         let model_id = model_id.into();
         let (tx, rx) = sync_channel::<SpillJob>(SPILL_CHANNEL_CAP);
 
+        let budget_bytes = crate::ssd_tier::active()
+            .as_ref()
+            .map_or(0, crate::ssd_tier::effective_namespace_budget);
         let ns = model_id.clone();
         let _ = thread::Builder::new()
             .name("rmlx-kv-spill".into())
@@ -134,9 +149,11 @@ impl SsdSpiller {
                         return;
                     }
                 };
-                tracing::info!(namespace = %ns, dir = %dir.display(), "kv-spill: drain thread started");
+                tracing::info!(namespace = %ns, dir = %dir.display(), budget_bytes, "kv-spill: drain thread started");
                 for job in rx {
-                    drain_one(&index, &dir, device, job);
+                    if drain_one(&index, &dir, device, job) {
+                        crate::ssd_tier::enforce_budget_after_spill(&index, &ns, budget_bytes);
+                    }
                 }
                 tracing::debug!(namespace = %ns, "kv-spill: drain thread exiting (all senders dropped)");
             });
@@ -151,8 +168,10 @@ impl SsdSpiller {
     /// Test-only: spawn a drain thread bound to an explicit `dir` + `index`,
     /// bypassing `paths::kv_cache_dir` so tests are hermetic (no env-var
     /// coupling, no shared workspace `.rmlx/`). Same drain semantics as
-    /// [`Self::spawn`]. Returns the handle plus the spawned thread's
-    /// `JoinHandle` so a test can join after dropping the sender.
+    /// [`Self::spawn`], including the post-spill evict-to-budget pass —
+    /// `budget_bytes` stands in for what [`Self::spawn`] reads from the
+    /// installed config (`0` = no ceiling). Returns the handle plus the spawned
+    /// thread's `JoinHandle` so a test can join after dropping the sender.
     #[cfg(test)]
     #[allow(
         clippy::expect_used,
@@ -164,14 +183,18 @@ impl SsdSpiller {
         device: Device,
         dir: PathBuf,
         index: SsdKvIndex,
+        budget_bytes: u64,
     ) -> (Self, thread::JoinHandle<()>) {
         let model_id = model_id.into();
+        let ns = model_id.clone();
         let (tx, rx) = sync_channel::<SpillJob>(SPILL_CHANNEL_CAP);
         let handle = thread::Builder::new()
             .name("rmlx-kv-spill-test".into())
             .spawn(move || {
                 for job in rx {
-                    drain_one_inner(&index, &dir, device, job, None);
+                    if drain_one_inner(&index, &dir, device, job, None) {
+                        crate::ssd_tier::enforce_budget_after_spill(&index, &ns, budget_bytes);
+                    }
                 }
             })
             .expect("spawn test drain thread");
@@ -211,6 +234,9 @@ impl SsdSpiller {
                 }
             })
             .expect("spawn test drain thread");
+        // No budget pass: this variant exists to observe the emitted spill
+        // event, and an eviction racing that observation would make the row
+        // count it asserts on depend on timing.
         (
             Self {
                 tx,
@@ -258,8 +284,12 @@ impl SsdSpiller {
 /// Fire-and-forget: any error is `warn!`ed and the job dropped. Never panics.
 /// Emits a [`SsdSpillEvent`] via the process-global event recorder (if set)
 /// with per-phase timing and byte count.
-fn drain_one(index: &SsdKvIndex, dir: &std::path::Path, device: Device, job: SpillJob) {
-    drain_one_inner(index, dir, device, job, None);
+///
+/// Returns `true` only when the block reached the index, which is the one
+/// outcome that grew the namespace and therefore the only one worth running an
+/// evict-to-budget pass after.
+fn drain_one(index: &SsdKvIndex, dir: &std::path::Path, device: Device, job: SpillJob) -> bool {
+    drain_one_inner(index, dir, device, job, None)
 }
 
 /// Core of [`drain_one`], factored so tests can inject an explicit recorder.
@@ -278,7 +308,7 @@ fn drain_one_inner(
     device: Device,
     job: SpillJob,
     test_recorder: Option<&EventRecorder>,
-) {
+) -> bool {
     let SpillJob {
         hash,
         layout_key,
@@ -303,7 +333,7 @@ fn drain_one_inner(
                     "kv-spill: serialize failed, dropping job"
                 );
                 let _ = std::fs::remove_file(&path);
-                return;
+                return false;
             }
         };
 
@@ -324,7 +354,7 @@ fn drain_one_inner(
             error = %e,
             "kv-spill: index record failed, dropping job"
         );
-        return;
+        return false;
     }
     let dur_index_us = t_idx.elapsed().as_micros() as u64;
     let dur_us = t0.elapsed().as_micros() as u64;
@@ -371,6 +401,7 @@ fn drain_one_inner(
     // Feed the Prometheus histogram accumulator (registered by rmlx-server at
     // startup via `set_ssd_spill_prom_hook`). No-op when unset.
     call_ssd_spill_prom_hook(dur_us, byte_size);
+    true
 }
 
 #[cfg(test)]

--- a/crates/rmlx-kv-ssd/src/spill_tests.rs
+++ b/crates/rmlx-kv-ssd/src/spill_tests.rs
@@ -12,6 +12,11 @@ const MODEL_ID: &str = "Gemma4ForConditionalGeneration/test-snap";
 /// placeholder so the recorded row's `layout_key` column is observable.
 const TEST_LAYOUT_KEY: u64 = 0xa55a_5aa5_d00d_d00du64;
 
+/// "No on-disk ceiling configured" — what `SsdSpiller::spawn` resolves to when
+/// the SSD tier is unconfigured. Tests that are not about the budget pass it so
+/// their block counts do not depend on eviction.
+const NO_BUDGET: u64 = 0;
+
 fn job(hash: u64) -> SpillJob {
     SpillJob {
         hash,
@@ -42,8 +47,14 @@ fn spill_writes_file_and_index_row() {
     let index = SsdKvIndex::open_at(&db).unwrap();
 
     let hash = 0xdead_beef_0000_0001u64;
-    let (spiller, handle) =
-        SsdSpiller::spawn_with_index(MODEL_ID, TEST_LAYOUT_KEY, Device::Cpu, dir.clone(), index);
+    let (spiller, handle) = SsdSpiller::spawn_with_index(
+        MODEL_ID,
+        TEST_LAYOUT_KEY,
+        Device::Cpu,
+        dir.clone(),
+        index,
+        NO_BUDGET,
+    );
     spiller.try_spill(job(hash));
     drop(spiller); // close the channel so the drain thread exits
     handle.join().unwrap();
@@ -95,8 +106,14 @@ fn spill_failure_does_not_panic_and_drains_on() {
 
     let db = tmp.path().join("index.db");
     let index = SsdKvIndex::open_at(&db).unwrap();
-    let (spiller, handle) =
-        SsdSpiller::spawn_with_index(MODEL_ID, TEST_LAYOUT_KEY, Device::Cpu, bad_dir, index);
+    let (spiller, handle) = SsdSpiller::spawn_with_index(
+        MODEL_ID,
+        TEST_LAYOUT_KEY,
+        Device::Cpu,
+        bad_dir,
+        index,
+        NO_BUDGET,
+    );
 
     // This job must fail to serialize but not crash the thread.
     spiller.try_spill(job(0x1111));
@@ -169,6 +186,68 @@ fn spawn_returns_handle_that_exits_on_drop() {
     assert_eq!(spiller.model_id(), format!("{MODEL_ID}-spawn"));
     assert_eq!(spiller.layout_key(), TEST_LAYOUT_KEY);
     drop(spiller); // closing the channel lets the production drain thread exit
+}
+
+/// The drain thread is the only writer that grows the namespace, and between
+/// model loads nothing else evicts — so if it does not enforce the configured
+/// ceiling, a long-lived `serve` runs past `--kv-ssd-cache-gb` for its whole
+/// lifetime and only comes back under it at the next attach. Spill more blocks
+/// than the budget holds and require the drain thread to have evicted down to
+/// it by the time it exits.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn drain_thread_evicts_to_the_namespace_budget() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().to_path_buf();
+    let db = dir.join("index.db");
+
+    // Size one block by spilling a single job with no budget, then set the
+    // budget to two blocks' worth. Deriving the budget from the measured block
+    // size keeps the test independent of the .kvb serialization size.
+    let probe_index = SsdKvIndex::open_at(&db).unwrap();
+    let (probe_spiller, probe_handle) = SsdSpiller::spawn_with_index(
+        MODEL_ID,
+        TEST_LAYOUT_KEY,
+        Device::Cpu,
+        dir.clone(),
+        probe_index,
+        NO_BUDGET,
+    );
+    probe_spiller.try_spill(job(0x9000));
+    drop(probe_spiller);
+    probe_handle.join().unwrap();
+    let one_block = SsdKvIndex::open_at(&db).unwrap().total_bytes().unwrap();
+    assert!(one_block > 0, "probe spill must have recorded a block");
+    let budget = one_block * 2;
+
+    // Now spill six blocks through a drain thread that knows the budget.
+    let index = SsdKvIndex::open_at(&db).unwrap();
+    let (spiller, handle) =
+        SsdSpiller::spawn_with_index(MODEL_ID, TEST_LAYOUT_KEY, Device::Cpu, dir, index, budget);
+    for i in 0..6u64 {
+        spiller.try_spill(job(0x9100 + i));
+        // The channel is bounded and `try_spill` drops on overflow; the drain
+        // has to keep up for the block count to be the one under test.
+        thread::sleep(std::time::Duration::from_millis(5));
+    }
+    drop(spiller);
+    handle.join().unwrap();
+
+    let idx = SsdKvIndex::open_at(&db).unwrap();
+    let total = idx.total_bytes().unwrap();
+    assert!(
+        total <= budget,
+        "drain thread must hold the namespace at or under its {budget}-byte \
+         budget, found {total}"
+    );
+    assert_eq!(
+        idx.prune_missing().unwrap(),
+        0,
+        "every surviving row must still have its .kvb on disk"
+    );
 }
 
 /// SSD-tier observability (step2-A): after a successful `drain_one`, the

--- a/crates/rmlx-kv-ssd/src/spill_tests.rs
+++ b/crates/rmlx-kv-ssd/src/spill_tests.rs
@@ -229,9 +229,6 @@ fn drain_thread_evicts_to_the_namespace_budget() {
         SsdSpiller::spawn_with_index(MODEL_ID, TEST_LAYOUT_KEY, Device::Cpu, dir, index, budget);
     for i in 0..6u64 {
         spiller.try_spill(job(0x9100 + i));
-        // The channel is bounded and `try_spill` drops on overflow; the drain
-        // has to keep up for the block count to be the one under test.
-        thread::sleep(std::time::Duration::from_millis(5));
     }
     drop(spiller);
     handle.join().unwrap();

--- a/crates/rmlx-kv-ssd/src/ssd_index.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_index.rs
@@ -28,7 +28,14 @@
 //! schema_version (
 //! version INTEGER PRIMARY KEY NOT NULL -- 2
 //! )
+//!
+//! INDEX kv_blocks_last_used ON kv_blocks (last_used) -- LRU eviction order
 //! ```
+//!
+//! The `last_used` index is created idempotently on every open: it carries no
+//! row-format change, so it needs no `schema_version` bump, and LRU eviction
+//! runs after every spilled block and would otherwise sort the whole table to
+//! find the oldest row.
 //!
 //! The `(hash, layout_key)` composite PK is defence-in-depth: the chained
 //! digests stores under a given `layout_key` are already disjoint from
@@ -115,6 +122,18 @@ CREATE TABLE IF NOT EXISTS schema_version (
 );
 ";
 
+/// LRU eviction runs after every spilled block and reads rows in `last_used`
+/// order. Without this index SQLite sorts the whole table before it can yield
+/// the first row, so stopping the scan early saves the row decode but not the
+/// sort — the dominant cost at a large ceiling.
+///
+/// Indexes carry no row-format change, so this is created idempotently on every
+/// open rather than being tied to a `schema_version` bump (which would wipe
+/// existing namespaces for no reason).
+const SCHEMA_INDEXES: &str = "
+CREATE INDEX IF NOT EXISTS kv_blocks_last_used ON kv_blocks (last_used);
+";
+
 // ── Row ───────────────────────────────────────────────────────────────────────
 
 /// A single row from the `kv_blocks` table.
@@ -136,6 +155,19 @@ pub struct KvBlockRow {
     pub byte_size: u64,
     /// Unix epoch timestamp of last access.
     pub last_used: u64,
+}
+
+/// Outcome of one [`SsdKvIndex::evict_lru_until`] pass over a namespace.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default)]
+pub struct NamespaceEviction {
+    /// Absolute paths of the `.kvb` files whose rows this call removed. A row
+    /// another evictor took first is absent, so `paths.len()` is the number of
+    /// rows genuinely evicted here and every path is one this caller owns.
+    pub paths: Vec<PathBuf>,
+    /// Indexed footprint in bytes once the deletes committed. Saves the caller
+    /// a second `SUM(byte_size)` over the table.
+    pub total_bytes_after: u64,
 }
 
 // ── Index ─────────────────────────────────────────────────────────────────────
@@ -202,7 +234,10 @@ impl SsdKvIndex {
             // them first would mask a pre-release v1 layout.
             let version = read_schema_version(&conn)?;
             match version {
-                Some(v) if v == SCHEMA_VERSION => Ok(Self { conn }),
+                Some(v) if v == SCHEMA_VERSION => {
+                    conn.execute_batch(SCHEMA_INDEXES)?;
+                    Ok(Self { conn })
+                }
                 Some(v) => Err(SsdKvIndexError::SchemaMismatch {
                     found: v,
                     expected: SCHEMA_VERSION,
@@ -338,63 +373,82 @@ impl SsdKvIndex {
     /// Evict the oldest-used blocks until the total `byte_size` in the index is
     /// ≤ `budget_bytes`.
     ///
-    /// Rows are deleted in ascending `last_used` order (oldest first). The
-    /// method returns the **absolute paths** of the evicted `.kvb` files so
-    /// the caller can delete them from disk.
+    /// Rows are deleted in ascending `last_used` order (oldest first), inside a
+    /// single transaction, so a failure part-way leaves the index exactly as it
+    /// was rather than dropping rows whose files the caller never gets told to
+    /// unlink. `budget_bytes == 0` is taken literally here ("keep nothing") —
+    /// the tier-level "no ceiling configured" reading lives in
+    /// [`crate::ssd_tier::enforce_namespace_budget`].
     ///
-    /// If the total stored size is already within budget, returns an empty vec.
-    pub fn evict_lru_until(&self, budget_bytes: u64) -> Result<Vec<PathBuf>> {
-        let total: i64 = self
-            .conn
-            .query_row(
-                "SELECT COALESCE(SUM(byte_size), 0) FROM kv_blocks",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap_or(0);
-
-        if total <= 0 || total as u64 <= budget_bytes {
-            return Ok(Vec::new());
+    /// The returned [`NamespaceEviction`] carries the **absolute paths** of the
+    /// `.kvb` files whose rows this call actually removed, so the caller can
+    /// unlink exactly those, plus the resulting footprint.
+    ///
+    /// Runs after every spilled block, so it must not be O(rows): the scan stops
+    /// as soon as the running total is within budget instead of materialising
+    /// the whole table, and projects only the four columns eviction needs.
+    pub fn evict_lru_until(&self, budget_bytes: u64) -> Result<NamespaceEviction> {
+        let total = self.total_bytes()?;
+        if total <= budget_bytes {
+            return Ok(NamespaceEviction {
+                paths: Vec::new(),
+                total_bytes_after: total,
+            });
         }
 
-        // Collect candidates oldest-first.
-        let mut stmt = self.conn.prepare_cached(
-            "SELECT hash, layout_key, path, model_id, kv_quant, byte_size, last_used
-             FROM kv_blocks ORDER BY last_used ASC",
-        )?;
-        let all: Vec<KvBlockRow> = stmt
-            .query_map([], row_from_row)?
-            .collect::<std::result::Result<_, _>>()?;
-
-        let mut running: u64 = total as u64;
-        let mut evicted_paths: Vec<PathBuf> = Vec::new();
-        let mut evicted_keys: Vec<(String, u64)> = Vec::new();
-
-        for row in all {
-            if running <= budget_bytes {
-                break;
-            }
-            tracing::info!(
-                hash = %row.hash,
-                layout_key = row.layout_key,
-                path = %row.path.display(),
-                byte_size = row.byte_size,
-                last_used = row.last_used,
-                "kv-index: evicting block (LRU)"
-            );
-            running = running.saturating_sub(row.byte_size);
-            evicted_paths.push(row.path.clone());
-            evicted_keys.push((row.hash.clone(), row.layout_key));
-        }
-
-        for (hash, lk) in &evicted_keys {
-            self.conn.execute(
-                "DELETE FROM kv_blocks WHERE hash = ?1 AND layout_key = ?2",
-                params![hash, *lk as i64],
+        // Oldest-first candidates, taking only as many as it takes to get under
+        // the ceiling.
+        let mut candidates: Vec<(String, u64, PathBuf, u64)> = Vec::new();
+        {
+            let mut stmt = self.conn.prepare_cached(
+                "SELECT hash, layout_key, path, byte_size
+                 FROM kv_blocks ORDER BY last_used ASC",
             )?;
+            let mut rows = stmt.query([])?;
+            let mut running = total;
+            while running > budget_bytes {
+                let Some(r) = rows.next()? else { break };
+                let byte_size = r.get::<_, i64>(3)?.max(0) as u64;
+                running = running.saturating_sub(byte_size);
+                candidates.push((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, i64>(1)? as u64,
+                    PathBuf::from(r.get::<_, String>(2)?),
+                    byte_size,
+                ));
+            }
         }
 
-        Ok(evicted_paths)
+        // One transaction: either every selected row goes, or none does, so the
+        // returned paths always match what was actually removed.
+        let tx = self.conn.unchecked_transaction()?;
+        let mut paths: Vec<PathBuf> = Vec::with_capacity(candidates.len());
+        let mut freed: u64 = 0;
+        for (hash, layout_key, path, byte_size) in candidates {
+            let n = tx.execute(
+                "DELETE FROM kv_blocks WHERE hash = ?1 AND layout_key = ?2",
+                params![hash, layout_key as i64],
+            )?;
+            // A no-op DELETE means another evictor already took this row; it
+            // owns the file, so this call neither counts it nor unlinks it.
+            if n > 0 {
+                tracing::debug!(
+                    hash = %hash,
+                    layout_key,
+                    path = %path.display(),
+                    byte_size,
+                    "kv-index: evicting block (LRU)"
+                );
+                freed = freed.saturating_add(byte_size);
+                paths.push(path);
+            }
+        }
+        tx.commit()?;
+
+        Ok(NamespaceEviction {
+            paths,
+            total_bytes_after: total.saturating_sub(freed),
+        })
     }
 
     /// Total `byte_size` summed over all indexed blocks.
@@ -680,6 +734,7 @@ pub fn evict_pool_lru_until(kv_root: &Path, global_budget_bytes: u64) -> Result<
 fn init_v2_schema(conn: &Connection) -> Result<()> {
     conn.execute_batch(SCHEMA_PRAGMAS)?;
     conn.execute_batch(SCHEMA_TABLES)?;
+    conn.execute_batch(SCHEMA_INDEXES)?;
     conn.execute(
         "INSERT OR IGNORE INTO schema_version (version) VALUES (?1)",
         params![SCHEMA_VERSION],

--- a/crates/rmlx-kv-ssd/src/ssd_index_tests.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_index_tests.rs
@@ -158,16 +158,21 @@ fn evict_lru_returns_oldest_first_and_leaves_within_budget() {
         .unwrap();
 
     let evicted = idx.evict_lru_until(1500).unwrap();
-    assert_eq!(evicted.len(), 2);
-    assert_eq!(evicted[0], path("aaa"));
-    assert_eq!(evicted[1], path("bbb"));
+    assert_eq!(evicted.paths.len(), 2);
+    assert_eq!(evicted.paths[0], path("aaa"));
+    assert_eq!(evicted.paths[1], path("bbb"));
+    assert_eq!(
+        evicted.total_bytes_after, 1000,
+        "the reported footprint must be the post-eviction one"
+    );
 
     assert!(idx.lookup("ccc", LK_A).unwrap().is_some());
     assert!(idx.lookup("aaa", LK_A).unwrap().is_none());
     assert!(idx.lookup("bbb", LK_A).unwrap().is_none());
 
     let evicted2 = idx.evict_lru_until(1500).unwrap();
-    assert!(evicted2.is_empty());
+    assert!(evicted2.paths.is_empty());
+    assert_eq!(evicted2.total_bytes_after, 1000);
 }
 
 #[test]
@@ -202,7 +207,8 @@ fn total_bytes_sums_all_rows_and_tracks_eviction() {
 fn evict_empty_index_is_noop() {
     let idx = open();
     let evicted = idx.evict_lru_until(0).unwrap();
-    assert!(evicted.is_empty());
+    assert!(evicted.paths.is_empty());
+    assert_eq!(evicted.total_bytes_after, 0);
 }
 
 #[test]
@@ -227,9 +233,10 @@ fn evict_zero_budget_evicts_all() {
         )
         .unwrap();
     let evicted = idx.evict_lru_until(0).unwrap();
-    assert_eq!(evicted.len(), 2);
-    assert_eq!(evicted[0], PathBuf::from("/tmp/x.kvb"));
-    assert_eq!(evicted[1], PathBuf::from("/tmp/y.kvb"));
+    assert_eq!(evicted.paths.len(), 2);
+    assert_eq!(evicted.paths[0], PathBuf::from("/tmp/x.kvb"));
+    assert_eq!(evicted.paths[1], PathBuf::from("/tmp/y.kvb"));
+    assert_eq!(evicted.total_bytes_after, 0);
 }
 
 // ── prune_missing ─────────────────────────────────────────────────────────

--- a/crates/rmlx-kv-ssd/src/ssd_tier.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_tier.rs
@@ -168,16 +168,19 @@ pub fn active() -> Option<SsdTierConfig> {
 
 /// The byte ceiling one namespace may occupy under `cfg`.
 ///
-/// The per-namespace budget is implicitly capped by the global pool ceiling
-/// (`min(per_ns, global)`); when `global_budget_bytes == 0` the per-namespace
-/// budget stands alone. Both the attach-time maintenance pass and the spill
-/// drain thread resolve their ceiling through here so they cannot disagree
-/// about what the configured budget means.
+/// A zero budget on either side means "that dimension is unconfigured", not
+/// "keep nothing": with no per-namespace budget the global pool ceiling governs
+/// the namespace on its own, and with no global pool the per-namespace budget
+/// stands alone. When both are set the namespace is capped by the tighter of
+/// the two. The result is therefore non-zero whenever the tier is on (which
+/// [`install_config`] defines as at least one budget being non-zero), so the
+/// attach-time maintenance pass and the spill drain thread — the two callers —
+/// always read the same ceiling as a ceiling.
 pub(crate) fn effective_namespace_budget(cfg: &SsdTierConfig) -> u64 {
-    if cfg.global_budget_bytes > 0 {
-        cfg.per_namespace_budget_bytes.min(cfg.global_budget_bytes)
-    } else {
-        cfg.per_namespace_budget_bytes
+    match (cfg.per_namespace_budget_bytes, cfg.global_budget_bytes) {
+        (0, global) => global,
+        (per_ns, 0) => per_ns,
+        (per_ns, global) => per_ns.min(global),
     }
 }
 
@@ -342,17 +345,7 @@ fn startup_maintenance(index: &SsdKvIndex, namespace: &str, budget_bytes: u64) {
         Ok(_) => {}
         Err(e) => tracing::warn!(namespace, error = %e, "ssd-tier prune_missing failed"),
     }
-    let before = index.total_bytes().unwrap_or(0);
-    let evicted = enforce_namespace_budget(index, namespace, budget_bytes);
-    let after = index.total_bytes().unwrap_or(0);
-    tracing::info!(
-        namespace,
-        budget_bytes,
-        bytes_before = before,
-        bytes_after = after,
-        evicted,
-        "ssd-tier startup evict-to-budget complete"
-    );
+    enforce_namespace_budget(index, namespace, budget_bytes);
 }
 
 /// Evict oldest-first until the namespace footprint is within `budget_bytes`,
@@ -364,31 +357,39 @@ fn startup_maintenance(index: &SsdKvIndex, namespace: &str, budget_bytes: u64) {
 /// runs it after each block it writes, so the configured budget holds for the
 /// whole life of the process instead of only at the moment a model is loaded.
 ///
-/// Best-effort throughout: an index error is `warn!`ed and treated as "evicted
-/// nothing"; a file that is already gone is not an error (a second evictor, or
-/// an operator's `rm`, reaching the same block first leaves exactly the state
-/// this pass wanted).
+/// `budget_bytes == 0` means "no ceiling configured" and evicts nothing.
+/// [`effective_namespace_budget`] only yields zero when the tier is off, so
+/// this is a backstop: eviction is the one operation where the two readings of
+/// zero differ by the whole namespace, and no caller gets to pick the wrong one.
 ///
-/// **Safe to run against a namespace with in-flight hydrate + spill traffic.**
-/// `evict_lru_until` deletes the index row before this fn deletes the file, so
-/// a concurrent lookup either does not find the row (a plain miss) or reads a
-/// file that has since vanished — which the hydrator already handles as a
-/// corrupt block: drop the row, `warn!`, and fall through to a full prefill. No
-/// reader can be handed a block other than the one it asked for, because a
-/// block is only ever reachable through its own `(hash, layout_key)` row.
+/// Best-effort throughout: an index error is `warn!`ed and treated as "evicted
+/// nothing"; a file that is already gone is not an error (an operator's `rm`
+/// reaching the block first leaves exactly the state this pass wanted).
+///
+/// **Safe to run against a namespace with in-flight hydrate + spill traffic**,
+/// in this specific sense: no reader is ever handed a block other than the one
+/// it asked for. A block is only reachable through its own `(hash, layout_key)`
+/// row, and `evict_lru_until` commits the row deletion before this fn unlinks
+/// the file, so a concurrent lookup either misses outright or fails its read and
+/// falls through to a full prefill. It does **not** claim every block survives:
+/// the hydrate-side cleanup path can still drop a block that a re-spill
+/// recreated underneath it (see `SsdHydrator::lookup_inner`).
 pub(crate) fn enforce_namespace_budget(
     index: &SsdKvIndex,
     namespace: &str,
     budget_bytes: u64,
 ) -> u64 {
-    let evicted = match index.evict_lru_until(budget_bytes) {
-        Ok(paths) => paths,
+    if budget_bytes == 0 {
+        return 0;
+    }
+    let eviction = match index.evict_lru_until(budget_bytes) {
+        Ok(e) => e,
         Err(e) => {
             tracing::warn!(namespace, error = %e, "ssd-tier evict_lru_until failed");
-            Vec::new()
+            return 0;
         }
     };
-    for p in &evicted {
+    for p in &eviction.paths {
         match std::fs::remove_file(p) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -400,29 +401,26 @@ pub(crate) fn enforce_namespace_budget(
 
     // Publish the eviction count to the Prometheus counter hook.
     // Zero when already within budget — no counter bump needed.
-    let evict_count = evicted.len() as u64;
+    let evict_count = eviction.paths.len() as u64;
     if evict_count > 0 {
         call_ssd_evict_total_hook(namespace, evict_count);
+        // One aggregate per pass. The per-row line is `debug!`: at the ceiling
+        // this runs after every spilled block, and an info-per-row would rotate
+        // the run's log history out against `RMLX_LOG_CAP_MB`.
+        tracing::info!(
+            namespace,
+            budget_bytes,
+            evicted = evict_count,
+            bytes_after = eviction.total_bytes_after,
+            "ssd-tier evict-to-budget complete"
+        );
     }
 
     // Publish the on-disk footprint to the Prometheus gauge. Running on every
     // spill is what keeps `rmlx_ssd_bytes_used` tracking the tier instead of
     // freezing at the value measured when the model was loaded.
-    call_ssd_bytes_used_hook(namespace, index.total_bytes().unwrap_or(0));
+    call_ssd_bytes_used_hook(namespace, eviction.total_bytes_after);
     evict_count
-}
-
-/// Enforce `budget_bytes` on `namespace` from the spill drain thread.
-///
-/// Thin gate over [`enforce_namespace_budget`]: a zero budget means "no
-/// ceiling configured for this spiller" and must not be handed to
-/// `evict_lru_until`, which would read it as "keep nothing" and empty the
-/// namespace.
-pub(crate) fn enforce_budget_after_spill(index: &SsdKvIndex, namespace: &str, budget_bytes: u64) {
-    if budget_bytes == 0 {
-        return;
-    }
-    enforce_namespace_budget(index, namespace, budget_bytes);
 }
 
 /// pre-release schema wipe: walk every namespace under `kv_root` and

--- a/crates/rmlx-kv-ssd/src/ssd_tier.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_tier.rs
@@ -166,6 +166,21 @@ pub fn active() -> Option<SsdTierConfig> {
     CONFIG.get().cloned().flatten()
 }
 
+/// The byte ceiling one namespace may occupy under `cfg`.
+///
+/// The per-namespace budget is implicitly capped by the global pool ceiling
+/// (`min(per_ns, global)`); when `global_budget_bytes == 0` the per-namespace
+/// budget stands alone. Both the attach-time maintenance pass and the spill
+/// drain thread resolve their ceiling through here so they cannot disagree
+/// about what the configured budget means.
+pub(crate) fn effective_namespace_budget(cfg: &SsdTierConfig) -> u64 {
+    if cfg.global_budget_bytes > 0 {
+        cfg.per_namespace_budget_bytes.min(cfg.global_budget_bytes)
+    } else {
+        cfg.per_namespace_budget_bytes
+    }
+}
+
 /// Resolve the on-disk namespace for `model_id` under the active config.
 ///
 /// Returns a borrowed slice of `cfg.default_namespace` when present, or an
@@ -276,13 +291,7 @@ pub fn prepare_attach(
 
     // Startup maintenance: drop rows whose .kvb vanished, then evict
     // oldest-first until the persisted footprint is within budget.
-    // Per-namespace budget is implicitly capped by the global pool ceiling
-    // (`min(per_ns, global)`); when global == 0 the per-ns budget stands alone.
-    let effective_per_ns = if cfg.global_budget_bytes > 0 {
-        cfg.per_namespace_budget_bytes.min(cfg.global_budget_bytes)
-    } else {
-        cfg.per_namespace_budget_bytes
-    };
+    let effective_per_ns = effective_namespace_budget(&cfg);
     // Open the namespace index here — this is the single `paths::home()`
     // resolution on the attach path — then hand the opened handle to the
     // maintenance routine. Keeping the open at the boundary means the
@@ -316,12 +325,6 @@ pub fn prepare_attach(
 /// the attach path. This keeps the routine root-injectable (tests open against
 /// a temp dir) and free of the `OnceLock` ordering hazard.
 #[allow(
-    clippy::cognitive_complexity,
-    reason = "prune → evict → prometheus hooks: sequential best-effort operations \
-              each with their own error arms; splitting would obscure the linear \
-              maintenance sequence"
-)]
-#[allow(
     clippy::semicolon_if_nothing_returned,
     reason = "tracing macros expand to expressions in macro position; the trailing \
               tracing::info! / tracing::warn! in match arms are the last expression, \
@@ -340,39 +343,86 @@ fn startup_maintenance(index: &SsdKvIndex, namespace: &str, budget_bytes: u64) {
         Err(e) => tracing::warn!(namespace, error = %e, "ssd-tier prune_missing failed"),
     }
     let before = index.total_bytes().unwrap_or(0);
-    let evict_count = match index.evict_lru_until(budget_bytes) {
-        Ok(evicted) => {
-            for p in &evicted {
-                if let Err(e) = std::fs::remove_file(p) {
-                    tracing::warn!(path = %p.display(), error = %e, "ssd-tier evicted-block file remove failed");
-                }
-            }
-            let after = index.total_bytes().unwrap_or(0);
-            tracing::info!(
-                namespace,
-                budget_bytes,
-                bytes_before = before,
-                bytes_after = after,
-                evicted = evicted.len(),
-                "ssd-tier startup evict-to-budget complete"
-            );
-            evicted.len() as u64
-        }
+    let evicted = enforce_namespace_budget(index, namespace, budget_bytes);
+    let after = index.total_bytes().unwrap_or(0);
+    tracing::info!(
+        namespace,
+        budget_bytes,
+        bytes_before = before,
+        bytes_after = after,
+        evicted,
+        "ssd-tier startup evict-to-budget complete"
+    );
+}
+
+/// Evict oldest-first until the namespace footprint is within `budget_bytes`,
+/// delete each evicted `.kvb`, and republish the two Prometheus hooks. Returns
+/// the number of blocks evicted.
+///
+/// This is the single eviction routine for the tier: the attach-time
+/// maintenance pass runs it after `prune_missing`, and the spill drain thread
+/// runs it after each block it writes, so the configured budget holds for the
+/// whole life of the process instead of only at the moment a model is loaded.
+///
+/// Best-effort throughout: an index error is `warn!`ed and treated as "evicted
+/// nothing"; a file that is already gone is not an error (a second evictor, or
+/// an operator's `rm`, reaching the same block first leaves exactly the state
+/// this pass wanted).
+///
+/// **Safe to run against a namespace with in-flight hydrate + spill traffic.**
+/// `evict_lru_until` deletes the index row before this fn deletes the file, so
+/// a concurrent lookup either does not find the row (a plain miss) or reads a
+/// file that has since vanished — which the hydrator already handles as a
+/// corrupt block: drop the row, `warn!`, and fall through to a full prefill. No
+/// reader can be handed a block other than the one it asked for, because a
+/// block is only ever reachable through its own `(hash, layout_key)` row.
+pub(crate) fn enforce_namespace_budget(
+    index: &SsdKvIndex,
+    namespace: &str,
+    budget_bytes: u64,
+) -> u64 {
+    let evicted = match index.evict_lru_until(budget_bytes) {
+        Ok(paths) => paths,
         Err(e) => {
             tracing::warn!(namespace, error = %e, "ssd-tier evict_lru_until failed");
-            0
+            Vec::new()
         }
     };
+    for p in &evicted {
+        match std::fs::remove_file(p) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                tracing::warn!(path = %p.display(), error = %e, "ssd-tier evicted-block file remove failed");
+            }
+        }
+    }
 
     // Publish the eviction count to the Prometheus counter hook.
-    // evict_count == 0 when already within budget — no counter bump needed.
+    // Zero when already within budget — no counter bump needed.
+    let evict_count = evicted.len() as u64;
     if evict_count > 0 {
         call_ssd_evict_total_hook(namespace, evict_count);
     }
 
-    // Publish the on-disk footprint to the Prometheus gauge after maintenance.
-    let total = index.total_bytes().unwrap_or(0);
-    call_ssd_bytes_used_hook(namespace, total);
+    // Publish the on-disk footprint to the Prometheus gauge. Running on every
+    // spill is what keeps `rmlx_ssd_bytes_used` tracking the tier instead of
+    // freezing at the value measured when the model was loaded.
+    call_ssd_bytes_used_hook(namespace, index.total_bytes().unwrap_or(0));
+    evict_count
+}
+
+/// Enforce `budget_bytes` on `namespace` from the spill drain thread.
+///
+/// Thin gate over [`enforce_namespace_budget`]: a zero budget means "no
+/// ceiling configured for this spiller" and must not be handed to
+/// `evict_lru_until`, which would read it as "keep nothing" and empty the
+/// namespace.
+pub(crate) fn enforce_budget_after_spill(index: &SsdKvIndex, namespace: &str, budget_bytes: u64) {
+    if budget_bytes == 0 {
+        return;
+    }
+    enforce_namespace_budget(index, namespace, budget_bytes);
 }
 
 /// pre-release schema wipe: walk every namespace under `kv_root` and

--- a/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
@@ -222,6 +222,94 @@ fn startup_maintenance_prunes_and_evicts_to_budget() {
     assert!(surviving_files <= 1);
 }
 
+// ── Runtime budget enforcement ────────────────────────────────────────────
+
+/// Seed `dir`'s index with `n` blocks of `size` bytes each, returning the
+/// opened index. Every block has a real file on disk so eviction has something
+/// to remove.
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn seed_blocks(dir: &Path, ns: &str, lk: u64, n: usize, size: usize) -> SsdKvIndex {
+    std::fs::create_dir_all(dir).unwrap();
+    let idx = SsdKvIndex::open_at(&dir.join("index.db")).unwrap();
+    for i in 0..n {
+        let name = format!("blk{i:04}");
+        let p = dir.join(format!("{name}.kvb"));
+        std::fs::write(&p, vec![0u8; size]).unwrap();
+        idx.record(&name, lk, &p, ns, "k8v8", size as u64).unwrap();
+    }
+    idx
+}
+
+/// The tier only grew and never shrank between model loads: nothing in the
+/// serving path called `evict_lru_until`, so a namespace that spilled past
+/// `--kv-ssd-cache-gb` stayed past it until the next attach. This is the pass
+/// that closes that, and the property it owns is "the footprint comes back
+/// under the ceiling, and the bytes that left disk really left disk".
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn enforce_namespace_budget_brings_footprint_within_budget() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let ns = "budget-ns";
+    let dir = tmp.path().join(ns);
+    let lk: u64 = 0x0f0f_0f0f_0f0f_0f0f;
+    let idx = seed_blocks(&dir, ns, lk, 5, 1000);
+    assert_eq!(idx.total_bytes().unwrap(), 5000);
+
+    let evicted = enforce_namespace_budget(&idx, ns, 2500);
+
+    assert_eq!(
+        evicted, 3,
+        "5 x 1000 bytes down to 2500 evicts three blocks"
+    );
+    assert!(idx.total_bytes().unwrap() <= 2500);
+    // The index and the disk must agree: no row may point at a file that the
+    // pass deleted, and no deleted row may leave its file behind.
+    assert_eq!(idx.prune_missing().unwrap(), 0, "no row lost its file");
+    let files_left = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().extension().is_some_and(|x| x == "kvb"))
+        .count();
+    assert_eq!(files_left, 2, "evicted blocks must be gone from disk");
+}
+
+/// A zero budget means "no ceiling configured", but `evict_lru_until` reads a
+/// zero budget as "keep nothing". [`enforce_budget_after_spill`] is the gate
+/// between those two readings, and this pins both sides of it: the raw pass
+/// empties the namespace, the gated one leaves it alone.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn enforce_budget_after_spill_ignores_a_zero_budget() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let ns = "zero-budget-ns";
+    let lk: u64 = 0x1234;
+
+    // Ungated: a zero budget is "keep nothing".
+    let raw_dir = tmp.path().join("raw");
+    let raw = seed_blocks(&raw_dir, ns, lk, 3, 100);
+    assert_eq!(enforce_namespace_budget(&raw, ns, 0), 3);
+    assert_eq!(raw.total_bytes().unwrap(), 0);
+
+    // Gated: a zero budget is "no ceiling", so nothing moves.
+    let gated_dir = tmp.path().join("gated");
+    let gated = seed_blocks(&gated_dir, ns, lk, 3, 100);
+    enforce_budget_after_spill(&gated, ns, 0);
+    assert_eq!(
+        gated.total_bytes().unwrap(),
+        300,
+        "an unconfigured ceiling must not empty the namespace"
+    );
+}
+
 /// unit test: double `install_config` returns `Err(SsdTierAlreadyInstalled)`.
 ///
 /// Test process is shared, so this test (and only this test) drives the

--- a/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
@@ -279,35 +279,54 @@ fn enforce_namespace_budget_brings_footprint_within_budget() {
     assert_eq!(files_left, 2, "evicted blocks must be gone from disk");
 }
 
-/// A zero budget means "no ceiling configured", but `evict_lru_until` reads a
-/// zero budget as "keep nothing". [`enforce_budget_after_spill`] is the gate
-/// between those two readings, and this pins both sides of it: the raw pass
-/// empties the namespace, the gated one leaves it alone.
+/// Zero is the one budget where the two possible readings — "no ceiling" and
+/// "keep nothing" — differ by the whole namespace. The tier-level routine reads
+/// it as "no ceiling" for every caller, so no call site has to be wrapped to
+/// survive it. (The literal reading still lives on the raw index API, which
+/// `evict_zero_budget_evicts_all` pins.)
 #[test]
 #[allow(
     clippy::unwrap_used,
     reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
 )]
-fn enforce_budget_after_spill_ignores_a_zero_budget() {
+fn enforce_namespace_budget_ignores_a_zero_budget() {
     let tmp = tempfile::TempDir::new().unwrap();
     let ns = "zero-budget-ns";
     let lk: u64 = 0x1234;
 
-    // Ungated: a zero budget is "keep nothing".
-    let raw_dir = tmp.path().join("raw");
-    let raw = seed_blocks(&raw_dir, ns, lk, 3, 100);
-    assert_eq!(enforce_namespace_budget(&raw, ns, 0), 3);
-    assert_eq!(raw.total_bytes().unwrap(), 0);
-
-    // Gated: a zero budget is "no ceiling", so nothing moves.
-    let gated_dir = tmp.path().join("gated");
-    let gated = seed_blocks(&gated_dir, ns, lk, 3, 100);
-    enforce_budget_after_spill(&gated, ns, 0);
+    let dir = tmp.path().join("ns");
+    let idx = seed_blocks(&dir, ns, lk, 3, 100);
+    assert_eq!(enforce_namespace_budget(&idx, ns, 0), 0);
     assert_eq!(
-        gated.total_bytes().unwrap(),
+        idx.total_bytes().unwrap(),
         300,
         "an unconfigured ceiling must not empty the namespace"
     );
+}
+
+/// `--kv-ssd-global-gb N --kv-ssd-cache-gb 0` turns the tier on, so the
+/// namespace ceiling it resolves to has to be a real ceiling. Resolving it to
+/// zero gave the attach path "delete everything" and the runtime path "never
+/// enforce" off the same config.
+#[test]
+fn effective_namespace_budget_never_yields_zero_while_the_tier_is_on() {
+    let cfg = |per_ns: u64, global: u64| SsdTierConfig {
+        per_namespace_budget_bytes: per_ns,
+        global_budget_bytes: global,
+        default_namespace: None,
+        per_project_budgets: BTreeMap::default(),
+    };
+
+    // No per-namespace ceiling: the global pool governs the namespace alone.
+    assert_eq!(effective_namespace_budget(&cfg(0, 900)), 900);
+    // No global pool: the per-namespace budget stands alone.
+    assert_eq!(effective_namespace_budget(&cfg(700, 0)), 700);
+    // Both set: the tighter of the two, either way round.
+    assert_eq!(effective_namespace_budget(&cfg(700, 900)), 700);
+    assert_eq!(effective_namespace_budget(&cfg(900, 700)), 700);
+    // Both zero is the tier being off; nothing enforces, and the eviction
+    // routine treats the zero as "no ceiling" rather than "keep nothing".
+    assert_eq!(effective_namespace_budget(&cfg(0, 0)), 0);
 }
 
 /// unit test: double `install_config` returns `Err(SsdTierAlreadyInstalled)`.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -109,9 +109,9 @@ mutually exclusive.
 | `--tts-model-path` | path | — | Path to a Qwen3-TTS model snapshot directory. Required for `POST /v1/audio/speech`. Codec decoder not yet implemented; returns 501 until then. Env: `RMLX_TTS_MODEL_PATH`. |
 | `--tts-tokenizer-path` | path | — | Path to the Qwen3-TTS speech tokenizer snapshot directory. Used alongside `--tts-model-path`. Env: `RMLX_TTS_TOKENIZER_PATH`. |
 | `--mm-cache-bytes` | usize | `536870912` (512 MiB) | Byte budget for the multimodal encoder-output cache. Vision-tower (and Whisper-encoder) outputs are cached keyed on the post-preprocess pixel/PCM content hash **plus the producing model's identity** so repeated calls with identical inputs skip the encoder. The model-identity component means a shared cache in multi-model `--registry` mode never serves one model's encoder output to another for the same image/audio (cached outputs are projected to a model's hidden size and must not cross models). `0` disables the cache. Env: `RMLX_MM_CACHE_BYTES`. |
-| `--kv-ssd-cache-gb` | f64 | 0.0 | SSD prompt-cache tier budget in GiB per namespace. `0` = tier off (RAM-only). Blocks land in `<RMLX_HOME>/cache/kv/<namespace>/`. |
+| `--kv-ssd-cache-gb` | f64 | 0.0 | SSD prompt-cache tier budget in GiB per namespace. `0` = no per-namespace ceiling (tier off unless `--kv-ssd-global-gb > 0`). Blocks land in `<RMLX_HOME>/cache/kv/<namespace>/`. |
 | `--project` | string | (model id) | SSD prompt-cache namespace name. Requires `--kv-ssd-cache-gb > 0`. |
-| `--kv-ssd-global-gb` | f64 | 0.0 | Global SSD pool ceiling across all namespaces in GiB. `0` = no global cap. Effective per-namespace ceiling is `min(--kv-ssd-cache-gb, --kv-ssd-global-gb)` when global > 0. |
+| `--kv-ssd-global-gb` | f64 | 0.0 | Global SSD pool ceiling across all namespaces in GiB. `0` = no global cap. Effective per-namespace ceiling is the tighter of the two flags when both are > 0, and whichever one is set when only one is — a `0` is "unconfigured", never a zero-byte ceiling. |
 | `--prompt-cache-ram-gb` | f64 | 2.0 | RAM cap for the in-process prompt cache in GiB. |
 | `--paged-kv` | bool flag | off | Route K8V4/K8V8/Planar caches through the block-table paged storage path. Incompatible with `bf16`/`none` and `rot_k*` cache types. |
 | `--paged-kv-page-tokens` | i32 | 32 | Tokens per paged-KV block. Requires `--paged-kv`. |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -138,7 +138,10 @@ mutually exclusive.
 > reloading weights — one resident model can serve multiple KV codecs / context
 > ceilings. Requests that omit the fields use these launch defaults. See
 > `docs/SERVER.md` § "Per-request KV-config hot-swap". `--kv-ssd-cache-gb` stays
-> launch-fixed (SSD live reconfig deferred — `docs/SSD_TIER.md`).
+> launch-fixed — there is no route to change it on a running server — but the
+> value it is set to is enforced continuously, not only at model load, so the
+> ceiling holds for the life of the process (`docs/SSD_TIER.md` §
+> "Evict-to-budget (runtime)").
 
 **KV-bits mapping** (`--kv-bits` + `--kv-group-size`):
 

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -262,8 +262,9 @@ quant for a 128k request, `none` for a short chat) with zero downtime.
 - **Single-MLX claim is unaffected** — one model stays resident throughout.
 - **Anthropic `/v1/messages`** does not expose these fields (stricter wire
   spec); it always uses the launch default.
-- **Deferred:** live SSD-tier reconfiguration (per-request `kv_ssd` toggle) is
-  **not** implemented — see `docs/SSD_TIER.md` § "Live reconfiguration (deferred)".
+- **Not offered:** a per-request `kv_ssd` toggle. The SSD tier is per-namespace
+  global machinery, not a lookup salt, so it cannot be overridden for one
+  request — see `docs/SSD_TIER.md` § "Live reconfiguration".
 
 ### Multimodal content parts — image + native audio input
 

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -338,9 +338,10 @@ effectively disabled.
 `SsdSpiller::spawn` resolves the namespace byte ceiling once, from the installed
 config via `ssd_tier::effective_namespace_budget` — the same figure the
 attach-time maintenance pass evicts to. After each block it records, the drain
-thread calls `enforce_budget_after_spill`, which evicts LRU-first until the
+thread calls `enforce_namespace_budget`, which evicts LRU-first until the
 namespace is back within that ceiling and republishes `rmlx_ssd_bytes_used` /
-`rmlx_ssd_evict_total`.
+`rmlx_ssd_evict_total`. That is the same routine the attach path runs, so the
+two cannot disagree about what the configured budget means.
 
 The drain thread owns this because it is the only writer that grows the tier, it
 already holds the index handle, and it runs off the inference path. Without it
@@ -350,16 +351,36 @@ model loads grew past `--kv-ssd-cache-gb` for its whole lifetime, and the
 loaded. (Measured on a 4-request session: gemma-4-e2b at a 0.02 GiB ceiling held
 47.1 MB, Ternary-Bonsai-8B at a 0.3 GiB ceiling held 980.6 MB.)
 
-A budget of `0` means "no ceiling configured", and
-`enforce_budget_after_spill` returns without touching the index for it —
-`evict_lru_until(0)` would read a zero budget as "keep nothing".
+`effective_namespace_budget` resolves the ceiling as: no per-namespace budget →
+the global pool ceiling governs the namespace alone; no global pool → the
+per-namespace budget stands alone; both set → the tighter of the two. It
+therefore only yields `0` when the tier is off, so a zero can never mean
+"ceiling of zero bytes". `enforce_namespace_budget` treats `0` as "no ceiling
+configured" for every caller and evicts nothing — the literal "keep nothing"
+reading stays on the raw `SsdKvIndex::evict_lru_until` API.
 
-The pass is safe against in-flight hydrates on the same namespace. Rows are
-deleted before their `.kvb` files, so a concurrent lookup either does not find
-the row (a plain miss) or fails its read and takes the existing corrupt-block
-path — drop the row, `warn!`, full prefill. A block is only ever reachable
-through its own `(hash, layout_key)` row, so no reader can be handed a block
-other than the one it asked for.
+Eviction reads rows in `last_used` order and runs after every spilled block, so
+it must not be O(rows): the scan stops as soon as the running total is back under
+the ceiling, an index on `last_used` keeps SQLite from sorting the table to find
+the oldest row, and the post-eviction footprint is returned rather than re-summed
+by the caller. Measured at 100k rows (≈200 GiB of 2 MiB blocks), one block over
+budget: ~41 ms → ~3.1 ms per spilled block, the remainder being the one
+`SUM(byte_size)` that decides whether there is anything to do.
+
+The deletes run in a single transaction, so a SQLite failure part-way leaves the
+index untouched instead of dropping rows whose files the caller is never told to
+unlink — those files would be unreclaimable, since `prune_missing` drops rows
+whose file vanished and not the inverse. Only rows this call actually deleted are
+returned, so the eviction count published to `rmlx_ssd_evict_total` cannot
+double-count a row a second evictor removed first.
+
+The pass is safe against in-flight hydrates on the same namespace, in this
+specific sense: **no reader is handed a block other than the one it asked for**.
+Rows are deleted before their `.kvb` files, and a block is only reachable through
+its own `(hash, layout_key)` row, so a concurrent lookup either does not find the
+row (a plain miss) or finds its file already gone and falls through to a full
+prefill. It is not a claim that no block is lost — the hydrate-side cleanup can
+still drop a block that a re-spill recreated underneath it (see below).
 
 The job carries the last chained-block digest of the entry's prompt as `hash`
 (the block's identity), plus `layout_key`, `model_id`, `kv_quant`, and the
@@ -593,7 +614,19 @@ is a startup error (exit 2).
 - Spill errors are always `warn!`-logged and dropped; the inference path is
   unaffected.
 - Hydrate errors (corrupt file, metadata mismatch) are `warn!`-logged; the
-  request falls through to a full re-prefill.
+  request falls through to a full re-prefill. A block whose file is simply
+  *gone* is not one of these: LRU eviction unlinks blocks whose rows it has
+  already deleted, so a hydrate finding no file is the routine outcome of a
+  racing eviction. That case is `debug!`-logged and treated as a miss, so a tier
+  running normally at its ceiling does not stream corruption warnings.
+- Both cleanup paths delete the index row before unlinking the file, matching
+  the eviction order. An interrupted cleanup therefore leaves an unreferenced
+  row, which `prune_missing` reclaims at the next attach, rather than an
+  unreferenced file, which nothing reclaims. A re-spill of the same hash landing
+  between a failed read and its cleanup can still cost that block; the row and
+  the file are the same for identical content, and `last_used` is
+  second-granular, so there is nothing to compare-and-delete against short of a
+  per-row generation counter.
 - Index open failures disable the tier for the affected namespace; other
   namespaces and the RAM cache are unaffected.
 

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -196,29 +196,61 @@ under one KV layout cannot collide with the same block cached under another.
 `layout_key`) at `attach_at_load` before the index is opened, so operators can
 correlate log rows with the active layout during debugging.
 
-## Live reconfiguration (deferred — issue #26)
+## Live reconfiguration
 
-Issue #26 makes the KV **codec** and **context ceiling** per-request hot-swappable
-on a resident model (see `docs/SERVER.md` § "Per-request KV-config hot-swap").
-The SSD tier is **deliberately excluded** from that per-request surface and stays
-launch-fixed (`--kv-ssd-cache-gb`, attached once at `attach_at_load`).
+Per-request KV **codec** and **context ceiling** are hot-swappable on a resident
+model (see `docs/SERVER.md` § "Per-request KV-config hot-swap"). The SSD tier is
+**deliberately excluded** from that per-request surface: it stays launch-fixed
+(`--kv-ssd-cache-gb`, attached once at `attach_at_load`).
 
-**Why deferred.** The tier is wired into the prompt cache via a per-namespace
-spiller + hydrator keyed by `(namespace, layout_key)`, opened against an on-disk
-`ssd_index` and `.kvb` block files at load. A per-request SSD toggle would need
-to tear down and re-attach that per-namespace tier (close/reopen the index,
-respawn the spiller, re-key the hydrator) mid-flight — architecturally heavy and
+**Why it is not a per-request override.** The tier is wired into the prompt cache
+via a per-namespace spiller + hydrator keyed by `(namespace, layout_key)`, opened
+against an on-disk `ssd_index` and `.kvb` block files at load. A per-request SSD
+toggle would have to tear that down and re-attach it mid-flight (close/reopen the
+index, respawn the spiller, re-key the hydrator) — architecturally heavy and
 orthogonal to the read-only-weights insight that makes codec/ctx hot-swap cheap.
-The per-request codec/ctx override delivers the issue's core benefit (resident
-multi-KV sweeps, per-request KV policy) without it.
 
-The codec partitioning that #26 added to the **RAM** prompt cache
+The codec partitioning applied to the **RAM** prompt cache
 (`KvQuant::cache_key_salt()` XOR'd into the block-hash seed) composes correctly
 with `layout_key`: on an SSD-active run the seed mixes both, so RAM slots are
-codec-partitioned even though the SSD tier itself remains single-codec for the
-resident lifetime. A live SSD reconfiguration is a well-scoped follow-up
-(tracked in issue #30): per-namespace tier teardown/attach driven by a
-control-plane drain+reattach setter.
+codec-partitioned even though the SSD tier itself stays single-codec for the
+resident lifetime.
+
+### What a live *budget* change would take
+
+The per-namespace budget is now a live quantity: the spill drain thread evicts to
+it after every block (§ "Evict-to-budget (runtime)"), so changing it changes tier
+behaviour immediately rather than at the next model load. What is missing is only
+the surface to change it through — the value is resolved once at
+`SsdSpiller::spawn` from the `OnceLock` config, and there is no control-plane
+route for it.
+
+Such a change would **not** need a drain of in-flight requests. Eviction is
+already concurrency-safe by construction (same argument as § "Evict-to-budget
+(runtime)"), and the budget has no bearing on how a block is keyed, read, or
+decoded.
+
+### What a live *enable / disable* would take
+
+Detaching the tier on a resident model means dropping the spiller + hydrator from
+the live `PromptCache<E>` **and** clearing the recorded `AttachParams`, so that
+`ArchPromptCache::ensure` does not re-install them the next time the cache is
+rebuilt for a capacity change.
+
+This too is not corruption-shaped, for a structural reason worth stating: within
+one resident model, `layout_key` can only change if `kv_quant` changes, and
+`layout_key` is *lookup namespacing*, not data layout. Because the block digests
+are chained from the seed, a query computed under one seed cannot partially match
+a slot stored under another — block 0 already differs, `find_best_prefix` returns
+`None`, and the request re-prefills. A mid-flight enable or disable can therefore
+lose spills and strand slots as unfindable, but cannot produce a wrong-length or
+wrong-codec reuse.
+
+What it *would* need is a decision on the control-plane surface. The existing
+lifecycle routes are per-model (`POST /v1/models/{id}/load` / `/unload`,
+`GET /v1/models/{id}/status`); the SSD tier is per-*namespace*, and a namespace
+can be shared by several models via `--project`. Neither is a subset of the
+other, so the route shape is a design call, not an implementation detail.
 
 ---
 
@@ -293,11 +325,41 @@ exceeded), the spill hook receives the evicted entry. The spiller:
      bytes (CPU eval), writes to `<namespace_dir>/<hash>.kvb`.
    - Records the block in `SsdKvIndex` via `index.record`.
    - On any error: `warn!`, remove partial `.kvb` if it exists, drop job.
+   - On a block that reached the index, runs the **evict-to-budget pass**
+     (below).
 
 The drain thread opens the `SsdKvIndex` once on startup. If the index cannot be
 opened, the thread drains the channel (to unblock senders) and exits; the
 spiller silently drops subsequent jobs. The cache continues working with spill
 effectively disabled.
+
+### Evict-to-budget (runtime)
+
+`SsdSpiller::spawn` resolves the namespace byte ceiling once, from the installed
+config via `ssd_tier::effective_namespace_budget` — the same figure the
+attach-time maintenance pass evicts to. After each block it records, the drain
+thread calls `enforce_budget_after_spill`, which evicts LRU-first until the
+namespace is back within that ceiling and republishes `rmlx_ssd_bytes_used` /
+`rmlx_ssd_evict_total`.
+
+The drain thread owns this because it is the only writer that grows the tier, it
+already holds the index handle, and it runs off the inference path. Without it
+the budget was enforced **only at attach**: a `serve` that stayed up between
+model loads grew past `--kv-ssd-cache-gb` for its whole lifetime, and the
+`rmlx_ssd_bytes_used` gauge stayed frozen at the value measured when the model
+loaded. (Measured on a 4-request session: gemma-4-e2b at a 0.02 GiB ceiling held
+47.1 MB, Ternary-Bonsai-8B at a 0.3 GiB ceiling held 980.6 MB.)
+
+A budget of `0` means "no ceiling configured", and
+`enforce_budget_after_spill` returns without touching the index for it —
+`evict_lru_until(0)` would read a zero budget as "keep nothing".
+
+The pass is safe against in-flight hydrates on the same namespace. Rows are
+deleted before their `.kvb` files, so a concurrent lookup either does not find
+the row (a plain miss) or fails its read and takes the existing corrupt-block
+path — drop the row, `warn!`, full prefill. A block is only ever reachable
+through its own `(hash, layout_key)` row, so no reader can be handed a block
+other than the one it asked for.
 
 The job carries the last chained-block digest of the entry's prompt as `hash`
 (the block's identity), plus `layout_key`, `model_id`, `kv_quant`, and the
@@ -504,14 +566,27 @@ is a startup error (exit 2).
 
 - `prune_missing`: drops index rows whose `.kvb` file has been deleted outside
   the process (manual cleanup, OS eviction). Returns count of pruned rows.
-- `evict_lru_until(effective_budget)`: deletes oldest rows + their `.kvb` files
-  until the index total is within budget.
+- `enforce_namespace_budget(effective_budget)`: deletes oldest rows + their
+  `.kvb` files until the index total is within budget, then republishes the
+  `ssd_bytes_used` gauge and the `ssd_evict_total` counter.
+
+**Runtime maintenance per namespace**
+
+- The spill drain thread runs `enforce_namespace_budget` after every block it
+  records, so the ceiling holds for the life of the process and not only at
+  attach. See § "Evict-to-budget (runtime)".
+- `prune_missing` stays attach-only: a row whose file vanished mid-run is
+  repaired on the read path (hydrate drops it and re-prefills), so a periodic
+  scan of every row would buy nothing.
 
 **Budget accounting**
 
 - `SsdKvIndex::total_bytes()` sums `byte_size` over all indexed rows.
 - `byte_size` is the on-disk size written at spill time and stored in the index.
   It does not account for filesystem fragmentation.
+- The budget is a **ceiling on the indexed total**, checked after each spill. A
+  single block larger than the whole ceiling is written and then immediately
+  evicted; the tier does not refuse an over-sized block up front.
 
 **Failure containment**
 


### PR DESCRIPTION
Addresses #30 and closes #342.

### The budget had no runtime consumer

`evict_lru_until` was reachable only from `prepare_attach` (once per model load) and `evict_pool_lru_until` only from `install_config` (once at startup). So the configured per-namespace ceiling was enforced at attach and **never again**. Measured overshoot on real models, same 5 temp=0 completions per architecture at a ceiling sized to hold one block:

| arch | ceiling | before | after | evictions |
|---|---|---|---|---|
| gemma-4-e2b (`kv_h == 1`) | 21,474,836 B | 47,146,240 B (**2.2× over**) | 11,786,560 B | 0 → 3 |
| Ternary-Bonsai-8B (`kv_h > 1`) | 322,122,547 B | 980,641,752 B (**3.0× over**) | 245,160,432 B | 0 → 3 |

Output digests identical across tier-off / tier-on-before / tier-on-after on both architectures. Both binaries snapshotted and sha-verified distinct before the A/B.

The spill drain thread now enforces the ceiling after every block it records, sharing one eviction routine with the attach path.

### What #30 asked for, and why this is not that

The ticket bundles three things, and only one survived contact with the code:

- **"Live resize" was vacuous** — the budget had no runtime reader, so changing it live changed a number nobody consulted until the next model load. This branch builds the substrate that leg silently assumes.
- **The stated payoff is gone.** It was motivated by letting `rmlx bench` reconfigure between cells; `bench` runs one cell per process and **hard-refuses** any run served from the SSD tier (`ssd_hits > 0` → abort), so a live reattach would give it nothing.
- **The quiesce is not needed** for enable/disable/resize. `layout_key` is lookup *namespacing*, not data layout, and within one resident model it can only move if `kv_quant` moves. Digests chain from a seed, so a query under seed A cannot *partially* match a slot under seed B — block 0 already differs and `find_best_prefix` returns `None`. A mid-flight change can lose spills and strand slots as unfindable; it cannot yield a wrong-length or wrong-codec reuse.
- **The control-plane surface is a genuine design question and is left open** — see below.

### Concurrency safety

The pass is safe against in-flight traffic because of an ordering: `evict_lru_until` deletes the index **row** and returns paths; the caller unlinks the **file** afterwards. A block is reachable only through its `(hash, layout_key)` row, so a racing hydrate either misses the row, or holds a row whose file has vanished → read fails → the block is treated as absent → full prefill. Every racing outcome collapses to a correct prefill.

That is an argument, so it is tested rather than asserted. A three-thread test (grower, evictor, hydrator) checks every served block against the **K-dequant of the cache actually spilled under that prompt** — not just its token ids, which are recomputed from the caller's own prompt and would not catch a foreign block. Mutating the comparison to a neighbouring prompt gives max err 0.996 against a 1e-3 threshold, a ~1000× separation.

Review caught that the check ran only inside the hit arm, so a zero-hit run would pass vacuously — and that this was **reachable, not hypothetical**: measured 13 hits / 227 misses at the original budget. Fixed by asserting `hits > 0` *and* re-sizing the budget to force ~31% hits; then 100/100 green under 18 CPU spinners.

### Review round

- **HIGH — the shared resolver returned a value its two consumers read oppositely.** This branch extracted `effective_namespace_budget`, which returns 0 for `--kv-ssd-global-gb > 0` with `--kv-ssd-cache-gb 0`; the runtime path read 0 as "no ceiling" (enforcement silently off) while the attach path read it as "keep nothing" (**empties every namespace on every model load**). Fixed at the source — `(0, global) => global` — and the guard wrapper deleted. That closes #342, which had been filed as pre-existing; shipping a shared resolver whose consumer must be wrapped to survive its return value is the defect, not the wrapper.
- **O(N) per spilled block.** Eviction went from once-per-load to once-per-block while doing two full-table aggregates plus a full `ORDER BY` scan materialising every row with four heap allocations each — and with a spill channel bounded at 16 that drops on overflow, that is a **spill-loss** path, not just wasted CPU. Now streams with early break, projects 4 columns, moves instead of cloning, and returns the post-eviction total. **41 ms → 3.1 ms** at 100k rows. A `last_used` index was needed to get there: early-stopping alone only reached 20.6 ms, because SQLite sorts the whole table before yielding row one.
- **No transaction on the row deletes**, so a partial failure left rows gone with files never unlinked — and nothing reclaims a file with no row, so the ceiling would silently stop holding. Now atomic, and only rows whose DELETE actually removed something are returned and unlinked.
- **Log levels were inverted for the new steady state.** One `info!` per evicted row was fine once per model load; as steady state it streams for the life of a `serve` and evicts the runtime history `RMLX_LOG_CAP_MB` exists to preserve. Demoted to `debug!`, with one aggregate per pass. Real-model log: 23 aggregate lines, 0 per-row lines at info.
- **Routine evictions logged as corruption.** "Row present, file gone" went from never-happens to designed steady state, and every instance hit hydrate's `warn!("corrupt block")`. Now typed as missing-vs-corrupt at the read, no re-stat. Real run: 0 warnings.
- `evict_count` reported candidates rather than rows removed — over-reporting into an append-only metrics store with two drain threads on one namespace. Now counts actual removals.

One review item was **rejected with reason**: a compare-and-delete for hydrate's cleanup has no discriminator, since `last_used` is second-granular and a re-spill of the same hash reproduces an identical path and byte_size. Reordering to row-before-file was done instead — a strict improvement, since the residual failure leaves an unreferenced *row* (`prune_missing` reclaims it) rather than an unreferenced *file* (nothing does). Documented as partially open rather than claimed closed.

### Left open, deliberately

**The control-plane surface.** With the budget now live, a resize is a one-value swap needing no drain and a disable is a spiller detach whose worst case is a lost spill. But the tier is keyed per-**namespace** while every existing lifecycle route is per-**model**, and `--project` lets N models share one namespace — neither is a subset of the other. `POST /v1/cache/{namespace}`? `PATCH /v1/models/{id}/ssd`? That is an API decision, not an executor's guess. Suggest re-scoping #30 to exactly that question.

`make ci` green — 2632 workspace tests, 6 mutation checks all red-first.

Follow-up filed: **#343** — `last_used` is second-granular, so LRU picks an arbitrary victim among blocks touched in the same second. It is what made the race test's hit rate low enough to matter.
