### PR TITLE
docs(kv,ffi): `none` is a mixture, gemma-4 is not head_dim 256, and the SDPA cost is measured not asserted (#331, #337)

### DIFF
--- a/crates/rmlx-models/src/kv_cache/mod.rs
+++ b/crates/rmlx-models/src/kv_cache/mod.rs
@@ -19,8 +19,14 @@
 //! `KvQuant::None` path (removed then restored) is opt-in via `--kv-quant
 //! none` (alias `bf16`), as the closest available comparison against mlx-lm's
 //! bf16-KV champion. It holds a `[B, kv_h, S, D]` bf16 K and V buffer per
-//! layer, grown lazily toward the `--max-ctx` ceiling rather than allocated at
-//! it. Auto-resolver default is unchanged (still K8V8).
+//! layer. On the arches that adopted the lazy ring — gemma4, qwen3,
+//! qwen3_5_moe, qwen3_vl_moe, the ones that call `kv_max_seq_and_ceiling` and
+//! `with_max_seq_ceiling` — that buffer starts small and grows toward the
+//! `--max-ctx` ceiling instead of being allocated at it. laguna, gemma3,
+//! qwen2 and bitnet still construct at the resolved `--max-ctx`
+//! (`max_ctx_override.unwrap_or(KV_MAX_SEQ_DEFAULT)`, no ceiling set), so a
+//! large `--max-ctx` is an eager allocation there. Auto-resolver default is
+//! unchanged (still K8V8).
 //!
 //! `none` is **not** a pure-bf16 control: [`kv_quant_for_layer`] promotes the
 //! boundary layers to `K8V8` under every base mode, `None` included, so on an

--- a/crates/rmlx-models/src/kv_cache/mod.rs
+++ b/crates/rmlx-models/src/kv_cache/mod.rs
@@ -16,12 +16,17 @@
 //! # Quantization modes (S2.4)
 //!
 //! Default KV caches are quantized (K8V4, K8V8, Planar). The unquantised
-//! `KvQuant::None` path (removed then restored)
-//! is opt-in only via `--kv-quant none` (alias `bf16`) for apples-to-apples
-//! comparison against mlx-lm's bf16-KV champion. It pre-allocates a
-//! `[B, kv_h, max_seq, D]` bf16 buffer per layer for both K and V — at 4096
-//! ctx this is fine; at 128k ctx it would be ~64 GB. Auto-resolver default
-//! is unchanged (still K8V8).
+//! `KvQuant::None` path (removed then restored) is opt-in via `--kv-quant
+//! none` (alias `bf16`), as the closest available comparison against mlx-lm's
+//! bf16-KV champion. It holds a `[B, kv_h, S, D]` bf16 K and V buffer per
+//! layer, grown lazily toward the `--max-ctx` ceiling rather than allocated at
+//! it. Auto-resolver default is unchanged (still K8V8).
+//!
+//! `none` is **not** a pure-bf16 control: [`kv_quant_for_layer`] promotes the
+//! boundary layers to `K8V8` under every base mode, `None` included, so on an
+//! arch whose boundary layers hold a real cache the run is a mixture. See the
+//! per-arch counts and measured ratios in `docs/KV_QUANT.md`
+//! §Layer-adaptive overrides before reading any "vs `none`" number.
 //!
 //! `KvQuant::K8V4` is a CLAUDE.md-mandated baseline for Qwen MoE PPL recovery:
 //! - K uses affine q8_0 (symmetric 8-bit, `group_size=128`).
@@ -71,11 +76,13 @@ mod tests;
 pub const LAYER_ADAPTIVE_TAIL_N: usize = 8;
 
 /// Default number of head layers forced to `KvQuant::K8V8` by
-/// [`kv_quant_for_layer`] when `ctx >= 32K`.
+/// [`kv_quant_for_layer`], at every context length.
 ///
 /// Bench findings show first-layer KV vectors carry the highest absolute magnitudes
 /// (embedding residual is large before deep normalisation) and that forcing
-/// q8_0 on the first 2 layers recovers 37–91% of turbo2 quality loss.
+/// q8_0 on the first 2 layers recovers 37–91% of turbo2 quality loss at ≥32K
+/// context. That sweep is the evidence for the constant, not a gate on it:
+/// [`kv_quant_for_layer`] is never handed a context length.
 pub const LAYER_ADAPTIVE_HEAD_N: usize = 2;
 
 /// Layer-adaptive KV quantization.
@@ -92,7 +99,8 @@ pub const LAYER_ADAPTIVE_HEAD_N: usize = 2;
 ///   V-quant (turbo3/planar).
 /// - **Head**: first-layer K/V vectors carry large absolute magnitudes
 ///   (embedding residual before deep normalisation). q8_0 on the first 2
-///   layers recovers 37–91% of turbo2 quality degradation at ≥32K ctx.
+///   layers was measured to recover 37–91% of turbo2 quality degradation at
+///   ≥32K ctx; the promotion itself is unconditional.
 ///
 /// # Usage
 ///
@@ -114,9 +122,15 @@ pub const LAYER_ADAPTIVE_HEAD_N: usize = 2;
 /// override is by layer index, not by model name or KV mode — no hardcoded
 /// model branches.
 ///
-/// When `base_quant` is already `KvQuant::K8V8`, the override is a no-op.
-/// The only observable change is on `KvQuant::Planar`, `KvQuant::K8V4` (V
-/// side), and `KvQuant::Mixed` boundary layers, which are promoted to K8V8.
+/// `KvQuant::K8V8` is the only base mode for which this is a no-op. **Every**
+/// other base mode is promoted on the boundary layers — `KvQuant::None`
+/// included, so `--kv-quant none` allocates a bf16/K8V8 *mixture* rather than
+/// a bf16 control wherever those layers hold a real token-indexed cache. Two
+/// per-arch filters can still cancel the promotion in practice: a windowed
+/// layer runs the bf16 rotating ring regardless of the flag, and a shared-KV
+/// layer (Gemma4 `num_kv_shared_layers`) owns no cache to promote. Per-arch
+/// counts and the measured byte ratios are in `docs/KV_QUANT.md`
+/// §Layer-adaptive overrides.
 ///
 /// When `head_n == 0` and `tail_n == 0`, `base_quant` is always returned.
 pub fn kv_quant_for_layer(

--- a/crates/rmlx-models/src/kv_cache/tests.rs
+++ b/crates/rmlx-models/src/kv_cache/tests.rs
@@ -881,6 +881,39 @@ mod tests {
         }
     }
 
+    /// `KvQuant::None` is **not** exempt from the boundary promotion.
+    ///
+    /// This is what makes `--kv-quant none` a bf16/K8V8 mixture rather than a
+    /// bf16 control on any architecture whose boundary layers hold a real
+    /// token-indexed cache — and every published "vs `none`" ratio is read
+    /// against that mixture. `K8V8` is the only base mode the override leaves
+    /// alone; adding a second exemption here would silently change what a
+    /// recorded control measured.
+    #[test]
+    fn kv_quant_for_layer_promotes_none_base_at_boundaries() {
+        // 36 layers, every one full-attention: Ternary-Bonsai-8B's shape, the
+        // arch where the promotion is fully in effect.
+        let n = 36;
+        let base = KvQuant::None;
+        let promoted: Vec<usize> = (0..n)
+            .filter(|&i| {
+                kv_quant_for_layer(i, n, base, LAYER_ADAPTIVE_TAIL_N, LAYER_ADAPTIVE_HEAD_N) != base
+            })
+            .collect();
+        assert_eq!(
+            promoted,
+            vec![0, 1, 28, 29, 30, 31, 32, 33, 34, 35],
+            "`none` must be promoted on the first 2 + last 8 layers, not passed through"
+        );
+        for &i in &promoted {
+            assert_eq!(
+                kv_quant_for_layer(i, n, base, LAYER_ADAPTIVE_TAIL_N, LAYER_ADAPTIVE_HEAD_N),
+                KvQuant::K8V8,
+                "promoted layer {i} must land on K8V8"
+            );
+        }
+    }
+
     #[test]
     fn kv_quant_for_layer_planar_tail_overridden() {
         // Planar base: last 8 of 40 layers become K8V8; head 2 also become K8V8.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -136,9 +136,11 @@ mutually exclusive.
 > promotes the first 2 and last 8 layers to `K8V8` under *every* base mode,
 > `none` included. Wherever those layers hold a real token-indexed cache the
 > run is a bf16/K8V8 mixture — measured 1.145× true bf16 on Ternary-Bonsai-8B,
-> 1.109× on Qwen3.6-35B-A3B, and 1.000× on gemma-4 e2b/e4b (where the promotion
-> is cancelled by sliding-window and shared-KV layers). Per-arch counts and the
-> byte math: `docs/KV_QUANT.md` § "Layer-adaptive overrides".
+> 1.109× on Qwen3.6-35B-A3B and 1.000× on gemma-4-e2b. gemma-4-e4b is 1.000×
+> by the same layer-structure argument rather than by measurement: its
+> promoted head layers are sliding and its promoted tail is entirely shared-KV,
+> so nothing the promotion touches owns a quantizable cache. Per-arch counts
+> and the byte math: `docs/KV_QUANT.md` § "Layer-adaptive overrides".
 
 > **Per-request override (issue #26).** `--kv-quant` and `--max-ctx` set the
 > **launch defaults**. On a running server, the OpenAI route accepts per-request

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -132,6 +132,14 @@ mutually exclusive.
 > Qwen3 and Qwen3.5-MoE generate paths (the remaining arches do not call it
 > yet). Layout detail in `docs/KV_QUANT.md` § "Memory truth".
 
+> **`--kv-quant none` is not a pure-bf16 control.** `kv_quant_for_layer`
+> promotes the first 2 and last 8 layers to `K8V8` under *every* base mode,
+> `none` included. Wherever those layers hold a real token-indexed cache the
+> run is a bf16/K8V8 mixture — measured 1.145× true bf16 on Ternary-Bonsai-8B,
+> 1.109× on Qwen3.6-35B-A3B, and 1.000× on gemma-4 e2b/e4b (where the promotion
+> is cancelled by sliding-window and shared-KV layers). Per-arch counts and the
+> byte math: `docs/KV_QUANT.md` § "Layer-adaptive overrides".
+
 > **Per-request override (issue #26).** `--kv-quant` and `--max-ctx` set the
 > **launch defaults**. On a running server, the OpenAI route accepts per-request
 > `kv_quant` / `max_ctx` fields that override them for one request without

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -119,7 +119,7 @@ two are easy to conflate:
 |---|---|---|
 | Prefill attention, `head_dim` 64 or 128, Q not f32 | **yes**, `steel_attention_<dtype>_bq64_…` | MLX's `sdpa_full` takes the NAX branch unless `head_dim == 80` or Q is f32 without TF32 |
 | Prefill attention, `head_dim` 256 or 512 | no | MLX has no fused prefill kernel at either width, NAX or otherwise. See [Head-dim dispatch](#head-dim-dispatch-and-the-unfused-fallback) — that gap is about a missing kernel *shape*, not about NAX |
-| Decode attention, any `head_dim`, any codec | no | `bq64` is a query tile of 64; decode is `q_seq = 1`, and MLX routes `q_seq <= 8` to `sdpa_vector`, which has no NAX variant |
+| Decode attention, any `head_dim`, any codec | no | `bq64` is a query tile of 64, and decode is `q_seq = 1`. At `head_dim` ≤ 256 MLX routes `q_seq <= 8` to `sdpa_vector`, which has no NAX variant; at 512 there is no vector kernel either and decode falls to the composite path. Neither reaches NAX |
 | Our own `.metal` kernels | no | all of them are `q_seq = 1` decode kernels. NAX's one matmul tile shape has an M floor of 16; at `q_seq = 1` the only M available is `heads_per_kv` (4–8 on our models), so the tile can never be more than half filled |
 
 So the bf16 mirror's decode advantage over a quantized codec is bandwidth and
@@ -752,41 +752,68 @@ Gemma-4 is **not** a `head_dim` 256 model end-to-end: only its
 window-bounded layers are 256 wide, and the layers whose `kL` grows with the
 prompt are 512 wide. That distinction decides who actually pays.
 
-**What the fallback costs.** Isolated `mx.fast.scaled_dot_product_attention`,
-mlx 0.31.2, M5 Max, bf16, causal, `q_seq = kv_seq = L`, best-of-5; a repeat run
-of the 8192 cells moved every figure by under 1.5%. A fused kernel present at
-both widths would land near **2.0×** going 128 → 256, because doubling
-`head_dim` doubles the FLOPs:
+**What the fallback costs.** Reproduce with
+[`scripts/sdpa_headdim_bench.py`](../scripts/sdpa_headdim_bench.py), which
+prints the metallib inventory it measured against — **re-run it when the pin
+moves**, because these numbers are only valid for the kernel set above. Below:
+mlx 0.31.2, M5 Max, bf16, causal, `q_seq = kv_seq = L`, best-of-5 after a
+pipeline pre-warm, median of two runs. `L ≥ 8192` reproduced within 6%; the
+`L = 2048` row is launch-bound and is not load-bearing.
 
-| q:kv heads | L | `head_dim` 128 | 256 | 512 | 256 ÷ 128 |
-|---|---|---|---|---|---|
-| 8:1 | 2 048 | 1.42 ms | 2.29 ms | 2.30 ms | 1.61× |
-| 8:1 | 8 192 | 3.04 ms | 17.30 ms | 26.31 ms | **5.69×** |
-| 8:1 | 32 768 | 42.7 ms | 310.6 ms | 473.3 ms | **7.27×** |
-| 32:8 | 2 048 | 0.98 ms | 4.54 ms | 6.90 ms | **4.63×** |
-| 32:8 | 8 192 | 11.06 ms | 71.54 ms | 108.23 ms | **6.47×** |
-| 32:8 | 32 768 | 198.0 ms | 1 308.0 ms | 2 105.6 ms | **6.61×** |
+| q:kv heads | L | `head_dim` 128 | 256 | 512 | 256 ÷ 128 | peak, 256 |
+|---|---|---|---|---|---|---|
+| 8:1 | 2 048 | 0.71 ms | 1.27 ms | 1.73 ms | 1.79× | 99 MB |
+| 8:1 | 8 192 | 3.03 ms | 17.28 ms | 26.17 ms | **5.70×** | 1.25 GB |
+| 8:1 | 32 768 | 44.5 ms | 313.0 ms | 489.9 ms | **7.03×** | 18.7 GB |
+| 32:8 | 2 048 | 1.07 ms | 4.64 ms | 7.00 ms | **4.35×** | 390 MB |
+| 32:8 | 8 192 | 11.9 ms | 72.0 ms | 107.8 ms | **6.06×** | 4.8 GB |
+| 32:8 | 32 768 | 200.1 ms | 1 276.1 ms | 2 142.3 ms | **6.38×** | 71.7 GB |
 
-In achieved throughput: `head_dim` 128 reaches 88–103 TF/s at `L ≥ 8192`,
-`head_dim` 256 sits at 27–32 TF/s — roughly a third, for work that is only
-twice as large.
+A fused kernel present at both widths would land near 2.0×, since doubling
+`head_dim` doubles the FLOPs. Every cell from `L = 2048` up at 32:8, and from
+`L = 8192` up at 8:1, is past 4×. Only the smallest cell is inside the
+"costs little" band, so the gap is a real cost, not a curiosity.
+
+**Why it is more than 2×.** The two paths do not perform the same work, and
+the `causal` section of the harness measures it directly — `causal ÷ unmasked`
+at `L = 8192`:
+
+| `head_dim` | 8:1 | 32:8 | reading |
+|---|---|---|---|
+| 128 (fused) | 0.566 | 0.511 | skips fully-masked tiles — does ~half the rectangle |
+| 256 (composite) | 1.318 | 1.331 | computes the whole rectangle, then pays to build and apply the mask |
+| 512 (composite) | 1.160 | 1.150 | same |
+
+So going 128 → 256 costs 2× for the wider head **and another 2× for losing the
+causal skip** — 4× the arithmetic. Normalising each path by the work it
+actually performs (`2·H·L²·D` fused, `4·H·L²·D` composite), the fused path
+sustains 44–49 TF/s and the composite 28–32 TF/s. That closes the measurement:
+`4 × (46.2 / 30.5) = 6.06×` against 6.06× measured at 32:8 / 8192, and
+`4 × (44.0 / 27.6) = 6.38×` against 6.38× at 32:8 / 32768. The composite path
+is not catastrophically inefficient per FLOP — it is asked to do four times as
+many, and it materialises the score tensor to do them.
+
+Quoting a single dense-equivalent `4·H·L²·D` rate for both would overstate the
+fused path by 2×; the ratios above are convention-free either way.
 
 The 512 column is the control. Both 256 and 512 are unfused, and 512 ÷ 256
-measures 1.00–1.61× — *below* the 2.0× FLOP ideal, which is what a shared
+lands at 1.36–1.68× — *below* the 2.0× FLOP ideal, which is what a shared
 composite path predicts: its fixed `[H, L, L]` score cost does not grow with
 `head_dim`. The cliff is at the 128 → 256 boundary, not "wider heads are
 slower".
 
-Peak memory is the same story told in bytes. At `L = 32768`, 32:8:
-671 MB at `head_dim` 128 against **71.7 GB** at 256 — the materialised score
-tensor is 32 × 32768² × 2 B = 68.7 GB on its own.
+Peak memory is the same story told in bytes: at `L = 32768`, 32:8, 671 MB at
+`head_dim` 128 against **71.7 GB** at 256 — the materialised score tensor is
+32 × 32768² × 2 B = 68.7 GB on its own.
 
 Decode is unaffected in the way that matters: at `q_seq = 1` the score tensor
-is `[H, 1, kL]`, so the composite path has no O(L²) term. Measured at the one
-decode cell that clears this host's ~200 µs dispatch floor (32:8,
-`kL = 32768`), the unfused 512-wide path reads KV at 312 GB/s against the
-256-wide vector kernel's 360 GB/s; every other decode cell was dispatch-bound
-and cannot resolve a kernel-level difference.
+is `[H, 1, kL]`, so the composite path has no O(L²) term. In the only decode
+shape that stays clear of this host's ~200 µs dispatch floor (32:8,
+`kL = 32768`, three runs) the unfused 512-wide path reads KV at ≈315 GB/s
+against the 256-wide vector kernel's ≈355 GB/s — a modest deficit, not a
+cliff. Every other decode cell moved by up to 2.2× run to run and cannot
+resolve a kernel-level difference; the harness prints them all so that stays
+visible rather than being quoted selectively.
 
 **What rMLX actually pays.** Less than the isolated `L = kL` numbers above,
 for two structural reasons:

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -118,7 +118,7 @@ two are easy to conflate:
 | Path | NAX? | Why |
 |---|---|---|
 | Prefill attention, `head_dim` 64 or 128, Q not f32 | **yes**, `steel_attention_<dtype>_bq64_…` | MLX's `sdpa_full` takes the NAX branch unless `head_dim == 80` or Q is f32 without TF32 |
-| Prefill attention, `head_dim` 256 | no | MLX ships `steel_attention` for `bd` 64 / 80 / 128 only — a 256-wide head has no fused prefill kernel at all and runs the composite matmul+softmax fallback |
+| Prefill attention, `head_dim` 256 or 512 | no | MLX has no fused prefill kernel at either width, NAX or otherwise. See [Head-dim dispatch](#head-dim-dispatch-and-the-unfused-fallback) — that gap is about a missing kernel *shape*, not about NAX |
 | Decode attention, any `head_dim`, any codec | no | `bq64` is a query tile of 64; decode is `q_seq = 1`, and MLX routes `q_seq <= 8` to `sdpa_vector`, which has no NAX variant |
 | Our own `.metal` kernels | no | all of them are `q_seq = 1` decode kernels. NAX's one matmul tile shape has an M floor of 16; at `q_seq = 1` the only M available is `heads_per_kv` (4–8 on our models), so the tile can never be more than half filled |
 
@@ -132,17 +132,17 @@ archives inside a GPU capture — the whole `mlx.metallib` is also embedded in a
 bundle, so only the small per-pipeline archives are evidence of a *created*
 pipeline:
 
-- Ternary-Bonsai-8B (`head_dim` 128) creates three
+- Ternary-Bonsai-8B (every layer `head_dim` 128) creates three
   `steel_attention_bfloat16_bq64_bk32_bd128_wm4_wn1_mask*` pipelines — the
   causal, aligned-masked and unaligned-masked prefill permutations. NAX is
   engaged and Q is already bf16, so there is no f32 gate to fix.
-- gemma-4-e2b (`head_dim` 256) creates none, on the same tooling and prompt
-  size. It does create `steel_gemm_fused_nax_*`, i.e. NAX GEMM is live for a
-  model whose attention can never use NAX.
-- Both decode through `sdpa_vector`.
+- gemma-4-e2b creates none, on the same tooling and prompt size. Its sliding
+  layers are 256-wide and its full-attention layers 512-wide, and MLX ships no
+  fused attention kernel at either. It does create `steel_gemm_fused_nax_*`,
+  i.e. NAX GEMM is live for a model whose attention can never use NAX.
 
-Of the test targets only Bonsai-8B is `head_dim` 128; the gemma-4 family, the
-Qwen3.6 / Qwen3.5 family (Bonsai-27B included) and medgemma are all 256.
+Which widths reach which kernel, and what the fallback costs, is
+[Head-dim dispatch](#head-dim-dispatch-and-the-unfused-fallback).
 
 #### What the build checks
 
@@ -696,8 +696,7 @@ is ignored when `freqs` is provided; `has_value = false` is set on the
 
 ### `scaled_dot_product_attention`
 
-Fused FlashAttention-style SDPA. Wraps
-`mlx_fast_scaled_dot_product_attention`. Arguments:
+Wraps `mlx_fast_scaled_dot_product_attention`. Arguments:
 
 - `q`, `k`, `v`: `[batch, n_heads, seq_len, head_dim]`.
 - `scale`: `1/sqrt(head_dim)` or `1.0` (Gemma4 uses `1.0`).
@@ -705,6 +704,128 @@ Fused FlashAttention-style SDPA. Wraps
   `"additive"` (caller supplies additive mask), or `""` (no mask).
 - `mask_arr`: ignored when `mask_mode = "causal"`; null sentinel when `None`.
 - `sinks`: always null sentinel (not used at this stage).
+
+It is **not** unconditionally a FlashAttention kernel. Whether the call reaches
+a fused kernel or a composite graph is decided by `head_dim`, silently.
+
+#### Head-dim dispatch and the unfused fallback
+
+`ScaledDotProductAttention::use_fallback`
+(`mlx/backend/metal/scaled_dot_product_attention.cpp:618-636`, v0.31.2) gates
+on `head_dim` and on `q_seq`:
+
+| Route | `head_dim` accepted | Other conditions |
+|---|---|---|
+| `sdpa_full` (fused `steel_attention`) | 64, 80, 128 | `q_seq > 8` (prefill), and the mask is absent, an array, or causal with `q_seq <= kL` |
+| `sdpa_vector` (fused) | 64, 96, 128, 256 | `q_seq <= 8` (decode), `q_seq <= kL`, `q_seq × gqa_factor <= 32` |
+| composite graph | any | whatever both gates reject |
+
+The composite route is the unfused lambda at `mlx/fast.cpp:717` —
+`matmul(q, kᵀ)` → mask → `softmax` → `matmul`, with the
+`[B, n_heads, L_q, L_k]` score tensor **materialised**.
+
+The shipped kernel inventory agrees with the gate:
+
+```sh
+LIB="$(brew --prefix mlx)/lib/mlx.metallib"
+xcrun metal-nm --defined-only "$LIB" | grep -o 'steel_attention[a-z0-9_]*' | sort -u
+# ... _bd64_ / _bd80_ / _bd128_ only — no bd256, no bd512
+xcrun metal-nm --defined-only "$LIB" | grep -o 'sdpa_vector[a-z0-9_]*' | sort -u
+# ... _64_64 / _96_96 / _128_128 / _256_256 — no 512
+```
+
+So above `head_dim` 128 there is **no fused prefill kernel at all**, and at
+`head_dim` 512 there is no fused decode kernel either.
+
+**Which of our models sit where** (per-layer `head_dim` from each snapshot's
+`config.json`; the gemma-4 split is applied in `gemma4/loader.rs`, sliding
+layers take `head_dim`, full-attention layers take `global_head_dim`):
+
+| Family | Windowed / linear layers | Full-attention layers | Fused prefill? |
+|---|---|---|---|
+| Ternary-Bonsai-8B (`Qwen3ForCausalLM`) | — (all 36 are full-attention) | 128 | **yes** |
+| gemma-4 e2b / e4b / 26b / 31b | 256, SWA (`kL ≤ window`) | **512** | no, at either width |
+| medgemma 1.5 4b (`Gemma3…`) | 256, SWA (`kL ≤ window`) | 256 | no |
+| Qwen3.6-35B-A3B, Bonsai-27B (`Qwen3_5…`) | GDN — no SDPA | 256 | no |
+
+Gemma-4 is **not** a `head_dim` 256 model end-to-end: only its
+window-bounded layers are 256 wide, and the layers whose `kL` grows with the
+prompt are 512 wide. That distinction decides who actually pays.
+
+**What the fallback costs.** Isolated `mx.fast.scaled_dot_product_attention`,
+mlx 0.31.2, M5 Max, bf16, causal, `q_seq = kv_seq = L`, best-of-5; a repeat run
+of the 8192 cells moved every figure by under 1.5%. A fused kernel present at
+both widths would land near **2.0×** going 128 → 256, because doubling
+`head_dim` doubles the FLOPs:
+
+| q:kv heads | L | `head_dim` 128 | 256 | 512 | 256 ÷ 128 |
+|---|---|---|---|---|---|
+| 8:1 | 2 048 | 1.42 ms | 2.29 ms | 2.30 ms | 1.61× |
+| 8:1 | 8 192 | 3.04 ms | 17.30 ms | 26.31 ms | **5.69×** |
+| 8:1 | 32 768 | 42.7 ms | 310.6 ms | 473.3 ms | **7.27×** |
+| 32:8 | 2 048 | 0.98 ms | 4.54 ms | 6.90 ms | **4.63×** |
+| 32:8 | 8 192 | 11.06 ms | 71.54 ms | 108.23 ms | **6.47×** |
+| 32:8 | 32 768 | 198.0 ms | 1 308.0 ms | 2 105.6 ms | **6.61×** |
+
+In achieved throughput: `head_dim` 128 reaches 88–103 TF/s at `L ≥ 8192`,
+`head_dim` 256 sits at 27–32 TF/s — roughly a third, for work that is only
+twice as large.
+
+The 512 column is the control. Both 256 and 512 are unfused, and 512 ÷ 256
+measures 1.00–1.61× — *below* the 2.0× FLOP ideal, which is what a shared
+composite path predicts: its fixed `[H, L, L]` score cost does not grow with
+`head_dim`. The cliff is at the 128 → 256 boundary, not "wider heads are
+slower".
+
+Peak memory is the same story told in bytes. At `L = 32768`, 32:8:
+671 MB at `head_dim` 128 against **71.7 GB** at 256 — the materialised score
+tensor is 32 × 32768² × 2 B = 68.7 GB on its own.
+
+Decode is unaffected in the way that matters: at `q_seq = 1` the score tensor
+is `[H, 1, kL]`, so the composite path has no O(L²) term. Measured at the one
+decode cell that clears this host's ~200 µs dispatch floor (32:8,
+`kL = 32768`), the unfused 512-wide path reads KV at 312 GB/s against the
+256-wide vector kernel's 360 GB/s; every other decode cell was dispatch-bound
+and cannot resolve a kernel-level difference.
+
+**What rMLX actually pays.** Less than the isolated `L = kL` numbers above,
+for two structural reasons:
+
+- Prefill is chunked per arch (`prefill_chunk.rs`: gemma-4 1024,
+  Qwen3.5-MoE 2048), so the score tensor is `[H_q, chunk, kL]` — linear in
+  `kL`, not quadratic in the prompt. It is still large in absolute terms:
+  Qwen3.6-35B-A3B (16 q heads, chunk 2048) materialises 2.1 GB per
+  full-attention layer per chunk at `kL = 32768`, 8.6 GB at 128k. Chunking
+  bounds the growth, it does not remove the tensor.
+- On gemma-4 the 256-wide layers are sliding-window, so their `kL` is capped
+  at 512 / 1024 tokens no matter how long the prompt is.
+
+The families that pay a *growing*-`kL` composite cost are Qwen3.5 / Qwen3.6
+(10 of 40 layers on Qwen3.6-35B-A3B, 16 of 64 on Bonsai-27B), medgemma
+(5 of 34), and gemma-4's global layers — the last at 512, where no upstream
+proposal reaches.
+
+**Upstream status** (ml-explore/mlx, checked 2026-08-16). This belongs
+upstream, and it is already in flight there; none of it has merged:
+
+| PR | What | State |
+|---|---|---|
+| [#3293](https://github.com/ml-explore/mlx/pull/3293) | `head_dim=256` in `sdpa_full` + a `bd=256` steel instantiation | closed, unmerged |
+| [#3660](https://github.com/ml-explore/mlx/pull/3660) | revival of #3293 for 192/256, routed above `kL > 16384` | closed, unmerged |
+| [#3842](https://github.com/ml-explore/mlx/pull/3842) | a NAX `bd=256` full-attention path | open |
+| [#4185](https://github.com/ml-explore/mlx/pull/4185) | `force_fused` flag, which also restores 192/256 behind it | open |
+
+#3660 was closed with "we decided to add a `force_fused` option to the API to
+let users make the decision, instead of providing builtin heuristics" — so the
+direction upstream is an explicit opt-in, not a wider default. **No proposal
+covers `head_dim` 512**, so gemma-4's global layers stay composite regardless.
+
+There is nothing to port until a release ships one of these. A hand-written
+`bd=256` flash kernel here is not on the table: it duplicates upstream work,
+and the one attention-kernel class this repo has hand-written — flash-*decode*
+over a quant store — landed at 4–14% of MLX's per-byte throughput
+(`docs/PERF_BASELINE.md`). That is a different kernel, but it is the only
+calibration we have for what writing one here costs.
 
 ---
 

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -487,7 +487,8 @@ the identity *at the logical-mapping level* (the transposes cancel), so the
 common path stays correct. It is **byte-identical** to the pre-fix head-major
 grouping only when `head_dim % 128 == 0` — then every q8 group of 128 stays
 inside one head. That holds for every current QuantK-routed target arch
-(Qwen3.5-MoE linear `head_dim=128`, Gemma3 and Gemma4 text KV `head_dim=256`),
+(Qwen3.5-MoE linear `head_dim=128`, Gemma3 text KV `head_dim=256`, Gemma4 text
+KV `head_dim=256` on SWA layers and `512` on full-attention layers),
 so the cold path is byte-identical in practice. When `head_dim` is not a
 multiple of 128 (no current target arch, but exercised by the `d=64` cross-head
 round-trip test) a q8 group spans a (head,token) boundary, so its per-group

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -1486,6 +1486,12 @@ same shape — so the "true bf16" column is not an unchecked derivation:
 | gemma-4-e2b (`Gemma4…`) | 12 SWA + 3 global, of 35 | **0** | 31 776 768 | 31 776 768 | **1.000×** |
 | Qwen3.6-35B-A3B (`Qwen3_5Moe…`) | 10 global, of 40 | 2 | 88 215 552 | 79 564 800 | **1.109×** |
 
+The ratios drift a little with context — the bf16 term scales with filled
+length while the promoted layers' q8_0 term scales with `KV_PAGE_SIZE`-rounded
+capacity — so Bonsai reads 1.1447 at the `S = 3801` measured here, 1.1435 at
+32k (`docs/PERF_BASELINE.md`), tending to 1.1432. Treat these as 1.14× and
+1.11×, not as constants.
+
 How each row closes, at cache offset `S = prompt_len + max_tokens - 1`. The
 per-token rates come from `KvCache::resident_bytes`: a `KvStorage::None` layer
 is `filled_seq_bytes` over the two bf16 mirrors, a q8_0 layer adds packed codes

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -554,7 +554,8 @@ logical-mapping level, so the common path stays correct. The cold output is
 **byte-identical** to the pre-fix head-major grouping only when
 `head_dim % 128 == 0` (every q8 group of 128 stays inside one head) — which
 holds for every current QuantK-routed target arch (Qwen3.5-MoE linear
-`head_dim=128`, Gemma3 and Gemma4 text KV `head_dim=256`), so the cold path is
+`head_dim=128`, Gemma3 text KV `head_dim=256`, Gemma4 text KV `head_dim=256`
+on SWA layers and `512` on full-attention layers), so the cold path is
 byte-identical in practice. When `head_dim` is not a multiple of 128 (no current
 target arch, but exercised directly by the `d=64` cross-head round-trip test) a
 q8 group of 128 spans a (head,token) boundary and its per-group `abs_max` scale
@@ -1437,14 +1438,98 @@ request-level `KvQuant`:
 vectors carry the highest per-token information density; forcing 8-bit
 recovers PPL quality lost to aggressive V quantization.
 
-**Head layers** (at context ≥ 32K, `LAYER_ADAPTIVE_HEAD_N = 2`): the first 2
-layers are forced to `K8V8`. First-layer K/V vectors carry large absolute
-magnitudes (embedding residual is large before deep normalisation); q8_0
-on the first 2 layers recovers 37–91% of turbo2 quality degradation at ≥32K
-context.
+**Head layers** (`LAYER_ADAPTIVE_HEAD_N = 2`): the first 2 layers are forced to
+`K8V8`. First-layer K/V vectors carry large absolute magnitudes (embedding
+residual is large before deep normalisation). The reference sweep that set this
+constant measured 37–91% of turbo2's quality degradation recovered at ≥32K
+context — but that is the *evidence* for the constant, not a gate on it.
+`kv_quant_for_layer` is never handed a context length and promotes the first 2
+layers at every prompt size.
 
-When the base mode is already `K8V8`, both overrides are no-ops. The override
-is by absolute layer index; it is arch-agnostic.
+When the base mode is already `K8V8`, both overrides are no-ops.
+
+### `--kv-quant none` is not bf16
+
+`KvQuant::None` is **not** exempt. `kv_quant_for_layer` promotes head and tail
+layers whatever the base mode is, so wherever those layers hold a real
+token-indexed cache, `--kv-quant none` allocates a **mixture** of bf16 and
+K8V8 — not a bf16 control. Every "vs `none`" ratio in this repo is therefore a
+ratio between two mixtures, and on the architecture where the promotion bites
+hardest the denominator is already 1.14× true bf16.
+
+The override is by absolute layer index and carries no arch branch, but its
+*effect* is strongly per-arch, because two independent things can make a
+promoted layer a no-op:
+
+- **Windowed layers ignore the codec.** A cache built with a sliding window
+  runs the bf16 rotating ring regardless of the flag
+  (`KvCache::with_quant_max_seq_window` — mlx-lm's
+  `RotatingKVCache.to_quantized` raises `NotImplementedError` and rMLX matches
+  it). Promoting an SWA layer to `K8V8` changes nothing it stores.
+- **Shared-KV layers own no cache.** Gemma4's `num_kv_shared_layers` points
+  every layer from `n_layers - num_kv_shared_layers` onward back at an earlier
+  layer's cache (`gemma4/loader.rs::build_previous_kvs`); those layers are
+  handed `cache: None` and their own slot stays empty. Promoting them changes
+  nothing either.
+
+On gemma-4 e2b and e4b **both** filters apply and cancel the policy entirely:
+the only promoted layers that own a cache are 0 and 1, and both are sliding.
+
+Measured with `rmlx baseline --prompt-tokens 4096 --max-tokens 32 --max-ctx
+8192 --metrics off --log debug`, reading the per-generation `kv_bytes` event.
+Each row is pinned by two runs — `--kv-quant none` and `--kv-quant k8v8` at the
+same shape — so the "true bf16" column is not an unchecked derivation:
+
+| model | attention layers holding KV | promoted layers that change storage | `none`, attention KV | true bf16 | `none` ÷ bf16 |
+|---|---|---|---|---|---|
+| Ternary-Bonsai-8B (`Qwen3ForCausalLM`) | 36 global, of 36 | 10 | 641 581 056 | 560 480 256 | **1.145×** |
+| gemma-4-e2b (`Gemma4…`) | 12 SWA + 3 global, of 35 | **0** | 31 776 768 | 31 776 768 | **1.000×** |
+| Qwen3.6-35B-A3B (`Qwen3_5Moe…`) | 10 global, of 40 | 2 | 88 215 552 | 79 564 800 | **1.109×** |
+
+How each row closes, at cache offset `S = prompt_len + max_tokens - 1`. The
+per-token rates come from `KvCache::resident_bytes`: a `KvStorage::None` layer
+is `filled_seq_bytes` over the two bf16 mirrors, a q8_0 layer adds packed codes
+plus one `f32` scale per 128 values over a `KV_PAGE_SIZE = 256`-rounded
+capacity.
+
+- **Bonsai-8B** (`S = 3801`, `kv_h = 8`, `head_dim = 128`, capacity 3840). A
+  bf16 layer holds `2 × 8 × 128 × 2 B = 4096 B` per token, so true bf16 is
+  `36 × 4096 × 3801 = 560 480 256`. A promoted layer adds `2112 B` per token
+  of q8_0 K+V. That predicts `k8v8` at
+  `36 × (4096 × 3801 + 2112 × 3840) = 852 443 136` — measured 852 443 136, so
+  the split behind the `none` figure is pinned, not assumed.
+- **gemma-4-e2b** (`S = 4148`). 12 SWA rings at `2 × 1 × 256 × 2 B = 1024 B`
+  per token, capped at the 512 window, plus 3 global caches at
+  `2 × 1 × 512 × 2 B = 2048 B` per token — `global_head_dim` is 512, not 256.
+  The pure-bf16 identity `12 × 1024 × 512 + 3 × 2048 × 4148 = 31 776 768` is
+  the measured `none` **to the byte**: the promotion adds nothing. `k8v8`
+  measured 45 563 904, exactly `31 776 768 + 3 × 1056 × 4352`, confirming only
+  the 3 global caches are quantizable.
+- **Qwen3.6-35B-A3B** (`S = 3885`, capacity 4096). True bf16 over the 10
+  full-attention layers is `10 × 2048 × 3885 = 79 564 800`. Measured
+  `k8v8 − none = 34 603 008` = `8 × 1056 × 4096`, i.e. only 8 layers changed —
+  which is what identifies the other 2 as already promoted under `none`, adding
+  `2 × 1056 × 4096 = 8 650 752`.
+
+The raw `kv_bytes` on the Qwen3.5 family is larger than the attention-KV column
+above (152 604 672 under `none` here) because it also sums the fixed-size GDN
+recurrent state — 64 389 120 B, codec-independent, and it cancels exactly
+between the two runs. Against that denominator the ratio dilutes to 1.060×.
+The 1.109× is the attention-KV ratio, which is the one a codec comparison is
+about.
+
+Two things follow for anyone reading a codec table:
+
+1. A codec measured at `1.04× none` on Bonsai is `1.19×` true bf16. The
+   correction is a factor, not a rounding error.
+2. Cross-architecture ratios against `none` are not like-for-like: the same
+   flag means pure bf16 on gemma-4 e2b/e4b and a 26/10 mixture on Bonsai-8B.
+
+Recording the effective mixture alongside `kv_bytes` was considered and not
+done: the total is summed at 14 per-arch call sites, and threading a codec
+histogram through all of them buys a diagnostic that this table already states
+per architecture. The requested codec remains the correct *label* for a metrics
+row — what was missing was the interpretation, which is now here.
 
 ---
 
@@ -1709,7 +1794,10 @@ Stores that keep the CPU `IsoBlocks` (the V-only `iso3` / `iso4` codecs) add a
 bits per value, 3.0× bf16). That sideband is the constant `FIXED_QUAT`
 replicated per group, not data — the GPU ring the K-only and symmetric codecs
 decode from does not carry it, which is why `k_iso3/4` and `iso3_sym/4_sym`
-measure ≈1.00–1.02× `none` while `iso3` / `iso4` measure ≈2.1×.
+measure ≈1.00–1.02× `none` while `iso3` / `iso4` measure ≈2.1×. Those are
+whole-cache ratios against the `none` *control*, which is itself a mixture on
+some architectures — see §"`--kv-quant none` is not bf16". The per-group
+figures above are the store density and are unaffected.
 
 **No iso codec is a memory win, at any head_dim.** 8 B per 4 values is exactly
 bf16's density before the per-token norm is added, so the packed side is

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -707,7 +707,7 @@ audio fields under `audio_config`.
 | `num_key_value_heads` | int | SWA-layer KV heads |
 | `num_global_key_value_heads` | int | full-attention KV heads (26B/31B) |
 | `head_dim` | int | 256 for SWA layers |
-| `global_head_dim` | int | 512 for full-attention layers (31B) |
+| `global_head_dim` | int | 512 for full-attention layers (every size: e2b, e4b, 26B, 31B) |
 | `intermediate_size` | int | dense MLP width |
 | `vocab_size` | int | 262 144 |
 | `sliding_window` | int | SWA window (default 512) |
@@ -798,8 +798,11 @@ for full-attention layers is taken from `num_global_key_value_heads` in this
 case.
 
 **Dual head dimensions.** SWA layers use `head_dim` (256); full-attention
-layers use `global_head_dim` (512 on 31B). Partial rotary factor applies to
-`global_head_dim` for the full-attention RoPE.
+layers use `global_head_dim` (512 on every size, e2b through 31B — see
+`gemma4/loader.rs`). Partial rotary factor applies to `global_head_dim` for
+the full-attention RoPE. No gemma-4 layer is 128 wide, which is why none of
+them reaches MLX's fused attention kernel — see `docs/FFI.md`
+§`scaled_dot_product_attention`.
 
 **AltUp residual.** `hidden_size_per_layer_input` enables an AltUp-style
 residual gate when non-zero.

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -278,9 +278,34 @@ across the runs of a cell.
 
 The KV-bytes column is the reason to stop optimizing this family for
 throughput: `k_iso3/4` measures **1.003–1.006×** `none` and `k_rotor3/4`
-**1.11–1.17×**. A codec that is not smaller than bf16 has no bandwidth prize
-to collect, so parity with `none` is the ceiling, not a milestone on the way
-past it.
+**1.11–1.17×**. A codec that is not smaller than the bf16 it replaces has no
+bandwidth prize to collect, so parity is the ceiling, not a milestone on the
+way past it.
+
+**`none` is not bf16 on Bonsai — read the ratios accordingly.**
+`kv_quant_for_layer` promotes the first 2 and last 8 layers to `K8V8` under
+every base mode, `KvQuant::None` included, so the `none` control on a 36-layer
+dense arch is a 26-bf16 / 10-K8V8 mixture. See `docs/KV_QUANT.md`
+§Layer-adaptive overrides for the mechanism and the measured per-arch ratios.
+Restating this table against true bf16. That denominator is derived, not
+separately measured, but it is checkable: at `S = 31 553 + 128 − 1 = 31 680`
+(the fixture length above, `rmlx bench --max-tokens` default 128) the
+`filled_seq_bytes` identity for a `KvStorage::None` layer gives
+`36 × 4096 B/token × 31 680 = 4 671 406 080`, and adding the 10 promoted
+layers' q8_0 stores at `2112 B/token × 31 744` (capacity page-rounded to
+`KV_PAGE_SIZE = 256`) reproduces the recorded `none` figure 5 341 839 360 to
+the byte:
+
+| model | `none` ÷ true bf16 | `k_iso3` ÷ true bf16 | `k_rotor3` ÷ true bf16 |
+|---|---|---|---|
+| Bonsai-8B | **1.144×** | **1.150×** | **1.274×** |
+| gemma-4-e2b | 1.000× | 1.003× | 1.167× |
+
+gemma-4-e2b is unaffected because none of its promoted layers owns a
+quantizable cache — layers 0 and 1 are sliding (bf16 rotating ring regardless
+of the flag) and the last 8 are shared-KV consumers with no cache slot of their
+own. The correction is a Bonsai-side factor, not a table-wide one, which is
+itself the point: a "vs `none`" ratio is not comparable across architectures.
 
 Marginal cost over the replicated 16k→32k segment (`itl_p50` ms per 1k KV
 tokens) is unchanged by the dispatcher fix, as predicted — the fix moved the
@@ -291,13 +316,16 @@ intercept, not the slope:
 | Bonsai-8B | 0.261 | 1.799 (6.9×) | 2.178 (8.3×) |
 | gemma-4-e2b | 0.025 | 0.432 | 0.567 |
 
-Read e2b's ratio-to-`none` with care: only its 7 global layers grow, so the
+Read e2b's ratio-to-`none` with care: only its global layers grow, so the
 `none` denominator is near zero and the ratio inflates. Compare the absolute
 ms/1k across models instead. Counted from the per-dispatch `trace!` under
-`--log verbose`, the flash-decode kernel fires once per *growing* attention
-layer per decode step and is handed the full prefix — 26 of 36 layers on
-Bonsai (the first 2 and last 8 are forced to K8V8), 7 of 35 on e2b. What
-remains is per-KV-token work inside the kernel, not data movement.
+`--log verbose`, the flash-decode kernel fires once per full-attention layer
+per decode step and is handed the full prefix — 26 of 36 layers on Bonsai (the
+first 2 and last 8 are promoted to K8V8), 7 of 35 on e2b. Those 7 e2b
+dispatches read only **3** distinct caches: `num_kv_shared_layers = 20` leaves
+layers 15+ without a cache of their own, so the four later full-attention
+layers attend over the caches of layers 4, 9 and 14. What remains is
+per-KV-token work inside the kernel, not data movement.
 
 Each new codec: invoke `scripts/bench_codec_cell.sh --kv-quant <codec> --model <model>` per cell (3 cells per codec, A.y-excluded skipped), then append to this table.
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -287,8 +287,9 @@ way past it.
 every base mode, `KvQuant::None` included, so the `none` control on a 36-layer
 dense arch is a 26-bf16 / 10-K8V8 mixture. See `docs/KV_QUANT.md`
 §Layer-adaptive overrides for the mechanism and the measured per-arch ratios.
-Restating this table against true bf16. That denominator is derived, not
-separately measured, but it is checkable: at `S = 31 553 + 128 − 1 = 31 680`
+The table below restates this one against true bf16. That denominator is
+derived, not separately measured, but it is checkable: at
+`S = 31 553 + 128 − 1 = 31 680`
 (the fixture length above, `rmlx bench --max-tokens` default 128) the
 `filled_seq_bytes` identity for a `KvStorage::None` layer gives
 `36 × 4096 B/token × 31 680 = 4 671 406 080`, and adding the 10 promoted
@@ -298,8 +299,15 @@ the byte:
 
 | model | `none` ÷ true bf16 | `k_iso3` ÷ true bf16 | `k_rotor3` ÷ true bf16 |
 |---|---|---|---|
-| Bonsai-8B | **1.144×** | **1.150×** | **1.274×** |
+| Bonsai-8B | **1.144×** (at 32k) | **1.150×** | **1.274×** |
 | gemma-4-e2b | 1.000× | 1.003× | 1.167× |
+
+Bonsai's `none` ÷ bf16 drifts slightly with context, which is why
+`docs/KV_QUANT.md` quotes 1.145× and this table 1.144×: the bf16 term scales
+with filled length while the promoted layers' q8_0 term scales with
+`KV_PAGE_SIZE`-rounded *capacity*, so the ratio is 1.1447 at `S = 3801`,
+1.1435 here at `S = 31 680`, and tends to 1.1432 as the rounding washes out.
+Treat it as 1.14× and read the exact figure at the context you care about.
 
 gemma-4-e2b is unaffected because none of its promoted layers owns a
 quantizable cache — layers 0 and 1 are sliding (bf16 rotating ring regardless
@@ -322,10 +330,13 @@ ms/1k across models instead. Counted from the per-dispatch `trace!` under
 `--log verbose`, the flash-decode kernel fires once per full-attention layer
 per decode step and is handed the full prefix — 26 of 36 layers on Bonsai (the
 first 2 and last 8 are promoted to K8V8), 7 of 35 on e2b. Those 7 e2b
-dispatches read only **3** distinct caches: `num_kv_shared_layers = 20` leaves
-layers 15+ without a cache of their own, so the four later full-attention
-layers attend over the caches of layers 4, 9 and 14. What remains is
-per-KV-token work inside the kernel, not data movement.
+dispatches read only **3** distinct caches. `num_kv_shared_layers = 20` leaves
+layers 15+ without a cache of their own, and `build_previous_kvs`
+(`gemma4/loader.rs`) points each of them at the **last** non-shared layer of
+its attention type — layer 14 for full-attention. So layers 19, 24, 29 and 34
+all attend over layer 14's cache, while layers 4 and 9 serve one dispatch
+each: three caches, seven dispatches, five of them on layer 14. What remains
+is per-KV-token work inside the kernel, not data movement.
 
 Each new codec: invoke `scripts/bench_codec_cell.sh --kv-quant <codec> --model <model>` per cell (3 cells per codec, A.y-excluded skipped), then append to this table.
 

--- a/scripts/sdpa_headdim_bench.py
+++ b/scripts/sdpa_headdim_bench.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""What MLX's SDPA dispatch costs as a function of `head_dim`.
+
+Reproduces the measurement block in `docs/FFI.md`
+§`scaled_dot_product_attention` → "Head-dim dispatch and the unfused fallback".
+Re-run this whenever the pinned MLX pair moves: the numbers in that doc are
+valid only for the metallib this script reports at startup.
+
+MLX ships a fused prefill kernel (`steel_attention`) only at `head_dim`
+64 / 80 / 128, and a fused decode kernel (`sdpa_vector`) only at 64 / 96 / 128 /
+256. Everything else silently falls back to the composite graph in
+`mlx/fast.cpp` — `matmul(q, k^T)` -> mask -> softmax -> matmul, with the
+`[B, n_heads, L_q, L_k]` score tensor materialised. This measures the gap.
+
+Three sections, each answering one question:
+
+  prefill  How much does the fallback cost at prefill shapes (q_seq == kv_seq)?
+           Criterion, fixed before the first run: at matched (B, H, L), going
+           128 -> 256 doubles the FLOPs, so a fused kernel present at both
+           widths lands near 2.0x. <= 2.4x means the gap costs <= ~20% and is a
+           curiosity; >= 4.0x means >= 2x overhead and upstream work pays.
+           `head_dim` 512 is the control: it is unfused like 256, so 512 / 256
+           near 2.0x would mean "wider is slower" rather than "the kernel is
+           missing".
+
+  decode   Is decode affected? At `q_seq = 1` the score tensor is [H, 1, kL],
+           so the fallback has no O(L^2) term. Cells below this host's dispatch
+           floor (~200 us) cannot resolve a kernel-level difference and are
+           reported as such rather than quoted.
+
+  causal   How much work does each path actually perform? A fused kernel can
+           skip fully-masked tiles; the composite path computes the whole
+           rectangle and then masks it. `causal / unmasked` near 0.5 means the
+           tiles are skipped, near or above 1.0 means they are not. This is
+           what decides whether a throughput figure should be normalised by
+           2*H*L^2*D or by 4*H*L^2*D.
+
+Preconditions:
+
+  - Python MLX whose bundled metallib matches the pinned Homebrew bottle. The
+    startup banner prints both the version and the `steel_attention` /
+    `sdpa_vector` inventory so a run records the toolchain it measured. Verify
+    against the bottle with:
+        xcrun metal-nm --defined-only "$(brew --prefix mlx)/lib/mlx.metallib"
+  - Exclusive GPU. Hold the rMLX claim file or make sure nothing else is on the
+    device; a competing process invalidates every cell.
+  - Peak allocation reaches ~72 GB at the largest cell (the materialised score
+    tensor). Drop 32768 from `--lengths` on a smaller machine.
+
+Usage:
+
+    python3 scripts/sdpa_headdim_bench.py                 # all three sections
+    python3 scripts/sdpa_headdim_bench.py --json out.json
+    python3 scripts/sdpa_headdim_bench.py --sections prefill --lengths 2048,8192
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+import mlx.core as mx
+
+# (label, n_q_heads, n_kv_heads) — the real GQA ratios of our test targets.
+SHAPES = (
+    ("8:1", 8, 1),  # gemma-4-e2b
+    ("32:8", 32, 8),  # Ternary-Bonsai-8B
+)
+HEAD_DIMS = (128, 256, 512)
+WARMUP = 2
+ITERS = 5
+
+
+def banner():
+    """Print the toolchain a run measured, so its numbers stay attributable."""
+    print(f"mlx {mx.__version__}  device {mx.default_device()}")
+    libs = glob.glob(
+        os.path.join(os.path.dirname(os.path.dirname(mx.__file__)), "**", "*.metallib"),
+        recursive=True,
+    )
+    if not libs:
+        print("metallib: not found next to the mlx package — inventory unknown")
+        return
+    lib = libs[0]
+    try:
+        syms = subprocess.run(
+            ["xcrun", "metal-nm", "--defined-only", lib],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        print(f"metallib {lib}: inventory unavailable ({exc})")
+        return
+    full = sorted({m for m in re.findall(r"steel_attention\w*_(bd\d+)_", syms)})
+    vec = sorted({m for m in re.findall(r"sdpa_vector\w*?_(\d+)_\1", syms)}, key=int)
+    print(f"metallib {lib}")
+    print(f"  steel_attention (fused prefill): {', '.join(full) or 'none'}")
+    print(f"  sdpa_vector (fused decode):      {', '.join(vec) or 'none'}")
+
+
+def prewarm():
+    """Force pipeline creation for every kernel this run will time.
+
+    Metal builds a compute pipeline the first time a kernel shape is
+    dispatched, and that one-time cost lands on whichever cell happens to be
+    measured first — inflating it by ~2x at the small end, where it is the same
+    order as the cell itself. Paying it up front on throwaway shapes keeps the
+    first row comparable with the rest.
+    """
+    for d in HEAD_DIMS:
+        for mask in ("causal", None):
+            run(8, 1, 128, 128, d, mask)
+            run(8, 1, 1, 128, d, mask)
+
+
+def _best_ms(q, k, v, scale, mask):
+    def once():
+        mx.eval(mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask))
+
+    for _ in range(WARMUP):
+        once()
+    mx.synchronize()
+    best = float("inf")
+    for _ in range(ITERS):
+        t0 = time.perf_counter()
+        once()
+        mx.synchronize()
+        best = min(best, time.perf_counter() - t0)
+    return best
+
+
+def run(hq, hkv, q_len, kv_len, d, mask, track_peak=False):
+    """Time one SDPA shape. Returns (ms, peak_bytes|None)."""
+    scale = d**-0.5
+    q = mx.random.normal((1, hq, q_len, d)).astype(mx.bfloat16)
+    k = mx.random.normal((1, hkv, kv_len, d)).astype(mx.bfloat16)
+    v = mx.random.normal((1, hkv, kv_len, d)).astype(mx.bfloat16)
+    mx.eval(q, k, v)
+    if track_peak:
+        mx.reset_peak_memory()
+    best = _best_ms(q, k, v, scale, mask)
+    peak = mx.get_peak_memory() if track_peak else None
+    del q, k, v
+    mx.clear_cache()
+    return best, peak
+
+
+def prefill(lengths, rows):
+    print("\n## prefill — q_seq == kv_seq == L, causal")
+    print("\n| q:kv | L | head_dim | ms | peak MB | vs head_dim 128 |")
+    print("|---|---|---|---|---|---|")
+    for label, hq, hkv in SHAPES:
+        for length in lengths:
+            base = None
+            for d in HEAD_DIMS:
+                ms, peak = run(hq, hkv, length, length, d, "causal", track_peak=True)
+                base = ms if d == 128 else base
+                rows.append(
+                    {
+                        "section": "prefill",
+                        "shape": label,
+                        "L": length,
+                        "D": d,
+                        "ms": ms * 1e3,
+                        "peak_mb": peak / 1e6,
+                        "vs_d128": ms / base,
+                    }
+                )
+                print(
+                    f"| {label} | {length} | {d} | {ms * 1e3:.3f} | "
+                    f"{peak / 1e6:.1f} | {ms / base:.2f}x |",
+                    flush=True,
+                )
+
+
+def decode(lengths, rows):
+    print("\n## decode — q_seq == 1, unmasked")
+    print("\n| q:kv | kL | head_dim | us | GB/s KV read |")
+    print("|---|---|---|---|---|")
+    for label, hq, hkv in SHAPES:
+        for kv_len in lengths:
+            for d in HEAD_DIMS:
+                ms, _ = run(hq, hkv, 1, kv_len, d, None)
+                gbps = (2.0 * hkv * kv_len * d * 2) / ms / 1e9
+                rows.append(
+                    {
+                        "section": "decode",
+                        "shape": label,
+                        "kL": kv_len,
+                        "D": d,
+                        "us": ms * 1e6,
+                        "gbps": gbps,
+                    }
+                )
+                print(
+                    f"| {label} | {kv_len} | {d} | {ms * 1e6:.1f} | {gbps:.1f} |",
+                    flush=True,
+                )
+
+
+def causal(lengths, rows):
+    print("\n## causal ablation — does the path skip fully-masked tiles?")
+    print("\n| q:kv | L | head_dim | causal ms | unmasked ms | ratio |")
+    print("|---|---|---|---|---|---|")
+    for label, hq, hkv in SHAPES:
+        for length in lengths:
+            for d in HEAD_DIMS:
+                c, _ = run(hq, hkv, length, length, d, "causal")
+                u, _ = run(hq, hkv, length, length, d, None)
+                rows.append(
+                    {
+                        "section": "causal",
+                        "shape": label,
+                        "L": length,
+                        "D": d,
+                        "causal_ms": c * 1e3,
+                        "unmasked_ms": u * 1e3,
+                        "ratio": c / u,
+                    }
+                )
+                print(
+                    f"| {label} | {length} | {d} | {c * 1e3:.3f} | "
+                    f"{u * 1e3:.3f} | {c / u:.3f} |",
+                    flush=True,
+                )
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--json", help="also write every row to this path")
+    ap.add_argument(
+        "--sections",
+        default="prefill,decode,causal",
+        help="comma-separated subset of prefill,decode,causal",
+    )
+    ap.add_argument(
+        "--lengths",
+        default="2048,8192,32768",
+        help="comma-separated prefill lengths; decode uses the last two",
+    )
+    args = ap.parse_args(argv)
+
+    lengths = [int(x) for x in args.lengths.split(",")]
+    wanted = [s.strip() for s in args.sections.split(",")]
+    banner()
+    prewarm()
+
+    rows = []
+    if "prefill" in wanted:
+        prefill(lengths, rows)
+    if "decode" in wanted:
+        decode(lengths[-2:], rows)
+    if "causal" in wanted:
+        # One length is enough: the question is which side of 0.5 the ratio
+        # falls on, and that is a property of the dispatch, not of L.
+        causal(lengths[len(lengths) // 2 : len(lengths) // 2 + 1], rows)
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump(rows, fh, indent=1)
+        print(f"\nwrote {len(rows)} rows to {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #331. Closes #337.

Two documentation-truth issues. Both premises were partly false, and correcting
them turned up further wrong claims in the same files.

## #331 — `--kv-quant none` is not bf16

`kv_quant_for_layer` forces **K8V8 on the first 2 and last 8 layers** regardless of
the requested codec. Its only no-op base mode is `K8V8` itself — `None` is promoted
like everything else.

Two of the issue's own premises are false:

- **It is not Qwen3-family policy.** The helper is arch-agnostic and called by
  **7 architectures** (bitnet, qwen2, qwen3, qwen3_5_moe, gemma3, gemma4, laguna),
  none with a `None` guard.
- **`none` on gemma-4 e2b is not "a different mixture".** It is *exactly* pure
  bf16. Two filters cancel the promotion: the promoted head layers (0, 1) are
  sliding, and the rotating ring ignores the codec flag; the promoted tail sits
  past `n_layers - num_kv_shared_layers`, so those layers get `cache: None` and own
  no cache.

The docs were also wrong in a way the issue did not mention: `KV_QUANT.md` claimed
head-layer promotion happens "at context ≥ 32K" and that "the only observable
change is on `Planar`, `K8V4` (V side), and `Mixed`". `kv_quant_for_layer` takes no
context argument at all, and `kv_quant_for_ctx` selects the *base* mode by prompt
length and never feeds `head_n`/`tail_n`.

Measured with `rmlx baseline --prompt-tokens 4096 --max-tokens 32 --max-ctx 8192
--kv-quant {none,k8v8} --metrics off --log debug`, scratch `RMLX_HOME`. Every
prediction was stated from code *before* its control run and hit to the byte:

| model | `none` (attn KV) | true bf16 | ratio | control: k8v8 predicted → measured |
|---|---|---|---|---|
| Ternary-Bonsai-8B | 641 581 056 | 560 480 256 | **1.145×** | 852 443 136 → 852 443 136 |
| gemma-4-e2b | 31 776 768 | 31 776 768 | **1.000×** | 45 563 904 → 45 563 904 |
| Qwen3.6-35B-A3B | 88 215 552 | 79 564 800 | **1.109×** | 187 207 680 → 187 207 680 |

The e2b identity also proves `global_head_dim = 512` is what the KV actually uses —
the byte total only closes at 512, not 256. An independent corroboration from data
already in the repo: the pre-existing recorded e2b 32k `none` figure 218 148 864
equals `12 × 1024 × 512 + 3 × 2048 × 34 482` exactly, which closes only if
`global_head_dim` is 512 and only three global caches exist.

**Deleted:** the `ctx >= 32K` gate (doc plus two code comments), the "only
Planar/K8V4/Mixed change" claim, and a stale module doc claiming the ring
pre-allocates ~64 GB at 128k. **Added:** the mechanism, the two cancelling filters,
the measured table, caveats at both PERF_BASELINE "vs `none`" tables, a CLI operator
note, and a mutation-checked regression test — verified red when a `None` exemption
is injected, and red again if the promotion target is changed, so it pins both the
set and the target.

The issue's third ask — report the effective mixture alongside `kv_bytes` — is
**declined**, with the reasoning recorded in the doc: the total is summed at 14
per-arch call sites, and a runtime histogram buys a diagnostic the table now states
permanently.

## #337 — head_dim 256 has no fused attention kernel

The kernel-shape fact was **already documented** at `docs/FFI.md:121`. What was
wrong is the adjacent line — *"the gemma-4 family … are all 256"* — which the issue
repeats.

Every gemma-4 size carries `global_head_dim = 512`; the loader gives sliding layers
256 and full-attention layers 512. So gemma-4's 256-wide layers are
*window-bounded* and its growing-`kL` layers are 512 wide — a gap no upstream
proposal touches. Upstream PR #3660's own "Scope correction" says the same thing
independently. `docs/FFI.md:142` ("Both decode through `sdpa_vector`") was false for
those 512-wide layers: mlx 0.31.2 has no `sdpa_vector_*_512`.

Verified against the pinned metallib with `xcrun metal-nm`: `steel_attention` at
bd64 (18), bd80 (6), bd128 (18) — **no bd256/bd512**; `sdpa_vector` at 64/96/128/256
— **no 512**.

Upstream, as the issue asked: ml-explore/mlx **#3293** and **#3660** closed
unmerged, **#3842** and **#4185** open. #3660 closed with *"we decided to add a
`force_fused` option … instead of providing builtin heuristics."* Option 1 is
already in flight and not ours to duplicate.

### The measurement, and what committing it exposed

The first draft quoted an 18-cell SDPA table with no reproduction path. Committing
the harness (`scripts/sdpa_headdim_bench.py`, linked from the table caption, which
prints its own metallib inventory) exposed two defects in the numbers it was meant
to reproduce:

- The **first measured cell in a process absorbed one-time Metal pipeline
  creation** — the 8:1 L=2048/128 cell read 1.42 ms cold, 0.69 ms warm. Added a
  prewarm over every `(head_dim, mask)` pair. `L ≥ 8192` was unaffected and
  reproduces within 6%; the table is now the median of two post-prewarm runs and
  the launch-bound row is flagged. The old L=2048 row was an artefact and is gone.
- The **decode figures came from a single run**. Three runs give ≈315 vs ≈355 GB/s;
  other cells move up to 2.2× and are now described as unresolvable rather than
  quoted.

The FLOP convention was unstated, and the obvious fixes for it are both wrong. A
causal ablation (now a harness section) measures `causal ÷ unmasked` at **0.51–0.57
at head_dim 128** but **1.15–1.33 at 256/512**: the fused kernel skips fully-masked
tiles, while the composite computes the whole rectangle *and* pays extra to build
and apply the mask. Halving both ranges would therefore have understated the
composite by 2× — it genuinely performs the dense count.

Normalising each path by the work it actually performs (`2·H·L²·D` fused,
`4·H·L²·D` composite) gives 44–49 vs 28–32 TF/s, and that closes the measurement
quantitatively:

```
4 × (46.2 / 30.5) = 6.06×   vs   6.06× measured   (32:8, L=8192)
4 × (44.0 / 27.6) = 6.38×   vs   6.38× measured   (32:8, L=32768)
```

So the 128→256 penalty is 2× for the wider head **and another 2× for losing the
causal skip**. The first draft's "roughly a third, for work that is only twice as
large" was the dense-count artefact and is deleted.

Peak memory at L=32768, 32:8 heads: 671 MB → **71.7 GB** (the score tensor alone is
68.7 GB). Decode is structurally unaffected (`[H, 1, kL]` score).

**Deleted:** the "all 256" sentence, the wrong decode attribution, and "Fused
FlashAttention-style SDPA". The same half-truth is corrected in `MODELS.md` (×2),
`KV_QUANT.md` and `KV_CACHE.md`. One adjacent claim was *not* written as first
drafted: the upstream 8.59 GB/layer figure comes *with* chunking, so the doc does
not say chunking prevents multi-GB allocations — Qwen3.6-35B-A3B still materialises
2.1 GB/layer/chunk at 32k, 8.6 GB at 128k.

## Also corrected

- The e2b **KV sharing map**: `build_previous_kvs` records the *last* non-shared
  layer per attention type, so layers 19/24/29/34 all attend over layer **14**'s
  cache — not spread across 4, 9 and 14. Three caches, seven dispatches, five on
  layer 14.
- The **lazy-ring scope**: only gemma4, qwen3, qwen3_5_moe and qwen3_vl_moe set a
  ceiling; laguna, gemma3, qwen2 and bitnet still construct at the resolved
  `--max-ctx`. The sentence this replaces was wrong in the other direction.
- The **1.144 vs 1.145** discrepancy between files is real and explained rather
  than papered over: the ratio drifts with context because the bf16 term scales
  with filled length while the q8_0 term scales with `KV_PAGE_SIZE`-rounded
  capacity.

## Gates

`make ci` green. `cargo fmt --check` clean, `make lint` clean, `rmlx-models` 702
passed. All runs used a scratch `RMLX_HOME` with `--metrics off`; the real
`runs.db` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
