### PR TITLE
test(ci): wire the GPU suite into ci-perf, with a preflight and a gate that cannot be narrowed (#313)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ coverage grows.
    lies, call it out in code + docs.
 8. **Single MLX process per Mac**. Hold the claim file; unload competing MLX
    servers before claiming the GPU; never bypass the claim silently.
-9. **`make ci-perf` builds + tests under `release-perf` (panic=unwind, debug-assertions off), then runs `make gpu-test`.** A failure in the `release-perf` half that doesn't reproduce under `dev` → rebuild under `release-debug` (full DWARF) and re-run the failing case to capture symbols. Never rely on the `dev` profile to reproduce a release-mode bug — codegen and inlining differ. The `gpu-test` half is the exception and builds under `dev` on purpose: debug assertions are correctness guards and those are correctness tests.
+9. **`make ci-perf` builds + tests under `release-perf` (panic=unwind, debug-assertions off), then runs the GPU/Metal suite.** A failure in the `release-perf` half that doesn't reproduce under `dev` → rebuild under `release-debug` (full DWARF) and re-run the failing case to capture symbols. Never rely on the `dev` profile to reproduce a release-mode bug — codegen and inlining differ. The GPU half is the exception and builds under `dev` on purpose: debug assertions are correctness guards and those are correctness tests. Its consequence: **no gate anywhere executes a `Device::Gpu` test under `release-perf`** — `make test` / `make ci` are `dev` with no `--ignored`, `test-perf` is `release-perf` with no `--ignored`, the GPU suite is `dev` with `--ignored`. A GPU-path defect that appears only with debug-assertions off is therefore out of every gate's scope and must be reproduced by hand at that profile.
 10. **Every KV-cache codec ships an MSL (Metal) decode kernel.** A codec whose decode falls back to CPU dequant is not shippable — it strands the codec at single-digit TPS (GPU idle) and is a bug, not a valid mode. New KV codecs (and the decode path of existing ones) MUST decode on-GPU, reading the quant store directly (fused flash-decode-over-quant; see `docs/KV_QUANT.md`, `docs/FFI.md`, and #45). Each KV `.metal` kernel carries a **native-compilation test** (`xcrun -sdk macosx metal -c`, wired as `make check-metal-compiles` in `make ci`) so MSL syntax errors surface at CI, not on first GPU dispatch. Kernels stay **model-agnostic** — keyed off codec + shape (`head_dim`, `kv_heads`, `bits`), never an arch name.
 
 ## Coding style
@@ -203,10 +203,11 @@ Hard rules:
   serialized; `CRATE=` / `FILTER=` to narrow), or by hand as
   `cargo test -p <crate> --lib -- --ignored <filter> --test-threads=1`.
   `make gpu-test` is the only step that executes them — `make test` passes no
-  `--ignored` and the hosted CI has no Metal. It runs as the second half of
-  **`make ci-perf`**, the one shared gate that already assumes exclusive machine
-  access; it is deliberately not in `make ci`, which would then need the Metal
-  context to itself on every commit. A guard
+  `--ignored` and the hosted CI has no Metal. The same suite runs as the last
+  step of **`make ci-perf`** (invoked directly, so `CRATE=`/`VALIDATE=` cannot
+  narrow or disarm the gate), which is why `ci-perf` now requires an idle GPU
+  when it previously did not. It is deliberately not in `make ci`, which would
+  then need the Metal context to itself on every commit. A guard
   that only exercises a check the dispatcher rejects **before** touching a
   device-parameterized op is not a GPU test: pass `Device::Cpu` and leave it
   un-ignored — ignoring a CPU test silently stops running it. The CI gate
@@ -260,6 +261,7 @@ hand — keeps the CI gate and the local gate identical.
 | `make precommit` | `pre-commit run --all-files`. |
 | `make hooks` | Install the git `pre-commit` hook. |
 | `make ci` | `fmt-check + lint + test + deny + audit` — pre-merge gate. |
+| `make ci-perf` | `test-perf` under `release-perf` + the serialized GPU/Metal suite. Requires an idle GPU. Run before merging perf-sensitive or codec-layer changes (~21 min). |
 | `make tag` | Create annotated `v<version>` tag from `[workspace.package].version` (single source). |
 | `make release-package` | Build + bundle `dist/rmlx-v<ver>-aarch64-apple-darwin.tar.gz` (+ `.sha256`). |
 | `make release-sha` | Print sha256 of the `v<ver>` GitHub source tarball (`--write` patches the formula). |
@@ -275,7 +277,9 @@ hand — keeps the CI gate and the local gate identical.
 
 `MODEL` and `PORT` override at the CLI: `make info MODEL=/path/to/snapshot`.
 
-Run `make ci` before push. The per-commit `pre-commit` hook only runs the
+Run `make ci` before push, plus `make ci-perf` when the change touches
+`rmlx-kv-quant`, a `.metal` kernel, or a KV/decode path — `make ci` runs no GPU
+test. The per-commit `pre-commit` hook only runs the
 fast checks (fmt, clippy, file hygiene) — `cargo audit` and `cargo deny`
 fetch the RustSec advisory DB over the network and were stalling on slow
 links, so they are gated behind the `manual` stage. Trigger them via:
@@ -390,7 +394,8 @@ committed baseline: Bonsai ~110, Gemma4-e4b ~74, Qwen3.6 ~97 TPS) live in
 `git bisect skip`, exit 1 = regression. Two `Cargo.toml` perf profiles are
 in play: `release-perf` (`debug-assertions=false`, `overflow-checks=false`,
 stripped debug, `panic=unwind` kept for `MetalClaim::Drop` RAII — see Hard
-rule 9) is the canary / bench / `make ci-perf` profile; `release-debug`
+rule 9) is the canary / bench profile and the profile of `make ci-perf`'s
+`test-perf` half — its GPU half runs under `dev`, see Hard rule 9; `release-debug`
 (full DWARF, `debug=true`) is the samply flamegraph profile. Build targets:
 `make build-perf`, `make build-debug`, `make test-perf`, `make ci-perf`.
 The build-by-failure rule is in §Hard rules rule 9 — do not duplicate it here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ coverage grows.
    lies, call it out in code + docs.
 8. **Single MLX process per Mac**. Hold the claim file; unload competing MLX
    servers before claiming the GPU; never bypass the claim silently.
-9. **`make ci-perf` builds + tests under `release-perf` (panic=unwind, debug-assertions off).** A failure there that doesn't reproduce under `dev` → rebuild under `release-debug` (full DWARF) and re-run the failing case to capture symbols. Never rely on the `dev` profile to reproduce a release-mode bug — codegen and inlining differ.
+9. **`make ci-perf` builds + tests under `release-perf` (panic=unwind, debug-assertions off), then runs `make gpu-test`.** A failure in the `release-perf` half that doesn't reproduce under `dev` → rebuild under `release-debug` (full DWARF) and re-run the failing case to capture symbols. Never rely on the `dev` profile to reproduce a release-mode bug — codegen and inlining differ. The `gpu-test` half is the exception and builds under `dev` on purpose: debug assertions are correctness guards and those are correctness tests.
 10. **Every KV-cache codec ships an MSL (Metal) decode kernel.** A codec whose decode falls back to CPU dequant is not shippable — it strands the codec at single-digit TPS (GPU idle) and is a bug, not a valid mode. New KV codecs (and the decode path of existing ones) MUST decode on-GPU, reading the quant store directly (fused flash-decode-over-quant; see `docs/KV_QUANT.md`, `docs/FFI.md`, and #45). Each KV `.metal` kernel carries a **native-compilation test** (`xcrun -sdk macosx metal -c`, wired as `make check-metal-compiles` in `make ci`) so MSL syntax errors surface at CI, not on first GPU dispatch. Kernels stay **model-agnostic** — keyed off codec + shape (`head_dim`, `kv_heads`, `bits`), never an arch name.
 
 ## Coding style
@@ -203,9 +203,10 @@ Hard rules:
   serialized; `CRATE=` / `FILTER=` to narrow), or by hand as
   `cargo test -p <crate> --lib -- --ignored <filter> --test-threads=1`.
   `make gpu-test` is the only step that executes them — `make test` passes no
-  `--ignored` and the hosted CI has no Metal — so it is mandatory before merging
-  anything in the codec layer. It is deliberately not in `make ci` (needs the
-  Metal context to itself). A guard
+  `--ignored` and the hosted CI has no Metal. It runs as the second half of
+  **`make ci-perf`**, the one shared gate that already assumes exclusive machine
+  access; it is deliberately not in `make ci`, which would then need the Metal
+  context to itself on every commit. A guard
   that only exercises a check the dispatcher rejects **before** touching a
   device-parameterized op is not a GPU test: pass `Device::Cpu` and leave it
   un-ignored — ignoring a CPU test silently stops running it. The CI gate
@@ -251,7 +252,7 @@ hand — keeps the CI gate and the local gate identical.
 | `make build` | `cargo build --workspace --release`. |
 | `make check` | `cargo check --workspace --all-targets` (fast). |
 | `make test` | `cargo test --workspace` — **skips every `#[ignore]` GPU test**. |
-| `make gpu-test` | Run the GPU/Metal `#[ignore]` tests, `--test-threads=1` (`CRATE=` / `FILTER=` narrow). Needs exclusive machine access. Not in `make ci`. |
+| `make gpu-test` | Run the GPU/Metal `#[ignore]` tests, `--test-threads=1` (`CRATE=` / `FILTER=` narrow). Needs exclusive machine access. Part of `make ci-perf`, not `make ci`. |
 | `make fmt` / `make fmt-check` | Write / check `cargo fmt`. |
 | `make lint` | `cargo clippy -D warnings`. |
 | `make audit` | `cargo audit` with RustSec ignores from `deny.toml`. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,23 @@ make build          # cargo build --workspace --release
 make check          # fast cargo check
 make test           # workspace tests (needs a Metal GPU)
 make ci             # fmt-check + clippy + test + deny + audit  ← pre-PR gate
+make ci-perf        # test-perf + the GPU/Metal suite  ← also required, see below
 ```
 
 `make ci` must be green before you open a PR. The per-commit hook runs the fast
 checks; `cargo audit` / `cargo deny` are gated behind `make ci` (or
 `pre-commit run --hook-stage manual`).
+
+**`make ci` does not run the GPU tests.** Every test that reaches `Device::Gpu`
+carries `#[ignore]` (a shared Metal context driven from parallel `cargo test`
+threads aborts the whole binary), `make test` passes no `--ignored`, and the
+hosted CI has no Metal at all. `make ci-perf` is the gate that runs them,
+serialized and under Metal shader validation.
+
+Run it as well as `make ci` if your change touches **`crates/rmlx-kv-quant`, any
+`.metal` kernel, or a KV-cache / decode path**. It needs the GPU to itself —
+stop any `rmlx serve` first — and takes around 21 minutes. While iterating,
+`make gpu-test CRATE=… FILTER=…` runs a narrowed subset in seconds.
 
 Model-touching changes: see the regression-bench discipline in
 [`CLAUDE.md`](CLAUDE.md). At minimum the three test-target families (Gemma4,
@@ -42,7 +54,8 @@ of the recorded decode TPS.
 2. Keep changes surgical — match existing style, no drive-by refactors.
 3. Tests live in sibling `*_tests.rs` files (no inline `#[cfg(test)] mod`
    blocks — `make check-no-inline-tests` enforces this).
-4. `make ci` green locally.
+4. `make ci` green locally — plus `make ci-perf` for codec-layer / `.metal`
+   changes (see §Build & test).
 5. Open a PR into `main`. Fill in the PR template.
 
 `main` is protected: changes land via PR with CI green, not direct pushes.

--- a/Makefile
+++ b/Makefile
@@ -166,28 +166,52 @@ build-debug:     ## cargo build --profile release-debug (opt-level=3 + full DWAR
 test-perf:       ## cargo test --profile release-perf (release-perf profile, panic=unwind forced by cargo for test harness)
 	cargo test --workspace --profile release-perf
 
-# ci-perf runs `gpu-test` after `test-perf`, and it is the only shared gate that
-# does. `make ci` cannot: the GPU tests need the Metal context to themselves
-# (hard rule 8) and take minutes, which is the wrong price on every commit.
-# `ci-perf` already assumes exclusive machine access, so the constraint costs it
-# nothing it was not already paying.
+# ci-perf runs the GPU/Metal suite after `test-perf`, and it is the only shared
+# gate that does. `make ci` cannot: the GPU tests need the Metal context to
+# themselves (hard rule 8) and take minutes, which is the wrong price on every
+# commit. This is a real new cost for `ci-perf` and not a free one — the target
+# used to be a single `cargo test --workspace`, runnable next to a live
+# `rmlx serve`, and now it refuses to start unless the GPU is idle. It is simply
+# the cheapest place in the tree to pay it: `ci-perf` is already the long,
+# pre-merge-only target, and the preflight line below makes the new precondition
+# fail in milliseconds instead of after the release-perf half.
 #
-# `test-perf` first, deliberately: it covers the whole workspace and a compile
-# error anywhere shows up there, whereas `gpu-test` visits five crates and holds
-# the GPU while it does. Fail on the broad, shareable step before spending
-# exclusive-GPU minutes.
+# Three lines, in this order, for two different reasons:
 #
-# The two steps run under different profiles on purpose. `gpu-test` builds under
-# `dev`, where debug assertions are live — they are correctness guards, and the
-# GPU tests are correctness tests. `test-perf` is the one that must be
-# release-perf, because that is the codegen a perf-sensitive change ships under.
+#   * `--preflight` FIRST because it is a precondition, not a test. It checks
+#     only the things that cost nothing to check — RMLX_SKIP_GPU unset, no
+#     competing MLX process, a non-empty classification — and those are the most
+#     likely way this gate fails in daily use. Discovering a live `rmlx serve`
+#     after `test-perf` has run throws away the ~16 min it took.
+#   * `test-perf` before the tests themselves because it covers the whole
+#     workspace, so a compile error anywhere shows up there, whereas the GPU run
+#     visits five crates and holds the GPU while it does. Fail on the broad,
+#     shareable step before spending exclusive-GPU minutes.
+#
+# The runner is invoked directly rather than through `$(MAKE) gpu-test`. Make
+# propagates command-line variables to sub-makes, so `make ci-perf CRATE=…` or
+# `VALIDATE=0` would silently reach the runner and narrow or disarm the gate:
+# `--crate` shrinks the classified population in lockstep with the executed one,
+# so the runner's own coverage check cannot tell that run from a complete one.
+# The knobs stay on `gpu-test`, where a human asking for a subset means it.
+#
+# The two halves run under different profiles on purpose. The GPU run builds
+# under `dev`, where debug assertions are live — 61 `debug_assert!` sites in
+# rmlx-kv-quant alone — and those are correctness guards on correctness tests.
+# `test-perf` is the one that must be release-perf, because that is the codegen a
+# perf-sensitive change ships under. The consequence is in hard rule 9: no gate
+# runs a GPU test with debug-assertions off, so a defect that only appears there
+# has to be reproduced by hand.
 #
 # Cost: the GPU half is ~4.5 min warm (318 tests, serialized, under Metal shader
-# validation). Whole target after a codec-layer edit, measured: ~21 min. See
+# validation). Whole target after a codec-layer edit, measured: ~21 min. The dev
+# profile is not shared with `test-perf` and is what `make target-gc` prunes
+# first, so a run after a GC pays a cold opt-level-0 build on top. See
 # docs/TESTING.md.
 ci-perf:         ## pre-push gate under release-perf + the serialized GPU/Metal suite (separate from make ci; run before merging perf-sensitive or codec-layer changes)
+	@bash scripts/run_gpu_tests.sh --preflight
 	$(MAKE) test-perf
-	$(MAKE) gpu-test
+	@bash scripts/run_gpu_tests.sh
 	@echo "ci-perf ok"
 
 # gpu-test: the execution step for the tests `check-gpu-tests-ignored` mandates.
@@ -198,9 +222,11 @@ ci-perf:         ## pre-push gate under release-perf + the serialized GPU/Metal 
 # category, and tests in it have gone red on main and stayed red undetected.
 #
 # It is NOT part of `make ci`: it needs exclusive access to the Metal context and
-# is far too slow to block every commit. It IS part of `ci-perf`, the one target
-# that already assumes exclusive machine access — see the note there. Run it
-# directly, narrowed with CRATE=/FILTER=, while iterating on the codec layer.
+# is far too slow to block every commit. `ci-perf` runs the same suite as its
+# third line — by calling the script directly, not this target, so that its
+# population cannot be narrowed from the command line (see the note there). This
+# target is the hand-driven entry point: narrow it with CRATE=/FILTER= while
+# iterating on the codec layer, rather than paying for the whole gate each time.
 #
 # Metal shader validation is ON here. An out-of-bounds device store is dropped
 # silently — command buffer completes, cb.error is nil, cargo exits 0, and the

--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,28 @@ build-debug:     ## cargo build --profile release-debug (opt-level=3 + full DWAR
 test-perf:       ## cargo test --profile release-perf (release-perf profile, panic=unwind forced by cargo for test harness)
 	cargo test --workspace --profile release-perf
 
-ci-perf:         ## pre-push gate under release-perf (separate from make ci; run before merging perf-sensitive changes)
+# ci-perf runs `gpu-test` after `test-perf`, and it is the only shared gate that
+# does. `make ci` cannot: the GPU tests need the Metal context to themselves
+# (hard rule 8) and take minutes, which is the wrong price on every commit.
+# `ci-perf` already assumes exclusive machine access, so the constraint costs it
+# nothing it was not already paying.
+#
+# `test-perf` first, deliberately: it covers the whole workspace and a compile
+# error anywhere shows up there, whereas `gpu-test` visits five crates and holds
+# the GPU while it does. Fail on the broad, shareable step before spending
+# exclusive-GPU minutes.
+#
+# The two steps run under different profiles on purpose. `gpu-test` builds under
+# `dev`, where debug assertions are live — they are correctness guards, and the
+# GPU tests are correctness tests. `test-perf` is the one that must be
+# release-perf, because that is the codegen a perf-sensitive change ships under.
+#
+# Cost: the GPU half is ~4.5 min warm (318 tests, serialized, under Metal shader
+# validation). Whole target after a codec-layer edit, measured: ~21 min. See
+# docs/TESTING.md.
+ci-perf:         ## pre-push gate under release-perf + the serialized GPU/Metal suite (separate from make ci; run before merging perf-sensitive or codec-layer changes)
 	$(MAKE) test-perf
+	$(MAKE) gpu-test
 	@echo "ci-perf ok"
 
 # gpu-test: the execution step for the tests `check-gpu-tests-ignored` mandates.
@@ -178,11 +198,9 @@ ci-perf:         ## pre-push gate under release-perf (separate from make ci; run
 # category, and tests in it have gone red on main and stayed red undetected.
 #
 # It is NOT part of `make ci`: it needs exclusive access to the Metal context and
-# is far too slow to block every commit. Run it before merging anything in the
-# codec layer. Folding it into `ci-perf` (the one target that already assumes
-# exclusive machine access) is the natural next step, but is blocked while any
-# GPU test is red on main — wiring a known-red step into a shared gate just
-# teaches people to skip the gate.
+# is far too slow to block every commit. It IS part of `ci-perf`, the one target
+# that already assumes exclusive machine access — see the note there. Run it
+# directly, narrowed with CRATE=/FILTER=, while iterating on the codec layer.
 #
 # Metal shader validation is ON here. An out-of-bounds device store is dropped
 # silently — command buffer completes, cb.error is nil, cargo exits 0, and the

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -186,10 +186,10 @@ It is fail-closed in three ways:
 * **Coverage.** Every classified test must actually run. If a crate executes
   fewer tests than were classified for it — a renamed fn, a target no longer
   built, a test compiled out behind a feature — that is an error. Checking only
-  for "executed zero" would let 237 of 238 run and still report green.
+  for "executed zero" would let 317 of 318 run and still report green.
 * **`RMLX_SKIP_GPU=1` is refused outright.** Every classified test opens with
   `if skip_if_no_gpu_env() { return; }`, so with it set the whole suite returns
-  before touching Metal and the gate would happily print `OK: 324 GPU tests
+  before touching Metal and the gate would happily print `OK: 318 GPU tests
   passed` having dispatched nothing. It is a documented setting for Metal-less
   environments, so a stale export in a dev shell would otherwise disarm the one
   step that proves the GPU path works.
@@ -201,33 +201,78 @@ real one and belongs to whoever is holding the tree.
 
 #### Where it runs: `make ci-perf`, not `make ci`
 
-`make ci-perf` runs `test-perf` and then `gpu-test`. That is the only shared
-gate that executes the GPU tests.
+`make ci-perf` is three lines, and it is the only shared gate that executes the
+GPU tests:
+
+```make
+ci-perf:
+	@bash scripts/run_gpu_tests.sh --preflight
+	$(MAKE) test-perf
+	@bash scripts/run_gpu_tests.sh
+```
 
 It is deliberately **not** in `make ci`. Two costs rule that out: the suite needs
 the Metal context to itself (CLAUDE.md hard rule 8), so `make ci` could no longer
 be run alongside a live `rmlx serve`; and it adds minutes to a target that runs
-on every commit. `ci-perf` already assumes exclusive machine access, so the GPU
-constraint costs it nothing it was not already paying.
+on every commit.
 
-`test-perf` runs first on purpose: it covers the whole workspace, so a compile
-error anywhere surfaces there, while `gpu-test` visits five crates and holds the
-GPU while it does. Fail on the broad, shareable step before spending
-exclusive-GPU minutes.
+**This is a real new cost for `ci-perf`, not a free one.** Before, `ci-perf` was
+exactly `cargo test --workspace --profile release-perf` — one invocation that
+runs no `#[ignore]` test and so needs no GPU to itself; it could be, and was, run
+next to a live server. It now refuses to start unless the GPU is idle. `ci-perf`
+is simply the cheapest place in the tree to pay that: it is already the long,
+pre-merge-only target, and the preflight line makes the new precondition fail in
+milliseconds rather than after the release-perf half.
 
-The two steps build under different profiles, also on purpose. `gpu-test` uses
-`dev`, where debug assertions are live — they are correctness guards and these
-are correctness tests. `test-perf` must be `release-perf`, because that is the
-codegen a perf-sensitive change ships under.
+That ordering is the point of splitting the runner across two lines.
+`--preflight` checks only the environment — `RMLX_SKIP_GPU` unset, no competing
+MLX process, a non-empty classification — and runs no tests. Those are the most
+likely way this gate fails in daily use, and finding out about a live `rmlx
+serve` after `test-perf` has finished throws away the ~16 min it took. The tests
+themselves go last, after `test-perf`, because `test-perf` covers the whole
+workspace: a compile error anywhere surfaces there, while the GPU run visits five
+crates and holds the GPU while it does.
 
-**What it costs.** Measured on this host. The `gpu-test` half alone, warm: 318
-GPU tests across 5 crates in **264 s** (~4.5 min) with shader validation on, of
-which the `rmlx-kv-quant` unit suite is 141 s. Whole `make ci-perf` after a
-codec-layer edit — the case that actually matters, since a `.metal` change
-invalidates `rmlx-kv-quant` and everything downstream of it: **~21 min**
-(1270 s green, 1358 s on the red run). Note that `ci-perf` otherwise touches
-only `release-perf`, so `gpu-test` brings a second, unshared `dev`-profile build
-of those five crates and their test binaries with it.
+`ci-perf` invokes the runner **directly** rather than through `make gpu-test`.
+Make propagates command-line variables into sub-makes, so `make ci-perf
+CRATE=rmlx-audio` would have run 7 of 318 tests and still printed `ci-perf ok`,
+and `make ci-perf VALIDATE=0` would have disarmed shader validation. Neither is
+catchable by the coverage check, because `--crate` narrows the classified
+population in lockstep with the executed one. The knobs stay on `make gpu-test`,
+where a human asking for a subset means it.
+
+The two halves build under different profiles, also on purpose. The GPU run uses
+`dev`, where debug assertions are live — 61 `debug_assert!` sites in
+`rmlx-kv-quant` alone — and those are correctness guards on correctness tests.
+`test-perf` must be `release-perf`, because that is the codegen a perf-sensitive
+change ships under. The consequence is recorded in CLAUDE.md hard rule 9: **no
+gate anywhere runs a `Device::Gpu` test with debug-assertions off**, so a GPU
+defect that only appears at that profile has to be reproduced by hand.
+
+**What it costs.** Measured on this host, both figures with a warm `target/`:
+
+| | |
+|---|---|
+| GPU suite alone | **264 s** (~4.5 min) — 318 tests over 5 crates, shader validation on, of which the `rmlx-kv-quant` unit suite is 141 s |
+| Whole `make ci-perf` after a codec-layer edit | **~21 min** (1270 s green, 1358 s on the red run) |
+
+The second is the number that matters, since a `.metal` change invalidates
+`rmlx-kv-quant` and everything downstream of it under `release-perf` too.
+
+**Neither figure includes a cold `dev` build, and that is the case to expect.**
+`ci-perf` otherwise touches only `release-perf`, so the GPU half brings a second,
+unshared `dev`-profile build of those five crates and their dependency trees with
+it — at `opt-level = 0`, and after `test-perf` has just built the same test
+binaries under `release-perf`. `target/debug` is also precisely what
+`scripts/target_gc.sh` prunes first: it protects `release-perf` and names
+`target/debug` as the dominant consumer. So the first `make ci-perf` after the
+`make target-gc` that `make ci` advertises pays a full cold `dev` build on top of
+the ~21 min.
+
+Sharing `release-perf` with `test-perf` would remove that, and is deliberately
+not done — it would run the GPU correctness suite with `debug_assert!` compiled
+out, which is the wrong trade for the layer with this repo's documented
+silent-corruption class.
 
 While iterating on the codec layer, run `make gpu-test` directly and narrow it
 with `CRATE=` / `FILTER=` rather than paying for the whole gate each time.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -196,9 +196,41 @@ It is fail-closed in three ways:
 * **Exclusive GPU.** It refuses to start while another MLX process holds the
   Metal context (CLAUDE.md hard rule 8).
 
-`make gpu-test` is not part of `make ci`: it needs the Metal context to itself
-and is too slow to block every commit. Run it before merging anything in the
-codec layer.
+There is no known-red baseline: the suite is green on `main`, so a failure is a
+real one and belongs to whoever is holding the tree.
+
+#### Where it runs: `make ci-perf`, not `make ci`
+
+`make ci-perf` runs `test-perf` and then `gpu-test`. That is the only shared
+gate that executes the GPU tests.
+
+It is deliberately **not** in `make ci`. Two costs rule that out: the suite needs
+the Metal context to itself (CLAUDE.md hard rule 8), so `make ci` could no longer
+be run alongside a live `rmlx serve`; and it adds minutes to a target that runs
+on every commit. `ci-perf` already assumes exclusive machine access, so the GPU
+constraint costs it nothing it was not already paying.
+
+`test-perf` runs first on purpose: it covers the whole workspace, so a compile
+error anywhere surfaces there, while `gpu-test` visits five crates and holds the
+GPU while it does. Fail on the broad, shareable step before spending
+exclusive-GPU minutes.
+
+The two steps build under different profiles, also on purpose. `gpu-test` uses
+`dev`, where debug assertions are live — they are correctness guards and these
+are correctness tests. `test-perf` must be `release-perf`, because that is the
+codegen a perf-sensitive change ships under.
+
+**What it costs.** Measured on this host. The `gpu-test` half alone, warm: 318
+GPU tests across 5 crates in **264 s** (~4.5 min) with shader validation on, of
+which the `rmlx-kv-quant` unit suite is 141 s. Whole `make ci-perf` after a
+codec-layer edit — the case that actually matters, since a `.metal` change
+invalidates `rmlx-kv-quant` and everything downstream of it: **~21 min**
+(1270 s green, 1358 s on the red run). Note that `ci-perf` otherwise touches
+only `release-perf`, so `gpu-test` brings a second, unshared `dev`-profile build
+of those five crates and their test binaries with it.
+
+While iterating on the codec layer, run `make gpu-test` directly and narrow it
+with `CRATE=` / `FILTER=` rather than paying for the whole gate each time.
 
 ### Metal shader validation (on by default here)
 
@@ -268,9 +300,9 @@ a **5.8× slowdown** (n=3 each). That is the reason this never goes near a perf
 cell.
 
 **Never draw a conclusion about model *output* from a validated run.** The unit
-suites are invariant — 234 passed and the same 4 known-red failures in every
-repetition of both modes, with zero invalid-access reports — but real inference
-is not. Ternary-Bonsai-8B (Qwen3 dense) intermittently degenerates under
+suites are invariant — the same pass/fail result in every repetition of both
+modes, with zero invalid-access reports — but real inference is not.
+Ternary-Bonsai-8B (Qwen3 dense) intermittently degenerates under
 validation: it emits a single token (id 0, `"!"`), reports `tps=0.064`, and
 exits 0 with no diagnostic on stderr and nothing in Unified Logging. Reproduced
 here 1 run in 3 at `--kv-quant k8v8` under `FAIL_MODE=allow`, and independently
@@ -286,17 +318,8 @@ ever reported. Whether it is a latent engine defect that instrumentation
 perturbs into visibility or a defect in the instrumentation itself is unresolved
 and tracked outside this document.
 
-Current state: the whole `rmlx-kv-quant` GPU suite (238 classified tests) runs
-clean under validation — zero invalid accesses.
-
-### Known-red baseline
-
-`make gpu-test` currently exits 1 on a clean tree. Four tests in the
-`rmlx-kv-quant` rotor fused-QK dispatch integration binary fail with
-`rotor fused-QK dispatch delta = 0` — the sym and K-only rotor codecs no longer
-reach the fused-QK kernel, while their K-asym siblings still do. This is tracked
-separately and is not a regression from any recent change; it is why the target
-is not yet wired into `ci-perf`. Anything failing **beyond** those four is yours.
+Current state: the whole GPU suite — all five crates, `rmlx-kv-quant` included —
+runs clean under validation, zero invalid accesses.
 
 ### `#[ignore]` is not a place to park a broken test
 

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -83,6 +83,13 @@
 #   bash scripts/run_gpu_tests.sh --crate rmlx-kv-quant
 #   bash scripts/run_gpu_tests.sh --crate rmlx-kv-quant --filter rotor_flash
 #   bash scripts/run_gpu_tests.sh --no-shader-validation
+#   bash scripts/run_gpu_tests.sh --preflight   # preconditions only, no tests
+#
+#   The narrowing options exist for iterating by hand. A gate must invoke this
+#   script with NO arguments — `--crate`/`--filter` narrow the classified
+#   population in lockstep with the executed one, so the coverage check below
+#   cannot tell a narrowed run from a complete one, and `--no-shader-validation`
+#   disarms the instrumentation entirely.
 #
 # Exit 0 = every selected GPU test passed. Exit 1 = a failure, a shader
 # validation diagnostic, or a run that executed nothing.
@@ -99,24 +106,30 @@ usage() {
     cat <<'USAGE'
 Usage: run_gpu_tests.sh [--crate <name>] [--filter <substring>]
                         [--shader-validation | --no-shader-validation]
+       run_gpu_tests.sh --preflight
 
   --crate <name>          restrict to one workspace member (e.g. rmlx-kv-quant)
   --filter <substring>    restrict to GPU test fns whose name contains <substring>
   --shader-validation     instrument every Metal pipeline and fail on an invalid
                           memory access (default)
   --no-shader-validation  run the tests uninstrumented
+  --preflight             check only the environment preconditions (no GPU
+                          variable set, no competing MLX process, a non-empty
+                          classification) and exit; runs no tests
 USAGE
 }
 
 ONLY_CRATE=""
 FILTER=""
 SHADER_VALIDATION=1
+PREFLIGHT=0
 while [ $# -gt 0 ]; do
     case "$1" in
         --crate)  ONLY_CRATE="${2:?--crate needs a value}"; shift 2 ;;
         --filter) FILTER="${2:?--filter needs a value}"; shift 2 ;;
         --shader-validation)    SHADER_VALIDATION=1; shift ;;
         --no-shader-validation) SHADER_VALIDATION=0; shift ;;
+        --preflight) PREFLIGHT=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) echo "ERROR: unknown argument '$1'" >&2; usage >&2; exit 1 ;;
     esac
@@ -206,6 +219,18 @@ listing="$(bash "${REPO_ROOT}/scripts/check_gpu_tests_ignored.sh" --list)"
 if [ -z "${listing}" ]; then
     echo "ERROR: check_gpu_tests_ignored.sh --list produced no GPU tests." >&2
     exit 1
+fi
+
+# Everything above this line is a precondition on the environment rather than a
+# test: the two refusals and a non-empty classification, all of them
+# milliseconds. `--preflight` stops here so a caller that is about to spend a
+# long time on something else can find out FIRST that this suite would refuse to
+# start. `make ci-perf` runs it before its release-perf half for exactly that
+# reason — discovering a live `rmlx serve` after the workspace suite has already
+# run wastes the whole of it.
+if [ "${PREFLIGHT}" = "1" ]; then
+    echo "preflight OK: GPU free, no skip variable, $(printf '%s\n' "${listing}" | grep -c '') tests classified."
+    exit 0
 fi
 
 # Apply the narrowing options, then group what is left by crate.

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -417,8 +417,8 @@ if [ -n "${failed_crates}" ]; then
     echo >&2
     echo "Reproduce one crate with:" >&2
     echo "  cargo test --no-fail-fast -p <crate> --tests -- --ignored --test-threads=1 <filter>" >&2
-    echo "Known-red baseline (tracked separately): the four rotor fused-QK dispatch" >&2
-    echo "tests in rmlx-kv-quant reporting 'dispatch delta = 0'. See docs/TESTING.md." >&2
+    echo "There is no known-red baseline: this suite is green on main, so any" >&2
+    echo "failure above is a real one. See docs/TESTING.md." >&2
     echo "A crate reported as 'ran uninstrumented' usually failed to BUILD: no test" >&2
     echo "binary means no Metal device and therefore no validation banner." >&2
     exit 1


### PR DESCRIPTION
Closes #313.

The runner shipped in #345; it was left unwired because it was red on four
`rotor*_fused_qk_dispatch` tests, and a knowingly-red step in a shared gate just
teaches people to skip the gate. #333 closed those, so this wires it.

Verified rather than assumed — the full runner on a clean tree at `14a8ca6f`,
across every crate the classifier covers, not just the one that motivated it:

```
OK: 318 GPU tests passed across 5 workspace member(s), shader validation clean.
rmlx-audio 7 | rmlx-kv-quant 229 | rmlx-kv-ssd 11 | rmlx-mlx 7 | rmlx-models 63
```

## Where, and why there

`ci-perf`, as the step after `test-perf`.

Not `make ci`: the suite needs the Metal context to itself, so `make ci` could no
longer run alongside a live `rmlx serve`, and it would add minutes to every commit.
Not a scheduled job either — hosted CI has no Metal.

`test-perf` runs first because it covers the whole workspace, so a compile error
anywhere surfaces there before the gate spends exclusive-GPU minutes. But that
ordering is only right for *failures*; the runner's preconditions are millisecond
checks and the most likely way this gate fails in daily use, so they are hoisted to
the front as a `--preflight` mode:

```
ci-perf:
	@bash scripts/run_gpu_tests.sh --preflight
	$(MAKE) test-perf
	@bash scripts/run_gpu_tests.sh
```

The preflight is mutation-checked, because a precondition that cannot refuse is
decoration:

| | |
|---|---|
| clean | `preflight OK: GPU free, no skip variable, 318 tests classified.` exit 0 |
| `RMLX_SKIP_GPU=1` | `ERROR: every GPU test would return before touching Metal` exit 1 |
| live `mlx_lm` decoy | `ERROR: another MLX process is live` exit 1 |

That second check needed two attempts: the first decoy was `exec`'d by `sh`, which
dropped the marker from argv, so the guard did not fire. Recording that as a pass
would have been a false negative.

## The gate could be narrowed from the command line

`$(MAKE) gpu-test` inherits command-line variables through `MAKEFLAGS`, so
`make ci-perf CRATE=rmlx-audio` ran 7 of 318 tests and still printed `ci-perf ok`,
and `make ci-perf VALIDATE=0` disabled the shader validation the design rests on.
The runner's own coverage check cannot catch either, because `--crate` narrows
`classified` in lockstep with `executed` — precisely the fail-open shape its header
says it exists to prevent.

`ci-perf` now calls `bash scripts/run_gpu_tests.sh` directly. `make -n` alone would
have been weak proof: make also *exports* CLI variables into the recipe
environment, so removing them from argv does not by itself keep them out of the
runner — it survives because it hard-resets its own locals (`FILTER=""`, not
`${FILTER:-}`), which had to be checked rather than assumed.

Dynamic proof, under exactly the environment `make ci-perf CRATE=rmlx-audio
FILTER=zzz VALIDATE=0` produces:

```
shader validation: ON
── rmlx-audio (7) ── rmlx-kv-quant (229) ── rmlx-kv-ssd (11) ── rmlx-mlx (7) ── rmlx-models (63)
OK: 318 GPU tests passed across 5 workspace member(s), shader validation clean.
```

## Mutation check of the gate itself

A 5% error injected into `rotorquant_dequantize_rotor3.metal` — MSL source, so
invisible to every CPU test and still clean under `check-metal-compiles`:

```
BROKEN    make ci-perf -> exit 2
          test-perf ... GREEN
          gpu-test  ... RED
            rotor_k3_msl_matches_cpu_within_eps
            rotor_v3_msl_matches_cpu_within_eps
RESTORED  make ci-perf -> exit 0
```

`test-perf` passing on the broken tree is the load-bearing half: the new step is the
only thing in the gate that could see the defect. Kernel restored byte-identical —
this branch touches no file under `crates/`.

## Cost, stated rather than elided

Full `make ci-perf` end-to-end on this branch: **1078 s (~18 min)**, exit 0. The
`gpu-test` half is ~220–265 s of that (three runs: 219 s, 264 s — warm-suite
variance is real, so the higher figure is conservative rather than central).

The two halves build under different profiles, deliberately: `gpu-test` stays on
`dev` because debug assertions are correctness guards and these are correctness
tests. A `--profile` passthrough to reuse what `test-perf` built was considered and
rejected — `release-perf` compiles out the 61 `debug_assert!` sites in
`rmlx-kv-quant`, which is the wrong trade for the layer carrying this repo's
documented silent-corruption class. The consequence is documented instead: the
second build lands in `target/debug`, which `scripts/target_gc.sh` prunes (it
protects only `release-perf`), so the first `ci-perf` after a `make target-gc` also
pays a cold opt-level-0 build that neither figure above includes.

## Docs — deleted what became false

- `docs/TESTING.md` — the `### Known-red baseline` section removed wholesale;
  replaced the "not part of `make ci`" paragraph with `#### Where it runs`
  (rationale, ordering, profiles, measured cost); four stale counts corrected.
- `Makefile` — removed the "blocked while any GPU test is red on main" note.
- `scripts/run_gpu_tests.sh` — the failure hint pointed at a known-red baseline that
  no longer exists.
- `CLAUDE.md` — hard rule 9 amended for the second half and its profile, *and* its
  consequence stated: no gate anywhere runs a `Device::Gpu` test under
  `release-perf`, so a defect visible only with debug-assertions off must be
  reproduced by hand. The perf-profiles paragraph is scoped to the `test-perf` half.
- `CONTRIBUTING.md` — the automated step existed but nothing routed a human to it.
  §Build & test and workflow step 4 now name `make ci-perf` for `rmlx-kv-quant` /
  `.metal` / KV-decode changes, with its cost and the narrowed `make gpu-test`
  escape hatch.

## A count worth explaining

The classifier emits **318** rows (`rmlx-kv-quant` 230), one of which is the
shader-validation canary; the runner excludes it, so its population is **317**; and
**318** pass because filters are substrings and over-match. All three numbers are
now stated with what each is, rather than a breakdown that sums neatly by counting
a test the run deliberately skips.

## Gates

`make ci` green. `make ci-perf` green end-to-end (1078 s). `make lint` clean,
`cargo fmt --all --check` clean, pre-commit clean, `bash -n` clean. No file under
`crates/` is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
