### PR TITLE
test(ci): run the GPU tests the ignore-rule mandates, and fix the two it would have caught (#332, #335, #313)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,8 +199,13 @@ Hard rules:
 - **Hard rule: a test that reaches `Device::Gpu` carries `#[ignore]`.** A shared
   Metal context driven from parallel `cargo test` threads aborts the whole test
   binary ("Rust cannot catch foreign exceptions"), taking every other test in
-  the crate with it. Run them as
-  `cargo test -p <crate> --lib -- --ignored <filter> --test-threads=1`. A guard
+  the crate with it. Run them with **`make gpu-test`** (every member crate,
+  serialized; `CRATE=` / `FILTER=` to narrow), or by hand as
+  `cargo test -p <crate> --lib -- --ignored <filter> --test-threads=1`.
+  `make gpu-test` is the only step that executes them — `make test` passes no
+  `--ignored` and the hosted CI has no Metal — so it is mandatory before merging
+  anything in the codec layer. It is deliberately not in `make ci` (needs the
+  Metal context to itself). A guard
   that only exercises a check the dispatcher rejects **before** touching a
   device-parameterized op is not a GPU test: pass `Device::Cpu` and leave it
   un-ignored — ignoring a CPU test silently stops running it. The CI gate
@@ -245,7 +250,8 @@ hand — keeps the CI gate and the local gate identical.
 | `make` / `make help` | List targets. |
 | `make build` | `cargo build --workspace --release`. |
 | `make check` | `cargo check --workspace --all-targets` (fast). |
-| `make test` | `cargo test --workspace`. |
+| `make test` | `cargo test --workspace` — **skips every `#[ignore]` GPU test**. |
+| `make gpu-test` | Run the GPU/Metal `#[ignore]` tests, `--test-threads=1` (`CRATE=` / `FILTER=` narrow). Needs exclusive machine access. Not in `make ci`. |
 | `make fmt` / `make fmt-check` | Write / check `cargo fmt`. |
 | `make lint` | `cargo clippy -D warnings`. |
 | `make audit` | `cargo audit` with RustSec ignores from `deny.toml`. |

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         metrics-init metrics-doctor metrics-doctor-fix metrics-export \
         metrics-backup metrics-replay-pending metrics-prompts-sync \
         metrics-champions metrics-champions-rmlx \
-        build-perf build-debug test-perf ci-perf model-check model-check-full \
+        build-perf build-debug test-perf ci-perf gpu-test model-check model-check-full \
         profile-samply profile-samply-debug profile-instruments bench asm perf-iter \
         canary canary-gate \
         mlx-preflight mlx-restore-pin target-gc target-size-report profile-gputrace \
@@ -139,6 +139,22 @@ test-perf:       ## cargo test --profile release-perf (release-perf profile, pan
 ci-perf:         ## pre-push gate under release-perf (separate from make ci; run before merging perf-sensitive changes)
 	$(MAKE) test-perf
 	@echo "ci-perf ok"
+
+# gpu-test: the execution step for the tests `check-gpu-tests-ignored` mandates.
+# Every test reaching Device::Gpu must carry #[ignore] (a shared Metal context
+# driven from parallel cargo-test threads aborts the whole binary), and until
+# this target existed nothing ran them: `make test` passes no --ignored and the
+# hosted CI has no Metal. GPU decode correctness for every KV codec sits in that
+# category, and tests in it have gone red on main and stayed red undetected.
+#
+# It is NOT part of `make ci`: it needs exclusive access to the Metal context and
+# is far too slow to block every commit. Run it before merging anything in the
+# codec layer. Folding it into `ci-perf` (the one target that already assumes
+# exclusive machine access) is the natural next step, but is blocked while any
+# GPU test is red on main — wiring a known-red step into a shared gate just
+# teaches people to skip the gate.
+gpu-test:        ## run the GPU/Metal #[ignore] tests serialized (CRATE= FILTER= to narrow); needs exclusive machine access
+	@bash scripts/run_gpu_tests.sh $(if $(CRATE),--crate $(CRATE),) $(if $(FILTER),--filter $(FILTER),)
 
 # model-check: run only the model-logic crates (rmlx-models, rmlx-runtime,
 # rmlx-quant) plus the KV-codec crate (rmlx-kv-quant). Excludes server, CLI, and

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ ci-perf:         ## pre-push gate under release-perf (separate from make ci; run
 # GPU test is red on main — wiring a known-red step into a shared gate just
 # teaches people to skip the gate.
 gpu-test:        ## run the GPU/Metal #[ignore] tests serialized (CRATE= FILTER= to narrow); needs exclusive machine access
-	@bash scripts/run_gpu_tests.sh $(if $(CRATE),--crate $(CRATE),) $(if $(FILTER),--filter $(FILTER),)
+	@bash scripts/run_gpu_tests.sh $(if $(CRATE),--crate '$(CRATE)',) $(if $(FILTER),--filter '$(FILTER)',)
 
 # model-check: run only the model-logic crates (rmlx-models, rmlx-runtime,
 # rmlx-quant) plus the KV-codec crate (rmlx-kv-quant). Excludes server, CLI, and

--- a/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
@@ -371,18 +371,25 @@ fn cpu_reference_dequant(
     }
 }
 
-/// Full-prefix correctness of the ring-only decode tail.
+/// Full-prefix correctness once the GPU ring is the store's only copy of K.
 ///
-/// After prefill + N fused decode steps the rotor K store's CPU `blocks` stay
-/// frozen at the prefill prefix — the per-step host download is skipped, so the
-/// decode tail lives only in the GPU ring. `dequant()` must still return the
-/// FULL prefix, rebuilt from the ring, with **no zero-padded gap**. Proven
-/// against a CPU-only reference store fed the identical K tokens.
+/// After prefill + N fused decode steps a rotor K-only store holds **nothing**
+/// on the host: the per-step block download is skipped, and the append releases
+/// the seeded prefill blocks as soon as the ring goes live, so the ring carries
+/// the whole `[0, prefill + steps)` prefix on its own. `dequant()` must still
+/// return the FULL prefix, rebuilt from the ring, with **no zero-padded gap**.
+/// Proven against a CPU-only reference store fed the identical K tokens.
+///
+/// The empty-blocks precondition is what makes the comparison load-bearing: with
+/// a host copy still resident, `dequant()` could pass by reading it and prove
+/// nothing about the ring.
 ///
 /// Mutation check: make `dequant()` decode `self.blocks` directly instead of
-/// `synced_rotor_k_blocks(...)`. It then decodes only the frozen prefill prefix
-/// and the loud length guard fires (`dequant` → `Err`, `.expect` panics — RED),
-/// catching exactly the truncation / zero-pad the ring rebuild prevents.
+/// `synced_rotor_k_blocks(...)`. With no host blocks left it decodes nothing,
+/// falls into the empty-store arm and returns a correctly-sized all-zero buffer
+/// — the length guard is satisfied, and the cosine against the CPU reference
+/// collapses to 0 (RED), catching exactly the zeroed prefix the ring rebuild
+/// prevents.
 #[allow(clippy::expect_used, reason = "test: invariants documented")]
 fn ring_only_tail_dequant_is_full_prefix(quant: KvQuant) {
     let device = Device::Gpu;
@@ -429,14 +436,15 @@ fn ring_only_tail_dequant_is_full_prefix(quant: KvQuant) {
     let full_seq = prefill + steps;
     let full_len = (kv_h * full_seq * head_dim) as usize;
 
-    // Ring-only-tail precondition: blocks froze at the prefill prefix, and the
-    // ring carries the decode tail.
+    // Ring-only precondition: the ring is live and is the store's sole copy of
+    // K — the append released the seeded prefill blocks. Anything left on the
+    // host would let the dequant below pass without touching the ring.
     assert!(ring_live, "ring must be live for the fused decode tail");
     assert_eq!(
         blocks_tokens,
-        (prefill * kv_h) as usize,
-        "CPU blocks must stay frozen at the prefill prefix (ring-only tail); got \
-         {blocks_tokens} tokens, shape[2]={}",
+        0,
+        "CPU blocks must be released once the ring is live (ring is the sole \
+         resident copy); got {blocks_tokens} tokens, shape[2]={}",
         shape.get(2).copied().unwrap_or(0)
     );
     assert_eq!(

--- a/crates/rmlx-kv-quant/src/kvcache/rotor_qjl_store_gate_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/rotor_qjl_store_gate_tests.rs
@@ -12,7 +12,7 @@
 //! The sibling `rotor_flash_dispatch_tests.rs` is deliberately env-free. This
 //! test is the opposite: it *seeds a QJL-off store, flips the env ON, and asks
 //! the update path which way it goes*. The store must win. Env writes are
-//! serialized on `ROTOR_QJL_ENV_LOCK`.
+//! serialized on the shared test env lock.
 //!
 //! # Mutation contract
 //!
@@ -28,7 +28,7 @@ use crate::quant::KvQuant;
 use crate::rotor_flash_decode_msl::rotor_flash_decode_dispatch_count;
 use crate::rotorquant::n_groups_for;
 use crate::storage::{KvStorage, QuantRotorK3, QuantRotorK4};
-use crate::test_utils::{lcg_data, skip_if_no_gpu_env, ROTOR_QJL_ENV_LOCK};
+use crate::test_utils::{env_lock, lcg_data, skip_if_no_gpu_env};
 use rmlx_mlx::{Array, Device, Dtype};
 
 const MAX_SEQ: i32 = 512;
@@ -97,13 +97,13 @@ fn store_flag_beats_env(quant: KvQuant) {
     let kv_h = 2_i32;
     let head_dim = 128_i32;
 
-    let _guard = ROTOR_QJL_ENV_LOCK.lock().expect("env lock poisoned");
+    let _guard = env_lock();
     // The CLI override shadows the env; if some other test installed it, the env
     // flip below is a no-op and the test cannot prove the store beats the env.
     if crate::rotor_qjl::rotor_qjl_cli_is_set() {
         return;
     }
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer.
+    // SAFETY: env lock held — no concurrent env reader/writer.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "1") };
     // Precondition: the env must actually read ON, otherwise the mutant (which
     // gates on the env) would also take the GPU branch and survive.
@@ -122,7 +122,7 @@ fn store_flag_beats_env(quant: KvQuant) {
     k_full.eval().expect("k eval");
     v_full.eval().expect("v eval");
 
-    // SAFETY: ROTOR_QJL_ENV_LOCK still held.
+    // SAFETY: env lock still held.
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
 
     assert!(
@@ -171,12 +171,12 @@ fn default_reaches_fused_kernel(quant: KvQuant) {
     let device = Device::Gpu;
     let scale = 1.0_f32 / (head_dim as f32).sqrt();
 
-    let _guard = ROTOR_QJL_ENV_LOCK.lock().expect("env lock poisoned");
+    let _guard = env_lock();
     if crate::rotor_qjl::rotor_qjl_cli_is_set() {
         return;
     }
     // Stock defaults: no env override.
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer.
+    // SAFETY: env lock held — no concurrent env reader/writer.
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
     // The whole point of this test is that the *default* keeps QJL off so the
     // fused path is reachable. Assert the default here so a future re-flip to

--- a/crates/rmlx-kv-quant/src/precompile_tests.rs
+++ b/crates/rmlx-kv-quant/src/precompile_tests.rs
@@ -98,6 +98,12 @@ fn rotor_symmetric_families_are_metal_when_qjl_off() {
     // test. A QJL-carrying store still keeps the CPU dequant path; that branch
     // is gated on the global toggle and not exercised here (QJL is off by
     // default). Grounded in the dispatcher, not by fiat.
+    //
+    // The whole body is a *reader* of the process-global QJL gate — the explicit
+    // check below and every `cpu_hot_path_reason()` call in the loop — so it must
+    // serialize against the tests that drive `RMLX_ROTOR_QJL`, or it samples one
+    // of their in-flight mutations and fails intermittently.
+    let _guard = crate::test_utils::env_lock();
     assert!(
         !crate::rotor_qjl::rotor_qjl_enabled(),
         "test assumes the default QJL-off state"
@@ -158,9 +164,7 @@ fn k_only_rotor_families_are_qjl_aware() {
     // `!rotor_qjl_enabled()`. The verdict tracks the live QJL gate: QJL on (the
     // default) → CPU (`Some`); QJL off → Metal (`None`). Drive both states via
     // the same env the dispatcher reads, so the test is tied to the dispatcher.
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
+    let _guard = crate::test_utils::env_lock();
     // The codec identity (K-only rotor) is QJL-independent — assert it always.
     for kq in [KvQuant::RotorKOnly3, KvQuant::RotorKOnly4] {
         assert!(
@@ -177,7 +181,7 @@ fn k_only_rotor_families_are_qjl_aware() {
     }
     let prev = std::env::var("RMLX_ROTOR_QJL").ok();
     for kq in [KvQuant::RotorKOnly3, KvQuant::RotorKOnly4] {
-        // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer.
+        // SAFETY: env lock held — no concurrent env reader/writer.
         unsafe { std::env::set_var("RMLX_ROTOR_QJL", "1") };
         assert!(
             kq.cpu_hot_path_reason().is_some(),
@@ -189,7 +193,7 @@ fn k_only_rotor_families_are_qjl_aware() {
             "{kq} with QJL off dispatches the rotor K MSL kernel — must be Metal (None)"
         );
     }
-    // SAFETY: ROTOR_QJL_ENV_LOCK held.
+    // SAFETY: env lock held.
     match prev {
         Some(p) => unsafe { std::env::set_var("RMLX_ROTOR_QJL", p) },
         None => unsafe { std::env::remove_var("RMLX_ROTOR_QJL") },

--- a/crates/rmlx-kv-quant/src/precompile_tests.rs
+++ b/crates/rmlx-kv-quant/src/precompile_tests.rs
@@ -91,6 +91,7 @@ fn v_only_iso_rotor_families_are_cpu_fallback_with_reason() {
 }
 
 #[test]
+#[allow(unsafe_code)]
 fn rotor_symmetric_families_are_metal_when_qjl_off() {
     // `Rotor3Sym` / `Rotor4Sym` have NO bf16 decode-seed early-return: with QJL
     // off (the default) decode is the quant-V flash kernel over both packed
@@ -103,10 +104,21 @@ fn rotor_symmetric_families_are_metal_when_qjl_off() {
     // check below and every `cpu_hot_path_reason()` call in the loop — so it must
     // serialize against the tests that drive `RMLX_ROTOR_QJL`, or it samples one
     // of their in-flight mutations and fails intermittently.
+    //
+    // The lock serializes access; it does not reset state. So establish the
+    // QJL-off precondition rather than asserting one this test never set — an
+    // inherited `RMLX_ROTOR_QJL=1` (a developer's export, `RMLX_ROTOR_QJL=1 make
+    // test`) would otherwise fail here with a message blaming the test. The
+    // guard restores the prior value on drop.
     let _guard = crate::test_utils::env_lock();
+    if crate::rotor_qjl::rotor_qjl_cli_is_set() {
+        return;
+    }
+    // SAFETY: env lock held — no concurrent env reader/writer.
+    unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
     assert!(
         !crate::rotor_qjl::rotor_qjl_enabled(),
-        "test assumes the default QJL-off state"
+        "QJL must be off once the env override is cleared and no CLI override is installed"
     );
     for kq in [KvQuant::Rotor3Sym, KvQuant::Rotor4Sym] {
         assert!(
@@ -179,7 +191,6 @@ fn k_only_rotor_families_are_qjl_aware() {
     if crate::rotor_qjl::rotor_qjl_cli_is_set() {
         return;
     }
-    let prev = std::env::var("RMLX_ROTOR_QJL").ok();
     for kq in [KvQuant::RotorKOnly3, KvQuant::RotorKOnly4] {
         // SAFETY: env lock held — no concurrent env reader/writer.
         unsafe { std::env::set_var("RMLX_ROTOR_QJL", "1") };
@@ -193,11 +204,9 @@ fn k_only_rotor_families_are_qjl_aware() {
             "{kq} with QJL off dispatches the rotor K MSL kernel — must be Metal (None)"
         );
     }
-    // SAFETY: env lock held.
-    match prev {
-        Some(p) => unsafe { std::env::set_var("RMLX_ROTOR_QJL", p) },
-        None => unsafe { std::env::remove_var("RMLX_ROTOR_QJL") },
-    }
+    // No manual restore: `_guard` puts `RMLX_ROTOR_QJL` back on drop, including
+    // while unwinding from either assertion above. Restoring here would only
+    // cover the path that does not need it.
 }
 
 #[test]

--- a/crates/rmlx-kv-quant/src/rotor_qjl_tests.rs
+++ b/crates/rmlx-kv-quant/src/rotor_qjl_tests.rs
@@ -7,9 +7,7 @@ use super::*;
 /// path is reachable at stock defaults, and QJL is opt-in.
 #[test]
 fn rotor_qjl_default_is_off() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
+    let _guard = crate::test_utils::env_lock();
     // Cannot pre-empt OnceLock state in tests reliably; skip when CLI is set.
     // Test the env-fallback path explicitly.
     if ROTOR_QJL_CLI.get().is_some() {
@@ -19,7 +17,7 @@ fn rotor_qjl_default_is_off() {
         return;
     }
     // Ensure env is not set in this thread before the read.
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    // SAFETY: env lock held — no concurrent env reader/writer in this binary.
     let prev = std::env::var(ROTOR_QJL_ENV).ok();
     unsafe { std::env::remove_var(ROTOR_QJL_ENV) };
     assert!(!rotor_qjl_enabled(), "default rotor QJL must be OFF");

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
@@ -21,10 +21,8 @@ fn quant_rotor_k3_new_shapes_correct() {
 
 #[test]
 fn quant_rotor_k3_roundtrip_no_qjl_matches_v_side() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    let _guard = crate::test_utils::env_lock();
+    // SAFETY: env lock held — no concurrent env reader/writer in this binary.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "0") };
 
     let b = 1;
@@ -115,11 +113,9 @@ fn quant_rotor_k3_short_blocks_without_ring_is_loud_not_zero_padded() {
 
 #[test]
 fn quant_rotor_k3_qjl_default_on() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
+    let _guard = crate::test_utils::env_lock();
     // Default ON when no env override is set.
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    // SAFETY: env lock held — no concurrent env reader/writer in this binary.
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
 
     let head_dim = 9;
@@ -158,10 +154,8 @@ fn quant_rotor_k3_reset_clears_seq() {
 /// the rotor3 single-codebook simplification noise).
 #[test]
 fn quant_rotor_k3_cosine_empirical_floor_head_dim_128_no_qjl() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    let _guard = crate::test_utils::env_lock();
+    // SAFETY: env lock held — no concurrent env reader/writer in this binary.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "0") };
 
     let head_dim = 128;
@@ -189,10 +183,8 @@ fn quant_rotor_k3_cosine_empirical_floor_head_dim_128_no_qjl() {
 /// values surface any head transposition as a large error.
 #[test]
 fn quant_rotor_k3_multi_append_matches_single_shot_gqa_with_qjl() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    let _guard = crate::test_utils::env_lock();
+    // SAFETY: env lock held — no concurrent env reader/writer in this binary.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "1") };
 
     let kv_h = 3_usize;
@@ -414,10 +406,8 @@ fn quant_rotor_k3_truncate_to_keeps_the_gpu_ring() {
 /// from).
 #[test]
 fn quant_rotor_k3_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer.
+    let _guard = crate::test_utils::env_lock();
+    // SAFETY: env lock held — no concurrent env reader/writer.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "0") };
 
     let head_dim = 9_usize; // n_groups = 3, exact
@@ -484,6 +474,6 @@ fn quant_rotor_k3_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
         );
     }
 
-    // SAFETY: ROTOR_QJL_ENV_LOCK still held.
+    // SAFETY: env lock still held.
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
@@ -17,10 +17,8 @@ fn quant_rotor_k4_new_shapes_correct() {
 
 #[test]
 fn quant_rotor_k4_roundtrip_no_qjl_matches_v_side() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    let _guard = crate::test_utils::env_lock();
+    // SAFETY: env lock held — no concurrent env reader/writer in this binary.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "0") };
 
     let b = 1;
@@ -70,10 +68,8 @@ fn quant_rotor_k4_reset_clears_seq() {
 /// Empirical cosine floor for rotor4_k @ head_dim=128, QJL off.
 #[test]
 fn quant_rotor_k4_cosine_empirical_floor_head_dim_128_no_qjl() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    let _guard = crate::test_utils::env_lock();
+    // SAFETY: env lock held — no concurrent env reader/writer in this binary.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "0") };
 
     let head_dim = 128;
@@ -101,10 +97,8 @@ fn quant_rotor_k4_cosine_empirical_floor_head_dim_128_no_qjl() {
 /// any head transposition as a large error.
 #[test]
 fn quant_rotor_k4_multi_append_matches_single_shot_gqa_with_qjl() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    let _guard = crate::test_utils::env_lock();
+    // SAFETY: env lock held — no concurrent env reader/writer in this binary.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "1") };
 
     let kv_h = 3_usize;
@@ -167,10 +161,8 @@ fn quant_rotor_k4_multi_append_matches_single_shot_gqa_with_qjl() {
 /// full rationale + mutation-check note.
 #[test]
 fn quant_rotor_k4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer.
+    let _guard = crate::test_utils::env_lock();
+    // SAFETY: env lock held — no concurrent env reader/writer.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "0") };
 
     let head_dim = 9_usize;
@@ -237,6 +229,6 @@ fn quant_rotor_k4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
         );
     }
 
-    // SAFETY: ROTOR_QJL_ENV_LOCK still held.
+    // SAFETY: env lock still held.
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k_qjl_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k_qjl_tests.rs
@@ -37,12 +37,10 @@ use crate::test_utils::{lcg_data, TEST_SEED};
 /// `qjl_codes` + `qjl_norms` per token.
 #[test]
 fn rotor_k3_qjl_sideband_captured() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
+    let _guard = crate::test_utils::env_lock();
     // QJL is off by default; this test exercises the sideband-capture path, so
     // enable it explicitly.
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    // SAFETY: env lock held — no concurrent env reader/writer in this binary.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "1") };
     let head_dim = 128;
     let n_rows = 16;
@@ -61,17 +59,15 @@ fn rotor_k3_qjl_sideband_captured() {
     );
     assert_eq!(blk.qjl_norms.len(), n_rows, "one qjl_norm per token");
 
-    // SAFETY: ROTOR_QJL_ENV_LOCK held.
+    // SAFETY: env lock held.
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
 }
 
 /// When the env disables QJL, no sideband bytes are emitted.
 #[test]
 fn rotor_k3_qjl_disabled_emits_no_sideband() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    let _guard = crate::test_utils::env_lock();
+    // SAFETY: env lock held — no concurrent env reader/writer in this binary.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "0") };
     let head_dim = 128;
     let n_rows = 8;
@@ -92,11 +88,9 @@ fn rotor_k3_qjl_disabled_emits_no_sideband() {
 /// Same parity check on rotor4_k.
 #[test]
 fn rotor_k4_qjl_sideband_captured() {
-    let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-        .lock()
-        .expect("env lock poisoned");
+    let _guard = crate::test_utils::env_lock();
     // QJL is off by default; enable it explicitly for this sideband test.
-    // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer in this binary.
+    // SAFETY: env lock held — no concurrent env reader/writer in this binary.
     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "1") };
     let head_dim = 128;
     let n_rows = 8;
@@ -111,6 +105,6 @@ fn rotor_k4_qjl_sideband_captured() {
     assert_eq!(blk.qjl_codes.len(), n_rows * head_dim.div_ceil(8));
     assert_eq!(blk.qjl_norms.len(), n_rows);
 
-    // SAFETY: ROTOR_QJL_ENV_LOCK held.
+    // SAFETY: env lock held.
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
 }

--- a/crates/rmlx-kv-quant/src/test_utils.rs
+++ b/crates/rmlx-kv-quant/src/test_utils.rs
@@ -52,28 +52,87 @@
 ///
 /// # Usage
 ///
+/// The guard restores the managed keys when it drops, so a test sets what it
+/// needs and does not clean up:
+///
 /// ```ignore
 /// #[test]
 /// fn my_test() {
 ///     let _guard = crate::test_utils::env_lock();
 ///     // SAFETY: env lock held — no concurrent env reader/writer.
 ///     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "0"); }
-///     // ... test body ...
-///     unsafe { std::env::remove_var("RMLX_ROTOR_QJL"); }
+///     // ... test body; no restore needed, `_guard` handles it ...
 /// }
 /// ```
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Acquire [`ENV_LOCK`] for the caller's scope.
+/// Environment keys the test suite mutates, snapshotted and restored by
+/// [`EnvGuard`].
 ///
-/// Poisoning is recovered rather than propagated: the guarded state is `()`, so
-/// a panic while holding the lock leaves nothing inconsistent, and re-panicking
-/// here would replace every subsequent test's real failure with "env lock
-/// poisoned" — hiding the one test that actually broke behind a cascade.
-pub(crate) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    ENV_LOCK
+/// Only `RMLX_ROTOR_QJL` qualifies: it is the one process-global that tests
+/// write, and it is deliberately not `OnceLock`-latched, so a leaked value
+/// changes what every later test observes. Keys that tests merely *read*
+/// (`RMLX_SKIP_GPU`, `RMLX_TURBO_FLASH`) need the lock, not restoration.
+const MANAGED_ENV_KEYS: [&str; 1] = ["RMLX_ROTOR_QJL"];
+
+/// Holds [`ENV_LOCK`] and restores [`MANAGED_ENV_KEYS`] to their pre-acquisition
+/// values on drop — including while unwinding from a failed assertion.
+///
+/// That last part is the point. Every writer in this suite is shaped
+/// `set_var` → `assert!` → restore, so a failing assertion used to skip its own
+/// restore and leak the value into every subsequent test; the next reader then
+/// failed with "test assumes the default QJL-off state" and buried the assertion
+/// that actually broke. Restoring in `Drop` makes the writers unwind-safe
+/// without each of them having to be.
+pub(crate) struct EnvGuard {
+    /// Dropped after `Drop::drop` returns, so the restore below runs while the
+    /// lock is still held.
+    _lock: std::sync::MutexGuard<'static, ()>,
+    prev: [(&'static str, Option<String>); MANAGED_ENV_KEYS.len()],
+}
+
+impl Drop for EnvGuard {
+    #[allow(unsafe_code, reason = "env restore under the lock this guard holds")]
+    fn drop(&mut self) {
+        for (key, prev) in &self.prev {
+            // SAFETY: `_lock` is still held (fields drop after this fn returns),
+            // so there is no concurrent env reader or writer in this binary.
+            match prev {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+    }
+}
+
+/// Acquire [`ENV_LOCK`], snapshotting [`MANAGED_ENV_KEYS`] for restoration.
+///
+/// Poisoning is recovered rather than propagated. That is sound *because* of
+/// the `Drop` restore above: the panicking test's guard put the managed keys
+/// back on its way out, so the environment this caller inherits is the one it
+/// would have seen had that test passed. Propagating instead would replace every
+/// later test's real failure with "env lock poisoned", hiding the one that broke
+/// behind a cascade.
+pub(crate) fn env_lock() -> EnvGuard {
+    let lock = ENV_LOCK
         .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    EnvGuard {
+        _lock: lock,
+        prev: MANAGED_ENV_KEYS.map(|key| (key, std::env::var(key).ok())),
+    }
+}
+
+/// Whether an `RMLX_SKIP_GPU` value means "skip": strictly `Some("1")`.
+///
+/// Split out from [`skip_if_no_gpu_env`] so the membership rule can be tested
+/// without touching the process environment. Setting `RMLX_SKIP_GPU` to probe
+/// this would be unsound: [`skip_if_no_gpu_env`] is read at the top of every
+/// GPU test in this binary, and none of them hold the lock, so a transient
+/// write can flip a live test between "run" and "silent skip" — a false green,
+/// or a Metal test un-ignored into a parallel run.
+pub(crate) fn skip_value_means_skip(value: Option<&str>) -> bool {
+    value == Some("1")
 }
 
 /// Returns `true` if the `RMLX_SKIP_GPU` environment variable is set to `"1"`.
@@ -81,11 +140,8 @@ pub(crate) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
 /// Parity tests call this at the top of their body as an additional opt-out
 /// beyond `#[ignore]`.  When `RMLX_SKIP_GPU=1`, the test exits silently
 /// without touching the GPU, even when run with `--include-ignored`.
-///
-/// This reads a process-global that a test in this binary mutates, so any test
-/// that *writes* `RMLX_SKIP_GPU` must hold [`env_lock`] while it does.
 pub(crate) fn skip_if_no_gpu_env() -> bool {
-    std::env::var("RMLX_SKIP_GPU").as_deref() == Ok("1")
+    skip_value_means_skip(std::env::var("RMLX_SKIP_GPU").ok().as_deref())
 }
 
 /// Run `cpu_path` and `msl_path` on `input` and assert max-abs-error ≤ `tol`.

--- a/crates/rmlx-kv-quant/src/test_utils.rs
+++ b/crates/rmlx-kv-quant/src/test_utils.rs
@@ -34,37 +34,56 @@
 //! | rot_k FWHT + affine q8 | 0.10 | one 8-bit quant step for D=128 FWHT range |
 //! | q8_0 group-128 affine | 5e-3 | f32 rounding in min/max scan |
 
-/// Process-global lock for tests that mutate `RMLX_ROTOR_QJL` in the env.
+/// Process-global lock for every test in this binary that touches the
+/// environment — as a **writer or a reader**.
 ///
-/// Hold for the **entire** test body (set → build → encode/decode → assert →
-/// clear). This prevents POSIX UB (setenv / getenv are not async-signal-safe
-/// across concurrent threads in a multi-threaded test binary).
+/// The granularity is the whole environment, not one variable: `setenv` is UB
+/// against a concurrent `getenv` of *any* key, so a per-variable lock would be
+/// unsound. Acquire it via [`env_lock`].
 ///
-/// Pattern imported from `rmlx-kv-ssd::block_io_tests`. `rmlx-kv-ssd` imports
-/// this constant rather than defining its own so there is a single source of
-/// truth.
+/// Hold it for the **entire** test body (set → build → encode/decode → assert →
+/// clear), not just across the mutation. A reader that samples an env-backed
+/// gate without it observes another test's in-flight mutation and fails
+/// intermittently — an unexplained flake that teaches everyone to re-run rather
+/// than investigate, and launders real failures in the process.
+///
+/// `rmlx-kv-ssd` keeps its own lock: it is a separate crate, so its tests run in
+/// a separate binary (separate process) and share no environment with this one.
 ///
 /// # Usage
 ///
 /// ```ignore
 /// #[test]
 /// fn my_test() {
-///     let _guard = crate::test_utils::ROTOR_QJL_ENV_LOCK
-///         .lock()
-///         .expect("env lock poisoned");
-///     // SAFETY: ROTOR_QJL_ENV_LOCK held — no concurrent env reader/writer.
+///     let _guard = crate::test_utils::env_lock();
+///     // SAFETY: env lock held — no concurrent env reader/writer.
 ///     unsafe { std::env::set_var("RMLX_ROTOR_QJL", "0"); }
 ///     // ... test body ...
 ///     unsafe { std::env::remove_var("RMLX_ROTOR_QJL"); }
 /// }
 /// ```
-pub(crate) static ROTOR_QJL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire [`ENV_LOCK`] for the caller's scope.
+///
+/// Poisoning is recovered rather than propagated: the guarded state is `()`, so
+/// a panic while holding the lock leaves nothing inconsistent, and re-panicking
+/// here would replace every subsequent test's real failure with "env lock
+/// poisoned" — hiding the one test that actually broke behind a cascade.
+pub(crate) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
 
 /// Returns `true` if the `RMLX_SKIP_GPU` environment variable is set to `"1"`.
 ///
 /// Parity tests call this at the top of their body as an additional opt-out
 /// beyond `#[ignore]`.  When `RMLX_SKIP_GPU=1`, the test exits silently
 /// without touching the GPU, even when run with `--include-ignored`.
+///
+/// This reads a process-global that a test in this binary mutates, so any test
+/// that *writes* `RMLX_SKIP_GPU` must hold [`env_lock`] while it does.
 pub(crate) fn skip_if_no_gpu_env() -> bool {
     std::env::var("RMLX_SKIP_GPU").as_deref() == Ok("1")
 }

--- a/crates/rmlx-kv-quant/src/test_utils_tests.rs
+++ b/crates/rmlx-kv-quant/src/test_utils_tests.rs
@@ -64,8 +64,12 @@ fn parity_check_fails_on_length_mismatch() {
 /// that silently no-oped when the var happened to be `"1"` already.
 #[test]
 fn skip_if_no_gpu_env_strict_membership() {
+    // `skip_if_no_gpu_env()` is read at the top of every GPU test in this
+    // binary, so mutating `RMLX_SKIP_GPU` unguarded can flip one of them from
+    // skip to run (or back) mid-flight — the exact opt-out those tests rely on.
+    let _guard = crate::test_utils::env_lock();
     let prior = std::env::var("RMLX_SKIP_GPU").ok();
-    // SAFETY: single-threaded test; we restore the prior value before exit.
+    // SAFETY: env lock held — no concurrent env reader/writer.
     unsafe { std::env::set_var("RMLX_SKIP_GPU", "0") };
     assert!(!skip_if_no_gpu_env(), "RMLX_SKIP_GPU=0 must return false");
     unsafe { std::env::set_var("RMLX_SKIP_GPU", "true") };

--- a/crates/rmlx-kv-quant/src/test_utils_tests.rs
+++ b/crates/rmlx-kv-quant/src/test_utils_tests.rs
@@ -1,9 +1,5 @@
-// unsafe_code: std::env::set_var / remove_var are unsafe in Rust 1.95+;
-// used in skip_if_no_gpu_env_strict_membership to pin env state for the test.
-#![allow(unsafe_code)]
-
 use super::{
-    cosine_similarity_per_row, fwht_normalize, lcg_data, skip_if_no_gpu_env,
+    cosine_similarity_per_row, fwht_normalize, lcg_data, skip_if_no_gpu_env, skip_value_means_skip,
     vectorized_parity_check, TEST_SEED,
 };
 
@@ -57,38 +53,89 @@ fn parity_check_fails_on_length_mismatch() {
     );
 }
 
-/// `skip_if_no_gpu_env` strict membership test: only `"1"` returns true.
+/// `RMLX_SKIP_GPU` strict membership: only `"1"` means skip.
 ///
-/// Sets the env var to each interesting value in turn, asserts the expected
-/// result, then restores the prior value.  Replaces the old conditional test
-/// that silently no-oped when the var happened to be `"1"` already.
+/// Asserted against the pure `skip_value_means_skip` rather than by writing the
+/// process environment. Writing it would be unsound at any parallelism: the
+/// reader `skip_if_no_gpu_env()` runs at the top of every `#[ignore]`d GPU test
+/// in this binary and none of them take the env lock, so a transient `"1"` can
+/// silently skip a live GPU test (a false green) and a transient `"0"` can
+/// un-ignore a Metal test into a parallel run. The membership rule is pure, so
+/// nothing is lost by testing it as such.
 #[test]
-fn skip_if_no_gpu_env_strict_membership() {
-    // `skip_if_no_gpu_env()` is read at the top of every GPU test in this
-    // binary, so mutating `RMLX_SKIP_GPU` unguarded can flip one of them from
-    // skip to run (or back) mid-flight — the exact opt-out those tests rely on.
-    let _guard = crate::test_utils::env_lock();
-    let prior = std::env::var("RMLX_SKIP_GPU").ok();
-    // SAFETY: env lock held — no concurrent env reader/writer.
-    unsafe { std::env::set_var("RMLX_SKIP_GPU", "0") };
-    assert!(!skip_if_no_gpu_env(), "RMLX_SKIP_GPU=0 must return false");
-    unsafe { std::env::set_var("RMLX_SKIP_GPU", "true") };
+fn skip_value_means_skip_is_strict_membership() {
     assert!(
-        !skip_if_no_gpu_env(),
-        "RMLX_SKIP_GPU=true must return false"
+        skip_value_means_skip(Some("1")),
+        "RMLX_SKIP_GPU=1 must mean skip"
     );
-    unsafe { std::env::remove_var("RMLX_SKIP_GPU") };
     assert!(
-        !skip_if_no_gpu_env(),
-        "RMLX_SKIP_GPU unset must return false"
+        !skip_value_means_skip(Some("0")),
+        "RMLX_SKIP_GPU=0 must not mean skip"
     );
-    unsafe { std::env::set_var("RMLX_SKIP_GPU", "1") };
-    assert!(skip_if_no_gpu_env(), "RMLX_SKIP_GPU=1 must return true");
-    // restore
-    match prior {
-        Some(v) => unsafe { std::env::set_var("RMLX_SKIP_GPU", v) },
-        None => unsafe { std::env::remove_var("RMLX_SKIP_GPU") },
-    }
+    assert!(
+        !skip_value_means_skip(Some("true")),
+        "RMLX_SKIP_GPU=true must not mean skip"
+    );
+    assert!(
+        !skip_value_means_skip(Some("")),
+        "RMLX_SKIP_GPU= (empty) must not mean skip"
+    );
+    assert!(
+        !skip_value_means_skip(None),
+        "RMLX_SKIP_GPU unset must not mean skip"
+    );
+}
+
+/// The env reader is wired to the membership rule above, not a second copy of
+/// it: whatever the process environment currently holds, the two agree.
+#[test]
+fn skip_if_no_gpu_env_matches_the_membership_rule() {
+    let observed = std::env::var("RMLX_SKIP_GPU").ok();
+    assert_eq!(
+        skip_if_no_gpu_env(),
+        skip_value_means_skip(observed.as_deref()),
+        "skip_if_no_gpu_env must delegate to skip_value_means_skip"
+    );
+}
+
+/// `EnvGuard` restores a managed key even when the holder panics.
+///
+/// This is the whole reason the guard exists. Every env writer in this suite is
+/// shaped `set_var` → `assert!` → restore, so a failing assertion skips its own
+/// restore; without a `Drop` restore the dirty value leaks into every later test
+/// and the next reader fails about its own precondition, burying the assertion
+/// that actually broke.
+///
+/// The lock is not reentrant, so each phase takes it in its own scope and the
+/// panicking closure acquires its own. The deliberate panic also poisons the
+/// lock, so this exercises the poison recovery in `env_lock()` at the same time.
+///
+/// Mutation check: delete the `impl Drop for EnvGuard` body — the key stays at
+/// `"1"` after the unwind and the final assertion fails (RED).
+#[test]
+#[allow(unsafe_code)]
+fn env_guard_restores_managed_key_when_the_holder_panics() {
+    let before = {
+        let _guard = crate::test_utils::env_lock();
+        std::env::var("RMLX_ROTOR_QJL").ok()
+    };
+
+    let caught = std::panic::catch_unwind(|| {
+        let _guard = crate::test_utils::env_lock();
+        // SAFETY: env lock held — no concurrent env reader/writer.
+        unsafe { std::env::set_var("RMLX_ROTOR_QJL", "1") };
+        panic!("simulated assertion failure while the environment is dirty");
+    });
+    assert!(caught.is_err(), "the closure was supposed to panic");
+
+    let after = {
+        let _guard = crate::test_utils::env_lock();
+        std::env::var("RMLX_ROTOR_QJL").ok()
+    };
+    assert_eq!(
+        before, after,
+        "EnvGuard must restore RMLX_ROTOR_QJL while unwinding, not leak it"
+    );
 }
 
 // ── cosine_similarity_per_row self-tests ─────────────────────────────────────

--- a/crates/rmlx-kv-quant/src/turbo_flash_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/turbo_flash_msl_tests.rs
@@ -7,6 +7,11 @@ fn test_turbo_flash_disabled_by_default() {
     //
     // To test with env var set, run:
     // RMLX_TURBO_FLASH=1 cargo test turbo_flash
+    //
+    // The `env::var` below is a raw, unlatched read, so it takes the env lock
+    // like any other reader: `setenv` is UB against a concurrent `getenv` of ANY
+    // key, and other tests in this binary write `RMLX_ROTOR_QJL`.
+    let _guard = crate::test_utils::env_lock();
     if std::env::var("RMLX_TURBO_FLASH").as_deref() != Ok("1") {
         assert!(
             !turbo_flash_enabled(),
@@ -46,6 +51,8 @@ fn test_turbo_flash_should_run_gated() {
     // 4. kv_seq > TURBO_FLASH_MIN_KV_SEQ
 
     // With default env (RMLX_TURBO_FLASH unset or "0"), should never run.
+    // Raw unlatched env read — takes the lock, as every reader must.
+    let _guard = crate::test_utils::env_lock();
     if std::env::var("RMLX_TURBO_FLASH").as_deref() != Ok("1") {
         assert!(!turbo_flash_should_run(1, 8192));
         assert!(!turbo_flash_should_run(1, 100));

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -2864,9 +2864,10 @@ fn write_rejects_truncated_rotor_k_store() {
 /// running.
 ///
 /// Mutation check: make `try_deep_clone` clone `self.blocks` directly (drop the
-/// `synced_rotor_k_blocks` reconcile) — the clone then carries only the frozen
-/// prefill prefix, `write_caches` trips the `ensure_rotor_k_blocks_cover_shape`
-/// guard, and `.expect("write_caches")` panics (RED).
+/// `synced_rotor_k_blocks` reconcile) — the clone then carries no blocks at all,
+/// the ring having been the sole copy, so `write_caches` trips the
+/// `ensure_rotor_k_blocks_cover_shape` guard on 0 != prefill+steps tokens and
+/// `.expect("write_caches")` panics (RED).
 #[test]
 #[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd rotor_k_only_ring_only_tail_ssd -- --ignored --test-threads=1"]
 #[allow(

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -2849,14 +2849,19 @@ fn write_rejects_truncated_rotor_k_store() {
     );
 }
 
-/// Full SSD spill/hydrate round-trip after a ring-only-tail decode.
+/// Full SSD spill/hydrate round-trip when the GPU ring is the store's only copy.
 ///
-/// After prefill + N fused decode steps the store keeps a ring-only tail (CPU
-/// blocks frozen at prefill; the decode tail lives only in the GPU ring). The
-/// spill clone (`KvCache::try_deep_clone`) materialises that tail into complete
-/// blocks, so `write_caches` → hydrate restores the **full** store — not a
-/// prefix truncated at the last CPU block. Asserted byte-exact against the live
-/// store's own `dequant()`.
+/// After prefill + N fused decode steps a rotor K-only store holds nothing on
+/// the host: the per-step block download is skipped, and the append releases the
+/// seeded prefill blocks once the ring is live, so the ring carries the whole
+/// prefix. The spill clone (`KvCache::try_deep_clone`) rebuilds it from the ring
+/// into complete blocks, so `write_caches` → hydrate restores the **full** store
+/// — not a prefix truncated at the last CPU block. Asserted byte-exact against
+/// the live store's own `dequant()`.
+///
+/// The empty-blocks precondition is what makes the round-trip load-bearing: with
+/// a host copy still resident the clone could pass without the ring rebuild ever
+/// running.
 ///
 /// Mutation check: make `try_deep_clone` clone `self.blocks` directly (drop the
 /// `synced_rotor_k_blocks` reconcile) — the clone then carries only the frozen
@@ -2910,13 +2915,13 @@ fn rotor_k_only_ring_only_tail_ssd_round_trip() {
             .unwrap();
     }
 
-    // Ring-only tail precondition + live full-prefix dequant.
+    // Ring-only precondition + live full-prefix dequant: the ring is the store's
+    // sole copy of K, so everything below exercises the rebuild-from-ring path.
     let (orig_dq, orig_seq, block_tokens) = rotor_k3_probe(&c);
     assert_eq!(orig_seq, prefill + steps, "shape[2] advanced with the ring");
     assert_eq!(
-        block_tokens,
-        (prefill * kv_h) as usize,
-        "CPU blocks frozen at prefill (ring-only tail)"
+        block_tokens, 0,
+        "CPU blocks must be released once the ring is live (ring is the sole resident copy)"
     );
 
     // Spill clone (materialises the tail) → write → hydrate.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -179,13 +179,33 @@ reasons unrelated to Metal — live network access, a missing cargo feature,
 `ignore`-marked doc-comment pseudo-code — and sweeping those in would keep this
 gate permanently red for things it cannot speak to.
 
-It **refuses to report OK if it executed no tests** (per crate and overall) — a
-filter that matches nothing is an error, not a green run — and refuses to start
-while another MLX process holds the GPU (CLAUDE.md hard rule 8).
+It is fail-closed in three ways:
+
+* **Coverage.** Every classified test must actually run. If a crate executes
+  fewer tests than were classified for it — a renamed fn, a target no longer
+  built, a test compiled out behind a feature — that is an error. Checking only
+  for "executed zero" would let 237 of 238 run and still report green.
+* **`RMLX_SKIP_GPU=1` is refused outright.** Every classified test opens with
+  `if skip_if_no_gpu_env() { return; }`, so with it set the whole suite returns
+  before touching Metal and the gate would happily print `OK: 324 GPU tests
+  passed` having dispatched nothing. It is a documented setting for Metal-less
+  environments, so a stale export in a dev shell would otherwise disarm the one
+  step that proves the GPU path works.
+* **Exclusive GPU.** It refuses to start while another MLX process holds the
+  Metal context (CLAUDE.md hard rule 8).
 
 `make gpu-test` is not part of `make ci`: it needs the Metal context to itself
 and is too slow to block every commit. Run it before merging anything in the
 codec layer.
+
+### Known-red baseline
+
+`make gpu-test` currently exits 1 on a clean tree. Four tests in the
+`rmlx-kv-quant` rotor fused-QK dispatch integration binary fail with
+`rotor fused-QK dispatch delta = 0` — the sym and K-only rotor codecs no longer
+reach the fused-QK kernel, while their K-asym siblings still do. This is tracked
+separately and is not a regression from any recent change; it is why the target
+is not yet wired into `ci-perf`. Anything failing **beyond** those four is yours.
 
 ### `#[ignore]` is not a place to park a broken test
 
@@ -550,26 +570,49 @@ They are read only inside test code (`tests/` and `*_tests.rs` files).
 ## Env-backed gates: readers need the lock too
 
 `rmlx-kv-quant` exposes `test_utils::env_lock()`, a process-global guard for
-every test in that binary that touches the environment. Two rules:
+every test in that binary that touches the environment. Three rules:
 
 1. **Hold it for the whole test body**, not just across the mutation.
 2. **Readers take it as well as writers.** A test that merely *reads* an
-   env-backed gate — `rotor_qjl_enabled()`, `skip_if_no_gpu_env()`, or anything
-   that calls them, such as `KvQuant::cpu_hot_path_reason()` — races the tests
-   that set `RMLX_ROTOR_QJL` / `RMLX_SKIP_GPU` and fails intermittently.
+   env-backed gate — `rotor_qjl_enabled()`, a raw
+   `std::env::var("RMLX_TURBO_FLASH")`, or anything that calls them, such as
+   `KvQuant::cpu_hot_path_reason()` — races the tests that set
+   `RMLX_ROTOR_QJL` and fails intermittently. Note that a *latched* accessor
+   being safe does not make a raw `env::var` of the same key safe.
+3. **Establish the state you assert.** The lock serializes access; it does not
+   reset it. A test that asserts "QJL is off" without clearing
+   `RMLX_ROTOR_QJL` first fails for anyone who has it exported, with a message
+   that blames the test.
 
 The granularity is the whole environment, not one variable: `setenv` is UB
 against a concurrent `getenv` of *any* key, so one lock is the correct scope and
 a per-variable lock would be unsound.
 
+`env_lock()` returns an `EnvGuard` that **restores the managed keys on drop**,
+including while unwinding from a failed assertion. Tests therefore set what they
+need and do not clean up. This is not a convenience: every writer is shaped
+`set_var` → `assert!` → restore, so before the guard existed a failing assertion
+skipped its own restore and leaked the value into every later test, which then
+failed with a message about its own precondition and buried the assertion that
+actually broke.
+
 Gates latched behind a `OnceLock` (`RMLX_TURBO_FLASH`, `RMLX_FUSED_QK`,
 `RMLX_SPARSE_ATTN`, `RMLX_PLANAR_FLASH_DECODE`) read the env exactly once per
 process, so no test can flip them mid-run — that is why the shell drivers set
 them per-process instead. `RMLX_ROTOR_QJL` is deliberately **not** latched (it is
-re-read on every construction), which is what makes it raceable.
+re-read on every construction), which is what makes it raceable, and it is the
+only key `EnvGuard` manages.
+
+`RMLX_SKIP_GPU` is deliberately **never written** by any test. Its reader
+`skip_if_no_gpu_env()` runs at the top of every `#[ignore]`d GPU test and none of
+those take the lock, so a transient write could silently skip a live GPU test or
+un-ignore a Metal one into a parallel run. The membership rule is factored out as
+the pure `skip_value_means_skip()` and tested directly instead.
 
 `rmlx-kv-ssd` keeps its own lock: separate crate, separate test binary,
 separate process, no shared environment.
+
+---
 
 ## In-process tests must not rely on the `paths::home()` `OnceLock`
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -155,14 +155,46 @@ not exempt); (2) the reachability seed is file-local, so a test that reaches
 Metal only through a helper defined in another module can draw a non-fatal
 false-positive warning — verify before acting on it.
 
-### `#[ignore]` is not a place to park a broken test
+### Running them: `make gpu-test`
 
-An ignored test runs only when someone asks for it, so a real failure can sit
-in the tree indefinitely. Run the ignored suites when touching a codec:
+`make test` is `cargo test --workspace` — it passes no `--ignored`, so it skips
+every test above. The hosted CI runs no tests at all and has no Metal. For a
+long time nothing ran them, and GPU tests went red on `main` and stayed red
+while every gate reported green. `make gpu-test` is the step that runs them:
 
 ```bash
-cargo test -p rmlx-kv-quant --lib -- --ignored --test-threads=1
+make gpu-test                                   # every member crate
+make gpu-test CRATE=rmlx-kv-quant               # one crate
+make gpu-test CRATE=rmlx-kv-quant FILTER=rotor_flash
 ```
+
+It runs exactly the set `check_gpu_tests_ignored.sh --list` classifies — the
+`#[test]` fns that reach `Device::Gpu` **and** carry `#[ignore]`. Deriving the
+population from the enforcing gate's own classifier is the point: a separate
+hand-maintained list would drift, and the rule would end up mandating `#[ignore]`
+on tests the runner never visits.
+
+It deliberately does **not** run every `#[ignore]` test. Many are ignored for
+reasons unrelated to Metal — live network access, a missing cargo feature,
+`ignore`-marked doc-comment pseudo-code — and sweeping those in would keep this
+gate permanently red for things it cannot speak to.
+
+It **refuses to report OK if it executed no tests** (per crate and overall) — a
+filter that matches nothing is an error, not a green run — and refuses to start
+while another MLX process holds the GPU (CLAUDE.md hard rule 8).
+
+`make gpu-test` is not part of `make ci`: it needs the Metal context to itself
+and is too slow to block every commit. Run it before merging anything in the
+codec layer.
+
+### `#[ignore]` is not a place to park a broken test
+
+An ignored test runs only when someone asks for it, so a real failure can sit in
+the tree indefinitely — that is the failure mode `make gpu-test` exists to close,
+not one it makes impossible. A test edited until it goes green is the same defect
+wearing a different hat: when a deliberate behaviour change makes an assertion
+stale, re-point the assertion at the new contract and then mutation-check it
+(revert the change; the repaired test must go red), rather than relaxing it.
 
 ---
 
@@ -514,6 +546,30 @@ They are read only inside test code (`tests/` and `*_tests.rs` files).
 | `RMLX_SPARSE_ATTN_STRICT` | `1` | Fail (not warn) on sparse-attn dispatch parity tests. |
 
 ---
+
+## Env-backed gates: readers need the lock too
+
+`rmlx-kv-quant` exposes `test_utils::env_lock()`, a process-global guard for
+every test in that binary that touches the environment. Two rules:
+
+1. **Hold it for the whole test body**, not just across the mutation.
+2. **Readers take it as well as writers.** A test that merely *reads* an
+   env-backed gate — `rotor_qjl_enabled()`, `skip_if_no_gpu_env()`, or anything
+   that calls them, such as `KvQuant::cpu_hot_path_reason()` — races the tests
+   that set `RMLX_ROTOR_QJL` / `RMLX_SKIP_GPU` and fails intermittently.
+
+The granularity is the whole environment, not one variable: `setenv` is UB
+against a concurrent `getenv` of *any* key, so one lock is the correct scope and
+a per-variable lock would be unsound.
+
+Gates latched behind a `OnceLock` (`RMLX_TURBO_FLASH`, `RMLX_FUSED_QK`,
+`RMLX_SPARSE_ATTN`, `RMLX_PLANAR_FLASH_DECODE`) read the env exactly once per
+process, so no test can flip them mid-run — that is why the shell drivers set
+them per-process instead. `RMLX_ROTOR_QJL` is deliberately **not** latched (it is
+re-read on every construction), which is what makes it raceable.
+
+`rmlx-kv-ssd` keeps its own lock: separate crate, separate test binary,
+separate process, no shared environment.
 
 ## In-process tests must not rely on the `paths::home()` `OnceLock`
 

--- a/scripts/check_gpu_tests_ignored.sh
+++ b/scripts/check_gpu_tests_ignored.sh
@@ -101,6 +101,16 @@
 
 set -euo pipefail
 
+# --list: print the COMPLIANT set (GPU-touching tests that carry #[ignore]) as
+# `<crate><TAB><fn>` and exit, instead of enforcing. `scripts/run_gpu_tests.sh`
+# consumes this so the rule and the runner cannot cover different populations —
+# a GPU test this gate mandates is by construction a GPU test that gets run.
+LIST_MODE=0
+if [ "${1:-}" = "--list" ]; then
+    LIST_MODE=1
+    shift
+fi
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CARGO_TOML="${REPO_ROOT}/Cargo.toml"
 
@@ -317,6 +327,13 @@ read -r -d '' AWK_DETECT <<'AWK' || true
             if (gpu[g] && !has_ignore && !exempt) {
                 printf "V  %s: %s\n", file_of[g], name_of[g]
             }
+            # The compliant set: GPU-touching AND ignored. This is exactly the
+            # population `scripts/run_gpu_tests.sh` must execute, so it is
+            # derived from the same classifier rather than from a second,
+            # drifting list. Exempt fns are device-as-value, not Metal.
+            if (gpu[g] && has_ignore && !exempt) {
+                printf "T  %s: %s\n", file_of[g], name_of[g]
+            }
             # Converse: an ignore claiming a Metal context on a test that
             # never reaches one. Warn — the test may have stopped running
             # (or reaches Metal only via a non-scanned source-file helper).
@@ -334,6 +351,7 @@ AWK
 total_files=0
 violations=""
 warnings=""
+gpu_tests=""
 
 for crate in "${members[@]}"; do
     crate_dir="${REPO_ROOT}/${crate}"
@@ -375,6 +393,7 @@ for crate in "${members[@]}"; do
         case "$line" in
             "V  "*) violations="${violations}  ${line#V  }"$'\n' ;;
             "W  "*) warnings="${warnings}  ${line#W  }"$'\n' ;;
+            "T  "*) gpu_tests="${gpu_tests}$(basename "${crate}")"$'\t'"${line##*: }"$'\n' ;;
         esac
     done <<< "$out"
 done
@@ -383,6 +402,16 @@ if [ "${total_files}" -eq 0 ]; then
     echo "ERROR: matched 0 test files across ${#members[@]} workspace members." >&2
     echo "A gate that scans nothing passes everything; refusing to report OK." >&2
     exit 1
+fi
+
+if [ "${LIST_MODE}" -eq 1 ]; then
+    if [ -z "${gpu_tests}" ]; then
+        echo "ERROR: classified 0 GPU-touching #[ignore] tests across ${total_files} files." >&2
+        echo "The detector found nothing to run; refusing to emit an empty list." >&2
+        exit 1
+    fi
+    printf '%s' "${gpu_tests}"
+    exit 0
 fi
 
 if [ -n "$warnings" ]; then

--- a/scripts/check_gpu_tests_ignored.sh
+++ b/scripts/check_gpu_tests_ignored.sh
@@ -369,6 +369,18 @@ for crate in "${members[@]}"; do
         exit 1
     fi
 
+    # The cargo package name, for `--list` consumers that feed it to
+    # `cargo test -p`. Read from the manifest rather than assumed equal to the
+    # directory basename: the two happen to match for every member today, but a
+    # mismatch would surface as an opaque "package not found" from cargo instead
+    # of failing at this gate, which is the fail-closed discipline the rest of
+    # this script follows.
+    pkg_name="$(awk -F'"' '/^name[[:space:]]*=/{print $2; exit}' "${crate_dir}/Cargo.toml" 2>/dev/null)"
+    if [ -z "${pkg_name}" ]; then
+        echo "ERROR: could not read [package] name from ${crate_dir}/Cargo.toml." >&2
+        exit 1
+    fi
+
     # Gather this crate's scanned files. Whole-crate reachability needs every
     # scanned file of the crate in ONE awk pass, so collect them per crate.
     crate_files=()
@@ -393,7 +405,7 @@ for crate in "${members[@]}"; do
         case "$line" in
             "V  "*) violations="${violations}  ${line#V  }"$'\n' ;;
             "W  "*) warnings="${warnings}  ${line#W  }"$'\n' ;;
-            "T  "*) gpu_tests="${gpu_tests}$(basename "${crate}")"$'\t'"${line##*: }"$'\n' ;;
+            "T  "*) gpu_tests="${gpu_tests}${pkg_name}"$'\t'"${line##*: }"$'\n' ;;
         esac
     done <<< "$out"
 done

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -31,13 +31,22 @@
 #
 # FAIL-CLOSED
 #   A gate that silently runs nothing passes everything. This one refuses to
-#   report OK unless it executed tests: an empty classification, a crate whose
-#   listed tests all failed to match, and a `--filter` that selects nothing are
-#   all errors, not green runs.
+#   report OK unless it executed every test the classifier named: an empty
+#   classification, a `--filter` that selects nothing, and a crate that executed
+#   FEWER tests than were classified for it are all errors, not green runs. The
+#   last one is the important case — checking only for "executed zero" lets 237
+#   of 238 run and still call it green, which is the classifier/runner divergence
+#   this design exists to prevent, surviving one layer down.
 #
-#   Tests that skip internally (model-gated cells with no snapshot present,
-#   `RMLX_SKIP_GPU=1`) still count as executed. That is accepted: this gate
-#   proves the suite RAN; per-test skip logic is the suite's own contract.
+#   `RMLX_SKIP_GPU=1` is refused outright rather than tolerated. Every classified
+#   test opens with `if skip_if_no_gpu_env() { return; }`, so with it set the
+#   whole suite returns before touching Metal and the gate would report a
+#   comfortable "OK: N GPU tests passed" having dispatched nothing. This gate
+#   exists to prove the GPU path RAN.
+#
+#   Model-gated cells that skip because no snapshot is present still count as
+#   executed; that is the suite's own documented contract and is not a
+#   process-wide off switch.
 #
 # USAGE
 #   bash scripts/run_gpu_tests.sh
@@ -47,6 +56,10 @@
 # Exit 0 = every selected GPU test passed. Exit 1 = a failure, or a run that
 # executed nothing.
 
+# No `-e`: cargo's exit code is captured explicitly via PIPESTATUS, and one
+# failing crate must not abort the remaining crates. The `[ ... ] && echo` guard
+# idioms below also return 1 when the guard is false, which `-e` would treat as
+# a fatal error.
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -70,6 +83,17 @@ while [ $# -gt 0 ]; do
         *) echo "ERROR: unknown argument '$1'" >&2; usage >&2; exit 1 ;;
     esac
 done
+
+# Every classified test starts with `if skip_if_no_gpu_env() { return; }`, so
+# this variable turns the entire suite into no-ops that still report as passed.
+# It is a documented setting for Metal-less environments, which means a stale
+# export in a dev shell would silently disarm the one step that proves the GPU
+# path works. Refuse rather than run a hollow suite.
+if [ "${RMLX_SKIP_GPU:-}" = "1" ]; then
+    echo "ERROR: RMLX_SKIP_GPU=1 — every GPU test would return before touching Metal." >&2
+    echo "This gate proves the GPU path RAN; unset it (or use 'make test' instead)." >&2
+    exit 1
+fi
 
 # CLAUDE.md hard rule 8 — a single MLX process per Mac. These tests build their
 # own Metal context; a co-resident server already holding the GPU makes any
@@ -100,10 +124,14 @@ while IFS=$'\t' read -r crate fn_name; do
     esac
 done <<< "${listing}"
 
+# `sort -u`, not `uniq`: uniq collapses only ADJACENT duplicates, which happens
+# to hold because the classifier's outer loop is per-member — but nothing
+# enforces that emit order, and a future change to it would silently run a crate
+# twice. Crate order is irrelevant to the run.
 crates=()
 while IFS= read -r c; do
     [ -n "$c" ] && crates+=("$c")
-done < <(printf '%s' "${selected}" | cut -f1 | uniq)
+done < <(printf '%s' "${selected}" | cut -f1 | sort -u)
 
 if [ ${#crates[@]} -eq 0 ]; then
     echo "ERROR: selection matched no GPU tests." >&2
@@ -118,20 +146,46 @@ total_passed=0
 total_failed=0
 
 for crate in "${crates[@]}"; do
+    # `classified` counts the classifier's LINES, not its unique names, because
+    # each line is a distinct `#[test]` fn: seven names are defined in more than
+    # one module today (e.g. `gpu_two_append_multi_head_roundtrip` x3), and those
+    # are three separate tests that all run. Deduping the coverage target would
+    # accept two of the three vanishing. The filter LIST is deduped, since
+    # passing one substring twice selects nothing extra.
+    classified=0
     filters=()
     while IFS=$'\t' read -r c fn_name; do
-        [ "$c" = "${crate}" ] && filters+=("${fn_name}")
+        [ "$c" = "${crate}" ] || continue
+        classified=$((classified + 1))
     done <<< "${selected}"
-    echo "── ${crate} (${#filters[@]} GPU tests) ──────────────────────────"
+    while IFS= read -r fn_name; do
+        [ -n "${fn_name}" ] && filters+=("${fn_name}")
+    done < <(printf '%s' "${selected}" | awk -F'\t' -v c="${crate}" '$1 == c {print $2}' | sort -u)
+    echo "── ${crate} (${classified} GPU tests) ──────────────────────────"
 
     log="$(mktemp -t "rmlx-gpu-test-${crate}")"
+    # `--tests` selects every target with `test = true` — the lib's unit tests,
+    # each bin's unit tests, and the `tests/*.rs` integration binaries. That is
+    # exactly the set the classifier scans, so the runner cannot be pointed at
+    # more or less than the rule covers. It is also the only spelling that gets
+    # all three without breaking:
+    #   * `--lib` hard-errors with "no library targets found in package" on a
+    #     bin-only member such as rmlx-cli, which the classifier does scan.
+    #   * `--all-targets` drags in benches, and criterion harnesses reject
+    #     `--ignored` outright ("error: unexpected argument found").
+    #   * doc-tests stay out either way, deliberately: `--ignored` makes rustdoc
+    #     compile ```ignore blocks, which are prose, not tests.
+    #
     # Names come from the classifier as bare fn identifiers, while libtest
     # matches against the full `module::path::fn` — so these are substring
     # filters, not `--exact`. Over-matching a sibling is harmless (it runs one
-    # extra test); under-matching is what fail-closed below catches.
-    # `--lib --bins --tests` excludes doc-tests: `--ignored` makes rustdoc
-    # compile ```ignore blocks, which are prose, not tests.
-    cargo test -p "${crate}" --lib --bins --tests -- \
+    # extra test); under-matching is what the coverage check below catches.
+    #
+    # `--no-fail-fast` is load-bearing for that check: without it cargo stops
+    # after the first test binary that fails, so every later binary in the crate
+    # silently never runs and the coverage shortfall reports as "a filter
+    # stopped matching" when the real cause was an earlier failure.
+    cargo test --no-fail-fast -p "${crate}" --tests -- \
         --ignored --test-threads=1 "${filters[@]}" 2>&1 | tee "${log}"
     rc=${PIPESTATUS[0]}
 
@@ -144,22 +198,36 @@ for crate in "${crates[@]}"; do
         }
         END { printf "%d %d", p, f }
     ' "${log}")"
+    # Harvest the failing test names while the log still exists — a red gate
+    # that only names the crate leaves an operator unable to tell their own
+    # regression from the known baseline without re-running by hand.
+    crate_fails="$(awk '
+        /^failures:$/ { f = 1; next }
+        /^test result:/ { f = 0 }
+        f && /^    [A-Za-z_]/ { print $1 }
+    ' "${log}" | sort -u)"
     rm -f "${log}"
     crate_passed=${counts% *}
     crate_failed=${counts#* }
     total_passed=$((total_passed + crate_passed))
     total_failed=$((total_failed + crate_failed))
+    executed=$((crate_passed + crate_failed))
 
-    # Per-crate fail-closed: the classifier said this crate has GPU tests, so a
-    # run that executed none of them means the filters stopped matching (a
-    # renamed test, a moved target) — silence, not success.
-    if [ "$((crate_passed + crate_failed))" -eq 0 ]; then
-        echo "ERROR: ${crate} has ${#filters[@]} classified GPU tests but executed 0." >&2
-        failed_crates="${failed_crates}  ${crate} (executed 0)"$'\n'
+    # Coverage check: every classified test must have actually run. A shortfall
+    # means a filter stopped matching — a renamed fn, a target that is no longer
+    # built, a test compiled out behind a feature — which is silence, not
+    # success. Over-matching inflates `executed` and is harmless, so this is a
+    # one-sided `-lt`.
+    if [ "${executed}" -lt "${classified}" ]; then
+        echo "ERROR: ${crate} classified ${classified} GPU tests but executed ${executed} — a filter stopped matching." >&2
+        failed_crates="${failed_crates}  ${crate}: under-matched (${executed}/${classified} executed)"$'\n'
         continue
     fi
     if [ "${rc}" -ne 0 ]; then
-        failed_crates="${failed_crates}  ${crate}"$'\n'
+        failed_crates="${failed_crates}  ${crate}:"$'\n'
+        if [ -n "${crate_fails}" ]; then
+            failed_crates="${failed_crates}$(printf '    %s\n' ${crate_fails})"$'\n'
+        fi
     fi
 done
 
@@ -169,7 +237,9 @@ if [ -n "${failed_crates}" ]; then
     printf '%s' "${failed_crates}" >&2
     echo >&2
     echo "Reproduce one crate with:" >&2
-    echo "  cargo test -p <crate> --lib --bins --tests -- --ignored --test-threads=1 <filter>" >&2
+    echo "  cargo test --no-fail-fast -p <crate> --tests -- --ignored --test-threads=1 <filter>" >&2
+    echo "Known-red baseline (tracked separately): the four rotor fused-QK dispatch" >&2
+    echo "tests in rmlx-kv-quant reporting 'dispatch delta = 0'. See docs/TESTING.md." >&2
     exit 1
 fi
 

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# scripts/run_gpu_tests.sh — execute the GPU (Metal-context) tests that
+# `scripts/check_gpu_tests_ignored.sh` mandates be `#[ignore]`d, serialized.
+#
+# WHY
+#   Every test reaching `Device::Gpu` is REQUIRED to carry `#[ignore]`, because a
+#   shared Metal context driven from parallel `cargo test` threads aborts the
+#   whole test binary. `make ci` enforces that rule. Nothing ever ran the tests
+#   it mandates: `make test` is a bare `cargo test --workspace` (no `--ignored`),
+#   and the hosted CI runs no tests and has no Metal. The result was a category
+#   of test that is mandatory to write, forbidden to run automatically, and
+#   therefore never run — every KV codec's on-GPU decode correctness lives in
+#   that category, and tests in it have gone red on `main` and stayed red while
+#   every gate reported green.
+#
+#   `--test-threads=1` is what makes running them safe: the Metal context is
+#   driven from one thread at a time, so the abort the `#[ignore]` rule protects
+#   against cannot happen.
+#
+# WHICH TESTS
+#   Exactly the compliant set from `check_gpu_tests_ignored.sh --list` —
+#   `#[test]` fns that reach `Device::Gpu` AND carry `#[ignore]`. Deriving the
+#   population from the enforcing gate's own classifier is the point: a second,
+#   hand-maintained list would drift, and the rule would end up mandating
+#   `#[ignore]` on tests this runner never visits.
+#
+#   It deliberately does NOT run every `#[ignore]` test. Plenty are ignored for
+#   reasons that have nothing to do with Metal — live network access, a missing
+#   cargo feature, `ignore`-marked doc-comment pseudo-code — and sweeping those
+#   in would make this gate permanently red for reasons it cannot speak to.
+#
+# FAIL-CLOSED
+#   A gate that silently runs nothing passes everything. This one refuses to
+#   report OK unless it executed tests: an empty classification, a crate whose
+#   listed tests all failed to match, and a `--filter` that selects nothing are
+#   all errors, not green runs.
+#
+#   Tests that skip internally (model-gated cells with no snapshot present,
+#   `RMLX_SKIP_GPU=1`) still count as executed. That is accepted: this gate
+#   proves the suite RAN; per-test skip logic is the suite's own contract.
+#
+# USAGE
+#   bash scripts/run_gpu_tests.sh
+#   bash scripts/run_gpu_tests.sh --crate rmlx-kv-quant
+#   bash scripts/run_gpu_tests.sh --crate rmlx-kv-quant --filter rotor_flash
+#
+# Exit 0 = every selected GPU test passed. Exit 1 = a failure, or a run that
+# executed nothing.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+    cat <<'USAGE'
+Usage: run_gpu_tests.sh [--crate <name>] [--filter <substring>]
+
+  --crate <name>       restrict to one workspace member (e.g. rmlx-kv-quant)
+  --filter <substring> restrict to GPU test fns whose name contains <substring>
+USAGE
+}
+
+ONLY_CRATE=""
+FILTER=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --crate)  ONLY_CRATE="${2:?--crate needs a value}"; shift 2 ;;
+        --filter) FILTER="${2:?--filter needs a value}"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "ERROR: unknown argument '$1'" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+# CLAUDE.md hard rule 8 — a single MLX process per Mac. These tests build their
+# own Metal context; a co-resident server already holding the GPU makes any
+# failure here unattributable. Refuse rather than pkill: killing a process this
+# script does not own is not its call.
+if pgrep -f 'rmlx serve|mlx_lm|paroquant|omlx' >/dev/null 2>&1; then
+    echo "ERROR: another MLX process is live — the GPU tests need the Metal context to themselves." >&2
+    pgrep -fl 'rmlx serve|mlx_lm|paroquant|omlx' >&2 || true
+    echo >&2
+    echo "Stop it first, e.g.:" >&2
+    echo "  pkill -f 'rmlx serve'; pkill -f mlx_lm; rm -f /tmp/rmlx.*.claim" >&2
+    exit 1
+fi
+
+listing="$(bash "${REPO_ROOT}/scripts/check_gpu_tests_ignored.sh" --list)"
+if [ -z "${listing}" ]; then
+    echo "ERROR: check_gpu_tests_ignored.sh --list produced no GPU tests." >&2
+    exit 1
+fi
+
+# Apply the narrowing options, then group what is left by crate.
+selected=""
+while IFS=$'\t' read -r crate fn_name; do
+    [ -z "${crate}" ] && continue
+    if [ -n "${ONLY_CRATE}" ] && [ "${crate}" != "${ONLY_CRATE}" ]; then continue; fi
+    case "${fn_name}" in
+        *"${FILTER}"*) selected="${selected}${crate}"$'\t'"${fn_name}"$'\n' ;;
+    esac
+done <<< "${listing}"
+
+crates=()
+while IFS= read -r c; do
+    [ -n "$c" ] && crates+=("$c")
+done < <(printf '%s' "${selected}" | cut -f1 | uniq)
+
+if [ ${#crates[@]} -eq 0 ]; then
+    echo "ERROR: selection matched no GPU tests." >&2
+    [ -n "${ONLY_CRATE}" ] && echo "  --crate '${ONLY_CRATE}'" >&2
+    [ -n "${FILTER}" ] && echo "  --filter '${FILTER}'" >&2
+    echo "A gate that runs nothing passes everything; refusing to report OK." >&2
+    exit 1
+fi
+
+failed_crates=""
+total_passed=0
+total_failed=0
+
+for crate in "${crates[@]}"; do
+    filters=()
+    while IFS=$'\t' read -r c fn_name; do
+        [ "$c" = "${crate}" ] && filters+=("${fn_name}")
+    done <<< "${selected}"
+    echo "── ${crate} (${#filters[@]} GPU tests) ──────────────────────────"
+
+    log="$(mktemp -t "rmlx-gpu-test-${crate}")"
+    # Names come from the classifier as bare fn identifiers, while libtest
+    # matches against the full `module::path::fn` — so these are substring
+    # filters, not `--exact`. Over-matching a sibling is harmless (it runs one
+    # extra test); under-matching is what fail-closed below catches.
+    # `--lib --bins --tests` excludes doc-tests: `--ignored` makes rustdoc
+    # compile ```ignore blocks, which are prose, not tests.
+    cargo test -p "${crate}" --lib --bins --tests -- \
+        --ignored --test-threads=1 "${filters[@]}" 2>&1 | tee "${log}"
+    rc=${PIPESTATUS[0]}
+
+    counts="$(awk '
+        /^test result:/ {
+            for (i = 1; i <= NF; i++) {
+                if ($(i+1) ~ /^passed/) { p += $i }
+                if ($(i+1) ~ /^failed/) { f += $i }
+            }
+        }
+        END { printf "%d %d", p, f }
+    ' "${log}")"
+    rm -f "${log}"
+    crate_passed=${counts% *}
+    crate_failed=${counts#* }
+    total_passed=$((total_passed + crate_passed))
+    total_failed=$((total_failed + crate_failed))
+
+    # Per-crate fail-closed: the classifier said this crate has GPU tests, so a
+    # run that executed none of them means the filters stopped matching (a
+    # renamed test, a moved target) — silence, not success.
+    if [ "$((crate_passed + crate_failed))" -eq 0 ]; then
+        echo "ERROR: ${crate} has ${#filters[@]} classified GPU tests but executed 0." >&2
+        failed_crates="${failed_crates}  ${crate} (executed 0)"$'\n'
+        continue
+    fi
+    if [ "${rc}" -ne 0 ]; then
+        failed_crates="${failed_crates}  ${crate}"$'\n'
+    fi
+done
+
+echo
+if [ -n "${failed_crates}" ]; then
+    echo "ERROR: GPU tests failed in:" >&2
+    printf '%s' "${failed_crates}" >&2
+    echo >&2
+    echo "Reproduce one crate with:" >&2
+    echo "  cargo test -p <crate> --lib --bins --tests -- --ignored --test-threads=1 <filter>" >&2
+    exit 1
+fi
+
+echo "OK: ${total_passed} GPU tests passed across ${#crates[@]} workspace member(s)."


### PR DESCRIPTION
Closes #332. Closes #335. Advances #313.

Three issues on one branch: two concrete red/racy GPU tests, then the gate that
would have caught them.

## #332 — stale rotor K-only assertions

`6d1e4b2` added `drop_blocks_when_ring_live_k{3,4}` so the K-only rotor append
releases its CPU blocks once the GPU ring is live, and updated
`resident_ring_tests.rs` but not `rotor_flash_dispatch_tests.rs`. Two `#[ignore]`d
tests were left asserting the pre-fix contract. **The tests were stale, not the
code** — `blocks_tokens == 0` is literally what `ks.blocks.clear()` now
guarantees.

Re-pointing them at the post-drop state makes the following dequant *more*
load-bearing: with no host copy left, reconstructing the prefix can only come
from the ring.

```
BEFORE   assertion failed: CPU blocks must stay frozen ... left: 0, right: 12
AFTER    11 passed
MUTATION revert drop_blocks_when_ring_live_k{3,4}  -> left: 12, right: 0  RED
MUTATION decode self.blocks directly               -> cosine 0            RED
```

The second mutation showed the doc comment was itself wrong — it claimed the
length guard fires, but with empty blocks `dequant` returns a correctly-sized
all-zero buffer and the cosine collapses instead. Comment corrected to the
observed behaviour.

The same #310 root cause was found in a second crate:
`rmlx-kv-ssd::block_io_tests::rotor_k_only_ring_only_tail_ssd_round_trip`, also
red on main. Fixed and mutation-checked identically.

Real-model proof at `--kv-quant k_rotor3` (the exact codec), both architectures:
gemma-4-e2b (`kv_h == 1`, shared-KV) and Ternary-Bonsai-8B (`kv_h > 1`, dense)
both generate coherent text.

## #335 — env-backed gate readers race the writers

`rotor_qjl_enabled()` is deliberately not `OnceLock`-latched, so an unlocked read
races the sibling test that sets `RMLX_ROTOR_QJL`. Scope was wider than reported:
the whole test body is a reader, and a second instance existed —
`skip_if_no_gpu_env_strict_membership` mutates `RMLX_SKIP_GPU` under a
`// SAFETY: single-threaded test` comment that is false, while
`skip_if_no_gpu_env()` is read by every GPU test in the binary.

`setenv` is UB against a concurrent `getenv` of *any* key, so the guard is
whole-environment (`test_utils::env_lock()`), not per-variable. It returns an
`EnvGuard` whose `Drop` restores the managed keys, so a panicking writer cannot
leak state into the next test.

Made falsifiable by widening the writer's window with a scratch 300 ms sleep:

```
RED       unlocked reader, widened window   20 / 20 runs failed
GREEN     locked reader,   same window       0 / 20 runs failed
MUTATION  guard removed,   same window      20 / 20 runs failed
```

The natural-ordering loop (40 full-binary iterations, 0 failures) is deliberately
*not* the evidence — the pre-fix natural failure rate is also near zero.

## #313 — the gate

`make test` passes no `--ignored`; `make ci` enforces the `#[ignore]` attribute
and adds no step that runs the tests it mandates; hosted CI has no Metal.

`scripts/run_gpu_tests.sh` + `make gpu-test` (`CRATE=` / `FILTER=`,
`--test-threads=1`) runs exactly the set `check_gpu_tests_ignored.sh --list`
classifies — a new emit mode of the *existing* awk detector, not a second parser,
so the rule and the runner cannot cover different populations.

Running *every* `#[ignore]`d test was implemented and then rejected: it swept in
five failures unrelated to Metal, and a gate permanently red for things it cannot
speak to is one people learn to skip.

Mutation-check of the gate itself — a 5% error injected into the on-GPU rotor K
dequant, silent numeric corruption invisible to every static gate:

```
BROKEN    ERROR: GPU tests failed in: rmlx-kv-quant
          rotor_flash_decode_dispatch_count_increments_on_gpu ... FAILED
RESTORED  OK: 2 GPU tests passed
```

Fail-closed paths, each mutation-checked:

- `RMLX_SKIP_GPU=1` refuses to start. Every classified test returns before
  touching Metal under that variable, so the gate would otherwise print
  "OK: 324 GPU tests passed" having dispatched nothing.
- Per-crate coverage assertion: classified count vs executed count, not merely
  "executed > 0". A single filter that stops matching (renamed fn, a test absent
  from the binary) is now an error rather than a green run.
- No-match `--filter` / `--crate` exit 1.

The coverage assertion went red on its first real run — 238 classified, 236
executed. Not a filter problem: `cargo test` stops after the first failing test
binary, so pre-existing failures were suppressing an entire integration binary
and its two GPU tests never ran. Fixed with `--no-fail-fast`. That is a second
instance of the same "mandatory to write, never run" class this issue is about.

**#313 stays open.** `make gpu-test` is deliberately *not* wired into `ci-perf`
yet: it is red on exactly four pre-existing `rotor*_fused_qk_dispatch` tests
tracked in #333, and wiring a knowingly-red step into a shared gate teaches
people to skip the gate. The runner names the failing tests and
`docs/TESTING.md` documents the baseline. Wiring is a one-line change once #333
closes.

## Gates

`make ci` green. `make lint` clean, `cargo fmt --check` clean,
`check_gpu_tests_ignored.sh` OK (302 files / 12 members), rmlx-kv-quant
384 passed / 219 ignored, rmlx-kv-ssd 86 passed / 11 ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
