### PR TITLE
test(kv): measure rotation quality and rate-distortion, not just round-trip cosine (#316, #318)

### DIFF
--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -40,6 +40,16 @@
 #[cfg(test)]
 pub(crate) mod test_utils;
 
+/// Rotation-quality gates: incoherence reduction and outlier-fixture cosine for
+/// every codec family that applies an orthogonal transform.
+#[cfg(test)]
+mod rotation_fidelity_tests;
+
+/// Rate-distortion reference: SQNR of every scalar-codebook codec against the
+/// fixed-rate Lloyd-Max Gaussian anchor for its bit width.
+#[cfg(test)]
+mod rate_distortion_tests;
+
 pub(crate) mod bytes;
 pub mod clifford;
 pub(crate) mod flash_decode_common;

--- a/crates/rmlx-kv-quant/src/rate_distortion_tests.rs
+++ b/crates/rmlx-kv-quant/src/rate_distortion_tests.rs
@@ -1,0 +1,566 @@
+//! Rate-distortion reference for the scalar-codebook KV codecs.
+//!
+//! # What the cosine gates cannot tell you
+//!
+//! A cosine floor answers "did this regress". It cannot answer "is this as good
+//! as the bit width allows", because it has no reference. This module supplies
+//! one: for a fixed-rate Lloyd-Max quantizer on the standard normal, achievable
+//! SQNR is a known constant per bit width — see
+//! [`crate::test_utils::LLOYD_MAX_GAUSSIAN_SQNR_DB`]. Measuring a codec against
+//! it converts "cosine 0.994" into "0.8 bits ahead of / behind a matched scalar
+//! quantizer at the same nominal rate", which is directly actionable.
+//!
+//! The fixture is i.i.d. standard normal on purpose: the anchor is defined for
+//! that source, and comparing a codec on non-Gaussian data against a Gaussian
+//! anchor would compare two different things. Outlier-channel behaviour is a
+//! separate axis, measured in `rotation_fidelity_tests.rs`.
+//!
+//! # The anchor is not free
+//!
+//! The anchor assumes the quantizer knows sigma and spends no rate saying so.
+//! Every codec here instead derives its scale from a per-group **maximum** and
+//! stores it, so it buys conditioning the anchor does not have and can
+//! legitimately land above it. That is why the report prints stored bits per
+//! value beside the dB: a codec 5 dB ahead of the 3-bit anchor while spending
+//! 11 bits per value has not beaten scalar quantization, it has changed the
+//! rate. The rate column is **reported, not gated** — sizing the codecs is
+//! tracked separately.
+//!
+//! The rate column is also **path-specific**: `run_iso` reports the CPU
+//! `IsoBlocks` figure, which carries a per-group quaternion sideband the GPU
+//! ring does not. See its doc comment before comparing iso against rotor.
+//!
+//! # What the measurement found
+//!
+//! The suspicion that motivated this reference was that mapping a *small*-group
+//! maximum onto the outermost centroid presents the codebook with data whose
+//! standard deviation is ≈ 1.47 rather than 1, and that this would cost several
+//! dB. It does not. Small groups come out **ahead** of the anchor — the group
+//! maximum is a strong conditioning statistic, it is reconstructed near-exactly
+//! by construction, and the remaining 2–3 elements are then known to be smaller
+//! than it. The shortfall appears at the other end: large groups at low bit
+//! widths, where one f32 scale per 32 values buys little and the outermost
+//! Lloyd-Max cell is very wide.
+
+use crate::isoquant::{iso_decode_fast, iso_encode_fast};
+use crate::planarquant::{planar_dequantize, planar_quantize};
+use crate::rotorquant::{n_groups_for, rotor3_decode, rotor3_encode, rotor4_decode, rotor4_encode};
+use crate::tcq::{tcq_quantize_v2, tcq_quantize_v3};
+use crate::test_utils::{
+    gaussian_data, lloyd_max_anchor_db, sqnr_db, wasted_bits, DB_PER_BIT, TEST_SEED,
+};
+use crate::turboquant::{
+    lloyd_gaussian_codebook, turbo_dequantize, turbo_dequantize_with_codebook, turbo_quantize_v,
+    turbo_quantize_v_with_codebook, GROUP_SIZE,
+};
+
+// ── Fixture ──────────────────────────────────────────────────────────────────
+
+const RD_ROWS: usize = 256;
+const RD_HEAD_DIM: usize = 128;
+const RD_SHAPE: [i32; 4] = [1, 1, RD_ROWS as i32, RD_HEAD_DIM as i32];
+const RD_VALUES: usize = RD_ROWS * RD_HEAD_DIM;
+
+/// i.i.d. standard normal, pinned seed — the source the anchors are defined for.
+fn gaussian_fixture() -> Vec<f32> {
+    gaussian_data(RD_VALUES, TEST_SEED)
+}
+
+/// Bits per value implied by a heap footprint over [`RD_VALUES`] values.
+fn bits_per_value(bytes: u64) -> f64 {
+    (bytes * 8) as f64 / RD_VALUES as f64
+}
+
+// ── Codec cells ──────────────────────────────────────────────────────────────
+
+/// A codec's encode+decode at a chosen bit width: decoded values plus the bits
+/// its own encode output occupies per input value.
+type CodecRun = fn(&[f32], u8) -> (Vec<f32>, f64);
+
+/// One `(codec, bit width)` cell: decoded values plus the bits its own encode
+/// output occupies per input value.
+struct Cell {
+    name: &'static str,
+    bits: u8,
+    run: fn(&[f32]) -> (Vec<f32>, f64),
+    /// Pinned ceiling on this cell's shortfall against its anchor, in bits.
+    /// Set at the measured value plus [`PIN_SLACK_BITS`].
+    budget: f64,
+}
+
+fn run_turbo(data: &[f32], bits: u8) -> (Vec<f32>, f64) {
+    let blocks = turbo_quantize_v(data, bits, &RD_SHAPE).expect("turbo_quantize_v");
+    let rate = bits_per_value(blocks.byte_size());
+    (turbo_dequantize(&blocks).expect("turbo_dequantize"), rate)
+}
+
+fn run_tcq(data: &[f32], bits: u8) -> (Vec<f32>, f64) {
+    let blocks = if bits == 2 {
+        tcq_quantize_v2(data, &RD_SHAPE).expect("tcq_quantize_v2")
+    } else {
+        tcq_quantize_v3(data, &RD_SHAPE).expect("tcq_quantize_v3")
+    };
+    let rate = bits_per_value(blocks.byte_size());
+    (turbo_dequantize(&blocks).expect("turbo_dequantize"), rate)
+}
+
+fn run_planar(data: &[f32], bits: u8) -> (Vec<f32>, f64) {
+    let blocks = planar_quantize(data, GROUP_SIZE, bits, &RD_SHAPE).expect("planar_quantize");
+    let rate = bits_per_value(blocks.byte_size());
+    (planar_dequantize(&blocks).expect("planar_dequantize"), rate)
+}
+
+/// iso, at the **CPU `IsoBlocks` rate**, not the ring-resident one.
+///
+/// The byte count includes the per-group quaternion array, so it reports
+/// ≈48.25 bits/value at `head_dim = 128`. That is the honest figure for the
+/// V-only `iso3` / `iso4` stores, which keep `IsoBlocks`. It is **not** the
+/// figure for `k_iso3/4` and `iso3_sym/4_sym`: the GPU ring those decode from
+/// does not carry the quaternion — it is the constant `FIXED_QUAT` replicated
+/// per group, not data — so they sit at ≈16.25 bits/value. See
+/// `docs/KV_QUANT.md` § iso3 "Memory truth". Quoting 48.25 against `rotor`'s
+/// 21.75 without that distinction inverts the comparison: on the ring path iso
+/// is the cheaper of the two.
+///
+/// The distortion is identical on both paths — the quaternion is a sideband,
+/// not an input to reconstruction — so only the rate column is affected.
+fn run_iso(data: &[f32], bits: u8) -> (Vec<f32>, f64) {
+    let (codes, scales, quats, norms) =
+        iso_encode_fast(data, RD_HEAD_DIM, 4, bits).expect("iso_encode_fast");
+    let bytes = 4 * (codes.len() + scales.len() + quats.len() + norms.len()) as u64;
+    let decoded = iso_decode_fast(&codes, &scales, &quats, &norms, RD_HEAD_DIM, 4, bits)
+        .expect("iso_decode_fast");
+    (decoded, bits_per_value(bytes))
+}
+
+fn run_rotor(data: &[f32], bits: u8) -> (Vec<f32>, f64) {
+    let rotors = crate::clifford::make_rotor_table(0, 0, n_groups_for(RD_HEAD_DIM));
+    let (codes, scales, norms) = if bits == 3 {
+        rotor3_encode(data, &rotors, RD_HEAD_DIM).expect("rotor3_encode")
+    } else {
+        rotor4_encode(data, &rotors, RD_HEAD_DIM).expect("rotor4_encode")
+    };
+    let bytes = 4 * (codes.len() + scales.len() + norms.len()) as u64;
+    let decoded = if bits == 3 {
+        rotor3_decode(&codes, &scales, &norms, &rotors, RD_HEAD_DIM).expect("rotor3_decode")
+    } else {
+        rotor4_decode(&codes, &scales, &norms, &rotors, RD_HEAD_DIM).expect("rotor4_decode")
+    };
+    (decoded, bits_per_value(bytes))
+}
+
+/// Every scalar-codebook codec at every bit width a shipped `KvQuant` variant
+/// can reach.
+///
+/// * `turbo` 2 / 3 / 4 — `K8VTurbo2`, `K8VTurbo3` + `TurboSym3`, `K8V4` +
+///   `TurboSym4` + `RotKTq4V`.
+/// * `tcq` 2 / 3 — `K8VTurbo2Tcq`, `K8VTurbo3Tcq`.
+/// * `planar` 3 / 4 — `Planar3`, `Planar` + `PlanarK`.
+/// * `iso` 3 / 4 — `Iso3` family, `Iso4` family.
+/// * `rotor` 3 / 4 — `Rotor3` family, `Rotor4` family.
+///
+/// `bits = 1` is tabulated in the anchors but no storage variant reaches it, so
+/// it is not measured here.
+const CELLS: &[Cell] = &[
+    Cell {
+        name: "turbo",
+        bits: 2,
+        run: |d| run_turbo(d, 2),
+        budget: 0.44,
+    },
+    Cell {
+        name: "turbo",
+        bits: 3,
+        run: |d| run_turbo(d, 3),
+        budget: 0.04,
+    },
+    Cell {
+        name: "turbo",
+        bits: 4,
+        run: |d| run_turbo(d, 4),
+        budget: -0.13,
+    },
+    Cell {
+        name: "tcq",
+        bits: 2,
+        run: |d| run_tcq(d, 2),
+        budget: 0.44,
+    },
+    Cell {
+        name: "tcq",
+        bits: 3,
+        run: |d| run_tcq(d, 3),
+        budget: 0.04,
+    },
+    Cell {
+        name: "planar",
+        bits: 3,
+        run: |d| run_planar(d, 3),
+        budget: -4.22,
+    },
+    Cell {
+        name: "planar",
+        bits: 4,
+        run: |d| run_planar(d, 4),
+        budget: -2.64,
+    },
+    Cell {
+        name: "iso",
+        bits: 3,
+        run: |d| run_iso(d, 3),
+        budget: -0.68,
+    },
+    Cell {
+        name: "iso",
+        bits: 4,
+        run: |d| run_iso(d, 4),
+        budget: -0.76,
+    },
+    Cell {
+        name: "rotor",
+        bits: 3,
+        run: |d| run_rotor(d, 3),
+        budget: -0.87,
+    },
+    Cell {
+        name: "rotor",
+        bits: 4,
+        run: |d| run_rotor(d, 4),
+        budget: -0.95,
+    },
+];
+
+// ── The gate ─────────────────────────────────────────────────────────────────
+
+/// Escalation line: a codec more than this many bits short of its anchor gets a
+/// filed follow-up with the measured number, not a relaxed threshold.
+///
+/// **This is a message channel, not an independent gate.** Every budget in
+/// [`CELLS`] is at most +0.44, so `wasted > 1.0` implies `wasted > cell.budget`
+/// for every cell and the absolute check can never be the only one that fires;
+/// it exists to label *why* a failure matters. The dependence runs one way only
+/// — the budget catches things this does not, which
+/// [`one_bit_short_codec_fails_the_rate_distortion_gate`] demonstrates at
+/// `bits = 4`.
+///
+/// Justification, stated before the measurements. The anchor is a *matched*
+/// fixed-rate Lloyd-Max quantizer on N(0,1): it knows sigma and pays no rate to
+/// say so. Every codec here pays extra rate — at minimum one f32 scale per
+/// group — so it starts with an advantage the anchor does not have and should
+/// meet or beat it. A full bit below the anchor means the nominal bit width is
+/// not delivering what the same number of bits delivers in the textbook
+/// construction.
+const MAX_WASTED_BITS: f64 = 1.0;
+
+/// Slack on each cell's pinned budget, in bits.
+///
+/// The absolute line above cannot be the only gate. Codecs sit at very
+/// different offsets from the anchor — `turbo4` is 0.23 bits *ahead* of it — so
+/// a codec that silently loses a full bit can still land inside a 1-bit
+/// absolute budget. [`one_bit_short_codec_fails_the_rate_distortion_gate`]
+/// demonstrates exactly that at `bits = 4`. Each cell therefore also carries
+/// its own pinned ceiling.
+///
+/// 0.10 bits = 0.60 dB. The fixture is seeded and every codec here is
+/// deterministic, so there is no run-to-run variation for the slack to absorb;
+/// it covers f32 and codegen drift only, and is an order of magnitude below the
+/// ~1.1 bits the mutation guard moves.
+const PIN_SLACK_BITS: f64 = 0.10;
+
+/// Measure every cell, print the table, and fail listing **all** cells that
+/// cross either their own pinned budget or the absolute escalation line.
+///
+/// Accumulating rather than asserting per cell keeps a single regression from
+/// hiding the rest of the table.
+#[test]
+fn scalar_codebook_rate_distortion_report() {
+    let data = gaussian_fixture();
+
+    println!(
+        "Rate-distortion vs fixed-rate Lloyd-Max N(0,1), \
+         i.i.d. Gaussian fixture ({RD_ROWS} x {RD_HEAD_DIM}):\n\
+         \x20 codec   bits   measured    anchor    wasted   budget   stored bits/value"
+    );
+
+    let mut over_budget: Vec<String> = Vec::new();
+    for cell in CELLS {
+        let (decoded, rate) = (cell.run)(&data);
+        let measured = sqnr_db(&data, &decoded);
+        let anchor = lloyd_max_anchor_db(cell.bits);
+        let wasted = wasted_bits(measured, anchor);
+
+        println!(
+            "\x20 {:7} {:4}   {measured:8.3} dB {anchor:7.3} dB  {wasted:+7.3}  {:+7.2}   {rate:6.2}",
+            cell.name, cell.bits, cell.budget,
+        );
+
+        if wasted > cell.budget {
+            over_budget.push(format!(
+                "{}{} regressed to {wasted:+.2} wasted bits, past its pinned {:+.2} \
+                 ({measured:.2} dB vs anchor {anchor:.2} dB) at {rate:.2} stored bits/value. \
+                 If the rate moved too this is a deliberate rate-for-distortion trade and the \
+                 budget needs re-pinning, not the codec reverting",
+                cell.name, cell.bits, cell.budget,
+            ));
+        }
+        if wasted > MAX_WASTED_BITS {
+            over_budget.push(format!(
+                "{}{} is {wasted:.2} bits short of its anchor, past the {MAX_WASTED_BITS:.1}-bit \
+                 escalation line — file a follow-up with this number",
+                cell.name, cell.bits,
+            ));
+        }
+    }
+
+    assert!(
+        over_budget.is_empty(),
+        "rate-distortion gate: {}",
+        over_budget.join("; "),
+    );
+}
+
+/// Every pinned budget sits at its cell's measured shortfall plus exactly
+/// [`PIN_SLACK_BITS`], and no cell has been quietly given more room than that.
+///
+/// A pinned floor is only meaningful if the pin is where it claims to be. This
+/// is the test that would go red if someone widened a budget to make a
+/// regression pass instead of investigating it.
+#[test]
+fn pinned_budgets_sit_one_slack_above_the_measurement() {
+    let data = gaussian_fixture();
+    for cell in CELLS {
+        let (decoded, _) = (cell.run)(&data);
+        let wasted = wasted_bits(sqnr_db(&data, &decoded), lloyd_max_anchor_db(cell.bits));
+        let headroom = cell.budget - wasted;
+        // Budgets are recorded to two decimal places, so allow half a unit in
+        // the last place on top of the slack itself.
+        assert!(
+            headroom >= 0.0,
+            "{}{} sits {:+.3} bits past its own budget — the report test is the one to read",
+            cell.name,
+            cell.bits,
+            -headroom,
+        );
+        assert!(
+            headroom <= PIN_SLACK_BITS + 0.005,
+            "{}{} has {headroom:+.3} bits of headroom against its budget, more than the \
+             {PIN_SLACK_BITS:.2} the pin convention allows. Either the budget was widened \
+             instead of investigating a regression, or the codec **improved** by \
+             {:.3} bits — if it improved, re-pin the budget to the new measurement",
+            cell.name,
+            cell.bits,
+            headroom - PIN_SLACK_BITS,
+        );
+    }
+}
+
+// ── Mutation guard ───────────────────────────────────────────────────────────
+
+/// A codebook with `2^bits` entries but only `2^(bits-1)` distinct
+/// reconstruction levels — a codec that is exactly one bit short of its label.
+///
+/// Each coarse centroid is emitted twice, the second copy nudged by 1e-4 so the
+/// encoder's strictly-ascending validation passes while the reconstruction is
+/// unchanged to five decimal places. This is the degenerate the reference
+/// exists to catch: nominal rate intact, delivered rate halved.
+fn one_bit_short_codebook(bits: u8) -> Vec<f32> {
+    let coarse = lloyd_gaussian_codebook(bits - 1).expect("coarse codebook");
+    let mut out = Vec::with_capacity(1usize << bits);
+    for &centroid in coarse {
+        out.push(centroid);
+        out.push(centroid + 1e-4);
+    }
+    out
+}
+
+/// Mutation guard: a codec one bit short of its label must fail the gate.
+///
+/// Without this the report is decoration — a threshold nothing in the tree can
+/// cross proves only that the tree is unchanged.
+///
+/// Note which half of the gate catches it. At `bits = 3` the mutation crosses
+/// both the pinned budget and the absolute escalation line. At `bits = 4` it
+/// crosses **only** the pinned budget: honest `turbo4` sits 0.23 bits *ahead*
+/// of its anchor, so losing a full bit still lands inside the 1-bit absolute
+/// line. That is the concrete reason [`PIN_SLACK_BITS`] exists — an absolute
+/// anchor budget alone would have let this through.
+#[test]
+fn one_bit_short_codec_fails_the_rate_distortion_gate() {
+    let data = gaussian_fixture();
+
+    for bits in [3u8, 4] {
+        let codebook = one_bit_short_codebook(bits);
+        assert_eq!(
+            codebook.len(),
+            1usize << bits,
+            "codebook must be full width"
+        );
+
+        let blocks = turbo_quantize_v_with_codebook(&data, bits, &RD_SHAPE, Some(&codebook))
+            .expect("turbo_quantize_v_with_codebook");
+        let decoded = turbo_dequantize_with_codebook(&blocks, Some(&codebook))
+            .expect("turbo_dequantize_with_codebook");
+
+        let measured = sqnr_db(&data, &decoded);
+        let anchor = lloyd_max_anchor_db(bits);
+        let wasted = wasted_bits(measured, anchor);
+
+        // The honest codec at the same nominal width, and the budget the report
+        // would have judged it against.
+        let (honest_decoded, _) = run_turbo(&data, bits);
+        let honest = sqnr_db(&data, &honest_decoded);
+        let budget = CELLS
+            .iter()
+            .find(|c| c.name == "turbo" && c.bits == bits)
+            .map(|c| c.budget)
+            .expect("turbo cell for this bit width");
+
+        println!(
+            "one-bit-short turbo{bits}: {measured:.2} dB ({wasted:+.2} bits) vs honest \
+             turbo{bits} {honest:.2} dB ({:+.2} bits); budget {budget:+.2}, escalation line \
+             {MAX_WASTED_BITS:+.2}",
+            wasted_bits(honest, anchor),
+        );
+
+        assert!(
+            wasted > budget,
+            "a turbo{bits} with only {} distinct levels reported {wasted:+.2} wasted bits and \
+             passed its pinned budget of {budget:+.2} — the gate cannot fail",
+            1usize << (bits - 1),
+        );
+        assert!(
+            honest - measured > 0.5 * DB_PER_BIT,
+            "halving the level count cost only {:.2} dB at bits={bits}; the mutation is not \
+             lossy enough to be a guard",
+            honest - measured,
+        );
+    }
+}
+
+// ── Measured anomaly, pinned ─────────────────────────────────────────────────
+
+/// The 3-bit and 4-bit widths of iso, rotor and planar cost **byte-identical**
+/// storage, so in each family one width is strictly dominated.
+///
+/// All three pack codes into u32 words under the shared `32 / bits`
+/// vals-per-word convention, and at every shipped group size the word count
+/// comes out the same for `bits = 3` and `bits = 4`: iso and rotor put one
+/// group in one word either way, and planar's 32-value block takes
+/// `ceil(32/10) = ceil(32/8) = 4` words. The 3-bit variants therefore burn the
+/// spare bits rather than saving anything, and the comparison between the two
+/// widths is pure quality at fixed rate.
+///
+/// * `iso` and `rotor` — the 4-bit width wins, so the 3-bit width is dominated.
+/// * `planar` — the **3-bit** width wins, by ~3.9 dB, so `planar4` is
+///   dominated. Per pair the larger element is pinned to the outermost
+///   centroid, leaving the smaller one on the grid `centroid / max_centroid`,
+///   whose outermost gap is `(2.152 - 1.344)/2.152 = 0.375` at 3 bits and
+///   `(2.718 - 2.052)/2.718 = 0.245` at 4 bits — only 1.5x finer, while the
+///   16-angle Givens search that has to land *both* elements on centroids gets
+///   no larger. The extra bit does not pay for itself.
+///
+/// The test pins what is measured rather than the ordering everyone expects, so
+/// the day a family's packing or codebook is fixed this goes red and gets
+/// re-pointed at the new contract instead of quietly agreeing with whatever the
+/// code does.
+#[test]
+fn byte_identical_bit_widths_leave_one_width_dominated() {
+    let data = gaussian_fixture();
+
+    // (family, encoder, which width wins)
+    let families: [(&str, CodecRun, u8); 3] = [
+        ("iso", run_iso, 4),
+        ("rotor", run_rotor, 4),
+        ("planar", run_planar, 3),
+    ];
+    for (family, run, winner) in families {
+        let (three, three_rate) = run(&data, 3);
+        let (four, four_rate) = run(&data, 4);
+        let three_db = sqnr_db(&data, &three);
+        let four_db = sqnr_db(&data, &four);
+
+        println!(
+            "{family}: 3-bit {three_db:.2} dB @ {three_rate:.2} bits/value | \
+             4-bit {four_db:.2} dB @ {four_rate:.2} bits/value | \
+             winner {winner}-bit by {:.2} dB",
+            (three_db - four_db).abs(),
+        );
+
+        assert!(
+            (three_rate - four_rate).abs() < 1e-9,
+            "{family} 3-bit and 4-bit are supposed to occupy byte-identical storage: \
+             {three_rate:.2} vs {four_rate:.2} bits per value. If a packing change made them \
+             differ, this comparison is no longer at fixed rate — re-point the test"
+        );
+
+        let (winner_db, loser_db, loser) = if winner == 3 {
+            (three_db, four_db, 4)
+        } else {
+            (four_db, three_db, 3)
+        };
+        assert!(
+            winner_db > loser_db,
+            "{family}{loser} {loser_db:.2} dB now beats {family}{winner} {winner_db:.2} dB at \
+             the same rate. The documented dominance has flipped — update docs/KV_QUANT.md \
+             and this test rather than deleting it"
+        );
+    }
+}
+
+/// The Viterbi trellis buys **0.000 dB** over plain nearest-centroid, at both
+/// shipped widths, on structured and unstructured data alike.
+///
+/// The trellis degeneracy itself is already documented — the per-step cost
+/// `dist(value, codebook[level])` does not depend on the state, and
+/// `build_transition_table` makes every level reachable from every state, so
+/// the admissible level sequences are the full product set and the
+/// minimum-cost path is the per-step greedy minimum. What was missing is the
+/// number: TCQ is the one codec here whose stated purpose is to claw back part
+/// of the gap to the rate-distortion bound, and the claw-back measures as
+/// exactly zero.
+///
+/// On i.i.d. data the codes come out byte-identical. On a structured sweep the
+/// codes *differ* — the forward pass breaks ties differently — but the
+/// distortion does not move, which is the stronger statement and the one the
+/// existing non-strict `tcq >= turbo` cosine gate cannot make.
+///
+/// Pinned as an equality so that giving the trellis a real constraint turns
+/// this red and gets it re-pointed at the new contract.
+#[test]
+fn trellis_coded_quantization_claws_back_nothing() {
+    let gaussian = gaussian_fixture();
+    // A sweep along the dim axis: strongly inter-element-correlated, the
+    // structure a trellis is supposed to exploit.
+    let sweep: Vec<f32> = (0..RD_VALUES)
+        .map(|i| (((i % RD_HEAD_DIM) as f32) * 0.05).sin() * 2.0)
+        .collect();
+
+    for bits in [2u8, 3] {
+        for (label, data) in [("i.i.d. gaussian", &gaussian), ("dim-axis sweep", &sweep)] {
+            let trellis = if bits == 2 {
+                tcq_quantize_v2(data, &RD_SHAPE).expect("tcq_quantize_v2")
+            } else {
+                tcq_quantize_v3(data, &RD_SHAPE).expect("tcq_quantize_v3")
+            };
+            let greedy = turbo_quantize_v(data, bits, &RD_SHAPE).expect("turbo_quantize_v");
+
+            let trellis_db = sqnr_db(data, &turbo_dequantize(&trellis).expect("dequant"));
+            let greedy_db = sqnr_db(data, &turbo_dequantize(&greedy).expect("dequant"));
+            let gain = trellis_db - greedy_db;
+
+            println!(
+                "tcq{bits} on {label}: {trellis_db:.4} dB vs turbo{bits} {greedy_db:.4} dB \
+                 = {gain:+.4} dB ({} bits); codes identical: {}",
+                gain / DB_PER_BIT,
+                trellis.codes == greedy.codes,
+            );
+
+            assert!(
+                gain.abs() < 1e-3,
+                "the trellis moved distortion by {gain:+.4} dB at bits={bits} on {label}. \
+                 It is documented as degenerate and measured at 0.000 dB — if it now does \
+                 something, update docs/KV_QUANT.md and re-point this test"
+            );
+        }
+    }
+}

--- a/crates/rmlx-kv-quant/src/rotation_fidelity_tests.rs
+++ b/crates/rmlx-kv-quant/src/rotation_fidelity_tests.rs
@@ -1,0 +1,944 @@
+//! Rotation-quality gates for the KV codecs that apply an orthogonal transform.
+//!
+//! # What the existing cosine gates do not measure
+//!
+//! Every per-codec cosine gate in this crate runs on [`lcg_data`] — i.i.d.
+//! uniform on `[-1, 1]`. That distribution is already close to maximally
+//! incoherent (mean `mu` ≈ 1.72 at `head_dim = 128`, against a minimum of 1),
+//! so no rotation can improve it; a Hadamard actually pushes it *up*, toward
+//! the i.i.d. Gaussian value of ≈ 2.87, by the central limit theorem. The
+//! cosine gates therefore measure round-trip quantizer fidelity and nothing
+//! about rotation quality — a rotation replaced by the identity passes them
+//! all.
+//!
+//! Rotation-based KV codecs exist to neutralise **outlier channels**, so the
+//! gates here run on [`outlier_fixture`] and measure the incoherence parameter
+//!
+//! ```text
+//! mu(x) = sqrt(d) · max_i |x_i| / ||x||_2
+//! ```
+//!
+//! directly, before and after each codec's transform. See
+//! [`crate::test_utils::outlier_channel_data`] for what real K-cache data looks
+//! like and the citations behind the fixture's shape.
+//!
+//! # The block-size ceiling
+//!
+//! Only one codec family applies a full-dimension orthogonal transform. The
+//! rest rotate inside small blocks, and a block-`b` orthogonal transform can
+//! reduce `mu` by at most `sqrt(b)`:
+//!
+//! > Let `P = max_j |x_j|`, attained in block `B`. A block-diagonal orthogonal
+//! > map preserves `||y_B||_2 = ||x_B||_2 >= P`, and any `b`-vector has
+//! > `max_j |y_j| >= ||y_B||_2 / sqrt(b)`, so the new peak is at least
+//! > `P / sqrt(b)`. `||y||_2 = ||x||_2`, therefore
+//! > `mu_after >= mu_before / sqrt(b)`.
+//!
+//! | Codec family | Transform | Block | `mu` ceiling |
+//! |---|---|---|---|
+//! | `rot_k` / `RotK` | Walsh-Hadamard, full `head_dim` | `head_dim` | `sqrt(head_dim)` |
+//! | `iso3` / `iso4` | isoclinic SO(4), fixed quaternion | 4 | 2.00 |
+//! | `rotor3` / `rotor4` | Cl(3,0) rotor sandwich, static per (layer, head) | 3 | 1.73 |
+//! | `planar3` / `planar4` | Givens, 16-entry codebook, per-pair search | 2 | 1.41 |
+//!
+//! This is not a defect in the block-local codecs — they buy packing
+//! efficiency, a different axis. The gates below pin what each family actually
+//! delivers so the naming stops implying a capability only one family has.
+//!
+//! # Deterministic Hadamard
+//!
+//! `rot_k` uses a plain Sylvester Hadamard with no random sign flips. The
+//! incoherence guarantee from the QuIP line of work is stated for a
+//! *randomized* Hadamard, so a deterministic `H` has adversarial inputs in
+//! principle. [`hadamard_incoherence_ratio_beats_every_block_local_rotation`]
+//! measures what it delivers on this fixture rather than assuming the
+//! guarantee transfers.
+
+use crate::clifford::{make_rotor_table, rotor_sandwich, Rotor, MV_DIM};
+use crate::isoquant::{
+    iso_decode_fast, iso_encode_fast, quat_conjugate, quat_multiply, FIXED_QUAT,
+};
+use crate::planarquant::{planar_dequantize, planar_quantize, planar_rotation_codebook};
+use crate::rotorquant::{
+    n_groups_for, rotor3_decode, rotor3_encode, rotor4_decode, rotor4_encode, ROTOR3_GROUP_SIZE,
+};
+use crate::test_utils::{
+    cosine_similarity_per_row, fwht_normalize, incoherence_per_row, lcg_data, outlier_fixture,
+    sqnr_db, CosineStats, DB_PER_BIT, OUTLIER_HEAD_DIM, OUTLIER_ROWS, TEST_SEED,
+};
+use crate::turboquant::GROUP_SIZE;
+
+// ── Row-wise rotations, expressed with each codec's own primitives ───────────
+
+/// `rot_k`: normalized Walsh-Hadamard over the whole `head_dim`.
+///
+/// This is the same [`fwht_normalize`] call the existing `rot_k` cosine gate
+/// uses as the CPU reference for `K_rot = K @ R`.
+fn rotate_hadamard(buf: &mut [f32]) {
+    fwht_normalize(buf, OUTLIER_HEAD_DIM);
+}
+
+/// The same Walsh-Hadamard truncated to blocks of 4 — the plausible way `rot_k`
+/// stops being a full-dimension transform, as opposed to being deleted.
+///
+/// Still orthogonal, still self-inverse, still genuinely decorrelating; it just
+/// works over 4 coordinates instead of 128. The block-`b` ceiling therefore caps
+/// it at `sqrt(4) = 2.00x` of `mu` reduction and at `log2(sqrt(4)) = 1.0` bits
+/// of affine gain, both below the gates — so its rejection is a theorem, not an
+/// empirical hope.
+fn rotate_hadamard_block4(buf: &mut [f32]) {
+    fwht_normalize(buf, 4);
+}
+
+/// `iso3` / `iso4`: left isoclinic quaternion product on each block of 4.
+///
+/// `iso_encode_fast` computes `quat_multiply(FIXED_QUAT, row_block / norm)`.
+/// The per-row L2 normalisation is a positive scalar and `mu` is scale
+/// invariant, so dropping it here changes nothing the statistic can see. The
+/// quaternion and the product are the codec's own.
+fn rotate_iso(buf: &mut [f32]) {
+    for block in buf.chunks_exact_mut(4) {
+        let rotated = quat_multiply(FIXED_QUAT, [block[0], block[1], block[2], block[3]]);
+        block.copy_from_slice(&rotated);
+    }
+}
+
+/// `rotor3` / `rotor4`: Cl(3,0) rotor sandwich on each block of 3.
+///
+/// Mirrors `rotor3_encode`: embed the 3-vector as the grade-1 part of a
+/// multivector, apply `R · mv · R̃`, read the grade-1 part back. The sandwich
+/// preserves grade, so grades 0/2/3 stay zero and the codec's per-group
+/// `max|r_i|` over all 8 components is in fact a max over these 3 — the reason
+/// the effective sample count for the scale is 3, not 8.
+///
+/// The rotor table is `make_rotor_table(layer, head, n_groups)`, the same
+/// deterministic per-(layer, head, group) table production uses.
+///
+/// The draw is a parameter because it matters. Unlike iso (one fixed constant
+/// quaternion) and planar (searched per pair, so it follows the data), a rotor
+/// table is drawn per (layer, head) and only the handful of groups holding
+/// outlier channels affect `mu` — at `head_dim = 128` with 4 outliers that is
+/// four rotors out of 43. A single draw is a four-sample estimate, so
+/// [`rotor_block_rotation_incoherence_gate`] sweeps draws rather than pinning
+/// one.
+fn rotate_rotor_with(buf: &mut [f32], layer: u32, head: u32) {
+    let n_groups = n_groups_for(OUTLIER_HEAD_DIM);
+    let rotors = make_rotor_table(layer, head, n_groups);
+
+    for row in buf.chunks_exact_mut(OUTLIER_HEAD_DIM) {
+        for group in 0..n_groups {
+            let base = group * 4;
+            let rotor: Rotor = [
+                rotors[base],
+                rotors[base + 1],
+                rotors[base + 2],
+                rotors[base + 3],
+            ];
+
+            let start = group * ROTOR3_GROUP_SIZE;
+            let mut mv = [0.0f32; MV_DIM];
+            for e in 0..ROTOR3_GROUP_SIZE {
+                if start + e < OUTLIER_HEAD_DIM {
+                    mv[e + 1] = row[start + e];
+                }
+            }
+            let rotated = rotor_sandwich(rotor, &mv);
+            for e in 0..ROTOR3_GROUP_SIZE {
+                if start + e < OUTLIER_HEAD_DIM {
+                    row[start + e] = rotated[e + 1];
+                }
+            }
+        }
+    }
+}
+
+/// (layer, head) draws swept by the rotor gates, so a pin describes the family
+/// rather than one table.
+const ROTOR_DRAWS: [(u32, u32); 8] = [
+    (0, 0),
+    (0, 1),
+    (1, 0),
+    (3, 2),
+    (7, 5),
+    (11, 0),
+    (17, 9),
+    (31, 13),
+];
+
+/// The `(0, 0)` draw — used where a single representative table is all the
+/// comparison needs (the cross-family table, the substitute guards).
+fn rotate_rotor(buf: &mut [f32]) {
+    rotate_rotor_with(buf, 0, 0);
+}
+
+/// `planar3` / `planar4`: the Givens rotation `planar_quantize` actually chose
+/// for each pair, replayed out of the encoded block's `rotations` field.
+///
+/// Reading the encoder's decision back rather than re-running the search keeps
+/// this measurement tied to the shipped selection rule (minimise max-abs
+/// reconstruction error under the `bits`-wide codebook), which is why the
+/// rotation — and therefore `mu` — depends on `bits` for this family and not
+/// for the other two.
+fn rotate_planar(buf: &mut [f32], bits: u8) {
+    let shape = [1, 1, OUTLIER_ROWS as i32, OUTLIER_HEAD_DIM as i32];
+    let blocks = planar_quantize(buf, GROUP_SIZE, bits, &shape).expect("planar_quantize");
+    let codebook = planar_rotation_codebook();
+
+    for (pair, values) in buf.chunks_exact_mut(2).enumerate() {
+        // 4-bit index per pair, 2 per byte, low nibble first.
+        let index = usize::from((blocks.rotations[pair / 2] >> ((pair % 2) * 4)) & 0xF);
+        let entry = codebook[index];
+        let ya = entry[0].mul_add(values[0], entry[1] * values[1]);
+        let yb = entry[2].mul_add(values[0], entry[3] * values[1]);
+        values[0] = ya;
+        values[1] = yb;
+    }
+}
+
+// ── The gate, as one function both the gates and the guards call ─────────────
+
+/// Mean-`mu` reduction factor `mu_before / mu_after` delivered by `rotate` on
+/// the canonical outlier fixture.
+///
+/// `> 1` means the transform reduced incoherence; `1.0` means it did nothing.
+/// Every gate and every mutation guard below goes through this one function, so
+/// a guard cannot drift away from the gate it is guarding.
+fn mean_mu_reduction(rotate: impl FnOnce(&mut [f32])) -> f64 {
+    let data = outlier_fixture();
+    let before = incoherence_per_row(&data, OUTLIER_HEAD_DIM);
+    let mut rotated = data;
+    rotate(&mut rotated);
+    let after = incoherence_per_row(&rotated, OUTLIER_HEAD_DIM);
+    before.mean / after.mean
+}
+
+/// Minimum `mu` reduction demanded of a full-dimension orthogonal transform.
+///
+/// Justification, and it is a separation argument rather than a prediction of
+/// the measured value. The block-`b` ceiling in the module docs says a
+/// transform that reduces `mu` by a factor `R` must have `b >= R²`. Demanding
+/// `R >= 3.0` therefore demands an effective block of **at least 9**, which no
+/// degenerate can supply: block-4 iso caps at 2.00x, block-3 rotor at 1.73x,
+/// block-2 planar at 1.41x, a block-4 truncated Hadamard at 2.00x, and the
+/// identity sits at 1.00x. The only transform in the crate that can clear it is
+/// one that mixes the whole `head_dim`. 3.0 is thus the smallest round number
+/// that separates "full-dimension" from every alternative, chosen from the
+/// ceilings rather than fitted to the codec.
+///
+/// Do not try to predict the measured 3.89x from the fixture parameters. A
+/// natural back-of-envelope — outlier mass spread evenly, `mu` lands near the
+/// i.i.d. Gaussian value of 2.87 — gives `8.37 / 2.87 = 2.9x` and would
+/// wrongly predict this gate goes red. It is wrong because the Hadamard image
+/// of 4 outlier channels takes only `2^4 = 16` distinct values across the 128
+/// coordinates, so the post-rotation peak is a max over ~16 effective draws
+/// rather than 128, and `mu_after` (2.15) lands *below* the i.i.d. value.
+///
+/// [`identity_rotation_excluded_by_the_hadamard_incoherence_threshold`] and
+/// [`non_full_dimension_rotations_fail_the_hadamard_incoherence_gate`] assert
+/// the separation.
+const HADAMARD_MIN_MU_REDUCTION: f64 = 3.0;
+
+/// The full-dimension Hadamard clears the reduction gate, and no block-local
+/// rotation comes close.
+///
+/// Reported alongside is each block-local family's `sqrt(block)` ceiling, so
+/// the table in the module docs is checked rather than asserted in prose.
+#[test]
+fn hadamard_incoherence_ratio_beats_every_block_local_rotation() {
+    let hadamard = mean_mu_reduction(rotate_hadamard);
+    let iso = mean_mu_reduction(rotate_iso);
+    let rotor = mean_mu_reduction(rotate_rotor);
+    let planar3 = mean_mu_reduction(|buf| rotate_planar(buf, 3));
+    let planar4 = mean_mu_reduction(|buf| rotate_planar(buf, 4));
+
+    println!(
+        "mu reduction on the outlier fixture (head_dim={OUTLIER_HEAD_DIM}, rows={OUTLIER_ROWS}):\n\
+         \x20 hadamard(full) {hadamard:.4}x  ceiling {:.2}x\n\
+         \x20 iso(block 4)   {iso:.4}x  ceiling 2.00x\n\
+         \x20 rotor(block 3) {rotor:.4}x  ceiling 1.73x\n\
+         \x20 planar3(pair)  {planar3:.4}x  ceiling 1.41x\n\
+         \x20 planar4(pair)  {planar4:.4}x  ceiling 1.41x",
+        (OUTLIER_HEAD_DIM as f64).sqrt(),
+    );
+
+    assert!(
+        hadamard >= HADAMARD_MIN_MU_REDUCTION,
+        "rot_k Hadamard reduced mean mu by only {hadamard:.4}x, below the \
+         {HADAMARD_MIN_MU_REDUCTION:.1}x a full-dimension orthogonal transform must deliver \
+         on this fixture"
+    );
+
+    for (name, reduction, ceiling) in [
+        ("iso", iso, 4.0f64),
+        ("rotor", rotor, 3.0),
+        ("planar3", planar3, 2.0),
+        ("planar4", planar4, 2.0),
+    ] {
+        assert!(
+            reduction <= ceiling.sqrt() + 1e-3,
+            "{name} reported a {reduction:.4}x mu reduction, above the sqrt({ceiling}) = \
+             {:.4}x a block-{ceiling} orthogonal transform can deliver — the measurement or \
+             the declared block size is wrong",
+            ceiling.sqrt(),
+        );
+        assert!(
+            hadamard > reduction,
+            "{name} ({reduction:.4}x) matched or beat the full-dimension Hadamard \
+             ({hadamard:.4}x) — the block-size table in the module docs is wrong"
+        );
+    }
+}
+
+/// The threshold excludes the identity.
+///
+/// Named for what it is: `mean_mu_reduction(|_| {})` divides `before.mean` by
+/// itself, so the `1.0` is exact by construction and this pins the *constant
+/// comparison* `1.0 < 3.0`, not the behaviour of the statistic. The guard that
+/// mutates a real transform is
+/// [`non_full_dimension_rotations_fail_the_hadamard_incoherence_gate`].
+#[test]
+fn identity_rotation_excluded_by_the_hadamard_incoherence_threshold() {
+    let reduction = mean_mu_reduction(|_| {});
+    assert!(
+        (reduction - 1.0).abs() < 1e-9,
+        "the identity must leave mu untouched, got {reduction:.6}x"
+    );
+    assert!(
+        reduction < HADAMARD_MIN_MU_REDUCTION,
+        "the identity passed a gate that demands {HADAMARD_MIN_MU_REDUCTION:.1}x — \
+         the gate cannot fail and is worthless"
+    );
+}
+
+/// Mutation guard: every rotation that is orthogonal but not full-dimension
+/// must fail the gate.
+///
+/// These are the plausible degradations, not the crude one — genuine orthogonal
+/// transforms that genuinely decorrelate, over too few dimensions. The first is
+/// the likeliest real defect: `rot_k`'s own FWHT called with the wrong width.
+#[test]
+fn non_full_dimension_rotations_fail_the_hadamard_incoherence_gate() {
+    for (name, reduction) in [
+        (
+            "hadamard truncated to block-4",
+            mean_mu_reduction(rotate_hadamard_block4),
+        ),
+        ("iso block-4", mean_mu_reduction(rotate_iso)),
+        ("rotor block-3", mean_mu_reduction(rotate_rotor)),
+        (
+            "planar block-2",
+            mean_mu_reduction(|buf| rotate_planar(buf, 4)),
+        ),
+    ] {
+        println!("{name}: {reduction:.4}x against a {HADAMARD_MIN_MU_REDUCTION:.1}x gate");
+        assert!(
+            reduction < HADAMARD_MIN_MU_REDUCTION,
+            "{name} reached {reduction:.4}x and passed a gate meant to require a \
+             full-dimension transform"
+        );
+    }
+}
+
+// ── Per-family pinned reductions ─────────────────────────────────────────────
+
+/// Slack under a pinned block-local `mu` reduction, in reduction factor.
+///
+/// A family may lose 0.05 of its measured reduction *factor* before the floor
+/// bites — 3.6% of iso's measurement, 4.6% of rotor's. The fixture is seeded and
+/// the transforms are deterministic, so nothing varies run to run; the slack
+/// covers f32 and codegen drift. It is small enough that the identity — the
+/// limit case at exactly `1.00x` — stays outside every floor, by 0.031 at the
+/// tightest (rotor, whose floor is pinned to the weakest of several draws).
+const BLOCK_REDUCTION_SLACK: f64 = 0.05;
+
+/// Assert a block-local family's `mu` reduction sits between its `sqrt(block)`
+/// ceiling and its pinned measurement.
+///
+/// Two-sided on purpose. The ceiling is a theorem (see the module docs) and
+/// catches a measurement that claims more decorrelation than the block size
+/// allows. The floor, `measured - BLOCK_REDUCTION_SLACK`, catches the
+/// regression that matters — a rotation quietly becoming weaker.
+fn assert_block_local_reduction(name: &str, block: usize, reduction: f64, measured: f64) {
+    let ceiling = (block as f64).sqrt();
+    let floor = measured - BLOCK_REDUCTION_SLACK;
+    println!("{name}: mu reduction {reduction:.4}x (block {block}, ceiling {ceiling:.4}x, floor {floor:.4}x)");
+    assert!(
+        reduction <= ceiling + 1e-3,
+        "{name} reduction {reduction:.4}x exceeds the block-{block} ceiling {ceiling:.4}x"
+    );
+    assert!(
+        reduction >= floor,
+        "{name} reduction {reduction:.4}x fell below the pinned floor {floor:.4}x"
+    );
+}
+
+/// `iso3` / `iso4` — block 4, ceiling `sqrt(4) = 2.00x`.
+///
+/// The fixed golden-ratio quaternion spreads a lone large coordinate over the
+/// block with weights `(1, phi, phi-1, 1)/sqrt(5)`, whose largest entry is
+/// `phi/sqrt(5) = 0.7236`. A single dominant coordinate therefore keeps 72% of
+/// its peak, i.e. a 1.38x reduction — well short of the 2.00x an SO(4) rotation
+/// could in principle deliver, because the quaternion is fixed rather than
+/// fitted to the data.
+///
+/// The rotation does not depend on `bits`, so iso3 and iso4 share this gate.
+#[test]
+fn iso_block_rotation_incoherence_gate() {
+    assert_block_local_reduction("iso3/iso4", 4, mean_mu_reduction(rotate_iso), 1.3846);
+}
+
+/// `rotor3` / `rotor4` — block 3, ceiling `sqrt(3) = 1.73x`.
+///
+/// The rotor is a random SO(3) element drawn from a per-(layer, head, group)
+/// seed, not fitted to the data, so on average it spreads a dominant coordinate
+/// over the block only partially. The rotation does not depend on `bits`, so
+/// rotor3 and rotor4 share this gate.
+///
+/// **Swept over draws, not pinned to one.** Only the groups holding outlier
+/// channels move `mu`, which at `head_dim = 128` with 4 outliers is four rotors
+/// of 43; a single `(layer, head)` table is therefore a four-sample estimate.
+/// Across [`ROTOR_DRAWS`] the reduction spans 1.0815x–1.2089x, so a pin taken
+/// from the `(0, 0)` draw alone (1.1815x) would sit above what half the other
+/// draws deliver and would go red on a different layer. The floor is pinned to
+/// the **weakest** draw instead, so it describes the family.
+#[test]
+fn rotor_block_rotation_incoherence_gate() {
+    let reductions: Vec<(u32, u32, f64)> = ROTOR_DRAWS
+        .iter()
+        .map(|&(layer, head)| {
+            (
+                layer,
+                head,
+                mean_mu_reduction(|b| rotate_rotor_with(b, layer, head)),
+            )
+        })
+        .collect();
+
+    let weakest = reductions
+        .iter()
+        .map(|&(_, _, r)| r)
+        .fold(f64::INFINITY, f64::min);
+    let strongest = reductions
+        .iter()
+        .map(|&(_, _, r)| r)
+        .fold(f64::NEG_INFINITY, f64::max);
+
+    println!(
+        "rotor mu reduction across {} (layer, head) draws: weakest {weakest:.4}x, \
+         strongest {strongest:.4}x — {}",
+        reductions.len(),
+        reductions
+            .iter()
+            .map(|(l, h, r)| format!("({l},{h}) {r:.4}"))
+            .collect::<Vec<_>>()
+            .join(" "),
+    );
+
+    // Every draw must clear the ceiling; the floor is pinned to the weakest.
+    for &(layer, head, reduction) in &reductions {
+        assert!(
+            reduction <= (3.0f64).sqrt() + 1e-3,
+            "rotor draw ({layer},{head}) reduction {reduction:.4}x exceeds the block-3 ceiling"
+        );
+    }
+    assert_block_local_reduction("rotor3/rotor4 (weakest draw)", 3, weakest, 1.0815);
+}
+
+/// `planar3` — block 2, ceiling `sqrt(2) = 1.41x`.
+///
+/// Unlike iso and rotor, the Givens angle is *searched* per pair, so the
+/// rotation depends on the codebook and therefore on `bits`. The search
+/// minimises reconstruction error, not incoherence, which is why the delivered
+/// reduction is far below the ceiling.
+#[test]
+fn planar3_pair_rotation_incoherence_gate() {
+    assert_block_local_reduction(
+        "planar3",
+        2,
+        mean_mu_reduction(|b| rotate_planar(b, 3)),
+        1.1910,
+    );
+}
+
+/// `planar4` — block 2, ceiling `sqrt(2) = 1.41x`. See
+/// [`planar3_pair_rotation_incoherence_gate`].
+#[test]
+fn planar4_pair_rotation_incoherence_gate() {
+    assert_block_local_reduction(
+        "planar4",
+        2,
+        mean_mu_reduction(|b| rotate_planar(b, 4)),
+        1.1518,
+    );
+}
+
+// ── Does the rotation earn its keep? ─────────────────────────────────────────
+
+/// The i.i.d. uniform fixture the existing per-codec cosine gates use, at the
+/// outlier fixture's shape so the two are directly comparable.
+fn lcg_fixture() -> Vec<f32> {
+    lcg_data(OUTLIER_ROWS * OUTLIER_HEAD_DIM, TEST_SEED)
+}
+
+/// Symmetric 8-bit affine at `group_size = 64` — `rot_k`'s quantizer, with no
+/// rotation.
+fn affine_q8_g64(data: &[f32]) -> Vec<f32> {
+    const GROUP: usize = 64;
+    let mut decoded = vec![0.0f32; data.len()];
+    for (group, out) in data
+        .chunks_exact(GROUP)
+        .zip(decoded.chunks_exact_mut(GROUP))
+    {
+        let abs_max = group.iter().copied().fold(0.0f32, |a, v| a.max(v.abs()));
+        let scale = if abs_max > 0.0 { abs_max / 127.0 } else { 0.0 };
+        let inv_scale = if scale > 0.0 { 1.0 / scale } else { 0.0 };
+        for (&v, slot) in group.iter().zip(out.iter_mut()) {
+            let code = (v * inv_scale).round().clamp(-128.0, 127.0) as i8;
+            *slot = scale * f32::from(code);
+        }
+    }
+    decoded
+}
+
+/// Run `rotate` over each `head_dim` row, quantize with [`affine_q8_g64`], then
+/// undo `rotate` — the `rot_k` pipeline, parameterised by the transform.
+///
+/// Every rotation here is orthogonal and involutive-by-inverse, so `unrotate`
+/// is supplied explicitly rather than assumed.
+fn rotated_affine_roundtrip(
+    data: &[f32],
+    rotate: impl Fn(&mut [f32]),
+    unrotate: impl Fn(&mut [f32]),
+) -> Vec<f32> {
+    let mut buf = data.to_vec();
+    rotate(&mut buf);
+    let mut decoded = affine_q8_g64(&buf);
+    unrotate(&mut decoded);
+    decoded
+}
+
+/// `rot_k`: FWHT, [`affine_q8_g64`], FWHT back (the normalized Hadamard is
+/// self-inverse). Same protocol as `rot_k_hadamard_8bit_cosine_gate`, at the
+/// outlier fixture's `head_dim = 128`.
+fn rot_k_roundtrip(data: &[f32]) -> Vec<f32> {
+    rotated_affine_roundtrip(data, rotate_hadamard, rotate_hadamard)
+}
+
+/// Inverse of [`rotate_iso`]: left-multiply by the conjugate quaternion, which
+/// is what `iso_decode_fast` does.
+fn unrotate_iso(buf: &mut [f32]) {
+    let conjugate = quat_conjugate(FIXED_QUAT);
+    for block in buf.chunks_exact_mut(4) {
+        let restored = quat_multiply(conjugate, [block[0], block[1], block[2], block[3]]);
+        block.copy_from_slice(&restored);
+    }
+}
+
+/// Bits of SQNR `rotate` buys over the same quantizer with no transform at all.
+///
+/// The gate and both mutation guards call this one function, so a guard cannot
+/// drift away from the gate it guards.
+fn rotation_gain_bits(
+    data: &[f32],
+    rotate: impl Fn(&mut [f32]),
+    unrotate: impl Fn(&mut [f32]),
+) -> f64 {
+    let rotated = sqnr_db(data, &rotated_affine_roundtrip(data, rotate, unrotate));
+    let plain = sqnr_db(data, &affine_q8_g64(data));
+    (rotated - plain) / DB_PER_BIT
+}
+
+/// Minimum SQNR the Hadamard must buy over the identical unrotated quantizer,
+/// on outlier data, in bits.
+///
+/// The model, stated so it can be checked. `rot_k`'s K-side quantizer is a
+/// symmetric 8-bit affine over a group of 64 channels, so its step is set by
+/// that group's largest magnitude and the SQNR gain from any transform is
+/// exactly `log2(peak_plain / peak_rotated)` for the group. That is the same
+/// quantity the block-`b` ceiling bounds: `peak` can fall by at most `sqrt(b)`,
+/// so a block-`b` transform can buy at most `log2(sqrt(b)) = 0.5·log2(b)` bits
+/// — 1.00 for block-4, 0.79 for block-3, 0.50 for block-2, 0 for the identity.
+///
+/// **Demanding 1.5 bits therefore demands an effective block of at least 8**,
+/// which is the separation the gate is for. It is not a fraction of the outlier
+/// ratio: a tempting model says one channel at `r` inflates the step by `r` and
+/// a rotation recovers `log2(20) ≈ 4.3` bits, but that is wrong — the transform
+/// spreads the outlier's energy into every coordinate, so the RMS that sets the
+/// *new* peak rises too. The measured fall is 4.06x in the group peak, i.e.
+/// 2.02 bits, not 4.3.
+///
+/// 1.5 sits between what a full-dimension transform delivers here and the
+/// strongest substitute: measured 1.81 bits against 0.91 for a block-4
+/// truncation of the same Hadamard. Both bounds are asserted —
+/// [`identity_rotation_excluded_by_the_rot_k_gain_threshold`] and
+/// [`non_full_dimension_rotations_fail_the_rot_k_gain_gate`].
+const ROT_K_MIN_OUTLIER_GAIN_BITS: f64 = 1.5;
+
+/// The decisive `rot_k` measurement: the Hadamard is worth bits on outlier
+/// data, and is a **net loss** on the i.i.d. fixture the older gate uses.
+///
+/// This is the property the codec exists for and the one no LCG-fixture gate
+/// can see. See [`identity_rotation_fails_the_rot_k_gain_gate`] and
+/// [`block_local_rotation_fails_the_rot_k_gain_gate`] for the guards.
+#[test]
+fn rot_k_hadamard_buys_bits_on_outlier_data_and_costs_them_on_iid_data() {
+    let outlier = outlier_fixture();
+    let uniform = lcg_fixture();
+
+    let outlier_gain = rotation_gain_bits(&outlier, rotate_hadamard, rotate_hadamard);
+    let uniform_gain = rotation_gain_bits(&uniform, rotate_hadamard, rotate_hadamard);
+
+    println!(
+        "rot_k Hadamard vs the same affine-q8-g64 quantizer without it:\n\
+         \x20 outlier fixture: {:.3} dB rotated vs {:.3} dB plain = {outlier_gain:+.3} bits\n\
+         \x20 i.i.d. uniform : {:.3} dB rotated vs {:.3} dB plain = {uniform_gain:+.3} bits",
+        sqnr_db(&outlier, &rot_k_roundtrip(&outlier)),
+        sqnr_db(&outlier, &affine_q8_g64(&outlier)),
+        sqnr_db(&uniform, &rot_k_roundtrip(&uniform)),
+        sqnr_db(&uniform, &affine_q8_g64(&uniform)),
+    );
+
+    assert!(
+        outlier_gain >= ROT_K_MIN_OUTLIER_GAIN_BITS,
+        "the Hadamard bought only {outlier_gain:+.3} bits on outlier data, below the \
+         {ROT_K_MIN_OUTLIER_GAIN_BITS:.1} bits a full-dimension decorrelating transform must \
+         deliver against an outlier-inflated group scale"
+    );
+    assert!(
+        uniform_gain < 0.0,
+        "the Hadamard gained {uniform_gain:+.3} bits on i.i.d. uniform data. It is supposed \
+         to *lose* there — the transform pushes uniform toward Gaussian, raising the \
+         peak-to-RMS ratio the quantizer step is set by. If this passes, the i.i.d. fixture \
+         has changed and the premise that it cannot measure rotation quality needs re-checking"
+    );
+}
+
+/// The threshold excludes the identity.
+///
+/// Named for what it is: `rotation_gain_bits` with no transform subtracts a
+/// value from itself, so the `0.0` is exact by construction and this pins the
+/// constant comparison `0.0 < 1.5`. The guards that mutate a real transform are
+/// in [`non_full_dimension_rotations_fail_the_rot_k_gain_gate`].
+#[test]
+fn identity_rotation_excluded_by_the_rot_k_gain_threshold() {
+    let gain = rotation_gain_bits(&outlier_fixture(), |_| {}, |_| {});
+    assert!(
+        gain.abs() < 1e-9,
+        "the identity must buy exactly nothing, got {gain:+.6} bits"
+    );
+    assert!(
+        gain < ROT_K_MIN_OUTLIER_GAIN_BITS,
+        "a codec that does not rotate reported {gain:+.3} bits of rotation gain — \
+         the gate cannot fail"
+    );
+}
+
+/// Mutation guard: orthogonal transforms that are not full-dimension must fail
+/// the gain gate.
+///
+/// The plausible degradations. `0.5·log2(b)` caps a block-`b` transform at 1.00
+/// bit (block-4) and 0.79 (block-3), both under the 1.5-bit gate, so these
+/// rejections are theorems rather than empirical hopes. The truncated FWHT is
+/// the likeliest real defect — `rot_k`'s own transform called with the wrong
+/// width.
+#[test]
+fn non_full_dimension_rotations_fail_the_rot_k_gain_gate() {
+    let data = outlier_fixture();
+    for (name, gain) in [
+        (
+            "hadamard truncated to block-4",
+            rotation_gain_bits(&data, rotate_hadamard_block4, rotate_hadamard_block4),
+        ),
+        (
+            "iso block-4 isoclinic",
+            rotation_gain_bits(&data, rotate_iso, unrotate_iso),
+        ),
+    ] {
+        println!("{name} buys {gain:+.3} bits against a {ROT_K_MIN_OUTLIER_GAIN_BITS:.1}-bit gate");
+        assert!(
+            gain < ROT_K_MIN_OUTLIER_GAIN_BITS,
+            "{name} reported {gain:+.3} bits and passed a gate meant to require a \
+             full-dimension transform"
+        );
+    }
+}
+
+// ── Outlier-fixture cosine gates ─────────────────────────────────────────────
+
+/// Tolerance on a pinned cosine measurement, as a multiple of the reconstruction
+/// error `1 - cos`.
+///
+/// The crate's older cosine gates pin at `measured - 0.001`. That convention
+/// cannot work here: `rot_k` scores 0.999991 on this fixture and 0.999881 with
+/// the Hadamard deleted outright, so an absolute 0.001 slack is **fifty times
+/// wider than the entire effect** and the removal sails through. Sizing the
+/// tolerance to the error instead — a codec may double `1 - cos` before the
+/// floor bites — makes one rule work across five orders of magnitude of codec
+/// quality.
+///
+/// The fixture is seeded and every codec here is deterministic, so nothing
+/// varies run to run; the tolerance covers f32 and codegen drift, which moves
+/// these cosines by ~1e-7 against a `rot_k` budget of 9e-6.
+const COSINE_ERROR_TOLERANCE: f32 = 2.0;
+
+/// Floor derived from a pinned outlier-fixture cosine measurement.
+///
+/// Shared by the gates and by
+/// [`lossier_codecs_fail_the_outlier_cosine_floors`], so a guard cannot drift
+/// away from the floor it is guarding.
+fn outlier_cosine_floor(measured: f32) -> f32 {
+    COSINE_ERROR_TOLERANCE.mul_add(measured - 1.0, 1.0)
+}
+
+/// Pinned outlier-fixture cosine measurements, `(mean, min)`.
+///
+/// One definition each, referenced by the gate and by the mutation guard.
+const ROT_K_PIN: (f32, f32) = (0.999_989, 0.999_980);
+const ISO3_PIN: (f32, f32) = (0.996_769, 0.992_033);
+const ISO4_PIN: (f32, f32) = (0.998_764, 0.997_551);
+const ROTOR3_PIN: (f32, f32) = (0.995_003, 0.989_004);
+const ROTOR4_PIN: (f32, f32) = (0.998_991, 0.997_015);
+const PLANAR3_PIN: (f32, f32) = (0.999_960, 0.999_871);
+const PLANAR4_PIN: (f32, f32) = (0.999_932, 0.999_615);
+
+/// Assert a codec's outlier-fixture cosine against its pinned measurement, and
+/// report its i.i.d. number beside it.
+///
+/// `measured_mean` / `measured_min` are the observed values; the floor is
+/// derived as `1 - COSINE_ERROR_TOLERANCE * (1 - measured)`.
+///
+/// These are regression floors. They are **not** on their own evidence that a
+/// rotation works: cosine is dominated by a row's largest components, and on
+/// this fixture those are the outlier channels, which every codec here
+/// reconstructs well because its scale is a per-group *maximum* and therefore
+/// already adapts to them. The reported i.i.d. column makes that visible —
+/// several codecs score *higher* on the outlier fixture than on the uniform
+/// one. The rotation question is answered by the incoherence gates above and by
+/// [`rot_k_hadamard_buys_bits_on_outlier_data_and_costs_them_on_iid_data`].
+fn assert_outlier_cosine(
+    name: &str,
+    roundtrip: impl Fn(&[f32]) -> Vec<f32>,
+    measured_mean: f32,
+    measured_min: f32,
+) {
+    let floor_mean = outlier_cosine_floor(measured_mean);
+    let floor_min = outlier_cosine_floor(measured_min);
+
+    let outlier = outlier_fixture();
+    let outlier_stats: CosineStats =
+        cosine_similarity_per_row(&outlier, &roundtrip(&outlier), OUTLIER_HEAD_DIM);
+
+    let uniform = lcg_fixture();
+    let uniform_stats = cosine_similarity_per_row(&uniform, &roundtrip(&uniform), OUTLIER_HEAD_DIM);
+
+    println!(
+        "{name} cosine: outlier mean={:.6} min={:.6} | i.i.d. mean={:.6} \
+         (floors {floor_mean:.6} / {floor_min:.6})",
+        outlier_stats.mean, outlier_stats.min, uniform_stats.mean,
+    );
+
+    assert!(
+        outlier_stats.mean >= floor_mean,
+        "{name} outlier-fixture mean cosine {:.6} fell below the floor {floor_mean:.6} \
+         (pinned measurement {measured_mean:.6}, error allowed to double)",
+        outlier_stats.mean,
+    );
+    assert!(
+        outlier_stats.min >= floor_min,
+        "{name} outlier-fixture min cosine {:.6} fell below the floor {floor_min:.6} \
+         (pinned measurement {measured_min:.6}, error allowed to double)",
+        outlier_stats.min,
+    );
+}
+
+fn iso_roundtrip(data: &[f32], bits: u8) -> Vec<f32> {
+    let (codes, scales, quats, norms) =
+        iso_encode_fast(data, OUTLIER_HEAD_DIM, 4, bits).expect("iso_encode_fast");
+    iso_decode_fast(&codes, &scales, &quats, &norms, OUTLIER_HEAD_DIM, 4, bits)
+        .expect("iso_decode_fast")
+}
+
+fn rotor_roundtrip(data: &[f32], bits: u8) -> Vec<f32> {
+    let rotors = make_rotor_table(0, 0, n_groups_for(OUTLIER_HEAD_DIM));
+    if bits == 3 {
+        let (codes, scales, norms) =
+            rotor3_encode(data, &rotors, OUTLIER_HEAD_DIM).expect("rotor3_encode");
+        rotor3_decode(&codes, &scales, &norms, &rotors, OUTLIER_HEAD_DIM).expect("rotor3_decode")
+    } else {
+        let (codes, scales, norms) =
+            rotor4_encode(data, &rotors, OUTLIER_HEAD_DIM).expect("rotor4_encode");
+        rotor4_decode(&codes, &scales, &norms, &rotors, OUTLIER_HEAD_DIM).expect("rotor4_decode")
+    }
+}
+
+fn planar_roundtrip(data: &[f32], bits: u8) -> Vec<f32> {
+    let n_rows = data.len() / OUTLIER_HEAD_DIM;
+    let shape = [1, 1, n_rows as i32, OUTLIER_HEAD_DIM as i32];
+    let blocks = planar_quantize(data, GROUP_SIZE, bits, &shape).expect("planar_quantize");
+    planar_dequantize(&blocks).expect("planar_dequantize")
+}
+
+/// `rot_k` Hadamard + 8-bit affine, outlier fixture.
+#[test]
+fn rot_k_outlier_cosine_gate() {
+    assert_outlier_cosine("rot_k h8", rot_k_roundtrip, ROT_K_PIN.0, ROT_K_PIN.1);
+}
+
+/// `iso3`, outlier fixture.
+#[test]
+fn iso3_outlier_cosine_gate() {
+    assert_outlier_cosine("iso3", |d| iso_roundtrip(d, 3), ISO3_PIN.0, ISO3_PIN.1);
+}
+
+/// `iso4`, outlier fixture.
+#[test]
+fn iso4_outlier_cosine_gate() {
+    assert_outlier_cosine("iso4", |d| iso_roundtrip(d, 4), ISO4_PIN.0, ISO4_PIN.1);
+}
+
+/// `rotor3`, outlier fixture.
+#[test]
+fn rotor3_outlier_cosine_gate() {
+    assert_outlier_cosine(
+        "rotor3",
+        |d| rotor_roundtrip(d, 3),
+        ROTOR3_PIN.0,
+        ROTOR3_PIN.1,
+    );
+}
+
+/// `rotor4`, outlier fixture.
+#[test]
+fn rotor4_outlier_cosine_gate() {
+    assert_outlier_cosine(
+        "rotor4",
+        |d| rotor_roundtrip(d, 4),
+        ROTOR4_PIN.0,
+        ROTOR4_PIN.1,
+    );
+}
+
+/// `planar3`, outlier fixture.
+#[test]
+fn planar3_outlier_cosine_gate() {
+    assert_outlier_cosine(
+        "planar3",
+        |d| planar_roundtrip(d, 3),
+        PLANAR3_PIN.0,
+        PLANAR3_PIN.1,
+    );
+}
+
+/// `planar4`, outlier fixture.
+#[test]
+fn planar4_outlier_cosine_gate() {
+    assert_outlier_cosine(
+        "planar4",
+        |d| planar_roundtrip(d, 4),
+        PLANAR4_PIN.0,
+        PLANAR4_PIN.1,
+    );
+}
+
+/// Within `iso` and `rotor`, the wider codebook must score higher on the
+/// fixture that can tell them apart.
+///
+/// A per-codec floor cannot catch a bit-width plumbing fault that makes iso4
+/// behave like iso3 — both floors would still hold. This ordering can.
+///
+/// `planar` is deliberately absent: it **inverts**, and does so on the i.i.d.
+/// fixture too. See `byte_identical_bit_widths_leave_one_width_dominated` in
+/// `rate_distortion_tests.rs`, which pins the inversion with dB numbers rather
+/// than hiding it here.
+#[test]
+fn wider_codebooks_score_higher_on_the_outlier_fixture() {
+    let data = outlier_fixture();
+    for (family, narrow, wide) in [
+        ("iso", iso_roundtrip(&data, 3), iso_roundtrip(&data, 4)),
+        (
+            "rotor",
+            rotor_roundtrip(&data, 3),
+            rotor_roundtrip(&data, 4),
+        ),
+    ] {
+        let narrow_cos = cosine_similarity_per_row(&data, &narrow, OUTLIER_HEAD_DIM).mean;
+        let wide_cos = cosine_similarity_per_row(&data, &wide, OUTLIER_HEAD_DIM).mean;
+        assert!(
+            wide_cos > narrow_cos,
+            "{family}4 cosine {wide_cos:.6} did not beat {family}3 {narrow_cos:.6}"
+        );
+    }
+}
+
+/// Mutation guard: every one of the seven cosine floors must reject a codec
+/// that genuinely loses more information than the one it was pinned from.
+///
+/// A floor nothing in the tree can cross proves only that the tree is
+/// unchanged. Each stand-in below is a real codec run on the real fixture,
+/// judged by [`outlier_cosine_floor`] — the same function the gates use — so
+/// this cannot drift away from what it guards:
+///
+/// * `rot_k` — the identical `affine q8 g64` quantizer with the Hadamard
+///   deleted. This is the case that motivated the error-relative tolerance: at
+///   the crate's usual absolute `measured - 0.001` the deletion passes.
+/// * `iso4`, `rotor4` — the same family one bit narrower.
+/// * `planar3` — `planar4`, which is measurably worse at identical storage.
+/// * `iso3`, `rotor3`, `planar4` — `turbo` at the same nominal width, i.e. one
+///   scale per 32 values instead of the family's per-2/3/4 scale.
+///
+/// The predicate is `mean` **or** `min` below its floor, mirroring the gate,
+/// which asserts both. `planar3` is caught on `min` alone: `planar4`'s mean sits
+/// 1.2e-5 above the mean floor while its min sits 1.3e-4 below the min floor.
+/// That is the tightest case here and the reason both statistics are pinned.
+#[test]
+fn lossier_codecs_fail_the_outlier_cosine_floors() {
+    let data = outlier_fixture();
+
+    let turbo = |bits: u8| {
+        let rows = data.len() / OUTLIER_HEAD_DIM;
+        let shape = [1, 1, rows as i32, OUTLIER_HEAD_DIM as i32];
+        let blocks =
+            crate::turboquant::turbo_quantize_v(&data, bits, &shape).expect("turbo_quantize_v");
+        crate::turboquant::turbo_dequantize(&blocks).expect("turbo_dequantize")
+    };
+
+    let cases: [(&str, (f32, f32), &str, Vec<f32>); 7] = [
+        (
+            "rot_k h8",
+            ROT_K_PIN,
+            "the same quantizer with the Hadamard deleted",
+            affine_q8_g64(&data),
+        ),
+        ("iso4", ISO4_PIN, "iso3", iso_roundtrip(&data, 3)),
+        ("rotor4", ROTOR4_PIN, "rotor3", rotor_roundtrip(&data, 3)),
+        (
+            "planar3",
+            PLANAR3_PIN,
+            "planar4",
+            planar_roundtrip(&data, 4),
+        ),
+        ("iso3", ISO3_PIN, "turbo3", turbo(3)),
+        ("rotor3", ROTOR3_PIN, "turbo3", turbo(3)),
+        ("planar4", PLANAR4_PIN, "turbo4", turbo(4)),
+    ];
+
+    for (owner, pin, substitute, decoded) in cases {
+        let stats = cosine_similarity_per_row(&data, &decoded, OUTLIER_HEAD_DIM);
+        let floor_mean = outlier_cosine_floor(pin.0);
+        let floor_min = outlier_cosine_floor(pin.1);
+
+        println!(
+            "{owner} floor ({floor_mean:.6} / {floor_min:.6}) vs {substitute}: \
+             mean {:.6} min {:.6}",
+            stats.mean, stats.min,
+        );
+        assert!(
+            stats.mean < floor_mean || stats.min < floor_min,
+            "{substitute} cleared the {owner} floor (mean {:.6} >= {floor_mean:.6} and \
+             min {:.6} >= {floor_min:.6}) — that floor cannot detect a genuinely lossier \
+             codec and is decoration",
+            stats.mean,
+            stats.min,
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/test_utils.rs
+++ b/crates/rmlx-kv-quant/src/test_utils.rs
@@ -314,6 +314,353 @@ pub(crate) fn lcg_data(n: usize, seed: u64) -> Vec<f32> {
         .collect()
 }
 
+/// Generate `n` standard-normal f32 values from the same pinned Knuth LCG as
+/// [`lcg_data`], via Box–Muller.
+///
+/// Deterministic for a fixed `seed`; never `thread_rng`. Pairs of uniforms are
+/// consumed per pair of outputs; an odd `n` discards the second variate of the
+/// final pair.
+///
+/// `u1` is drawn on `(0, 1]` (`+1` before the divide) so `ln(u1)` is finite;
+/// `u2` on `[0, 1)`. Accumulated in f64 and narrowed once, so the output is
+/// bit-stable across optimisation levels.
+pub(crate) fn gaussian_data(n: usize, seed: u64) -> Vec<f32> {
+    const TWO_POW_32: f64 = 4_294_967_296.0;
+    let mut state = seed;
+    let mut next_u32 = || {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        (state >> 32) as u32
+    };
+
+    let mut out = Vec::with_capacity(n);
+    while out.len() < n {
+        let u1 = (f64::from(next_u32()) + 1.0) / TWO_POW_32; // (0, 1]
+        let u2 = f64::from(next_u32()) / TWO_POW_32; // [0, 1)
+        let r = (-2.0 * u1.ln()).sqrt();
+        let theta = std::f64::consts::TAU * u2;
+        out.push((r * theta.cos()) as f32);
+        if out.len() < n {
+            out.push((r * theta.sin()) as f32);
+        }
+    }
+    out
+}
+
+/// Generate `[n_rows, head_dim]` f32 modelling the **K-cache outlier-channel**
+/// shape: i.i.d. standard-normal base with `n_outlier_channels` persistent
+/// channels scaled by `outlier_ratio`.
+///
+/// # Why this shape
+///
+/// Uniform / i.i.d. fixtures are already close to maximally incoherent, so a
+/// rotation cannot improve them and a gate built on one cannot see rotation
+/// quality at all (see [`incoherence_per_row`]). Real K-cache activations are
+/// not i.i.d.: the reported structure is a handful of **fixed channels whose
+/// magnitude is large in every token**, which is why the KV-quantization
+/// literature quantizes Keys per-channel and Values per-token, and why the
+/// rotation-KV family exists at all.
+///
+/// * KIVI (Liu et al., ICML 2024, arXiv:2402.02750) — the Key cache has a few
+///   fixed channels with large magnitudes; the Value cache has no such pattern.
+/// * KVQuant (Hooper et al., NeurIPS 2024, arXiv:2401.18079) — same
+///   observation; motivates per-channel Key quantization.
+/// * LLM.int8() (Dettmers et al., 2022, arXiv:2208.07339) — emergent outlier
+///   features occupy a fraction of a percent of the hidden dimensions at
+///   magnitudes on the order of 20× the rest. That report is the source of the
+///   `20.0` default ratio in [`OUTLIER_RATIO`]; it is **not** the source of the
+///   channel count, see [`OUTLIER_CHANNELS`].
+/// * QuIP (Chee et al., 2023, arXiv:2307.13304) and QuaRot (Ashkboos et al.,
+///   2024, arXiv:2404.00456) — a full-dimension (randomized) Hadamard is the
+///   standard remedy, and the incoherence parameter is the standard measure of
+///   whether it worked.
+///
+/// This is a **model** of that shape, not a capture of any particular layer:
+/// the base is exactly i.i.d. Gaussian and every outlier channel gets the same
+/// ratio. It is adversarial in the one axis that matters here — a few
+/// coordinates carry most of the mass — and it is reproducible from a seed.
+///
+/// # Channel placement
+///
+/// Indices are `(i · head_dim / n + i · OUTLIER_CHANNEL_TWIST) mod head_dim`:
+/// an even spread so the channels cover the row, plus a stride so their
+/// **intra-block offsets differ**. The twist is load-bearing. A plain even
+/// spread at `head_dim = 128` with 4 channels gives 0 / 32 / 64 / 96, every one
+/// of which sits at offset 0 of a block of 2, 3 or 4 — the most aligned
+/// placement available, not a neutral one. That is harmless for iso, whose left
+/// quaternion product has the same largest column magnitude in every slot, but
+/// planar's per-pair Givens search is not symmetric under swapping the pair, so
+/// a constant offset would put an unmeasured bias into a pinned number. With
+/// the twist the four channels land on 0 / 37 / 74 / 111, whose offsets are
+/// distinct mod 4, cover both residues mod 2, and take three of three values
+/// mod 3.
+///
+/// # Panics
+///
+/// Panics (test-only) if `head_dim == 0` or
+/// `n_outlier_channels > head_dim`.
+pub(crate) fn outlier_channel_data(
+    n_rows: usize,
+    head_dim: usize,
+    n_outlier_channels: usize,
+    outlier_ratio: f32,
+    seed: u64,
+) -> Vec<f32> {
+    assert!(head_dim > 0, "outlier_channel_data: head_dim must be > 0");
+    assert!(
+        n_outlier_channels <= head_dim,
+        "outlier_channel_data: n_outlier_channels={n_outlier_channels} exceeds head_dim={head_dim}",
+    );
+
+    let mut data = gaussian_data(n_rows * head_dim, seed);
+    for channel in outlier_channels(head_dim, n_outlier_channels) {
+        for row in 0..n_rows {
+            // row < n_rows and channel < head_dim, so the index is in bounds.
+            data[row * head_dim + channel] *= outlier_ratio;
+        }
+    }
+    data
+}
+
+/// Stride applied on top of the even spread in [`outlier_channels`] so the
+/// chosen channels do not all share one intra-block offset.
+///
+/// 5 is coprime to 2, 3 and 4 — the block sizes of every rotation family here —
+/// so successive channels advance through the offsets rather than repeating one.
+const OUTLIER_CHANNEL_TWIST: usize = 5;
+
+/// Which channels [`outlier_channel_data`] scales. See its "Channel placement".
+///
+/// The twist is coprime to the block sizes but not to every `head_dim`, so for
+/// some counts the raw formula collides. Colliding slots walk forward to the
+/// next free channel, which keeps the result exactly `n_outlier_channels`
+/// distinct channels for any `n_outlier_channels <= head_dim` — without that, a
+/// channel scaled twice would get `ratio²` and the count would silently be an
+/// over-estimate.
+///
+/// # Panics
+///
+/// Panics (test-only) if `n_outlier_channels > head_dim`.
+pub(crate) fn outlier_channels(head_dim: usize, n_outlier_channels: usize) -> Vec<usize> {
+    assert!(
+        n_outlier_channels <= head_dim,
+        "outlier_channels: {n_outlier_channels} channels requested of head_dim={head_dim}",
+    );
+    let mut taken = vec![false; head_dim];
+    let mut out = Vec::with_capacity(n_outlier_channels);
+    for i in 0..n_outlier_channels {
+        let mut channel =
+            (i * head_dim / n_outlier_channels + i * OUTLIER_CHANNEL_TWIST) % head_dim;
+        while taken[channel] {
+            channel = (channel + 1) % head_dim;
+        }
+        taken[channel] = true;
+        out.push(channel);
+    }
+    out
+}
+
+/// Rows in the canonical outlier fixture — enough that the p99 of the per-row
+/// statistic is meaningful.
+pub(crate) const OUTLIER_ROWS: usize = 256;
+
+/// `head_dim` of the canonical outlier fixture. 128 is a real shipped head_dim
+/// (Bonsai / Qwen3) and a power of two, so the full-dimension Hadamard applies.
+pub(crate) const OUTLIER_HEAD_DIM: usize = 128;
+
+/// Outlier channels in the canonical fixture: 4 of 128 = 3.1%.
+///
+/// Deliberately **denser than the literature**, which puts emergent outlier
+/// features at a fraction of a percent of the hidden dimensions. The density is
+/// chosen so that every affine group of 64 — the group `rot_k` sets its 8-bit
+/// scale over — contains an outlier, which is the condition under which a
+/// full-dimension rotation has something to recover across the whole row. At a
+/// literature-faithful 0.8% (one channel of 128) one of the two groups is clean
+/// and the row-averaged gain roughly halves; the fixture would still be
+/// adversarial, just less uniformly so.
+///
+/// `outlier_channel_count_monotonically_raises_incoherence` sweeps this the way
+/// `outlier_ratio_monotonically_raises_incoherence` sweeps the magnitude, so
+/// neither parameter is a bare assertion.
+pub(crate) const OUTLIER_CHANNELS: usize = 4;
+
+/// Magnitude ratio of an outlier channel to the Gaussian base — the order of
+/// magnitude reported for emergent outlier features (arXiv:2208.07339).
+pub(crate) const OUTLIER_RATIO: f32 = 20.0;
+
+/// The canonical outlier-channel fixture every rotation gate measures against.
+pub(crate) fn outlier_fixture() -> Vec<f32> {
+    outlier_channel_data(
+        OUTLIER_ROWS,
+        OUTLIER_HEAD_DIM,
+        OUTLIER_CHANNELS,
+        OUTLIER_RATIO,
+        TEST_SEED,
+    )
+}
+
+// ── Incoherence statistic ────────────────────────────────────────────────────
+
+/// Summary statistics from [`incoherence_per_row`].
+pub(crate) struct IncoherenceStats {
+    /// Mean of `mu` across all rows.
+    pub mean: f64,
+    /// 99th percentile of `mu` (nearest-rank) — the tail a quantizer's range
+    /// has to cover.
+    pub p99: f64,
+    /// Maximum `mu` across all rows.
+    pub max: f64,
+    /// Number of rows processed.
+    pub n_rows: usize,
+}
+
+/// Per-row incoherence `mu(x) = sqrt(d) · max_i |x_i| / ||x||_2`.
+///
+/// `mu = 1` for a perfectly flat vector and `mu = sqrt(d)` for a one-hot
+/// vector, so it is a normalized peak-to-RMS ratio: exactly the quantity a
+/// uniform quantizer's range is set by, and exactly what a decorrelating
+/// rotation is supposed to reduce. The name and normalization follow QuIP
+/// (arXiv:2307.13304).
+///
+/// An all-zero row is defined as `mu = 1.0` — it is flat, and the ratio is
+/// otherwise `0/0`.
+///
+/// # Panics
+///
+/// Panics (test-only) if `head_dim == 0` or does not evenly divide `x.len()`,
+/// or if `x` is empty.
+pub(crate) fn incoherence_per_row(x: &[f32], head_dim: usize) -> IncoherenceStats {
+    assert!(
+        head_dim > 0 && !x.is_empty() && x.len().is_multiple_of(head_dim),
+        "incoherence_per_row: head_dim={head_dim} does not evenly divide a non-empty len={}",
+        x.len(),
+    );
+
+    let sqrt_d = (head_dim as f64).sqrt();
+    let mut mus: Vec<f64> = x
+        .chunks_exact(head_dim)
+        .map(|row| {
+            let peak = row
+                .iter()
+                .fold(0.0f64, |acc, &v| acc.max(f64::from(v).abs()));
+            let l2 = row
+                .iter()
+                .fold(0.0f64, |acc, &v| f64::from(v).mul_add(f64::from(v), acc))
+                .sqrt();
+            if l2 <= 0.0 {
+                1.0
+            } else {
+                sqrt_d * peak / l2
+            }
+        })
+        .collect();
+
+    let n_rows = mus.len();
+    let mean = mus.iter().sum::<f64>() / n_rows as f64;
+    mus.sort_by(f64::total_cmp);
+    // Nearest-rank p99: the smallest value at or above 99% of the sorted rows.
+    let rank = ((n_rows as f64) * 0.99).ceil().max(1.0) as usize;
+    let p99 = mus[rank.min(n_rows) - 1];
+    let max = mus[n_rows - 1];
+
+    IncoherenceStats {
+        mean,
+        p99,
+        max,
+        n_rows,
+    }
+}
+
+// ── Rate-distortion reference ────────────────────────────────────────────────
+
+/// dB per bit for a scalar quantizer: `20 · log10(2)`.
+///
+/// One extra bit halves the quantizer step, so it buys this much SQNR. Used to
+/// convert a dB shortfall into the directly meaningful unit — see
+/// [`wasted_bits`].
+pub(crate) const DB_PER_BIT: f64 = 6.020_599_913_279_624;
+
+/// SQNR in dB achievable by a **fixed-rate Lloyd-Max quantizer on the standard
+/// normal**, indexed by `bits - 1` for `bits ∈ {1, 2, 3, 4}`.
+///
+/// These are *not* the rate-distortion bound. The bound is `6.02 · b` dB and an
+/// optimally entropy-coded scalar quantizer sits ~1.53 dB below it (the gap
+/// between cubic quantizer cells and sphere packing); a fixed-rate Lloyd-Max
+/// quantizer is lower still. The values here are `10 · log10(1 / D)` for the
+/// classical minimum mean-square distortions `D` of Max (1960),
+/// "Quantizing for Minimum Distortion", IRE Trans. Inf. Theory 6(1), Table I:
+///
+/// | bits | levels | `D` | anchor |
+/// |---|---|---|---|
+/// | 1 | 2 | 0.363 4 | 4.396 dB |
+/// | 2 | 4 | 0.117 5 | 9.300 dB |
+/// | 3 | 8 | 0.034 54 | 14.616 dB |
+/// | 4 | 16 | 0.009 497 | 20.224 dB |
+///
+/// The anchor assumes the quantizer is **matched to the source** — it knows
+/// sigma and spends no rate saying so. Every codec here instead derives a scale
+/// from a per-group maximum and stores it, so the comparison is not
+/// apples-to-apples in the codec's favour: the codec pays extra rate for the
+/// scale and can therefore legitimately land *above* the anchor. What the
+/// anchor is good for is the other direction — landing well below it at the
+/// same nominal bit width means the bits are not buying what they should.
+pub(crate) const LLOYD_MAX_GAUSSIAN_SQNR_DB: [f64; 4] = [4.396, 9.300, 14.616, 20.224];
+
+/// [`LLOYD_MAX_GAUSSIAN_SQNR_DB`] for `bits`.
+///
+/// # Panics
+///
+/// Panics (test-only) for `bits` outside `1..=4` — no anchor is tabulated.
+pub(crate) fn lloyd_max_anchor_db(bits: u8) -> f64 {
+    assert!(
+        (1..=4).contains(&bits),
+        "lloyd_max_anchor_db: no Lloyd-Max anchor tabulated for bits={bits}",
+    );
+    LLOYD_MAX_GAUSSIAN_SQNR_DB[usize::from(bits) - 1]
+}
+
+/// Signal-to-quantization-noise ratio in dB: `10 · log10(P_signal / P_error)`.
+///
+/// Both powers are accumulated in f64. A zero error power returns
+/// `f64::INFINITY` (a lossless round-trip), and a zero signal power returns
+/// `f64::NEG_INFINITY` unless the error is also zero.
+///
+/// # Panics
+///
+/// Panics (test-only) if the two slices differ in length or are empty.
+pub(crate) fn sqnr_db(reference: &[f32], decoded: &[f32]) -> f64 {
+    assert_eq!(
+        reference.len(),
+        decoded.len(),
+        "sqnr_db: reference and decoded lengths differ ({} vs {})",
+        reference.len(),
+        decoded.len(),
+    );
+    assert!(!reference.is_empty(), "sqnr_db: empty input");
+
+    let mut signal = 0.0f64;
+    let mut error = 0.0f64;
+    for (&r, &d) in reference.iter().zip(decoded.iter()) {
+        let rf = f64::from(r);
+        let e = rf - f64::from(d);
+        signal = rf.mul_add(rf, signal);
+        error = e.mul_add(e, error);
+    }
+    if error <= 0.0 {
+        return f64::INFINITY;
+    }
+    10.0 * (signal / error).log10()
+}
+
+/// Shortfall of `measured_db` against `anchor_db`, expressed in bits.
+///
+/// Positive means the codec is that many bits short of the anchor; negative
+/// means it is ahead of it. See [`DB_PER_BIT`].
+pub(crate) fn wasted_bits(measured_db: f64, anchor_db: f64) -> f64 {
+    (anchor_db - measured_db) / DB_PER_BIT
+}
+
 /// Apply a normalized Walsh–Hadamard transform (FWHT) in-place, row-wise.
 ///
 /// `buf` is processed as `buf.len() / n` rows of `n` elements each. After the

--- a/crates/rmlx-kv-quant/src/test_utils_tests.rs
+++ b/crates/rmlx-kv-quant/src/test_utils_tests.rs
@@ -1,6 +1,8 @@
 use super::{
-    cosine_similarity_per_row, fwht_normalize, lcg_data, skip_if_no_gpu_env, skip_value_means_skip,
-    vectorized_parity_check, TEST_SEED,
+    cosine_similarity_per_row, fwht_normalize, gaussian_data, incoherence_per_row, lcg_data,
+    lloyd_max_anchor_db, outlier_channel_data, outlier_channels, outlier_fixture,
+    skip_if_no_gpu_env, skip_value_means_skip, sqnr_db, vectorized_parity_check, wasted_bits,
+    DB_PER_BIT, LLOYD_MAX_GAUSSIAN_SQNR_DB, OUTLIER_HEAD_DIM, OUTLIER_ROWS, TEST_SEED,
 };
 
 /// Identity codec (cpu == msl): must pass with zero error.
@@ -198,4 +200,323 @@ fn fwht_double_apply_is_identity() {
             "identity broken at index {i}: {o} vs {b}"
         );
     }
+}
+
+// ── incoherence_per_row self-tests ───────────────────────────────────────────
+
+/// Both endpoints of the statistic, against hand-computed values.
+///
+/// A flat vector has `max|x_i| = c` and `||x||_2 = c·sqrt(d)`, so
+/// `mu = sqrt(d)·c / (c·sqrt(d)) = 1` — the minimum. A one-hot vector has
+/// `max|x_i| = ||x||_2`, so `mu = sqrt(d)` — the maximum. Nothing else the
+/// statistic could be would satisfy both.
+#[test]
+fn incoherence_endpoints_are_one_and_sqrt_d() {
+    let d = 64usize;
+    let sqrt_d = (d as f64).sqrt();
+
+    let flat = vec![0.375f32; d];
+    let flat_stats = incoherence_per_row(&flat, d);
+    assert_eq!(flat_stats.n_rows, 1);
+    assert!(
+        (flat_stats.mean - 1.0).abs() < 1e-9,
+        "flat vector mu {} != 1.0",
+        flat_stats.mean,
+    );
+
+    let mut one_hot = vec![0.0f32; d];
+    one_hot[7] = -2.5;
+    let one_hot_stats = incoherence_per_row(&one_hot, d);
+    assert!(
+        (one_hot_stats.mean - sqrt_d).abs() < 1e-6,
+        "one-hot mu {} != sqrt({d}) = {sqrt_d}",
+        one_hot_stats.mean,
+    );
+}
+
+/// An all-zero row is flat, so it is defined as `mu = 1.0` rather than `0/0`.
+#[test]
+fn incoherence_zero_row_is_one() {
+    let stats = incoherence_per_row(&[0.0f32; 16], 16);
+    assert!((stats.mean - 1.0).abs() < 1e-9, "mean={}", stats.mean);
+}
+
+/// `mean < p99 <= max` on a mixed set of rows, and the tail statistics pick out
+/// the one-hot rows rather than averaging them away.
+///
+/// 100 rows with the last 2 one-hot: nearest-rank p99 is the 99th ordered
+/// value, which lands inside the one-hot pair, so both `p99` and `max` see
+/// `mu = sqrt(16) = 4` while the mean stays near 1.
+#[test]
+fn incoherence_tail_statistics_track_the_worst_rows() {
+    let d = 16usize;
+    let mut data = vec![1.0f32; d * 100];
+    for row in 98..100 {
+        for slot in data.iter_mut().skip(row * d).take(d) {
+            *slot = 0.0;
+        }
+        data[row * d] = 1.0;
+    }
+
+    let stats = incoherence_per_row(&data, d);
+    assert_eq!(stats.n_rows, 100);
+    assert!((stats.max - 4.0).abs() < 1e-6, "max={}", stats.max);
+    assert!((stats.p99 - 4.0).abs() < 1e-6, "p99={}", stats.p99);
+    assert!(
+        stats.mean < stats.p99 && stats.p99 <= stats.max,
+        "expected mean < p99 <= max, got {} / {} / {}",
+        stats.mean,
+        stats.p99,
+        stats.max,
+    );
+}
+
+// ── fixture self-tests ───────────────────────────────────────────────────────
+
+/// `gaussian_data` is seed-deterministic and is actually standard normal.
+#[test]
+fn gaussian_data_is_deterministic_and_standard_normal() {
+    let a = gaussian_data(4096, TEST_SEED);
+    let b = gaussian_data(4096, TEST_SEED);
+    assert_eq!(a, b, "gaussian_data must be reproducible from its seed");
+    assert_ne!(
+        a,
+        gaussian_data(4096, TEST_SEED ^ 1),
+        "a different seed must produce different data"
+    );
+
+    let n = a.len() as f64;
+    let mean = a.iter().map(|&v| f64::from(v)).sum::<f64>() / n;
+    let var = a.iter().map(|&v| f64::from(v) * f64::from(v)).sum::<f64>() / n - mean * mean;
+    // 4096 samples: the sample mean has sd 1/64 and the sample variance sd
+    // sqrt(2/4096) ≈ 0.022, so these bounds are ~4 sigma.
+    assert!(mean.abs() < 0.07, "sample mean {mean} is not ~0");
+    assert!(
+        (var - 1.0).abs() < 0.09,
+        "sample variance {var} is not ~1 — Box-Muller is miswired"
+    );
+}
+
+/// The outlier fixture is adversarial, and the i.i.d. fixtures are not.
+///
+/// Threshold justification, stated before the measurement: for an i.i.d. row of
+/// length `d`, `||x||_2 ≈ sqrt(d)·sigma`, so `mu ≈ max_i|x_i| / sigma` — the
+/// expected max of `d` samples in sigma units. At `d = 128` that is ≈ 2.83 for
+/// a Gaussian and ≈ 1.71 for uniform-on-[-1,1]. **5.0 is ~1.8x above the
+/// Gaussian i.i.d. value, so no i.i.d. fixture can reach it** — which is
+/// exactly what the two negative controls below assert. Passing it therefore
+/// means the fixture really does concentrate its mass in a few coordinates.
+#[test]
+fn outlier_fixture_is_adversarial_and_iid_fixtures_are_not() {
+    const ADVERSARIAL_FLOOR: f64 = 5.0;
+
+    let outlier = incoherence_per_row(&outlier_fixture(), OUTLIER_HEAD_DIM);
+    assert!(
+        outlier.mean >= ADVERSARIAL_FLOOR,
+        "outlier fixture mean mu {:.4} < {ADVERSARIAL_FLOOR} — fixture is not adversarial",
+        outlier.mean,
+    );
+
+    // Negative control 1: the same Gaussian base with the outlier channels
+    // removed. This isolates the channels as the cause.
+    let plain_gaussian = gaussian_data(OUTLIER_ROWS * OUTLIER_HEAD_DIM, TEST_SEED);
+    let plain = incoherence_per_row(&plain_gaussian, OUTLIER_HEAD_DIM);
+    assert!(
+        plain.mean < ADVERSARIAL_FLOOR,
+        "i.i.d. Gaussian mean mu {:.4} reached the adversarial floor {ADVERSARIAL_FLOOR} — \
+         the floor does not separate outlier data from i.i.d. data",
+        plain.mean,
+    );
+
+    // Negative control 2: the LCG uniform fixture every existing cosine gate
+    // uses. It is the least adversarial of the three.
+    let uniform = incoherence_per_row(
+        &lcg_data(OUTLIER_ROWS * OUTLIER_HEAD_DIM, TEST_SEED),
+        OUTLIER_HEAD_DIM,
+    );
+    assert!(
+        uniform.mean < plain.mean,
+        "uniform mean mu {:.4} should sit below Gaussian {:.4}",
+        uniform.mean,
+        plain.mean,
+    );
+
+    println!(
+        "incoherence mean mu at head_dim={OUTLIER_HEAD_DIM}: \
+         uniform={:.4}  gaussian={:.4}  outlier={:.4} (p99={:.4} max={:.4})",
+        uniform.mean, plain.mean, outlier.mean, outlier.p99, outlier.max,
+    );
+}
+
+/// The channel placement really does spread intra-block offsets, as its doc
+/// claims, rather than parking every outlier at offset 0.
+///
+/// The plain even spread this replaced gave 0 / 32 / 64 / 96 — offset 0 for
+/// every block size in play. That is the most aligned placement available, and
+/// planar's per-pair Givens search is not symmetric under swapping the pair, so
+/// it would bake an unmeasured bias into a pinned number.
+#[test]
+fn outlier_channels_do_not_share_one_intra_block_offset() {
+    let channels = outlier_channels(OUTLIER_HEAD_DIM, 4);
+    assert_eq!(channels, vec![0, 37, 74, 111], "placement changed");
+
+    for block in [2usize, 3, 4] {
+        let offsets: std::collections::BTreeSet<usize> =
+            channels.iter().map(|c| c % block).collect();
+        let expected = block.min(channels.len());
+        assert!(
+            offsets.len() >= expected.min(3),
+            "block {block}: outliers occupy only offsets {offsets:?} — a constant intra-block \
+             offset biases the block-local rotation gates"
+        );
+    }
+
+    // Every affine group of 64 must contain an outlier: that is the condition
+    // the rot_k gain justification rests on.
+    for group in 0..OUTLIER_HEAD_DIM / 64 {
+        assert!(
+            channels.iter().any(|c| c / 64 == group),
+            "affine group {group} of 64 has no outlier — the rot_k gain argument does not hold"
+        );
+    }
+}
+
+/// A larger outlier ratio makes the fixture strictly more adversarial.
+#[test]
+fn outlier_ratio_monotonically_raises_incoherence() {
+    let mut previous = 0.0f64;
+    for ratio in [1.0f32, 5.0, 10.0, 20.0] {
+        let data = outlier_channel_data(64, OUTLIER_HEAD_DIM, 4, ratio, TEST_SEED);
+        let stats = incoherence_per_row(&data, OUTLIER_HEAD_DIM);
+        assert!(
+            stats.mean > previous,
+            "mu did not increase at ratio {ratio}: {:.4} <= {previous:.4}",
+            stats.mean,
+        );
+        previous = stats.mean;
+    }
+}
+
+/// `mu` against outlier-channel count: sharp rise, an early peak, then decay
+/// back to the i.i.d. value once "outlier" describes every channel.
+///
+/// The count is as load-bearing as the ratio — the `rot_k` gain justification
+/// turns on every affine group of 64 containing one — so it gets a sweep rather
+/// than a bare assertion. It is **not** monotone, and asserting that it were
+/// would have been wrong: `mu = sqrt(d)·max/||x||_2` grows its numerator only as
+/// the max of `n` draws while the denominator grows as `sqrt(n)`, so past a
+/// handful of channels the denominator wins.
+///
+/// The endpoint is the strong check. Scaling *every* channel by the same factor
+/// is a pure change of units, and `mu` is scale invariant, so `n = head_dim`
+/// must reproduce `n = 0` exactly. That validates the statistic and the
+/// collision handling in `outlier_channels` at once — a placement that scaled
+/// some channel twice would fail it.
+#[test]
+fn incoherence_against_outlier_channel_count_rises_peaks_then_returns() {
+    let measure = |channels: usize| {
+        let data = outlier_channel_data(256, OUTLIER_HEAD_DIM, channels, 20.0, TEST_SEED);
+        incoherence_per_row(&data, OUTLIER_HEAD_DIM).mean
+    };
+
+    let baseline = measure(0);
+    let curve: Vec<(usize, f64)> = [1usize, 2, 4, 8, 32]
+        .into_iter()
+        .map(|n| (n, measure(n)))
+        .collect();
+    let saturated = measure(OUTLIER_HEAD_DIM);
+
+    println!(
+        "mu vs outlier channels at head_dim={OUTLIER_HEAD_DIM}: 0 -> {baseline:.4}, {}, \
+         {OUTLIER_HEAD_DIM} -> {saturated:.4}",
+        curve
+            .iter()
+            .map(|(n, m)| format!("{n} -> {m:.4}"))
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+
+    // A single channel already more than doubles the i.i.d. value.
+    let (_, one) = curve[0];
+    assert!(
+        one > 2.0 * baseline,
+        "one outlier channel gave mu {one:.4}, not clear of twice the i.i.d. {baseline:.4}"
+    );
+
+    // Past the peak the statistic decays: rare is what makes an outlier.
+    let (_, two) = curve[1];
+    let (_, eight) = curve[3];
+    let (_, thirty_two) = curve[4];
+    assert!(
+        two > eight && eight > thirty_two,
+        "mu did not decay past its peak: 2 -> {two:.4}, 8 -> {eight:.4}, 32 -> {thirty_two:.4}"
+    );
+
+    // Scale invariance: every channel scaled is a change of units.
+    let drift = (saturated - baseline).abs() / baseline;
+    println!("scale-invariance residual: {drift:.3e} relative");
+    assert!(
+        drift < 1e-5,
+        "scaling every channel moved mu by {drift:.3e} relative ({baseline:.6} -> \
+         {saturated:.6}); that is far beyond f32 rounding, so either the statistic is not \
+         scale invariant or a channel was scaled twice"
+    );
+}
+
+// ── rate-distortion helper self-tests ────────────────────────────────────────
+
+/// A lossless round-trip has infinite SQNR; a known error power gives the
+/// hand-computed dB.
+#[test]
+fn sqnr_db_matches_hand_computed_values() {
+    let reference = lcg_data(1024, TEST_SEED);
+    assert!(
+        sqnr_db(&reference, &reference).is_infinite(),
+        "identity round-trip must report infinite SQNR"
+    );
+
+    // Scale every sample by 0.9: error = 0.1·x, so P_err = 0.01·P_sig and
+    // SQNR = 10·log10(100) = 20 dB. The tolerance covers the f32 rounding of
+    // the `v * 0.9` product itself, not the f64 statistic.
+    let scaled: Vec<f32> = reference.iter().map(|&v| v * 0.9).collect();
+    let measured = sqnr_db(&reference, &scaled);
+    assert!(
+        (measured - 20.0).abs() < 1e-4,
+        "expected 20 dB, got {measured}"
+    );
+}
+
+/// The anchors are ordered, sit below the `6.02·b` rate-distortion bound they
+/// are explicitly not, and approach one bit per step from below.
+#[test]
+fn lloyd_max_anchors_are_below_the_rate_distortion_bound() {
+    for (i, &anchor) in LLOYD_MAX_GAUSSIAN_SQNR_DB.iter().enumerate() {
+        let bits = u8::try_from(i + 1).expect("bits index fits u8");
+        assert!(
+            (lloyd_max_anchor_db(bits) - anchor).abs() < 1e-12,
+            "lloyd_max_anchor_db({bits}) disagrees with the table"
+        );
+        let bound = DB_PER_BIT * f64::from(bits);
+        assert!(
+            anchor < bound,
+            "anchor {anchor} at bits={bits} is at or above the {bound} dB bound — \
+             a fixed-rate Lloyd-Max quantizer cannot reach the bound"
+        );
+        if i > 0 {
+            let step = anchor - LLOYD_MAX_GAUSSIAN_SQNR_DB[i - 1];
+            assert!(
+                step > 0.0 && step < DB_PER_BIT,
+                "step to bits={bits} was {step} dB; expected 0 < step < {DB_PER_BIT}"
+            );
+        }
+    }
+}
+
+/// `wasted_bits` is the dB shortfall divided by one bit's worth of dB, signed
+/// so that "ahead of the anchor" is negative.
+#[test]
+fn wasted_bits_converts_db_shortfall_to_bits() {
+    assert!((wasted_bits(14.616, 14.616)).abs() < 1e-12);
+    assert!((wasted_bits(14.616 - DB_PER_BIT, 14.616) - 1.0).abs() < 1e-9);
+    assert!((wasted_bits(14.616 + 2.0 * DB_PER_BIT, 14.616) + 2.0).abs() < 1e-9);
 }

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -902,7 +902,11 @@ Storing rotated K (`K_rot = K Rᵀ`) and pre-rotating queries (`Q_rot = Q Rᵀ`)
 before the score matmul leaves attention scores identical to the unrotated
 computation up to quantization error on `K_rot`. A Hadamard rotation
 decorrelates K channels and equalizes their dynamic range, reducing affine
-quantization error in the rotated basis.
+quantization error in the rotated basis — **but only when the channels were
+unequal to begin with**. Measured against the identical unrotated quantizer:
+**+1.81 bits** on outlier-channel data and **−0.63 bits** on i.i.d. uniform
+data, where the transform raises the peak-to-RMS ratio the group scale is set
+by. See "Codec fidelity — measured" below.
 
 K is never inverse-rotated — the rotation cancels algebraically. This
 distinguishes rot_k from V-side rotation schemes (PlanarQuant, TurboQuant)
@@ -935,9 +939,14 @@ precomputed `R` matrix.
 
 **CLI**: `--ctk rot_k [--ctv <affine-tag>]`.
 
-**Cosine gate**: K-side cosine similarity ≥ 0.9970 (mean), ≥ 0.9950 (min)
+**Cosine gate**: K-side cosine similarity ≥ 0.9970 (mean), ≥ 0.9990 (min)
 on LCG fixture data (head_dim=64, 8-bit affine group_size=64).
-Test: `rot_k_hadamard_8bit_cosine_gate` in `rot_k_tests.rs`.
+Test: `rot_k_hadamard_8bit_cosine_gate` in `rot_k_tests.rs`. That gate
+measures the quantizer, not the rotation — deleting the Hadamard leaves cosine
+at 0.999881 against 0.999989, inside its 0.001 slack, so it passes.
+The rotation is gated by `rot_k_hadamard_buys_bits_on_outlier_data_and_costs_them_on_iid_data`
+and `hadamard_incoherence_ratio_beats_every_block_local_rotation` in
+`rotation_fidelity_tests.rs`.
 
 ---
 
@@ -1047,6 +1056,13 @@ plain turbo3 on unstructured data with the same codebook. A state-dependent
 (grade-aware) codebook would be required to obtain a shaping gain; that
 follow-up is deferred. The `>=` quality gate in `tcq_tests.rs` is satisfied
 by equality and does not demonstrate a strict improvement over plain turbo3.
+
+**Measured claw-back: 0.000 dB**, at both shipped widths, on i.i.d. Gaussian
+(codes byte-identical to plain turbo) *and* on a dim-axis sweep (codes differ
+by tie-breaking, distortion identical to four decimals — the stronger
+statement, and the one the non-strict cosine gate cannot make). Pinned by
+`trellis_coded_quantization_claws_back_nothing` in `rate_distortion_tests.rs`,
+as an equality, so giving the trellis a real constraint turns it red.
 
 **Bench** (canary shape 4096 prompt, 100 decode tokens, release-perf binary, 3-run mean):
 
@@ -4003,8 +4019,164 @@ removed in a future cleanup.
 
 ---
 
+## Codec fidelity — measured
+
+Two CPU-only measurement surfaces in `rmlx-kv-quant`, both deterministic from
+`TEST_SEED`, both inside `make model-check`. Neither needs a model snapshot or
+the GPU. See `docs/TESTING.md` for how to run them and for the helper list.
+
+### Incoherence — does the rotation do anything
+
+`crates/rmlx-kv-quant/src/rotation_fidelity_tests.rs`.
+
+The per-codec cosine gates all run on the i.i.d.-uniform LCG fixture, which is
+already close to maximally incoherent (mean `mu = sqrt(d)·max|x_i|/||x||_2` of
+1.72 at `head_dim = 128`, against a minimum of 1). A decorrelating rotation
+cannot improve that and in fact makes it slightly worse — the Hadamard pushes
+uniform toward Gaussian, whose `mu` is 2.87. **The LCG cosine gates therefore
+carry no information about rotation quality: an identity rotation passes every
+one of them.**
+
+The outlier fixture is i.i.d. Gaussian with 4 of 128 channels scaled 20x, a
+model of the persistent per-channel Key outliers reported by KIVI
+(arXiv:2402.02750) and KVQuant (arXiv:2401.18079) at the magnitude ratio
+reported for emergent outlier features (arXiv:2208.07339). Mean `mu` = 8.37
+(p99 10.72).
+
+The channel **count** is not from the literature — 4 of 128 is 3.1%, some 30x
+denser than the reported emergent-outlier fraction. It is chosen so that every
+affine group of 64 contains an outlier, the condition under which a
+full-dimension rotation has something to recover across the whole row. Both
+fixture parameters are swept rather than asserted: `mu` against the ratio is
+monotone, and `mu` against the channel count rises, peaks near 2 channels, then
+decays back to exactly the i.i.d. value once every channel is scaled (a pure
+change of units, which `mu` is invariant to).
+
+A block-`b` orthogonal transform can reduce `mu` by at most `sqrt(b)`: the peak
+coordinate's block preserves its L2 norm, and a `b`-vector's max is at least
+its norm over `sqrt(b)`. Measured on the outlier fixture at `head_dim = 128`:
+
+| Family | Transform | Block | `mu` ceiling | `mu` reduction |
+|---|---|---|---:|---:|
+| `rot_k` / `RotK` | Walsh-Hadamard, full `head_dim` | 128 | 11.31x | **3.89x** |
+| `iso3` / `iso4` | isoclinic SO(4), fixed quaternion | 4 | 2.00x | 1.38x |
+| `planar3` | Givens, 16-entry codebook, per-pair search | 2 | 1.41x | 1.19x |
+| `planar4` | Givens, 16-entry codebook, per-pair search | 2 | 1.41x | 1.15x |
+| `rotor3` / `rotor4` | Cl(3,0) rotor sandwich, static per (layer, head) | 3 | 1.73x | 1.08–1.21x |
+
+The rotor row is a range, not a point. Only the groups holding outlier channels
+move `mu` — four rotors of 43 at `head_dim = 128` — so a single `(layer, head)`
+table is a four-sample estimate. Across eight draws the reduction spans
+1.0815x–1.2089x; the gate pins the weakest, so it describes the family rather
+than one layer.
+
+Only `rot_k` applies a full-dimension transform. The block-local families
+deliver between 1.15x and 1.38x, well under their own ceilings, because their
+rotations are fixed (iso, rotor) or fitted to reconstruction error rather than
+to incoherence (planar). **This is not a defect in them** — they buy packing
+efficiency, a different axis — but the "rotation" naming implies a capability
+only one family has.
+
+`rot_k` end to end, against the identical `affine q8 group=64` quantizer with
+the Hadamard deleted:
+
+| Fixture | rotated | unrotated | delta |
+|---|---:|---:|---:|
+| outlier channels | 46.95 dB | 36.06 dB | **+1.81 bits** |
+| i.i.d. uniform (LCG) | 44.53 dB | 48.30 dB | **−0.63 bits** |
+
+The rotation is worth most of two bits where it matters and costs two thirds of
+a bit where it does not. Both directions are gated.
+
+The gain is exactly `log2(peak_plain / peak_rotated)` over the affine group,
+which is the same quantity the block ceiling bounds: a block-`b` transform can
+buy at most `0.5·log2(b)` bits. That is what makes the 1.5-bit gate a
+separation rather than a fitted number — it demands an effective block of 8 or
+more. Substitutes measure 0.91 bits (the same Hadamard truncated to blocks of
+4) and 0.47 (the iso quaternion), both rejected.
+
+### Rate-distortion — is the bit width delivering
+
+`crates/rmlx-kv-quant/src/rate_distortion_tests.rs`.
+
+Measured against the fixed-rate Lloyd-Max SQNR for the standard normal (Max
+1960, Table I): 4.396 / 9.300 / 14.616 / 20.224 dB at 1–4 bits. That anchor is
+**not** the rate-distortion bound (`6.02·b` dB) and assumes a quantizer matched
+to the source, spending no rate on its scale. Every codec here stores a
+per-group scale, so it can legitimately land above the anchor; the rate column
+is what makes the dB interpretable. i.i.d. Gaussian fixture, 256 x 128:
+
+| Codec | bits | measured | anchor | wasted bits | stored bits/value |
+|---|---:|---:|---:|---:|---:|
+| turbo | 2 | 7.232 dB | 9.300 dB | +0.344 | 3.00 |
+| turbo | 3 | 14.956 dB | 14.616 dB | −0.056 | 4.00 |
+| turbo | 4 | 21.630 dB | 20.224 dB | −0.233 | 5.00 |
+| tcq | 2 | 7.232 dB | 9.300 dB | +0.344 | 3.00 |
+| tcq | 3 | 14.956 dB | 14.616 dB | −0.056 | 4.00 |
+| planar | 3 | 40.604 dB | 14.616 dB | −4.316 | 22.00 |
+| planar | 4 | 36.724 dB | 20.224 dB | −2.741 | 22.00 |
+| iso | 3 | 19.292 dB | 14.616 dB | −0.777 | 48.25 † |
+| iso | 4 | 25.395 dB | 20.224 dB | −0.859 | 48.25 † |
+| rotor | 3 | 20.432 dB | 14.616 dB | −0.966 | 21.75 |
+| rotor | 4 | 26.555 dB | 20.224 dB | −1.052 | 21.75 |
+
+No shipped cell is short of its anchor by more than 0.35 bits.
+
+† **The iso rate is path-specific.** 48.25 is the CPU `IsoBlocks` figure, which
+carries a per-group quaternion sideband; it is the right number for the V-only
+`iso3` / `iso4` stores. `k_iso3/4` and `iso3_sym/4_sym` decode from a GPU ring
+that does not carry the quaternion — it is the constant `FIXED_QUAT` replicated
+per group, not data — and sit at **16.25** bits/value. See § iso3 "Memory
+truth". Read against rotor's 21.75 without that distinction the table inverts
+the comparison: on the ring path iso is the cheaper of the two. Distortion is
+identical on both paths, so only the rate column is affected.
+
+**The small-group-scale mismatch is not a loss.** Deriving the scale from the
+maximum of 3 or 4 samples presents the codebook with data of standard deviation
+≈ 1.47 rather than 1, but the small groups come out *ahead* of the anchor, not
+behind it: the group maximum is a strong conditioning statistic, it is
+reconstructed near-exactly by construction, and the two or three remaining
+elements are then known to be smaller than it. The shortfall is at the other
+end of the range — large groups at low bit widths (`turbo`/`tcq` at 2 bits,
+one f32 scale per 32 values, +0.34 bits).
+
+**The 3-bit and 4-bit widths of iso, rotor and planar cost byte-identical
+storage** — already stated for iso under § iso3 "Memory truth" and for rotor in
+the `rotorquant` module docs; what is new here is the consequence. All three
+pack under the shared `32 / bits` vals-per-word convention, and at every shipped group size the word count is the same for
+`bits = 3` and `bits = 4`. Each family therefore has one strictly dominated
+width — same bytes, worse quality:
+
+| Family | 3-bit | 4-bit | Dominated |
+|---|---:|---:|---|
+| iso | 19.29 dB | 25.40 dB | `iso3` loses 6.10 dB for nothing |
+| rotor | 20.43 dB | 26.56 dB | `rotor3` loses 6.12 dB for nothing |
+| planar | 40.60 dB | 36.72 dB | **`planar4` loses 3.88 dB for nothing** |
+
+The planar direction is the surprising one, and it reproduces on the LCG
+fixture: measured mean cosine 0.999956 for planar3 against 0.999901 for
+planar4. Do **not** read the committed cosine floors (`planar_v3` 0.9989 against
+`planar_v4` 0.9942) as corroboration — they are not commensurable. The v3 floor
+is a local measurement minus 0.001; the v4 floor is an upstream README anchor
+minus 0.001 and is not a measurement of this code at all. The real signal is the
+5.5e-5 gap between the measured means, not the 4.7e-3 gap between those floors.
+Per pair the larger element is pinned to the outermost
+centroid, leaving the smaller on the grid `centroid / max_centroid`, whose
+outermost gap is `(2.152 − 1.344)/2.152 = 0.375` at 3 bits and
+`(2.718 − 2.052)/2.718 = 0.245` at 4 bits — only 1.5x finer, while the 16-angle
+Givens search that must land *both* elements on centroids gets no larger. The
+extra bit does not pay for itself. All three are pinned by
+`byte_identical_bit_widths_leave_one_width_dominated`; fixing the packing or
+the codebook is a separate change.
+
+**TCQ's claw-back measures 0.000 dB.** See the trellis degeneracy note under
+`K8VTurbo3Tcq` below.
+
+---
+
 ## See also
 
 - `docs/KV_CACHE.md` — flag surface, Qwen MoE PPL disaster, codec matrix.
 - `docs/WEIGHT_QUANTS.md` — weight quantization families (separate from KV).
 - `docs/SSD_TIER.md` — SSD spill / hydrate for long-context eviction.
+- `docs/TESTING.md` — cosine, incoherence and rate-distortion gates; helpers.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -384,9 +384,15 @@ Every KV-cache codec has a per-codec cosine-similarity quality gate in the
 dequantize round-trip preserves the directional information in each row vector
 to within an empirically derived floor.
 
-All cosine gates use the **same LCG fixture** (seed `TEST_SEED =
+The gates below use the **LCG fixture** (seed `TEST_SEED =
 0x0000_00C0_FFEE_BEEF`, Knuth LCG) so they are deterministic and require no
 model snapshot or GPU.
+
+**What they do not measure.** The LCG fixture is i.i.d. uniform, which is
+already close to maximally incoherent, so a decorrelating rotation cannot
+improve it — an identity rotation passes every gate in the table below. That
+axis is covered separately by the incoherence gates; see "Rotation-quality
+gates".
 
 ### Thresholds
 
@@ -407,6 +413,10 @@ All helpers live in `crates/rmlx-kv-quant/src/test_utils.rs`:
 
 - `cosine_similarity_per_row` — f64-accumulator cosine per `head_dim`-sized row; returns `CosineStats { mean, min, n_rows }`.
 - `lcg_data(n, seed)` — deterministic LCG fixture data in `[-1.0, 1.0]` (upper 32 bits of state, symmetric; a `>> 33` bug that biased output to `[-1.0, ~0.0)` was fixed).
+- `gaussian_data(n, seed)` — standard normal from the same LCG via Box–Muller.
+- `outlier_channel_data(rows, head_dim, channels, ratio, seed)` — Gaussian base with persistent high-magnitude channels; `outlier_fixture()` is the canonical 256 x 128, 4 channels at 20x. The doc comment carries the citations for that shape.
+- `incoherence_per_row` — `mu = sqrt(d)·max|x_i|/||x||_2` per row; returns `IncoherenceStats { mean, p99, max, n_rows }`.
+- `sqnr_db` / `wasted_bits` / `lloyd_max_anchor_db` / `LLOYD_MAX_GAUSSIAN_SQNR_DB` / `DB_PER_BIT` — rate-distortion reference.
 - `fwht_normalize(buf, n)` — CPU Walsh-Hadamard transform (self-inverse when applied twice), used by the rot_k cosine test.
 - `TEST_SEED` — pinned seed constant (`0x0000_00C0_FFEE_BEEF`). Never replace with `thread_rng`.
 
@@ -415,6 +425,80 @@ All helpers live in `crates/rmlx-kv-quant/src/test_utils.rs`:
 ```bash
 cargo test -p rmlx-kv-quant cosine_gate
 ```
+
+---
+
+## Rotation-quality gates
+
+`crates/rmlx-kv-quant/src/rotation_fidelity_tests.rs`. CPU-only, no snapshot,
+inside `make model-check`.
+
+```bash
+cargo test -p rmlx-kv-quant --lib rotation_fidelity -- --nocapture
+```
+
+Measured on `outlier_fixture()` — i.i.d. Gaussian with 4 of 128 channels at
+20x, modelling the persistent per-channel Key outliers the KV-quantization
+literature reports. Numbers and their derivation live in `docs/KV_QUANT.md`
+§ "Codec fidelity — measured".
+
+| Gate | Asserts |
+|---|---|
+| `hadamard_incoherence_ratio_beats_every_block_local_rotation` | `rot_k` reduces mean `mu` ≥ 3x (measured 3.89x); every block-local family stays under its `sqrt(block)` ceiling and under `rot_k`. |
+| `non_full_dimension_rotations_fail_the_hadamard_incoherence_gate` | Mutation guard: the same FWHT truncated to block-4, plus the iso / rotor / planar transforms, all fail. Rejection is a theorem — `mu` reduction of `R` needs block ≥ `R²`, so 3.0 needs block ≥ 9. |
+| `identity_rotation_excluded_by_the_hadamard_incoherence_threshold` | Pins that the threshold excludes 1.00x. Named for what it is: the ratio is exact by construction, so this is a constant comparison, not a transform mutation. |
+| `iso_block_rotation_incoherence_gate`, `planar3_…`, `planar4_…` | Two-sided: under the `sqrt(block)` ceiling (a theorem) and over the pinned floor (the regression guard). |
+| `rotor_block_rotation_incoherence_gate` | Same, **swept over 8 `(layer, head)` draws** and pinned to the weakest (1.0815x of 1.0815–1.2089x). Only ~4 rotors of 43 touch outlier channels, so one draw is a four-sample estimate. |
+| `rot_k_hadamard_buys_bits_on_outlier_data_and_costs_them_on_iid_data` | The Hadamard buys ≥ 1.5 bits of SQNR over the same quantizer without it on outlier data (measured +1.81), and **loses** bits on i.i.d. data (−0.63). |
+| `non_full_dimension_rotations_fail_the_rot_k_gain_gate` | Mutation guard: block-4 truncated FWHT (+0.91) and the iso quaternion (+0.47). A block-`b` transform can buy at most `0.5·log2(b)` bits, so 1.5 demands block ≥ 8. |
+| `identity_rotation_excluded_by_the_rot_k_gain_threshold` | Pins that the threshold excludes 0.00 bits; exact by construction, as above. |
+| `<codec>_outlier_cosine_gate` (7) | Outlier-fixture cosine floors for `rot_k`, `iso3/4`, `rotor3/4`, `planar3/4`. |
+| `lossier_codecs_fail_the_outlier_cosine_floors` | Mutation guard for all seven floors: each is shown to reject a genuinely lossier real codec, judged by the same floor function the gates use. |
+| `wider_codebooks_score_higher_on_the_outlier_fixture` | iso4 > iso3 and rotor4 > rotor3 — catches a bit-width plumbing fault a per-codec floor cannot. |
+
+**Outlier cosine floors use an error-relative tolerance**, not the `measured −
+0.001` convention above: a codec may double `1 − cos` before the floor bites.
+The absolute convention cannot work here — `rot_k` scores 0.999989 and 0.999881
+with the Hadamard deleted outright, so a 0.001 slack is fifty times wider than
+the whole effect and the deletion passes. `lossier_codecs_fail_the_outlier_cosine_floors`
+checks all seven against a genuinely lossier real codec.
+
+---
+
+## Rate-distortion reference
+
+`crates/rmlx-kv-quant/src/rate_distortion_tests.rs`. CPU-only, no snapshot,
+inside `make model-check`.
+
+```bash
+cargo test -p rmlx-kv-quant --lib rate_distortion -- --nocapture
+```
+
+Every scalar-codebook codec at every shipped bit width, encoded and decoded on
+an i.i.d. Gaussian fixture, reported as SQNR against the fixed-rate Lloyd-Max
+Gaussian anchor for that width and converted to wasted bits. The full table is
+in `docs/KV_QUANT.md` § "Codec fidelity — measured".
+
+Two thresholds, both stated in bits:
+
+- **Absolute** — `MAX_WASTED_BITS = 1.0` against the anchor. The escalation
+  line: a codec past it gets a filed follow-up with the measured number.
+- **Per-cell pinned** — `measured + PIN_SLACK_BITS` (0.10 bits = 0.60 dB).
+  This is the gate that fires. The absolute line above cannot fire on its own —
+  every budget is ≤ +0.44, so crossing 1.0 implies crossing the budget too; it
+  labels *why* a failure matters rather than adding independent coverage. And
+  the absolute line alone would not be enough: codecs sit at very different
+  offsets from the anchor (`turbo4` is 0.23 bits *ahead*), so one that silently
+  loses a full bit can still land inside a 1-bit absolute budget.
+  `one_bit_short_codec_fails_the_rate_distortion_gate` demonstrates exactly
+  that at `bits = 4`. `pinned_budgets_sit_one_slack_above_the_measurement`
+  keeps the pins where they claim to be.
+
+Two measured facts are pinned as equalities so a fix turns them red rather than
+passing silently: `trellis_coded_quantization_claws_back_nothing` (TCQ = plain
+turbo, 0.000 dB) and `byte_identical_bit_widths_leave_one_width_dominated`
+(iso, rotor and planar cost the same bytes at 3 and 4 bits, so each family has
+a strictly dominated width).
 
 ---
 


### PR DESCRIPTION
Closes #316. Closes #318.

Both issues asked whether the codec fidelity gates measure anything. They largely
did not — and both issues' own central hypotheses turned out to be false.

## #316 — rotation quality was unverifiable

Every per-codec cosine gate ran on `lcg_data`, i.i.d. uniform. Measured mean
incoherence `mu = sqrt(d)·max|x_i|/||x||₂` is **1.7163** at `head_dim = 128`
(i.i.d. Gaussian 2.8666, minimum 1.0) — already near-maximally incoherent, so
rotation cannot help and an identity rotation passes. `rg incoherence` over the repo
returned zero hits.

**The fixture, with its distribution stated.** i.i.d. standard normal, 4 of 128
channels scaled 20×, from the pinned Knuth LCG via Box–Muller. Cited in the helper
doc: KIVI (2402.02750) and KVQuant (2401.18079) both report the Key cache having a
few *fixed* channels large in every token (Values do not); LLM.int8() (2208.07339)
is the source of the 20× ratio; QuIP (2307.13304) defines `mu`; QuaRot (2404.00456)
is the Hadamard remedy. Measured mean `mu` **8.2141**.

The channel *density* (4 of 128 = 3.1%) is deliberately ~30× denser than the
fraction-of-a-percent the literature reports, and is now justified on its own terms
rather than by citation: it is chosen so both affine groups of 64 are contaminated,
which is the case the rot_k gain gate is sized against.

| family | mu reduction | ceiling `sqrt(b)` |
|---|---:|---:|
| Hadamard (full 128) | **3.87×** | 11.31× |
| iso (block 4) | 1.33× | 2.00× |
| planar3 / planar4 (block 2) | 1.14× / 1.10× | 1.41× |
| rotor (block 3) | 1.03–1.21× (8 draws) | 1.73× |

**Thresholds are separations from a theorem, not offsets from a measurement.**
`R >= 3.0` demands an effective block >= 9, which no degenerate supplies (2.00 /
1.73 / 1.41 / 1.00). `rot_k >= 1.5 bits` demands effective block >= 8, since gain is
`log2(peak_plain/peak_rotated)` — the same quantity the block ceiling bounds.

## #318 — no rate-distortion reference

No SQNR or anchor existed anywhere (`rg sqnr` → zero hits). Lloyd-Max anchors
re-derived independently from Max (1960) Table I: 4.396 / 9.300 / 14.616 / 20.224 dB.

**The suspected mismatch is falsified.** The issue's arithmetic is right
(E[max of 4 half-normals] = 1.4659) but its conclusion is not: small groups come out
*ahead* of the anchor (iso3 −0.78, rotor3 −0.97 bits), because the group max is
strong conditioning and is reconstructed near-exactly. The real shortfall is at the
other end — large groups at low bit width (turbo2/tcq2 at +0.344).

Max shortfall across all eleven cells is +0.344 bits, so the issue's ">1 bit short →
file a follow-up" criterion is vacuous. No follow-up filed.

Two findings pinned as equalities so a fix goes red rather than passing silently:
**TCQ claws back 0.000 dB** at both widths (codes byte-identical on i.i.d. data; on a
dim-axis sweep codes differ but distortion matches to 4 dp), and iso/rotor/planar
cost byte-identical storage at 3 and 4 bits, so each family has a strictly dominated
width.

## What the review round changed

Three of the original justifications did not survive independent re-derivation, and
two pinned numbers were wrong.

- **The Hadamard derivation predicted its own gate red.** `sqrt(1724) = 41.52`, not
  36; `mu ≈ 5.45`, not 6.3; and the chain terminated at `8.37/2.87 = 2.87 < 3.0`.
  Deleted. The threshold always rested on the ceiling theorem instead, which is what
  it now says — with a note on *why* the envelope argument fails (the Hadamard image
  of 4 channels takes only 2⁴ = 16 distinct values across 128 coordinates, so
  `mu_after` lands below the i.i.d. value), so the next person to re-derive it stops
  there rather than concluding the gate is broken.
- **The rot_k gain model was wrong by 2.1×.** 12.177 dB is a 4.06× fall in the group
  peak = 2.02 bits, not `log2(20) ≈ 4.3`. Replaced with the exact model.
- **The rotor pin was a 4-sample estimate**, and worse than reported: `rotate_rotor`
  drew one table at layer 0 / head 0, and the four outlier channels land in just four
  rotor groups reused across all 256 rows. Across 8 draws the reduction spans
  **1.0815–1.2089** — the old floor of 1.0979 would have gone **red on 2 of them**.
  The gate now sweeps draws and pins the weakest.
- **The fixture placement contradicted its own comment.** Channels 0/32/64/96 sit at
  intra-block offset 0 for blocks 2, 3 and 4 — maximally *aligned*, the opposite of
  what was claimed. Since planar's Givens search is not symmetric under swapping the
  pair, documenting the bias would have left it inside a pinned number, so the
  placement changed (stride 5, coprime to 2/3/4 → 0/37/74/111) and everything
  downstream was re-measured and re-pinned.
- **The iso rate figure mixed two residency paths.** 48.25 bits/value is the CPU
  `IsoBlocks` path including the constant `FIXED_QUAT` sideband; the ring-resident
  figure the shipped codecs decode from is **16.25**. On the ring path iso is
  *cheaper* than rotor's 21.75, not 2.2× dearer. Both rows are now footnoted.
- A "planar3 beats planar4" claim was corroborated with two floors that are not
  commensurable (one is an upstream README anchor, not a measurement of this code).
  Now cites the measured pair, 0.999956 vs 0.999901.

**A density sweep falsified its own premise.** Written expecting monotonicity, it
failed at 4 channels (8.3078 <= 8.5583): `mu`'s numerator grows as the max of `n`
draws while its denominator grows as `sqrt(n)`, so it peaks near 2 and decays. The
test now pins the true shape, plus an endpoint that at `n = head_dim` scaling every
channel is a change of units, so `mu` must reproduce `n = 0` (measured residual
1.168e-9 relative).

## Mutation battery — all red, tree restored between each

| | mutation | result |
|---|---|---|
| M1 | iso rotation → identity | `1.0000x < 1.3346x` |
| M2 | rotor + planar → identity | `1.0000x` vs 1.0315 / 1.1410 / 1.1018 |
| M3 | rot_k cosine gate, Hadamard deleted | `0.999881 < 0.999978` |
| M4 | iso group 4 → 32 | iso3 `−0.06` past pinned `−0.68`; iso4 `−0.23` past `−0.76` |
| M5 | budget widened 0.44 → 0.94 | `+0.596 headroom > 0.10` |
| M6 | cosine pin → old absolute convention | *"that floor cannot detect a genuinely lossier codec"* |

M6 is the direct proof the error-relative tolerance is load-bearing: under the
crate's old absolute convention the rot_k slack was 50× wider than the whole effect,
so deleting the Hadamard passed it.

`lossier_codecs_fail_the_outlier_cosine_floors` puts seven real substitutes through
`outlier_cosine_floor` — the same function the gates use, so guard and gate cannot
drift. Every floor rejects a genuinely lossier codec; planar3's does so on `min`
only, and that is documented rather than hidden.

## Gates

`make ci` green. `cargo fmt --check` clean, `make lint` clean, 410 rmlx-kv-quant,
773 across the model-check crates, both structural gates OK. CPU-only by nature — no
GPU tests added, nothing `#[ignore]`d.

## Not proven

The rot_k gain fell 2.02 → 1.81 bits under the new fixture placement, so the margin
over the 1.5 threshold is 0.31 bits against 0.91 for the strongest substitute. The
separation is theorem-backed (effective block >= 8) and holds, but the headroom is
thinner than before the placement change.
