### PR TITLE
perf(decode): measure the host sampler's cost across context — the kill criterion is not met (#359)

### DIFF
--- a/crates/rmlx-cli/src/commands/bench.rs
+++ b/crates/rmlx-cli/src/commands/bench.rs
@@ -618,9 +618,17 @@ pub(crate) struct BenchArgs {
     pub temperature: f32,
     /// Nucleus threshold; `1.0` disables it.
     pub top_p: f32,
+    /// Top-k cutoff; `0` disables it.
+    pub top_k: u32,
     /// Sign-aware multiplicative repetition penalty; `1.0` is the no-op.
     pub repetition_penalty: f32,
 }
+
+/// Upper bound on `--temperature`, matching the one the HTTP surface and
+/// `--default-temperature` already enforce. Above it the distribution flattens
+/// toward uniform over the vocabulary, and at infinity it is exactly uniform —
+/// benchable, but not a cell any served request can reach.
+const MAX_TEMPERATURE: f32 = 2.0;
 
 impl BenchArgs {
     /// `true` when the cell routes through the host sampler rather than the GPU
@@ -639,11 +647,25 @@ impl BenchArgs {
     /// Reject sampler knobs that cannot produce a meaningful cell, before the
     /// model is loaded. A NaN temperature would silently fail the `> 0.0` gate
     /// and bench greedy under a sampling label; a non-positive repetition
-    /// penalty divides positive logits by zero or flips their sign.
+    /// penalty divides positive logits by zero or flips their sign; and a
+    /// distribution filter at temperature 0 is never reached at all, so the cell
+    /// would be recorded carrying a setting it did not exercise.
+    #[allow(
+        clippy::float_cmp,
+        reason = "exact identity comparisons on purpose: these gates must agree with the sampler's own exact identity checks, and a tolerance would let a knob through that the sampler treats as set"
+    )]
     fn validate_sampling(&self) -> anyhow::Result<()> {
         if self.temperature.is_nan() || self.temperature < 0.0 {
             return Err(anyhow::anyhow!(
                 "--temperature must be >= 0 (got {}); 0 is greedy",
+                self.temperature
+            ));
+        }
+        if self.temperature > MAX_TEMPERATURE {
+            return Err(anyhow::anyhow!(
+                "--temperature must be <= {MAX_TEMPERATURE} (got {}); that is the bound the HTTP \
+                 surface and --default-temperature enforce, so a higher value benches a cell no \
+                 served request can reach",
                 self.temperature
             ));
         }
@@ -657,6 +679,19 @@ impl BenchArgs {
             return Err(anyhow::anyhow!(
                 "--repetition-penalty must be > 0 (got {}); 1 is the exact no-op",
                 self.repetition_penalty
+            ));
+        }
+        // The distribution filters live downstream of the softmax, which only the
+        // temperature path runs. At temperature 0 the cell is a GPU argmax and
+        // never reaches them, so accepting the flag would record a nucleus or
+        // top-k setting against a cell that applied neither.
+        if self.temperature == 0.0 && (self.top_p != 1.0 || self.top_k != 0) {
+            return Err(anyhow::anyhow!(
+                "--top-p / --top-k require --temperature > 0 (got top_p={}, top_k={} at \
+                 temperature 0): both filter the post-softmax distribution, which the greedy \
+                 path never builds, so the cell would carry a setting it did not exercise",
+                self.top_p,
+                self.top_k
             ));
         }
         Ok(())
@@ -676,7 +711,7 @@ fn measure_one(
     let sampler_cfg = rmlx_models::SamplerConfig {
         temperature: args.temperature,
         top_p: args.top_p,
-        top_k: 0,
+        top_k: args.top_k,
         min_p: 0.0,
         seed: None,
         top_logprobs_k: 0,
@@ -1174,6 +1209,7 @@ fn emit_json(ctx: &ReportCtx<'_>, s: &BenchSummary, samples: &[RunSample]) -> an
             "host_sampled": ctx.args.host_sampled(),
             "temperature": ctx.args.temperature,
             "top_p": ctx.args.top_p,
+            "top_k": ctx.args.top_k,
             "repetition_penalty": ctx.args.repetition_penalty,
         },
         "metrics": {
@@ -1218,8 +1254,8 @@ fn emit_table(ctx: &ReportCtx<'_>, s: &BenchSummary) {
     // it was — but a sampled cell can never be mistaken for a greedy one.
     if ctx.args.host_sampled() {
         println!(
-            "sampling: host path — temperature={} top_p={} repetition_penalty={}",
-            ctx.args.temperature, ctx.args.top_p, ctx.args.repetition_penalty
+            "sampling: host path — temperature={} top_p={} top_k={} repetition_penalty={}",
+            ctx.args.temperature, ctx.args.top_p, ctx.args.top_k, ctx.args.repetition_penalty
         );
     }
     println!(

--- a/crates/rmlx-cli/src/commands/bench.rs
+++ b/crates/rmlx-cli/src/commands/bench.rs
@@ -614,6 +614,53 @@ pub(crate) struct BenchArgs {
     pub allow_truncate: bool,
     /// Emit the summary as one JSON object instead of a table.
     pub json: bool,
+    /// Sampling temperature. `0.0` keeps the cell on the GPU argmax path.
+    pub temperature: f32,
+    /// Nucleus threshold; `1.0` disables it.
+    pub top_p: f32,
+    /// Sign-aware multiplicative repetition penalty; `1.0` is the no-op.
+    pub repetition_penalty: f32,
+}
+
+impl BenchArgs {
+    /// `true` when the cell routes through the host sampler rather than the GPU
+    /// argmax. Mirrors the decode loop's own gate
+    /// (`sampling_active() || penalties_active()`); it exists here so the
+    /// summary can label a cell that is not the greedy shape everything else in
+    /// this file measures.
+    #[allow(
+        clippy::float_cmp,
+        reason = "exact identity comparison on purpose: it must agree with PenaltyConfig::penalties_active(), which is also exact. A tolerance here would label a cell greedy that the decode loop routes through the host sampler"
+    )]
+    fn host_sampled(&self) -> bool {
+        self.temperature > 0.0 || self.repetition_penalty != 1.0
+    }
+
+    /// Reject sampler knobs that cannot produce a meaningful cell, before the
+    /// model is loaded. A NaN temperature would silently fail the `> 0.0` gate
+    /// and bench greedy under a sampling label; a non-positive repetition
+    /// penalty divides positive logits by zero or flips their sign.
+    fn validate_sampling(&self) -> anyhow::Result<()> {
+        if self.temperature.is_nan() || self.temperature < 0.0 {
+            return Err(anyhow::anyhow!(
+                "--temperature must be >= 0 (got {}); 0 is greedy",
+                self.temperature
+            ));
+        }
+        if self.top_p.is_nan() || self.top_p <= 0.0 || self.top_p > 1.0 {
+            return Err(anyhow::anyhow!(
+                "--top-p must be in (0, 1] (got {}); 1 disables nucleus truncation",
+                self.top_p
+            ));
+        }
+        if self.repetition_penalty.is_nan() || self.repetition_penalty <= 0.0 {
+            return Err(anyhow::anyhow!(
+                "--repetition-penalty must be > 0 (got {}); 1 is the exact no-op",
+                self.repetition_penalty
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// Run one generation and return its sample, or the reason there is none.
@@ -623,16 +670,22 @@ fn measure_one(
     prompt_ids: &[u32],
     args: &BenchArgs,
 ) -> anyhow::Result<RunSample> {
+    // Greedy by default. The seed is the fixed default, and the RNG is fresh per
+    // run, so a sampled cell still produces one token stream across every run —
+    // which is what the digest guard checks.
     let sampler_cfg = rmlx_models::SamplerConfig {
-        temperature: 0.0,
-        top_p: 1.0,
+        temperature: args.temperature,
+        top_p: args.top_p,
         top_k: 0,
         min_p: 0.0,
         seed: None,
         top_logprobs_k: 0,
     };
     let mut rng = rmlx_models::Pcg32::new(sampler_cfg.seed_or_default());
-    let penalty_cfg = rmlx_models::PenaltyConfig::default();
+    let penalty_cfg = rmlx_models::PenaltyConfig {
+        rep_penalty: args.repetition_penalty,
+        ..rmlx_models::PenaltyConfig::default()
+    };
     let mut token_history: Vec<u32> = Vec::new();
 
     // Empty the prompt cache so this generation is a guaranteed miss and runs a
@@ -1021,6 +1074,7 @@ pub(crate) fn run_bench(args: BenchArgs) -> anyhow::Result<()> {
              run-to-run spread, and this instrument does not report a central value without one"
         ));
     }
+    args.validate_sampling()?;
 
     let tokenizer = tokenizers::Tokenizer::from_file(args.model.join("tokenizer.json"))
         .map_err(|e| anyhow::anyhow!("cannot load tokenizer.json: {e}"))?;
@@ -1116,6 +1170,12 @@ fn emit_json(ctx: &ReportCtx<'_>, s: &BenchSummary, samples: &[RunSample]) -> an
         "cpus": ctx.cpus,
         "contended": ctx.contended,
         "token_digest": format!("{:#018x}", s.token_digest),
+        "sampling": {
+            "host_sampled": ctx.args.host_sampled(),
+            "temperature": ctx.args.temperature,
+            "top_p": ctx.args.top_p,
+            "repetition_penalty": ctx.args.repetition_penalty,
+        },
         "metrics": {
             "ttft_ms": spread_json(&s.ttft_ms),
             "decode_tps": spread_json(&s.decode_tps),
@@ -1154,6 +1214,14 @@ fn emit_table(ctx: &ReportCtx<'_>, s: &BenchSummary) {
         ctx.args.warmup,
         ctx.load_ms
     );
+    // Named only when it is not the greedy default, so the common line stays as
+    // it was — but a sampled cell can never be mistaken for a greedy one.
+    if ctx.args.host_sampled() {
+        println!(
+            "sampling: host path — temperature={} top_p={} repetition_penalty={}",
+            ctx.args.temperature, ctx.args.top_p, ctx.args.repetition_penalty
+        );
+    }
     println!(
         "{:<16} {:>14} {:>14} {:>14} {:>9}",
         "metric", "median", "min", "max", "range%"

--- a/crates/rmlx-cli/src/commands/bench_tests.rs
+++ b/crates/rmlx-cli/src/commands/bench_tests.rs
@@ -1,3 +1,7 @@
+// LOC-exempt: sibling test file for one command. Its length tracks the number of
+// refusals `rmlx bench` makes, and each refusal's test carries the reasoning for
+// why that measurement condition is load-bearing — prose that is the point, not
+// padding. Splitting by topic would separate a guard from the argument for it.
 //! Unit tests for the `rmlx bench` instrument.
 //!
 //! The subject here is the instrument's refusal behaviour, not its arithmetic:
@@ -249,6 +253,7 @@ fn unrunnable_args(runs: u32) -> BenchArgs {
         json: false,
         temperature: 0.0,
         top_p: 1.0,
+        top_k: 0,
         repetition_penalty: 1.0,
     }
 }
@@ -297,12 +302,66 @@ fn negative_temperature_is_refused() {
 fn out_of_range_top_p_is_refused() {
     for bad in [0.0f32, -0.1, 1.5, f32::NAN] {
         let mut args = unrunnable_args(3);
+        args.temperature = 0.7;
         args.top_p = bad;
         let msg = run_bench(args)
             .expect_err("out-of-range --top-p must be refused")
             .to_string();
         assert!(msg.contains("--top-p"), "wrong rejection for {bad}: {msg}");
     }
+}
+
+/// The binary bounds temperature to [0, 2] on the HTTP surface and on
+/// `--default-temperature`. Above that the distribution flattens toward uniform
+/// over the vocabulary; at infinity it is exactly uniform. Benching a cell no
+/// served request can reach is not a measurement of anything served.
+#[test]
+fn above_range_temperature_is_refused() {
+    for bad in [2.5f32, f32::INFINITY] {
+        let mut args = unrunnable_args(3);
+        args.temperature = bad;
+        let msg = run_bench(args)
+            .expect_err("out-of-range --temperature must be refused")
+            .to_string();
+        assert!(
+            msg.contains("--temperature"),
+            "wrong rejection for {bad}: {msg}"
+        );
+    }
+}
+
+/// The distribution filters sit downstream of the softmax, which the greedy path
+/// never builds. Accepting them at temperature 0 records a nucleus or top-k
+/// setting against a cell that applied neither — the exact "silently no-opping
+/// into a greedy run wearing a sampled label" this validator exists to stop.
+#[test]
+fn distribution_filters_at_temperature_zero_are_refused() {
+    let mut nucleus = unrunnable_args(3);
+    nucleus.top_p = 0.9;
+    let msg = run_bench(nucleus)
+        .expect_err("--top-p at temperature 0 must be refused")
+        .to_string();
+    assert!(msg.contains("--top-p"), "wrong rejection: {msg}");
+
+    let mut topk = unrunnable_args(3);
+    topk.top_k = 20;
+    let msg = run_bench(topk)
+        .expect_err("--top-k at temperature 0 must be refused")
+        .to_string();
+    assert!(msg.contains("--top-k"), "wrong rejection: {msg}");
+
+    // ...and both clear the gate once the sampler actually runs.
+    let mut sampled = unrunnable_args(3);
+    sampled.temperature = 0.7;
+    sampled.top_p = 0.95;
+    sampled.top_k = 20;
+    let msg = run_bench(sampled)
+        .expect_err("the nonexistent model path must be what fails")
+        .to_string();
+    assert!(
+        !msg.contains("--top-p") && !msg.contains("--top-k"),
+        "filters are legitimate above temperature 0: {msg}"
+    );
 }
 
 /// A repetition penalty of zero divides positive logits by zero; a negative one
@@ -361,11 +420,19 @@ fn host_sampled_matches_the_decode_loop_gate() {
         "a penalty reads logits to host even at temperature 0"
     );
 
+    // top_p alone cannot reach this predicate at all: `validate_sampling`
+    // refuses the combination first. Were it ever accepted, the cell would be
+    // labelled greedy — which is what it would in fact be, since the filters run
+    // only inside the temperature path.
     let mut nucleus_only = unrunnable_args(3);
     nucleus_only.top_p = 0.9;
     assert!(
         !nucleus_only.host_sampled(),
-        "top_p alone does nothing at temperature 0 — the sampler never runs"
+        "the filters do not by themselves take the host path"
+    );
+    assert!(
+        nucleus_only.validate_sampling().is_err(),
+        "and the combination never reaches a run: it is refused up front"
     );
 }
 

--- a/crates/rmlx-cli/src/commands/bench_tests.rs
+++ b/crates/rmlx-cli/src/commands/bench_tests.rs
@@ -229,17 +229,17 @@ fn equal_medians_with_different_stability_are_distinguishable() {
     );
 }
 
-/// The instrument has no single-run mode. The check fires before any file is
-/// read, so a bogus model path cannot be what produced the error.
-#[test]
-fn single_run_invocation_is_refused_before_any_io() {
-    let args = BenchArgs {
+/// A greedy, otherwise-valid argument bundle pointing at paths that do not
+/// exist, so any error a test observes came from an argument check rather than
+/// from I/O.
+fn unrunnable_args(runs: u32) -> BenchArgs {
+    BenchArgs {
         model: PathBuf::from("/nonexistent/model"),
         prompt: PathBuf::from("/nonexistent/prompt.txt"),
         prompt_label: "x".to_owned(),
         device: Device::Cpu,
         max_tokens: 8,
-        runs: 1,
+        runs,
         warmup: 0,
         kv_quant: rmlx_kv_quant::KvQuant::None,
         max_ctx: None,
@@ -247,13 +247,125 @@ fn single_run_invocation_is_refused_before_any_io() {
         cap_is_explicit: false,
         allow_truncate: false,
         json: false,
-    };
-    let msg = run_bench(args)
+        temperature: 0.0,
+        top_p: 1.0,
+        repetition_penalty: 1.0,
+    }
+}
+
+/// The instrument has no single-run mode. The check fires before any file is
+/// read, so a bogus model path cannot be what produced the error.
+#[test]
+fn single_run_invocation_is_refused_before_any_io() {
+    let msg = run_bench(unrunnable_args(1))
         .expect_err("--runs 1 must be refused")
         .to_string();
     assert!(
         msg.contains("--runs must be at least"),
         "must refuse for lack of spread, not for the missing paths: {msg}"
+    );
+}
+
+// ── Sampler knobs ───────────────────────────────────────────────────
+
+/// A NaN temperature fails the decode loop's `> 0.0` gate silently: the cell
+/// would run greedy while every label on it said otherwise. Rejected up front,
+/// before the model is loaded.
+#[test]
+fn nan_temperature_is_refused() {
+    let mut args = unrunnable_args(3);
+    args.temperature = f32::NAN;
+    let msg = run_bench(args)
+        .expect_err("NaN temperature must be refused")
+        .to_string();
+    assert!(msg.contains("--temperature"), "wrong rejection: {msg}");
+}
+
+#[test]
+fn negative_temperature_is_refused() {
+    let mut args = unrunnable_args(3);
+    args.temperature = -0.5;
+    let msg = run_bench(args)
+        .expect_err("negative temperature must be refused")
+        .to_string();
+    assert!(msg.contains("--temperature"), "wrong rejection: {msg}");
+}
+
+/// `top_p` outside `(0, 1]` filters every token or none of them; neither is a
+/// nucleus. The sampler's own gate would quietly no-op instead.
+#[test]
+fn out_of_range_top_p_is_refused() {
+    for bad in [0.0f32, -0.1, 1.5, f32::NAN] {
+        let mut args = unrunnable_args(3);
+        args.top_p = bad;
+        let msg = run_bench(args)
+            .expect_err("out-of-range --top-p must be refused")
+            .to_string();
+        assert!(msg.contains("--top-p"), "wrong rejection for {bad}: {msg}");
+    }
+}
+
+/// A repetition penalty of zero divides positive logits by zero; a negative one
+/// flips their sign. Both produce a token stream that is not a penalised one.
+#[test]
+fn non_positive_repetition_penalty_is_refused() {
+    for bad in [0.0f32, -1.0, f32::NAN] {
+        let mut args = unrunnable_args(3);
+        args.repetition_penalty = bad;
+        let msg = run_bench(args)
+            .expect_err("non-positive --repetition-penalty must be refused")
+            .to_string();
+        assert!(
+            msg.contains("--repetition-penalty"),
+            "wrong rejection for {bad}: {msg}"
+        );
+    }
+}
+
+/// The identity values must pass — a guard that refuses the default would be
+/// vacuously "correct" on every test above.
+#[test]
+fn default_sampler_knobs_pass_validation() {
+    let msg = run_bench(unrunnable_args(3))
+        .expect_err("the nonexistent model path must be what fails")
+        .to_string();
+    assert!(
+        !msg.contains("--temperature")
+            && !msg.contains("--top-p")
+            && !msg.contains("--repetition-penalty"),
+        "greedy defaults must clear the sampler checks: {msg}"
+    );
+}
+
+/// The label the summary prints keys off the same condition the decode loop
+/// uses to leave the GPU argmax path.
+#[test]
+fn host_sampled_matches_the_decode_loop_gate() {
+    let greedy = unrunnable_args(3);
+    assert!(
+        !greedy.host_sampled(),
+        "temperature 0, no penalty: GPU path"
+    );
+
+    let mut sampled = unrunnable_args(3);
+    sampled.temperature = 0.7;
+    assert!(
+        sampled.host_sampled(),
+        "temperature > 0 reads logits to host"
+    );
+
+    let mut penalised = unrunnable_args(3);
+    penalised.repetition_penalty = 1.1;
+    assert!(
+        penalised.host_sampled(),
+        "a penalty reads logits to host even at temperature 0"
+    );
+
+    let mut nucleus_only = unrunnable_args(3);
+    nucleus_only.top_p = 0.9;
+    assert!(
+        !nucleus_only.host_sampled(),
+        "top_p alone does nothing at temperature 0 — the sampler never runs"
     );
 }
 

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -1226,6 +1226,23 @@ enum Cmd {
         /// (`longctx_<N>k.json`). Env: `RMLX_PROMPTS_DIR`.
         #[arg(long, env = "RMLX_PROMPTS_DIR", value_name = "PATH")]
         prompts_dir: Option<PathBuf>,
+        /// Sampling temperature. `0` (the default) is greedy: the GPU argmax
+        /// path, with no logits row read back to the host. Any positive value
+        /// routes the cell through the host sampler instead, which is the only
+        /// way to bench that path — every other shape this binary measures is
+        /// greedy. The seed is the fixed default, so runs stay comparable.
+        #[arg(long, default_value_t = 0.0, value_name = "FLOAT")]
+        temperature: f32,
+        /// Nucleus threshold. Applied only when `--temperature` is positive;
+        /// `1.0` (the default) disables it. Its cost is an ordering pass over
+        /// the whole vocabulary, so bench it separately from temperature alone.
+        #[arg(long, default_value_t = 1.0, value_name = "FLOAT")]
+        top_p: f32,
+        /// Sign-aware multiplicative repetition penalty over the trailing
+        /// 20-token window. `1.0` (the default) is the exact no-op. A value
+        /// other than 1 reads the logits row to the host even at temperature 0.
+        #[arg(long, default_value_t = 1.0, value_name = "FLOAT")]
+        repetition_penalty: f32,
     },
     /// Manage named server profiles in `<RMLX_HOME>/profiles.toml`.
     Profile {
@@ -2317,6 +2334,9 @@ fn main() -> Result<()> {
             allow_truncate,
             json,
             prompts_dir,
+            temperature,
+            top_p,
+            repetition_penalty,
         } => {
             let cap_is_explicit = max_prompt_tokens.is_some();
             let max_prompt_tokens = parse_max_prompt_tokens(
@@ -2366,6 +2386,9 @@ fn main() -> Result<()> {
                 cap_is_explicit,
                 allow_truncate,
                 json,
+                temperature,
+                top_p,
+                repetition_penalty,
             })?;
         }
         Cmd::Eval { cmd } => match cmd {

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -1233,11 +1233,18 @@ enum Cmd {
         /// greedy. The seed is the fixed default, so runs stay comparable.
         #[arg(long, default_value_t = 0.0, value_name = "FLOAT")]
         temperature: f32,
-        /// Nucleus threshold. Applied only when `--temperature` is positive;
-        /// `1.0` (the default) disables it. Its cost is an ordering pass over
-        /// the whole vocabulary, so bench it separately from temperature alone.
+        /// Nucleus threshold. Requires `--temperature` > 0; `1.0` (the default)
+        /// disables it. Its cost is an ordering pass over the whole vocabulary,
+        /// so bench it separately from temperature alone.
         #[arg(long, default_value_t = 1.0, value_name = "FLOAT")]
         top_p: f32,
+        /// Top-k cutoff. Requires `--temperature` > 0; `0` (the default)
+        /// disables it. Also an ordering pass over the whole vocabulary. Needed
+        /// to reproduce the served default: several snapshots ship a `top_k` in
+        /// `generation_config.json`, so a request that omits sampling fields
+        /// gets one.
+        #[arg(long, default_value_t = 0, value_name = "N")]
+        top_k: u32,
         /// Sign-aware multiplicative repetition penalty over the trailing
         /// 20-token window. `1.0` (the default) is the exact no-op. A value
         /// other than 1 reads the logits row to the host even at temperature 0.
@@ -2336,6 +2343,7 @@ fn main() -> Result<()> {
             prompts_dir,
             temperature,
             top_p,
+            top_k,
             repetition_penalty,
         } => {
             let cap_is_explicit = max_prompt_tokens.is_some();
@@ -2388,6 +2396,7 @@ fn main() -> Result<()> {
                 json,
                 temperature,
                 top_p,
+                top_k,
                 repetition_penalty,
             })?;
         }

--- a/crates/rmlx-models/src/decode_loop.rs
+++ b/crates/rmlx-models/src/decode_loop.rs
@@ -20,9 +20,9 @@
 //! dispatched at all — there is nothing to overlap, and the loop runs strictly
 //! serial: wait for the forward, read the row back, pick a token, dispatch the
 //! next forward. That costs both the host work and the overlap the greedy path
-//! gets for free, which is why the `sampler_profile` event reports the host work
-//! as a *lower bound* on the difference and the honest end-to-end figure is a
-//! decode-TPS comparison against a greedy control. See `docs/SAMPLING.md`.
+//! gets for free, and the `sampler_profile` event only measures the first of the
+//! two — the honest end-to-end figure is a decode-TPS comparison against a
+//! greedy control. See `docs/SAMPLING.md`.
 //!
 //! The only per-arch hole is `forward_step` (an `impl FnMut`, monomorphized —
 //! never a `Box<dyn>` on the per-token hot path). Prompt-cache policy, cache
@@ -628,10 +628,15 @@ pub(crate) fn pipelined_decode(
 /// therefore a host-work floor, not its total cost. Every other path forces the
 /// row to the host inside the window and is fully accounted.
 ///
-/// It is also a floor in a second, path-independent way: the host path forfeits
-/// the greedy path's software pipelining, and that loss lands in `step` rather
-/// than in `sample`. A decode-TPS comparison against a greedy control is the
-/// end-to-end figure; this is the component that is attributable to host work.
+/// It also omits, on every path, the software pipelining the host path forfeits:
+/// that loss lands in `step` rather than in `sample`. A decode-TPS comparison
+/// against a greedy control is the end-to-end figure; this is the component
+/// attributable to host work.
+///
+/// Neither omission makes the ratio a bound, because a contended host pushes it
+/// the other way: `sample` is pure host CPU while `sync` is dominated by GPU
+/// execution, so CPU steal stretches the numerator alone. Read it on a quiet
+/// host, or read it knowing both errors are present with opposite signs.
 fn emit_sampler_profile(
     ctx: &DecodeCtx<'_>,
     host_steps: u32,

--- a/crates/rmlx-models/src/decode_loop.rs
+++ b/crates/rmlx-models/src/decode_loop.rs
@@ -3,12 +3,26 @@
 //! Shared, model-agnostic pipelined decode loop.
 //!
 //! One copy of the autoregressive decode pipeline every pipelined arch (qwen3,
-//! qwen3_5_moe, gemma4, gemma3, qwen2) previously hand-copied. The pipeline
-//! ordering — `choose_token` → `async_eval(next_y)` → drain the *previous*
-//! step's pending token via `to_bytes()` → `try_clone`/feed — overlaps host
-//! sampling/penalty work with the in-flight GPU forward. Reordering (draining
-//! before dispatching the next forward) serializes CPU/GPU and is a measurable
-//! decode regression; do not.
+//! qwen3_5_moe, gemma4, gemma3, qwen2) previously hand-copied.
+//!
+//! # Two selection paths, and only one of them pipelines
+//!
+//! **Greedy** (`temperature == 0`, no penalties, no constraint mask, no
+//! logprobs). `choose_token` returns a *lazy* GPU argmax, so the ordering
+//! `choose_token` → `async_eval(next_y)` → drain the **previous** step's pending
+//! token via `to_bytes()` → `try_clone`/feed leaves the GPU running this step
+//! while the host waits on the last one and builds the next graph. Reordering
+//! (draining before dispatching the next forward) serializes CPU and GPU and is
+//! a measurable decode regression; do not.
+//!
+//! **Host selection** (anything else). The chosen token is a function of the
+//! logits row, so the row has to be on the host before the next forward can be
+//! dispatched at all — there is nothing to overlap, and the loop runs strictly
+//! serial: wait for the forward, read the row back, pick a token, dispatch the
+//! next forward. That costs both the host work and the overlap the greedy path
+//! gets for free, which is why the `sampler_profile` event reports the host work
+//! as a *lower bound* on the difference and the honest end-to-end figure is a
+//! decode-TPS comparison against a greedy control. See `docs/SAMPLING.md`.
 //!
 //! The only per-arch hole is `forward_step` (an `impl FnMut`, monomorphized —
 //! never a `Box<dyn>` on the per-token hot path). Prompt-cache policy, cache

--- a/crates/rmlx-models/src/decode_loop.rs
+++ b/crates/rmlx-models/src/decode_loop.rs
@@ -458,10 +458,14 @@ pub(crate) fn pipelined_decode(
         // computed above; the pre-drain may have called `constraint.advance()`,
         // which can flip `wants_mask`, so recomputing here would diverge.
         // Timed only on the host-selection path; a greedy step takes no clock
-        // readings it would not have taken before.
+        // readings it would not have taken before. The window spans every
+        // host-selection consumer of the logits row, not just `choose_token`:
+        // logprob capture performs its own full readback plus a log-softmax and a
+        // top-k over the whole vocabulary, and leaving it outside would report a
+        // near-zero cost for the one path whose selection is free (a lazy GPU
+        // argmax) and whose readback is the entire expense.
         let sample_t0 = drain_now.then(Instant::now);
         let next_y = choose_token(ctx, &logits_flat, mask_active)?;
-        let sample_dt = sample_t0.map_or(0, |t| t.elapsed().as_nanos());
         let _ = next_y.async_eval();
         // capture this step's logprobs from `logits_flat` + the chosen token.
         // Stashed in `pending_logprobs`; emitted with the matching ProbeStep next
@@ -469,6 +473,7 @@ pub(crate) fn pipelined_decode(
         if lp_k > 0 {
             pending_logprobs = capture_logprobs(&logits_flat, &next_y, lp_k);
         }
+        let sample_dt = sample_t0.map_or(0, |t| t.elapsed().as_nanos());
         let fwd_dt = fwd_t0.elapsed().as_nanos();
 
         // The actual GPU sync materializes here on the *previous* step's pending
@@ -609,6 +614,24 @@ pub(crate) fn pipelined_decode(
 /// forward. `sample_share_pct` is that cost as a fraction of the steps that
 /// actually paid it, not of every step in the run, so a request that engages a
 /// constraint engine part-way through is not diluted by its greedy prefix.
+///
+/// # What `sample` does and does not include
+///
+/// It covers every host-side consumer of the logits row — the readback, the
+/// mask fill, penalties, softmax, the filters, the draw, and logprob capture.
+///
+/// It does **not** cover GPU work that a selection path merely *schedules*. The
+/// constraint-mask-only path (`temperature == 0`, no penalties, no logprobs) is
+/// the one case that matters: `apply_mask_argmax` returns a lazy graph, so only
+/// its host-side bias fill is timed here and the GPU add + argmax execute at the
+/// next step's `eval`, where they are billed to `sync`. That path's figure is
+/// therefore a host-work floor, not its total cost. Every other path forces the
+/// row to the host inside the window and is fully accounted.
+///
+/// It is also a floor in a second, path-independent way: the host path forfeits
+/// the greedy path's software pipelining, and that loss lands in `step` rather
+/// than in `sample`. A decode-TPS comparison against a greedy control is the
+/// end-to-end figure; this is the component that is attributable to host work.
 fn emit_sampler_profile(
     ctx: &DecodeCtx<'_>,
     host_steps: u32,

--- a/crates/rmlx-models/src/decode_loop.rs
+++ b/crates/rmlx-models/src/decode_loop.rs
@@ -311,6 +311,17 @@ pub(crate) fn pipelined_decode(
     let device = ctx.device;
     let vocab = ctx.vocab;
 
+    // Host-selection accounting. Only steps that read the logits row to the host
+    // (constraint mask, temperature, penalties, logprobs) contribute; a pure
+    // greedy run leaves `host_steps` at 0 and emits nothing. `sync` is the wait
+    // for the forward that must finish before any host work can start — GPU
+    // latency, not sampler cost — and is timed apart from `sample` so the two are
+    // never conflated.
+    let mut host_steps: u32 = 0;
+    let mut sync_total_ns: u128 = 0;
+    let mut sample_total_ns: u128 = 0;
+    let mut host_step_total_ns: u128 = 0;
+
     let _decode_span = info_span!("decode", n_tokens = ctx.n_tokens).entered();
 
     let mut y: Array = {
@@ -378,10 +389,23 @@ pub(crate) fn pipelined_decode(
         // logprob capture needs host logits per step → also drains here.
         let lp_k = ctx.sampler_cfg.top_logprobs_k as usize;
         let drain_now = mask_active || sampling_active || penalties_active || lp_k > 0;
-        // Force eager eval of logits on the masked path to prevent stale GPU data.
-        if mask_active {
+        // Every host-selection path needs the logits row materialized, so the
+        // forward has to have finished before any of them can start. Wait for it
+        // here, once: the masked path needs the eager eval anyway (otherwise the
+        // mask composes against stale GPU data), and the sampling / penalty /
+        // logprob paths would each block on the same graph a few lines later,
+        // inside the readback. Hoisting it keeps the wait out of the sampler
+        // timer, which would otherwise report forward latency as sampler cost.
+        // MLX evaluates one stream in order, so materializing this step's logits
+        // also completes the previous step's pending token — the total wait is
+        // unchanged, only its attribution.
+        let sync_dt = if drain_now {
+            let sync_t0 = Instant::now();
             logits_flat.eval()?;
-        }
+            sync_t0.elapsed().as_nanos()
+        } else {
+            0
+        };
         let pre_drain_eos = if drain_now {
             if let Some(p) = pending.take() {
                 let top_bytes = p.to_bytes()?;
@@ -419,7 +443,11 @@ pub(crate) fn pipelined_decode(
         // Reuse the SAME pre-advance `mask_active` the eval() gate and pre-drain
         // computed above; the pre-drain may have called `constraint.advance()`,
         // which can flip `wants_mask`, so recomputing here would diverge.
+        // Timed only on the host-selection path; a greedy step takes no clock
+        // readings it would not have taken before.
+        let sample_t0 = drain_now.then(Instant::now);
         let next_y = choose_token(ctx, &logits_flat, mask_active)?;
+        let sample_dt = sample_t0.map_or(0, |t| t.elapsed().as_nanos());
         let _ = next_y.async_eval();
         // capture this step's logprobs from `logits_flat` + the chosen token.
         // Stashed in `pending_logprobs`; emitted with the matching ProbeStep next
@@ -476,10 +504,17 @@ pub(crate) fn pipelined_decode(
         }
         let eval_dt = eval_t0.elapsed().as_nanos();
 
+        let step_dt = step_t0.elapsed().as_nanos();
         stats.forward_total_ns += fwd_dt;
         stats.eval_total_ns += eval_dt;
-        stats.step_total_ns += step_t0.elapsed().as_nanos();
+        stats.step_total_ns += step_dt;
         stats.decode_steps += 1;
+        if drain_now {
+            host_steps += 1;
+            sync_total_ns += sync_dt;
+            sample_total_ns += sample_dt;
+            host_step_total_ns += step_dt;
+        }
 
         if emitted_eos {
             early_stop = true;
@@ -537,10 +572,64 @@ pub(crate) fn pipelined_decode(
         }
     }
 
+    emit_sampler_profile(
+        ctx,
+        host_steps,
+        sync_total_ns,
+        sample_total_ns,
+        host_step_total_ns,
+    );
+
     // Final act of the decode phase: mint the post-decode witness. The caller
     // needs it to record `kv_cache_bytes`, so the metric can only be sampled
     // here — after the decode-time ring is resident.
     Ok((stats, PostDecode::seal()))
+}
+
+/// Emit the `sampler_profile` event for the host-selection steps of one decode
+/// call. Silent when no step took that path, so a greedy run — the shape
+/// `scripts/perf_canary.sh` measures — produces no event at all.
+///
+/// The event exists because the host-selection cost is otherwise unobservable:
+/// it is charged to whichever step it ran in and never separated from the
+/// forward. `sample_share_pct` is that cost as a fraction of the steps that
+/// actually paid it, not of every step in the run, so a request that engages a
+/// constraint engine part-way through is not diluted by its greedy prefix.
+fn emit_sampler_profile(
+    ctx: &DecodeCtx<'_>,
+    host_steps: u32,
+    sync_total_ns: u128,
+    sample_total_ns: u128,
+    host_step_total_ns: u128,
+) {
+    if host_steps == 0 {
+        return;
+    }
+    let n = f64::from(host_steps);
+    let sync_ms = (sync_total_ns as f64) / 1.0e6;
+    let sample_ms = (sample_total_ns as f64) / 1.0e6;
+    let step_ms = (host_step_total_ns as f64) / 1.0e6;
+    tracing::info!(
+        target: "sampler_profile",
+        arch = ctx.arch,
+        vocab = ctx.vocab,
+        n_steps = host_steps,
+        temperature = ctx.sampler_cfg.temperature,
+        top_p = ctx.sampler_cfg.top_p,
+        top_k = ctx.sampler_cfg.top_k,
+        min_p = ctx.sampler_cfg.min_p,
+        rep_penalty = ctx.penalty_cfg.rep_penalty,
+        top_logprobs_k = ctx.sampler_cfg.top_logprobs_k,
+        sync_per_step_ms = sync_ms / n,
+        sample_per_step_ms = sample_ms / n,
+        step_per_step_ms = step_ms / n,
+        sample_share_pct = if step_ms > 0.0 {
+            100.0 * sample_ms / step_ms
+        } else {
+            0.0
+        },
+        "sampler_profile"
+    );
 }
 
 /// Resolve the per-token `piece`: `tokenizer.id_to_token` when `resolve_pieces`,

--- a/crates/rmlx-models/src/decode_loop_tests.rs
+++ b/crates/rmlx-models/src/decode_loop_tests.rs
@@ -615,6 +615,74 @@ fn pipelined_decode_lp_k_captures() {
     );
 }
 
+/// The host-selection paths (temperature, penalties) hoist the logits eval out
+/// of the sampler so the GPU wait can be timed apart from the host work. That
+/// rearranges *when* the graph is materialised, which is exactly the kind of
+/// change that produces a stale or half-evaluated read — so pin the emitted
+/// stream. Both rows are sharply peaked, so at temperature 0.7 the softmax is
+/// one-hot to within f32 and the sampled id is the argmax regardless of the RNG
+/// draw; the assertion is on token identity, not on a distribution.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn pipelined_decode_host_path_emits_the_argmax_stream() {
+    let _g = mlx_guard();
+    let rows = vec![vec![0.0, 40.0, 0.0, 0.0], vec![0.0, 0.0, 0.0, 40.0]];
+    let eos = [3u32];
+
+    let ids_for = |cfg: &SamplerConfig, pen: &PenaltyConfig| -> Vec<u32> {
+        let tk = tiny_tokenizer(4);
+        let calls = Cell::new(0);
+        let mut rng = Pcg32::new(1);
+        let mut hist: Vec<u32> = vec![0];
+        let mut steps: Vec<ProbeStep> = vec![ProbeStep {
+            token_id: 0,
+            piece: "t0".to_string().into_boxed_str(),
+            max_abs_logit: 0.0,
+            nan_count: 0,
+            logprobs: None,
+        }];
+        let mut step_fn = |_: &ProbeStep| None;
+        let mut c = ctx(
+            &tk,
+            4,
+            32,
+            &eos,
+            &mut step_fn,
+            None,
+            cfg,
+            &mut rng,
+            pen,
+            &mut hist,
+            true,
+        );
+        pipelined_decode(&mut c, 0, &mut steps, scripted(&rows, &calls)).unwrap();
+        steps.iter().map(|s| s.token_id).collect()
+    };
+
+    let greedy = ids_for(&greedy_cfg(), &no_penalties());
+    assert_eq!(greedy, vec![0, 1, 3], "GPU argmax path");
+
+    let sampled = ids_for(
+        &SamplerConfig {
+            temperature: 0.7,
+            ..greedy_cfg()
+        },
+        &no_penalties(),
+    );
+    assert_eq!(greedy, sampled, "temperature path over a one-hot softmax");
+
+    // A repetition penalty at temperature 0 takes the host argmax path. The
+    // window holds ids 0 and 1, and 40.0 / 1.1 still dominates the zeros.
+    let penalised = ids_for(
+        &greedy_cfg(),
+        &PenaltyConfig {
+            rep_penalty: 1.1,
+            ..PenaltyConfig::default()
+        },
+    );
+    assert_eq!(greedy, penalised, "host argmax-with-penalties path");
+}
+
 /// A scripted forward that serves `rows` and then fails on call `fail_at`
 /// (0-based over calls into the loop), simulating a decode step that dies
 /// mid-stream — a store refusing an append, a Metal dispatch fault, etc.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -571,33 +571,53 @@ agree; see the drift refusal below.
 | `--allow-truncate` | bool flag | off | Opt into truncating an over-cap prompt on `--device gpu`. |
 | `--json` | bool flag | off | Emit one JSON object (per-metric spreads plus every individual run) instead of the table. |
 | `--prompts-dir` | path | (cwd walk) | Root to search for `longctx_<N>k.json`. Env: `RMLX_PROMPTS_DIR`. |
-| `--temperature` | f32 | `0.0` | `0` is greedy (GPU argmax, no logits row read back). Positive routes the cell through the host sampler. |
-| `--top-p` | f32 | `1.0` | Nucleus threshold, applied only when `--temperature` is positive. `1.0` disables it. |
+| `--temperature` | f32 | `0.0` | `0` is greedy (GPU argmax, no logits row read back). Positive routes the cell through the host sampler. Bounded to `[0, 2]`, the same range the HTTP surface and `--default-temperature` enforce. |
+| `--top-p` | f32 | `1.0` | Nucleus threshold. Requires `--temperature > 0`; `1.0` disables it. |
+| `--top-k` | u32 | `0` | Top-k cutoff. Requires `--temperature > 0`; `0` disables it. |
 | `--repetition-penalty` | f32 | `1.0` | Sign-aware multiplicative penalty over the trailing 20-token window. `1.0` is the exact no-op. |
 
 #### Benching the host sampler
 
-Every other shape this binary measures is greedy, so without these three flags
+Every other shape this binary measures is greedy, so without these four flags
 the sampling / penalty path is invisible to the bench harness — and to
-`scripts/perf_canary.sh`, which is greedy-only. It is not free: see
-`docs/SAMPLING.md` § *Cost of the host path* for the measured figures.
+`scripts/perf_canary.sh`, which is greedy-only. That path is what ordinary
+served traffic takes: a request omitting sampling fields resolves temperature
+from `generation_config.json` or a hard-coded `1.0`, and several snapshots ship
+`top_p` and `top_k` with it. It is not free: see `docs/SAMPLING.md` § *Cost of
+the host path*.
 
 ```bash
+# the issue's two named knobs
 rmlx bench --model /path/to/snapshot --prompt-tokens 4096 --max-tokens 100 \
   --temperature 0.7 --repetition-penalty 1.1
+
+# what a served request that omits sampling fields actually gets, for a
+# snapshot whose generation_config.json carries top_p 0.95 / top_k 64
+rmlx bench --model /path/to/snapshot --prompt-tokens 4096 --max-tokens 100 \
+  --temperature 1.0 --top-p 0.95 --top-k 64
 ```
 
 The seed is the fixed default and the RNG is fresh per run, so a sampled cell
 still produces one token stream across every run — the digest check applies
 unchanged. A cell that is not greedy is named on its own line in the table and
-under `sampling` in the JSON, so it cannot be read as a greedy one. Values
-outside their valid ranges (a NaN or negative temperature, a `--top-p` outside
-`(0, 1]`, a non-positive `--repetition-penalty`) are refused before the model
-loads rather than silently no-opping into a greedy run wearing a sampled label.
+under `sampling` in the JSON, so it cannot be read as a greedy one.
 
-Per-step host-sampler timings for the run land in the `sampler_profile` tracing
-event (`sync_per_step_ms`, `sample_per_step_ms`, `step_per_step_ms`,
-`sample_share_pct`), emitted only when a step took the host path.
+Refused before the model loads, rather than silently no-opping into a greedy run
+wearing a sampled label:
+
+- a NaN or negative `--temperature`, or one above 2;
+- a `--top-p` outside `(0, 1]`;
+- a non-positive `--repetition-penalty`;
+- `--top-p` or `--top-k` at `--temperature 0`. Both filter the post-softmax
+  distribution, which the greedy path never builds, so the cell would be
+  recorded carrying a setting it did not exercise.
+
+Per-step host-sampler timings land in the `sampler_profile` tracing event
+(`sync_per_step_ms`, `sample_per_step_ms`, `step_per_step_ms`,
+`sample_share_pct`), emitted only when a step took the host path — **once per
+generation**, so a `--warmup 1 --runs 3` cell writes four events. Take the
+median of the last three; the first is the warmup's. The event is not folded
+into the summary table or the JSON.
 
 #### Refusals
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -571,6 +571,33 @@ agree; see the drift refusal below.
 | `--allow-truncate` | bool flag | off | Opt into truncating an over-cap prompt on `--device gpu`. |
 | `--json` | bool flag | off | Emit one JSON object (per-metric spreads plus every individual run) instead of the table. |
 | `--prompts-dir` | path | (cwd walk) | Root to search for `longctx_<N>k.json`. Env: `RMLX_PROMPTS_DIR`. |
+| `--temperature` | f32 | `0.0` | `0` is greedy (GPU argmax, no logits row read back). Positive routes the cell through the host sampler. |
+| `--top-p` | f32 | `1.0` | Nucleus threshold, applied only when `--temperature` is positive. `1.0` disables it. |
+| `--repetition-penalty` | f32 | `1.0` | Sign-aware multiplicative penalty over the trailing 20-token window. `1.0` is the exact no-op. |
+
+#### Benching the host sampler
+
+Every other shape this binary measures is greedy, so without these three flags
+the sampling / penalty path is invisible to the bench harness — and to
+`scripts/perf_canary.sh`, which is greedy-only. It is not free: see
+`docs/SAMPLING.md` § *Cost of the host path* for the measured figures.
+
+```bash
+rmlx bench --model /path/to/snapshot --prompt-tokens 4096 --max-tokens 100 \
+  --temperature 0.7 --repetition-penalty 1.1
+```
+
+The seed is the fixed default and the RNG is fresh per run, so a sampled cell
+still produces one token stream across every run — the digest check applies
+unchanged. A cell that is not greedy is named on its own line in the table and
+under `sampling` in the JSON, so it cannot be read as a greedy one. Values
+outside their valid ranges (a NaN or negative temperature, a `--top-p` outside
+`(0, 1]`, a non-positive `--repetition-penalty`) are refused before the model
+loads rather than silently no-opping into a greedy run wearing a sampled label.
+
+Per-step host-sampler timings for the run land in the `sampler_profile` tracing
+event (`sync_per_step_ms`, `sample_per_step_ms`, `step_per_step_ms`,
+`sample_share_pct`), emitted only when a step took the host path.
 
 #### Refusals
 
@@ -603,9 +630,11 @@ is a hard error naming the cause, never a silent zero or a plausible default:
   run hit a stall rather than whether the cell settled. Its spread is still
   printed.
 - **Runs that decoded different tokens.** Every run in a cell feeds the same
-  prompt to the same model at temperature 0, so every run must emit a
-  byte-identical token stream. `bench` digests each run's token ids (FNV-1a-64,
-  warmup runs included) and aborts when they disagree. This is not only a
+  prompt to the same model with the same sampler settings and a fresh RNG at the
+  fixed default seed, so every run must emit a byte-identical token stream —
+  including a sampled cell, where the draw is reproducible. `bench` digests each
+  run's token ids (FNV-1a-64, warmup runs included) and aborts when they
+  disagree. This is not only a
   reproducibility check: a KV cache that silently stops being written decodes
   *faster* while producing wrong tokens, so a timing-only instrument is biased
   toward accepting exactly that defect.

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -501,6 +501,15 @@ metrics DB.
 - Warmup 1 discarded, 3 measured runs; median decode_tps + sample stddev reported in CSV
 - DB record: one `rmlx baseline --record` call per model after the measured runs
 
+**The canary decodes greedily, and that is a scope limit, not a detail.**
+`rmlx baseline` has no sampler knobs, so every canary and A/B number in this
+file is the GPU-argmax path. The host-selection path — temperature, penalties,
+constraint masks, logprobs — reads the whole logits row back per token and costs
+9–14 % of decode throughput before top-p and a quarter of it with, on all three
+canary architectures. No canary run can observe that; use `rmlx bench
+--temperature / --top-p / --repetition-penalty` and the `sampler_profile` event.
+See § *Host-sampler cost* below and `docs/SAMPLING.md`.
+
 **Per-model kv_quant resolved by arch resolver (auto):**
 - Bonsai (Qwen3ForCausalLM, 2bit): `mixed_k8g64_v4g64`
 - Gemma4-e4b (mxfp8): `k8v8`
@@ -527,6 +536,53 @@ decode_tps (the bf16 q/k/v compute is cheaper than the prior f32 path); Gemma4
 and Qwen3.6 (separate arch files) are unchanged. On the `none` path the gain
 widens with context as KV bandwidth dominates: Bonsai `none` decode_tps
 ~101→~135 at 4 k, ~48→~83 at 16 k, ~19→~38 at 64 k.
+
+## Host-sampler cost (2026-08-16)
+
+First measurement of the sampling / penalty / mask / logprob path, which every
+other table in this file excludes.
+
+**Binary**: `target/release-perf/rmlx`.
+**Harness**: `rmlx bench --prompt-tokens 4096 --max-tokens 100 --max-ctx 8192
+--runs 3 --warmup 1`, `kv_quant=auto`, scratch `RMLX_HOME`, `--metrics off`.
+**Hardware**: M5 Max. **Host was NOT quiescent** — a VM held ~1.1 cores for the
+whole session, and `scripts/perf_ab.sh` refused to run on it (exit 125). These
+are single-arm medians on a contended host, not an interleaved A/B: read the
+column separations, not the third decimal.
+
+`share%` is `sampler_profile{sample_share_pct}` — host-side sampler wall-clock
+over step wall-clock, counting only steps that took the host path. It is a
+**lower bound** on what a GPU-side sampler would recover, because the host path
+also forfeits the greedy path's software pipelining (it cannot dispatch the next
+forward until the row is back and a token is chosen). The decode-TPS column is
+the end-to-end figure and is larger in every cell.
+
+| model | vocab | cell | sample ms/step | share% | decode_tps | vs greedy |
+|---|---:|---|---:|---:|---:|---:|
+| mlx-community__gemma-4-e2b-it-mxfp8 | 262144 | greedy | — | — | 129.22 | — |
+| mlx-community__gemma-4-e2b-it-mxfp8 | 262144 | rep-penalty 1.1 | 0.228 | 2.75 | 122.88 | −4.9 % |
+| mlx-community__gemma-4-e2b-it-mxfp8 | 262144 | temp 0.7 | 0.880 | 9.80 | 111.03 | −14.1 % |
+| mlx-community__gemma-4-e2b-it-mxfp8 | 262144 | temp 0.7 + rep 1.1 | 0.874 | 9.88 | 113.86 | −11.9 % |
+| mlx-community__gemma-4-e2b-it-mxfp8 | 262144 | temp 0.7 + top-p 0.95 | 2.525 | 22.89 | 90.62 | −29.9 % |
+| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 151669 | greedy | — | — | 134.50 | — |
+| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 151669 | rep-penalty 1.1 | 0.141 | 1.72 | 117.81 | −12.4 % |
+| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 151669 | temp 0.7 | 0.487 | 5.82 | 116.36 | −13.5 % |
+| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 151669 | temp 0.7 + rep 1.1 | 0.491 | 5.87 | 115.38 | −14.2 % |
+| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 151669 | temp 0.7 + top-p 0.95 | 1.665 | 17.15 | 99.49 | −26.0 % |
+| mlx-community__Qwen3.6-35B-A3B-8bit | 248320 | greedy | — | — | 98.61 | — |
+| mlx-community__Qwen3.6-35B-A3B-8bit | 248320 | rep-penalty 1.1 | 0.218 | 2.04 | 93.42 | −5.3 % |
+| mlx-community__Qwen3.6-35B-A3B-8bit | 248320 | temp 0.7 | 0.790 | 7.09 | 89.50 | −9.2 % |
+| mlx-community__Qwen3.6-35B-A3B-8bit | 248320 | temp 0.7 + top-p 0.95 | 2.847 | 20.67 | 72.59 | −26.4 % |
+
+The rep-penalty cell was re-measured at `--runs 4 --warmup 2` on Qwen3.6 after
+the 3-run cell was refused for drift; every other cell settled at the default
+shape.
+
+Reading it: temperature alone is 5.8–9.8 % of step time, a repetition penalty
+alone is 1.7–2.8 % (its arithmetic touches ≤20 ids — the transfer and the host
+argmax are the whole cost), and **top-p triples the host work** to 17–23 %
+because it sorts the entire vocabulary. Within a stage the cost tracks vocabulary
+size: 0.880 ms/step at 262144 against 0.487 ms/step at 151669, temp 0.7.
 
 ## K8VTurbo3 promotion bench (2026-05-30)
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -503,12 +503,20 @@ metrics DB.
 
 **The canary decodes greedily, and that is a scope limit, not a detail.**
 `rmlx baseline` has no sampler knobs, so every canary and A/B number in this
-file is the GPU-argmax path. The host-selection path — temperature, penalties,
-constraint masks, logprobs — reads the whole logits row back per token and costs
-9–14 % of decode throughput before top-p and a quarter of it with, on all three
-canary architectures. No canary run can observe that; use `rmlx bench
---temperature / --top-p / --repetition-penalty` and the `sampler_profile` event.
-See § *Host-sampler cost* below and `docs/SAMPLING.md`.
+file is the GPU-argmax path. It is also *not* the served default: a
+`/v1/chat/completions` request that omits sampling fields resolves temperature
+from `generation_config.json` or a hard-coded `1.0`, and several snapshots ship
+`top_p` and `top_k` alongside it, so ordinary served traffic takes the
+host-selection path on every token. Measured at 4k, that path costs 9–14 % of
+decode throughput at temperature alone, 5–12 % at a repetition penalty alone,
+and about a quarter of it once a nucleus filter is on. No canary run can observe
+any of it; use `rmlx bench --temperature / --top-p / --top-k /
+--repetition-penalty` and the `sampler_profile` event. See § *Host-sampler cost*
+below and `docs/SAMPLING.md`.
+
+Those figures are from gemma-4-**e2b**, Ternary-Bonsai-8B and Qwen3.6-35B-A3B.
+Only two of the three are canary models — the canary's Gemma4 is **e4b**, and no
+sampled cell was taken on it.
 
 **Per-model kv_quant resolved by arch resolver (auto):**
 - Bonsai (Qwen3ForCausalLM, 2bit): `mixed_k8g64_v4g64`
@@ -537,52 +545,73 @@ and Qwen3.6 (separate arch files) are unchanged. On the `none` path the gain
 widens with context as KV bandwidth dominates: Bonsai `none` decode_tps
 ~101→~135 at 4 k, ~48→~83 at 16 k, ~19→~38 at 64 k.
 
-## Host-sampler cost (2026-08-16)
+## Host-sampler cost — PROVISIONAL, NOT AN ANCHOR (2026-08-16)
 
 First measurement of the sampling / penalty / mask / logprob path, which every
-other table in this file excludes.
+other table in this file excludes. **Nothing here is an anchor**: it is not
+interleaved, it was taken on a host the A/B harness refused, and no regression
+gate should diff against it. The interpretation, the full per-knob tables and
+the caveats live in `docs/SAMPLING.md` § *Cost of the host path*; this section
+records the provenance and the verdict.
 
-**Binary**: `target/release-perf/rmlx`.
-**Harness**: `rmlx bench --prompt-tokens 4096 --max-tokens 100 --max-ctx 8192
---runs 3 --warmup 1`, `kv_quant=auto`, scratch `RMLX_HOME`, `--metrics off`.
-**Hardware**: M5 Max. **Host was NOT quiescent** — a VM held ~1.1 cores for the
-whole session, and `scripts/perf_ab.sh` refused to run on it (exit 125). These
-are single-arm medians on a contended host, not an interleaved A/B: read the
-column separations, not the third decimal.
+**Why it is provisional.** `scripts/perf_ab.sh` refused this host with exit 125
+— a VM at 114 % of a core, later joined by an npm process at 131 %. The
+threshold was not raised and `--allow-busy-host` was not passed. What follows
+are single-arm, non-interleaved medians. The dataset's own noise floor is about
+2.5 percentage points: at 4k, gemma-4-e2b's `temp 0.7 + rep 1.1` cell measured
+*faster* (113.86 tok/s) than its `temp 0.7` cell (111.03) despite doing strictly
+more work. No throughput delta below that is reported as an effect, and the
+per-cell throughput deltas are therefore recorded in `docs/SAMPLING.md` rather
+than here.
+
+**Binary**: `target/release-perf/rmlx`. **Harness**: `rmlx bench --max-tokens
+100`, scratch `RMLX_HOME`, `--metrics off`; 1 warmup + 3 measured runs at 4k, 1
++ 2 at 16k/64k. **Hardware**: M5 Max.
 
 `share%` is `sampler_profile{sample_share_pct}` — host-side sampler wall-clock
-over step wall-clock, counting only steps that took the host path. It is a
-**lower bound** on what a GPU-side sampler would recover, because the host path
-also forfeits the greedy path's software pipelining (it cannot dispatch the next
-forward until the row is back and a token is chosen). The decode-TPS column is
-the end-to-end figure and is larger in every cell.
+over step wall-clock, over the steps that took the host path — as the **median
+over the measured generations**, the warmup's event discarded. It is a
+within-step ratio, so it survives a cell whose `decode_tps` the harness refused
+to median, and two cells below are in exactly that state.
 
-| model | vocab | cell | sample ms/step | share% | decode_tps | vs greedy |
-|---|---:|---|---:|---:|---:|---:|
-| mlx-community__gemma-4-e2b-it-mxfp8 | 262144 | greedy | — | — | 129.22 | — |
-| mlx-community__gemma-4-e2b-it-mxfp8 | 262144 | rep-penalty 1.1 | 0.228 | 2.75 | 122.88 | −4.9 % |
-| mlx-community__gemma-4-e2b-it-mxfp8 | 262144 | temp 0.7 | 0.880 | 9.80 | 111.03 | −14.1 % |
-| mlx-community__gemma-4-e2b-it-mxfp8 | 262144 | temp 0.7 + rep 1.1 | 0.874 | 9.88 | 113.86 | −11.9 % |
-| mlx-community__gemma-4-e2b-it-mxfp8 | 262144 | temp 0.7 + top-p 0.95 | 2.525 | 22.89 | 90.62 | −29.9 % |
-| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 151669 | greedy | — | — | 134.50 | — |
-| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 151669 | rep-penalty 1.1 | 0.141 | 1.72 | 117.81 | −12.4 % |
-| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 151669 | temp 0.7 | 0.487 | 5.82 | 116.36 | −13.5 % |
-| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 151669 | temp 0.7 + rep 1.1 | 0.491 | 5.87 | 115.38 | −14.2 % |
-| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 151669 | temp 0.7 + top-p 0.95 | 1.665 | 17.15 | 99.49 | −26.0 % |
-| mlx-community__Qwen3.6-35B-A3B-8bit | 248320 | greedy | — | — | 98.61 | — |
-| mlx-community__Qwen3.6-35B-A3B-8bit | 248320 | rep-penalty 1.1 | 0.218 | 2.04 | 93.42 | −5.3 % |
-| mlx-community__Qwen3.6-35B-A3B-8bit | 248320 | temp 0.7 | 0.790 | 7.09 | 89.50 | −9.2 % |
-| mlx-community__Qwen3.6-35B-A3B-8bit | 248320 | temp 0.7 + top-p 0.95 | 2.847 | 20.67 | 72.59 | −26.4 % |
+`sample` is `O(vocab)` and context-invariant while `step` grows with context, so
+the share is a falling curve and a single short-context point is its maximum.
+Per-context, `temperature 0.7` / `repetition-penalty 1.1`:
 
-The rep-penalty cell was re-measured at `--runs 4 --warmup 2` on Qwen3.6 after
-the 3-run cell was refused for drift; every other cell settled at the default
-shape.
+| model | codec | 4k | 16k | 64k |
+|---|---|---|---|---|
+| mlx-community__gemma-4-e2b-it-mxfp8 | auto | 10.00 / 2.76 | 9.29 / 2.63 | 8.30 / 2.24 |
+| mlx-community__Qwen3.6-35B-A3B-8bit | auto | 6.98 / 2.04 | 6.56 / 1.94 | 4.58 / 1.41 |
+| mlx-community__Qwen3.6-35B-A3B-8bit | none | — | 6.68 / 2.12 | 5.25 / 1.47 |
+| prism-ml__Ternary-Bonsai-8B-mlx-2bit | auto | 5.80 / 1.78 | 0.65 / 0.19 | 0.18 / 0.06 |
+| prism-ml__Ternary-Bonsai-8B-mlx-2bit | none | — | 4.54 / 1.42 | 2.10 / 0.60 |
 
-Reading it: temperature alone is 5.8–9.8 % of step time, a repetition penalty
-alone is 1.7–2.8 % (its arithmetic touches ≤20 ids — the transfer and the host
-argmax are the whole cost), and **top-p triples the host work** to 17–23 %
-because it sorts the entire vocabulary. Within a stage the cost tracks vocabulary
-size: 0.880 ms/step at 262144 against 0.487 ms/step at 151669, temp 0.7.
+**The two Bonsai `auto` long-context rows are not usable.** That codec
+(`mixed_k8g64_v4g64`) decodes at 13.2 tok/s at 16k and 3.6 at 64k — 76 and
+282 ms per step against the ~12 and ~26 ms the `--kv-quant none` anchors above
+record, with `sync_per_step_ms` still at 2.8 ms, so the extra time is host work
+inside the forward. Their share is divided by a separate defect. That gap is
+itself worth a look; it is not this section's subject.
+
+**Verdict against the issue's kill criterion** (host share under 3 % for both
+temperature and repetition penalty): **not met.** It holds in exactly one of the
+nine legitimate (model, context, codec) cells — Ternary-Bonsai-8B at 64k on
+`none`, 2.10 / 0.60 — and fails everywhere else, including at 64k on both other
+architectures. Sliding-window attention barely dilutes it at all: gemma-4-e2b
+still pays 8.3 % at 64k because its step time hardly grows with context.
+
+**Correctness of the instrumenting change**, recorded here because it is the
+evidence a reviewer needs and a bench digest cannot supply it (that check
+compares runs of one binary inside one process):
+
+| binary | sha256 (head) | `sample_share_pct` in image | `bench --top-k` | gemma-4-e2b greedy digest | Ternary-Bonsai-8B greedy digest |
+|---|---|---|---|---|---|
+| `rmlx.main` (main) | `c51cafa64597f127` | absent | absent | `0xda06c1ec7c73fbb3` | `0xa14ed09c9440e9db` |
+| `rmlx.patch` (branch) | `2132dc9138630908` | present | present | `0xda06c1ec7c73fbb3` | `0xa14ed09c9440e9db` |
+
+Two separately built binaries, verified distinct by digest and by a symbol check
+in each direction, produce byte-identical greedy token streams on both required
+architectures at the 4k canary shape.
 
 ## K8VTurbo3 promotion bench (2026-05-30)
 

--- a/docs/SAMPLING.md
+++ b/docs/SAMPLING.md
@@ -20,6 +20,9 @@ scaling, nucleus and top-k filtering, and an inverse-CDF draw.
 Both paths return the same shape (`[1] I32`) so all downstream call sites
 (materialise via `to_bytes` → `i32::from_le_bytes`) are unchanged.
 
+The two paths are not equally fast, and the gap is not small — see
+[Cost of the host path](#cost-of-the-host-path) for the measured figures.
+
 ---
 
 ## Pipeline
@@ -257,6 +260,93 @@ at their identity values (`rep_penalty == 1.0`, `presence_penalty == 0.0`,
 `frequency_penalty == 0.0`, `logit_bias.is_empty()`). The decode loop checks
 this once per step; if false and temperature is also 0, the entire host path
 is skipped and no GPU-to-host transfer occurs.
+
+---
+
+## Cost of the host path
+
+The host path is not a cheap variant of the greedy one. It costs a
+`vocab`-sized GPU-to-host transfer plus `O(vocab)` host arithmetic per token,
+and — because the next forward cannot be dispatched until the row has been read
+back and a token chosen — it also gives up the software pipelining the greedy
+path gets for free. Greedy returns a *lazy* GPU argmax and dispatches the next
+step while the GPU is still busy; the host path runs strictly serial.
+
+### The instrument
+
+The shared decode loop emits a `sampler_profile` event once per generation,
+covering only the steps that took the host path. A purely greedy run emits
+nothing and takes no extra clock readings.
+
+| Field | Meaning |
+|---|---|
+| `sync_per_step_ms` | Wait for the forward before the row can be read. GPU latency, not sampler cost. |
+| `sample_per_step_ms` | Readback plus all host arithmetic — mask, penalties, softmax, filters, draw. |
+| `step_per_step_ms` | Whole step, host-path steps only. |
+| `sample_share_pct` | `sample / step`. |
+
+`sample_share_pct` is a **lower bound** on what a GPU-side sampler could
+recover: it counts the host work but not the lost pipelining. The end-to-end
+figure is a decode-TPS comparison against a greedy control at the same shape,
+which is larger in every cell measured.
+
+Drive the path from the bench harness with `rmlx bench --temperature`,
+`--top-p` and `--repetition-penalty`. `scripts/perf_canary.sh` is greedy-only
+and cannot observe this class at all.
+
+### Measured, 2026-08-16, M5 Max
+
+`release-perf`, `rmlx bench --prompt-tokens 4096 --max-tokens 100 --max-ctx
+8192`, `kv_quant=auto`, 1 warmup + 3 measured runs, median. Host was not
+quiescent (a VM held ~1.1 cores throughout), which inflates host-side work
+relative to GPU wait — so these shares are upper-ish estimates of the host
+component, and the decode-TPS deltas are the conservative end-to-end figure.
+
+| Model | vocab | cell | `sample` ms/step | `share%` | decode TPS vs greedy |
+|---|---:|---|---:|---:|---:|
+| gemma-4-e2b-it-mxfp8 | 262144 | greedy | — | — | 129.22 (control) |
+| gemma-4-e2b-it-mxfp8 | 262144 | `--repetition-penalty 1.1` | 0.228 | 2.75 | −4.9 % |
+| gemma-4-e2b-it-mxfp8 | 262144 | `--temperature 0.7` | 0.880 | 9.80 | −14.1 % |
+| gemma-4-e2b-it-mxfp8 | 262144 | `--temperature 0.7 --top-p 0.95` | 2.525 | 22.89 | −29.9 % |
+| Ternary-Bonsai-8B-2bit | 151669 | greedy | — | — | 134.50 (control) |
+| Ternary-Bonsai-8B-2bit | 151669 | `--repetition-penalty 1.1` | 0.141 | 1.72 | −12.4 % |
+| Ternary-Bonsai-8B-2bit | 151669 | `--temperature 0.7` | 0.487 | 5.82 | −13.5 % |
+| Ternary-Bonsai-8B-2bit | 151669 | `--temperature 0.7 --top-p 0.95` | 1.665 | 17.15 | −26.0 % |
+| Qwen3.6-35B-A3B-8bit | 248320 | greedy | — | — | 98.61 (control) |
+| Qwen3.6-35B-A3B-8bit | 248320 | `--repetition-penalty 1.1` | 0.218 | 2.04 | −5.3 % |
+| Qwen3.6-35B-A3B-8bit | 248320 | `--temperature 0.7` | 0.790 | 7.09 | −9.2 % |
+| Qwen3.6-35B-A3B-8bit | 248320 | `--temperature 0.7 --top-p 0.95` | 2.847 | 20.67 | −26.4 % |
+
+Reading it:
+
+- **Temperature alone** costs 5.8–9.8 % of step time in host work and 9–14 % of
+  decode throughput. The work is the transfer plus a full-vocabulary softmax.
+- **A repetition penalty alone** is the cheapest host cell — 1.7–2.8 % — because
+  the penalty itself touches at most 20 ids; the transfer and the host argmax
+  are the whole cost. Its throughput hit is still 5–12 %, which is the lost
+  pipelining, not the arithmetic.
+- **Top-p is the dominant term.** Adding `--top-p 0.95` roughly triples the host
+  work, to 17–23 % of step time and a quarter of throughput, because it sorts
+  the entire vocabulary. Anyone optimising this path should start here and
+  should not assume the other stages behave the same way.
+- The cost tracks vocabulary size within a stage, as expected: at temperature
+  0.7 the 262144-token vocabulary pays 0.880 ms/step against 0.487 ms/step for
+  the 151669-token one.
+
+### Host selection is not bit-identical to the GPU argmax
+
+At `--temperature 0.0001` the host categorical sampler is arithmetically an
+argmax (every non-maximal logit underflows to exactly zero), so its token stream
+should match the greedy GPU `argmax` stream. On gemma-4-e2b it does, for all 100
+tokens. On Ternary-Bonsai-8B it agrees through 32 tokens and diverges by 64 —
+and the `--repetition-penalty 1.1` cell, which reaches the same host argmax by a
+different route, produces the *same* divergent stream. So the two host paths
+agree with each other and disagree with the GPU reduction, which is the
+signature of an exact tie in the logits row being broken differently rather than
+of a faulty readback.
+
+This is a property of the sampler itself, not of any one caller, and it matters
+to anything that treats the two paths as interchangeable oracles.
 
 ### Inverse-CDF sample
 

--- a/docs/SAMPLING.md
+++ b/docs/SAMPLING.md
@@ -392,17 +392,25 @@ context-invariant cost either.
 
 **Bonsai's collapse is a codec artifact, not attention.** Its `auto` codec
 (`mixed_k8g64_v4g64`) decodes at 13.2 tok/s at 16k and 3.6 at 64k — step times
-of 76 and 282 ms against the ~12 and ~26 ms the `--kv-quant none` anchors
-recorded above. The extra time is host-side work inside the forward
+of 76 and 282 ms, against 11.1 and 24.7 ms for the same model and contexts on
+`--kv-quant none` below. The extra time is host-side work inside the forward
 (`sync_per_step_ms` stays at 2.8 ms while the step runs 282 ms), so the share
-there is being divided by a separate defect. The `none` arm below is the one to
-read for that model.
+there is being divided by a separate defect rather than by attention. The `none`
+arm is the one to read for that model. The codec gap itself is worth its own
+look and is not this section's subject.
+
+Bonsai's "served default" row is not the expensive shape the other two models
+show, for a mundane reason: it ships no `generation_config.json`, so its served
+default is the hard-coded `temperature 1.0` with no filters — the same cost as
+the temperature cell. The filters are what make gemma-4's and Qwen3.6's served
+defaults three to four times dearer.
 
 #### The same models on a healthy codec (`--kv-quant none`)
 
-Re-run with `--kv-quant none`, whose long-context decode rates (95.6 / 41.4
-tok/s for Bonsai at 16k / 64k) sit next to the anchors recorded in
-`docs/PERF_BASELINE.md`, so the denominator is legitimate attention cost:
+Re-run with `--kv-quant none`. Its greedy control decodes Bonsai at 95.6 tok/s
+at 16k and 41.4 at 64k, against the ~83 and ~38 recorded for that model and
+codec in `docs/PERF_BASELINE.md` — the same regime, on a busier host, rather
+than the 13.2 / 3.6 above. The denominator is legitimate attention cost:
 
 | model | ctx | cell | `sample` ms/step | `step` ms/step | `share%` | decode_tps |
 |---|---:|---|---:|---:|---:|---:|

--- a/docs/SAMPLING.md
+++ b/docs/SAMPLING.md
@@ -263,91 +263,6 @@ is skipped and no GPU-to-host transfer occurs.
 
 ---
 
-## Cost of the host path
-
-The host path is not a cheap variant of the greedy one. It costs a
-`vocab`-sized GPU-to-host transfer plus `O(vocab)` host arithmetic per token,
-and — because the next forward cannot be dispatched until the row has been read
-back and a token chosen — it also gives up the software pipelining the greedy
-path gets for free. Greedy returns a *lazy* GPU argmax and dispatches the next
-step while the GPU is still busy; the host path runs strictly serial.
-
-### The instrument
-
-The shared decode loop emits a `sampler_profile` event once per generation,
-covering only the steps that took the host path. A purely greedy run emits
-nothing and takes no extra clock readings.
-
-| Field | Meaning |
-|---|---|
-| `sync_per_step_ms` | Wait for the forward before the row can be read. GPU latency, not sampler cost. |
-| `sample_per_step_ms` | Readback plus all host arithmetic — mask, penalties, softmax, filters, draw. |
-| `step_per_step_ms` | Whole step, host-path steps only. |
-| `sample_share_pct` | `sample / step`. |
-
-`sample_share_pct` is a **lower bound** on what a GPU-side sampler could
-recover: it counts the host work but not the lost pipelining. The end-to-end
-figure is a decode-TPS comparison against a greedy control at the same shape,
-which is larger in every cell measured.
-
-Drive the path from the bench harness with `rmlx bench --temperature`,
-`--top-p` and `--repetition-penalty`. `scripts/perf_canary.sh` is greedy-only
-and cannot observe this class at all.
-
-### Measured, 2026-08-16, M5 Max
-
-`release-perf`, `rmlx bench --prompt-tokens 4096 --max-tokens 100 --max-ctx
-8192`, `kv_quant=auto`, 1 warmup + 3 measured runs, median. Host was not
-quiescent (a VM held ~1.1 cores throughout), which inflates host-side work
-relative to GPU wait — so these shares are upper-ish estimates of the host
-component, and the decode-TPS deltas are the conservative end-to-end figure.
-
-| Model | vocab | cell | `sample` ms/step | `share%` | decode TPS vs greedy |
-|---|---:|---|---:|---:|---:|
-| gemma-4-e2b-it-mxfp8 | 262144 | greedy | — | — | 129.22 (control) |
-| gemma-4-e2b-it-mxfp8 | 262144 | `--repetition-penalty 1.1` | 0.228 | 2.75 | −4.9 % |
-| gemma-4-e2b-it-mxfp8 | 262144 | `--temperature 0.7` | 0.880 | 9.80 | −14.1 % |
-| gemma-4-e2b-it-mxfp8 | 262144 | `--temperature 0.7 --top-p 0.95` | 2.525 | 22.89 | −29.9 % |
-| Ternary-Bonsai-8B-2bit | 151669 | greedy | — | — | 134.50 (control) |
-| Ternary-Bonsai-8B-2bit | 151669 | `--repetition-penalty 1.1` | 0.141 | 1.72 | −12.4 % |
-| Ternary-Bonsai-8B-2bit | 151669 | `--temperature 0.7` | 0.487 | 5.82 | −13.5 % |
-| Ternary-Bonsai-8B-2bit | 151669 | `--temperature 0.7 --top-p 0.95` | 1.665 | 17.15 | −26.0 % |
-| Qwen3.6-35B-A3B-8bit | 248320 | greedy | — | — | 98.61 (control) |
-| Qwen3.6-35B-A3B-8bit | 248320 | `--repetition-penalty 1.1` | 0.218 | 2.04 | −5.3 % |
-| Qwen3.6-35B-A3B-8bit | 248320 | `--temperature 0.7` | 0.790 | 7.09 | −9.2 % |
-| Qwen3.6-35B-A3B-8bit | 248320 | `--temperature 0.7 --top-p 0.95` | 2.847 | 20.67 | −26.4 % |
-
-Reading it:
-
-- **Temperature alone** costs 5.8–9.8 % of step time in host work and 9–14 % of
-  decode throughput. The work is the transfer plus a full-vocabulary softmax.
-- **A repetition penalty alone** is the cheapest host cell — 1.7–2.8 % — because
-  the penalty itself touches at most 20 ids; the transfer and the host argmax
-  are the whole cost. Its throughput hit is still 5–12 %, which is the lost
-  pipelining, not the arithmetic.
-- **Top-p is the dominant term.** Adding `--top-p 0.95` roughly triples the host
-  work, to 17–23 % of step time and a quarter of throughput, because it sorts
-  the entire vocabulary. Anyone optimising this path should start here and
-  should not assume the other stages behave the same way.
-- The cost tracks vocabulary size within a stage, as expected: at temperature
-  0.7 the 262144-token vocabulary pays 0.880 ms/step against 0.487 ms/step for
-  the 151669-token one.
-
-### Host selection is not bit-identical to the GPU argmax
-
-At `--temperature 0.0001` the host categorical sampler is arithmetically an
-argmax (every non-maximal logit underflows to exactly zero), so its token stream
-should match the greedy GPU `argmax` stream. On gemma-4-e2b it does, for all 100
-tokens. On Ternary-Bonsai-8B it agrees through 32 tokens and diverges by 64 —
-and the `--repetition-penalty 1.1` cell, which reaches the same host argmax by a
-different route, produces the *same* divergent stream. So the two host paths
-agree with each other and disagree with the GPU reduction, which is the
-signature of an exact tie in the logits row being broken differently rather than
-of a faulty readback.
-
-This is a property of the sampler itself, not of any one caller, and it matters
-to anything that treats the two paths as interchangeable oracles.
-
 ### Inverse-CDF sample
 
 Given the filtered, renormalised probability vector, one `Pcg32` draw
@@ -380,6 +295,220 @@ model at temperature > 0. This is a documented contract; callers that want
 true stochasticity must supply a distinct seed per request.
 
 ---
+
+## Cost of the host path
+
+The host path is not a cheap variant of the greedy one. It costs a
+`vocab`-sized GPU-to-host transfer plus `O(vocab)` host arithmetic per token,
+and — because the next forward cannot be dispatched until the row has been read
+back and a token chosen — it also gives up the software pipelining the greedy
+path gets for free. Greedy returns a *lazy* GPU argmax and dispatches the next
+step while the GPU is still busy; the host path runs strictly serial.
+
+**It is the served default, not an opt-in.** `resolve_sampling_params` takes
+temperature from, in order: the request, `--default-temperature`,
+`generation_config.json`, then a hard-coded `1.0`. So a
+`/v1/chat/completions` request that omits sampling fields never lands on the
+greedy path unless an operator put it there. Worse for cost, the snapshots
+carry filters too — gemma-4 ships `temperature 1.0, top_p 0.95, top_k 64` and
+Qwen3.6 `1.0 / 0.95 / 20` — so the served default is the *most* expensive shape
+below, not the cheapest.
+
+### The instrument
+
+The shared decode loop emits a `sampler_profile` event once per generation,
+covering only the steps that took the host path. A purely greedy run emits
+nothing and takes no extra clock readings.
+
+| Field | Meaning |
+|---|---|
+| `sync_per_step_ms` | Wait for the forward before the row can be read. GPU latency, not sampler cost. |
+| `sample_per_step_ms` | Readback plus all host arithmetic — mask, penalties, softmax, filters, draw, and logprob capture. |
+| `step_per_step_ms` | Whole step, host-path steps only. |
+| `sample_share_pct` | `sample / step`. |
+
+Drive the path from the bench harness with `rmlx bench --temperature`,
+`--top-p`, `--top-k` and `--repetition-penalty`. `scripts/perf_canary.sh` is
+greedy-only and cannot observe this class at all.
+
+**`sample_share_pct` is not a bound in either direction.** Two errors act on
+it with opposite signs:
+
+- It *understates*, by omitting cost the host path causes but does not spend
+  inside the window: the forfeited pipelining, and — on the constraint-mask-only
+  path — the GPU add + argmax that `apply_mask_argmax` merely schedules, which
+  execute at the next step's `eval` and are billed to `sync`. Every other path
+  forces the row to the host inside the window and is fully accounted.
+- It *overstates* on a contended host, because `sample` is pure host CPU while
+  `sync` is dominated by GPU execution, so CPU steal stretches the numerator
+  only. Every figure below was taken under such contention.
+
+The end-to-end figure is a decode-TPS comparison against a greedy control at the
+same shape; the share is the component attributable to host work.
+
+### Measured, 2026-08-16, M5 Max — PROVISIONAL
+
+`release-perf`, `rmlx bench --max-tokens 100`, 1 warmup + 3 measured runs at 4k
+and 1 + 2 at 16k/64k. `share%` is the **median over the measured generations**
+(the warmup's event is discarded); it is a within-step ratio, so it survives a
+cell whose `decode_tps` the harness refused to median.
+
+**These are single-arm medians on a contended host, not an interleaved A/B.**
+`scripts/perf_ab.sh` refused the host (exit 125: a VM at 114 % of a core, later
+joined by an npm process at 131 %), and the threshold was not raised. Treat the
+column separations as the result and the third digit as noise. The dataset's own
+noise floor is about 2.5 points: at 4k, gemma-4-e2b's `temp 0.7 + rep 1.1` cell
+measured *faster* than its `temp 0.7` cell (113.86 vs 111.03 tok/s) despite
+doing strictly more work. No throughput delta below that is reported as an
+effect.
+
+#### Share versus context
+
+`sample` is `O(vocab)` and context-invariant; `step` grows with context. The
+share is therefore a falling curve, and a single short-context point is its
+maximum rather than its value. `kv_quant=auto`:
+
+| model | vocab | attention | cell | 4k | 16k | 64k |
+|---|---:|---|---|---:|---:|---:|
+| gemma-4-e2b | 262144 | sliding-window | `--temperature 0.7` | 10.00 % | 9.29 % | 8.30 % |
+| gemma-4-e2b | 262144 | sliding-window | `--repetition-penalty 1.1` | 2.76 % | 2.63 % | 2.24 % |
+| gemma-4-e2b | 262144 | sliding-window | served default | 24.82 % | 24.35 % | 22.30 % |
+| Qwen3.6-35B-A3B | 248320 | global | `--temperature 0.7` | 6.98 % | 6.56 % | 4.58 % |
+| Qwen3.6-35B-A3B | 248320 | global | `--repetition-penalty 1.1` | 2.04 % | 1.94 % | 1.41 % |
+| Qwen3.6-35B-A3B | 248320 | global | served default | 22.55 % | 21.15 % | (cell did not complete) |
+| Ternary-Bonsai-8B | 151669 | global | `--temperature 0.7` | 5.80 % | 0.65 % | 0.18 % |
+| Ternary-Bonsai-8B | 151669 | global | `--repetition-penalty 1.1` | 1.78 % | 0.19 % | 0.06 % |
+| Ternary-Bonsai-8B | 151669 | global | served default | 5.88 % | 0.65 % | 0.18 % |
+
+`sample` itself is flat across context, as predicted: gemma-4-e2b holds
+0.901 / 0.854 / 0.879 ms per step at temperature 0.7, Bonsai 0.498 / 0.499 /
+0.510, Qwen3.6 0.796 / 0.811 / 0.807. Everything the curve does, it does through
+the denominator.
+
+**Gemma-4 barely falls at all** — 10.0 % to 8.3 % over a 16× context increase —
+because its sliding-window attention keeps step time nearly context-independent
+(8.92 → 10.59 ms). An arch that does not pay for context does not dilute a
+context-invariant cost either.
+
+**Bonsai's collapse is a codec artifact, not attention.** Its `auto` codec
+(`mixed_k8g64_v4g64`) decodes at 13.2 tok/s at 16k and 3.6 at 64k — step times
+of 76 and 282 ms against the ~12 and ~26 ms the `--kv-quant none` anchors
+recorded above. The extra time is host-side work inside the forward
+(`sync_per_step_ms` stays at 2.8 ms while the step runs 282 ms), so the share
+there is being divided by a separate defect. The `none` arm below is the one to
+read for that model.
+
+#### The same models on a healthy codec (`--kv-quant none`)
+
+Re-run with `--kv-quant none`, whose long-context decode rates (95.6 / 41.4
+tok/s for Bonsai at 16k / 64k) sit next to the anchors recorded in
+`docs/PERF_BASELINE.md`, so the denominator is legitimate attention cost:
+
+| model | ctx | cell | `sample` ms/step | `step` ms/step | `share%` | decode_tps |
+|---|---:|---|---:|---:|---:|---:|
+| Ternary-Bonsai-8B | 16k | `--temperature 0.7` | 0.505 | 11.13 | 4.54 % | 87.8 |
+| Ternary-Bonsai-8B | 16k | `--repetition-penalty 1.1` | 0.150 | 10.55 | 1.42 % | 92.8 |
+| Ternary-Bonsai-8B | 64k | `--temperature 0.7` | 0.519 | 24.70 | 2.10 % | 39.5 |
+| Ternary-Bonsai-8B | 64k | `--repetition-penalty 1.1` | 0.143 | 23.76 | 0.60 % | 41.1 |
+| Qwen3.6-35B-A3B | 16k | `--temperature 0.7` | 0.828 | 12.39 | 6.68 % | 80.7 |
+| Qwen3.6-35B-A3B | 16k | `--repetition-penalty 1.1` | 0.239 | 11.30 | 2.12 % | 88.5 |
+| Qwen3.6-35B-A3B | 64k | `--temperature 0.7` | 0.838 | 16.00 | 5.25 % | (unsettled) |
+| Qwen3.6-35B-A3B | 64k | `--repetition-penalty 1.1` | 0.239 | 16.28 | 1.47 % | (unsettled) |
+
+The two Qwen3.6 64k cells had their `decode_tps` refused for not settling under
+host contention; their `share` is a within-step ratio and is unaffected.
+
+#### Per-context verdict against the issue's kill criterion
+
+The criterion — host share under 3 % for both temperature and repetition
+penalty — evaluated per context rather than once:
+
+| model | codec | 4k | 16k | 64k |
+|---|---|---|---|---|
+| gemma-4-e2b (sliding-window, vocab 262144) | auto | **NOT MET** 10.00 / 2.76 | **NOT MET** 9.29 / 2.63 | **NOT MET** 8.30 / 2.24 |
+| Qwen3.6-35B-A3B (global, 248320) | auto | **NOT MET** 6.98 / 2.04 | **NOT MET** 6.56 / 1.94 | **NOT MET** 4.58 / 1.41 |
+| Qwen3.6-35B-A3B | none | — | **NOT MET** 6.68 / 2.12 | **NOT MET** 5.25 / 1.47 |
+| Ternary-Bonsai-8B (global, 151669) | auto | **NOT MET** 5.80 / 1.78 | (MET 0.65 / 0.19 — collapsed denominator, see above) | (MET 0.18 / 0.06 — same) |
+| Ternary-Bonsai-8B | none | — | **NOT MET** 4.54 / 1.42 | **MET** 2.10 / 0.60 |
+
+(`temperature 0.7` / `repetition-penalty 1.1`, in that order.)
+
+**The criterion is not met.** It is met in exactly one of the nine legitimate
+(model, context, codec) cells — Ternary-Bonsai-8B at 64k on `none` — and missed
+everywhere else, including at 64k on both other architectures. The two Bonsai
+`auto` cells that clear it do so against a step time inflated by the codec, not
+by attention.
+
+What the sweep does narrow is the shape of the claim. The cost falls with
+context on globally-attending models, so it is worst at short context; and it
+falls hardly at all on sliding-window attention, where gemma-4-e2b still pays
+8.3 % at 64k. It also scales with vocabulary. "Sampling is expensive" is
+therefore too broad: it is expensive at large vocabularies, at short-to-medium
+context, and on architectures whose step time does not grow with context — and
+it is expensive at *every* context measured once the ordering filters the served
+defaults enable are switched on.
+
+#### Cost by knob, at 4k
+
+| Model | vocab | cell | `sample` ms/step | `share%` | decode TPS vs greedy |
+|---|---:|---|---:|---:|---:|
+| gemma-4-e2b | 262144 | greedy | — | — | 129.22 (control) |
+| gemma-4-e2b | 262144 | `--repetition-penalty 1.1` | 0.228 | 2.75 | −4.9 % |
+| gemma-4-e2b | 262144 | `--temperature 0.7` | 0.880 | 9.80 | −14.1 % |
+| gemma-4-e2b | 262144 | `--temperature 0.7 --repetition-penalty 1.1` | 0.874 | 9.88 | −11.9 % |
+| gemma-4-e2b | 262144 | `--temperature 0.7 --top-p 0.95` | 2.525 | 22.89 | −29.9 % |
+| Ternary-Bonsai-8B | 151669 | greedy | — | — | 134.50 (control) |
+| Ternary-Bonsai-8B | 151669 | `--repetition-penalty 1.1` | 0.141 | 1.72 | −12.4 % |
+| Ternary-Bonsai-8B | 151669 | `--temperature 0.7` | 0.487 | 5.82 | −13.5 % |
+| Ternary-Bonsai-8B | 151669 | `--temperature 0.7 --repetition-penalty 1.1` | 0.491 | 5.87 | −14.2 % |
+| Ternary-Bonsai-8B | 151669 | `--temperature 0.7 --top-p 0.95` | 1.665 | 17.15 | −26.0 % |
+| Qwen3.6-35B-A3B | 248320 | greedy | — | — | 98.61 (control) |
+| Qwen3.6-35B-A3B | 248320 | `--repetition-penalty 1.1` | 0.218 | 2.04 | −5.3 % |
+| Qwen3.6-35B-A3B | 248320 | `--temperature 0.7` | 0.790 | 7.09 | −9.2 % |
+| Qwen3.6-35B-A3B | 248320 | `--temperature 0.7 --top-p 0.95` | 2.847 | 20.67 | −26.4 % |
+
+Reading it:
+
+- **Temperature alone** is 5.8–9.8 % of step time in host work at 4k. The work
+  is the transfer plus a full-vocabulary softmax.
+- **A repetition penalty alone** is the cheapest host cell — 1.7–2.8 % — because
+  the penalty arithmetic touches at most 20 ids; the transfer and the host argmax
+  are the whole cost. Its throughput deltas (−4.9 / −12.4 / −5.3 %) are *not*
+  explained by `sample`: subtracting it from the greedy step leaves 0.17 ms
+  (gemma), 0.64 ms (Bonsai) and 0.35 ms (Qwen3.6) unaccounted, a spread too wide
+  for a structurally identical change. The forfeited pipelining is the obvious
+  candidate and it is untested — no measurement here isolates it.
+- **The ordering filters are the dominant term.** `--top-p 0.95` roughly triples
+  the host work, to 17–23 % of step time, because it sorts the entire
+  vocabulary; `--top-k` does the same. Anyone optimising this path should start
+  there and should not assume the other stages behave alike.
+- The cost tracks vocabulary size within a stage: at temperature 0.7 the
+  262144-token vocabulary pays 0.880 ms/step against 0.487 ms/step for the
+  151669-token one.
+
+### Host selection is not bit-identical to the GPU argmax
+
+At `--temperature 0.0001` the host categorical sampler is arithmetically an
+argmax (every non-maximal logit underflows to exactly zero), so its token stream
+should match the greedy GPU `argmax` stream. On gemma-4-e2b it does, for all 100
+tokens. On Ternary-Bonsai-8B it agrees through 32 tokens and diverges by 64. The
+divergence is reproducible and every run within a cell agrees, so it is a
+deterministic property of the two paths and not a race.
+
+**The mechanism is not established.** The candidate is tie-breaking: MLX's
+`argmax` returns the first maximal index and Rust's `Iterator::max_by` returns
+the last, so an exact tie in the logits row would select different tokens. But
+that does not predict what was observed. `--repetition-penalty 1.1` is a
+different objective, not another route to the same argmax — it divides positive
+logits of the trailing-20 ids by 1.1 — and its stream, which is selected by
+`max_by`, matched the temperature stream, which is selected by
+`sample_inverse_cdf` (the first index whose cumulative sum passes an RNG draw).
+Under a two-way tie those two agree only by chance. Confirming or discarding the
+hypothesis needs the top-2 logits at the first divergent step, which nothing here
+dumps.
+
+What *is* established: the two paths are not interchangeable oracles on every
+model, which matters to anything that treats one as a reference for the other.
 
 ## Special tokens
 


### PR DESCRIPTION
Advances #359 — delivers its measurement, does not close it.

The issue is explicit: *"the first deliverable is a number, not a kernel. Kill
criterion: under 3% of step time on both, close the issue."* This branch produces
that number. **The criterion is not met**, so the kernel work is justified and #359
stays open for it.

## The defect is real, and was invisible for two reasons

`logits_to_host_f32` does a blocking `eval()`, a `to_bytes()`, and an O(vocab) host
conversion every token on the sampling / penalty / mask / logprob paths. Nothing
measured it, because:

1. The shared decode loop charged that work to the **forward** timer, so
   `decode_profile` reported it as forward latency.
2. Every bench shape in the repo is greedy, so `perf_canary.sh` structurally cannot
   see the class.

Measuring it also exposed a false claim in `decode_loop.rs`: the module said the
pipeline "overlaps host sampling/penalty work with the in-flight GPU forward". It
cannot — the chosen token is a function of the logits row, so the row must be on the
host before the next forward can be dispatched. The overlap exists only on the greedy
path, where there is no host sampling work to overlap. That matters, because it is
why the instrumented share **understates** the real cost.

`sampler.rs` is untouched (`git diff --name-only` confirms). No sampling arithmetic
changed.

## The measurement, swept across context

The first cut measured one shape. `sample_share_pct`'s denominator is step wall-clock,
which grows with context, while the sampler cost is O(vocab) and context-invariant —
so a single short-context point is the maximum of the curve, and this repo has made
wrong calls from single-context numbers before. Swept:

| model | codec | 4k | 16k | 64k |
|---|---|---|---|---|
| gemma-4-e2b (SWA, vocab 262144) | auto | 10.00 / 2.76 | 9.29 / 2.63 | 8.30 / 2.24 |
| Qwen3.6-35B-A3B (global, 248320) | auto | 6.98 / 2.04 | 6.56 / 1.94 | 4.58 / 1.41 |
| Qwen3.6-35B-A3B | none | — | 6.68 / 2.12 | 5.25 / 1.47 |
| Ternary-Bonsai-8B (global, 151669) | none | — | 4.54 / 1.42 | **2.10 / 0.60** |

(`temp 0.7` / `rep-penalty 1.1`, share %. Bold = kill criterion met.)

**Met in 1 of 9 cells; not met in the other 8**, including at 64k on both other
architectures. `sample` is flat across context exactly as the mechanism predicts
(gemma 0.901 / 0.854 / 0.879 ms), confirming the dilution is denominator-driven.

Two things the single point hid:

- **Gemma-4 barely dilutes** — 10.0 → 8.3 % over a 16× context increase — because
  sliding-window attention keeps step time near-constant (8.92 → 10.59 ms). An
  architecture that does not pay for context cannot dilute a context-invariant cost.
- **Bonsai's earlier "MET" at `auto` was an artifact.** Its `auto` codec decodes at
  13.2 / 3.6 TPS at 16k / 64k — 76 ms and 282 ms per step against 11.1 and 24.7 ms on
  `none`, with `sync` flat at 2.8 ms, so the excess is host work inside the forward.
  Re-running the dense models on `none` moved Bonsai 16k from 0.65 % (met) to 4.54 %
  (not met). Filed separately as #374: a defect on the default codec path was about to
  close a different issue on false evidence.

## The served default is the expensive cell

`SamplingParams::default()` is `temperature: 1.0`, so a `/v1/chat/completions` request
that omits `temperature` already takes the host path on every token. Worse: gemma-4
ships `temperature 1.0, top_p 0.95, top_k 64` in `generation_config.json` and Qwen3.6
ships `1.0 / 0.95 / 20`, so the served default is the **ordering-filter** cell —
**24.8 % / 22.6 %** of step time. `--top-k` was added to `rmlx bench` because without
it that configuration was unmeasurable.

Bonsai ships no `generation_config.json`, which is the only reason its served default
is cheap.

## What changed

- `decode_loop.rs` — hoisted the logits `eval()` each host-selection path performed a
  few lines later inside the readback, timed as `sync` (GPU wait, not sampler cost).
  New `sampler_profile` event: `sync_per_step_ms`, `sample_per_step_ms`,
  `step_per_step_ms`, `sample_share_pct`, over host-path steps only. Greedy takes no
  extra clock readings and emits nothing.
- The timed window now covers `capture_logprobs`. It previously closed before it, so
  greedy+logprobs reported a near-zero share while paying the full O(vocab) readback
  — an under-reporting path, on a metric whose whole purpose is a threshold. The mask
  path's remaining limitation (lazy graph; the GPU add+argmax bills to the *next*
  step's `sync`) is documented at the emission site.
- `rmlx bench --temperature / --top-p / --top-k / --repetition-penalty`, validated
  before model load. `--top-p` / `--top-k` are refused at temperature 0 rather than
  recorded as a nucleus setting on a cell that never ran one.

## Correctness, kept separate from the perf claim

Two separately built binaries, verified distinct by `shasum` and by symbol check both
ways: `rmlx.main` `c51cafa6…` (no `sample_share_pct`, no `--top-k`) vs `rmlx.patch`
`2132dc91…` (both present).

Criterion stated first: greedy token digest byte-identical on both required
architectures.

| model | main | patch |
|---|---|---|
| gemma-4-e2b | `0xda06c1ec7c73fbb3` | `0xda06c1ec7c73fbb3` |
| Ternary-Bonsai-8B | `0xa14ed09c9440e9db` | `0xa14ed09c9440e9db` |

Both new guards mutation-checked: red under `if false`, green on restore. The
`host_steps == 0` gate is falsified empirically — greedy runs emit 0
`sampler_profile` lines, sampled runs emit exactly 4.

## Anchors: provisional, deliberately

`scripts/perf_ab.sh` refused this host twice (exit 125 — a VM at 114 %, later npm at
131 %). The threshold was **not** raised. The throughput figures are therefore
single-arm medians on a contended host, and they live in a section headed
**PROVISIONAL, NOT AN ANCHOR** with the refusal recorded, no per-cell deltas, and the
~2.5-point noise floor derived from an inversion in the data itself (a cell with
strictly more work measured faster).

An earlier draft attributed an unexplained residual to "the lost pipelining, not the
arithmetic". That is replaced by the residuals stated (0.17 / 0.64 / 0.35 ms) and
"the pipelining hypothesis is untested".

`share%` is also not a bound in either direction, and both docs now say so: on a
quiescent host it omits the lost pipelining (lower bound), on this host it is inflated
by CPU steal (upper-ish). The two errors have opposite sign.

## Not proven

**Greedy no-regression is not measured.** The A/B harness refused twice and was not
overridden. Code-level argument only: on the greedy path `drain_now` is false, so
`drain_now.then(Instant::now)` yields `None` and the hoisted `eval` is skipped exactly
as the old `if mask_active` was — one extra boolean test per step. That is an
argument, not a measurement. `target/release-perf/rmlx.main` is left in place to
re-run the A/B on a quiet host.

Qwen3.6's 64k `served` cell died mid-prefill and its 64k `decode_tps` did not settle;
the shares are unaffected (within-step ratios) and could not change the verdict.

## Also found, filed separately

The host sampler is **not** bit-identical to the GPU argmax — at `--temperature
0.0001` Bonsai diverges from greedy by 64 tokens while gemma-4 does not. Filed as
#373, and stated in `docs/SAMPLING.md` as **unconfirmed**: the leading hypothesis is
that MLX `argmax` returns the first maximum while `max_by` returns the last, but no
logits row has been inspected. An earlier draft asserted a tie-break signature on
reasoning that does not hold — the two host paths break ties by different rules, so
their agreement is evidence against that hypothesis, not for it. This bears directly
on #359's own merge gate, which assumes the CPU path is a valid oracle for a future
GPU sampler.

## Gates

`make ci` green. `make lint` clean, `cargo fmt --check` clean,
`check-no-inline-tests` / `check-gpu-tests-ignored` pass.
