### PR TITLE
perf(ssd): microsecond LRU stamps with a durable clamp, and two wipe defects (#343)

### DIFF
--- a/crates/rmlx-kv-ssd/src/hydrate_tests.rs
+++ b/crates/rmlx-kv-ssd/src/hydrate_tests.rs
@@ -588,11 +588,11 @@ fn budget_enforcement_racing_hydrates_never_serves_a_foreign_block() {
     // keeps the namespace over the ceiling (so the budget pass always has work
     // and lookups keep missing), while the prompt blocks are not crowded down to
     // a survival rate that would let a slow box reach zero hits and skip the
-    // content check entirely. `last_used` is unix *seconds* (`unix_now`) and the
-    // race finishes well inside one, so every row ties and `ORDER BY last_used
-    // ASC` has no tiebreak — which block gets evicted is arbitrary, and headroom
-    // is what keeps `hits > 0` robust rather than lucky. Measured: ~31% hits,
-    // ~69% misses over 240 lookups.
+    // content check entirely. A hit does touch its block to the back of the
+    // eviction queue, but the writer records fresh filler continuously and every
+    // one of those lands ahead of it, so a prompt block survives only until
+    // enough newer filler arrives — the headroom is what keeps `hits > 0`
+    // robust rather than lucky. Measured: ~32-42% hits over 240 lookups.
     let budget = fx.block_bytes * (RACE_PROMPTS as u64 * 4);
 
     // Pre-race pass on quiet state: every prompt hits and its content is its

--- a/crates/rmlx-kv-ssd/src/lib.rs
+++ b/crates/rmlx-kv-ssd/src/lib.rs
@@ -4,7 +4,7 @@
 //! Owns the entire SSD KV story:
 //!
 //! - [`ssd_index`] — SQLite index of on-disk `.kvb` blocks (`SsdKvIndex`,
-//!   schema v2, LRU eviction, layout-key column).
+//!   schema v3, LRU eviction, layout-key column).
 //! - [`block_io`] — `KvBlockWriter` / `KvBlockReader` (safetensors record
 //!   format per `KvStorage` variant) — the authoritative dispatch for
 //!   Contract B (every codec adds one match arm here).

--- a/crates/rmlx-kv-ssd/src/lib.rs
+++ b/crates/rmlx-kv-ssd/src/lib.rs
@@ -11,7 +11,7 @@
 //! - [`spill`] — `SsdSpiller` + `SpillJob` + bounded-channel drain thread.
 //! - [`hydrate`] — `SsdHydrator` for on-demand RAM-miss reload.
 //! - [`ssd_tier`] — `install_config`, `attach_at_load`, `compute_layout_key`,
-//!   pre-release v1 wipe.
+//!   stale-schema namespace wipe.
 //! - [`hooks`] — process-global Prometheus hook setters + SSD event recorder.
 //! - [`traits::SsdHydrate`] — single trait arch entries implement; bridges the
 //!   prompt cache to the SSD hydrator.

--- a/crates/rmlx-kv-ssd/src/ssd_index.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_index.rs
@@ -11,7 +11,7 @@
 //! The path is always resolved through `rmlx_core::paths` — never a
 //! hard-coded or CWD-relative string.
 //!
-//! # Schema (v3 — )
+//! # Schema (v3)
 //!
 //! ```text
 //! kv_blocks (
@@ -33,7 +33,8 @@
 //! ```
 //!
 //! `last_used` is microseconds, not seconds, and [`now_stamp_us`] hands out a
-//! strictly increasing value. Eviction orders by that column alone, so a
+//! value that strictly increases within the process (carried across restarts
+//! by [`adopt_persisted_stamps`]). Eviction orders by that column alone, so a
 //! coarse clock made every row touched in the same interval tie and left the
 //! victim to whatever order SQLite happened to yield — the failure mode grows
 //! with request rate, which is when the tier matters most.
@@ -106,10 +107,16 @@ type Result<T> = std::result::Result<T, SsdKvIndexError>;
 ///
 /// - v1 → v2: `layout_key` column + composite PK + the `schema_version` table.
 /// - v2 → v3: `last_used` changed unit from seconds to microseconds. The column
-///   type is unchanged, but a v2 row and a v3 row are three orders of magnitude
-///   apart, so the two must never share a table — a mixed table would report
-///   nonsense to any operator query and leave the v2 rows ordered among
-///   themselves as coarsely as before.
+///   type and the table shape are unchanged; only the stored unit moved, so
+///   v2 rows must not be left to sit beside v3 rows three orders of magnitude
+///   away.
+///
+/// v2 rows are **convertible** — `UPDATE kv_blocks SET last_used = last_used *
+/// 1000000` is the whole migration. They are wiped anyway, and that is a
+/// choice, not a constraint: rMLX is unreleased, the tier is a pure cache
+/// whose worst loss is one re-prefill per block, and carrying migration code
+/// (plus the branch in the wipe pass that has to let a v2 DB through so it can
+/// be converted) buys nothing a warm cache does not rebuild in minutes.
 pub(crate) const SCHEMA_VERSION: i64 = 3;
 
 const SCHEMA_PRAGMAS: &str = "
@@ -119,7 +126,7 @@ PRAGMA foreign_keys = ON;
 PRAGMA busy_timeout = 5000;
 ";
 
-pub(crate) const SCHEMA_TABLES: &str = "
+const SCHEMA_TABLES: &str = "
 CREATE TABLE IF NOT EXISTS kv_blocks (
     hash        TEXT    NOT NULL,
     layout_key  INTEGER NOT NULL,
@@ -248,28 +255,29 @@ impl SsdKvIndex {
             // them first would mask a pre-release v1 layout.
             let version = read_schema_version(&conn)?;
             match version {
-                Some(v) if v == SCHEMA_VERSION => {
-                    conn.execute_batch(SCHEMA_INDEXES)?;
-                    Ok(Self { conn })
+                Some(v) if v == SCHEMA_VERSION => conn.execute_batch(SCHEMA_INDEXES)?,
+                Some(v) => {
+                    return Err(SsdKvIndexError::SchemaMismatch {
+                        found: v,
+                        expected: SCHEMA_VERSION,
+                    })
                 }
-                Some(v) => Err(SsdKvIndexError::SchemaMismatch {
-                    found: v,
-                    expected: SCHEMA_VERSION,
-                }),
                 None => {
                     // Pre-release v1 — the cross-namespace wipe in
                     // ssd_tier::install_config should have removed this DB
                     // before we got here.
-                    Err(SsdKvIndexError::SchemaMismatch {
+                    return Err(SsdKvIndexError::SchemaMismatch {
                         found: 1,
                         expected: SCHEMA_VERSION,
-                    })
+                    });
                 }
             }
         } else {
             init_current_schema(&conn)?;
-            Ok(Self { conn })
         }
+
+        adopt_persisted_stamps(&conn)?;
+        Ok(Self { conn })
     }
 
     // ── Read ─────────────────────────────────────────────────────────────────
@@ -748,12 +756,20 @@ pub fn evict_pool_lru_until(kv_root: &Path, global_budget_bytes: u64) -> Result<
 /// version row).
 fn init_current_schema(conn: &Connection) -> Result<()> {
     conn.execute_batch(SCHEMA_PRAGMAS)?;
-    conn.execute_batch(SCHEMA_TABLES)?;
-    conn.execute_batch(SCHEMA_INDEXES)?;
-    conn.execute(
+    // The tables and the version row commit together. Another process running
+    // the stale-schema wipe must never see `kv_blocks` without a
+    // `schema_version` row: that reads as version 0, which is "superseded", and
+    // the pass would delete a namespace this call is still creating.
+    // `PRAGMA journal_mode` cannot run inside a transaction, so the pragmas
+    // stay outside it.
+    let tx = conn.unchecked_transaction()?;
+    tx.execute_batch(SCHEMA_TABLES)?;
+    tx.execute_batch(SCHEMA_INDEXES)?;
+    tx.execute(
         "INSERT OR IGNORE INTO schema_version (version) VALUES (?1)",
         params![SCHEMA_VERSION],
     )?;
+    tx.commit()?;
     Ok(())
 }
 
@@ -792,36 +808,69 @@ pub fn hash_to_hex(digest: u64) -> String {
     format!("{digest:016x}")
 }
 
-/// Highest stamp this process has issued. Guards the two ways a raw wall clock
-/// stops being a usable LRU key: two writes inside the same microsecond, and a
-/// clock stepped backwards by NTP.
+/// Highest stamp this process has issued, seeded on every index open from what
+/// is already on disk ([`adopt_persisted_stamps`]). Guards the two ways a raw
+/// wall clock stops being a usable LRU key: two writes inside the same
+/// microsecond, and a clock that moved backwards.
 static LAST_STAMP_US: AtomicU64 = AtomicU64::new(0);
 
-/// Strictly increasing microseconds since the unix epoch.
+/// Microseconds since the unix epoch, strictly increasing **within this
+/// process** (up to the u64 microsecond epoch, around the year 586524, past
+/// which it saturates).
 ///
 /// Eviction orders rows by this value alone, so equal values put the victim
 /// choice back on whatever order SQLite happens to yield. Clamping against the
 /// last stamp issued makes the sequence strictly increasing across every thread
-/// in the process — which is a total order, so ties do not arise and no
-/// tiebreak column is needed.
+/// here, and [`adopt_persisted_stamps`] carries that across a restart.
+///
+/// It is **not** a total order over a namespace shared by two processes: the
+/// Metal claim file is keyed by port, so two servers on different ports can
+/// each write the same pool, and two writes in the same microsecond from
+/// different processes still tie. The pool sweep's `(namespace, hash)`
+/// tiebreak is what keeps that case deterministic.
 ///
 /// It stays a wall-clock value rather than a plain counter because the
 /// cross-namespace sweep merges rows from independent namespace databases and
 /// has to compare them; a per-database counter carries no meaning outside its
-/// own database, and a counter alone would not survive a restart.
+/// own database.
 fn now_stamp_us() -> u64 {
     let wall = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_micros() as u64;
-    let mut issued = wall;
-    // The closure never returns None, so `fetch_update` cannot fail; `issued`
-    // holds the value from the invocation whose compare-exchange won.
-    let _ = LAST_STAMP_US.fetch_update(Ordering::AcqRel, Ordering::Acquire, |prev| {
-        issued = wall.max(prev.saturating_add(1));
-        Some(issued)
-    });
-    issued
+    let mut prev = LAST_STAMP_US.load(Ordering::Acquire);
+    loop {
+        let next = wall.max(prev.saturating_add(1));
+        match LAST_STAMP_US.compare_exchange_weak(prev, next, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => return next,
+            Err(observed) => prev = observed,
+        }
+    }
+}
+
+/// Raise [`LAST_STAMP_US`] above every stamp already stored in `conn`.
+///
+/// The clamp is process state and starts at zero, so on its own it does not
+/// survive a restart. If the wall clock moved backwards while the process was
+/// down — an NTP step, a manual date change, RTC drift across sleep — every
+/// block written after the restart would stamp *below* the rows already on
+/// disk and be evicted first. That inversion persists for as long as the clock
+/// lags, which is worse than the same-second tie it replaced.
+///
+/// Reading the persisted maximum on open also picks up rows another process
+/// wrote, so two servers sharing a pool converge on each other's stamps at
+/// every open instead of drifting apart.
+///
+/// One indexed `MAX(last_used)` per open — the `kv_blocks_last_used` index
+/// makes it a single b-tree descent, not a scan.
+fn adopt_persisted_stamps(conn: &Connection) -> Result<()> {
+    let max_seen: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(last_used), 0) FROM kv_blocks",
+        [],
+        |r| r.get(0),
+    )?;
+    LAST_STAMP_US.fetch_max(max_seen.max(0) as u64, Ordering::AcqRel);
+    Ok(())
 }
 
 fn row_from_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<KvBlockRow> {

--- a/crates/rmlx-kv-ssd/src/ssd_index.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_index.rs
@@ -2,7 +2,7 @@
 //!
 //! [`SsdKvIndex`] tracks `.kvb` safetensors files written by 's
 //! `KvBlockWriter`. Each row records the file path, identity fields, byte
-//! size, and a `last_used` unix timestamp so that an LRU-by-size eviction
+//! size, and a `last_used` timestamp so that an LRU-by-size eviction
 //! policy can be applied when the on-disk budget is exceeded.
 //!
 //! # DB location
@@ -11,7 +11,7 @@
 //! The path is always resolved through `rmlx_core::paths` — never a
 //! hard-coded or CWD-relative string.
 //!
-//! # Schema (v2 — )
+//! # Schema (v3 — )
 //!
 //! ```text
 //! kv_blocks (
@@ -21,16 +21,22 @@
 //! model_id TEXT NOT NULL, -- "<arch>/<snapshot>" identity
 //! kv_quant TEXT NOT NULL, -- KvQuant Display string
 //! byte_size INTEGER NOT NULL, -- on-disk byte size of the .kvb file
-//! last_used INTEGER NOT NULL, -- unix epoch (seconds)
+//! last_used INTEGER NOT NULL, -- unix epoch MICROSECONDS (see now_stamp_us)
 //! PRIMARY KEY (hash, layout_key)
 //! )
 //!
 //! schema_version (
-//! version INTEGER PRIMARY KEY NOT NULL -- 2
+//! version INTEGER PRIMARY KEY NOT NULL -- 3
 //! )
 //!
 //! INDEX kv_blocks_last_used ON kv_blocks (last_used) -- LRU eviction order
 //! ```
+//!
+//! `last_used` is microseconds, not seconds, and [`now_stamp_us`] hands out a
+//! strictly increasing value. Eviction orders by that column alone, so a
+//! coarse clock made every row touched in the same interval tie and left the
+//! victim to whatever order SQLite happened to yield — the failure mode grows
+//! with request rate, which is when the tier matters most.
 //!
 //! The `last_used` index is created idempotently on every open: it carries no
 //! row-format change, so it needs no `schema_version` bump, and LRU eviction
@@ -46,11 +52,13 @@
 //!
 //! # Pre-release schema upgrade
 //!
-//! rMLX is unreleased, so the v1 → v2 transition is a one-time wipe rather
-//! than a row-by-row migration. The cross-namespace wipe pass is driven by
+//! rMLX is unreleased, so a schema transition is a one-time wipe rather than a
+//! row-by-row migration — the tier is a pure cache, so dropping it costs a
+//! re-prefill and nothing else. The cross-namespace wipe pass is driven by
 //! [`crate::ssd_tier::install_config`] before any [`SsdKvIndex::open`] runs
-//! in-process; per-DB, [`SsdKvIndex::open`] enforces `schema_version = 2` and
-//! returns [`SsdKvIndexError::SchemaMismatch`] on any other value.
+//! in-process; per-DB, [`SsdKvIndex::open`] enforces
+//! `schema_version = SCHEMA_VERSION` and returns
+//! [`SsdKvIndexError::SchemaMismatch`] on any other value.
 
 #![allow(
     clippy::cognitive_complexity,
@@ -59,6 +67,7 @@
     clippy::too_many_lines
 )]
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::{params, Connection};
@@ -77,9 +86,9 @@ pub enum SsdKvIndexError {
     #[error("kv-index io: {0}")]
     Io(#[from] std::io::Error),
     /// the on-disk DB advertises a schema version this binary does not
-    /// understand. Pre-release v1 namespaces are wiped by
-    /// [`crate::ssd_tier::install_config`] BEFORE `open` runs, so any
-    /// mismatch surfacing here is a future schema we cannot interpret.
+    /// understand. [`crate::ssd_tier::install_config`] wipes such namespaces
+    /// BEFORE `open` runs, so a mismatch surfacing here means `open` was
+    /// reached without that pass — the namespace is disabled for the run.
     #[error("kv-index schema mismatch: DB version {found}, expected {expected}")]
     SchemaMismatch {
         /// Schema version found in the DB.
@@ -93,10 +102,15 @@ type Result<T> = std::result::Result<T, SsdKvIndexError>;
 
 // ── Schema + pragmas ──────────────────────────────────────────────────────────
 
-/// Current `kv_blocks` schema version. Bumped from implicit v1 →
-/// explicit v2 when the `layout_key` column + composite PK + `schema_version`
-/// table were added.
-pub(crate) const SCHEMA_VERSION: i64 = 2;
+/// Current `kv_blocks` schema version.
+///
+/// - v1 → v2: `layout_key` column + composite PK + the `schema_version` table.
+/// - v2 → v3: `last_used` changed unit from seconds to microseconds. The column
+///   type is unchanged, but a v2 row and a v3 row are three orders of magnitude
+///   apart, so the two must never share a table — a mixed table would report
+///   nonsense to any operator query and leave the v2 rows ordered among
+///   themselves as coarsely as before.
+pub(crate) const SCHEMA_VERSION: i64 = 3;
 
 const SCHEMA_PRAGMAS: &str = "
 PRAGMA journal_mode = WAL;
@@ -105,7 +119,7 @@ PRAGMA foreign_keys = ON;
 PRAGMA busy_timeout = 5000;
 ";
 
-const SCHEMA_TABLES: &str = "
+pub(crate) const SCHEMA_TABLES: &str = "
 CREATE TABLE IF NOT EXISTS kv_blocks (
     hash        TEXT    NOT NULL,
     layout_key  INTEGER NOT NULL,
@@ -153,7 +167,7 @@ pub struct KvBlockRow {
     pub kv_quant: String,
     /// On-disk byte size of the `.kvb` file.
     pub byte_size: u64,
-    /// Unix epoch timestamp of last access.
+    /// Microseconds since the unix epoch at last access (see `now_stamp_us`).
     pub last_used: u64,
 }
 
@@ -198,11 +212,11 @@ impl SsdKvIndex {
     ///
     /// The DB is placed at `<kv_cache_dir(namespace)>/index.db`. Behaviour:
     ///
-    /// 1. File absent → create v2 schema + insert `schema_version = 2`.
+    /// 1. File absent → create the current schema + insert `schema_version`.
     /// 2. File present, **no `schema_version` table** → this is a pre-release
     ///    v1 DB. Return `SchemaMismatch`.
-    /// 3. File present, `schema_version != 2` → `SchemaMismatch`.
-    /// 4. File present, `schema_version == 2` → proceed.
+    /// 3. File present, `schema_version != SCHEMA_VERSION` → `SchemaMismatch`.
+    /// 4. File present, `schema_version == SCHEMA_VERSION` → proceed.
     pub fn open(namespace: &str) -> Result<Self> {
         let dir = rmlx_core::paths::kv_cache_dir(namespace);
         let db_path = dir.join("index.db");
@@ -217,7 +231,7 @@ impl SsdKvIndex {
     /// Open an in-memory index (for tests).
     pub fn open_memory() -> Result<Self> {
         let conn = Connection::open_in_memory()?;
-        init_v2_schema(&conn)?;
+        init_current_schema(&conn)?;
         Ok(Self { conn })
     }
 
@@ -230,7 +244,7 @@ impl SsdKvIndex {
         conn.execute_batch(SCHEMA_PRAGMAS)?;
 
         if file_existed {
-            // Inspect schema_version before creating any v2 tables — touching
+            // Inspect schema_version before creating any table — touching
             // them first would mask a pre-release v1 layout.
             let version = read_schema_version(&conn)?;
             match version {
@@ -253,7 +267,7 @@ impl SsdKvIndex {
                 }
             }
         } else {
-            init_v2_schema(&conn)?;
+            init_current_schema(&conn)?;
             Ok(Self { conn })
         }
     }
@@ -317,7 +331,7 @@ impl SsdKvIndex {
     /// `hash` is the chained FNV-1a-64 digest formatted as a hex string.
     /// `layout_key` is the stable u64 over the arch + KV layout.
     /// `path` must be the absolute path to the `.kvb` file. `last_used` is
-    /// set to the current unix epoch.
+    /// set to a fresh [`now_stamp_us`] value.
     pub fn record(
         &self,
         hash: &str,
@@ -327,7 +341,7 @@ impl SsdKvIndex {
         kv_quant: &str,
         byte_size: u64,
     ) -> Result<()> {
-        let now = unix_now();
+        let now = now_stamp_us();
         let path_str = path.to_string_lossy();
         self.conn.execute(
             "INSERT OR REPLACE INTO kv_blocks
@@ -357,7 +371,7 @@ impl SsdKvIndex {
     ///
     /// No-ops silently if `(hash, layout_key)` is not found.
     pub fn touch(&self, hash: &str, layout_key: u64) -> Result<()> {
-        let now = unix_now();
+        let now = now_stamp_us();
         let n = self.conn.execute(
             "UPDATE kv_blocks SET last_used = ?1 WHERE hash = ?2 AND layout_key = ?3",
             params![now as i64, hash, layout_key as i64],
@@ -728,10 +742,11 @@ pub fn evict_pool_lru_until(kv_root: &Path, global_budget_bytes: u64) -> Result<
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/// Initialise a fresh v2 schema on a connection: create the tables + insert
-/// the version row. Idempotent on a clean DB; safe to call on an
-/// already-initialised v2 DB (INSERT OR IGNORE on version row).
-fn init_v2_schema(conn: &Connection) -> Result<()> {
+/// Initialise a fresh [`SCHEMA_VERSION`] schema on a connection: create the
+/// tables + insert the version row. Idempotent on a clean DB; safe to call on
+/// an already-initialised DB at the same version (INSERT OR IGNORE on the
+/// version row).
+fn init_current_schema(conn: &Connection) -> Result<()> {
     conn.execute_batch(SCHEMA_PRAGMAS)?;
     conn.execute_batch(SCHEMA_TABLES)?;
     conn.execute_batch(SCHEMA_INDEXES)?;
@@ -747,7 +762,7 @@ fn init_v2_schema(conn: &Connection) -> Result<()> {
 /// `Ok(Some(v))` when the `schema_version` table exists and holds a row;
 /// `Ok(None)` when the table itself is absent (pre-release v1);
 /// `Err(_)` only on a genuine SQLite error.
-fn read_schema_version(conn: &Connection) -> Result<Option<i64>> {
+pub(crate) fn read_schema_version(conn: &Connection) -> Result<Option<i64>> {
     // Detect the table without creating it (DROP-and-recreate would mask v1).
     let table_present: bool = conn
         .query_row(
@@ -777,11 +792,36 @@ pub fn hash_to_hex(digest: u64) -> String {
     format!("{digest:016x}")
 }
 
-fn unix_now() -> u64 {
-    SystemTime::now()
+/// Highest stamp this process has issued. Guards the two ways a raw wall clock
+/// stops being a usable LRU key: two writes inside the same microsecond, and a
+/// clock stepped backwards by NTP.
+static LAST_STAMP_US: AtomicU64 = AtomicU64::new(0);
+
+/// Strictly increasing microseconds since the unix epoch.
+///
+/// Eviction orders rows by this value alone, so equal values put the victim
+/// choice back on whatever order SQLite happens to yield. Clamping against the
+/// last stamp issued makes the sequence strictly increasing across every thread
+/// in the process — which is a total order, so ties do not arise and no
+/// tiebreak column is needed.
+///
+/// It stays a wall-clock value rather than a plain counter because the
+/// cross-namespace sweep merges rows from independent namespace databases and
+/// has to compare them; a per-database counter carries no meaning outside its
+/// own database, and a counter alone would not survive a restart.
+fn now_stamp_us() -> u64 {
+    let wall = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
-        .as_secs()
+        .as_micros() as u64;
+    let mut issued = wall;
+    // The closure never returns None, so `fetch_update` cannot fail; `issued`
+    // holds the value from the invocation whose compare-exchange won.
+    let _ = LAST_STAMP_US.fetch_update(Ordering::AcqRel, Ordering::Acquire, |prev| {
+        issued = wall.max(prev.saturating_add(1));
+        Some(issued)
+    });
+    issued
 }
 
 fn row_from_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<KvBlockRow> {

--- a/crates/rmlx-kv-ssd/src/ssd_index_tests.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_index_tests.rs
@@ -127,6 +127,170 @@ fn cross_layout_lookup_is_a_miss() {
     );
 }
 
+// ── LRU stamp granularity ─────────────────────────────────────────────────
+
+/// Microseconds alone are not a total order: a burst of calls fits inside one,
+/// and a clock stepped backwards by NTP would hand out a decreasing value.
+/// Eviction has no tiebreak column, so the stamp source itself has to be the
+/// total order.
+#[test]
+fn now_stamp_us_is_strictly_increasing() {
+    let stamps: Vec<u64> = (0..10_000).map(|_| now_stamp_us()).collect();
+    for pair in stamps.windows(2) {
+        if let [a, b] = *pair {
+            assert!(b > a, "stamp {b} did not advance past {a}");
+        }
+    }
+}
+
+/// The eviction victim must be the least *recently used* block, not an
+/// arbitrary member of whatever set shares a coarse timestamp.
+///
+/// Everything here — eight `record`s and three `touch`es — happens inside a
+/// single wall-clock second, which is the ordinary case for a server under
+/// load. At second granularity every row carries the same `last_used`,
+/// `ORDER BY last_used ASC` has no tiebreak, and SQLite yields rows in
+/// insert order: eviction then takes `b0..b2` (the three blocks that were
+/// just touched and are the *most* recently used) and keeps `b3..b5`. The
+/// touches are deliberately applied to the earliest-inserted blocks so the
+/// two orderings disagree on every row rather than by luck.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn evict_lru_picks_the_least_recently_used_within_one_second() {
+    let idx = open();
+    let names: Vec<String> = (0..8).map(|i| format!("b{i}")).collect();
+    for name in &names {
+        idx.record(
+            name,
+            LK_A,
+            &PathBuf::from(format!("/tmp/{name}.kvb")),
+            "m",
+            "k",
+            1000,
+        )
+        .unwrap();
+    }
+
+    // Re-use b0, b1, b2 — they become the three most recently used blocks.
+    // LRU order is now b3, b4, b5, b6, b7, b0, b1, b2.
+    for name in names.iter().take(3) {
+        idx.touch(name, LK_A).unwrap();
+    }
+
+    // 8000 bytes down to 5000 evicts exactly the three oldest: b3, b4, b5.
+    let evicted = idx.evict_lru_until(5000).unwrap();
+    let got: Vec<String> = evicted
+        .paths
+        .iter()
+        .map(|p| p.file_stem().unwrap_or_default().to_string_lossy().into())
+        .collect();
+    assert_eq!(
+        got,
+        vec!["b3".to_string(), "b4".to_string(), "b5".to_string()],
+        "eviction must take the least recently used blocks, in LRU order"
+    );
+    for name in ["b0", "b1", "b2", "b6", "b7"] {
+        assert!(
+            idx.lookup(name, LK_A).unwrap().is_some(),
+            "{name} was more recently used than every evicted block and must survive"
+        );
+    }
+}
+
+/// The stamps have to separate blocks written from different threads too —
+/// that is where the tie was originally observed, and a coarse clock ties
+/// hardest exactly when request rate is highest.
+///
+/// Two properties, both false at second granularity: every row carries a
+/// distinct stamp, and within one thread the stamps follow the order that
+/// thread touched its own blocks in.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
+)]
+fn concurrent_touches_get_distinct_ordered_stamps() {
+    use std::sync::{Arc, Barrier};
+
+    const THREADS: usize = 3;
+    const PER_THREAD: usize = 16;
+
+    let tmp = TempDir::new().unwrap();
+    let db = tmp.path().join("index.db");
+    let _seed = SsdKvIndex::open_at(&db).unwrap();
+
+    // Every thread has to be running before any is joined, so the spawns are
+    // collected up front rather than folded into the join.
+    let barrier = Arc::new(Barrier::new(THREADS));
+    let mut handles = Vec::with_capacity(THREADS);
+    for t in 0..THREADS {
+        let (db, barrier) = (db.clone(), Arc::clone(&barrier));
+        handles.push(std::thread::spawn(move || {
+            let idx = SsdKvIndex::open_at(&db).unwrap();
+            let names: Vec<String> = (0..PER_THREAD).map(|i| format!("t{t}-{i:02}")).collect();
+            barrier.wait();
+            for name in &names {
+                idx.record(
+                    name,
+                    LK_A,
+                    &PathBuf::from(format!("/tmp/{name}.kvb")),
+                    "m",
+                    "k",
+                    1,
+                )
+                .unwrap();
+            }
+            // Touch in a fixed order; the resulting stamps must follow it.
+            for name in &names {
+                idx.touch(name, LK_A).unwrap();
+            }
+            names
+        }));
+    }
+
+    let mut per_thread: Vec<Vec<String>> = Vec::with_capacity(THREADS);
+    for h in handles {
+        per_thread.push(h.join().expect("worker thread panicked"));
+    }
+
+    let idx = SsdKvIndex::open_at(&db).unwrap();
+    let stamp = |name: &str| {
+        idx.lookup(name, LK_A)
+            .unwrap()
+            .expect("row present")
+            .last_used
+    };
+
+    let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    for names in &per_thread {
+        let mut prev: Option<u64> = None;
+        for name in names {
+            let s = stamp(name);
+            assert!(
+                seen.insert(s),
+                "stamp {s} collides across rows; a shared stamp leaves eviction \
+                 without a tiebreak and the victim arbitrary"
+            );
+            if let Some(p) = prev {
+                assert!(
+                    s > p,
+                    "{name} was touched after the previous block in its thread \
+                     but carries stamp {s} <= {p}"
+                );
+            }
+            prev = Some(s);
+        }
+    }
+    assert_eq!(seen.len(), THREADS * PER_THREAD);
+}
+
 // ── evict_lru_until ───────────────────────────────────────────────────────
 
 #[test]
@@ -309,7 +473,7 @@ fn open_at_tempfile_roundtrip() {
         .unwrap();
     }
 
-    // Re-open — schema v2 + row persists.
+    // Re-open — schema version accepted + row persists.
     let idx2 = SsdKvIndex::open_at(&db).unwrap();
     let row = idx2
         .lookup(&hash_to_hex(42), LK_A)
@@ -320,7 +484,7 @@ fn open_at_tempfile_roundtrip() {
     assert_eq!(row.layout_key, LK_A);
 }
 
-/// unit test #5: an existing DB tagged with `schema_version != 2`
+/// unit test #5: an existing DB tagged with an unknown `schema_version`
 /// surfaces `SchemaMismatch`.
 #[test]
 #[allow(
@@ -352,7 +516,7 @@ fn schema_mismatch_on_unknown_version() {
 /// A DB whose `kv_blocks` table exists but has NO `schema_version` table
 /// is the pre-release v1 layout. `install_config` was supposed to wipe
 /// such namespaces; if `open_at` is asked to consume one directly it must
-/// surface `SchemaMismatch { found: 1, expected: 2 }`.
+/// surface `SchemaMismatch { found: 1, .. }`.
 #[test]
 #[allow(
     clippy::unwrap_used,
@@ -529,4 +693,79 @@ fn single_namespace_no_global_budget_noop() {
     assert_eq!(report.blocks_evicted, 0);
     let idx = SsdKvIndex::open_at(&alpha.join("index.db")).unwrap();
     assert_eq!(idx.total_bytes().unwrap(), 3000);
+}
+
+/// The pool sweep merges rows from independent namespace databases, so its
+/// ordering has to come from the stamp itself — no per-database counter could
+/// compare `alpha`'s rows against `beta`'s.
+///
+/// Recorded and touched inside one wall-clock second, as a live pool is. At
+/// second granularity all six rows tie and the sweep falls back to its
+/// `(namespace, hash)` tiebreak, which evicts `alpha/a0`, `alpha/a1`,
+/// `alpha/a2` — alphabetically first, and here the three *most* recently used.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn evict_pool_lru_orders_across_namespaces_within_one_second() {
+    let tmp = TempDir::new().unwrap();
+    let kv_root = tmp.path().to_path_buf();
+
+    // Recorded oldest-first across both namespaces, interleaved.
+    let alpha = seed_ns_recorded(&kv_root, "alpha", &["a0", "a1", "a2"]);
+    let beta = seed_ns_recorded(&kv_root, "beta", &["b0", "b1", "b2"]);
+
+    // Re-use alpha's blocks: they become the three most recently used in the
+    // pool. LRU order is now b0, b1, b2, a0, a1, a2.
+    {
+        let idx_a = SsdKvIndex::open_at(&alpha.join("index.db")).unwrap();
+        for name in ["a0", "a1", "a2"] {
+            idx_a.touch(name, LK_A).unwrap();
+        }
+    }
+
+    // 6000 bytes down to 3500 evicts three rows: the beta blocks.
+    let report = evict_pool_lru_until(&kv_root, 3500).unwrap();
+    assert_eq!(report.blocks_evicted, 3);
+    assert_eq!(
+        report.namespaces_touched, 1,
+        "only beta holds least-recently-used blocks, so only beta may be touched"
+    );
+
+    let idx_a = SsdKvIndex::open_at(&alpha.join("index.db")).unwrap();
+    let idx_b = SsdKvIndex::open_at(&beta.join("index.db")).unwrap();
+    for name in ["a0", "a1", "a2"] {
+        assert!(
+            idx_a.lookup(name, LK_A).unwrap().is_some(),
+            "{name} was used after every beta block and must survive"
+        );
+        assert!(alpha.join(format!("{name}.kvb")).exists());
+    }
+    for name in ["b0", "b1", "b2"] {
+        assert!(
+            idx_b.lookup(name, LK_A).unwrap().is_none(),
+            "{name} evicted"
+        );
+        assert!(!beta.join(format!("{name}.kvb")).exists());
+    }
+}
+
+/// Like [`seed_ns_rows`] but stamps each row through the public `record` path
+/// instead of hand-writing a `last_used` value, so the rows carry whatever
+/// granularity the index actually issues.
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn seed_ns_recorded(kv_root: &Path, ns: &str, names: &[&str]) -> PathBuf {
+    let ns_dir = kv_root.join(ns);
+    fs::create_dir_all(&ns_dir).unwrap();
+    let idx = SsdKvIndex::open_at(&ns_dir.join("index.db")).unwrap();
+    for name in names {
+        let p = ns_dir.join(format!("{name}.kvb"));
+        fs::write(&p, vec![0u8; 1000]).unwrap();
+        idx.record(name, LK_A, &p, ns, "k8v8", 1000).unwrap();
+    }
+    ns_dir
 }

--- a/crates/rmlx-kv-ssd/src/ssd_index_tests.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_index_tests.rs
@@ -157,7 +157,7 @@ fn now_stamp_us_is_strictly_increasing() {
 #[test]
 #[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "every unwrap is on an in-memory SQLite index this test just opened; a failure is a broken fixture and must abort rather than be reported as a passing eviction"
 )]
 fn evict_lru_picks_the_least_recently_used_within_one_second() {
     let idx = open();
@@ -210,11 +210,11 @@ fn evict_lru_picks_the_least_recently_used_within_one_second() {
 #[test]
 #[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "temp-dir SQLite opens and writes from the worker threads; a failure inside a worker is a broken fixture and must abort that thread so the join surfaces it"
 )]
 #[allow(
     clippy::expect_used,
-    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
+    reason = "thread join plus lookups of rows the workers just wrote; a missing row or a panicked worker is a test failure and must surface rather than be swallowed"
 )]
 fn concurrent_touches_get_distinct_ordered_stamps() {
     use std::sync::{Arc, Barrier};
@@ -289,6 +289,75 @@ fn concurrent_touches_get_distinct_ordered_stamps() {
         }
     }
     assert_eq!(seen.len(), THREADS * PER_THREAD);
+}
+
+/// A clamp that only remembers what *this* process issued is not durable. A
+/// restart reloads it at zero, so if the wall clock moved backwards while the
+/// process was down (NTP step, manual date change, RTC drift across sleep)
+/// every freshly written block stamps *below* the rows already on disk and
+/// becomes the first eviction victim. That inversion persists for as long as
+/// the clock lags — strictly worse than the same-second tie, which at least
+/// resolved itself a second later.
+///
+/// Persisting rows stamped ahead of the current clock and then opening the
+/// index fresh is exactly what a restart after a backwards step looks like
+/// from the index's point of view.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture setup on a temp-dir SQLite DB this test just created; a failure here is a broken fixture and should abort the test"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "the row was inserted a few lines above, so its absence is a broken fixture rather than a condition under test"
+)]
+fn a_fresh_open_orders_new_blocks_above_rows_written_before_a_clock_step() {
+    let tmp = TempDir::new().unwrap();
+    let db = tmp.path().join("index.db");
+    // 10 s beyond the stamp source's current position, i.e. the clock has since
+    // stepped back by 10 s relative to what is already persisted.
+    let ahead = now_stamp_us() + 10_000_000;
+    {
+        let idx = SsdKvIndex::open_at(&db).unwrap();
+        idx.conn
+            .execute(
+                "INSERT INTO kv_blocks
+                 (hash, layout_key, path, model_id, kv_quant, byte_size, last_used)
+                 VALUES ('before', ?1, '/tmp/before.kvb', 'm', 'k', 1000, ?2)",
+                params![LK_A as i64, ahead as i64],
+            )
+            .unwrap();
+    }
+
+    // The restart.
+    let idx = SsdKvIndex::open_at(&db).unwrap();
+    idx.record(
+        "after",
+        LK_A,
+        &PathBuf::from("/tmp/after.kvb"),
+        "m",
+        "k",
+        1000,
+    )
+    .unwrap();
+
+    let before = idx.lookup("before", LK_A).unwrap().expect("seeded row");
+    let after = idx.lookup("after", LK_A).unwrap().expect("recorded row");
+    assert!(
+        after.last_used > before.last_used,
+        "a block written after the restart carries stamp {} but the row already \
+         on disk carries {}; the newer block would be evicted first",
+        after.last_used,
+        before.last_used
+    );
+
+    // The evictor has to agree, not just the raw column.
+    let evicted = idx.evict_lru_until(1000).unwrap();
+    assert_eq!(
+        evicted.paths,
+        vec![PathBuf::from("/tmp/before.kvb")],
+        "eviction must take the older block, not the one written after the restart"
+    );
 }
 
 // ── evict_lru_until ───────────────────────────────────────────────────────
@@ -706,7 +775,7 @@ fn single_namespace_no_global_budget_noop() {
 #[test]
 #[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "temp-dir namespace databases and their .kvb files, all created by this test; a failure is a broken fixture and must abort rather than be reported as a passing sweep"
 )]
 fn evict_pool_lru_orders_across_namespaces_within_one_second() {
     let tmp = TempDir::new().unwrap();
@@ -756,7 +825,7 @@ fn evict_pool_lru_orders_across_namespaces_within_one_second() {
 /// granularity the index actually issues.
 #[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "fixture setup: creates a namespace dir, its index and its .kvb files under a temp dir; a failure here is a broken fixture, not a condition under test"
 )]
 fn seed_ns_recorded(kv_root: &Path, ns: &str, names: &[&str]) -> PathBuf {
     let ns_dir = kv_root.join(ns);

--- a/crates/rmlx-kv-ssd/src/ssd_tier.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_tier.rs
@@ -27,16 +27,21 @@
 //! still collide on `layout_key` and therefore share their cache, which is the
 //! intended behaviour — `layout_key` is weight-independent on purpose.
 //!
-//! ## Pre-release schema wipe
+//! ## Stale-schema wipe
 //!
 //! rMLX is unreleased, so the index schema advances by wiping rather than
 //! migrating. [`install_config`] walks every `<RMLX_HOME>/cache/kv/<ns>/`
 //! namespace BEFORE any [`SsdKvIndex::open`] runs: if `<ns>/index.db` holds a
-//! `kv_blocks` table at any schema version other than the current one (a
-//! missing `schema_version` table being the pre-release v1 layout), the ENTIRE
+//! `kv_blocks` table at a schema version this binary **supersedes** (a missing
+//! `schema_version` table being the pre-release v1 layout), the ENTIRE
 //! namespace dir is removed (`fs::remove_dir_all`) and dropped bytes are logged
 //! with an `ssd_cache_pre_release_wipe` event. The pass is idempotent — a
 //! second boot at the current schema is a no-op (dropped_bytes=0).
+//!
+//! A namespace at a **newer** version is left in place and `warn!`ed: two rMLX
+//! builds at different schema versions on one machine is ordinary, and wiping
+//! forward would let the older one destroy the newer one's pool on every
+//! alternate boot.
 
 use std::borrow::Cow;
 use std::path::Path;
@@ -424,12 +429,20 @@ pub(crate) fn enforce_namespace_budget(
     evict_count
 }
 
-/// pre-release schema wipe: walk every namespace under `kv_root` and
-/// remove any whose `index.db` is not at the current schema version.
+/// Stale-schema wipe: walk every namespace under `kv_root` and remove any
+/// whose `index.db` is at a schema version this binary supersedes.
+///
+/// A namespace at a **newer** version is left alone and `warn!`ed. Two rMLX
+/// builds on one machine at different schema versions is ordinary (a
+/// tap-installed release beside a dev build); wiping forward would have the
+/// older binary destroy the newer one's whole pool on every alternate boot.
+/// Reclaiming those bytes is a garbage-collection problem, and the operator
+/// gets the namespace name and version to act on.
 ///
 /// Idempotent — on a clean boot every namespace is skipped, dropped_bytes
 /// is 0, and no `fs::remove_dir_all` runs. Emits a single
-/// `ssd_cache_pre_release_wipe` event listing the removed namespaces.
+/// `ssd_cache_pre_release_wipe` event listing the removed namespaces with the
+/// version each was found at.
 ///
 /// Best-effort: I/O errors on individual entries are `warn!`ed and the walk
 /// continues. Public only for the `cfg(test)` harness that exercises the wipe
@@ -456,7 +469,7 @@ fn wipe_stale_schema_namespaces(kv_root: &Path) {
         }
     };
 
-    let mut wiped_namespaces: Vec<String> = Vec::new();
+    let mut wiped_namespaces: Vec<(String, i64)> = Vec::new();
     let mut total_dropped_bytes: u64 = 0;
 
     for entry in entries.flatten() {
@@ -468,20 +481,35 @@ fn wipe_stale_schema_namespaces(kv_root: &Path) {
         if !db_path.exists() {
             continue; // empty namespace dir — nothing to migrate
         }
-        if !is_stale_schema(&db_path) {
-            continue;
-        }
-
-        let dropped = dir_size_bytes(&ns_path);
+        let Some(found) = namespace_schema_version(&db_path) else {
+            continue; // not a KV index, or unreadable — never ours to remove
+        };
         let ns_name = ns_path
             .file_name()
             .and_then(|s| s.to_str())
             .unwrap_or("?")
             .to_string();
 
+        if found > crate::ssd_index::SCHEMA_VERSION {
+            tracing::warn!(
+                event = "ssd_cache_newer_schema_skipped",
+                namespace = %ns_name,
+                found_version = found,
+                expected_version = crate::ssd_index::SCHEMA_VERSION,
+                "namespace was written by a newer rMLX; leaving it for that \
+                 binary. This build cannot use it — remove the directory by \
+                 hand to reclaim the space."
+            );
+            continue;
+        }
+        if found == crate::ssd_index::SCHEMA_VERSION {
+            continue;
+        }
+
+        let dropped = dir_size_bytes(&ns_path);
         match std::fs::remove_dir_all(&ns_path) {
             Ok(()) => {
-                wiped_namespaces.push(ns_name);
+                wiped_namespaces.push((ns_name, found));
                 total_dropped_bytes += dropped;
             }
             Err(e) => tracing::warn!(
@@ -495,8 +523,9 @@ fn wipe_stale_schema_namespaces(kv_root: &Path) {
     if wiped_namespaces.is_empty() {
         tracing::debug!(
             event = "ssd_cache_pre_release_wipe",
-            namespaces = ?Vec::<String>::new(),
+            namespaces = ?Vec::<(String, i64)>::new(),
             dropped_bytes = 0u64,
+            expected_version = crate::ssd_index::SCHEMA_VERSION,
             "ssd-cache wipe pass — nothing to drop"
         );
     } else {
@@ -504,36 +533,34 @@ fn wipe_stale_schema_namespaces(kv_root: &Path) {
             event = "ssd_cache_pre_release_wipe",
             namespaces = ?wiped_namespaces,
             dropped_bytes = total_dropped_bytes,
-            reason = "pre-release schema upgrade",
-            "dropped pre-release v1 namespaces"
+            expected_version = crate::ssd_index::SCHEMA_VERSION,
+            reason = "index schema superseded",
+            "dropped namespaces at a superseded index schema"
         );
     }
 }
 
-/// True iff `index.db` is a SQLite file holding a `kv_blocks` table whose
-/// schema version is not the one this binary writes. A missing
-/// `schema_version` table reads as the pre-release v1 layout.
+/// The `kv_blocks` schema version `index.db` advertises, or `None` when the
+/// file is not one of our KV indexes.
 ///
-/// Any error opening / inspecting the file is treated as "leave it alone", as
-/// is a file with no `kv_blocks` table at all — this helper must never wipe a
-/// DB it does not recognise as a KV index.
+/// `Some(1)` is the pre-release layout (a `kv_blocks` table and no
+/// `schema_version` table). `None` covers a file that cannot be opened, has no
+/// `kv_blocks` table, or whose version cannot be read — the caller removes
+/// directories, so anything unrecognised must be left alone.
 ///
-/// Version mismatch in either direction is wiped, not just an older one. The
-/// tier is a pure cache with no source-of-truth content, so a binary that
-/// cannot read a namespace has exactly two options: reclaim the bytes, or
-/// strand them and disable the namespace for that run — the latter is what a
-/// downgrade used to do, leaving the directory on disk with nothing able to
-/// reclaim it.
+/// Returning the version rather than a stale/not-stale verdict keeps the
+/// policy (wipe older, warn on newer) at the call site, where the log event
+/// that reports it also lives.
 #[allow(
     clippy::manual_let_else,
     reason = "early-return on Err(_) is cleaner here: the connection is consumed \
               in a separate query_row call, so the let-else form would need to \
               restructure non-trivially around the borrow"
 )]
-fn is_stale_schema(db_path: &Path) -> bool {
+fn namespace_schema_version(db_path: &Path) -> Option<i64> {
     let conn = match rusqlite::Connection::open(db_path) {
         Ok(c) => c,
-        Err(_) => return false,
+        Err(_) => return None,
     };
     let has_kv_blocks: bool = conn
         .query_row(
@@ -543,13 +570,12 @@ fn is_stale_schema(db_path: &Path) -> bool {
         )
         .unwrap_or(false);
     if !has_kv_blocks {
-        return false;
+        return None;
     }
-    // Absent schema_version table ⇒ pre-release v1.
     match crate::ssd_index::read_schema_version(&conn) {
-        Ok(Some(v)) => v != crate::ssd_index::SCHEMA_VERSION,
-        Ok(None) => true,
-        Err(_) => false,
+        Ok(Some(v)) => Some(v),
+        Ok(None) => Some(1), // pre-release v1: no schema_version table
+        Err(_) => None,
     }
 }
 

--- a/crates/rmlx-kv-ssd/src/ssd_tier.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_tier.rs
@@ -29,13 +29,14 @@
 //!
 //! ## Pre-release schema wipe
 //!
-//! rMLX is unreleased, so the index schema bumped from implicit v1 → explicit
-//! v2 by wiping rather than migrating. [`install_config`] walks every
-//! `<RMLX_HOME>/cache/kv/<ns>/` namespace BEFORE any [`SsdKvIndex::open`]
-//! runs: if `<ns>/index.db` exists and lacks the `schema_version` table, the
-//! ENTIRE namespace dir is removed (`fs::remove_dir_all`) and dropped bytes
-//! are logged with an `ssd_cache_pre_release_wipe` event. The pass is
-//! idempotent — a second boot with the v2 schema is a no-op (dropped_bytes=0).
+//! rMLX is unreleased, so the index schema advances by wiping rather than
+//! migrating. [`install_config`] walks every `<RMLX_HOME>/cache/kv/<ns>/`
+//! namespace BEFORE any [`SsdKvIndex::open`] runs: if `<ns>/index.db` holds a
+//! `kv_blocks` table at any schema version other than the current one (a
+//! missing `schema_version` table being the pre-release v1 layout), the ENTIRE
+//! namespace dir is removed (`fs::remove_dir_all`) and dropped bytes are logged
+//! with an `ssd_cache_pre_release_wipe` event. The pass is idempotent — a
+//! second boot at the current schema is a no-op (dropped_bytes=0).
 
 use std::borrow::Cow;
 use std::path::Path;
@@ -93,7 +94,7 @@ static CONFIG: OnceLock<Option<SsdTierConfig>> = OnceLock::new();
 /// builds, a second call PANICS to surface the bug. The wipe runs
 /// unconditionally on the first call, including when the tier is OFF — that
 /// way switching `--kv-ssd-cache-gb` 0 → N between restarts cannot resurrect
-/// a v1 namespace.
+/// a namespace at a superseded schema.
 ///
 /// callers must pass an `SsdTierConfig` directly. `per_project_budgets`
 /// MUST be empty in — populated by from `projects.toml`. After
@@ -143,7 +144,7 @@ pub fn install_config(cfg: SsdTierConfig) -> Result<()> {
     }
 
     // single startup pass; runs BEFORE any namespace SsdKvIndex::open.
-    wipe_pre_release_v1_namespaces(&rmlx_core::paths::cache_dir().join("kv"));
+    wipe_stale_schema_namespaces(&rmlx_core::paths::cache_dir().join("kv"));
 
     // cross-namespace LRU enforcement. No-op when global_budget == 0.
     if let Some(c) = CONFIG.get().and_then(|v| v.as_ref()) {
@@ -424,9 +425,9 @@ pub(crate) fn enforce_namespace_budget(
 }
 
 /// pre-release schema wipe: walk every namespace under `kv_root` and
-/// remove any whose `index.db` lacks the v2 `schema_version` table.
+/// remove any whose `index.db` is not at the current schema version.
 ///
-/// Idempotent — on a clean v2 boot every namespace is skipped, dropped_bytes
+/// Idempotent — on a clean boot every namespace is skipped, dropped_bytes
 /// is 0, and no `fs::remove_dir_all` runs. Emits a single
 /// `ssd_cache_pre_release_wipe` event listing the removed namespaces.
 ///
@@ -439,7 +440,7 @@ pub(crate) fn enforce_namespace_budget(
               byte accumulation, and structured tracing — sequential with no \
               natural split that would not fragment the schema-wipe logic"
 )]
-fn wipe_pre_release_v1_namespaces(kv_root: &Path) {
+fn wipe_stale_schema_namespaces(kv_root: &Path) {
     if !kv_root.exists() {
         return;
     }
@@ -467,7 +468,7 @@ fn wipe_pre_release_v1_namespaces(kv_root: &Path) {
         if !db_path.exists() {
             continue; // empty namespace dir — nothing to migrate
         }
-        if !is_pre_release_v1(&db_path) {
+        if !is_stale_schema(&db_path) {
             continue;
         }
 
@@ -509,32 +510,31 @@ fn wipe_pre_release_v1_namespaces(kv_root: &Path) {
     }
 }
 
-/// True iff `index.db` is a SQLite file holding the v1 `kv_blocks` table but
-/// lacking the v2 `schema_version` table. Any error opening / inspecting the
-/// file is treated as "not v1" (leave it alone) — the in-place `SsdKvIndex::open`
-/// will surface a `SchemaMismatch` on a future schema and the operator can
-/// investigate, rather than this helper silently wiping unrelated DBs.
+/// True iff `index.db` is a SQLite file holding a `kv_blocks` table whose
+/// schema version is not the one this binary writes. A missing
+/// `schema_version` table reads as the pre-release v1 layout.
+///
+/// Any error opening / inspecting the file is treated as "leave it alone", as
+/// is a file with no `kv_blocks` table at all — this helper must never wipe a
+/// DB it does not recognise as a KV index.
+///
+/// Version mismatch in either direction is wiped, not just an older one. The
+/// tier is a pure cache with no source-of-truth content, so a binary that
+/// cannot read a namespace has exactly two options: reclaim the bytes, or
+/// strand them and disable the namespace for that run — the latter is what a
+/// downgrade used to do, leaving the directory on disk with nothing able to
+/// reclaim it.
 #[allow(
     clippy::manual_let_else,
     reason = "early-return on Err(_) is cleaner here: the connection is consumed \
               in a separate query_row call, so the let-else form would need to \
               restructure non-trivially around the borrow"
 )]
-fn is_pre_release_v1(db_path: &Path) -> bool {
+fn is_stale_schema(db_path: &Path) -> bool {
     let conn = match rusqlite::Connection::open(db_path) {
         Ok(c) => c,
         Err(_) => return false,
     };
-    let has_schema_version: bool = conn
-        .query_row(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_version'",
-            [],
-            |_| Ok(true),
-        )
-        .unwrap_or(false);
-    if has_schema_version {
-        return false;
-    }
     let has_kv_blocks: bool = conn
         .query_row(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='kv_blocks'",
@@ -542,7 +542,15 @@ fn is_pre_release_v1(db_path: &Path) -> bool {
             |_| Ok(true),
         )
         .unwrap_or(false);
-    has_kv_blocks
+    if !has_kv_blocks {
+        return false;
+    }
+    // Absent schema_version table ⇒ pre-release v1.
+    match crate::ssd_index::read_schema_version(&conn) {
+        Ok(Some(v)) => v != crate::ssd_index::SCHEMA_VERSION,
+        Ok(None) => true,
+        Err(_) => false,
+    }
 }
 
 /// Sum the size of every file inside `dir` (non-recursive enough — namespaces

--- a/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
@@ -114,18 +114,40 @@ fn seed_current_schema_namespace(kv_root: &Path, ns: &str) -> std::path::PathBuf
     ns_dir
 }
 
-/// Seed a namespace holding the current table shape but tagged with an
-/// explicit `schema_version` of `version`, plus a dummy `.kvb`.
+/// Seed a namespace at the **v2** table shape, tagged with an explicit
+/// `schema_version` of `version`, plus a dummy `.kvb`.
+///
+/// The DDL is written out here rather than reused from the production
+/// constant, the same way `seed_v1_namespace` does: a migration fixture has to
+/// pin the historical shape it claims to be, or a later schema bump silently
+/// turns it into a test of the current shape wearing an old version number.
+/// v2 and v3 differ only in the unit stored in `last_used`, so this is also
+/// what a real v2 file looks like.
 #[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "fixture setup under a temp dir this test owns; a failure is a broken fixture, not a condition under test"
 )]
 fn seed_namespace_at_version(kv_root: &Path, ns: &str, version: i64) -> std::path::PathBuf {
     let ns_dir = kv_root.join(ns);
     std::fs::create_dir_all(&ns_dir).unwrap();
     std::fs::write(ns_dir.join("dummy.kvb"), b"placeholder").unwrap();
     let conn = rusqlite::Connection::open(ns_dir.join("index.db")).unwrap();
-    conn.execute_batch(crate::ssd_index::SCHEMA_TABLES).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE kv_blocks (
+            hash        TEXT    NOT NULL,
+            layout_key  INTEGER NOT NULL,
+            path        TEXT    NOT NULL,
+            model_id    TEXT    NOT NULL,
+            kv_quant    TEXT    NOT NULL,
+            byte_size   INTEGER NOT NULL,
+            last_used   INTEGER NOT NULL,
+            PRIMARY KEY (hash, layout_key)
+        );
+        CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY NOT NULL
+        );",
+    )
+    .unwrap();
     conn.execute(
         "INSERT INTO schema_version (version) VALUES (?1)",
         rusqlite::params![version],
@@ -168,13 +190,14 @@ fn wipe_removes_pre_release_v1_namespace() {
 /// changing the table shape, so a v2 DB opens cleanly at the SQL level and its
 /// rows would silently mix two units three orders of magnitude apart.
 ///
-/// Leaving it in place is worse than a wipe: `SsdKvIndex::open` rejects the
-/// version, so the namespace is disabled for the run and its `.kvb` bytes are
-/// stranded with nothing able to reclaim them.
+/// Left in place it is dead weight: `SsdKvIndex::open` rejects the version, so
+/// the namespace is disabled for the run and its `.kvb` bytes sit there with
+/// nothing able to reclaim them. Only versions this binary supersedes are
+/// wiped — see `wipe_keeps_a_namespace_from_a_newer_binary`.
 #[test]
 #[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "fixture setup under a temp dir this test owns; a failure is a broken fixture, not a condition under test"
 )]
 fn wipe_removes_superseded_schema_namespace() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -191,6 +214,121 @@ fn wipe_removes_superseded_schema_namespace() {
     assert!(
         current.exists(),
         "current-schema namespace must survive the same pass"
+    );
+}
+
+/// A namespace written by a **newer** binary must survive. Two rMLX builds on
+/// one machine at different schema versions is the ordinary case here (a
+/// tap-installed release beside a dev build), and wiping forward means the
+/// older binary silently destroys the newer one's whole KV pool on every
+/// alternate boot. Stranded bytes are a reclamation problem; they do not
+/// license deleting a cache this binary simply cannot read.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture setup under a temp dir this test owns; a failure is a broken fixture, not a condition under test"
+)]
+fn wipe_keeps_a_namespace_from_a_newer_binary() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let kv_root = tmp.path().to_path_buf();
+    let newer = seed_namespace_at_version(
+        &kv_root,
+        "from-the-future",
+        crate::ssd_index::SCHEMA_VERSION + 1,
+    );
+
+    wipe_stale_schema_namespaces(&kv_root);
+
+    assert!(
+        newer.exists(),
+        "a namespace at a newer schema must be left for the binary that wrote it"
+    );
+    assert!(
+        newer.join("index.db").exists(),
+        "its index must be intact, not merely its directory"
+    );
+}
+
+/// Schema creation must be atomic. `SCHEMA_TABLES` creates `kv_blocks` and
+/// `schema_version`; the version *row* lands later. A concurrent
+/// `wipe_stale_schema_namespaces` that reads the DB in between sees a
+/// `kv_blocks` table and an empty `schema_version`, which
+/// `read_schema_version` reports as version 0 — stale — and the pass deletes a
+/// namespace another process is in the middle of creating.
+///
+/// The property is that the half-built state is never observable from another
+/// connection, which SQLite guarantees once the three steps share one
+/// transaction.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "temp-dir SQLite fixtures created by this test; a failure is a broken fixture, not a condition under test"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "thread join: a panic in the worker is a test failure and must surface, not be swallowed"
+)]
+fn schema_init_never_exposes_tables_without_their_version_row() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    const ROUNDS: usize = 60;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let observed_half_built = Arc::new(AtomicU64::new(0));
+    let rounds_run = Arc::new(AtomicU64::new(0));
+
+    let watcher = {
+        let (root, observed, rounds_run) = (
+            root.clone(),
+            Arc::clone(&observed_half_built),
+            Arc::clone(&rounds_run),
+        );
+        std::thread::spawn(move || {
+            while rounds_run.load(Ordering::Acquire) < ROUNDS as u64 {
+                for i in 0..ROUNDS {
+                    let db = root.join(format!("ns{i}")).join("index.db");
+                    if !db.exists() {
+                        continue;
+                    }
+                    let Ok(conn) = rusqlite::Connection::open(&db) else {
+                        continue;
+                    };
+                    let has_blocks = conn
+                        .query_row(
+                            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='kv_blocks'",
+                            [],
+                            |_| Ok(true),
+                        )
+                        .unwrap_or(false);
+                    if !has_blocks {
+                        continue;
+                    }
+                    // Exactly what `is_stale_schema` asks. Version 0 means the
+                    // table exists but carries no row yet.
+                    if matches!(crate::ssd_index::read_schema_version(&conn), Ok(Some(0))) {
+                        observed.fetch_add(1, Ordering::AcqRel);
+                    }
+                }
+                std::thread::yield_now();
+            }
+        })
+    };
+
+    for i in 0..ROUNDS {
+        let dir = root.join(format!("ns{i}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _idx = SsdKvIndex::open_at(&dir.join("index.db")).unwrap();
+        rounds_run.fetch_add(1, Ordering::AcqRel);
+    }
+    watcher.join().expect("watcher thread panicked");
+
+    assert_eq!(
+        observed_half_built.load(Ordering::Acquire),
+        0,
+        "another process observed kv_blocks without its schema_version row; the \
+         wipe pass would have deleted a namespace mid-creation"
     );
 }
 

--- a/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
@@ -63,7 +63,7 @@ fn compute_layout_key_is_distinct_across_tuples() {
     }
 }
 
-// ── wipe_pre_release_v1_namespaces ────────────────────────────────
+// ── wipe_stale_schema_namespaces ──────────────────────────────────
 
 /// Seed a v1-shaped namespace dir on disk under `kv_root`: a dummy `.kvb`
 /// file plus an `index.db` whose `kv_blocks` table matches the pre-
@@ -105,18 +105,38 @@ fn seed_v1_namespace(kv_root: &Path, ns: &str) -> std::path::PathBuf {
     clippy::unwrap_used,
     reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
 )]
-fn seed_v2_namespace(kv_root: &Path, ns: &str) -> std::path::PathBuf {
+fn seed_current_schema_namespace(kv_root: &Path, ns: &str) -> std::path::PathBuf {
     let ns_dir = kv_root.join(ns);
     std::fs::create_dir_all(&ns_dir).unwrap();
     let db_path = ns_dir.join("index.db");
-    // SsdKvIndex::open_at seeds a fresh v2 schema on a non-existent file.
-    let _ = SsdKvIndex::open_at(&db_path).expect("seed v2");
+    // SsdKvIndex::open_at seeds the current schema on a non-existent file.
+    let _ = SsdKvIndex::open_at(&db_path).expect("seed current schema");
+    ns_dir
+}
+
+/// Seed a namespace holding the current table shape but tagged with an
+/// explicit `schema_version` of `version`, plus a dummy `.kvb`.
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn seed_namespace_at_version(kv_root: &Path, ns: &str, version: i64) -> std::path::PathBuf {
+    let ns_dir = kv_root.join(ns);
+    std::fs::create_dir_all(&ns_dir).unwrap();
+    std::fs::write(ns_dir.join("dummy.kvb"), b"placeholder").unwrap();
+    let conn = rusqlite::Connection::open(ns_dir.join("index.db")).unwrap();
+    conn.execute_batch(crate::ssd_index::SCHEMA_TABLES).unwrap();
+    conn.execute(
+        "INSERT INTO schema_version (version) VALUES (?1)",
+        rusqlite::params![version],
+    )
+    .unwrap();
     ns_dir
 }
 
 /// unit test #3: wipe-on-upgrade. Seed a v1 namespace, drive
-/// `wipe_pre_release_v1_namespaces`, assert the dir is gone and a fresh
-/// `SsdKvIndex::open_at` against the (now-absent) path succeeds with v2.
+/// `wipe_stale_schema_namespaces`, assert the dir is gone and a fresh
+/// `SsdKvIndex::open_at` against the (now-absent) path succeeds.
 #[test]
 #[allow(
     clippy::expect_used,
@@ -132,47 +152,78 @@ fn wipe_removes_pre_release_v1_namespace() {
     let ns_dir = seed_v1_namespace(&kv_root, "wipe-v1");
 
     assert!(ns_dir.exists(), "fixture should seed namespace dir");
-    wipe_pre_release_v1_namespaces(&kv_root);
+    wipe_stale_schema_namespaces(&kv_root);
     assert!(!ns_dir.exists(), "v1 namespace must be removed");
 
-    // Re-creating the namespace (as a real model load would) → fresh v2 DB.
+    // Re-creating the namespace (as a real model load would) → fresh DB.
     std::fs::create_dir_all(&ns_dir).unwrap();
     let db_path = ns_dir.join("index.db");
-    let idx = SsdKvIndex::open_at(&db_path).expect("fresh v2 open");
+    let idx = SsdKvIndex::open_at(&db_path).expect("fresh open");
     // Sanity: empty index.
     assert_eq!(idx.total_bytes().unwrap(), 0);
 }
 
-/// unit test #4: no-op on an already-v2 namespace.
+/// A superseded-but-tagged namespace has to be reclaimed too, not only the
+/// untagged v1 layout. `last_used` moved from seconds to microseconds without
+/// changing the table shape, so a v2 DB opens cleanly at the SQL level and its
+/// rows would silently mix two units three orders of magnitude apart.
+///
+/// Leaving it in place is worse than a wipe: `SsdKvIndex::open` rejects the
+/// version, so the namespace is disabled for the run and its `.kvb` bytes are
+/// stranded with nothing able to reclaim them.
 #[test]
 #[allow(
     clippy::unwrap_used,
     reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
 )]
-fn wipe_is_noop_on_v2_namespace() {
+fn wipe_removes_superseded_schema_namespace() {
     let tmp = tempfile::TempDir::new().unwrap();
     let kv_root = tmp.path().to_path_buf();
-    let ns_dir = seed_v2_namespace(&kv_root, "wipe-v2");
+    let stale = seed_namespace_at_version(&kv_root, "wipe-v2", 2);
+    let current = seed_current_schema_namespace(&kv_root, "keep-current");
+
+    wipe_stale_schema_namespaces(&kv_root);
+
+    assert!(
+        !stale.exists(),
+        "superseded-schema namespace must be removed"
+    );
+    assert!(
+        current.exists(),
+        "current-schema namespace must survive the same pass"
+    );
+}
+
+/// unit test #4: no-op on a namespace already at the current schema.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn wipe_is_noop_on_current_schema_namespace() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let kv_root = tmp.path().to_path_buf();
+    let ns_dir = seed_current_schema_namespace(&kv_root, "wipe-current");
     let db_path = ns_dir.join("index.db");
 
     let before_meta = std::fs::metadata(&db_path).unwrap();
     let before_mtime = before_meta.modified().unwrap();
     let before_size = before_meta.len();
 
-    wipe_pre_release_v1_namespaces(&kv_root);
+    wipe_stale_schema_namespaces(&kv_root);
 
-    assert!(ns_dir.exists(), "v2 namespace must survive the wipe");
-    assert!(db_path.exists(), "v2 index.db must survive the wipe");
+    assert!(ns_dir.exists(), "namespace must survive the wipe");
+    assert!(db_path.exists(), "index.db must survive the wipe");
     let after_meta = std::fs::metadata(&db_path).unwrap();
     // mtime must not regress; size must be unchanged.
     assert_eq!(
         after_meta.len(),
         before_size,
-        "v2 index.db size must not change"
+        "index.db size must not change"
     );
     assert!(
         after_meta.modified().unwrap() >= before_mtime,
-        "v2 index.db mtime must not regress"
+        "index.db mtime must not regress"
     );
 }
 

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -91,11 +91,13 @@ fields zero → tier OFF; the `OnceLock` stores `None`.
 
 At startup, `install_config` runs two operations before any model loads:
 
-1. **Pre-release schema wipe** — scans every `<RMLX_HOME>/cache/kv/<ns>/`
-   directory. If `index.db` holds a `kv_blocks` table at any `schema_version`
-   other than the current one (a missing `schema_version` table reads as the v1
-   layout), the entire namespace directory is removed (`fs::remove_dir_all`)
-   and a `ssd_cache_pre_release_wipe` tracing event records the dropped bytes.
+1. **Stale-schema wipe** — scans every `<RMLX_HOME>/cache/kv/<ns>/` directory.
+   If `index.db` holds a `kv_blocks` table at a `schema_version` this binary
+   supersedes (a missing `schema_version` table reads as the v1 layout), the
+   entire namespace directory is removed (`fs::remove_dir_all`) and a
+   `ssd_cache_pre_release_wipe` tracing event records the dropped bytes plus
+   the version each namespace was found at. A **newer** version is left in
+   place and warned about instead (see "Namespaces from a newer binary").
    Idempotent: a clean boot at the current schema is a no-op. A directory with
    no `kv_blocks` table is never touched.
 
@@ -131,14 +133,12 @@ schema_version (
 )
 ```
 
-### last_used is the LRU total order
+### last_used is the LRU ordering key
 
-Eviction sorts on `last_used` and nothing else, so the column has to be a
-**total order over accesses**, not just an approximate one. `record` and
-`touch` stamp it from `ssd_index::now_stamp_us`, which reads the wall clock in
-microseconds and clamps the result above the highest value the process has
-already issued. That covers the two ways a raw clock stops being usable here:
-several writes inside one microsecond, and a clock stepped backwards by NTP.
+Eviction sorts on `last_used` and nothing else, so the column has to order
+accesses, not merely approximate them. `record` and `touch` stamp it from
+`ssd_index::now_stamp_us`, which reads the wall clock in microseconds and
+clamps the result above the highest value **this process** has issued.
 
 Seconds do not work. Under any realistic request rate many blocks land in the
 same second, `ORDER BY last_used ASC` has no tiebreak, and the victim becomes
@@ -147,14 +147,31 @@ discarded ahead of one used 100 ms ago, so the tier can throw away exactly the
 prefix it is about to be asked for. The degradation toward random replacement
 grows with request rate, i.e. it is worst when the tier matters most.
 
-It stays a wall-clock value rather than a plain counter for two reasons: the
+It stays a wall-clock value rather than a plain counter because the
 cross-namespace sweep merges rows from independent namespace databases and has
-to compare them (a per-database counter means nothing outside its own
-database), and the ordering has to survive a restart.
+to compare them; a per-database counter means nothing outside its own database.
 
-Because the stamp source is already a total order, no tiebreak column is
-needed and the `kv_blocks_last_used` index stays single-column — the index that
-keeps eviction from sorting the whole table.
+**Durability across restarts.** The clamp is process state and starts at zero,
+so `SsdKvIndex::open_at` seeds it from `MAX(last_used)` in the namespace it is
+opening (`adopt_persisted_stamps`, one indexed b-tree descent). Without that,
+a restart that follows a backwards clock step — NTP correction, a manual date
+change, RTC drift across sleep — writes blocks that sort *below* every row
+already on disk and evicts the newest data first, for as long as the clock
+lags. That inversion is persistent, and therefore worse than the same-second
+tie it replaced.
+
+**Scope: one process.** The stamps are a total order within a server, not
+across two. The Metal claim file is keyed by port (`/tmp/rmlx.<port>.claim`),
+so two `rmlx serve` instances on different ports each run `install_config` and
+can write the same pool; two writes landing in the same microsecond from
+different processes still tie. Seeding the clamp at every open narrows the
+window (each open adopts the other's stamps) but does not close it, and
+`evict_lru_until`'s `ORDER BY last_used ASC` has no tiebreak. The pool sweep's
+`(namespace, hash)` tiebreak is what keeps *that* path deterministic.
+
+No tiebreak column was added, so the `kv_blocks_last_used` index stays
+single-column — that is the index that keeps eviction from sorting the whole
+table.
 
 ### Composite Primary Key
 
@@ -176,7 +193,7 @@ behaviour — `layout_key` is weight-independent on purpose.
 
 - File absent → creates the current schema, inserts `schema_version = 3`.
 - File present, `schema_version` table missing → `SchemaMismatch` (pre-release v1 DB; should have been wiped by `install_config`).
-- File present, `schema_version != 3` → `SchemaMismatch` (a schema this binary cannot interpret).
+- File present, `schema_version != 3` → `SchemaMismatch` (a schema this binary cannot interpret; older ones are wiped by `install_config` first, newer ones are deliberately left in place).
 - File present, `schema_version == 3` → open succeeds.
 
 ### Migration
@@ -190,17 +207,31 @@ cost of a wipe is one re-prefill per dropped block.
 | v1 (no `schema_version` table, `hash` is the sole PK) | `layout_key` column + composite PK + `schema_version` table | Namespace dir removed at startup |
 | v2 | `last_used` unit: seconds → microseconds | Namespace dir removed at startup |
 
-`install_config` removes the entire namespace directory for any `index.db`
-whose version is not the current one, before any `SsdKvIndex::open` call runs
-in-process. A v2 table could not simply be reused: the shape is identical, so
-new microsecond rows and old second rows would coexist three orders of
-magnitude apart, reporting nonsense to any operator query and leaving the old
-rows as coarsely ordered among themselves as before.
+`install_config` removes the entire namespace directory for any `index.db` at a
+version this binary **supersedes**, before any `SsdKvIndex::open` call runs
+in-process.
 
-The mismatch is wiped in **either** direction, not only for older versions. A
-namespace this binary cannot read has exactly two possible fates — reclaim the
-bytes, or strand them while `SsdKvIndex::open` disables the namespace for the
-run — and nothing else reclaims a stranded namespace.
+The v2 case is a deliberate choice, not a forced one. The table shape did not
+change, so the rows are convertible in a single statement (`UPDATE kv_blocks
+SET last_used = last_used * 1000000`). They are wiped anyway because rMLX is
+pre-release and carrying migration code — plus the branch in the wipe pass that
+would have to let a v2 DB through to be converted — buys nothing that a warm
+cache does not rebuild in minutes. What is *not* an option is leaving v2 rows
+in place unconverted: they would sit three orders of magnitude below every new
+row and be evicted first regardless of use.
+
+### Namespaces from a newer binary
+
+A namespace at a version **newer** than this binary's is left alone and
+`warn!`ed (`event = "ssd_cache_newer_schema_skipped"`, with `found_version` and
+`expected_version`). Two rMLX builds at different schema versions on one
+machine is ordinary — a tap-installed release beside a dev build — and wiping
+forward would have the older binary destroy the newer one's whole pool on every
+alternate boot. This build cannot use such a namespace; reclaiming its bytes is
+an operator action, and the warning names the directory.
+
+A directory whose `index.db` has no `kv_blocks` table, or cannot be read at
+all, is never touched.
 
 ---
 
@@ -450,9 +481,9 @@ Algorithm:
 
 2. If pool_bytes <= global_budget_bytes: return EvictionReport (no-op).
 
-3. Sort merged list ascending by last_used (oldest first; the namespace + hash
-   tie-break is dead weight now that stamps are a total order, and is kept only
-   to make the sort itself deterministic).
+3. Sort merged list ascending by last_used (oldest first, tie-break by
+   namespace + hash — the stamp source only totally orders one process, so this
+   is what keeps the victim deterministic when two servers share the pool).
 
 4. Walk oldest-first, accumulate evictions until running_total <= global_budget_bytes.
 
@@ -621,7 +652,7 @@ is a startup error (exit 2).
 **Startup sequence (per serve invocation)**
 
 1. `install_config` is called once before any model loads.
-2. Pre-release v1 namespace wipe runs across all `<RMLX_HOME>/cache/kv/` dirs.
+2. Stale-schema namespace wipe runs across all `<RMLX_HOME>/cache/kv/` dirs.
 3. If `global_budget_bytes > 0`, cross-namespace LRU runs (`evict_pool_lru_until`).
 4. For each model loaded: `attach_at_load` → per-namespace startup maintenance
    (prune missing blocks, evict to per-namespace budget), then spiller +

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -60,7 +60,7 @@ flag itself is not an error.
 │  Tier 3 — SSD                                                       │
 │  <RMLX_HOME>/cache/kv/<namespace>/                                  │
 │    <hash>.kvb          — safetensors block file (one per KV slot)   │
-│    index.db            — SsdKvIndex v2 (SQLite, WAL mode)           │
+│    index.db            — SsdKvIndex v3 (SQLite, WAL mode)           │
 │                                                                     │
 │  On RAM miss: SsdHydrator reads .kvb → GPU upload → promote to     │
 │  Tier 1 without re-prefill.                                         │
@@ -92,10 +92,12 @@ fields zero → tier OFF; the `OnceLock` stores `None`.
 At startup, `install_config` runs two operations before any model loads:
 
 1. **Pre-release schema wipe** — scans every `<RMLX_HOME>/cache/kv/<ns>/`
-   directory. If `index.db` lacks the `schema_version` table (v1 layout), the
-   entire namespace directory is removed (`fs::remove_dir_all`) and a
-   `ssd_cache_pre_release_wipe` tracing event records the dropped bytes.
-   Idempotent: a clean v2 boot is a no-op.
+   directory. If `index.db` holds a `kv_blocks` table at any `schema_version`
+   other than the current one (a missing `schema_version` table reads as the v1
+   layout), the entire namespace directory is removed (`fs::remove_dir_all`)
+   and a `ssd_cache_pre_release_wipe` tracing event records the dropped bytes.
+   Idempotent: a clean boot at the current schema is a no-op. A directory with
+   no `kv_blocks` table is never touched.
 
 2. **Cross-namespace LRU enforcement** — when `global_budget_bytes > 0`,
    calls `evict_pool_lru_until` to bring the pool under the global ceiling
@@ -106,7 +108,7 @@ Effective per-namespace ceiling when both budgets are set:
 
 ---
 
-## SsdKvIndex — Schema v2
+## SsdKvIndex — Schema v3
 
 Each namespace has one SQLite database at
 `<RMLX_HOME>/cache/kv/<namespace>/index.db`. The database runs in WAL mode
@@ -120,14 +122,39 @@ kv_blocks (
     model_id    TEXT    NOT NULL,   -- "<arch>/<snapshot>" identity string
     kv_quant    TEXT    NOT NULL,   -- KvQuant Display string (e.g. "k8v4")
     byte_size   INTEGER NOT NULL,   -- on-disk byte size of the .kvb file
-    last_used   INTEGER NOT NULL,   -- unix epoch seconds (updated on touch)
+    last_used   INTEGER NOT NULL,   -- unix epoch MICROSECONDS (see below)
     PRIMARY KEY (hash, layout_key)
 )
 
 schema_version (
-    version     INTEGER PRIMARY KEY NOT NULL   -- 2
+    version     INTEGER PRIMARY KEY NOT NULL   -- 3
 )
 ```
+
+### last_used is the LRU total order
+
+Eviction sorts on `last_used` and nothing else, so the column has to be a
+**total order over accesses**, not just an approximate one. `record` and
+`touch` stamp it from `ssd_index::now_stamp_us`, which reads the wall clock in
+microseconds and clamps the result above the highest value the process has
+already issued. That covers the two ways a raw clock stops being usable here:
+several writes inside one microsecond, and a clock stepped backwards by NTP.
+
+Seconds do not work. Under any realistic request rate many blocks land in the
+same second, `ORDER BY last_used ASC` has no tiebreak, and the victim becomes
+whichever row SQLite happens to yield first — a block used 900 ms ago can be
+discarded ahead of one used 100 ms ago, so the tier can throw away exactly the
+prefix it is about to be asked for. The degradation toward random replacement
+grows with request rate, i.e. it is worst when the tier matters most.
+
+It stays a wall-clock value rather than a plain counter for two reasons: the
+cross-namespace sweep merges rows from independent namespace databases and has
+to compare them (a per-database counter means nothing outside its own
+database), and the ordering has to survive a restart.
+
+Because the stamp source is already a total order, no tiebreak column is
+needed and the `kv_blocks_last_used` index stays single-column — the index that
+keeps eviction from sorting the whole table.
 
 ### Composite Primary Key
 
@@ -145,20 +172,35 @@ behaviour — `layout_key` is weight-independent on purpose.
 
 ### Schema Version Enforcement
 
-`SsdKvIndex::open` inspects the DB before touching any v2 tables:
+`SsdKvIndex::open` inspects the DB before touching any table:
 
-- File absent → creates v2 schema, inserts `schema_version = 2`.
+- File absent → creates the current schema, inserts `schema_version = 3`.
 - File present, `schema_version` table missing → `SchemaMismatch` (pre-release v1 DB; should have been wiped by `install_config`).
-- File present, `schema_version != 2` → `SchemaMismatch` (future schema this binary cannot interpret).
-- File present, `schema_version == 2` → open succeeds.
+- File present, `schema_version != 3` → `SchemaMismatch` (a schema this binary cannot interpret).
+- File present, `schema_version == 3` → open succeeds.
 
-### V1 → V2 Migration
+### Migration
 
-rMLX is unreleased. The v1 → v2 transition is a **one-time wipe**, not a
-row-by-row migration. A v1 DB has a `kv_blocks` table whose `hash` column is
-the sole primary key (no `layout_key` column, no `schema_version` table).
-`install_config` removes the entire namespace directory for any such DB before
-any `SsdKvIndex::open` call runs in-process.
+rMLX is unreleased, so every schema transition is a **one-time wipe**, not a
+row-by-row migration. The tier holds nothing that is not regenerable, so the
+cost of a wipe is one re-prefill per dropped block.
+
+| From | What changed | What happens to existing data |
+|---|---|---|
+| v1 (no `schema_version` table, `hash` is the sole PK) | `layout_key` column + composite PK + `schema_version` table | Namespace dir removed at startup |
+| v2 | `last_used` unit: seconds → microseconds | Namespace dir removed at startup |
+
+`install_config` removes the entire namespace directory for any `index.db`
+whose version is not the current one, before any `SsdKvIndex::open` call runs
+in-process. A v2 table could not simply be reused: the shape is identical, so
+new microsecond rows and old second rows would coexist three orders of
+magnitude apart, reporting nonsense to any operator query and leaving the old
+rows as coarsely ordered among themselves as before.
+
+The mismatch is wiped in **either** direction, not only for older versions. A
+namespace this binary cannot read has exactly two possible fates — reclaim the
+bytes, or strand them while `SsdKvIndex::open` disables the namespace for the
+run — and nothing else reclaims a stranded namespace.
 
 ---
 
@@ -408,7 +450,9 @@ Algorithm:
 
 2. If pool_bytes <= global_budget_bytes: return EvictionReport (no-op).
 
-3. Sort merged list ascending by last_used (oldest first, tie-break by namespace + hash).
+3. Sort merged list ascending by last_used (oldest first; the namespace + hash
+   tie-break is dead weight now that stamps are a total order, and is kept only
+   to make the sort itself deterministic).
 
 4. Walk oldest-first, accumulate evictions until running_total <= global_budget_bytes.
 
@@ -623,10 +667,11 @@ is a startup error (exit 2).
   the eviction order. An interrupted cleanup therefore leaves an unreferenced
   row, which `prune_missing` reclaims at the next attach, rather than an
   unreferenced file, which nothing reclaims. A re-spill of the same hash landing
-  between a failed read and its cleanup can still cost that block; the row and
-  the file are the same for identical content, and `last_used` is
-  second-granular, so there is nothing to compare-and-delete against short of a
-  per-row generation counter.
+  between a failed read and its cleanup can still cost that block: the row and
+  the file are the same for identical content, so the cleanup cannot tell the
+  re-spilled row from the one it read. (`last_used` distinguishes them, but the
+  reader captured no stamp to compare against, so acting on it would need a
+  compare-and-delete the cleanup path does not have.)
 - Index open failures disable the tier for the affected namespace; other
   namespaces and the RAM cache are unaffected.
 


### PR DESCRIPTION
Closes #343.

## The defect

`last_used` was stamped with `SystemTime::now()...as_secs()`, while both eviction
paths order on that column alone (`ORDER BY last_used ASC` per namespace; a Rust
sort keyed `(last_used, namespace, hash)` for the cross-namespace pool). Blocks
touched in the same second tie, and the victim is whatever the tiebreak yields —
`kv_blocks` is a rowid table, so at equal `last_used` the index scan returns
*insert* order, i.e. exactly opposite to LRU once a touch has reordered anything.

## The fix

`now_stamp_us()` — wall-clock microseconds, clamped above the highest stamp the
process has issued. Strictly increasing, so ties cannot arise within a process,
and the single-column `kv_blocks_last_used` index stays usable (no tiebreak
column ⇒ no composite index). It stays a wall clock rather than a counter because
the pool sweep merges rows from independent namespace databases and must compare
them.

Red on unfixed code:

```
evict_lru_picks_the_least_recently_used_within_one_second
  left: ["b0", "b1", "b2"]      <- the three MOST recently used got evicted
 right: ["b3", "b4", "b5"]
concurrent_touches_get_distinct_ordered_stamps
  stamp 1786810026 collides across rows            <- a unix *second*
evict_pool_lru_orders_across_namespaces_within_one_second
  a0 was used after every beta block and must survive
```

The touched subset is the *earliest-inserted* set, so LRU order and insert order
disagree on every row — the unfixed code cannot pass by luck, and the first test
stays red on a milliseconds-only fix.

## Durability, which the first cut got wrong

The clamp was a per-process `static`, so it evaporated on restart and was not
shared between processes — while the code and docs claimed it survived both. That
is reachable, not theoretical: the claim file is keyed by *port*
(`/tmp/rmlx.<port>.claim`), so two `serve` instances on different ports write the
same pool with two independent clamps. And after a backwards clock step followed
by a restart, the static reloads at 0 and fresh blocks get stamps *below* every
persisted row — a permanent LRU inversion, strictly worse than the tie this issue
reported.

`open_at` now seeds the clamp from `COALESCE(MAX(last_used),0)` on both branches —
one b-tree descent on the existing index.

```
red    a_fresh_open_orders_new_blocks_above_rows_written_before_a_clock_step
       stamp 1786812657546844 vs persisted 1786812667531301   (10 s inversion)
```

The residual cross-process same-microsecond tie is documented rather than
eliminated; closing it needs stamp allocation inside the SQL write, which costs a
correlated subquery per spill and still would not order across namespaces. The
pool sweep's `(namespace, hash)` tiebreak is therefore load-bearing, not the "dead
weight" the first draft called it.

## Two wipe defects found on the way

**The wipe could delete a live, current-schema namespace.** `init_current_schema`
ran `SCHEMA_TABLES`, `SCHEMA_INDEXES` and the version `INSERT` as three separate
auto-committed batches. A concurrent process saw `kv_blocks` present with an empty
`schema_version`, which `read_schema_version` maps to `Ok(Some(0))` ⇒ superseded ⇒
`remove_dir_all` on a directory another process was writing. Previously the mere
*existence* of `schema_version` short-circuited the check; widening the predicate
to the version value opened the window. Schema creation is now one transaction
(pragmas stay outside — `journal_mode` cannot run inside one).

```
red    schema_init_never_exposes_tables_without_their_version_row
       left: 4   right: 0        (4 half-built observations in 60 rounds)
```

**The wipe ran forward as well as backward.** `v != SCHEMA_VERSION` also deleted
*newer* namespaces, and `install_config` runs on every boot including when the
tier is OFF — so a brew-installed release and a dev build on one machine would
destroy the pool on alternate boots. Now `found < SCHEMA_VERSION` wipes, and
`found > SCHEMA_VERSION` emits `event = "ssd_cache_newer_schema_skipped"` with the
namespace and both versions, leaving it for the binary that wrote it.

## Schema and existing data

`SCHEMA_VERSION` 2 → 3. Table shape is unchanged, so a v2 (seconds) row and a v3
(µs) row would sit 10³ apart. v2 namespaces are wiped at startup — a deliberate
pre-release choice to avoid carrying migration code, not something forced by the
unit change (the conversion is a one-statement
`UPDATE kv_blocks SET last_used = last_used * 1000000`, and the docs now say so).
The tier is a pure cache; the cost is one re-prefill per dropped block.

This also closed a latent hole: a v2→v3 bump previously left a namespace
unreadable by `open` with its `.kvb` bytes stranded and nothing able to reclaim
them.

## Mutation checks

Each reverts exactly one fix and reds exactly one test, with the other 93 green:

| Mutation | Red |
|---|---|
| `as_micros` → `as_secs` and drop clamp | 3 LRU tests + `now_stamp_us_is_strictly_increasing` |
| keep µs, drop only the clamp | `now_stamp_us_is_strictly_increasing` |
| drop `adopt_persisted_stamps` | `a_fresh_open_orders_new_blocks_above_rows_written_before_a_clock_step` |
| schema init back to 3 auto-committed batches | `schema_init_never_exposes_tables_without_their_version_row` |
| `found > SCHEMA_VERSION` → `false` | `wipe_keeps_a_namespace_from_a_newer_binary` |
| restore v1-only schema probe | `wipe_removes_superseded_schema_namespace` |

## Real models

Two verified-distinct binaries, identical 12-request workload through `rmlx serve`
with a real SSD budget, scratch `RMLX_HOME`, `--metrics off`:

| build | model | rows | distinct `last_used` | rows sharing a stamp | largest tie group |
|---|---|---|---|---|---|
| seconds | gemma-4-e2b (`kv_h==1`) | 11 | 2 | **11** | 7 |
| **fixed** | gemma-4-e2b | 11 | **11** | **0** | 1 |
| seconds | Ternary-Bonsai-8B (`kv_h>1`) | 11 | 6 | **9** | 3 |
| **fixed** | Ternary-Bonsai-8B | 11 | **11** | **0** | 1 |

Stamp ordering across a real restart (kill, relaunch on the same `RMLX_HOME`):
both models, 10 rows / 10 distinct, all 5 post-restart rows above the pre-restart
max, no inversion.

Tight-budget no-regression: gemma-4-e2b 8 evict passes, 10 386 840 B ≤ 12 884 901 B;
Bonsai-8B 8 evict passes, 249 807 888 B ≤ 268 435 456 B. In both the 3 survivors
are the 3 newest by stamp.

## Scope note

The end-to-end evidence is spill-path only. SSD *hydrate* does not fire on current
`main` — an unrelated seed regression makes the tier 0-hit — which is fixed
separately; it is why this branch measures stamps at spill rather than a
hydrate-driven MRU bump.

## Gates

`make ci` green. `make lint` clean, `cargo test --workspace` 2650 passed,
`check-no-inline-tests` and `check-gpu-tests-ignored` OK. Every mutation reverted
and verified absent. All serve processes killed; the real `runs.db` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
