### PR TITLE
feat(profiling): headless GPU timing via xctrace, and shader validation in the GPU gate (#330, #328)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         profile-samply profile-samply-debug profile-instruments bench asm perf-iter \
         canary canary-gate \
         mlx-preflight mlx-restore-pin target-gc target-size-report profile-gputrace \
+        profile-mst \
         build-capture test-capture gputrace-preflight traces-gc \
         ssd-canary ssd-canary-gate \
         bench-codec-cell \
@@ -108,8 +109,9 @@ traces-gc:       ## report .rmlx/traces against the retention caps (APPLY=1 to p
 # `make test` is `cargo test --workspace` without --all-features, so it compiles
 # these out entirely. Run from `ci` as well, or an off-by-one in the window
 # policy passes the gate green.
-test-capture: ## run the GPU-capture unit tests (feature-gated, so plain `make test` skips them; also a `make ci` step)
+test-capture: ## run the feature-gated GPU-profiling unit tests (capture window + xctrace parser; plain `make test` skips them; also a `make ci` step)
 	cargo test -p rmlx-mlx --features metal-capture --lib metal_capture
+	cargo test -p rmlx-mlx --features metal-capture --lib xctrace
 	cargo test -p rmlx-cli --features metal-capture --bin rmlx gpu_capture
 
 profile-gputrace: ## capture a decode-window Metal GPU trace (CODEC= MODEL= required; enforces the .rmlx/traces cap unless KEEP_ALL=1)
@@ -123,6 +125,30 @@ profile-gputrace: ## capture a decode-window Metal GPU trace (CODEC= MODEL= requ
 		$(if $(PROMPT_TOKENS),--prompt-tokens $(PROMPT_TOKENS),) \
 		$(if $(SKIP),--skip $(SKIP),) $(if $(STEPS),--steps $(STEPS),) \
 		$(if $(GEN),--gen $(GEN),) $(if $(KEEP_ALL),--keep-all,)
+
+# profile-mst: the timing half of GPU profiling. A .gputrace answers WHICH
+# kernels ran; this answers HOW LONG they took and how long the GPU waited on
+# the host (start-latency, the CPU->GPU gap) — the one signal a capture cannot
+# give, since a replay has the replay's schedule. Records the live process,
+# exports metal-gpu-intervals and parses it; the parser refuses a misaligned
+# table rather than printing plausible wrong numbers.
+#
+# The recording starts at process launch (xctrace --attach is broken for this
+# template), so it includes weight load and prefill — SKIP_MS= leaves them out
+# of the summary.
+profile-mst: ## record a Metal System Trace of a live rmlx run and summarise GPU time + CPU->GPU gap (MODEL= required; CODEC= TIME_LIMIT= SKIP_MS= PROMPT_TOKENS= GEN= KEEP=)
+	@if [ -z "$(MODEL)" ]; then \
+		echo "Usage: make profile-mst MODEL=<snapshot-abs-path> \
+[CODEC=none] [TIME_LIMIT=12] [SKIP_MS=4000] [PROMPT_TOKENS=512] [GEN=400] [KEEP=5]"; \
+		exit 2; \
+	fi
+	bash scripts/mst_capture.sh --model $(MODEL) \
+		$(if $(CODEC),--kv-quant $(CODEC),) \
+		$(if $(TIME_LIMIT),--time-limit $(TIME_LIMIT),) \
+		$(if $(SKIP_MS),--skip-ms $(SKIP_MS),) \
+		$(if $(PROMPT_TOKENS),--prompt-tokens $(PROMPT_TOKENS),) \
+		$(if $(GEN),--max-tokens $(GEN),) \
+		$(if $(KEEP),--keep $(KEEP),)
 
 mlx-restore-pin: ## restore mlx 0.31.2 + mlx-c 0.6.0_2 (nax-capable pair) and relink
 	bash scripts/mlx_restore_pin.sh
@@ -153,8 +179,16 @@ ci-perf:         ## pre-push gate under release-perf (separate from make ci; run
 # exclusive machine access) is the natural next step, but is blocked while any
 # GPU test is red on main — wiring a known-red step into a shared gate just
 # teaches people to skip the gate.
-gpu-test:        ## run the GPU/Metal #[ignore] tests serialized (CRATE= FILTER= to narrow); needs exclusive machine access
-	@bash scripts/run_gpu_tests.sh $(if $(CRATE),--crate '$(CRATE)',) $(if $(FILTER),--filter '$(FILTER)',)
+#
+# Metal shader validation is ON here. An out-of-bounds device store is dropped
+# silently — command buffer completes, cb.error is nil, cargo exits 0, and the
+# tests over the frozen buffer still pass — so without instrumentation this
+# target cannot see the repo's documented silent-corruption class at all. It
+# costs throughput, which is why it lives on this target and not on any cell
+# whose numbers get recorded. VALIDATE=0 opts out.
+gpu-test:        ## run the GPU/Metal #[ignore] tests serialized under Metal shader validation (CRATE= FILTER= to narrow, VALIDATE=0 to skip instrumentation); needs exclusive machine access
+	@bash scripts/run_gpu_tests.sh $(if $(CRATE),--crate '$(CRATE)',) $(if $(FILTER),--filter '$(FILTER)',) \
+		$(if $(filter 0,$(VALIDATE)),--no-shader-validation,)
 
 # model-check: run only the model-logic crates (rmlx-models, rmlx-runtime,
 # rmlx-quant) plus the KV-codec crate (rmlx-kv-quant). Excludes server, CLI, and

--- a/Makefile
+++ b/Makefile
@@ -134,14 +134,18 @@ profile-gputrace: ## capture a decode-window Metal GPU trace (CODEC= MODEL= requ
 # table rather than printing plausible wrong numbers.
 #
 # The recording starts at process launch (xctrace --attach is broken for this
-# template), so it includes weight load and prefill — SKIP_MS= leaves them out
-# of the summary.
-profile-mst: ## record a Metal System Trace of a live rmlx run and summarise GPU time + CPU->GPU gap (MODEL= required; CODEC= TIME_LIMIT= SKIP_MS= PROMPT_TOKENS= GEN= KEEP=)
-	@if [ -z "$(MODEL)" ]; then \
-		echo "Usage: make profile-mst MODEL=<snapshot-abs-path> \
-[CODEC=none] [TIME_LIMIT=12] [SKIP_MS=4000] [PROMPT_TOKENS=512] [GEN=400] [KEEP=5]"; \
-		exit 2; \
-	fi
+# template). Weight load submits no GPU work so it leaves no rows, but prefill
+# does: SKIP_MS= drops it from the summary, and DEFAULTS to the prefill_ms the
+# run itself reported, so the decode boundary is measured rather than guessed.
+# PROMPT_TOKENS must be a size with a checked-in prompt fixture.
+# MODEL falls back to the workspace default like `make serve` / `make info`, so
+# there is no "MODEL is required" guard to write here — it could never fire.
+# scripts/mst_capture.sh validates the snapshot path and every numeric argument.
+#
+#   make profile-mst MODEL=<snapshot-abs-path> [CODEC=none] [TIME_LIMIT=18]
+#     [SKIP_MS=<default: the run's measured prefill_ms>] [GEN=600] [KEEP=5]
+#     [PROMPT_TOKENS=4096|8192|16384|32768|65536|131072]
+profile-mst: ## record a Metal System Trace of a live rmlx run and summarise GPU time + CPU->GPU gap (CODEC= TIME_LIMIT= SKIP_MS= PROMPT_TOKENS= GEN= KEEP=)
 	bash scripts/mst_capture.sh --model $(MODEL) \
 		$(if $(CODEC),--kv-quant $(CODEC),) \
 		$(if $(TIME_LIMIT),--time-limit $(TIME_LIMIT),) \

--- a/crates/rmlx-kv-quant/Cargo.toml
+++ b/crates/rmlx-kv-quant/Cargo.toml
@@ -18,3 +18,10 @@ thiserror  = { workspace = true }
 tracing    = { workspace = true }
 
 [dev-dependencies]
+
+# Positive control for the shader-validation gate: a kernel that stores out of
+# bounds on purpose, so `scripts/run_gpu_tests.sh` can prove its detector still
+# matches this toolchain's report before trusting a clean scan. Off by default —
+# nothing builds it unless the gate asks for it.
+[features]
+shader-validation-canary = []

--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -74,6 +74,10 @@ pub mod rotor_fused_qk_msl;
 pub mod rotor_qjl;
 pub mod rotorquant;
 pub mod rotorquant_msl;
+/// Deliberately out-of-bounds kernel used as the positive control for the
+/// shader-validation gate. Off by default; see `scripts/run_gpu_tests.sh`.
+#[cfg(feature = "shader-validation-canary")]
+pub mod shader_validation_canary;
 pub mod sparse_attn;
 pub mod sparse_v_msl;
 pub mod storage;

--- a/crates/rmlx-kv-quant/src/metal/shader_validation_canary.metal
+++ b/crates/rmlx-kv-quant/src/metal/shader_validation_canary.metal
@@ -1,0 +1,15 @@
+// NOT a codec kernel. This stores OUT OF BOUNDS on purpose.
+//
+// It is the positive control for the shader-validation gate: an out-of-bounds
+// device store is dropped silently by Metal, so the only way to know the gate's
+// detector still matches this toolchain's report format is to emit one on
+// demand and check that it is caught. Built only under the
+// `shader-validation-canary` feature, and its test refuses to dispatch unless
+// MTL_SHADER_VALIDATION is on, so the write is always instrumented (and, under
+// the gate's FAIL_MODE=zerofill, discarded) rather than corrupting memory.
+//
+// Keep the store far past the end so no rounding of the allocation can make it
+// accidentally land in bounds.
+uint i            = thread_position_in_grid.x;
+out[i]            = inp[i];
+out[i + 1000000u] = 1.0f;

--- a/crates/rmlx-kv-quant/src/shader_validation_canary.rs
+++ b/crates/rmlx-kv-quant/src/shader_validation_canary.rs
@@ -71,9 +71,15 @@ pub fn dispatch_out_of_bounds_store(device: Device) -> Result<()> {
 
     let mut outputs = kernel.apply(invoke, device)?;
     if let Some(out) = outputs.first_mut() {
-        // Forces the dispatch to actually run; without it the lazy graph may
-        // never submit and the canary would report a clean scan for a kernel
-        // that never executed.
+        // eval-ok: the dispatch IS the product here, not the value. Nothing
+        // ever reads this output — the canary exists to make the GPU execute an
+        // invalid store so the validation layer reports it — so MLX has no
+        // reason to materialise the node and, left lazy, the kernel never runs.
+        // Measured with validation on: with this eval the run emits one
+        // "Invalid device store … custom_kernel_rmlx_shader_validation_canary";
+        // without it, zero, with the validation banner present either way. A
+        // canary that does not dispatch would let the gate certify its detector
+        // against silence.
         out.eval()?;
     }
     Ok(())

--- a/crates/rmlx-kv-quant/src/shader_validation_canary.rs
+++ b/crates/rmlx-kv-quant/src/shader_validation_canary.rs
@@ -1,0 +1,84 @@
+//! Positive control for the shader-validation gate.
+//!
+//! `scripts/run_gpu_tests.sh` scans test output for Metal's invalid-access
+//! report. That scan is a hand-written pattern over an undocumented,
+//! version-specific message, and its *absence* is what the gate reports as
+//! success — so a wording change at a toolchain bump would silently convert it
+//! into a gate that runs, prints its banner, and can never fire.
+//!
+//! This module dispatches a kernel that stores out of bounds on purpose, so the
+//! gate can confirm the detector still matches before trusting a clean scan.
+//!
+//! Built only under the `shader-validation-canary` feature, and the test
+//! refuses to dispatch unless shader validation is actually enabled: with
+//! validation on the invalid write is instrumented and (under the gate's
+//! `FAIL_MODE=zerofill`) discarded, whereas dispatching it uninstrumented would
+//! be a real out-of-bounds write into an MLX-owned buffer.
+
+use rmlx_core::error::Result;
+use rmlx_mlx::metal_kernel::{MetalKernel, MetalKernelInvoke};
+use rmlx_mlx::{Array, Device, Dtype};
+use std::sync::OnceLock;
+
+const CANARY_SOURCE: &str = include_str!("metal/shader_validation_canary.metal");
+
+static CANARY_KERNEL: OnceLock<Result<MetalKernel>> = OnceLock::new();
+
+fn canary_kernel() -> Result<&'static MetalKernel> {
+    CANARY_KERNEL
+        .get_or_init(|| {
+            MetalKernel::new(
+                "rmlx_shader_validation_canary",
+                "",
+                CANARY_SOURCE,
+                &["inp"],
+                &["out"],
+            )
+        })
+        .as_ref()
+        .map_err(|e| {
+            rmlx_core::error::Error::Mlx(format!("shader_validation_canary kernel init: {e}"))
+        })
+}
+
+/// Whether Metal's shader validation is enabled for this process.
+///
+/// Read from the environment because that is the only place it can be set:
+/// Metal inserts the validation layer at device creation and there is no
+/// in-process way to add it later.
+#[must_use]
+pub fn shader_validation_enabled() -> bool {
+    std::env::var("MTL_SHADER_VALIDATION").is_ok_and(|v| v != "0" && !v.is_empty())
+}
+
+/// Dispatch the deliberately out-of-bounds kernel.
+///
+/// # Errors
+/// Any FFI failure building or running the kernel. Note that the invalid store
+/// itself does **not** produce an error: the command buffer completes, its
+/// `error` is nil and the process exits 0. That is the whole point — the signal
+/// is a diagnostic in the output, not a status code.
+pub fn dispatch_out_of_bounds_store(device: Device) -> Result<()> {
+    let n = 256_i32;
+    let input = Array::from_f32_slice(&vec![1.0_f32; n as usize], &[n])?;
+
+    let kernel = canary_kernel()?;
+    let mut invoke = MetalKernelInvoke::new();
+    invoke.add_input(&input)?;
+    invoke.add_output_shape(&[n], Dtype::F32)?;
+    invoke.set_grid(n, 1, 1)?;
+    invoke.set_thread_group(64, 1, 1)?;
+
+    let mut outputs = kernel.apply(invoke, device)?;
+    if let Some(out) = outputs.first_mut() {
+        // Forces the dispatch to actually run; without it the lazy graph may
+        // never submit and the canary would report a clean scan for a kernel
+        // that never executed.
+        out.eval()?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "shader_validation_canary_tests.rs"]
+mod shader_validation_canary_tests;

--- a/crates/rmlx-kv-quant/src/shader_validation_canary_tests.rs
+++ b/crates/rmlx-kv-quant/src/shader_validation_canary_tests.rs
@@ -1,0 +1,32 @@
+//! The gate's positive control.
+//!
+//! Run by `scripts/run_gpu_tests.sh` before it trusts a clean scan, never as
+//! part of the correctness suite — the runner excludes this name from the
+//! population it derives from the ignore-rule classifier.
+
+use super::{dispatch_out_of_bounds_store, shader_validation_enabled};
+use rmlx_mlx::Device;
+
+#[test]
+#[ignore = "drives the GPU; run serialized via scripts/run_gpu_tests.sh"]
+fn shader_validation_canary_emits_an_invalid_access_report() {
+    // Refuses to dispatch uninstrumented. With validation on the store is
+    // caught and dropped; without it, this would be a genuine out-of-bounds
+    // write into an MLX-owned buffer, which is not something to do for a test.
+    if !shader_validation_enabled() {
+        println!(
+            "SKIP shader_validation_canary: MTL_SHADER_VALIDATION is not set, so the \
+             deliberate out-of-bounds store would be a real one."
+        );
+        return;
+    }
+    // The dispatch itself must SUCCEED. An invalid device store does not fail
+    // the command buffer: it is dropped, `cb.error` stays nil, and the process
+    // exits 0. The gate's assertion is on the diagnostic text this produces, so
+    // an error here means the canary never ran, not that it worked.
+    #[allow(
+        clippy::expect_used,
+        reason = "the canary failing to dispatch must abort loudly: a silent skip would let the gate trust a scan that proved nothing"
+    )]
+    dispatch_out_of_bounds_store(Device::Gpu).expect("canary kernel must dispatch");
+}

--- a/crates/rmlx-mlx/Cargo.toml
+++ b/crates/rmlx-mlx/Cargo.toml
@@ -18,10 +18,20 @@ thiserror   = { workspace = true }
 tracing     = { workspace = true }
 safetensors = { workspace = true }
 
+# Profiling-only tool: parses an `xctrace export` and summarises GPU submission
+# time and the CPU->GPU gap. `required-features` keeps it out of
+# `cargo check --all-targets`, which builds with no features on.
+[[example]]
+name = "gpu_timeline"
+path = "examples/gpu_timeline.rs"
+required-features = ["metal-capture"]
+
 [features]
-# Feature-gated GPU trace capture via MTLCaptureManager (debug only).
-# Enables `rmlx_mlx::metal_capture` — the arm / step / finish driver over
-# mlx_metal_start_capture / mlx_metal_stop_capture, plus the pure window policy.
+# Feature-gated GPU profiling (debug only). Two things ride on it:
+#   * `rmlx_mlx::metal_capture` — the arm / step / finish driver over
+#     mlx_metal_start_capture / mlx_metal_stop_capture, plus the window policy.
+#   * `rmlx_mlx::xctrace` — the `xctrace export` XML parser behind
+#     `scripts/mst_capture.sh`.
 # Do NOT enable in release builds; the feature tag keeps binaries clean.
 metal-capture = []
 

--- a/crates/rmlx-mlx/examples/gpu_timeline.rs
+++ b/crates/rmlx-mlx/examples/gpu_timeline.rs
@@ -92,6 +92,26 @@ fn per_second(count: u64, span_ns: u64) -> String {
     format!("{rate:.1}")
 }
 
+/// Busy time as a share of the span. Labelled "of span" rather than "duty
+/// cycle" when several channels are populated, because their busy times overlap
+/// and the sum can exceed the span.
+fn busy_fraction(summary: &GpuIntervalSummary, populated: usize) -> String {
+    let span = summary.span_ns();
+    if span == 0 {
+        return "n/a".to_owned();
+    }
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "display only; a --time-limit-bounded span stays far inside f64's exact integer range"
+    )]
+    let pct = summary.busy_ns() as f64 * 100.0 / span as f64;
+    if populated > 1 {
+        format!("{pct:.1}% of span, summed")
+    } else {
+        format!("{pct:.1}% of span")
+    }
+}
+
 fn report(summary: &GpuIntervalSummary, args: &Args) {
     println!(
         "rows: {} total, {} matched{}{}",
@@ -106,12 +126,38 @@ fn report(summary: &GpuIntervalSummary, args: &Args) {
             String::new()
         }
     );
+    // The busy FRACTION is the number to read `start-latency` against, so print
+    // it rather than leaving it to be computed by hand from two other columns.
+    // At a high fraction the gap is queueing behind work already submitted; the
+    // host-stall signal is idle GPU, i.e. span - busy.
+    let populated = summary
+        .channels
+        .iter()
+        .filter(|c| c.submissions > 0)
+        .count();
     println!(
-        "span: {} ms   gpu busy: {} ms (channels overlap)   {} submissions/s",
+        "span: {} ms   gpu busy: {} ms ({})   idle: {} ms   {} submissions/s",
         ms(summary.span_ns()),
         ms(summary.busy_ns()),
+        busy_fraction(summary, populated),
+        ms(summary.span_ns().saturating_sub(summary.busy_ns())),
         per_second(summary.rows_matched, summary.span_ns())
     );
+    if summary.busy_ns() > summary.span_ns() {
+        // Only definitely wrong in this direction: concurrent channels overlap,
+        // so their summed busy time can exceed the wall-clock span outright.
+        println!(
+            "note: busy exceeds span — {populated} channels ran concurrently and their \
+             busy times overlap, so this is a sum, not a duty cycle."
+        );
+    } else if populated > 1 {
+        // Not an error, just an accounting caveat: read the dominant channel's
+        // own busy against the span for a duty cycle.
+        println!(
+            "note: busy is summed over {populated} channels; for a duty cycle read the \
+             dominant channel's busy against the span."
+        );
+    }
     println!();
     println!(
         "{:<10} {:>8} {:>11} {:>11} {:>11} {:>11} {:>11} {:>11}",

--- a/crates/rmlx-mlx/examples/gpu_timeline.rs
+++ b/crates/rmlx-mlx/examples/gpu_timeline.rs
@@ -1,0 +1,200 @@
+//! Summarises a `metal-gpu-intervals` export from `xcrun xctrace export`.
+//!
+//! An example rather than a subcommand: this is profiling tooling, and the
+//! shipped binary stays one artifact with no dev-only surface in it.
+//!
+//! ```sh
+//! cargo run -q -p rmlx-mlx --features metal-capture --example gpu_timeline -- \
+//!     --input gpu.xml --process rmlx --csv gpu.csv
+//! ```
+//!
+//! `scripts/mst_capture.sh` drives record + export + this, and is the intended
+//! entry point.
+
+// A user-facing CLI tool: stdout IS its output, which CLAUDE.md permits for
+// operator-facing commands.
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use rmlx_mlx::xctrace::{summarise_gpu_intervals, summary_csv, GpuIntervalSummary, SummaryFilter};
+use std::process::ExitCode;
+
+fn usage() -> &'static str {
+    "usage: gpu_timeline --input <gpu.xml> [--process <substring>] [--skip-ms N] [--csv <path>]\n\
+     \n\
+       --input <path>       XML from `xctrace export --xpath ...metal-gpu-intervals...`\n\
+       --process <substr>   keep only submissions attributed to a matching process\n\
+       --skip-ms N          ignore the first N ms of the matched process's own GPU\n\
+                            work, i.e. prefill — a recording can only start at\n\
+                            launch (--attach is broken for this template), and\n\
+                            weight load submits nothing so it leaves no rows\n\
+       --csv <path>         also write the per-channel table as CSV\n"
+}
+
+struct Args {
+    input: String,
+    process: Option<String>,
+    skip_ms: u64,
+    csv: Option<String>,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut input = None;
+    let mut process = None;
+    let mut skip_ms = 0u64;
+    let mut csv = None;
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        let mut value = |name: &str| args.next().ok_or_else(|| format!("{name} needs a value"));
+        match arg.as_str() {
+            "--input" => input = Some(value("--input")?),
+            "--process" => process = Some(value("--process")?),
+            "--skip-ms" => {
+                let raw = value("--skip-ms")?;
+                skip_ms = raw
+                    .parse()
+                    .map_err(|_| format!("--skip-ms expects an integer, got {raw:?}"))?;
+            }
+            "--csv" => csv = Some(value("--csv")?),
+            "-h" | "--help" => return Err(String::new()),
+            other => return Err(format!("unknown argument '{other}'")),
+        }
+    }
+    Ok(Args {
+        input: input.ok_or_else(|| "--input is required".to_owned())?,
+        process,
+        skip_ms,
+        csv,
+    })
+}
+
+/// Nanoseconds as milliseconds, three decimals — the scale a decode step lives at.
+fn ms(ns: u64) -> String {
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "display only; a trace is bounded by --time-limit so ns stays far inside f64's exact integer range"
+    )]
+    let millis = ns as f64 / 1.0e6;
+    format!("{millis:.3}")
+}
+
+/// Submissions per second over the matched span. The independent cross-check
+/// against a decode rate: at one GPU kick per decode step this tracks TPS, and
+/// a wild disagreement means the window is not the window it was thought to be.
+fn per_second(count: u64, span_ns: u64) -> String {
+    if span_ns == 0 {
+        return "n/a".to_owned();
+    }
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "display only; counts and a --time-limit-bounded span stay far inside f64's exact integer range"
+    )]
+    let rate = count as f64 * 1.0e9 / span_ns as f64;
+    format!("{rate:.1}")
+}
+
+fn report(summary: &GpuIntervalSummary, args: &Args) {
+    println!(
+        "rows: {} total, {} matched{}{}",
+        summary.rows_total,
+        summary.rows_matched,
+        args.process
+            .as_deref()
+            .map_or_else(String::new, |p| format!(" (process contains {p:?})")),
+        if args.skip_ms > 0 {
+            format!(" (first {} ms skipped)", args.skip_ms)
+        } else {
+            String::new()
+        }
+    );
+    println!(
+        "span: {} ms   gpu busy: {} ms (channels overlap)   {} submissions/s",
+        ms(summary.span_ns()),
+        ms(summary.busy_ns()),
+        per_second(summary.rows_matched, summary.span_ns())
+    );
+    println!();
+    println!(
+        "{:<10} {:>8} {:>11} {:>11} {:>11} {:>11} {:>11} {:>11}",
+        "channel", "subs", "busy ms", "dur p50", "dur p95", "lat p50", "lat p95", "lat max"
+    );
+    for c in &summary.channels {
+        println!(
+            "{:<10} {:>8} {:>11} {:>11} {:>11} {:>11} {:>11} {:>11}",
+            c.channel,
+            c.submissions,
+            ms(c.busy_ns),
+            ms(c.duration_pct(50)),
+            ms(c.duration_pct(95)),
+            ms(c.latency_pct(50)),
+            ms(c.latency_pct(95)),
+            ms(c.latency_pct(100)),
+        );
+        if c.latency_samples() < usize::try_from(c.submissions).unwrap_or(usize::MAX) {
+            // Said out loud rather than folded into the percentiles: a NULL
+            // start-latency is "not measured", and averaging it in as zero
+            // would understate the very gap this table is read for.
+            println!(
+                "{:<10} {:>8} {}",
+                "",
+                "",
+                format_args!(
+                    "note: {} of {} submissions carry no start-latency",
+                    c.submissions.saturating_sub(c.latency_samples() as u64),
+                    c.submissions
+                )
+            );
+        }
+    }
+    println!();
+    println!("processes seen:");
+    for (name, count) in summary.processes.iter().take(8) {
+        println!("  {count:>8}  {name}");
+    }
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(args) => args,
+        Err(msg) => {
+            if !msg.is_empty() {
+                eprintln!("error: {msg}");
+            }
+            eprint!("{}", usage());
+            return ExitCode::from(2);
+        }
+    };
+
+    let xml = match std::fs::read_to_string(&args.input) {
+        Ok(xml) => xml,
+        Err(err) => {
+            eprintln!("error: reading {}: {err}", args.input);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let filter = SummaryFilter {
+        process: args.process.as_deref(),
+        skip_ms: args.skip_ms,
+    };
+    let summary = match summarise_gpu_intervals(&xml, filter) {
+        Ok(summary) => summary,
+        Err(err) => {
+            // The parser refuses a layout it cannot align rather than emitting
+            // shifted numbers, so this path is a real answer, not a nuisance.
+            eprintln!("error: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    report(&summary, &args);
+
+    if let Some(path) = args.csv.as_deref() {
+        if let Err(err) = std::fs::write(path, summary_csv(&summary)) {
+            eprintln!("error: writing {path}: {err}");
+            return ExitCode::FAILURE;
+        }
+        println!();
+        println!("csv: {path}");
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -45,6 +45,11 @@ pub mod metal_capture;
 pub mod metal_kernel;
 mod nax;
 mod sys;
+/// Parser for `xcrun xctrace export` XML — the headless route to GPU wall-clock
+/// timing and the CPU→GPU gap. Debug-only, behind the same feature as
+/// `metal_capture`: it is profiling tooling, not part of the served binary.
+#[cfg(feature = "metal-capture")]
+pub mod xctrace;
 
 use std::cell::Cell;
 use std::ptr;

--- a/crates/rmlx-mlx/src/xctrace.rs
+++ b/crates/rmlx-mlx/src/xctrace.rs
@@ -132,6 +132,15 @@ pub enum XctraceError {
         available: String,
     },
 
+    /// A column that must carry a value was NULL.
+    #[error("row {row} column '{mnemonic}': <sentinel/> where a value is required")]
+    NullCell {
+        /// Zero-based row number.
+        row: usize,
+        /// Mnemonic of the offending column.
+        mnemonic: String,
+    },
+
     /// A cell that must hold an integer did not.
     #[error("row {row} column '{mnemonic}': {value:?} is not an integer")]
     NotAnInteger {
@@ -287,6 +296,13 @@ impl RowView<'_> {
     ///
     /// # Errors
     /// [`XctraceError::UnknownColumn`] when the schema has no such column.
+    ///
+    /// The `ColumnCountMismatch` arm is defence in depth and is not reachable
+    /// today: `finish_row` has already proven the row has exactly one cell per
+    /// declared column before a `RowView` can exist, so an index that
+    /// `column_index` returned is always in range. It is kept rather than
+    /// replaced with an unreachable-panic so that a future change to that
+    /// invariant surfaces as the parser's own named refusal.
     pub fn cell(&self, mnemonic: &str) -> Result<&Cell> {
         let idx = self.schema.column_index(mnemonic)?;
         self.cells
@@ -315,6 +331,24 @@ impl RowView<'_> {
                 mnemonic: mnemonic.to_owned(),
                 value: text.to_owned(),
             })
+    }
+
+    /// Integer value under `mnemonic`, refusing a NULL.
+    ///
+    /// For the load-bearing numeric columns, where a `<sentinel/>` read as `0`
+    /// is a measurement rather than an absence: a NULL `start` pins the
+    /// computed origin of a window to zero, which silently turns a
+    /// process-relative skip back into a trace-relative one and inflates the
+    /// reported span.
+    ///
+    /// # Errors
+    /// [`XctraceError::NullCell`] when the cell is NULL, plus everything
+    /// [`Self::u64`] can raise.
+    pub fn u64_required(&self, mnemonic: &str) -> Result<u64> {
+        self.u64(mnemonic)?.ok_or_else(|| XctraceError::NullCell {
+            row: self.row,
+            mnemonic: mnemonic.to_owned(),
+        })
     }
 
     /// Display form under `mnemonic`, or `None` when the cell is NULL.
@@ -355,30 +389,41 @@ impl<'a> Scanner<'a> {
         Self { src, pos: 0 }
     }
 
+    // Loops rather than recursing over skipped declarations, comments and CDATA:
+    // tail-call elimination is not a language guarantee, and a run of them in a
+    // 100 MB document would grow the stack linearly under an unoptimised build.
     fn next(&mut self) -> Result<Option<Event<'a>>> {
-        let rest = self.src.get(self.pos..).unwrap_or_default();
-        if rest.is_empty() {
-            return Ok(None);
-        }
-        if !rest.starts_with('<') {
-            // Text run up to the next tag.
-            let end = rest.find('<').unwrap_or(rest.len());
-            let text = rest.get(..end).unwrap_or_default();
-            self.pos += end;
-            return Ok(Some(Event::Text(text)));
-        }
-        // Declarations, comments and CDATA carry nothing this parser needs, but
-        // skipping them blindly would also skip a malformed tag, so each is
-        // matched by its own terminator and an unterminated one is an error.
-        for (open, close) in [("<?", "?>"), ("<!--", "-->"), ("<![CDATA[", "]]>")] {
-            if rest.starts_with(open) {
-                let Some(end) = rest.find(close) else {
-                    return malformed(self.pos, format!("unterminated {open}"));
-                };
-                self.pos += end + close.len();
-                return self.next();
+        let rest = loop {
+            let rest = self.src.get(self.pos..).unwrap_or_default();
+            if rest.is_empty() {
+                return Ok(None);
             }
-        }
+            if !rest.starts_with('<') {
+                // Text run up to the next tag.
+                let end = rest.find('<').unwrap_or(rest.len());
+                let text = rest.get(..end).unwrap_or_default();
+                self.pos += end;
+                return Ok(Some(Event::Text(text)));
+            }
+            // Declarations, comments and CDATA carry nothing this parser needs,
+            // but skipping them blindly would also skip a malformed tag, so each
+            // is matched by its own terminator and an unterminated one is an
+            // error.
+            let mut skipped = false;
+            for (open, close) in [("<?", "?>"), ("<!--", "-->"), ("<![CDATA[", "]]>")] {
+                if rest.starts_with(open) {
+                    let Some(end) = rest.find(close) else {
+                        return malformed(self.pos, format!("unterminated {open}"));
+                    };
+                    self.pos += end + close.len();
+                    skipped = true;
+                    break;
+                }
+            }
+            if !skipped {
+                break rest;
+            }
+        };
         let Some(close_idx) = rest.find('>') else {
             return malformed(self.pos, "unterminated tag");
         };
@@ -529,6 +574,19 @@ where
                 visit(&view)?;
                 row_index += 1;
             }
+            // A self-closing <row/> carries no cells at all. Skipping it would
+            // surface an export of them as NoRows ("the recording captured
+            // nothing") instead of as the layout change it is.
+            Event::Empty { name: "row", .. } => {
+                let Some(schema) = schema.as_ref() else {
+                    return Err(XctraceError::MissingSchema);
+                };
+                return Err(XctraceError::ColumnCountMismatch {
+                    row: row_index,
+                    expected: schema.columns.len(),
+                    actual: 0,
+                });
+            }
             Event::Open { .. } | Event::Empty { .. } | Event::Close { .. } | Event::Text(_) => {}
         }
     }
@@ -540,6 +598,28 @@ where
         });
     }
     Ok(schema)
+}
+
+/// Reads only the `<schema>` header, without visiting a single row.
+///
+/// Lets a caller reject the wrong table before choosing how to walk it, so a
+/// mis-aimed `--xpath` refuses the same way whatever options were passed.
+///
+/// # Errors
+/// [`XctraceError::MissingSchema`] when the document has no schema element,
+/// plus any scanning error.
+pub fn schema_of(xml: &str) -> Result<Schema> {
+    let mut scanner = Scanner::new(xml);
+    while let Some(event) = scanner.next()? {
+        if let Event::Open {
+            name: "schema",
+            attrs,
+        } = event
+        {
+            return parse_schema(&mut scanner, attrs);
+        }
+    }
+    Err(XctraceError::MissingSchema)
 }
 
 fn parse_schema(scanner: &mut Scanner<'_>, attrs: &str) -> Result<Schema> {
@@ -558,11 +638,24 @@ fn parse_schema(scanner: &mut Scanner<'_>, attrs: &str) -> Result<Schema> {
                     _ => None,
                 };
             }
-            Event::Text(text) => match current {
-                Some("mnemonic") => mnemonic = Some(unescape(text)),
-                Some("engineering-type") => engineering_type = Some(unescape(text)),
-                _ => {}
-            },
+            // Clearing on close is what makes this safe against a
+            // pretty-printed export: without it the state survives past
+            // </mnemonic>, and the indentation before the next element
+            // overwrites the mnemonic just read with whitespace. parse_row
+            // already guards the same way.
+            Event::Close {
+                name: "mnemonic" | "engineering-type",
+            } => current = None,
+            Event::Text(text) => {
+                let trimmed = text.trim();
+                if !trimmed.is_empty() {
+                    match current {
+                        Some("mnemonic") => mnemonic = Some(unescape(trimmed)),
+                        Some("engineering-type") => engineering_type = Some(unescape(trimmed)),
+                        _ => {}
+                    }
+                }
+            }
             Event::Close { name: "col" } => {
                 let index = columns.len();
                 columns.push(Column {

--- a/crates/rmlx-mlx/src/xctrace.rs
+++ b/crates/rmlx-mlx/src/xctrace.rs
@@ -1,0 +1,748 @@
+//! Parser for the XML that `xcrun xctrace export` writes.
+//!
+//! # Why this exists
+//!
+//! A `.gputrace` names the kernels a decode window ran but holds no timing, and
+//! its replay has the replay's schedule rather than the run's. The one headless
+//! source of real GPU wall-clock on this hardware is the *Metal System Trace*
+//! instrument, whose `metal-gpu-intervals` table carries, per GPU submission,
+//! `start` and `duration` in nanoseconds and — the signal nothing else
+//! exposes — `start-latency`, the gap between the CPU submitting work and the
+//! GPU starting it. `xctrace export` emits that table as XML and offers no
+//! other format, so reading it needs a parser.
+//!
+//! # The encoding, and why a naive reader gets plausible wrong numbers
+//!
+//! Rows are **positional**: the `<schema>` element declares N columns in order,
+//! and every `<row>` carries exactly N direct children, one per column, in that
+//! order. Three properties make a naive reader misalign silently rather than
+//! fail:
+//!
+//! * **`<sentinel/>` is NULL and still occupies a column slot.** Skipping it
+//!   shifts every later column left by one.
+//! * **Repeated values are `id`/`ref` back-references.** The first occurrence of
+//!   a value carries `id="N"`; later occurrences are `<tag ref="N"/>` with no
+//!   content of their own.
+//! * **`id`s are minted at every nesting depth, and a `ref` may point into
+//!   another column's subtree.** A `<process>` element first appears nested
+//!   inside a `<formatted-label>` cell and is then referenced by the `process`
+//!   column of the same row. Indexing only top-level elements leaves that
+//!   reference unresolvable.
+//!
+//! Each of those failures reads as a shifted-but-well-formed table — the number
+//! in the `duration` slot is a real number, just from the wrong column. So this
+//! parser refuses instead of guessing, on three independent invariants:
+//!
+//! 1. A row's direct-child count must equal the declared column count.
+//! 2. Each non-NULL cell's tag must equal its column's declared
+//!    `engineering-type`. This is what makes a one-column shift impossible to
+//!    miss: shifting almost always lands a tag against the wrong type.
+//! 3. Every `ref` must resolve to an `id` already seen.
+//!
+//! Columns are addressed by **mnemonic**, never by index, so a future reordering
+//! of the schema cannot silently change which number a caller reads.
+//!
+//! # Scope
+//!
+//! Deliberately not a general XML parser: it handles the subset `xctrace`
+//! emits (elements, attributes, text, the standard entities) and rejects
+//! anything else rather than guessing. Documents are read whole, so bound a
+//! recording with `--time-limit`; an 8-second trace exports tens of MB.
+
+use std::collections::HashMap;
+
+/// Reasons this parser refuses a document. Every variant names the position it
+/// gave up at, because "the layout moved" is only actionable with a location.
+#[derive(Debug, thiserror::Error)]
+#[allow(
+    clippy::exhaustive_enums,
+    reason = "callers match on these to tell a layout change from a bad filter; a hidden catch-all would defeat that"
+)]
+pub enum XctraceError {
+    /// The document is not the shape `xctrace export` writes.
+    #[error("malformed xml at byte {offset}: {reason}")]
+    MalformedXml {
+        /// Byte offset into the document where the scan gave up.
+        offset: usize,
+        /// What was expected there.
+        reason: String,
+    },
+
+    /// No `<schema>` element — usually an `--xpath` that matched nothing.
+    #[error("no <schema> element found; did the --xpath match a table?")]
+    MissingSchema,
+
+    /// A `<col>` lacked the parts needed to address it.
+    #[error("column {index} is missing its <{part}>")]
+    IncompleteColumn {
+        /// Zero-based column position in the schema.
+        index: usize,
+        /// The child element that was absent.
+        part: &'static str,
+    },
+
+    /// A row had a different number of cells than the schema declares.
+    #[error("row {row}: schema declares {expected} columns but the row has {actual} cells")]
+    ColumnCountMismatch {
+        /// Zero-based row number.
+        row: usize,
+        /// Column count from the `<schema>` element.
+        expected: usize,
+        /// Direct children counted in the row.
+        actual: usize,
+    },
+
+    /// A cell's element tag disagrees with the column's declared type.
+    #[error(
+        "row {row} column {column} ({mnemonic}): expected <{expected}> \
+         but found <{actual}> — the columns are misaligned"
+    )]
+    ColumnTypeMismatch {
+        /// Zero-based row number.
+        row: usize,
+        /// Zero-based column position.
+        column: usize,
+        /// Declared mnemonic of that column.
+        mnemonic: String,
+        /// `engineering-type` the schema declares.
+        expected: String,
+        /// Tag actually found.
+        actual: String,
+    },
+
+    /// A `ref` pointed at an `id` that has not been seen.
+    #[error("row {row} column {column}: ref=\"{id}\" does not resolve to any id")]
+    UnresolvedRef {
+        /// Zero-based row number.
+        row: usize,
+        /// Zero-based column position.
+        column: usize,
+        /// The unresolved id.
+        id: String,
+    },
+
+    /// A caller asked for a column this schema does not declare.
+    #[error("schema '{schema}' has no column '{mnemonic}' (have: {available})")]
+    UnknownColumn {
+        /// Name of the parsed schema.
+        schema: String,
+        /// Mnemonic that was requested.
+        mnemonic: String,
+        /// Comma-separated list of declared mnemonics.
+        available: String,
+    },
+
+    /// A cell that must hold an integer did not.
+    #[error("row {row} column '{mnemonic}': {value:?} is not an integer")]
+    NotAnInteger {
+        /// Zero-based row number.
+        row: usize,
+        /// Mnemonic of the offending column.
+        mnemonic: String,
+        /// The text that failed to parse.
+        value: String,
+    },
+
+    /// The table parsed but is the wrong one.
+    #[error("expected schema '{expected}' but the export holds '{actual}'")]
+    WrongSchema {
+        /// Schema the caller requires.
+        expected: String,
+        /// Schema the document declares.
+        actual: String,
+    },
+
+    /// A well-formed export with no rows. Never silently reported as an empty
+    /// result: it means the recording captured nothing, which is a failed run,
+    /// not a run with zero GPU work.
+    #[error("schema '{schema}' parsed but contains no rows")]
+    NoRows {
+        /// Name of the parsed schema.
+        schema: String,
+    },
+
+    /// The requested skip covers everything the matched process did.
+    #[error(
+        "skip of {skip_ms} ms covers the whole {span_ms} ms of GPU work recorded \
+         for this process — lower it, or record for longer"
+    )]
+    SkipExceedsSpan {
+        /// The skip that was asked for.
+        skip_ms: u64,
+        /// GPU-work span actually available, milliseconds.
+        span_ms: u64,
+    },
+}
+
+/// Convenience alias for this module's fallible operations.
+pub type Result<T> = std::result::Result<T, XctraceError>;
+
+/// One declared column of a table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "a mirror of the <col> element; it gains a field only if the export format does"
+)]
+pub struct Column {
+    /// Short machine name, e.g. `start-latency`. Callers address columns by this.
+    pub mnemonic: String,
+    /// Element tag every non-NULL cell in this column must carry.
+    pub engineering_type: String,
+}
+
+/// The `<schema>` header of an exported table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "a mirror of the <schema> element; it gains a field only if the export format does"
+)]
+pub struct Schema {
+    /// Schema name, e.g. `metal-gpu-intervals`.
+    pub name: String,
+    /// Declared columns, in row order.
+    pub columns: Vec<Column>,
+}
+
+impl Schema {
+    /// Zero-based position of `mnemonic`.
+    ///
+    /// # Errors
+    /// [`XctraceError::UnknownColumn`] when the schema does not declare it —
+    /// callers get a named failure rather than a silent `None` that reads as
+    /// "this row had no value".
+    pub fn column_index(&self, mnemonic: &str) -> Result<usize> {
+        self.columns
+            .iter()
+            .position(|c| c.mnemonic == mnemonic)
+            .ok_or_else(|| XctraceError::UnknownColumn {
+                schema: self.name.clone(),
+                mnemonic: mnemonic.to_owned(),
+                available: self
+                    .columns
+                    .iter()
+                    .map(|c| c.mnemonic.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            })
+    }
+}
+
+/// One cell. `Null` is the `<sentinel/>` that occupies a slot without a value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(
+    clippy::exhaustive_enums,
+    reason = "a cell is a value or a sentinel; the export format has no third case"
+)]
+pub enum Cell {
+    /// `<sentinel/>` — no value, but a column slot all the same.
+    Null,
+    /// A value, either inline or resolved through a `ref`.
+    Value {
+        /// Element tag; equals the column's `engineering-type`.
+        tag: String,
+        /// Text content. Raw units — nanoseconds for durations.
+        text: String,
+        /// The `fmt` attribute: the display form, and the only useful value for
+        /// composite cells such as `process`, whose text content is empty.
+        fmt: String,
+    },
+}
+
+impl Cell {
+    /// Text content, or `None` for a `<sentinel/>`.
+    #[must_use]
+    pub fn text(&self) -> Option<&str> {
+        match self {
+            Self::Null => None,
+            Self::Value { text, .. } => Some(text),
+        }
+    }
+
+    /// Display form, or `None` for a `<sentinel/>`.
+    #[must_use]
+    pub fn fmt(&self) -> Option<&str> {
+        match self {
+            Self::Null => None,
+            Self::Value { fmt, .. } => Some(fmt),
+        }
+    }
+}
+
+/// A row plus the schema needed to address it by name.
+#[derive(Debug)]
+pub struct RowView<'a> {
+    schema: &'a Schema,
+    cells: &'a [Cell],
+    row: usize,
+}
+
+impl RowView<'_> {
+    /// Zero-based row number within the table.
+    #[must_use]
+    pub fn row_number(&self) -> usize {
+        self.row
+    }
+
+    /// The cell under `mnemonic`.
+    ///
+    /// # Errors
+    /// [`XctraceError::UnknownColumn`] when the schema has no such column.
+    pub fn cell(&self, mnemonic: &str) -> Result<&Cell> {
+        let idx = self.schema.column_index(mnemonic)?;
+        self.cells
+            .get(idx)
+            .ok_or(XctraceError::ColumnCountMismatch {
+                row: self.row,
+                expected: self.schema.columns.len(),
+                actual: self.cells.len(),
+            })
+    }
+
+    /// Integer value under `mnemonic`, or `None` when the cell is NULL.
+    ///
+    /// # Errors
+    /// [`XctraceError::NotAnInteger`] when the cell holds something else. A
+    /// non-numeric duration is a layout change, not a zero.
+    pub fn u64(&self, mnemonic: &str) -> Result<Option<u64>> {
+        let Some(text) = self.cell(mnemonic)?.text() else {
+            return Ok(None);
+        };
+        text.trim()
+            .parse::<u64>()
+            .map(Some)
+            .map_err(|_| XctraceError::NotAnInteger {
+                row: self.row,
+                mnemonic: mnemonic.to_owned(),
+                value: text.to_owned(),
+            })
+    }
+
+    /// Display form under `mnemonic`, or `None` when the cell is NULL.
+    ///
+    /// # Errors
+    /// [`XctraceError::UnknownColumn`] when the schema has no such column.
+    pub fn fmt(&self, mnemonic: &str) -> Result<Option<&str>> {
+        Ok(self.cell(mnemonic)?.fmt())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// XML scanning
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, PartialEq, Eq)]
+enum Event<'a> {
+    Open { name: &'a str, attrs: &'a str },
+    Empty { name: &'a str, attrs: &'a str },
+    Close { name: &'a str },
+    Text(&'a str),
+}
+
+fn malformed<T>(offset: usize, reason: impl Into<String>) -> Result<T> {
+    Err(XctraceError::MalformedXml {
+        offset,
+        reason: reason.into(),
+    })
+}
+
+struct Scanner<'a> {
+    src: &'a str,
+    pos: usize,
+}
+
+impl<'a> Scanner<'a> {
+    fn new(src: &'a str) -> Self {
+        Self { src, pos: 0 }
+    }
+
+    fn next(&mut self) -> Result<Option<Event<'a>>> {
+        let rest = self.src.get(self.pos..).unwrap_or_default();
+        if rest.is_empty() {
+            return Ok(None);
+        }
+        if !rest.starts_with('<') {
+            // Text run up to the next tag.
+            let end = rest.find('<').unwrap_or(rest.len());
+            let text = rest.get(..end).unwrap_or_default();
+            self.pos += end;
+            return Ok(Some(Event::Text(text)));
+        }
+        // Declarations, comments and CDATA carry nothing this parser needs, but
+        // skipping them blindly would also skip a malformed tag, so each is
+        // matched by its own terminator and an unterminated one is an error.
+        for (open, close) in [("<?", "?>"), ("<!--", "-->"), ("<![CDATA[", "]]>")] {
+            if rest.starts_with(open) {
+                let Some(end) = rest.find(close) else {
+                    return malformed(self.pos, format!("unterminated {open}"));
+                };
+                self.pos += end + close.len();
+                return self.next();
+            }
+        }
+        let Some(close_idx) = rest.find('>') else {
+            return malformed(self.pos, "unterminated tag");
+        };
+        let inner = rest.get(1..close_idx).unwrap_or_default();
+        let tag_start = self.pos;
+        self.pos += close_idx + 1;
+
+        if let Some(name) = inner.strip_prefix('/') {
+            let name = name.trim();
+            if name.is_empty() {
+                return malformed(tag_start, "empty closing tag");
+            }
+            return Ok(Some(Event::Close { name }));
+        }
+        let (inner, empty) = match inner.strip_suffix('/') {
+            Some(stripped) => (stripped, true),
+            None => (inner, false),
+        };
+        let inner = inner.trim_end();
+        let split = inner
+            .find(|c: char| c.is_whitespace())
+            .unwrap_or(inner.len());
+        let name = inner.get(..split).unwrap_or_default();
+        if name.is_empty() {
+            return malformed(tag_start, "empty tag name");
+        }
+        let attrs = inner.get(split..).unwrap_or_default();
+        Ok(Some(if empty {
+            Event::Empty { name, attrs }
+        } else {
+            Event::Open { name, attrs }
+        }))
+    }
+}
+
+/// Reads `name="value"` pairs. Values are always double-quoted in `xctrace`
+/// output; a single-quoted or unquoted attribute is rejected rather than
+/// guessed at.
+fn attr(attrs: &str, want: &str) -> Option<String> {
+    let mut rest = attrs;
+    while let Some(eq) = rest.find('=') {
+        let (name_part, after) = rest.split_at(eq);
+        let name = name_part.trim();
+        let after = after.get(1..)?.trim_start();
+        let quoted = after.strip_prefix('"')?;
+        let end = quoted.find('"')?;
+        let value = quoted.get(..end)?;
+        if name == want {
+            return Some(unescape(value));
+        }
+        rest = quoted.get(end + 1..)?;
+    }
+    None
+}
+
+/// The five predefined XML entities. Encoder labels really do contain `&` —
+/// the driver coalesces encoders and names the row `EncA & EncB` — so leaving
+/// `&amp;` in place would corrupt the one field used to identify a submission.
+fn unescape(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_owned();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(idx) = rest.find('&') {
+        out.push_str(rest.get(..idx).unwrap_or_default());
+        let tail = rest.get(idx..).unwrap_or_default();
+        let mut matched = false;
+        for (entity, ch) in [
+            ("&amp;", '&'),
+            ("&lt;", '<'),
+            ("&gt;", '>'),
+            ("&quot;", '"'),
+            ("&apos;", '\''),
+        ] {
+            if tail.starts_with(entity) {
+                out.push(ch);
+                rest = tail.get(entity.len()..).unwrap_or_default();
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            // Numeric or unknown entity: keep it verbatim rather than dropping
+            // characters. Nothing in this export has produced one.
+            out.push('&');
+            rest = tail.get(1..).unwrap_or_default();
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// What an element contributes once seen: its tag, text and display form. Kept
+/// for every element carrying an `id`, at any depth, because a `ref` may point
+/// into another column's subtree.
+#[derive(Clone)]
+struct Interned {
+    tag: String,
+    text: String,
+    fmt: String,
+}
+
+/// An element currently open inside a row. `id` is carried so the interned copy
+/// can be completed in O(1) when the element closes and its text is known.
+struct Frame {
+    tag: String,
+    text: String,
+    fmt: String,
+    id: Option<String>,
+}
+
+/// Parses an exported table, calling `visit` once per row.
+///
+/// Streaming rather than collecting: a bounded recording still exports tens of
+/// MB, and callers aggregate as they go.
+///
+/// # Errors
+/// Any of [`XctraceError`]. The parser refuses a document it cannot align
+/// rather than returning partial or shifted rows.
+pub fn for_each_row<F>(xml: &str, mut visit: F) -> Result<Schema>
+where
+    F: FnMut(&RowView<'_>) -> Result<()>,
+{
+    let mut scanner = Scanner::new(xml);
+    let mut schema: Option<Schema> = None;
+    let mut ids: HashMap<String, Interned> = HashMap::new();
+    let mut row_index = 0usize;
+
+    while let Some(event) = scanner.next()? {
+        match event {
+            Event::Open {
+                name: "schema",
+                attrs,
+            } => {
+                schema = Some(parse_schema(&mut scanner, attrs)?);
+            }
+            Event::Open { name: "row", .. } => {
+                let Some(schema) = schema.as_ref() else {
+                    return Err(XctraceError::MissingSchema);
+                };
+                let cells = parse_row(&mut scanner, schema, &mut ids, row_index)?;
+                let view = RowView {
+                    schema,
+                    cells: &cells,
+                    row: row_index,
+                };
+                visit(&view)?;
+                row_index += 1;
+            }
+            Event::Open { .. } | Event::Empty { .. } | Event::Close { .. } | Event::Text(_) => {}
+        }
+    }
+
+    let schema = schema.ok_or(XctraceError::MissingSchema)?;
+    if row_index == 0 {
+        return Err(XctraceError::NoRows {
+            schema: schema.name,
+        });
+    }
+    Ok(schema)
+}
+
+fn parse_schema(scanner: &mut Scanner<'_>, attrs: &str) -> Result<Schema> {
+    let name = attr(attrs, "name").unwrap_or_default();
+    let mut columns: Vec<Column> = Vec::new();
+    let mut mnemonic: Option<String> = None;
+    let mut engineering_type: Option<String> = None;
+    let mut current: Option<&'static str> = None;
+
+    while let Some(event) = scanner.next()? {
+        match event {
+            Event::Open { name: tag, .. } => {
+                current = match tag {
+                    "mnemonic" => Some("mnemonic"),
+                    "engineering-type" => Some("engineering-type"),
+                    _ => None,
+                };
+            }
+            Event::Text(text) => match current {
+                Some("mnemonic") => mnemonic = Some(unescape(text)),
+                Some("engineering-type") => engineering_type = Some(unescape(text)),
+                _ => {}
+            },
+            Event::Close { name: "col" } => {
+                let index = columns.len();
+                columns.push(Column {
+                    mnemonic: mnemonic.take().ok_or(XctraceError::IncompleteColumn {
+                        index,
+                        part: "mnemonic",
+                    })?,
+                    engineering_type: engineering_type.take().ok_or(
+                        XctraceError::IncompleteColumn {
+                            index,
+                            part: "engineering-type",
+                        },
+                    )?,
+                });
+                current = None;
+            }
+            Event::Close { name: "schema" } => {
+                return Ok(Schema { name, columns });
+            }
+            Event::Empty { .. } | Event::Close { .. } => {}
+        }
+    }
+    Err(XctraceError::MissingSchema)
+}
+
+/// Consumes one `<row>`, returning exactly one cell per declared column.
+///
+/// Depth tracking is what keeps nested elements out of the column sequence
+/// while still interning their ids: only elements closing back to depth 0
+/// inside the row are cells.
+fn parse_row(
+    scanner: &mut Scanner<'_>,
+    schema: &Schema,
+    ids: &mut HashMap<String, Interned>,
+    row_index: usize,
+) -> Result<Vec<Cell>> {
+    let mut cells: Vec<Cell> = Vec::with_capacity(schema.columns.len());
+    // One frame per open element inside the row. A frame is a cell only when it
+    // closes back to an empty stack; everything deeper is nested detail whose
+    // ids still have to be interned.
+    let mut stack: Vec<Frame> = Vec::new();
+
+    while let Some(event) = scanner.next()? {
+        match event {
+            Event::Close { name } if name == "row" && stack.is_empty() => {
+                return finish_row(cells, schema, row_index);
+            }
+            Event::Open { name, attrs } => {
+                stack.push(Frame {
+                    tag: name.to_owned(),
+                    text: String::new(),
+                    fmt: attr(attrs, "fmt").unwrap_or_default(),
+                    id: attr(attrs, "id"),
+                });
+            }
+            Event::Close { name } => {
+                let Some(done) = stack.pop() else {
+                    return Err(XctraceError::MalformedXml {
+                        offset: scanner.pos,
+                        reason: format!("closing </{name}> with no matching open inside <row>"),
+                    });
+                };
+                if done.tag != name {
+                    return Err(XctraceError::MalformedXml {
+                        offset: scanner.pos,
+                        reason: format!("closing </{name}> does not match open <{}>", done.tag),
+                    });
+                }
+                // Interned at close, not at open: text is only known now, and a
+                // ref that resolved to a still-open element would silently read
+                // as empty. Close-time interning turns that into an
+                // UnresolvedRef instead.
+                if let Some(id) = done.id {
+                    ids.insert(
+                        id,
+                        Interned {
+                            tag: done.tag.clone(),
+                            text: done.text.clone(),
+                            fmt: done.fmt.clone(),
+                        },
+                    );
+                }
+                if stack.is_empty() {
+                    cells.push(Cell::Value {
+                        tag: done.tag,
+                        text: done.text,
+                        fmt: done.fmt,
+                    });
+                }
+            }
+            Event::Empty { name, attrs } => {
+                let cell = if name == "sentinel" {
+                    Cell::Null
+                } else if let Some(id) = attr(attrs, "ref") {
+                    let target =
+                        ids.get(&id)
+                            .cloned()
+                            .ok_or_else(|| XctraceError::UnresolvedRef {
+                                row: row_index,
+                                column: cells.len(),
+                                id: id.clone(),
+                            })?;
+                    Cell::Value {
+                        tag: target.tag,
+                        text: target.text,
+                        fmt: target.fmt,
+                    }
+                } else {
+                    let interned = Interned {
+                        tag: name.to_owned(),
+                        text: String::new(),
+                        fmt: attr(attrs, "fmt").unwrap_or_default(),
+                    };
+                    if let Some(id) = attr(attrs, "id") {
+                        ids.insert(id, interned.clone());
+                    }
+                    Cell::Value {
+                        tag: interned.tag,
+                        text: interned.text,
+                        fmt: interned.fmt,
+                    }
+                };
+                if stack.is_empty() {
+                    cells.push(cell);
+                }
+            }
+            Event::Text(text) => {
+                if let Some(top) = stack.last_mut() {
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() {
+                        top.text.push_str(&unescape(trimmed));
+                    }
+                }
+            }
+        }
+    }
+    Err(XctraceError::MalformedXml {
+        offset: scanner.pos,
+        reason: "document ended inside <row>".to_owned(),
+    })
+}
+
+/// The two alignment invariants. Checked together so a shifted row reports the
+/// column it went wrong at rather than just a count.
+fn finish_row(cells: Vec<Cell>, schema: &Schema, row_index: usize) -> Result<Vec<Cell>> {
+    if cells.len() != schema.columns.len() {
+        return Err(XctraceError::ColumnCountMismatch {
+            row: row_index,
+            expected: schema.columns.len(),
+            actual: cells.len(),
+        });
+    }
+    for (index, (cell, column)) in cells.iter().zip(schema.columns.iter()).enumerate() {
+        if let Cell::Value { tag, .. } = cell {
+            if tag != &column.engineering_type {
+                return Err(XctraceError::ColumnTypeMismatch {
+                    row: row_index,
+                    column: index,
+                    mnemonic: column.mnemonic.clone(),
+                    expected: column.engineering_type.clone(),
+                    actual: tag.clone(),
+                });
+            }
+        }
+    }
+    Ok(cells)
+}
+
+// The `metal-gpu-intervals` summary lives in a sibling file and is re-exported
+// here, so callers still see one `xctrace` module. The split is the natural
+// seam: everything above is table-generic and works for any exported schema,
+// everything below knows one table's column names.
+#[path = "xctrace_gpu_intervals.rs"]
+mod gpu_intervals;
+
+pub use gpu_intervals::{
+    summarise_gpu_intervals, summary_csv, ChannelStats, GpuIntervalSummary, SummaryFilter,
+    GPU_INTERVALS_SCHEMA,
+};
+
+#[cfg(test)]
+#[path = "xctrace_tests.rs"]
+mod xctrace_tests;

--- a/crates/rmlx-mlx/src/xctrace_gpu_intervals.rs
+++ b/crates/rmlx-mlx/src/xctrace_gpu_intervals.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::fmt::Write as _;
 
-use super::{for_each_row, Result, XctraceError};
+use super::{for_each_row, schema_of, Result, XctraceError};
 
 /// Schema this summary reads. Exported with
 /// `--xpath '/trace-toc/run[@number="1"]/data/table[@schema="metal-gpu-intervals"]'`.
@@ -132,6 +132,18 @@ pub struct SummaryFilter<'a> {
 /// empty summary is indistinguishable from a run that recorded nothing, and
 /// reporting zeros for it is how a profiling harness lies.
 pub fn summarise_gpu_intervals(xml: &str, filter: SummaryFilter<'_>) -> Result<GpuIntervalSummary> {
+    // Checked up front, from the header alone, so the wrong table refuses
+    // identically whatever the options say. Left inside the row walk it would
+    // be reached only after a full pass, and the `skip_ms > 0` branch — which
+    // reads columns this schema may not have — would refuse with
+    // `UnknownColumn` instead: same input, two different named failures.
+    let schema = schema_of(xml)?;
+    if schema.name != GPU_INTERVALS_SCHEMA {
+        return Err(XctraceError::WrongSchema {
+            expected: GPU_INTERVALS_SCHEMA.to_owned(),
+            actual: schema.name,
+        });
+    }
     if filter.skip_ms == 0 {
         return summarise_from(xml, filter.process, 0);
     }
@@ -146,9 +158,13 @@ pub fn summarise_gpu_intervals(xml: &str, filter: SummaryFilter<'_>) -> Result<G
                 return Ok(());
             }
         }
-        let start = row.u64("start")?.unwrap_or_default();
+        // Required, not defaulted: one NULL `start` would pin `earliest` to 0,
+        // and the origin below would collapse to a bare `skip_ms` — a
+        // trace-relative floor wearing a process-relative label, with the
+        // SkipExceedsSpan guard unable to fire.
+        let start = row.u64_required("start")?;
         earliest = earliest.min(start);
-        latest = latest.max(start.saturating_add(row.u64("duration")?.unwrap_or_default()));
+        latest = latest.max(start.saturating_add(row.u64_required("duration")?));
         Ok(())
     })?;
     if earliest == u64::MAX {
@@ -183,34 +199,40 @@ fn summarise_from(
 
     let schema = for_each_row(xml, |row| {
         summary.rows_total += 1;
-        let process = row.fmt("process")?.unwrap_or("<unattributed>").to_owned();
-        *processes.entry(process.clone()).or_default() += 1;
-        if let Some(want) = process_filter {
-            if !process.contains(want) {
-                return Ok(());
+        // Looked up by borrow and only allocated on first sight: the trip count
+        // here is rows in the export — hundreds of thousands — while the key
+        // sets are a handful of processes and three channels.
+        let process = row.fmt("process")?.unwrap_or("<unattributed>");
+        match processes.get_mut(process) {
+            Some(n) => *n += 1,
+            None => {
+                processes.insert(process.to_owned(), 1);
             }
         }
-        let start = row.u64("start")?.unwrap_or_default();
+        let keep = process_filter.is_none_or(|want| process.contains(want));
+        if !keep {
+            return Ok(());
+        }
+        // See the note in summarise_gpu_intervals: a NULL here is an absence,
+        // and read as 0 it would set first_start to 0 and inflate span_ns.
+        let start = row.u64_required("start")?;
         if start < start_floor_ns {
             return Ok(());
         }
         summary.rows_matched += 1;
 
-        let duration = row.u64("duration")?.unwrap_or_default();
+        let duration = row.u64_required("duration")?;
         first_start = first_start.min(start);
         summary.last_end_ns = summary.last_end_ns.max(start.saturating_add(duration));
 
-        let channel = row
-            .cell("channel-name")?
-            .text()
-            .unwrap_or("<none>")
-            .to_owned();
-        let stats = channels
-            .entry(channel.clone())
-            .or_insert_with(|| ChannelStats {
-                channel,
+        let channel = row.cell("channel-name")?.text().unwrap_or("<none>");
+        let stats = match channels.get_mut(channel) {
+            Some(stats) => stats,
+            None => channels.entry(channel.to_owned()).or_insert(ChannelStats {
+                channel: channel.to_owned(),
                 ..ChannelStats::default()
-            });
+            }),
+        };
         stats.submissions += 1;
         stats.busy_ns = stats.busy_ns.saturating_add(duration);
         stats.durations_ns.push(duration);
@@ -220,12 +242,6 @@ fn summarise_from(
         Ok(())
     })?;
 
-    if schema.name != GPU_INTERVALS_SCHEMA {
-        return Err(XctraceError::WrongSchema {
-            expected: GPU_INTERVALS_SCHEMA.to_owned(),
-            actual: schema.name,
-        });
-    }
     if summary.rows_matched == 0 {
         let mut what = schema.name;
         if let Some(f) = process_filter {
@@ -269,6 +285,16 @@ pub fn summary_csv(summary: &GpuIntervalSummary) -> String {
          latency_samples,latency_p50_ns,latency_p95_ns,latency_max_ns\n",
     );
     for c in &summary.channels {
+        // Empty, not 0, when nothing was measured: "no CPU->GPU gap" is the most
+        // interesting result this table can report, and a script that forgets to
+        // read latency_samples would otherwise record a fabricated best.
+        let lat = |p: u8| {
+            if c.latency_samples() == 0 {
+                String::new()
+            } else {
+                c.latency_pct(p).to_string()
+            }
+        };
         // Writing to a String cannot fail; the Result is discarded deliberately.
         let _ = writeln!(
             out,
@@ -279,9 +305,9 @@ pub fn summary_csv(summary: &GpuIntervalSummary) -> String {
             c.duration_pct(50),
             c.duration_pct(95),
             c.latency_samples(),
-            c.latency_pct(50),
-            c.latency_pct(95),
-            c.latency_pct(100),
+            lat(50),
+            lat(95),
+            lat(100),
         );
     }
     out

--- a/crates/rmlx-mlx/src/xctrace_gpu_intervals.rs
+++ b/crates/rmlx-mlx/src/xctrace_gpu_intervals.rs
@@ -1,0 +1,288 @@
+//! Summary of the `metal-gpu-intervals` table: per-GPU-submission wall-clock
+//! time and the CPU→GPU gap, aggregated per channel.
+//!
+//! Split from the parser in [`super`], which is table-generic; this half is the
+//! only part that knows column names. Re-exported through `xctrace`, so callers
+//! see a single module.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+
+use super::{for_each_row, Result, XctraceError};
+
+/// Schema this summary reads. Exported with
+/// `--xpath '/trace-toc/run[@number="1"]/data/table[@schema="metal-gpu-intervals"]'`.
+pub const GPU_INTERVALS_SCHEMA: &str = "metal-gpu-intervals";
+
+/// Per-channel aggregate of GPU submissions.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "a result record read field-by-field by reporting code"
+)]
+pub struct ChannelStats {
+    /// GPU channel: `Compute`, `Vertex`, `Fragment`.
+    pub channel: String,
+    /// Number of submissions on this channel.
+    pub submissions: u64,
+    /// Summed GPU-busy time, nanoseconds.
+    pub busy_ns: u64,
+    /// Sorted submission durations, nanoseconds.
+    durations_ns: Vec<u64>,
+    /// Sorted CPU→GPU gaps, nanoseconds. Shorter than `durations_ns` when some
+    /// rows carry a NULL `start-latency`.
+    latencies_ns: Vec<u64>,
+}
+
+impl ChannelStats {
+    /// Percentile of submission duration, nanoseconds. `p` in `0..=100`.
+    #[must_use]
+    pub fn duration_pct(&self, p: u8) -> u64 {
+        percentile(&self.durations_ns, p)
+    }
+
+    /// Percentile of CPU→GPU gap, nanoseconds. `p` in `0..=100`.
+    #[must_use]
+    pub fn latency_pct(&self, p: u8) -> u64 {
+        percentile(&self.latencies_ns, p)
+    }
+
+    /// How many rows carried a non-NULL `start-latency`.
+    #[must_use]
+    pub fn latency_samples(&self) -> usize {
+        self.latencies_ns.len()
+    }
+}
+
+fn percentile(sorted: &[u64], p: u8) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let last = sorted.len() - 1;
+    let idx = (usize::from(p.min(100)) * last).div_ceil(100);
+    sorted.get(idx).copied().unwrap_or_default()
+}
+
+/// Whole-table summary, optionally narrowed to one process.
+#[derive(Debug, Clone, Default)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "a result record read field-by-field by reporting code"
+)]
+pub struct GpuIntervalSummary {
+    /// Rows in the table, before any process filter.
+    pub rows_total: u64,
+    /// Rows kept by the process filter.
+    pub rows_matched: u64,
+    /// Per-channel aggregates, busiest first.
+    pub channels: Vec<ChannelStats>,
+    /// Process display names seen, with row counts, busiest first.
+    pub processes: Vec<(String, u64)>,
+    /// Earliest submission start, nanoseconds.
+    pub first_start_ns: u64,
+    /// Latest submission end, nanoseconds.
+    pub last_end_ns: u64,
+}
+
+impl GpuIntervalSummary {
+    /// Wall-clock span the matched submissions cover, nanoseconds.
+    #[must_use]
+    pub fn span_ns(&self) -> u64 {
+        self.last_end_ns.saturating_sub(self.first_start_ns)
+    }
+
+    /// Summed GPU-busy time across channels, nanoseconds. Channels run
+    /// concurrently, so this can exceed [`Self::span_ns`].
+    #[must_use]
+    pub fn busy_ns(&self) -> u64 {
+        self.channels.iter().map(|c| c.busy_ns).sum()
+    }
+}
+
+/// Which submissions a summary counts.
+#[derive(Debug, Clone, Copy, Default)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "a plain options struct built with literal syntax at every call site"
+)]
+pub struct SummaryFilter<'a> {
+    /// Keep only rows whose `process` display form contains this — `rmlx`
+    /// matches `rmlx (12345)`.
+    pub process: Option<&'a str>,
+    /// Drop submissions starting within this many milliseconds of the
+    /// **matched process's own** first submission.
+    ///
+    /// `xctrace --attach` does not work for this template, so a recording can
+    /// only start at process launch and its early GPU work is prefill. Reading
+    /// a decode-window CPU→GPU gap without excluding that mixes the two.
+    ///
+    /// Measured from the matched process rather than from the trace, because
+    /// weight load submits nothing to the GPU: its duration varies with page
+    /// cache and model size and is simply absent from this table. A
+    /// trace-relative skip would therefore have to be tuned per model and per
+    /// run, and overshooting it silently discards the decode window.
+    pub skip_ms: u64,
+}
+
+/// Parses a `metal-gpu-intervals` export and summarises it.
+///
+/// # Errors
+/// [`XctraceError::WrongSchema`] when the export is a different table, plus any
+/// parse error. A filter that matches no row is [`XctraceError::NoRows`]: an
+/// empty summary is indistinguishable from a run that recorded nothing, and
+/// reporting zeros for it is how a profiling harness lies.
+pub fn summarise_gpu_intervals(xml: &str, filter: SummaryFilter<'_>) -> Result<GpuIntervalSummary> {
+    if filter.skip_ms == 0 {
+        return summarise_from(xml, filter.process, 0);
+    }
+    // The origin is not known until the table has been read once. Rows are
+    // cheap to revisit; buffering them all is the memory this parser streams to
+    // avoid.
+    let mut earliest = u64::MAX;
+    let mut latest = 0u64;
+    for_each_row(xml, |row| {
+        if let Some(want) = filter.process {
+            if !row.fmt("process")?.unwrap_or_default().contains(want) {
+                return Ok(());
+            }
+        }
+        let start = row.u64("start")?.unwrap_or_default();
+        earliest = earliest.min(start);
+        latest = latest.max(start.saturating_add(row.u64("duration")?.unwrap_or_default()));
+        Ok(())
+    })?;
+    if earliest == u64::MAX {
+        return Err(XctraceError::NoRows {
+            schema: filter.process.map_or_else(
+                || GPU_INTERVALS_SCHEMA.to_owned(),
+                |f| format!("{GPU_INTERVALS_SCHEMA} filtered to process containing {f:?}"),
+            ),
+        });
+    }
+    let origin_ns = earliest.saturating_add(filter.skip_ms.saturating_mul(1_000_000));
+    if origin_ns >= latest {
+        // Naming the span it had to work with is the difference between a
+        // usable error and one that reads as "the run recorded nothing".
+        return Err(XctraceError::SkipExceedsSpan {
+            skip_ms: filter.skip_ms,
+            span_ms: latest.saturating_sub(earliest) / 1_000_000,
+        });
+    }
+    summarise_from(xml, filter.process, origin_ns)
+}
+
+fn summarise_from(
+    xml: &str,
+    process_filter: Option<&str>,
+    start_floor_ns: u64,
+) -> Result<GpuIntervalSummary> {
+    let mut summary = GpuIntervalSummary::default();
+    let mut channels: HashMap<String, ChannelStats> = HashMap::new();
+    let mut processes: HashMap<String, u64> = HashMap::new();
+    let mut first_start = u64::MAX;
+
+    let schema = for_each_row(xml, |row| {
+        summary.rows_total += 1;
+        let process = row.fmt("process")?.unwrap_or("<unattributed>").to_owned();
+        *processes.entry(process.clone()).or_default() += 1;
+        if let Some(want) = process_filter {
+            if !process.contains(want) {
+                return Ok(());
+            }
+        }
+        let start = row.u64("start")?.unwrap_or_default();
+        if start < start_floor_ns {
+            return Ok(());
+        }
+        summary.rows_matched += 1;
+
+        let duration = row.u64("duration")?.unwrap_or_default();
+        first_start = first_start.min(start);
+        summary.last_end_ns = summary.last_end_ns.max(start.saturating_add(duration));
+
+        let channel = row
+            .cell("channel-name")?
+            .text()
+            .unwrap_or("<none>")
+            .to_owned();
+        let stats = channels
+            .entry(channel.clone())
+            .or_insert_with(|| ChannelStats {
+                channel,
+                ..ChannelStats::default()
+            });
+        stats.submissions += 1;
+        stats.busy_ns = stats.busy_ns.saturating_add(duration);
+        stats.durations_ns.push(duration);
+        if let Some(latency) = row.u64("start-latency")? {
+            stats.latencies_ns.push(latency);
+        }
+        Ok(())
+    })?;
+
+    if schema.name != GPU_INTERVALS_SCHEMA {
+        return Err(XctraceError::WrongSchema {
+            expected: GPU_INTERVALS_SCHEMA.to_owned(),
+            actual: schema.name,
+        });
+    }
+    if summary.rows_matched == 0 {
+        let mut what = schema.name;
+        if let Some(f) = process_filter {
+            what = format!("{what} filtered to process containing {f:?}");
+        }
+        if start_floor_ns > 0 {
+            what = format!("{what} after the requested skip");
+        }
+        return Err(XctraceError::NoRows { schema: what });
+    }
+
+    summary.first_start_ns = if first_start == u64::MAX {
+        0
+    } else {
+        first_start
+    };
+    summary.channels = channels.into_values().collect();
+    for stats in &mut summary.channels {
+        stats.durations_ns.sort_unstable();
+        stats.latencies_ns.sort_unstable();
+    }
+    summary.channels.sort_by(|a, b| {
+        b.busy_ns
+            .cmp(&a.busy_ns)
+            .then_with(|| a.channel.cmp(&b.channel))
+    });
+    summary.processes = processes.into_iter().collect();
+    summary
+        .processes
+        .sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    Ok(summary)
+}
+
+/// Renders a summary as CSV — the form a regression script asserts on.
+///
+/// One row per channel; nanoseconds throughout, so no unit parsing downstream.
+#[must_use]
+pub fn summary_csv(summary: &GpuIntervalSummary) -> String {
+    let mut out = String::from(
+        "channel,submissions,busy_ns,dur_p50_ns,dur_p95_ns,\
+         latency_samples,latency_p50_ns,latency_p95_ns,latency_max_ns\n",
+    );
+    for c in &summary.channels {
+        // Writing to a String cannot fail; the Result is discarded deliberately.
+        let _ = writeln!(
+            out,
+            "{},{},{},{},{},{},{},{},{}",
+            c.channel,
+            c.submissions,
+            c.busy_ns,
+            c.duration_pct(50),
+            c.duration_pct(95),
+            c.latency_samples(),
+            c.latency_pct(50),
+            c.latency_pct(95),
+            c.latency_pct(100),
+        );
+    }
+    out
+}

--- a/crates/rmlx-mlx/src/xctrace_tests.rs
+++ b/crates/rmlx-mlx/src/xctrace_tests.rs
@@ -249,13 +249,147 @@ fn asking_for_a_column_the_schema_lacks_is_an_error_not_a_none() {
 }
 
 #[test]
-fn a_different_table_is_refused_by_name() {
+fn a_different_table_is_refused_by_name_on_both_skip_branches() {
     let xml = doc(ROWS_HAPPY).replace("metal-gpu-intervals", "metal-driver-intervals");
-    let err = summarise_gpu_intervals(&xml, all()).expect_err("the wrong table must be refused");
+    // The skip branch reads columns another schema need not have, so before the
+    // check was hoisted out of the row walk the same input refused as
+    // WrongSchema with skip 0 and as UnknownColumn with skip 1.
+    for skip_ms in [0, 1] {
+        let err = summarise_gpu_intervals(
+            &xml,
+            SummaryFilter {
+                process: None,
+                skip_ms,
+            },
+        )
+        .expect_err("the wrong table must be refused");
+        assert!(
+            matches!(err, XctraceError::WrongSchema { ref actual, .. } if actual == "metal-driver-intervals"),
+            "skip_ms={skip_ms} got {err}"
+        );
+    }
+}
+
+#[test]
+fn a_null_start_is_refused_rather_than_read_as_zero() {
+    // The row is otherwise well formed and the count is right, so nothing but
+    // an explicit NULL check sees this. Read as 0 it pins the computed origin
+    // of a window to zero: the skip silently reverts to trace-relative, the
+    // SkipExceedsSpan guard cannot fire, and span_ns inflates.
+    let rows = "<row><sentinel/><duration fmt=\"b\">2</duration>\
+                <sentinel/><gpu-channel-name fmt=\"Compute\">Compute</gpu-channel-name>\
+                <process fmt=\"rmlx (1)\"></process></row>";
+    for skip_ms in [0, 1] {
+        let err = summarise_gpu_intervals(
+            &doc(rows),
+            SummaryFilter {
+                process: None,
+                skip_ms,
+            },
+        )
+        .expect_err("a NULL start must be refused");
+        assert!(
+            matches!(err, XctraceError::NullCell { ref mnemonic, .. } if mnemonic == "start"),
+            "skip_ms={skip_ms} got {err}"
+        );
+    }
+}
+
+#[test]
+fn a_null_duration_is_refused_rather_than_read_as_zero() {
+    let rows = "<row><start-time fmt=\"a\">1</start-time><sentinel/>\
+                <sentinel/><gpu-channel-name fmt=\"Compute\">Compute</gpu-channel-name>\
+                <process fmt=\"rmlx (1)\"></process></row>";
+    let err = summarise_gpu_intervals(&doc(rows), all()).expect_err("a NULL duration is refused");
     assert!(
-        matches!(err, XctraceError::WrongSchema { ref actual, .. } if actual == "metal-driver-intervals"),
+        matches!(err, XctraceError::NullCell { ref mnemonic, .. } if mnemonic == "duration"),
         "got {err}"
     );
+}
+
+#[test]
+fn a_self_closing_row_is_refused_not_skipped() {
+    // Skipping it reports an export of them as NoRows — "the recording captured
+    // nothing" — instead of as the layout change it is.
+    let err = collect(&doc("<row/>")).expect_err("an empty row element must be refused");
+    assert!(
+        matches!(
+            err,
+            XctraceError::ColumnCountMismatch {
+                expected: 5,
+                actual: 0,
+                ..
+            }
+        ),
+        "got {err}"
+    );
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture is a literal in this file; a parse failure here is the test failing"
+)]
+fn a_pretty_printed_schema_parses_identically() {
+    // A real pretty-printer indents INSIDE the leaf elements as well as between
+    // them, so the mnemonic's text node arrives as "\n        start\n      ".
+    // Untrimmed that becomes the column name and every lookup fails; the
+    // close-reset does not help, because the text belongs to the open element.
+    let pretty = SCHEMA
+        .replace("><col>", ">\n    <col>\n      ")
+        .replace("<mnemonic>", "<mnemonic>\n        ")
+        .replace("</mnemonic>", "\n      </mnemonic>\n      ")
+        .replace("<engineering-type>", "<engineering-type>\n        ")
+        .replace("</engineering-type>", "\n      </engineering-type>\n    ")
+        .replace("</col>", "</col>\n");
+    assert!(
+        pretty.contains("<mnemonic>\n        start"),
+        "fixture must indent inside the element"
+    );
+    let xml = format!(
+        "<?xml version=\"1.0\"?><trace-query-result><node xpath='x'>{pretty}{ROWS_HAPPY}</node></trace-query-result>"
+    );
+    let summary = summarise_gpu_intervals(&xml, only("rmlx")).unwrap();
+    let compact = summarise_gpu_intervals(&doc(ROWS_HAPPY), only("rmlx")).unwrap();
+    assert_eq!(summary.rows_matched, compact.rows_matched);
+    assert_eq!(summary.span_ns(), compact.span_ns());
+    assert_eq!(summary_csv(&summary), summary_csv(&compact));
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture is a literal in this file; a parse failure here is the test failing"
+)]
+fn text_after_a_closed_element_is_not_attributed_to_it() {
+    // The whitespace trim covers a pretty-printed export; this covers the other
+    // half of the same fix. Without clearing the state on </mnemonic>, the
+    // stray text below is read as the mnemonic and the column becomes
+    // unaddressable — the schema parses, and every later lookup fails.
+    let schema = SCHEMA.replacen("</mnemonic>", "</mnemonic>stray", 1);
+    let xml = format!(
+        "<?xml version=\"1.0\"?><trace-query-result><node xpath='x'>{schema}{ROWS_HAPPY}</node></trace-query-result>"
+    );
+    let summary = summarise_gpu_intervals(&xml, only("rmlx")).unwrap();
+    assert_eq!(summary.rows_matched, 2);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture is a literal in this file; a parse failure here is the test failing"
+)]
+fn a_channel_with_no_latency_sample_reports_empty_not_zero() {
+    // Every row's start-latency is a sentinel, so the truth is "not measured".
+    // A 0 here reads as a zero CPU->GPU gap, the most interesting possible
+    // result, to any script that does not also read latency_samples.
+    let rows = "<row><start-time fmt=\"a\">1000</start-time><duration fmt=\"b\">10</duration>\
+                <sentinel/><gpu-channel-name fmt=\"Compute\">Compute</gpu-channel-name>\
+                <process fmt=\"rmlx (1)\"></process></row>";
+    let summary = summarise_gpu_intervals(&doc(rows), all()).unwrap();
+    let csv = summary_csv(&summary);
+    let row = csv.lines().nth(1).unwrap();
+    assert_eq!(row, "Compute,1,10,10,10,0,,,", "got {row}");
 }
 
 #[test]

--- a/crates/rmlx-mlx/src/xctrace_tests.rs
+++ b/crates/rmlx-mlx/src/xctrace_tests.rs
@@ -1,0 +1,419 @@
+//! Tests for the `xctrace export` XML parser.
+//!
+//! The fixtures below are cut down from a real `metal-gpu-intervals` export so
+//! they carry the encoding's three traps — a `<sentinel/>` in a middle column,
+//! `id`/`ref` back-references, and an id minted inside a nested subtree that a
+//! later column refers to. Each guard has a paired fixture that must be
+//! REFUSED: a parser that accepts them produces plausible, shifted numbers, and
+//! that is the failure this module exists to make impossible.
+
+use super::{
+    for_each_row, summarise_gpu_intervals, summary_csv, Cell, SummaryFilter, XctraceError,
+    GPU_INTERVALS_SCHEMA,
+};
+
+/// Everything, unfiltered.
+fn all() -> SummaryFilter<'static> {
+    SummaryFilter::default()
+}
+
+/// Only submissions attributed to a process whose name contains `p`.
+fn only(p: &str) -> SummaryFilter<'_> {
+    SummaryFilter {
+        process: Some(p),
+        skip_ms: 0,
+    }
+}
+
+/// Four columns, enough to place a NULL in the middle and reference across.
+const SCHEMA: &str = "\
+<schema name=\"metal-gpu-intervals\">\
+<col><mnemonic>start</mnemonic><name>Creation</name><engineering-type>start-time</engineering-type></col>\
+<col><mnemonic>duration</mnemonic><name>Duration</name><engineering-type>duration</engineering-type></col>\
+<col><mnemonic>start-latency</mnemonic><name>CPU to GPU Latency</name><engineering-type>duration</engineering-type></col>\
+<col><mnemonic>channel-name</mnemonic><name>Channel Name</name><engineering-type>gpu-channel-name</engineering-type></col>\
+<col><mnemonic>process</mnemonic><name>Process</name><engineering-type>process</engineering-type></col>\
+</schema>";
+
+fn doc(rows: &str) -> String {
+    format!("<?xml version=\"1.0\"?><trace-query-result><node xpath='x'>{SCHEMA}{rows}</node></trace-query-result>")
+}
+
+/// Row 1 defines ids; row 2 reaches back to them and puts NULL in the middle.
+/// Row 2's `process` cell refers to an id first minted INSIDE row 1's
+/// `<process>` subtree, which is the case that breaks a top-level-only index.
+const ROWS_HAPPY: &str = "\
+<row>\
+<start-time id=\"1\" fmt=\"00:00.001\">1000</start-time>\
+<duration id=\"2\" fmt=\"10.00 µs\">10000</duration>\
+<duration id=\"3\" fmt=\"5.00 µs\">5000</duration>\
+<gpu-channel-name id=\"4\" fmt=\"Compute\">Compute</gpu-channel-name>\
+<process id=\"5\" fmt=\"rmlx (99)\"><pid id=\"6\" fmt=\"99\">99</pid></process>\
+</row>\
+<row>\
+<start-time id=\"7\" fmt=\"00:00.002\">2000</start-time>\
+<duration ref=\"2\"/>\
+<sentinel/>\
+<gpu-channel-name ref=\"4\"/>\
+<process ref=\"5\"/>\
+</row>";
+
+fn collect(xml: &str) -> Result<Vec<Vec<Cell>>, XctraceError> {
+    let mut out = Vec::new();
+    for_each_row(xml, |row| {
+        let mut cells = Vec::new();
+        for column in [
+            "start",
+            "duration",
+            "start-latency",
+            "channel-name",
+            "process",
+        ] {
+            cells.push(row.cell(column)?.clone());
+        }
+        out.push(cells);
+        Ok(())
+    })?;
+    Ok(out)
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture is a literal in this file; a parse failure here is the test failing"
+)]
+fn back_references_and_a_middle_sentinel_keep_every_column_in_place() {
+    let rows = collect(&doc(ROWS_HAPPY)).unwrap();
+    assert_eq!(rows.len(), 2);
+
+    // Row 2 is the interesting one: a ref, a NULL third column, and a ref into
+    // a nested subtree. The duration must be row 1's value, NOT shifted.
+    let row2 = rows.get(1).unwrap();
+    assert_eq!(row2.first().unwrap().text(), Some("2000"), "start");
+    assert_eq!(
+        row2.get(1).unwrap().text(),
+        Some("10000"),
+        "duration resolved through ref"
+    );
+    assert_eq!(
+        row2.get(2).unwrap(),
+        &Cell::Null,
+        "sentinel must stay NULL, not absorb the next column"
+    );
+    assert_eq!(
+        row2.get(3).unwrap().text(),
+        Some("Compute"),
+        "channel must not shift left into the sentinel slot"
+    );
+    assert_eq!(
+        row2.get(4).unwrap().fmt(),
+        Some("rmlx (99)"),
+        "ref into a nested subtree must resolve"
+    );
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture is a literal in this file; a parse failure here is the test failing"
+)]
+fn nested_ids_do_not_consume_column_slots() {
+    // Row 1's <process> holds a nested <pid> carrying its own id. If nesting
+    // were counted as a column the row would have 6 cells, not 5.
+    let rows = collect(&doc(ROWS_HAPPY)).unwrap();
+    assert_eq!(rows.first().unwrap().len(), 5);
+    assert_eq!(
+        rows.first().unwrap().get(4).unwrap().fmt(),
+        Some("rmlx (99)")
+    );
+}
+
+// --- the refusals -----------------------------------------------------------
+
+#[test]
+fn a_row_short_of_a_column_is_refused_not_padded() {
+    // The sentinel is simply gone — the exact mutation a "skip NULLs" parser
+    // performs on itself. Four cells against five columns.
+    let rows = "<row><start-time fmt=\"a\">1</start-time><duration fmt=\"b\">2</duration>\
+                <gpu-channel-name fmt=\"Compute\">Compute</gpu-channel-name>\
+                <process fmt=\"rmlx (1)\"></process></row>";
+    let err = collect(&doc(rows)).expect_err("a short row must be refused");
+    assert!(
+        matches!(
+            err,
+            XctraceError::ColumnCountMismatch {
+                expected: 5,
+                actual: 4,
+                ..
+            }
+        ),
+        "got {err}"
+    );
+}
+
+#[test]
+fn a_column_shifted_by_one_is_caught_by_its_type() {
+    // Five cells, so the count check passes — but the sentinel was dropped and
+    // an extra appended, sliding channel-name into the start-latency slot.
+    // Only the type invariant can see this, and it is the shape that yields
+    // believable wrong numbers.
+    let rows = "<row><start-time fmt=\"a\">1</start-time><duration fmt=\"b\">2</duration>\
+                <gpu-channel-name fmt=\"Compute\">Compute</gpu-channel-name>\
+                <process fmt=\"rmlx (1)\"></process>\
+                <duration fmt=\"c\">3</duration></row>";
+    let err = collect(&doc(rows)).expect_err("a shifted row must be refused");
+    assert!(
+        matches!(err, XctraceError::ColumnTypeMismatch { column: 2, .. }),
+        "got {err}"
+    );
+    // Asserted through Display, because the message is what an operator acts
+    // on: it has to name the column that moved and both types, or "the layout
+    // changed" is untriageable.
+    let msg = err.to_string();
+    assert!(msg.contains("column 2 (start-latency)"), "got {msg}");
+    assert!(
+        msg.contains("expected <duration> but found <gpu-channel-name>"),
+        "got {msg}"
+    );
+}
+
+#[test]
+fn an_unresolvable_ref_is_refused_not_read_as_empty() {
+    let rows = "<row><start-time fmt=\"a\">1</start-time><duration ref=\"404\"/>\
+                <sentinel/><gpu-channel-name fmt=\"Compute\">Compute</gpu-channel-name>\
+                <process fmt=\"rmlx (1)\"></process></row>";
+    let err = collect(&doc(rows)).expect_err("a dangling ref must be refused");
+    assert!(
+        matches!(err, XctraceError::UnresolvedRef { ref id, .. } if id == "404"),
+        "got {err}"
+    );
+}
+
+#[test]
+fn a_ref_to_a_still_open_element_is_refused() {
+    // Interning at close is what makes this loud: interning at open would hand
+    // back an element with no text yet and read as an empty duration.
+    let rows = "<row><start-time id=\"9\" fmt=\"a\">1</start-time>\
+                <duration fmt=\"b\">2</duration><sentinel/>\
+                <gpu-channel-name fmt=\"Compute\">Compute</gpu-channel-name>\
+                <process id=\"5\" fmt=\"rmlx (1)\"><pid ref=\"5\"/></process></row>";
+    let err = collect(&doc(rows)).expect_err("a self-referential ref must be refused");
+    assert!(
+        matches!(err, XctraceError::UnresolvedRef { ref id, .. } if id == "5"),
+        "got {err}"
+    );
+}
+
+#[test]
+fn an_export_with_no_schema_is_refused() {
+    let err = for_each_row("<trace-query-result></trace-query-result>", |_| Ok(()))
+        .expect_err("a schema-less document must be refused");
+    assert!(matches!(err, XctraceError::MissingSchema), "got {err}");
+}
+
+#[test]
+fn a_schema_with_no_rows_is_refused_rather_than_summarised_as_zero() {
+    let err = for_each_row(&doc(""), |_| Ok(())).expect_err("an empty table must be refused");
+    assert!(matches!(err, XctraceError::NoRows { .. }), "got {err}");
+}
+
+#[test]
+fn a_non_numeric_duration_is_refused_rather_than_defaulted_to_zero() {
+    let rows =
+        "<row><start-time fmt=\"a\">1</start-time><duration fmt=\"b\">not-a-number</duration>\
+                <sentinel/><gpu-channel-name fmt=\"Compute\">Compute</gpu-channel-name>\
+                <process fmt=\"rmlx (1)\"></process></row>";
+    let mut seen = None;
+    let err = for_each_row(&doc(rows), |row| {
+        seen = Some(row.u64("duration")?);
+        Ok(())
+    })
+    .expect_err("a non-numeric duration must be refused");
+    assert!(
+        matches!(err, XctraceError::NotAnInteger { ref mnemonic, .. } if mnemonic == "duration"),
+        "got {err}"
+    );
+}
+
+#[test]
+fn asking_for_a_column_the_schema_lacks_is_an_error_not_a_none() {
+    let err = for_each_row(&doc(ROWS_HAPPY), |row| {
+        row.cell("occupancy")?;
+        Ok(())
+    })
+    .expect_err("an unknown column must be refused");
+    assert!(
+        matches!(err, XctraceError::UnknownColumn { ref mnemonic, .. } if mnemonic == "occupancy"),
+        "got {err}"
+    );
+}
+
+#[test]
+fn a_different_table_is_refused_by_name() {
+    let xml = doc(ROWS_HAPPY).replace("metal-gpu-intervals", "metal-driver-intervals");
+    let err = summarise_gpu_intervals(&xml, all()).expect_err("the wrong table must be refused");
+    assert!(
+        matches!(err, XctraceError::WrongSchema { ref actual, .. } if actual == "metal-driver-intervals"),
+        "got {err}"
+    );
+}
+
+#[test]
+fn a_process_filter_matching_nothing_is_an_error_not_an_empty_summary() {
+    let err = summarise_gpu_intervals(&doc(ROWS_HAPPY), only("no-such-process"))
+        .expect_err("a filter that selects nothing must be refused");
+    assert!(matches!(err, XctraceError::NoRows { .. }), "got {err}");
+}
+
+// --- the summary ------------------------------------------------------------
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture is a literal in this file; a parse failure here is the test failing"
+)]
+fn the_summary_totals_the_rows_it_kept() {
+    let summary = summarise_gpu_intervals(&doc(ROWS_HAPPY), only("rmlx")).unwrap();
+    assert_eq!(summary.rows_total, 2);
+    assert_eq!(summary.rows_matched, 2);
+    assert_eq!(summary.channels.len(), 1);
+
+    let compute = summary.channels.first().unwrap();
+    assert_eq!(compute.channel, "Compute");
+    assert_eq!(compute.submissions, 2);
+    assert_eq!(compute.busy_ns, 20000, "10000 inline + 10000 through a ref");
+    // Only row 1 carries a start-latency; row 2's is a sentinel. Counting the
+    // NULL as a zero would halve the reported CPU->GPU gap.
+    assert_eq!(compute.latency_samples(), 1);
+    assert_eq!(compute.latency_pct(50), 5000);
+    // start 1000, last end 2000+10000.
+    assert_eq!(summary.span_ns(), 11000);
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture is a literal in this file; a parse failure here is the test failing"
+)]
+fn the_csv_is_nanoseconds_and_one_row_per_channel() {
+    let summary = summarise_gpu_intervals(&doc(ROWS_HAPPY), all()).unwrap();
+    let csv = summary_csv(&summary);
+    let mut lines = csv.lines();
+    assert_eq!(
+        lines.next().unwrap(),
+        "channel,submissions,busy_ns,dur_p50_ns,dur_p95_ns,\
+         latency_samples,latency_p50_ns,latency_p95_ns,latency_max_ns"
+    );
+    assert_eq!(
+        lines.next().unwrap(),
+        "Compute,2,20000,10000,10000,1,5000,5000,5000"
+    );
+    assert!(lines.next().is_none(), "one channel, one row");
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture is a literal in this file; a parse failure here is the test failing"
+)]
+fn ampersands_in_a_label_survive_unescaping() {
+    // The driver coalesces consecutive compute encoders and names the row
+    // "EncA & EncB", which the export escapes. Leaving it escaped corrupts the
+    // one field that identifies a submission.
+    let rows = "<row><start-time fmt=\"a\">1</start-time><duration fmt=\"b\">2</duration>\
+                <sentinel/><gpu-channel-name fmt=\"EncA &amp; EncB\">EncA &amp; EncB</gpu-channel-name>\
+                <process fmt=\"rmlx (1)\"></process></row>";
+    let rows = collect(&doc(rows)).unwrap();
+    assert_eq!(
+        rows.first().unwrap().get(3).unwrap().text(),
+        Some("EncA & EncB")
+    );
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture is a literal in this file; a parse failure here is the test failing"
+)]
+fn a_skip_covering_the_whole_span_is_refused_and_says_what_it_had() {
+    // Starts are 1000 ns and 2000 ns, so any whole-millisecond skip lands past
+    // both. Reported as its own error, not as "no rows": overshooting the skip
+    // and recording nothing are different problems with different fixes.
+    let err = summarise_gpu_intervals(
+        &doc(ROWS_HAPPY),
+        SummaryFilter {
+            process: None,
+            skip_ms: 1,
+        },
+    )
+    .expect_err("a skip past every submission must be refused, not summarised as zero");
+    assert!(
+        matches!(err, XctraceError::SkipExceedsSpan { skip_ms: 1, .. }),
+        "got {err}"
+    );
+
+    // A zero skip is the identity, and must not shift the origin.
+    let kept = summarise_gpu_intervals(
+        &doc(ROWS_HAPPY),
+        SummaryFilter {
+            process: None,
+            skip_ms: 0,
+        },
+    )
+    .unwrap();
+    assert_eq!(kept.rows_matched, 2);
+}
+
+/// Another process submits at t=0; the process of interest only starts at
+/// t=10 ms, as rmlx does — weight load submits nothing to the GPU, so the
+/// process's own first row is prefill, not launch.
+const ROWS_TWO_PROCESSES: &str = "\
+<row>\
+<start-time id=\"1\" fmt=\"a\">0</start-time>\
+<duration id=\"2\" fmt=\"b\">1000</duration>\
+<sentinel/>\
+<gpu-channel-name id=\"3\" fmt=\"Compute\">Compute</gpu-channel-name>\
+<process id=\"4\" fmt=\"WindowServer (1)\"></process>\
+</row>\
+<row>\
+<start-time id=\"5\" fmt=\"a\">10000000</start-time>\
+<duration ref=\"2\"/>\
+<sentinel/>\
+<gpu-channel-name ref=\"3\"/>\
+<process id=\"6\" fmt=\"rmlx (99)\"></process>\
+</row>\
+<row>\
+<start-time id=\"7\" fmt=\"a\">20000000</start-time>\
+<duration ref=\"2\"/>\
+<sentinel/>\
+<gpu-channel-name ref=\"3\"/>\
+<process ref=\"6\"/>\
+</row>";
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture is a literal in this file; a parse failure here is the test failing"
+)]
+fn skip_ms_counts_from_the_matched_process_not_from_the_trace() {
+    // rmlx's own first submission is at 10 ms, so a 5 ms skip starts at 15 ms
+    // and keeps only the 20 ms row. Measured from the TRACE's first submission
+    // (t=0, another process) the cutoff would be 5 ms and both rows would
+    // survive — which is how a skip sized for one model's load time silently
+    // fails to exclude prefill on another.
+    let summary = summarise_gpu_intervals(
+        &doc(ROWS_TWO_PROCESSES),
+        SummaryFilter {
+            process: Some("rmlx"),
+            skip_ms: 5,
+        },
+    )
+    .unwrap();
+    assert_eq!(summary.rows_total, 3);
+    assert_eq!(summary.rows_matched, 1, "only the submission after 15 ms");
+}
+
+#[test]
+fn the_schema_name_constant_matches_the_fixture() {
+    assert!(SCHEMA.contains(GPU_INTERVALS_SCHEMA));
+}

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -337,38 +337,72 @@ A replay has the replay's schedule, not the schedule of the run you captured.
 Host round-trips — the blocking `Array::eval()` per layer per step, a per-step
 prefix restage — will **not** show up in a `.gputrace`, no matter how it is
 replayed. A timeline instrument over the live process does show them, headlessly
-and with nanosecond resolution:
+and with nanosecond resolution. That path is built:
 
 ```sh
-xcrun xctrace record --template 'Metal System Trace' --no-prompt \
-  --output run.trace --time-limit 8s --launch -- \
-  ./target/release-debug/rmlx --metrics off baseline --model /path/to/snapshot ...
-
-xcrun xctrace export --input run.trace \
-  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="metal-gpu-intervals"]' \
-  --output gpu.xml
+make profile-mst MODEL=/path/to/snapshot SKIP_MS=500
+# or, spelled out:
+bash scripts/mst_capture.sh --model /path/to/snapshot --kv-quant none \
+  --prompt-tokens 4096 --max-tokens 600 --time-limit 18 --skip-ms 500
 ```
 
-That table gives per-GPU-submission `start` and `duration` in nanoseconds,
+It records the live process, exports the `metal-gpu-intervals` table, parses it
+and prints a per-channel table plus a CSV a script can assert on. See
+[Reading the timeline](#reading-the-timeline) for what the numbers mean.
+
+The table gives per-GPU-submission `start` and `duration` in nanoseconds,
 `gpu-channel-name`, `start-latency` (the CPU→GPU gap), and `cmdbuffer-id` /
 `encoder-id`, per process; `metal-application-encoders-list` and
 `metal-command-buffer-completed` join on those ids. Measured run-to-run spread:
-0.06%. Three things to know before using it:
+0.06%. Four things to know before using it:
 
 - **`--attach <pid>` does not work** for this template — it reports "No
   configuration information received, will have to guess" and exports zero rows.
   Metal instrumentation has to be present at launch: use `--launch --` (or
-  `--all-processes`, which does pick up a running process).
+  `--all-processes`, which does pick up a running process). The harness uses
+  `--launch`, which is why a recording always starts at process launch.
+- **Weight load leaves no rows**; prefill does. Load is CPU and file I/O, so it
+  is simply absent from a GPU-interval table however long it took. `--skip-ms`
+  is therefore measured from *the matched process's own first submission*, not
+  from the start of the trace — that makes one value work across models
+  regardless of how long they take to load. Roughly
+  `prompt_tokens / prefill_tps` milliseconds covers prefill.
 - The export XML uses an **`id`/`ref` back-reference encoding** with positional
   columns and `<sentinel/>` for NULL. A naive parser silently misaligns columns,
   which reads as plausible-but-wrong numbers rather than an error.
-- **Volume**: an 8 s trace is a ~145 MB bundle and ~44 MB of XML for one table.
-  Bound it with `--time-limit`.
+  `rmlx_mlx::xctrace` refuses instead: it checks a row's cell count against the
+  schema, checks every cell's tag against the column's declared
+  `engineering-type`, and rejects an unresolvable `ref`.
+- **Volume**: a bundle runs ~300–400 MB and the one-table export ~110 MB for a
+  ~15 s recording. Bound it with `--time-limit`; `.rmlx/traces/mst` keeps the
+  newest `--keep` bundles (default 5) and prunes the rest, sidecar XML and CSV
+  included, after every successful run.
 
 Pipeline and function names do **not** survive the export (only encoder,
 command-buffer, buffer and queue labels), and the driver coalesces consecutive
 compute encoders into one GPU kick — so one row can cover several encoders. Pair
 it with the identity list from a capture when you need to know *which* kernel.
+
+#### Reading the timeline
+
+Measured decode-only windows, `--kv-quant none`, 4096-token prompt, 600 tokens:
+
+| Model | Compute subs | GPU busy / span | `start-latency` p50 | subs / token |
+|---|---|---|---|---|
+| gemma-4-e2b-it-mxfp8 | 26 027 | 4653 / 4705 ms (98.9%) | 4.25 ms | 45.8 |
+| Ternary-Bonsai-8B-mlx-2bit | 42 816 | 4274 / 4346 ms (98.4%) | 6.18 ms | 74.4 |
+
+Cross-check the window against a decode rate from an untraced run of the same
+cell before trusting it: e2b measured 120.8 decode TPS, so 600 tokens is 4.97 s
+against a 4.71 s window that starts 500 ms into GPU work (0.2% agreement);
+Bonsai measured 132.3 TPS, 4.53 s against a 4.35 s window (0.5%). A window that
+disagrees is not the window you think it is.
+
+**`start-latency` is queueing delay, not host stall, whenever the GPU is
+saturated.** At ~99% busy the gap measures how much work is already queued ahead
+of a submission — a 4 ms p50 against a 0.14 ms p50 duration means roughly 30
+submissions deep, not 4 ms of idle GPU waiting on the host. It is the *idle*
+case that indicts a host round-trip, so read it together with the busy fraction.
 
 ### Working with a bundle
 
@@ -429,9 +463,9 @@ bash scripts/traces_gc.sh --apply --max-age-days 7   # optional extra age rule
 
 ### Tests
 
-The window policy and the request validation are pure and unit-tested, but the
-tests are behind the same feature, so a plain `cargo test` does not compile
-them. Run them with:
+The window policy, the request validation and the `xctrace` export parser are
+pure and unit-tested, but the tests are behind the same feature, so a plain
+`cargo test` does not compile them. Run them with:
 
 ```sh
 make test-capture
@@ -439,6 +473,13 @@ make test-capture
 
 `make ci` runs that target too — without it, an off-by-one in the window policy
 would pass the gate green, since `make test` compiles these tests out entirely.
+
+The parser's tests are mostly *refusals*, and deliberately so: each pairs a
+fixture carrying one of the export encoding's traps with a mutated twin that
+must be rejected — a dropped `<sentinel/>`, a one-column shift that keeps the
+cell count intact, a dangling `ref`, a `ref` into a still-open element, a
+non-numeric duration, the wrong table, and a filter that selects nothing. Every
+one of those, accepted, yields a well-formed table of wrong numbers.
 
 ## 6. Ad-hoc cardinality counting with the `counts` crate
 
@@ -551,7 +592,8 @@ Notes:
 | Native Apple profiler | `make profile-instruments MODEL=...` |
 | Flamegraph (needs sudo) | `sudo cargo flamegraph --bin rmlx -- baseline ...` |
 | Heap profile | `cargo build --features rmlx-cli/dhat-heap && ./target/debug/rmlx baseline ...` |
-| GPU capture | Deferred — see §5 above |
+| GPU kernel identity (which kernels ran) | `make profile-gputrace CODEC=... MODEL=...` — see §5 |
+| GPU timing + CPU→GPU gap | `make profile-mst MODEL=... SKIP_MS=500` — see §5 |
 | Ad-hoc branch counts | `eprintln!` + `counts` crate |
 | Process memory snapshot | `rmlx_core::mach_mem::read_proc_mem()` — see §9 |
 | Prefill-chunk override | `RMLX_PREFILL_CHUNK_<ARCH>=<n>` — see §10 |

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -340,10 +340,10 @@ replayed. A timeline instrument over the live process does show them, headlessly
 and with nanosecond resolution. That path is built:
 
 ```sh
-make profile-mst MODEL=/path/to/snapshot SKIP_MS=500
+make profile-mst MODEL=/path/to/snapshot
 # or, spelled out:
 bash scripts/mst_capture.sh --model /path/to/snapshot --kv-quant none \
-  --prompt-tokens 4096 --max-tokens 600 --time-limit 18 --skip-ms 500
+  --prompt-tokens 4096 --max-tokens 600 --time-limit 18
 ```
 
 It records the live process, exports the `metal-gpu-intervals` table, parses it
@@ -353,8 +353,8 @@ and prints a per-channel table plus a CSV a script can assert on. See
 The table gives per-GPU-submission `start` and `duration` in nanoseconds,
 `gpu-channel-name`, `start-latency` (the CPU→GPU gap), and `cmdbuffer-id` /
 `encoder-id`, per process; `metal-application-encoders-list` and
-`metal-command-buffer-completed` join on those ids. Measured run-to-run spread:
-0.06%. Four things to know before using it:
+`metal-command-buffer-completed` join on those ids. Five things to know before
+using it:
 
 - **`--attach <pid>` does not work** for this template — it reports "No
   configuration information received, will have to guess" and exports zero rows.
@@ -362,11 +362,24 @@ The table gives per-GPU-submission `start` and `duration` in nanoseconds,
   `--all-processes`, which does pick up a running process). The harness uses
   `--launch`, which is why a recording always starts at process launch.
 - **Weight load leaves no rows**; prefill does. Load is CPU and file I/O, so it
-  is simply absent from a GPU-interval table however long it took. `--skip-ms`
-  is therefore measured from *the matched process's own first submission*, not
-  from the start of the trace — that makes one value work across models
-  regardless of how long they take to load. Roughly
-  `prompt_tokens / prefill_tps` milliseconds covers prefill.
+  is simply absent from a GPU-interval table however long it took, and the
+  traced process's very first row is already prefill. Nothing in the table marks
+  where prefill ends, and no `--skip-ms` value discovers it — re-summarising one
+  export at several skips just slides the window, `span(S) == span(0) - S` to
+  under 0.3 ms. The boundary has to come from outside, so the harness reads the
+  run's **own** `decode_profile{prefill_ms}` back out of
+  `<RMLX_HOME>/logs/<run-id>.jsonl` and defaults `--skip-ms` to it. That event
+  is a plain `info!`, so it is present at the default log level even though
+  `xctrace --launch` swallowed the child's stdout. An explicit `--skip-ms` still
+  wins; when no such event is found the harness says so and summarises the full
+  window rather than pretending. `--skip-ms` counts from the matched process's
+  own first submission, not from the start of the trace.
+- **Tracing costs about 1–3% of decode throughput.** Alternating traced and
+  untraced runs of the same cell, comparing each run's own
+  `n_steps / step_total_ms`: gemma-4-e2b −2.8% (n=3 pairs, this machine under
+  load) and −0.9% (n=3, independently, quiet). That straddles CLAUDE.md's ±1%
+  regression band, which is why `--metrics off` is forced: a traced run's
+  throughput must never be recorded.
 - The export XML uses an **`id`/`ref` back-reference encoding** with positional
   columns and `<sentinel/>` for NULL. A naive parser silently misaligns columns,
   which reads as plausible-but-wrong numbers rather than an error.
@@ -376,7 +389,10 @@ The table gives per-GPU-submission `start` and `duration` in nanoseconds,
 - **Volume**: a bundle runs ~300–400 MB and the one-table export ~110 MB for a
   ~15 s recording. Bound it with `--time-limit`; `.rmlx/traces/mst` keeps the
   newest `--keep` bundles (default 5) and prunes the rest, sidecar XML and CSV
-  included, after every successful run.
+  included, on **every** exit — a run that refuses its arguments is exactly when
+  bundles pile up, so a bound that only applied on success would not be one.
+  `make traces-gc` does not cover this directory: it owns `.gputrace` bundles
+  only, and its reported total is scoped to those.
 
 Pipeline and function names do **not** survive the export (only encoder,
 command-buffer, buffer and queue labels), and the driver coalesces consecutive
@@ -385,24 +401,54 @@ it with the identity list from a capture when you need to know *which* kernel.
 
 #### Reading the timeline
 
-Measured decode-only windows, `--kv-quant none`, 4096-token prompt, 600 tokens:
+Measured with `--kv-quant none`, a 4096-token prompt and 600 decoded tokens.
+`--skip-ms` is the run's own reported `prefill_ms`, which is what the harness
+defaults to:
 
-| Model | Compute subs | GPU busy / span | `start-latency` p50 | subs / token |
+| Model | `prefill_ms` | skip used | Compute subs | Compute busy / span | `start-latency` p50 |
+|---|---|---|---|---|---|
+| gemma-4-e2b-it-mxfp8 | 257.5 | 257 ms | 27 055 | 4908 / 5055 ms (97.1%) | 4.18 ms |
+| Ternary-Bonsai-8B-mlx-2bit | 1372.7 | 1373 ms | 44 534 | 4504 / 4690 ms (96.0%) | 6.27 ms |
+
+Note how far apart the two prefills are: a single hand-picked skip cannot serve
+both. A 500 ms skip leaves roughly a fifth of Bonsai's window as prefill while
+overshooting e2b's by 240 ms.
+
+**Cross-check the window within the run, against the same run's log.** The
+predictor is exact enough to be a gate:
+
+| Model | full span | `prefill_ms + step_total_ms` | decode span | `step_total_ms` |
 |---|---|---|---|---|
-| gemma-4-e2b-it-mxfp8 | 26 027 | 4653 / 4705 ms (98.9%) | 4.25 ms | 45.8 |
-| Ternary-Bonsai-8B-mlx-2bit | 42 816 | 4274 / 4346 ms (98.4%) | 6.18 ms | 74.4 |
+| gemma-4-e2b | 5311.96 ms | 5319.9 ms (0.15%) | 5054.86 ms | 5062.4 ms (0.15%) |
+| Ternary-Bonsai-8B | 6063.09 ms | 6044.0 ms (0.32%) | 4689.73 ms | 4671.3 ms (0.39%) |
 
-Cross-check the window against a decode rate from an untraced run of the same
-cell before trusting it: e2b measured 120.8 decode TPS, so 600 tokens is 4.97 s
-against a 4.71 s window that starts 500 ms into GPU work (0.2% agreement);
-Bonsai measured 132.3 TPS, 4.53 s against a 4.35 s window (0.5%). A window that
-disagrees is not the window you think it is.
+Do **not** cross-check against a decode rate from a *separate* untraced run: the
+two runs differ by the observer effect above and by ordinary run-to-run spread,
+and the comparison also has to add the prefill term back. Both windows are
+printed by the harness for exactly this reason.
 
-**`start-latency` is queueing delay, not host stall, whenever the GPU is
-saturated.** At ~99% busy the gap measures how much work is already queued ahead
-of a submission — a 4 ms p50 against a 0.14 ms p50 duration means roughly 30
-submissions deep, not 4 ms of idle GPU waiting on the host. It is the *idle*
-case that indicts a host round-trip, so read it together with the busy fraction.
+Run-to-run spread of the span is **0.04%–0.33%** (n=4 per model): 0.04% on
+Bonsai, 0.33% on e2b. The 0.06% quoted for a toy compute workload is a floor,
+not a bound.
+
+**`start-latency` measures queueing in both regimes — it is not a host-stall
+signal.** It is the gap between a command buffer being *created* (committed) and
+starting on the GPU, so it can only ever see backlog. At 97% busy that is what
+it reports: a 4.18 ms p50 against a 0.14 ms p50 duration is roughly 30
+submissions deep on e2b, ~176 on Bonsai. But it does not rise when the host is
+the bottleneck — it falls, because the queue is empty. Measured on a
+deliberately host-bound cell (gemma-4-e2b `--kv-quant k_rotor3 --rotor-qjl on`,
+which forces the rotor K path onto the CPU and decodes at ~4 TPS):
+
+| cell | Compute busy / span | `dur` p50 | `start-latency` p50 |
+|---|---|---|---|
+| e2b `none` (saturated) | 4908 / 5055 ms (97.1%) | 0.144 ms | 4.18 ms |
+| e2b `k_rotor3` + QJL (host-bound) | 416 / 7196 ms (5.8%) | 0.158 ms | **2.42 ms** |
+
+**The host-stall signal is idle GPU time — `span - busy`**, which the harness
+prints as `idle:`. In the host-bound row above that is 6.78 s of a 7.20 s
+window; the run's own log agrees, at 249 ms per decode step. Read `idle` first,
+and read `start-latency` as queue depth.
 
 ### Working with a bundle
 
@@ -593,7 +639,7 @@ Notes:
 | Flamegraph (needs sudo) | `sudo cargo flamegraph --bin rmlx -- baseline ...` |
 | Heap profile | `cargo build --features rmlx-cli/dhat-heap && ./target/debug/rmlx baseline ...` |
 | GPU kernel identity (which kernels ran) | `make profile-gputrace CODEC=... MODEL=...` — see §5 |
-| GPU timing + CPU→GPU gap | `make profile-mst MODEL=... SKIP_MS=500` — see §5 |
+| GPU timing + CPU→GPU gap | `make profile-mst MODEL=...` — see §5 |
 | Ad-hoc branch counts | `eprintln!` + `counts` crate |
 | Process memory snapshot | `rmlx_core::mach_mem::read_proc_mem()` — see §9 |
 | Prefill-chunk override | `RMLX_PREFILL_CHUNK_<ARCH>=<n>` — see §10 |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -216,7 +216,7 @@ validation and **scans the output**, failing the run when a diagnostic appears:
 Invalid device store at offset 4000064, executing kernel function: "custom_kernel_rmlx_q8_quantize"
 ```
 
-Four things decide how this is wired, each of which would otherwise produce a
+Five things decide how this is wired, each of which would otherwise produce a
 gate that runs and can never fire:
 
 * **The exit code is not the signal.** With validation on, cargo *still* exits 0
@@ -234,9 +234,21 @@ gate that runs and can never fire:
   process's stderr while libtest is mid-line, so a report routinely appears
   appended to a `test some::name ... ` prefix. Matching `^Invalid` catches only
   about half of them.
-* **The validation banner is asserted.** If Metal never prints `Metal GPU
-  Validation Enabled`, the suite ran uninstrumented and its silence proves
-  nothing, so the runner refuses to report OK.
+* **The validation banner is asserted, per crate.** If Metal never prints `Metal
+  GPU Validation Enabled` for a crate, that crate ran uninstrumented and its
+  silence proves nothing. (A crate reported this way has usually failed to
+  *build*: no test binary means no Metal device and therefore no banner.)
+* **A positive control runs first.** The banner proves the instrumentation
+  loaded; it says nothing about whether the *detector* still matches what the
+  layer emits, and the detector is a hand-written pattern over an undocumented,
+  version-specific message. So the runner first executes a kernel that stores
+  out of bounds on purpose — `crates/rmlx-kv-quant/src/shader_validation_canary.rs`,
+  behind the `shader-validation-canary` feature so nothing else builds it — and
+  refuses to trust a clean scan unless that produced a diagnostic it matched.
+  The canary declines to dispatch unless validation is on, so the deliberate
+  out-of-bounds write is never a real one. It is excluded from the population
+  `make gpu-test` derives from the ignore-rule classifier, since it is the
+  gate's self-test rather than a correctness test.
 
 Buffer labels would make a hit even more direct, but MLX owns the Metal
 allocator and mlx-c exposes no labelling API, so KV stores appear as
@@ -245,8 +257,33 @@ instead, and rMLX does control that: `custom_kernel_rmlx_<codec>_<op>` names the
 codec and the operation exactly.
 
 Validation costs throughput, so it belongs on this target and **not** on any
-cell whose numbers get recorded. `VALIDATE=0` opts out; the cost on a
-flash-decode subset measured 1.08 s → 1.11 s of test time.
+cell whose numbers get recorded. `VALIDATE=0` opts out.
+
+**What it costs.** On the `rmlx-kv-quant` GPU suite: **133 s → 157 s, +18%**
+(alternating pairs; an independent run measured 131.2 s → 154.6 s, +17.8%, n=3).
+A cold first run inflates the uninstrumented baseline, so compare adjacent runs.
+On real inference it is far worse — Ternary-Bonsai-8B decode 126.6 → 21.7 TPS,
+a **5.8× slowdown** (n=3 each). That is the reason this never goes near a perf
+cell.
+
+**Never draw a conclusion about model *output* from a validated run.** The unit
+suites are invariant — 234 passed and the same 4 known-red failures in every
+repetition of both modes, with zero invalid-access reports — but real inference
+is not. Ternary-Bonsai-8B (Qwen3 dense) intermittently degenerates under
+validation: it emits a single token (id 0, `"!"`), reports `tps=0.064`, and
+exits 0 with no diagnostic on stderr and nothing in Unified Logging. Reproduced
+here 1 run in 3 at `--kv-quant k8v8` under `FAIL_MODE=allow`, and independently
+6 in 12 at `k8v8` and 2 in 4 at `none`, against 0 of 13 unvalidated runs.
+gemma-4-e2b is clean throughout, so it is architecture-specific on this host.
+
+`MTL_SHADER_VALIDATION_FAIL_MODE` was tried as a discriminator, on the theory
+that `zerofill` silently dropping a KV store would explain it. It does not:
+`allow` permits the write and is where the degeneration reproduced, while
+`zerofill` — the setting this gate uses — was clean 3 of 3. So this is **not**
+evidence of an out-of-bounds write in the Qwen3 path, and no invalid access is
+ever reported. Whether it is a latent engine defect that instrumentation
+perturbs into visibility or a defect in the instrumentation itself is unresolved
+and tracked outside this document.
 
 Current state: the whole `rmlx-kv-quant` GPU suite (238 classified tests) runs
 clean under validation — zero invalid accesses.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -166,6 +166,7 @@ while every gate reported green. `make gpu-test` is the step that runs them:
 make gpu-test                                   # every member crate
 make gpu-test CRATE=rmlx-kv-quant               # one crate
 make gpu-test CRATE=rmlx-kv-quant FILTER=rotor_flash
+make gpu-test VALIDATE=0                        # without shader validation
 ```
 
 It runs exactly the set `check_gpu_tests_ignored.sh --list` classifies — the
@@ -197,6 +198,58 @@ It is fail-closed in three ways:
 `make gpu-test` is not part of `make ci`: it needs the Metal context to itself
 and is too slow to block every commit. Run it before merging anything in the
 codec layer.
+
+### Metal shader validation (on by default here)
+
+Running the GPU tests is necessary but not sufficient, because the failure this
+layer is prone to **does not fail a test**. An out-of-bounds device store from a
+Metal kernel is dropped: the command buffer completes, `cb.error` is `nil`, the
+process exits 0, and the assertions downstream of the frozen buffer still pass.
+Measured on a deliberately broken `q8_quantize` kernel — both GPU tests over it
+reported `ok` and the runner printed `OK: 2 GPU tests passed`, with no output of
+any kind about the invalid write.
+
+`make gpu-test` therefore instruments every pipeline with Metal's shader
+validation and **scans the output**, failing the run when a diagnostic appears:
+
+```
+Invalid device store at offset 4000064, executing kernel function: "custom_kernel_rmlx_q8_quantize"
+```
+
+Four things decide how this is wired, each of which would otherwise produce a
+gate that runs and can never fire:
+
+* **The exit code is not the signal.** With validation on, cargo *still* exits 0
+  and the tests *still* report `ok`. Only the diagnostic text distinguishes the
+  broken tree from the clean one.
+* **`MTL_SHADER_VALIDATION=1` alone reports nothing to stderr.**
+  `MTL_SHADER_VALIDATION_REPORT_TO_STDERR` defaults to `0`, so reports go to
+  Unified Logging (`man MetalValidation`). `scripts/run_gpu_tests.sh` owns the
+  whole `MTL_SHADER_VALIDATION_*` environment rather than inheriting it —
+  `DEFAULT_STATE`, `DISABLE_PIPELINES`, `ENABLE_ERROR_REPORTING`,
+  `GLOBAL_MEMORY`, `THREADGROUP_MEMORY`, `FAIL_MODE`, `REPORT_TO_STDERR` are all
+  pinned — so no stale export in a dev shell can leave it looking armed while
+  blind.
+* **The diagnostic is not line-anchored.** The validation layer writes to the
+  process's stderr while libtest is mid-line, so a report routinely appears
+  appended to a `test some::name ... ` prefix. Matching `^Invalid` catches only
+  about half of them.
+* **The validation banner is asserted.** If Metal never prints `Metal GPU
+  Validation Enabled`, the suite ran uninstrumented and its silence proves
+  nothing, so the runner refuses to report OK.
+
+Buffer labels would make a hit even more direct, but MLX owns the Metal
+allocator and mlx-c exposes no labelling API, so KV stores appear as
+`buffer: <unnamed>`. The **kernel function name** carries the attribution
+instead, and rMLX does control that: `custom_kernel_rmlx_<codec>_<op>` names the
+codec and the operation exactly.
+
+Validation costs throughput, so it belongs on this target and **not** on any
+cell whose numbers get recorded. `VALIDATE=0` opts out; the cost on a
+flash-decode subset measured 1.08 s → 1.11 s of test time.
+
+Current state: the whole `rmlx-kv-quant` GPU suite (238 classified tests) runs
+clean under validation — zero invalid accesses.
 
 ### Known-red baseline
 

--- a/scripts/lib/prefill_ms.py
+++ b/scripts/lib/prefill_ms.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Read `decode_profile{prefill_ms}` back out of an rmlx run log.
+
+Nothing in a Metal System Trace marks where prefill ends: weight load submits no
+GPU work, so the traced process's very first row is already prefill. The run
+itself knows the boundary and emits it as a plain `info!` event, which lands in
+`<RMLX_HOME>/logs/<run-id>.jsonl` even when `xctrace --launch` has swallowed the
+child's stdout. `scripts/mst_capture.sh` uses this to default `--skip-ms` to a
+measured value rather than a guessed one.
+
+Prints the rounded integer milliseconds, or nothing at all when the log carries
+no such event — the caller treats empty as "could not measure" and says so,
+rather than silently summarising a window that still contains prefill.
+"""
+
+import json
+import sys
+
+
+def prefill_ms(path):
+    """Last `prefill_ms` in the log, or None.
+
+    The last one, not the first: a run may decode more than once (a warmup pass
+    ahead of the measured one), and the trace window covers all of them. Taking
+    the first would place the boundary before work the summary still counts.
+    """
+    found = None
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            # Cheap reject before the JSON parse: these logs run to megabytes
+            # and only a couple of lines carry the field.
+            if '"prefill_ms"' not in line:
+                continue
+            try:
+                record = json.loads(line)
+            except ValueError:
+                continue
+            fields = record.get("fields")
+            if isinstance(fields, dict) and "prefill_ms" in fields:
+                try:
+                    found = float(fields["prefill_ms"])
+                except (TypeError, ValueError):
+                    continue
+    return found
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: prefill_ms.py <run-log.jsonl>", file=sys.stderr)
+        return 2
+    value = prefill_ms(sys.argv[1])
+    if value is None:
+        return 0
+    print(int(round(value)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mst_capture.sh
+++ b/scripts/mst_capture.sh
@@ -55,7 +55,8 @@ KV_QUANT="none"
 PROMPT_TOKENS=4096
 MAX_TOKENS=400
 TIME_LIMIT=12
-SKIP_MS=0
+# Empty means "not supplied" — the run's own measured prefill is used instead.
+SKIP_MS=""
 BIN="target/release/rmlx"
 KEEP=5
 OUT_DIR=""
@@ -68,8 +69,10 @@ usage: mst_capture.sh --model <snapshot-abs-path>
          [--max-tokens N]         tokens to decode (default 400)
          [--time-limit S]         seconds to record (default 12)
          [--skip-ms N]            drop the first N ms of THIS PROCESS's GPU work
-                                  from the summary, i.e. prefill. Weight load
-                                  submits nothing and is absent already.
+                                  from the summary. DEFAULT: the prefill_ms this
+                                  very run reported, read back from its own log,
+                                  so the decode window needs no guessing. Weight
+                                  load submits nothing and is absent already.
          [--binary PATH]          rmlx to run (default target/release/rmlx)
          [--keep N]               .trace bundles to retain (default 5)
          [--out-dir DIR]          default <RMLX_HOME>/traces/mst
@@ -97,7 +100,73 @@ if [ -z "$MODEL" ]; then
 	exit 2
 fi
 
-cd "$(dirname "$0")/.." || exit 1
+# Unvalidated numbers reach xctrace and rmlx as nonsense that fails much later
+# and much less clearly — `--time-limit abc` becomes the literal `abcs`.
+require_uint() { # name value
+	case "$2" in
+	'' | *[!0-9]*)
+		echo "ERROR: $1 must be a non-negative integer, got '$2'" >&2
+		exit 2
+		;;
+	esac
+}
+require_uint --time-limit "$TIME_LIMIT"
+require_uint --max-tokens "$MAX_TOKENS"
+require_uint --keep "$KEEP"
+require_uint --prompt-tokens "$PROMPT_TOKENS"
+[ -n "$SKIP_MS" ] && require_uint --skip-ms "$SKIP_MS"
+
+# baseline resolves --prompt-tokens to a checked-in fixture, so an unlisted size
+# is rejected after the model has loaded. Catch it here instead.
+case "$PROMPT_TOKENS" in
+4096 | 8192 | 16384 | 32768 | 65536 | 131072) ;;
+*)
+	echo "ERROR: --prompt-tokens $PROMPT_TOKENS has no prompt fixture." >&2
+	echo "  Valid: 4096, 8192, 16384, 32768, 65536, 131072 (prompts/longctx_*.json)" >&2
+	exit 2
+	;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+RMLX_HOME_DIR="${RMLX_HOME:-$PWD/.rmlx}"
+[ -n "$OUT_DIR" ] || OUT_DIR="$RMLX_HOME_DIR/traces/mst"
+mkdir -p "$OUT_DIR" || exit 1
+
+# Retention runs on EVERY exit, not only the happy one. The failure paths below
+# — bad arguments, a run that produced no rows — are the common ones while
+# debugging, which is exactly when bundles pile up at ~300-400 MB each, and a
+# bound that only applies to successful runs is not a bound.
+#
+# The bundle just written is excluded BY NAME. Guarding by ordinal position
+# alone deletes it whenever KEEP is 0, which `make profile-mst KEEP=0` reaches:
+# GNU make treats the string "0" as true, so `$(if 0,...)` passes it straight
+# through. KEEP is validated as an integer above, so `[` cannot fall through to
+# the delete on a non-numeric value either.
+prune_traces() {
+	rc=$?
+	# The bundle just written occupies one of the KEEP slots — but only if this
+	# run got far enough to write one. Reserving it unconditionally would prune
+	# one bundle too many on every preflight failure.
+	limit="$KEEP"
+	if [ -n "${trace:-}" ] && [ -e "${trace:-}" ]; then
+		limit=$((KEEP > 0 ? KEEP - 1 : 0))
+	fi
+	kept=0
+	while IFS= read -r old; do
+		[ -n "$old" ] || continue
+		[ "$old" = "${trace:-}" ] && continue
+		kept=$((kept + 1))
+		[ "$kept" -le "$limit" ] && continue
+		old_base="${old%.trace}"
+		size=$(du -sh "$old" 2>/dev/null | cut -f1)
+		rm -rf "$old" "${old_base}.gpu-intervals.xml" "${old_base}.channels.csv"
+		echo "retention: removed $(basename "$old") (${size:-?}, beyond the newest $KEEP)"
+	done < <(ls -1dt "$OUT_DIR"/*.trace 2>/dev/null)
+	return "$rc"
+}
+trap prune_traces EXIT
 
 if [ ! -x "$BIN" ]; then
 	echo "ERROR: $BIN not found or not executable." >&2
@@ -126,9 +195,6 @@ if pgrep -f 'rmlx serve|mlx_lm|paroquant|omlx' >/dev/null 2>&1; then
 	exit 1
 fi
 
-RMLX_HOME_DIR="${RMLX_HOME:-$PWD/.rmlx}"
-[ -n "$OUT_DIR" ] || OUT_DIR="$RMLX_HOME_DIR/traces/mst"
-mkdir -p "$OUT_DIR" || exit 1
 
 stamp=$(date +%Y%m%d-%H%M%S)
 model_tag=$(basename "${MODEL%/}")
@@ -192,15 +258,55 @@ if [ $rc -ne 0 ] || [ ! -s "$xml" ]; then
 	exit 1
 fi
 
+# Nothing in the GPU-interval table marks where prefill ends — weight load
+# submits no work, so the process's first row is already prefill and the
+# boundary is invisible. The run itself knows: `decode_profile{prefill_ms}` is a
+# plain info! event, so it is in the run's own log at the default level even
+# though `xctrace --launch` swallowed the child's stdout.
+if [ -z "$SKIP_MS" ]; then
+	log_file=$(ls -1t "$RMLX_HOME_DIR"/logs/*.jsonl 2>/dev/null | head -1)
+	if [ -n "$log_file" ]; then
+		SKIP_MS=$(python3 "$REPO_ROOT/scripts/lib/prefill_ms.py" "$log_file")
+	fi
+	if [ -n "$SKIP_MS" ]; then
+		echo "skip:       ${SKIP_MS} ms — measured prefill_ms, read back from this run's log"
+	else
+		SKIP_MS=0
+		echo "WARNING: no decode_profile{prefill_ms} in ${log_file:-<no log>}; the" >&2
+		echo "  summary below INCLUDES prefill. Pass --skip-ms explicitly." >&2
+	fi
+fi
+
+# --release, not the dev default: a 100 MB-scale scan, run twice below, must not
+# make the harness the slowest step in the loop it measures.
+summarise() { # skip_ms [csv_path]
+	if [ -n "${2:-}" ]; then
+		cargo run -q --release -p rmlx-mlx --features metal-capture --example gpu_timeline -- \
+			--input "$xml" --process "$(basename "$BIN")" --skip-ms "$1" --csv "$2"
+	else
+		cargo run -q --release -p rmlx-mlx --features metal-capture --example gpu_timeline -- \
+			--input "$xml" --process "$(basename "$BIN")" --skip-ms "$1"
+	fi
+}
+
+# Both windows are printed. The full one is what the within-run cross-check
+# needs (its span should equal prefill_ms + step_total_ms from the same log);
+# the decode-only one is what kernel questions are asked of.
 echo ""
+echo "== full window (prefill included) =============================="
+summarise 0
+rc=$?
+if [ $rc -eq 0 ] && [ "$SKIP_MS" != "0" ]; then
+	echo ""
+	echo "== decode-only window (first ${SKIP_MS} ms skipped) ============"
+	summarise "$SKIP_MS" "$csv"
+	rc=$?
+elif [ $rc -eq 0 ]; then
+	summarise 0 "$csv" >/dev/null
+	rc=$?
+fi
 # The parser refuses a misaligned or empty table rather than printing zeros, so
 # its exit code is load-bearing here.
-cargo run -q -p rmlx-mlx --features metal-capture --example gpu_timeline -- \
-	--input "$xml" \
-	--process "$(basename "$BIN")" \
-	--skip-ms "$SKIP_MS" \
-	--csv "$csv"
-rc=$?
 if [ $rc -ne 0 ]; then
 	echo "ERROR: summarising $xml failed (exit $rc)" >&2
 	echo "  If it reports no rows for this process, the run itself failed and" >&2
@@ -209,26 +315,6 @@ if [ $rc -ne 0 ]; then
 	exit $rc
 fi
 
-# --- retention --------------------------------------------------------------
-# Enforced here rather than left as an advisory: a bundle is ~145 MB per 8 s and
-# an A/B session writes several, so by the time anyone runs a cleanup the disk
-# is already full and the run in flight has already failed. Oldest first, never
-# the bundle just written, every removal printed with what it reclaimed.
-echo ""
-kept=0
-removed=0
-while IFS= read -r old; do
-	[ -n "$old" ] || continue
-	kept=$((kept + 1))
-	[ "$kept" -le "$KEEP" ] && continue
-	old_base="${old%.trace}"
-	size=$(du -sh "$old" 2>/dev/null | cut -f1)
-	rm -rf "$old" "${old_base}.gpu-intervals.xml" "${old_base}.channels.csv"
-	echo "retention: removed $(basename "$old") (${size:-?}, beyond the newest $KEEP)"
-	removed=$((removed + 1))
-done < <(ls -1dt "$OUT_DIR"/*.trace 2>/dev/null)
-echo "retention: $((kept - removed)) bundle(s) kept in $OUT_DIR (cap $KEEP)"
-
 echo ""
 echo "bundle: $trace"
 echo "table:  $xml"
@@ -236,9 +322,3 @@ echo "csv:    $csv"
 echo ""
 echo "This table has no kernel names — pair it with a capture when you need to"
 echo "know WHICH kernel: bash scripts/gputrace_kernels.sh <bundle>.gputrace"
-if [ "$SKIP_MS" = "0" ]; then
-	echo ""
-	echo "The summary above still includes prefill. For a decode-only window, re-run"
-	echo "the summary with a skip past it (prefill is roughly prompt_tokens/prefill_tps):"
-	echo "  target/debug/examples/gpu_timeline --input '$xml' --process $(basename "$BIN") --skip-ms 500"
-fi

--- a/scripts/mst_capture.sh
+++ b/scripts/mst_capture.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Record a Metal System Trace of a live rmlx run, export the GPU-interval table
+# and summarise it.
+#
+# WHY THIS AND NOT A .gputrace
+#   A `.gputrace` names the kernels a decode window ran but carries no timing of
+#   any kind, and only Xcode's GUI Profile replay would add any — against the
+#   replay's schedule, not the run's. Host round-trips (a blocking per-layer
+#   Array::eval, a per-step restage) therefore cannot appear in one at all.
+#   Metal System Trace records the live process and does, headlessly, with
+#   nanosecond resolution. Its `metal-gpu-intervals` table gives per GPU
+#   submission `start`, `duration`, and `start-latency` — the CPU->GPU gap, the
+#   signal nothing else on this hardware exposes.
+#
+#   Use it WITH `scripts/gputrace_kernels.sh`, not instead: the export carries no
+#   pipeline or function names, so "which kernel" still comes from a capture.
+#
+# THREE TRAPS, ALL HANDLED HERE
+#   1. `--attach <pid>` does not work for this template. It reports "No
+#      configuration information received, will have to guess" and exports zero
+#      rows: the Metal instrumentation has to be present at launch. This script
+#      uses `--launch --`, which is also why the recording necessarily starts at
+#      process launch. Weight load submits no GPU work so it leaves no rows, but
+#      prefill does: --skip-ms drops the first N ms of THIS PROCESS's GPU work to
+#      leave a decode-only window.
+#   2. The export XML is positional with `id`/`ref` back-references and
+#      `<sentinel/>` for NULL, and a naive reader silently misaligns columns —
+#      producing plausible wrong numbers rather than an error. Parsing is done
+#      by rmlx_mlx::xctrace, which refuses a layout it cannot align.
+#   3. Volume. An 8 s trace is a ~145 MB bundle and tens of MB of XML for one
+#      table. --time-limit bounds the recording and the newest --keep bundles
+#      are retained; the rest are removed after a successful run.
+#
+# WHAT IT CANNOT GIVE — do not plan around these; they are device ceilings.
+#   No per-dispatch kernel timing (supportsCounterSampling(atDispatchBoundary)
+#   is false), no occupancy / limiter / bandwidth counters (one counter set,
+#   GPUTimestamp), and no pipeline or function names in the export. The driver
+#   also coalesces consecutive compute encoders into one GPU kick, so one row
+#   can cover several encoders.
+#
+# USAGE
+#   bash scripts/mst_capture.sh --model /path/to/snapshot
+#   bash scripts/mst_capture.sh --model ... --kv-quant k8v8 --time-limit 12 \
+#       --prompt-tokens 4096 --max-tokens 400 --skip-ms 4000
+#
+# Exit 0 = a bundle, an export and a summary. Anything else is an error; an
+# empty or unparseable table is never reported as a run with no GPU work.
+
+set -uo pipefail
+
+MODEL=""
+KV_QUANT="none"
+# baseline resolves this to a canonical prompt fixture (prompts/longctx_<n>.json),
+# so only the sizes shipped there are valid: 4096, 8192, 16384, 32768, 65536, 131072.
+PROMPT_TOKENS=4096
+MAX_TOKENS=400
+TIME_LIMIT=12
+SKIP_MS=0
+BIN="target/release/rmlx"
+KEEP=5
+OUT_DIR=""
+
+usage() {
+	cat <<'USAGE'
+usage: mst_capture.sh --model <snapshot-abs-path>
+         [--kv-quant <codec>]     KV codec (default none)
+         [--prompt-tokens N]      4096|8192|16384|32768|65536|131072 (default 4096)
+         [--max-tokens N]         tokens to decode (default 400)
+         [--time-limit S]         seconds to record (default 12)
+         [--skip-ms N]            drop the first N ms of THIS PROCESS's GPU work
+                                  from the summary, i.e. prefill. Weight load
+                                  submits nothing and is absent already.
+         [--binary PATH]          rmlx to run (default target/release/rmlx)
+         [--keep N]               .trace bundles to retain (default 5)
+         [--out-dir DIR]          default <RMLX_HOME>/traces/mst
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--model) MODEL="${2:?--model needs a value}"; shift 2 ;;
+	--kv-quant) KV_QUANT="${2:?--kv-quant needs a value}"; shift 2 ;;
+	--prompt-tokens) PROMPT_TOKENS="${2:?--prompt-tokens needs a value}"; shift 2 ;;
+	--max-tokens) MAX_TOKENS="${2:?--max-tokens needs a value}"; shift 2 ;;
+	--time-limit) TIME_LIMIT="${2:?--time-limit needs a value}"; shift 2 ;;
+	--skip-ms) SKIP_MS="${2:?--skip-ms needs a value}"; shift 2 ;;
+	--binary) BIN="${2:?--binary needs a value}"; shift 2 ;;
+	--keep) KEEP="${2:?--keep needs a value}"; shift 2 ;;
+	--out-dir) OUT_DIR="${2:?--out-dir needs a value}"; shift 2 ;;
+	-h | --help) usage; exit 0 ;;
+	*) echo "ERROR: unknown argument '$1'" >&2; usage >&2; exit 2 ;;
+	esac
+done
+
+if [ -z "$MODEL" ]; then
+	usage >&2
+	exit 2
+fi
+
+cd "$(dirname "$0")/.." || exit 1
+
+if [ ! -x "$BIN" ]; then
+	echo "ERROR: $BIN not found or not executable." >&2
+	echo "  Build it with: make build       # cargo build --workspace --release" >&2
+	exit 1
+fi
+if [ ! -d "$MODEL" ]; then
+	echo "ERROR: model snapshot not found: $MODEL" >&2
+	exit 1
+fi
+if ! command -v xctrace >/dev/null 2>&1 && ! xcrun -f xctrace >/dev/null 2>&1; then
+	echo "ERROR: xctrace not available. Select full Xcode:" >&2
+	echo "  sudo xcode-select -s /Applications/Xcode.app/Contents/Developer" >&2
+	exit 1
+fi
+
+# CLAUDE.md hard rule 8 — a single MLX process per Mac. A co-resident server
+# also submits to the GPU, and Metal System Trace records the whole system, so
+# its rows would land in this table under a different process and any timing
+# read here would be unattributable. Refuse rather than pkill: killing a process
+# this script does not own is not its call.
+if pgrep -f 'rmlx serve|mlx_lm|paroquant|omlx' >/dev/null 2>&1; then
+	echo "ERROR: another MLX process is live — this trace needs the GPU to itself." >&2
+	pgrep -fl 'rmlx serve|mlx_lm|paroquant|omlx' >&2 || true
+	echo "Stop it first: pkill -f 'rmlx serve'; pkill -f mlx_lm; rm -f /tmp/rmlx.*.claim" >&2
+	exit 1
+fi
+
+RMLX_HOME_DIR="${RMLX_HOME:-$PWD/.rmlx}"
+[ -n "$OUT_DIR" ] || OUT_DIR="$RMLX_HOME_DIR/traces/mst"
+mkdir -p "$OUT_DIR" || exit 1
+
+stamp=$(date +%Y%m%d-%H%M%S)
+model_tag=$(basename "${MODEL%/}")
+base="$OUT_DIR/${model_tag}-${KV_QUANT}-${PROMPT_TOKENS}tok-${stamp}"
+trace="${base}.trace"
+xml="${base}.gpu-intervals.xml"
+csv="${base}.channels.csv"
+
+# Room for the prompt plus the generation: baseline defaults --max-ctx to 4096
+# and would otherwise reject the prefill and report a zero decode rate.
+max_ctx=$((PROMPT_TOKENS + MAX_TOKENS + 512))
+
+run_cmd=("$BIN" --metrics off baseline
+	--model "$MODEL"
+	--kv-quant "$KV_QUANT"
+	--prompt-tokens "$PROMPT_TOKENS"
+	--max-tokens "$MAX_TOKENS"
+	--max-ctx "$max_ctx")
+
+echo "recording:  model=$model_tag codec=$KV_QUANT prompt=$PROMPT_TOKENS gen=$MAX_TOKENS limit=${TIME_LIMIT}s"
+echo "trace:      $trace"
+# xctrace --launch takes the child's stdout and stderr with it, so a run that
+# refuses its arguments fails invisibly and shows up only as a table with no
+# rows for this process. Print the command so it can be re-run by hand.
+echo "running:    ${run_cmd[*]}"
+
+# --launch, not --attach (trap 1). --metrics off because a traced run's numbers
+# are perturbed and must never reach runs.db.
+xcrun xctrace record \
+	--template 'Metal System Trace' \
+	--no-prompt \
+	--output "$trace" \
+	--time-limit "${TIME_LIMIT}s" \
+	--launch -- "${run_cmd[@]}"
+rc=$?
+# A bounded recording ends by killing the launched process, so xctrace reports
+# the child's termination as a non-zero exit on the ordinary, successful path.
+# The exit code therefore cannot be the gate; the bundle and the exported table
+# are. A run that genuinely failed leaves no rows for this process, and the
+# summariser refuses that rather than printing zeros.
+if [ $rc -ne 0 ]; then
+	echo "note: xctrace record exited $rc — expected when --time-limit ends a" >&2
+	echo "  still-running process. The export below is what decides." >&2
+fi
+if [ ! -e "$trace" ]; then
+	echo "ERROR: no bundle at $trace — the recording did not start." >&2
+	exit 1
+fi
+
+echo ""
+echo "exporting:  metal-gpu-intervals -> $xml"
+xcrun xctrace export \
+	--input "$trace" \
+	--xpath '/trace-toc/run[@number="1"]/data/table[@schema="metal-gpu-intervals"]' \
+	--output "$xml"
+rc=$?
+if [ $rc -ne 0 ] || [ ! -s "$xml" ]; then
+	echo "ERROR: export produced no table. The recording holds no GPU intervals," >&2
+	echo "  which is what --attach produces; this script uses --launch, so check" >&2
+	echo "  that the run actually reached the GPU before the time limit." >&2
+	exit 1
+fi
+
+echo ""
+# The parser refuses a misaligned or empty table rather than printing zeros, so
+# its exit code is load-bearing here.
+cargo run -q -p rmlx-mlx --features metal-capture --example gpu_timeline -- \
+	--input "$xml" \
+	--process "$(basename "$BIN")" \
+	--skip-ms "$SKIP_MS" \
+	--csv "$csv"
+rc=$?
+if [ $rc -ne 0 ]; then
+	echo "ERROR: summarising $xml failed (exit $rc)" >&2
+	echo "  If it reports no rows for this process, the run itself failed and" >&2
+	echo "  xctrace swallowed its output. Re-run it directly to see why:" >&2
+	echo "    ${run_cmd[*]}" >&2
+	exit $rc
+fi
+
+# --- retention --------------------------------------------------------------
+# Enforced here rather than left as an advisory: a bundle is ~145 MB per 8 s and
+# an A/B session writes several, so by the time anyone runs a cleanup the disk
+# is already full and the run in flight has already failed. Oldest first, never
+# the bundle just written, every removal printed with what it reclaimed.
+echo ""
+kept=0
+removed=0
+while IFS= read -r old; do
+	[ -n "$old" ] || continue
+	kept=$((kept + 1))
+	[ "$kept" -le "$KEEP" ] && continue
+	old_base="${old%.trace}"
+	size=$(du -sh "$old" 2>/dev/null | cut -f1)
+	rm -rf "$old" "${old_base}.gpu-intervals.xml" "${old_base}.channels.csv"
+	echo "retention: removed $(basename "$old") (${size:-?}, beyond the newest $KEEP)"
+	removed=$((removed + 1))
+done < <(ls -1dt "$OUT_DIR"/*.trace 2>/dev/null)
+echo "retention: $((kept - removed)) bundle(s) kept in $OUT_DIR (cap $KEEP)"
+
+echo ""
+echo "bundle: $trace"
+echo "table:  $xml"
+echo "csv:    $csv"
+echo ""
+echo "This table has no kernel names — pair it with a capture when you need to"
+echo "know WHICH kernel: bash scripts/gputrace_kernels.sh <bundle>.gputrace"
+if [ "$SKIP_MS" = "0" ]; then
+	echo ""
+	echo "The summary above still includes prefill. For a decode-only window, re-run"
+	echo "the summary with a skip past it (prefill is roughly prompt_tokens/prefill_tps):"
+	echo "  target/debug/examples/gpu_timeline --input '$xml' --process $(basename "$BIN") --skip-ms 500"
+fi

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -130,6 +130,12 @@ done
 # Logging where nothing here reads them. FAIL_MODE=zerofill keeps the run alive
 # after the first hit (invalid writes are dropped), so one run reports every
 # offending kernel instead of the first. See `man MetalValidation`.
+#
+# Naming these is not enough on its own: `env NAME=VALUE` overrides exactly what
+# it names and passes the rest of the environment through, so any other MTL_*
+# knob — a stale export, or one a future toolchain adds — still reaches the test
+# process. `mtl_unset` below clears the whole MTL_* namespace first, so the
+# pinned set is the entire Metal configuration the tests run under.
 mtl_validation_env=(
     MTL_SHADER_VALIDATION=1
     MTL_SHADER_VALIDATION_DEFAULT_STATE=all
@@ -140,6 +146,18 @@ mtl_validation_env=(
     MTL_SHADER_VALIDATION_FAIL_MODE=zerofill
     MTL_SHADER_VALIDATION_REPORT_TO_STDERR=1
 )
+# Every inherited MTL_* name, as `-u NAME` pairs for `env`. Built once, before
+# any crate runs. It is non-empty in practice only when the caller has such
+# exports, so it is expanded alongside a non-empty array and never alone — an
+# empty array expansion under `set -u` is an error on the bash 3.2 that
+# `/usr/bin/env bash` resolves to here.
+mtl_unset=()
+while IFS='=' read -r mtl_name _; do
+    case "${mtl_name}" in
+    MTL_*) mtl_unset+=(-u "${mtl_name}") ;;
+    esac
+done < <(env)
+
 # Printed by Metal at device creation once the layer is live. Its absence means
 # the run was uninstrumented no matter what the variables above say.
 VALIDATION_BANNER='Metal GPU Validation Enabled'
@@ -152,6 +170,13 @@ VALIDATION_BANNER='Metal GPU Validation Enabled'
 # to start a line. Requiring one of the two markers within a bounded distance
 # is what keeps a test's own "invalid" wording from forging a hit.
 VALIDATION_DIAGNOSTIC='Invalid .{0,120}(at offset [0-9]+|executing kernel function:)'
+
+# Same environment the crates run under, hoisted so the canary above can use it.
+# `${arr[@]+"${arr[@]}"}` is the portable spelling: mtl_unset is empty whenever
+# the caller exported no MTL_* names, and expanding an empty array is an
+# unbound-variable error under `set -u` on the bash 3.2 that `/usr/bin/env bash`
+# resolves to here — being adjacent to a non-empty array does not help.
+validation_prefix_canary=(env ${mtl_unset[@]+"${mtl_unset[@]}"} "${mtl_validation_env[@]}")
 
 # Every classified test starts with `if skip_if_no_gpu_env() { return; }`, so
 # this variable turns the entire suite into no-ops that still report as passed.
@@ -184,9 +209,16 @@ if [ -z "${listing}" ]; then
 fi
 
 # Apply the narrowing options, then group what is left by crate.
+# The canary is the gate's own positive control, not part of the correctness
+# suite: it is run separately, first, with its own feature enabled. Left in this
+# population the coverage check would demand it run in the ordinary pass, where
+# the feature is off and it is not compiled at all.
+CANARY_TEST="shader_validation_canary_emits_an_invalid_access_report"
+
 selected=""
 while IFS=$'\t' read -r crate fn_name; do
     [ -z "${crate}" ] && continue
+    [ "${fn_name}" = "${CANARY_TEST}" ] && continue
     if [ -n "${ONLY_CRATE}" ] && [ "${crate}" != "${ONLY_CRATE}" ]; then continue; fi
     case "${fn_name}" in
         *"${FILTER}"*) selected="${selected}${crate}"$'\t'"${fn_name}"$'\n' ;;
@@ -214,10 +246,32 @@ failed_crates=""
 total_passed=0
 total_failed=0
 validation_hits=""
-saw_validation_banner=0
 
 if [ "${SHADER_VALIDATION}" = "1" ]; then
     echo "shader validation: ON (invalid Metal memory access fails this run)"
+    # A positive control, run before anything is trusted to be clean. The
+    # banner proves the instrumentation LOADED; it says nothing about whether
+    # the detector below still matches what this toolchain emits, and
+    # VALIDATION_DIAGNOSTIC is a hand-written pattern over an undocumented,
+    # version-specific message. Without this, a wording change at the next Xcode
+    # bump turns the gate into one that runs, banners, and never fires.
+    #
+    # The canary kernel stores out of bounds on purpose and lives behind its own
+    # feature, so it is not built into any ordinary test run.
+    canary_log="$(mktemp -t rmlx-gpu-canary)"
+    "${validation_prefix_canary[@]}" cargo test --no-fail-fast -p rmlx-kv-quant \
+        --features shader-validation-canary --lib -- \
+        --ignored --test-threads=1 "${CANARY_TEST}" >"${canary_log}" 2>&1
+    if ! grep -Eq "${VALIDATION_DIAGNOSTIC}" "${canary_log}"; then
+        echo "ERROR: the out-of-bounds canary produced no diagnostic this scan would" >&2
+        echo "  match, so a clean scan proves nothing. Either the canary did not run" >&2
+        echo "  or this toolchain's report format changed." >&2
+        echo "  Pattern: ${VALIDATION_DIAGNOSTIC}" >&2
+        echo "  Log: ${canary_log}" >&2
+        exit 1
+    fi
+    rm -f "${canary_log}"
+    echo "shader validation: detector confirmed against a deliberate OOB store"
 else
     echo "shader validation: OFF (--no-shader-validation) — an out-of-bounds"
     echo "  device store will be dropped silently and this run will not see it."
@@ -270,7 +324,8 @@ for crate in "${crates[@]}"; do
     # unbound-variable error under `set -u` on the bash 3.2 that
     # `/usr/bin/env bash` resolves to here.
     validation_prefix=(env)
-    [ "${SHADER_VALIDATION}" = "1" ] && validation_prefix=(env "${mtl_validation_env[@]}")
+    [ "${SHADER_VALIDATION}" = "1" ] &&
+        validation_prefix=(env ${mtl_unset[@]+"${mtl_unset[@]}"} "${mtl_validation_env[@]}")
     "${validation_prefix[@]}" cargo test --no-fail-fast -p "${crate}" --tests -- \
         --ignored --test-threads=1 "${filters[@]}" 2>&1 | tee "${log}"
     rc=${PIPESTATUS[0]}
@@ -294,7 +349,12 @@ for crate in "${crates[@]}"; do
     ' "${log}" | sort -u)"
 
     if [ "${SHADER_VALIDATION}" = "1" ]; then
-        grep -qF "${VALIDATION_BANNER}" "${log}" && saw_validation_banner=1
+        # Per crate, matching the coverage check's granularity. A single global
+        # OR would let one crate's banner vouch for a crate whose tests all
+        # returned before creating a Metal device.
+        if ! grep -qF "${VALIDATION_BANNER}" "${log}"; then
+            failed_crates="${failed_crates}  ${crate}: ran uninstrumented (no validation banner)"$'\n'
+        fi
         # Report the kernel each hit names, deduped — a codec's kernel name is
         # the actionable identifier here. The buffer field is not: MLX owns the
         # allocator, so KV stores come through as `buffer: <unnamed>`.
@@ -328,7 +388,12 @@ for crate in "${crates[@]}"; do
     if [ "${rc}" -ne 0 ]; then
         failed_crates="${failed_crates}  ${crate}:"$'\n'
         if [ -n "${crate_fails}" ]; then
-            failed_crates="${failed_crates}$(printf '    %s\n' ${crate_fails})"$'\n'
+            # Read loop, not an unquoted expansion: splitting on newlines that
+            # way also glob-expands each test name against the cwd.
+            while IFS= read -r fail_name; do
+                [ -n "${fail_name}" ] &&
+                    failed_crates="${failed_crates}    ${fail_name}"$'\n'
+            done <<< "${crate_fails}"
         fi
     fi
 done
@@ -346,16 +411,6 @@ if [ "${SHADER_VALIDATION}" = "1" ] && [ -n "${validation_hits}" ]; then
     exit 1
 fi
 
-# The banner is Metal's own confirmation that the instrumentation loaded. Without
-# it the suite ran uninstrumented and its silence means nothing, so reporting OK
-# would be the exact hollow pass this gate exists to prevent.
-if [ "${SHADER_VALIDATION}" = "1" ] && [ "${saw_validation_banner}" -eq 0 ]; then
-    echo "ERROR: shader validation was requested but Metal never printed" >&2
-    echo "  '${VALIDATION_BANNER}' — the run was NOT instrumented." >&2
-    echo "Check 'man MetalValidation' after a toolchain bump; refusing to report OK." >&2
-    exit 1
-fi
-
 if [ -n "${failed_crates}" ]; then
     echo "ERROR: GPU tests failed in:" >&2
     printf '%s' "${failed_crates}" >&2
@@ -364,6 +419,8 @@ if [ -n "${failed_crates}" ]; then
     echo "  cargo test --no-fail-fast -p <crate> --tests -- --ignored --test-threads=1 <filter>" >&2
     echo "Known-red baseline (tracked separately): the four rotor fused-QK dispatch" >&2
     echo "tests in rmlx-kv-quant reporting 'dispatch delta = 0'. See docs/TESTING.md." >&2
+    echo "A crate reported as 'ran uninstrumented' usually failed to BUILD: no test" >&2
+    echo "binary means no Metal device and therefore no validation banner." >&2
     exit 1
 fi
 

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -48,13 +48,44 @@
 #   executed; that is the suite's own documented contract and is not a
 #   process-wide off switch.
 #
+# SHADER VALIDATION (--shader-validation, on by default)
+#   An out-of-bounds device store from a Metal kernel is silently dropped: the
+#   command buffer completes, `cb.error` is nil, the process exits 0, and the
+#   assertions downstream of the frozen buffer still pass. That is this repo's
+#   documented silent-corruption class, and no amount of `cargo test` sees it —
+#   measured on a deliberately broken q8 quantize kernel, both GPU tests over it
+#   passed with no output at all.
+#
+#   Metal's shader validation instruments every pipeline and reports the invalid
+#   access, naming the kernel function. Two details decide the implementation:
+#
+#     * The report never reaches the exit code. Even with validation on, cargo
+#       exits 0 and the tests report `ok`. The signal is a diagnostic in the
+#       output, so this gate SCANS for it; a gate that trusts the exit code
+#       passes while the diagnostic scrolls past.
+#     * MTL_SHADER_VALIDATION=1 alone is not enough. Reports go to Unified
+#       Logging unless MTL_SHADER_VALIDATION_REPORT_TO_STDERR is set — it
+#       defaults to 0 (`man MetalValidation`). Setting only the first variable
+#       yields a gate that runs, prints its banner, and can never fire.
+#
+#   So this script owns the whole MTL_SHADER_VALIDATION_* environment rather
+#   than inheriting it: every knob that can disable instrumentation or muzzle
+#   reporting is pinned explicitly, so no stale export in a dev shell can leave
+#   the gate looking armed while it is blind. It then asserts the validation
+#   banner actually appeared — if the layer did not load, the run proved nothing
+#   and reporting green would be a lie.
+#
+#   Validation costs throughput, so it belongs here and not in any cell whose
+#   numbers get recorded. Pass --no-shader-validation to opt out.
+#
 # USAGE
 #   bash scripts/run_gpu_tests.sh
 #   bash scripts/run_gpu_tests.sh --crate rmlx-kv-quant
 #   bash scripts/run_gpu_tests.sh --crate rmlx-kv-quant --filter rotor_flash
+#   bash scripts/run_gpu_tests.sh --no-shader-validation
 #
-# Exit 0 = every selected GPU test passed. Exit 1 = a failure, or a run that
-# executed nothing.
+# Exit 0 = every selected GPU test passed. Exit 1 = a failure, a shader
+# validation diagnostic, or a run that executed nothing.
 
 # No `-e`: cargo's exit code is captured explicitly via PIPESTATUS, and one
 # failing crate must not abort the remaining crates. The `[ ... ] && echo` guard
@@ -67,22 +98,60 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 usage() {
     cat <<'USAGE'
 Usage: run_gpu_tests.sh [--crate <name>] [--filter <substring>]
+                        [--shader-validation | --no-shader-validation]
 
-  --crate <name>       restrict to one workspace member (e.g. rmlx-kv-quant)
-  --filter <substring> restrict to GPU test fns whose name contains <substring>
+  --crate <name>          restrict to one workspace member (e.g. rmlx-kv-quant)
+  --filter <substring>    restrict to GPU test fns whose name contains <substring>
+  --shader-validation     instrument every Metal pipeline and fail on an invalid
+                          memory access (default)
+  --no-shader-validation  run the tests uninstrumented
 USAGE
 }
 
 ONLY_CRATE=""
 FILTER=""
+SHADER_VALIDATION=1
 while [ $# -gt 0 ]; do
     case "$1" in
         --crate)  ONLY_CRATE="${2:?--crate needs a value}"; shift 2 ;;
         --filter) FILTER="${2:?--filter needs a value}"; shift 2 ;;
+        --shader-validation)    SHADER_VALIDATION=1; shift ;;
+        --no-shader-validation) SHADER_VALIDATION=0; shift ;;
         -h|--help) usage; exit 0 ;;
         *) echo "ERROR: unknown argument '$1'" >&2; usage >&2; exit 1 ;;
     esac
 done
+
+# Pinned rather than inherited. Every one of these can silently disarm the
+# gate: DEFAULT_STATE=none skips instrumenting pipelines, DISABLE_PIPELINES
+# exempts named ones, GLOBAL_MEMORY=0 / THREADGROUP_MEMORY=0 drop the
+# instrumentation this gate is about, ENABLE_ERROR_REPORTING=0 detects and says
+# nothing, and REPORT_TO_STDERR defaults to 0 so reports land in Unified
+# Logging where nothing here reads them. FAIL_MODE=zerofill keeps the run alive
+# after the first hit (invalid writes are dropped), so one run reports every
+# offending kernel instead of the first. See `man MetalValidation`.
+mtl_validation_env=(
+    MTL_SHADER_VALIDATION=1
+    MTL_SHADER_VALIDATION_DEFAULT_STATE=all
+    MTL_SHADER_VALIDATION_DISABLE_PIPELINES=
+    MTL_SHADER_VALIDATION_ENABLE_ERROR_REPORTING=1
+    MTL_SHADER_VALIDATION_GLOBAL_MEMORY=1
+    MTL_SHADER_VALIDATION_THREADGROUP_MEMORY=1
+    MTL_SHADER_VALIDATION_FAIL_MODE=zerofill
+    MTL_SHADER_VALIDATION_REPORT_TO_STDERR=1
+)
+# Printed by Metal at device creation once the layer is live. Its absence means
+# the run was uninstrumented no matter what the variables above say.
+VALIDATION_BANNER='Metal GPU Validation Enabled'
+# Shape of every report seen from this layer, across device and threadgroup
+# memory, loads and stores:
+#   Invalid device store at offset 4000068, executing kernel function: "..."
+# Deliberately NOT anchored at line start: the layer writes to the process's
+# stderr while libtest is mid-line, so a report routinely lands appended to a
+# `test some::name ... ` prefix, and `^Invalid` sees only the ones that happen
+# to start a line. Requiring one of the two markers within a bounded distance
+# is what keeps a test's own "invalid" wording from forging a hit.
+VALIDATION_DIAGNOSTIC='Invalid .{0,120}(at offset [0-9]+|executing kernel function:)'
 
 # Every classified test starts with `if skip_if_no_gpu_env() { return; }`, so
 # this variable turns the entire suite into no-ops that still report as passed.
@@ -144,6 +213,15 @@ fi
 failed_crates=""
 total_passed=0
 total_failed=0
+validation_hits=""
+saw_validation_banner=0
+
+if [ "${SHADER_VALIDATION}" = "1" ]; then
+    echo "shader validation: ON (invalid Metal memory access fails this run)"
+else
+    echo "shader validation: OFF (--no-shader-validation) — an out-of-bounds"
+    echo "  device store will be dropped silently and this run will not see it."
+fi
 
 for crate in "${crates[@]}"; do
     # `classified` counts the classifier's LINES, not its unique names, because
@@ -185,7 +263,15 @@ for crate in "${crates[@]}"; do
     # after the first test binary that fails, so every later binary in the crate
     # silently never runs and the coverage shortfall reports as "a filter
     # stopped matching" when the real cause was an earlier failure.
-    cargo test --no-fail-fast -p "${crate}" --tests -- \
+    # `env` prefix, not `export`: the validation settings apply to the test
+    # process and nothing else, and the empty-valued DISABLE_PIPELINES entry
+    # overrides a stale export rather than merging with it. The prefix keeps a
+    # bare `env` when validation is off, because expanding an empty array is an
+    # unbound-variable error under `set -u` on the bash 3.2 that
+    # `/usr/bin/env bash` resolves to here.
+    validation_prefix=(env)
+    [ "${SHADER_VALIDATION}" = "1" ] && validation_prefix=(env "${mtl_validation_env[@]}")
+    "${validation_prefix[@]}" cargo test --no-fail-fast -p "${crate}" --tests -- \
         --ignored --test-threads=1 "${filters[@]}" 2>&1 | tee "${log}"
     rc=${PIPESTATUS[0]}
 
@@ -206,6 +292,22 @@ for crate in "${crates[@]}"; do
         /^test result:/ { f = 0 }
         f && /^    [A-Za-z_]/ { print $1 }
     ' "${log}" | sort -u)"
+
+    if [ "${SHADER_VALIDATION}" = "1" ]; then
+        grep -qF "${VALIDATION_BANNER}" "${log}" && saw_validation_banner=1
+        # Report the kernel each hit names, deduped — a codec's kernel name is
+        # the actionable identifier here. The buffer field is not: MLX owns the
+        # allocator, so KV stores come through as `buffer: <unnamed>`.
+        hits="$(grep -Eo "${VALIDATION_DIAGNOSTIC}[^\"]*\"[^\"]*\"" "${log}" \
+                | grep -Eo 'kernel function: "[^"]*"' | sort | uniq -c | sort -rn)"
+        n_hits="$(grep -Ec "${VALIDATION_DIAGNOSTIC}" "${log}")"
+        if [ "${n_hits}" -gt 0 ]; then
+            validation_hits="${validation_hits}  ${crate}: ${n_hits} invalid access(es)"$'\n'
+            if [ -n "${hits}" ]; then
+                validation_hits="${validation_hits}$(printf '%s\n' "${hits}" | sed 's/^/    /')"$'\n'
+            fi
+        fi
+    fi
     rm -f "${log}"
     crate_passed=${counts% *}
     crate_failed=${counts#* }
@@ -232,6 +334,28 @@ for crate in "${crates[@]}"; do
 done
 
 echo
+# An invalid access is a failure even though every test reported `ok` and cargo
+# exited 0 — that is the whole point: the store is dropped, the buffer freezes,
+# and the assertions downstream of it still pass.
+if [ "${SHADER_VALIDATION}" = "1" ] && [ -n "${validation_hits}" ]; then
+    echo "ERROR: Metal shader validation reported invalid memory access:" >&2
+    printf '%s' "${validation_hits}" >&2
+    echo >&2
+    echo "An out-of-bounds device store is DROPPED, not raised: the tests above" >&2
+    echo "still passed and cargo still exited 0. Treat this as corruption." >&2
+    exit 1
+fi
+
+# The banner is Metal's own confirmation that the instrumentation loaded. Without
+# it the suite ran uninstrumented and its silence means nothing, so reporting OK
+# would be the exact hollow pass this gate exists to prevent.
+if [ "${SHADER_VALIDATION}" = "1" ] && [ "${saw_validation_banner}" -eq 0 ]; then
+    echo "ERROR: shader validation was requested but Metal never printed" >&2
+    echo "  '${VALIDATION_BANNER}' — the run was NOT instrumented." >&2
+    echo "Check 'man MetalValidation' after a toolchain bump; refusing to report OK." >&2
+    exit 1
+fi
+
 if [ -n "${failed_crates}" ]; then
     echo "ERROR: GPU tests failed in:" >&2
     printf '%s' "${failed_crates}" >&2
@@ -243,4 +367,8 @@ if [ -n "${failed_crates}" ]; then
     exit 1
 fi
 
-echo "OK: ${total_passed} GPU tests passed across ${#crates[@]} workspace member(s)."
+if [ "${SHADER_VALIDATION}" = "1" ]; then
+    echo "OK: ${total_passed} GPU tests passed across ${#crates[@]} workspace member(s), shader validation clean."
+else
+    echo "OK: ${total_passed} GPU tests passed across ${#crates[@]} workspace member(s) (uninstrumented)."
+fi

--- a/scripts/traces_gc.sh
+++ b/scripts/traces_gc.sh
@@ -127,8 +127,6 @@ while IFS=$'\t' read -r _ path; do
 done <<<"$listing"
 
 n=${#bundles[@]}
-total_before=$(du -sk "$DIR" 2>/dev/null | awk '{print $1}')
-total_before=${total_before:-0}
 
 kb_of() { du -sk "$1" 2>/dev/null | awk '{print $1}'; }
 h_of() { du -sh "$1" 2>/dev/null | awk '{print $1}'; }
@@ -145,6 +143,12 @@ for i in $(seq 0 $((n - 1))); do
 	running_total=$((running_total + k))
 	reason[i]=""
 done
+# Scoped to the bundles this script can actually evict, NOT `du` over the whole
+# directory: `.rmlx/traces/mst/` holds Metal System Trace bundles, which have
+# their own retention in scripts/mst_capture.sh and are invisible to the glob
+# above. Counting them here would report a total against a cap that can never
+# act on it.
+total_before=$running_total
 
 max_total_kb=$((MAX_TOTAL_GB * 1024 * 1024))
 
@@ -210,8 +214,7 @@ gb() { echo $(($1 / 1024 / 1024)); }
 
 echo ""
 if [ "$APPLY" = "1" ]; then
-	total_after=$(du -sk "$DIR" 2>/dev/null | awk '{print $1}')
-	total_after=${total_after:-0}
+	total_after=$((total_before - reclaimed))
 	echo "$DIR: $(gb "$total_before")G -> $(gb "$total_after")G, $evicted pruned (reclaimed $(gb "$reclaimed")G); caps: $MAX_COUNT bundles / ${MAX_TOTAL_GB}G"
 else
 	if [ "$evicted" -eq 0 ]; then


### PR DESCRIPTION
Closes #330. Closes #328.

Two profiling gaps: no headless GPU timing path, and OOB device stores dropped
silently by the correctness gate.

## #328 — shader validation in the GPU gate

**The premise needed correcting.** The issue states the diagnostic appears on
stderr with `MTL_SHADER_VALIDATION=1`. It does not — `man MetalValidation` shows
`MTL_SHADER_VALIDATION_REPORT_TO_STDERR` defaults to `0` and reports go to Unified
Logging. Setting only the documented variable yields a gate that runs, prints its
banner, and can never fire. The runner now pins the whole `MTL_SHADER_VALIDATION_*`
set and sweeps every inherited `MTL_*` rather than overlaying eight names on the
caller's environment.

Proven on a real KV kernel, not asserted: `scales[group_id + 1000000u] = 1.0f`
injected into `q8_quantize.metal`.

```
BEFORE  --no-shader-validation  EXIT=0  "OK: 2 GPU tests passed (uninstrumented)"
AFTER   validation on           EXIT=1
        Invalid device store at offset 4000064, executing kernel function:
          "custom_kernel_rmlx_q8_quantize"
        test result: ok. 2 passed; 0 failed   <-- cargo still exits 0
```

Four mutation checks: broken kernel + validation ON → red; broken kernel +
validation OFF → green (so the diagnostic is the only detector); clean tree +
validation ON → green; validation silently inactive + real OOB → red, because the
banner guard refuses rather than reporting a false clean.

The issue's non-negotiable clause — *"a validation gate that has never been
observed failing is not known to work"* — is now enforced in-tree rather than by
anecdote. A `shader-validation-canary` feature carries a deliberately
out-of-bounds kernel that the runner executes **first**, asserting the detector
still matches this toolchain's message format before it will trust a clean scan.
Mutating the regex gives `ERROR: the out-of-bounds canary produced no diagnostic`.

Two real defects found in the detector itself: the diagnostic often lands
*mid-line*, appended to a `test name ... ` prefix, so `^Invalid` would have missed
half the hits; and an empty-array expansion under `set -u` broke bash 3.2.

**Re-scoped:** buffer labelling is not achievable. MLX owns the Metal allocator and
mlx-c exposes no labelling API, so KV stores report as `buffer: <unnamed>`. The
kernel function name carries the attribution instead and rMLX does control it —
`custom_kernel_rmlx_q8_quantize` names codec and op exactly, strictly better than
an offset.

## #330 — xctrace Metal System Trace path

`crates/rmlx-mlx/src/xctrace.rs` + `xctrace_gpu_intervals.rs`, behind the existing
`metal-capture` feature so it is absent from the shipped binary, still compiled and
tested by `make ci`. No new dependency. Coded against a real recording, not the
schema docs: the export is self-describing, and every non-NULL cell's tag equals
its column's `engineering-type` — the invariant that makes a silent column shift
detectable.

Four refusal invariants: cell count vs schema, cell tag vs declared type, every
`ref` resolves, and a required numeric cell is never NULL. Columns are addressed by
mnemonic, never index.

Mutation-checked on the real 25 MB export, not only on fixtures:

```
one <sentinel/> removed  -> row 0: schema declares 18 columns but the row has 17 cells
count-preserving shift   -> row 0 column 4 (start-latency): expected <duration>
                            but found <metal-nesting-level> — the columns are misaligned
dangling ref             -> row 1 column 2: ref="999999" does not resolve to any id
unmutated control        -> exit 0
```

The second is the dangerous one: a naive parser reads `metal-nesting-level` (0) as
`start-latency` and reports a 0 ns CPU→GPU gap — plausible and wrong.

Parser output was cross-checked against an independent implementation on the real
export: 26 322 rows, per-process counts, per-channel counts, and 26 260 non-NULL
`start-latency` all matched exactly.

**The window is no longer a free parameter.** `--skip-ms` was originally
trace-relative; weight load submits no GPU work and leaves no rows, so the correct
skip varies per model and overshooting silently discards the decode window. It is
now measured from the matched process's own first submission, and defaults to the
run's *measured* `prefill_ms` read from its own log rather than a fixed constant —
257 ms for gemma-4-e2b, 1373 ms for Ternary-Bonsai-8B. Both windows are printed.
A missing `decode_profile` event warns loudly instead of silently including
prefill.

Real-model proof on both required architectures, cross-checked against each traced
run's own clock (two independent clocks, same process):

| model | full span vs `prefill_ms + step_total_ms` | decode span vs `step_total_ms` |
|---|---|---|
| gemma-4-e2b (`kv_h == 1`, shared-KV) | 0.15% | 0.15% |
| Ternary-Bonsai-8B (`kv_h > 1`, dense) | 0.32% | 0.39% |

**Retention:** `.rmlx/traces/mst` keeps the newest `--keep` (default 5), prunes
oldest-first with sidecars, and never the bundle just written — enforced by name,
not by ordinal position, so a non-numeric `--keep` can no longer delete everything
including the fresh capture. Pruning runs from an `EXIT` trap, so the failure paths
(which is when bundles pile up) prune too.

## Corrections to claims this branch originally published

An independent measurement pass refuted several of the numbers in the first draft;
they are corrected in the docs rather than left standing.

- **The cross-check recipe did not reproduce.** As first written it compared the
  window against a decode rate from a *separate* untraced run, which absorbs the
  error `prefill − skip`; the printed figures implied 0.2% / 0.5% but recompute to
  5.2% / 4.0%. The predictor that holds is within-run: `span(S) = prefill_ms +
  decode_ms − S`. A reader following the old recipe would have rejected a good
  window.
- **`start-latency` measures queueing in *both* regimes.** The saturated caveat was
  right — at 98.6% busy, a 3.95 ms p50 against a 0.14 ms p50 duration cannot be
  idle GPU (that would cap the duty cycle at 3.5%). But the claim that the idle
  case indicts a host round-trip is wrong: in a deliberately host-bound cell (5.8%
  busy, 6.78 s idle of 7.20 s) `start-latency` *fell* to 2.42 ms. `span − busy` is
  the host-stall signal, and it is now printed as `idle:`. The "~30 submissions
  deep" gloss was also model-specific — Bonsai is ~176 deep.
- **Tracing costs 1–3% of decode throughput.** Not stated at all before. It
  straddles the repo's ±1% regression band, which is why `mst_capture.sh` forces
  `--metrics off`.
- **Validation overhead was understated 6×.** The published 1.08 s → 1.11 s was one
  2-test integration target, not the gate. Measured on the crate the gate exists
  for: 133 s → 157 s, **+18%** (n=3 each, alternating). On real inference it is far
  worse — 5.5× on decode, 11.6× on prefill.
- **Run-to-run spread** is 0.04%–0.33% on real decode windows, not the 0.06% from
  a toy workload.

## Known-good but not behaviour-neutral

Validation does **not** preserve model output on every architecture. Ternary-Bonsai-8B
degenerates to a single token id 0 in roughly half of validated generates —
silently, exit 0, no diagnostic. Filed as #346 with the ruling-out work; the
`FAIL_MODE` discriminator comes out inverted from what an out-of-bounds store
predicts, so it is *not* evidence of one. `docs/TESTING.md` now says never to draw a
conclusion about model output from a validated run. Token output is bit-identical
under validation everywhere it does not degenerate (verified by hashing `token_id`
trace events across three cells).

## Gates

`make ci` green. `cargo fmt --check` clean, `make lint` clean, `make test-capture`
45 tests, all hygiene gates OK, `make gpu-test` green with `detector confirmed
against a deliberate OOB store`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
