### PR TITLE
perf(prefill): build attention masks on device — 2.6x gemma-4 long-context prefill, and the memory ramp is gone (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Prefill attention masks are built on device, not scalar-filled on the
+  host.** `build_chunked_prefill_mask` and `build_swa_prefill_mask` allocated
+  three full-size buffers per call — an `f32` `Vec`, its upload, and the bf16
+  cast — for a mask that is O(`seq` × `kv_len`). A 68 898-token gemma-4-e2b
+  prefill spent 69.5% of its main-thread samples there and drove free memory to
+  zero, which made every repeated in-process generation slower than the last
+  (gen3/gen1 prefill 1.24–1.33). The builders now compose the mask from MLX
+  position vectors (`arange` → broadcast compare → `where`), so it is produced
+  where it is consumed and never crosses the host boundary. Shared by every
+  architecture that chunk-prefills, and bit-identical: temp=0 token digests are
+  unchanged at 4k / 16k / 32k / 64k on gemma-4-e2b and at 4k / 64k on
+  Ternary-Bonsai-8B.
+
+  Measured `rmlx bench --kv-quant none --warmup 0 --runs 3`, quiet host, free
+  memory settled before each cell:
+
+  | cell | gen-1 prefill | gen3/gen1 | free-memory drop | compressor growth |
+  |---|---|---|---|---|
+  | gemma-4-e2b @68 898 before | 13 673–14 024 ms | 1.24–1.33 | 79.6–83.1 GiB (to 0.1 GiB) | +14.0–15.2 GiB |
+  | gemma-4-e2b @68 898 after | 4 762–5 277 ms | 0.97–1.00 | 52.8–61.2 GiB (to 12–24 GiB) | +0.00 GiB |
+  | Ternary-Bonsai-8B @68 898 before | 60 032 ms | 1.022 | to 0.1 GiB | +0.00 GiB |
+  | Ternary-Bonsai-8B @68 898 after | 59 296 ms | 1.030 | to 18.6 GiB | +0.00 GiB |
+
+  Bonsai's prefill time is unchanged (±3%, it is GPU-bound behind MLX's fused
+  `head_dim=128` kernel) but it no longer exhausts host memory to get there.
+  Decode TPS and `kv_cache_bytes` are unchanged on both architectures.
+
+  Note for anyone tempted by the obvious next step: **sharing one mask across
+  the layers of a forward call makes this worse, not better.** A mask handed to
+  every layer is a graph node with many consumers, so its buffer stays live for
+  the whole forward and the allocator cannot recycle it between layers —
+  measured at 2× the prefill time (9.5 s vs 4.8 s) and ~19 GiB more transient
+  demand on the same cell. `layers/mask.rs` records this.
 - **The fused-QK dispatch table listed eight codecs it could never serve, and
   a strict-mode test asserted four of them dispatch.** The head-major fused-QK
   shadow is seeded by re-encoding the bf16 K mirror, so a codec only reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Performance
 
 - **Prefill attention masks are built on device, not scalar-filled on the
   host.** `build_chunked_prefill_mask` and `build_swa_prefill_mask` allocated
@@ -19,29 +19,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   position vectors (`arange` → broadcast compare → `where`), so it is produced
   where it is consumed and never crosses the host boundary. Shared by every
   architecture that chunk-prefills, and bit-identical: temp=0 token digests are
-  unchanged at 4k / 16k / 32k / 64k on gemma-4-e2b and at 4k / 64k on
-  Ternary-Bonsai-8B.
+  unchanged on all three test-target families at every context measured.
 
-  Measured `rmlx bench --kv-quant none --warmup 0 --runs 3`, quiet host, free
-  memory settled before each cell:
+  Measured `rmlx bench --kv-quant none --warmup 0 --runs 3`, free memory
+  settled before each cell, before/after pairs run back-to-back at matched
+  host load. `prefill_ms` per generation, gen-1 first:
 
-  | cell | gen-1 prefill | gen3/gen1 | free-memory drop | compressor growth |
-  |---|---|---|---|---|
-  | gemma-4-e2b @68 898 before | 13 673–14 024 ms | 1.24–1.33 | 79.6–83.1 GiB (to 0.1 GiB) | +14.0–15.2 GiB |
-  | gemma-4-e2b @68 898 after | 4 762–5 277 ms | 0.97–1.00 | 52.8–61.2 GiB (to 12–24 GiB) | +0.00 GiB |
-  | Ternary-Bonsai-8B @68 898 before | 60 032 ms | 1.022 | to 0.1 GiB | +0.00 GiB |
-  | Ternary-Bonsai-8B @68 898 after | 59 296 ms | 1.030 | to 18.6 GiB | +0.00 GiB |
+  | cell | before | after | gen-1 Δ |
+  |---|---|---|---|
+  | gemma-4-e2b @4 096 | 254.9 / 213.8 / 219.4 ms | 226.1 / 184.9 / 185.5 ms | −11.3% |
+  | gemma-4-e2b @68 898 | 13 673–14 024 ms | 4 762–5 277 ms | −63% |
+  | Qwen3.6-35B-A3B @4 096 | 1 461.2 / 1 090.2 / 1 111.9 ms | 1 155.2 / 1 089.9 / 1 091.3 ms | −20.9% |
+  | Qwen3.6-35B-A3B @34k | 12 828.4 ms | 12 267.2 ms | −4.4% |
+  | Ternary-Bonsai-8B @4 096 | 1 347.8 / 1 358.3 ms | 1 364.7 ms | +0.9% |
+  | Ternary-Bonsai-8B @68 898 | 60 032.2 ms | 59 296.7 ms | −1.2% |
 
-  Bonsai's prefill time is unchanged (±3%, it is GPU-bound behind MLX's fused
-  `head_dim=128` kernel) but it no longer exhausts host memory to get there.
-  Decode TPS and `kv_cache_bytes` are unchanged on both architectures.
+  The small-shape case is the one a device-built mask could lose — it trades a
+  host upload for a handful of MLX dispatches — so the 4 096-token cells are
+  measured, not argued: both improve. Decode TPS, `kv_cache_bytes` and token
+  digests are unchanged on every cell.
 
-  Note for anyone tempted by the obvious next step: **sharing one mask across
-  the layers of a forward call makes this worse, not better.** A mask handed to
-  every layer is a graph node with many consumers, so its buffer stays live for
-  the whole forward and the allocator cannot recycle it between layers —
-  measured at 2× the prefill time (9.5 s vs 4.8 s) and ~19 GiB more transient
-  demand on the same cell. `layers/mask.rs` records this.
+  The gemma-4-e2b @68 898 cell is where the repeated-generation drift lived. It
+  no longer crosses the host's free-memory line, so the drift is gone rather
+  than reduced:
+
+  | | before | after |
+  |---|---|---|
+  | gen3/gen1 prefill | 1.24–1.33 | 0.97–1.00 |
+  | free memory low-water | 0.07–0.10 GiB | 12.4–23.9 GiB |
+  | compressor growth | +14.0–15.2 GiB | +0.00 GiB |
+  | decompressions | 6.2–6.3 M | 0.002–0.003 M |
+  | `build_attn_mask` share of main-thread samples | 69.5% | 0.07% |
+
+  Ternary-Bonsai-8B's prefill time is unchanged (±3%, it is GPU-bound behind
+  MLX's fused `head_dim=128` kernel) but at 68 898 tokens its free memory now
+  bottoms out at 18.6 GiB instead of 0.1 GiB.
+
+  Sharing one prefill mask across a forward call's layers — which
+  `qwen3_5_moe` and `qwen3_vl_moe` do and continue to do — was measured on both
+  architectures that use it and is **not** uniformly good or bad: on gemma-4-e2b
+  @68 898 sharing costs 2× the prefill time, on Qwen3.6 @34k it wins by 1.6%
+  (inside run-to-run spread). No hoist was added or removed here. `mask.rs`
+  records both numbers and does not claim a mechanism for the gemma-4 one.
+
+### Fixed
+
 - **The fused-QK dispatch table listed eight codecs it could never serve, and
   a strict-mode test asserted four of them dispatch.** The head-major fused-QK
   shadow is seeded by re-encoding the bf16 K mirror, so a codec only reaches

--- a/crates/rmlx-models/src/layers/mask.rs
+++ b/crates/rmlx-models/src/layers/mask.rs
@@ -1,7 +1,34 @@
 //! Attention mask builders for causal, chunked-prefill, and SWA forward passes.
+//!
+//! The two prefill builders are O(`new_seq` × (`offset` + `new_seq`)) in mask
+//! elements, which at long context is the largest single buffer a prefill chunk
+//! touches. They are therefore built from MLX position vectors — `arange`,
+//! a broadcast comparison, `where` — so the buffer is produced where it is
+//! consumed and never crosses the host boundary. Building them scalar-wise on
+//! the host instead cost three full-size buffers per call (an f32 `Vec`, its
+//! upload, and the bf16 cast) and made a 64k-token prefill allocate tens of GB
+//! of transient host memory, which on a loaded machine exhausts free RAM and
+//! turns repeated in-process generations into a monotonic slowdown.
+//!
+//! **Do not hoist one mask across the layers of a forward call.** It looks like
+//! an obvious saving — a chunk needs at most one full-attention and one banded
+//! mask — but a mask handed to every layer is a graph node with many consumers,
+//! so its buffer stays live for the whole forward and the allocator cannot
+//! recycle it between layers. Measured on a 35-layer model with a 68 898-token
+//! prompt, sharing the two masks cost **2x** the prefill time (9.5 s vs 4.8 s)
+//! and ~19 GiB more transient demand than letting each layer build its own.
+//! Per-layer construction is a produce-consume-free chain, and now that the
+//! buffer never touches the host it is cheap enough to want that chain.
 
 use rmlx_core::error::Result;
-use rmlx_mlx::{Array, Device, Dtype};
+use rmlx_mlx::{arange, greater_equal, scalar_f32, subtract, where_cond, Array, Device, Dtype};
+
+/// Additive bias applied to a blocked (query, key) pair.
+///
+/// Large-negative rather than `-inf` so a fully-blocked row still softmaxes to
+/// a finite distribution instead of NaN. Representable in bf16, which is the
+/// dtype every mask here is produced in.
+const BLOCKED_BIAS: f32 = -1e30;
 
 /// Pick SDPA mask mode for a forward step.
 ///
@@ -39,26 +66,39 @@ pub fn pick_attn_mask_mode(pre_offset: i32, new_seq: i32) -> &'static str {
 ///
 /// MLX's valid `mask_mode` values: `""`, `"causal"`, `"array"`.
 /// `"additive"` is NOT accepted by mlx-c — always use `"array"` with this mask.
-#[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
 pub fn build_chunked_prefill_mask(offset: i32, new_seq: i32, device: Device) -> Result<Array> {
-    let rows = new_seq as usize;
-    let cols = (offset + new_seq) as usize;
-    let mut data = vec![-1e30_f32; rows * cols];
+    // Query absolute positions as a column, key absolute positions as a row:
+    // the mask is their broadcast comparison.
+    let (q_pos, k_pos) = position_axes(offset, new_seq, device)?;
+    let allowed = greater_equal(&q_pos, &k_pos, device)?;
+    let (open, blocked) = mask_scalars(device)?;
+    where_cond(&allowed, &open, &blocked, device)
+}
 
-    for i in 0..rows {
-        // Query absolute position: offset + i. Allow keys 0..=offset+i.
-        let allow_up_to = offset as usize + i + 1; // exclusive upper bound
-        for j in 0..allow_up_to.min(cols) {
-            data[i * cols + j] = 0.0;
-        }
-    }
+/// Build the `[1, 1, new_seq, offset + new_seq]` query / key position axes the
+/// prefill masks compare.
+///
+/// `q_pos` holds absolute query positions `offset .. offset + new_seq` as a
+/// column; `k_pos` holds absolute key positions `0 .. offset + new_seq` as a
+/// row. Both are F32: every position a mask can address is an exact integer in
+/// F32 far below the 2^24 mantissa limit.
+fn position_axes(offset: i32, new_seq: i32, device: Device) -> Result<(Array, Array)> {
+    let cols = offset + new_seq;
+    let q_pos = arange(f64::from(offset), f64::from(cols), 1.0, device)?
+        .reshape(&[1, 1, new_seq, 1], device)?;
+    let k_pos = arange(0.0, f64::from(cols), 1.0, device)?.reshape(&[1, 1, 1, cols], device)?;
+    Ok((q_pos, k_pos))
+}
 
-    let mask_f32 = Array::from_f32_slice(&data, &[1, 1, rows as i32, cols as i32])?;
-    // Convert to BF16 to match Q/K/V dtype (MLX requires mask dtype to promote to output).
-    mask_f32.astype(Dtype::Bf16, device)
+/// The two values a `where` selects between to produce an additive mask:
+/// `0.0` where the pair is allowed, [`BLOCKED_BIAS`] where it is not.
+///
+/// BF16 to match Q/K/V dtype — MLX requires the mask dtype to promote to the
+/// SDPA output dtype.
+fn mask_scalars(device: Device) -> Result<(Array, Array)> {
+    let open = scalar_f32(0.0).astype(Dtype::Bf16, device)?;
+    let blocked = scalar_f32(BLOCKED_BIAS).astype(Dtype::Bf16, device)?;
+    Ok((open, blocked))
 }
 
 /// Build the banded-causal prefill mask for a Sliding-Window Attention (SWA) layer.
@@ -81,34 +121,28 @@ pub fn build_chunked_prefill_mask(offset: i32, new_seq: i32, device: Device) -> 
 /// `sliding_window_mask = create_attention_mask(h, cache[0], window_size=self.window_size)`
 /// where `create_attention_mask` in `base.py` uses:
 /// `mask[q, k] = True if (q_pos - k_pos >= window_size) or (k_pos > q_pos)`
-#[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
 pub fn build_swa_prefill_mask(
     offset: i32,
     new_seq: i32,
     window: usize,
     device: Device,
 ) -> Result<Array> {
-    let rows = new_seq as usize;
-    let cols = (offset + new_seq) as usize;
-    let window = window as i64;
-    let mut data = vec![-1e30_f32; rows * cols];
+    let (q_pos, k_pos) = position_axes(offset, new_seq, device)?;
+    // Not in the future: k_abs <= q_abs.
+    let causal = greater_equal(&q_pos, &k_pos, device)?;
+    // Within the window: q_abs - k_abs < window, i.e. k_abs >= q_abs - window + 1.
+    // `window - 1` is computed in i64 so a zero window (block everything) stays
+    // well-defined instead of wrapping.
+    let span = scalar_f32((window as i64 - 1) as f32);
+    let oldest_allowed = subtract(&q_pos, &span, device)?;
+    let in_window = greater_equal(&k_pos, &oldest_allowed, device)?;
 
-    for i in 0..rows {
-        let q_abs = i64::from(offset) + i as i64; // absolute query position
-        for j in 0..cols {
-            let k_abs = j as i64; // absolute key position
-                                  // Allow: key is not in the future AND within the window.
-            if k_abs <= q_abs && q_abs - k_abs < window {
-                data[i * cols + j] = 0.0;
-            }
-        }
-    }
-
-    let mask_f32 = Array::from_f32_slice(&data, &[1, 1, rows as i32, cols as i32])?;
-    mask_f32.astype(Dtype::Bf16, device)
+    let (open, blocked) = mask_scalars(device)?;
+    // Banded = allowed only where BOTH hold. Nested `where` rather than a
+    // logical-and op: the codebase's MLX surface has no boolean conjunction,
+    // and the SWA mask is window-bounded so the extra pass is cheap.
+    let banded = where_cond(&in_window, &open, &blocked, device)?;
+    where_cond(&causal, &banded, &blocked, device)
 }
 
 /// Build the decode mask for a Sliding-Window Attention (SWA) layer when
@@ -136,7 +170,7 @@ pub fn build_swa_decode_mask(
     let window = window as i32;
     let first_allowed = total_kv_len - window; // oldest allowed key index (absolute)
 
-    let mut data = vec![-1e30_f32; cols];
+    let mut data = vec![BLOCKED_BIAS; cols];
     for cell in data.iter_mut().skip(first_allowed as usize) {
         *cell = 0.0;
     }

--- a/crates/rmlx-models/src/layers/mask.rs
+++ b/crates/rmlx-models/src/layers/mask.rs
@@ -10,18 +10,35 @@
 //! of transient host memory, which on a loaded machine exhausts free RAM and
 //! turns repeated in-process generations into a monotonic slowdown.
 //!
-//! **Do not hoist one mask across the layers of a forward call.** It looks like
-//! an obvious saving — a chunk needs at most one full-attention and one banded
-//! mask — but a mask handed to every layer is a graph node with many consumers,
-//! so its buffer stays live for the whole forward and the allocator cannot
-//! recycle it between layers. Measured on a 35-layer model with a 68 898-token
-//! prompt, sharing the two masks cost **2x** the prefill time (9.5 s vs 4.8 s)
-//! and ~19 GiB more transient demand than letting each layer build its own.
-//! Per-layer construction is a produce-consume-free chain, and now that the
-//! buffer never touches the host it is cheap enough to want that chain.
+//! `build_swa_decode_mask` deliberately keeps its host fill. It is the
+//! `seq == 1` path, so it is O(`kv_len`) rather than O(`seq` × `kv_len`), and
+//! it is unreachable whenever the SWA cache rotates — which every shipped
+//! gemma3 / gemma4 / laguna configuration sets. Moving it to the device would
+//! add dispatches to a per-token path to save a buffer that is three orders of
+//! magnitude smaller than the ones above.
+//!
+//! **Sharing one mask across the layers of a forward call is not automatically
+//! a win; measure it per architecture.** It looks like an obvious saving — a
+//! chunk needs at most one full-attention and one banded mask. Two
+//! measurements, same binary except for the sharing, `--kv-quant none`,
+//! `--warmup 0 --runs 3`, free memory settled before each cell:
+//!
+//! * gemma-4-e2b (35 layers, 7 full + 28 SWA, `head_dim` 256), 68 898-token
+//!   prompt: sharing cost **2x** the prefill time (9.5 s vs 4.8 s) and pushed
+//!   the host from 0 to ~40 GiB of compressor growth. Per-layer wins by a lot.
+//! * Qwen3.6-35B-A3B (40 layers, 10 full + 30 linear, `head_dim` 256), 34k
+//!   prompt: 12.27 s shared vs 12.47 s per-layer — sharing wins by 1.6%, inside
+//!   run-to-run spread. No penalty at all.
+//!
+//! So the gemma-4 result does not generalise, and `qwen3_5_moe` / `qwen3_vl_moe`
+//! keep the per-forward `shared_mask` they have always had. What produces the
+//! gemma-4 magnitude is not established: one extra live mask is ~140 MB at that
+//! cell, two orders of magnitude short of the difference, and sharing strictly
+//! *reduces* total bytes allocated. Do not restate a mechanism for it here
+//! without measuring one.
 
 use rmlx_core::error::Result;
-use rmlx_mlx::{arange, greater_equal, scalar_f32, subtract, where_cond, Array, Device, Dtype};
+use rmlx_mlx::{arange, greater_equal, multiply, scalar_f32, where_cond, Array, Device, Dtype};
 
 /// Additive bias applied to a blocked (query, key) pair.
 ///
@@ -84,10 +101,19 @@ pub fn build_chunked_prefill_mask(offset: i32, new_seq: i32, device: Device) -> 
 /// F32 far below the 2^24 mantissa limit.
 fn position_axes(offset: i32, new_seq: i32, device: Device) -> Result<(Array, Array)> {
     let cols = offset + new_seq;
-    let q_pos = arange(f64::from(offset), f64::from(cols), 1.0, device)?
-        .reshape(&[1, 1, new_seq, 1], device)?;
+    let q_pos = position_column(i64::from(offset), new_seq, device)?;
     let k_pos = arange(0.0, f64::from(cols), 1.0, device)?.reshape(&[1, 1, 1, cols], device)?;
     Ok((q_pos, k_pos))
+}
+
+/// A `[1, 1, len, 1]` column of consecutive positions `start .. start + len`.
+///
+/// `start` is `i64` and may be negative: the SWA window edge sits `window - 1`
+/// positions behind the query, which is before position 0 until the first
+/// window has filled.
+fn position_column(start: i64, len: i32, device: Device) -> Result<Array> {
+    let stop = start + i64::from(len);
+    arange(start as f64, stop as f64, 1.0, device)?.reshape(&[1, 1, len, 1], device)
 }
 
 /// The two values a `where` selects between to produce an additive mask:
@@ -131,18 +157,21 @@ pub fn build_swa_prefill_mask(
     // Not in the future: k_abs <= q_abs.
     let causal = greater_equal(&q_pos, &k_pos, device)?;
     // Within the window: q_abs - k_abs < window, i.e. k_abs >= q_abs - window + 1.
-    // `window - 1` is computed in i64 so a zero window (block everything) stays
-    // well-defined instead of wrapping.
-    let span = scalar_f32((window as i64 - 1) as f32);
-    let oldest_allowed = subtract(&q_pos, &span, device)?;
+    // The window edge is its own position column rather than `q_pos` minus a
+    // scalar: same values, one op fewer, and no loose scalar in the graph.
+    // The arithmetic is i64 so a zero window (block everything) and a window
+    // reaching back past position 0 both stay well-defined instead of wrapping.
+    let edge_start = i64::from(offset) - (window as i64 - 1);
+    let oldest_allowed = position_column(edge_start, new_seq, device)?;
     let in_window = greater_equal(&k_pos, &oldest_allowed, device)?;
 
+    // Allowed where BOTH hold. Both operands are bool (MLX U8), so the product
+    // is their conjunction and stays U8 — one byte per cell. Selecting twice
+    // instead would materialise a full-size BF16 intermediate to feed the
+    // second selection, which is the traffic this construction exists to avoid.
+    let allowed = multiply(&causal, &in_window, device)?;
     let (open, blocked) = mask_scalars(device)?;
-    // Banded = allowed only where BOTH hold. Nested `where` rather than a
-    // logical-and op: the codebase's MLX surface has no boolean conjunction,
-    // and the SWA mask is window-bounded so the extra pass is cheap.
-    let banded = where_cond(&in_window, &open, &blocked, device)?;
-    where_cond(&causal, &banded, &blocked, device)
+    where_cond(&allowed, &open, &blocked, device)
 }
 
 /// Build the decode mask for a Sliding-Window Attention (SWA) layer when

--- a/crates/rmlx-models/src/layers/tests.rs
+++ b/crates/rmlx-models/src/layers/tests.rs
@@ -458,6 +458,10 @@ fn mlp_silu_shape() {
 )]
 fn prefill_masks_match_their_documented_rule() {
     let open = |v: f32| v == 0.0;
+    // Assert the blocked magnitude too, not just which cells are open: a
+    // blocked cell that is merely down-weighted still attends, which is the
+    // silent-wrong-output failure this test exists to catch.
+    let blocked = |v: f32| v < -1e29;
     for &(offset, new_seq) in &[(0, 1), (0, 4), (2, 3), (5, 1), (7, 9), (33, 16)] {
         let cols = (offset + new_seq) as usize;
         let rows = new_seq as usize;
@@ -469,15 +473,21 @@ fn prefill_masks_match_their_documented_rule() {
         for i in 0..rows {
             for j in 0..cols {
                 let q_abs = offset as usize + i;
+                let cell = vals[i * cols + j];
                 assert_eq!(
-                    open(vals[i * cols + j]),
+                    open(cell),
                     j <= q_abs,
                     "causal ({offset},{new_seq}) cell ({i},{j})"
+                );
+                assert_eq!(
+                    blocked(cell),
+                    j > q_abs,
+                    "causal ({offset},{new_seq}) blocked magnitude at ({i},{j}): {cell}"
                 );
             }
         }
 
-        for &window in &[1_usize, 2, 3, 8, 64] {
+        for &window in &[0_usize, 1, 2, 3, 8, 64] {
             let swa = build_swa_prefill_mask(offset, new_seq, window, Device::Cpu).unwrap();
             assert_eq!(swa.shape(), vec![1, 1, new_seq, offset + new_seq]);
             let vals = mask_bf16_to_f32(&swa);
@@ -485,13 +495,59 @@ fn prefill_masks_match_their_documented_rule() {
                 for j in 0..cols {
                     let q_abs = offset as usize + i;
                     let expect = j <= q_abs && q_abs - j < window;
+                    let cell = vals[i * cols + j];
                     assert_eq!(
-                        open(vals[i * cols + j]),
+                        open(cell),
                         expect,
                         "swa ({offset},{new_seq},w={window}) cell ({i},{j})"
+                    );
+                    assert_eq!(
+                        blocked(cell),
+                        !expect,
+                        "swa ({offset},{new_seq},w={window}) blocked magnitude at ({i},{j}): {cell}"
                     );
                 }
             }
         }
+    }
+}
+
+/// Every mask leaves the builders as BF16, and adding one to a BF16 score
+/// tensor keeps that tensor BF16.
+///
+/// The masks are assembled from `arange` position vectors, which MLX produces
+/// as F32. That F32 must stop at the comparison: the comparison yields a bool,
+/// and the `where` selects between two BF16 scalars. If any of it reached the
+/// output instead, an "array"-mode mask would promote the attention scores it
+/// is added to, widening the residual stream and the KV cache behind it — the
+/// F32-leak class, which is silent because the values stay correct.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "mask construction on Device::Cpu is infallible for these shapes; unwrap asserts that"
+)]
+fn masks_are_bf16_and_do_not_widen_scores() {
+    let dev = Device::Cpu;
+    let masks = [
+        ("chunked", build_chunked_prefill_mask(2, 3, dev).unwrap()),
+        ("swa-banded", build_swa_prefill_mask(2, 3, 2, dev).unwrap()),
+        (
+            "swa-decode",
+            build_swa_decode_mask(7, 4, dev)
+                .unwrap()
+                .expect("total_kv_len > window must yield a mask"),
+        ),
+    ];
+    for (name, mask) in &masks {
+        assert_eq!(mask.dtype(), Dtype::Bf16, "{name} mask dtype");
+        // An additive mask is summed into the scores; that sum must not widen.
+        let scores = rmlx_mlx::zeros(&mask.shape(), Dtype::Bf16, dev).unwrap();
+        let masked = rmlx_mlx::add(&scores, mask, dev).unwrap();
+        assert_eq!(
+            masked.dtype(),
+            Dtype::Bf16,
+            "{name} mask promoted BF16 scores"
+        );
     }
 }

--- a/crates/rmlx-models/src/layers/tests.rs
+++ b/crates/rmlx-models/src/layers/tests.rs
@@ -439,3 +439,59 @@ fn mlp_silu_shape() {
     out.eval().unwrap();
     assert_eq!(out.shape(), vec![1, 4], "mlp silu output shape");
 }
+
+/// Both prefill masks agree cell-for-cell with the rule they document, across
+/// offsets and windows that exercise every branch (first chunk, continuation,
+/// window narrower and wider than the chunk).
+///
+/// This is the guard on how the masks are *built*: they are assembled from MLX
+/// position vectors rather than a scalar host loop, so a broadcasting or
+/// off-by-one slip would silently open or close attention rather than fail.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "mask construction on Device::Cpu is infallible for these shapes; unwrap asserts that"
+)]
+fn prefill_masks_match_their_documented_rule() {
+    let open = |v: f32| v == 0.0;
+    for &(offset, new_seq) in &[(0, 1), (0, 4), (2, 3), (5, 1), (7, 9), (33, 16)] {
+        let cols = (offset + new_seq) as usize;
+        let rows = new_seq as usize;
+
+        let causal = build_chunked_prefill_mask(offset, new_seq, Device::Cpu).unwrap();
+        assert_eq!(causal.shape(), vec![1, 1, new_seq, offset + new_seq]);
+        let vals = mask_bf16_to_f32(&causal);
+        assert_eq!(vals.len(), rows * cols);
+        for i in 0..rows {
+            for j in 0..cols {
+                let q_abs = offset as usize + i;
+                assert_eq!(
+                    open(vals[i * cols + j]),
+                    j <= q_abs,
+                    "causal ({offset},{new_seq}) cell ({i},{j})"
+                );
+            }
+        }
+
+        for &window in &[1_usize, 2, 3, 8, 64] {
+            let swa = build_swa_prefill_mask(offset, new_seq, window, Device::Cpu).unwrap();
+            assert_eq!(swa.shape(), vec![1, 1, new_seq, offset + new_seq]);
+            let vals = mask_bf16_to_f32(&swa);
+            for i in 0..rows {
+                for j in 0..cols {
+                    let q_abs = offset as usize + i;
+                    let expect = j <= q_abs && q_abs - j < window;
+                    assert_eq!(
+                        open(vals[i * cols + j]),
+                        expect,
+                        "swa ({offset},{new_seq},w={window}) cell ({i},{j})"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -510,9 +510,9 @@ none`, 4096-token prompt, 128 generated):
 
 | | gemma-4-e2b | Ternary-Bonsai-8B |
 |---|---|---|
-| `baseline` (median of 3 invocations) | 257 ms | 1272 ms |
-| `bench` generation 1 (`--warmup 0`) | 250 ms (**−2.6%**) | 1297 ms (**+2.0%**) |
-| `bench` median (`--warmup 1`) | 207 ms (−19%) | 1345 ms (+5.8%) |
+| `baseline` (median of 3 invocations) | 220 ms | 1354 ms |
+| `bench` generation 1 (`--warmup 0`) | 221 ms (**+0.5%**) | 1354 ms (**+0.0%**) |
+| `bench` median (`--warmup 1`) | 189 ms (−14%) | 1418 ms (+4.7%) |
 
 Generation 1 agrees with `baseline` on both architectures; the divergence is the
 warmup, not a disagreement about what a TTFT is. Compare `bench` TTFTs to other
@@ -520,8 +520,10 @@ warmup, not a disagreement about what a TTFT is. Compare `bench` TTFTs to other
 TTFTs. Decode TPS does not have this problem — it averages the steady-state
 gaps *within* a generation, so it is robust in both tools.
 
-At long context the movement is large enough that `bench` refuses to report a
-median at all until the cell settles — see the drift refusal below.
+A warm-up shape is itself a trend, so `bench` can refuse a cell whose only
+problem is that generation 1 was the slowest — the gemma-4-e2b column above was
+read out of exactly such a refusal. Raise `--warmup` until consecutive runs
+agree; see the drift refusal below.
 
 | Flag | Type | Default | Description |
 |---|---|---|---|


### PR DESCRIPTION
Closes #320.

The ramp was real. The cause was not in-process software state — it was host memory
exhaustion, driven by `layers/mask.rs` scalar-filling an `O(seq × kv_len)` attention
mask on the CPU, once per layer per chunk.

## Diagnosis

`ttft_ms` is stamped after the prompt-cache snapshot deep-clone; `prefill_ms` before
it. The difference isolates the store at **0.7–1.5 ms** — the ramp is entirely inside
prefill compute, and decode is untouched (gen3/gen1 decode TPS 0.978–1.015).

A context sweep locates it precisely. Only the cell that exhausts free memory ramps;
below that line generation 1 is the *slowest*, which is ordinary warm-up:

| prompt tok | gen3/gen1 | min free | compressor Δ | decompressions |
|---|---:|---:|---:|---:|
| 4 096 | 0.711 | 69.6 GiB | 0 | 0 |
| 32 768 | 0.871 | 47.6 | 0 | 0 |
| 56 000 | 0.860 | 15.1 | 0 | 0 |
| 68 898 | **1.297** | **0.01** | **+12.8 GiB** | **6.1 M** |

Two of the issue's original conclusions are overturned:

- **"Not memory exhaustion: ~71 GB free, peak RSS 37.5 GB"** — wrong instrument. Free
  memory was sampled *before* the run, and `ps rss` undercounts Metal/IOKit pages
  (44 GiB reported while the system gives up 78 GiB). During the run free falls to
  0.01 GiB and stays there. A matched pair settles it: 56 000 tok peaked at 35.8 GiB
  RSS with **no** ramp; 68 898 tok at a 4× smaller chunk peaked at 35.0 GiB RSS
  **with** one. The discriminator is demand-vs-free, not RSS.
- **"Bonsai-8B @4k +22.0%, decode TPS −10.6%"** — does not reproduce on a quiet host
  (ratio 0.966, decode **+1.4%**, `bench` exit 0, zero compressions). Contended
  session, as this issue's own second comment predicted.

So the predicate is neither "in-process" nor "long context" — it is *transient demand
crossing the host's free-memory line*, visible as compressor growth during the run.
Bonsai at 65 536 tok reaches 0.29 GiB free and still does not ramp, because
`head_dim 128` reaches MLX's fused kernel and materialises no score matrix.

`samply` put **69.49%** of main-thread samples in `build_attn_mask`, with memmove/memset
self time at 63.5%. A 68 898-token prefill built ~1.72 × 10¹⁰ mask elements.

## The fix

Build the mask from MLX position vectors instead of a host `Vec` — device-side, no
upload, no host fill. `layers/mask.rs` is shared by all eight architectures, so this
is one model-agnostic change.

| cell | before gen-1 | after gen-1 | ratio after | digest |
|---|---:|---:|---:|---|
| gemma-4-e2b @4 096 | 313.1 ms | 198.4 ms | 0.844 | `0xd98077e147d7dcb3` ✓ |
| gemma-4-e2b @32 768 | 3 980.3 ms | 2 084.8 ms | 0.986 | `0x7b8d101a795fc2f1` ✓ |
| gemma-4-e2b @68 898 | 13 673–14 024 ms | **4 762–5 277 ms** | 0.973–1.008 | `0xd83191427a10685c` ✓ |
| Ternary-Bonsai-8B @4 096 | 1 347.8 ms | 1 364.7 ms | 0.990 | `0x18207153cbe02a51` ✓ |
| Ternary-Bonsai-8B @68 898 | 60 032.2 ms | 59 295.7 ms | 1.030 | `0x487e23afc31096e2` ✓ |
| Qwen3.6-35B-A3B @4 096 | 1 461.2 ms | 1 155.2 ms | 0.945 | `0x8d273a2e8b42b566` ✓ |
| Qwen3.6-35B-A3B @34k | 12 828.4 ms | 12 267.2 ms | 1.055 | `0x738ab4a5f05d86b6` ✓ |

All three required families, both context ends, every token digest bit-identical.

Gates on the issue's own cell, criteria stated before the run: ratio ≤ 1.15 →
**1.008**; free drop ≤ 65 GiB → **52.96**; compressor ≤ 1 GiB → **+0.00**;
decompressions ≤ 0.2 M → **0.002 M**; gen-1 ≤ 13 500 ms → **5 277 ms**.

Bonsai's prefill time cannot improve — it is GPU-bound behind the fused kernel — but
the shared fix still removes ~50 GiB of transient demand there: free memory bottoms
at **18.6 GiB instead of 0.1 GiB**.

Mechanism confirmed by re-profiling: `build_attn_mask` **69.49% → 0.07%**,
`memset_pattern16` self 22.52% → 0.14%, prefill main-thread samples −76%, and
`__psynch_cvwait` self 7.00% → **56.63%** — the host now waits on the GPU.

## What was proposed and rejected, on measurement

- **Hoisting one mask across the layers of a forward** (the diagnosis's primary
  proposal) was implemented, measured, and removed: on gemma-4 it ran **2× slower**
  with **+43–46 GiB** compressor growth versus +0.00. The mechanism is *not*
  established and the doc says so — the extra live mask is only ~140 MB at that cell,
  and sharing strictly reduces total bytes allocated, so the cost is downstream of
  holding the node, not the node itself.
- **But the penalty does not generalise.** Qwen3.6 hoists a shared mask across its 10
  FullAttention layers. Pre-registered threshold: per-layer beats shared by >5% ⇒ drop
  the hoist. Measured: shared **12 267.2 ms** vs per-layer **12 470.9 ms** — per-layer
  is 1.7% *slower*. So `qwen3_5_moe` and `qwen3_vl_moe` are untouched, and the module
  doc records both measurements side by side rather than stating a rule two shipped
  callers break.
- **Bounding MLX's buffer pool** cannot work as specified: the proposed source value
  (`max_recommended_working_set_size` = 107.52 GiB) is *below* the current default
  cache limit (121.60 GiB), so it would never bind. A cap that would bind needs a
  single-digit-GiB policy number — a new runtime knob — and it is no longer motivated:
  post-fix compressor growth is +0.00 GiB.
- **`mask_mode="causal"`** was verified sound upstream (mlx 0.31.2 builds causal as
  bottom-right aligned, matching this use) but not shipped: it needs an audit of every
  `additive_mask: Option<&Array>` consumer proving `None` + `"causal"` is honoured
  rather than silently unmasked, and for gemma-4 it buys ~nothing since `head_dim 256`
  fails `sdpa_full_supported_head_dim` and MLX materialises an equivalent mask itself.

## Correctness

The rules are provably unchanged: old `j < offset + i + 1` (with a no-op `.min(cols)`
clamp) ≡ new `q_pos >= k_pos`; old `k <= q && q - k < window` ≡ `causal ∧ in_window`
with both edges preserved. `arange(offset, offset+new_seq)` is total-size-exact, the
degenerate `new_seq == 0` matches the old empty-slice behaviour, and `seq == 1` never
reaches either prefill builder. The blocked value has identical bits — casting the f32
scalar and broadcasting rounds the same as casting the array.

No new decode-hot cost: both device builders are gated behind `seq > 1` at all eight
call sites, and the speculative verify path strictly improves.

`build_swa_decode_mask` deliberately keeps its host fill, now documented: it is
`seq == 1` only, unreachable whenever the SWA cache rotates (which every shipped
gemma3/gemma4/laguna path configures), so device dispatches would land on a per-token
path to no benefit.

## Dtype

The `check-no-scalar-f32-leak` gate fired on the first cut. Instrumented with one-shot
dtype events on a real chunked prefill rather than reasoned about: the flagged scalar
was rank-0 against an already-F32 `arange`, its product a 4 KB column consumed
immediately by a comparison returning U8, with U8 and Bf16 the only full-size
intermediates — not a live leak, and not a wider mask. Fixed at the cause anyway (the
window edge is now its own `position_column`), so no exemption marker is needed
anywhere.

Pinned two ways by `masks_are_bf16_and_do_not_widen_scores`: all three builders return
Bf16, *and* adding a mask to a Bf16 score tensor stays Bf16 — the actual leak
semantics. Forcing the scalars to F32 turns the test red **and** trips the CI gate.

## Mutation checks

End-to-end with the single change reverted: all four gates go red (ratio 1.237/1.328,
free drop 79.6/83.1 GiB, compressor +14.0/+15.2 GiB, decompressions 6.2/6.3 M).
Unit-level: SWA band edge `window-1` → `window` red; causal comparison direction
flipped red; `BLOCKED_BIAS` −1e30 → −1.0 red (the new blocked-magnitude oracle — the
old `open`-only oracle passed this mutation); dropping the window term from the
conjunction red. Binary A/B verified by symbol (`position_axes` present in the branch
binary, absent in HEAD's).

## Also

`docs/CLI.md`'s `bench` vs `baseline` table was stale for gemma-4-e2b and is
re-measured. Deleted the claim that long-context movement makes `bench` refuse a
median until the cell settles — falsified by this branch's own gen3/gen1 of 0.97–1.01
— and replaced with the warm-up-shape refusal actually observed.

## Gates

`make ci` green. `cargo fmt` clean, clippy `-D warnings` clean, `rmlx-models` 706
passed / 146 ignored, `check-no-scalar-f32-leak` and `check-no-inline-tests` OK. All
runs used a scratch `RMLX_HOME` + `--metrics off`; the real `runs.db` is untouched.

## Not proven

The Metal System Trace gate (Compute busy/span 34.4% → ≥60%) was not captured —
`mst_capture.sh` computes `max_ctx = prompt + gen + 512` and passes no
`--max-prompt-tokens`, so it cannot express a 68 898-token cell, and the hand-driven
export exceeded the time budget twice. The host-side complement stands in for it
(`__psynch_cvwait` self 7.0% → 56.6%).
