### PR TITLE
fix(kv): key the Qwen-MoE guard on the resolved architecture, and close the speculative bypass (#352)

### DIFF
--- a/crates/rmlx-models/src/arch/loader.rs
+++ b/crates/rmlx-models/src/arch/loader.rs
@@ -216,6 +216,23 @@ pub fn load_model(model_dir: &Path, _device: Device, opts: &LoadOpts) -> Result<
     let dequant_ms = t_dequant_start.elapsed().as_millis() as u64;
     tracing::debug!(dequant_ms, "arch::load_model: dequant phase complete");
 
+    // The checkpoint declares an architecture; the loader resolves one from the
+    // tensors it actually found. When they disagree, every predicate still
+    // keyed on the declaration is reasoning about a model that was not built —
+    // say so loudly and name both, because the declaration is model-side data
+    // that nothing validates.
+    let resolved_arch = arch.arch_class();
+    if resolved_arch != arch_str {
+        tracing::warn!(
+            declared_arch = arch_str,
+            resolved_arch,
+            model_dir = %model_dir.display(),
+            "declared architecture does not match the one the loader resolved from the \
+             checkpoint tensors — the resolved value is authoritative; any check still \
+             keyed on the declared name is unreliable for this snapshot"
+        );
+    }
+
     // -- Phase 3: gpu_residency -----------------------------------------------
     // MLX dispatches lazily -- arrays are not pushed to GPU during load.
     // gpu_residency_ms is documented as 0 (see LoadPhases doc).

--- a/crates/rmlx-models/src/arch/loader.rs
+++ b/crates/rmlx-models/src/arch/loader.rs
@@ -222,7 +222,15 @@ pub fn load_model(model_dir: &Path, _device: Device, opts: &LoadOpts) -> Result<
     // say so loudly and name both, because the declaration is model-side data
     // that nothing validates.
     let resolved_arch = arch.arch_class();
-    if resolved_arch != arch_str {
+    if resolved_arch != arch_str && super::registry::is_declared_arch_alias(arch_str, resolved_arch)
+    {
+        tracing::debug!(
+            declared_arch = arch_str,
+            resolved_arch,
+            "declared architecture is a known alias of the resolved class — expected, \
+             every consumer carries an explicit arm for it"
+        );
+    } else if resolved_arch != arch_str {
         tracing::warn!(
             declared_arch = arch_str,
             resolved_arch,

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -764,14 +764,27 @@ impl Architecture {
     /// Architecture class name as a static string, matching the canonical
     /// `model_type` identifiers used throughout rMLX (tracing fields, metrics).
     ///
-    /// This is the **resolved** class — what the loader actually built — not
-    /// the `architectures[0]` string the checkpoint declares. The two can
-    /// disagree, and where they do this one is the truth: both Qwen3.5 arch
-    /// strings share a single loader and model struct, so the sparse-MoE vs
-    /// dense-SwiGLU distinction is recovered from the built layers rather than
-    /// from the declaration. Safety predicates keyed on the architecture (the
-    /// Qwen-MoE K-side codec guard in particular) must use this, because a
-    /// checkpoint's self-declaration is model-side data that nothing validates.
+    /// Prefer this over the `architectures[0]` string a checkpoint declares:
+    /// the two can disagree, and where they do this one is the truth. Safety
+    /// predicates keyed on the architecture (the Qwen-MoE K-side codec guard in
+    /// particular) must use this, because a declaration is model-side data that
+    /// nothing validates.
+    ///
+    /// **Resolved for the Qwen3.5 family.** Both Qwen3.5 arch strings share a
+    /// single loader and model struct, so the sparse-MoE vs dense-SwiGLU
+    /// distinction is recovered from the built layers. Every other arm returns
+    /// the variant's canonical name.
+    ///
+    /// Known exception: `Qwen3VlMoe` also picks dense-vs-MoE per layer
+    /// (`mlp_only_layers` / `num_experts` / `decoder_sparse_step`), but there is
+    /// no registered dense Qwen3-VL arch string to report, so an all-dense
+    /// Qwen3-VL checkpoint is still labelled MoE and still refused K-side
+    /// codecs. Closing that needs a second registered class and arms for it in
+    /// every consumer, not just an accessor here.
+    ///
+    /// `Gemma4UnifiedForConditionalGeneration` is a deliberate alias: it
+    /// resolves to `Gemma4ForConditionalGeneration`, and every consumer carries
+    /// an explicit arm for the declared form (see `registry::is_declared_arch_alias`).
     pub fn arch_class(&self) -> &'static str {
         match self {
             Architecture::Gemma4(_) => "Gemma4ForConditionalGeneration",
@@ -779,13 +792,7 @@ impl Architecture {
             Architecture::Qwen2(_) => "Qwen2ForCausalLM",
             Architecture::Qwen3(_) => "Qwen3ForCausalLM",
             Architecture::Laguna(_) => "LagunaForCausalLM",
-            Architecture::Qwen3_5Moe(m) => {
-                if m.has_sparse_moe_layers() {
-                    "Qwen3_5MoeForConditionalGeneration"
-                } else {
-                    "Qwen3_5ForConditionalGeneration"
-                }
-            }
+            Architecture::Qwen3_5Moe(m) => m.arch_class(),
             Architecture::Qwen3VlMoe(_) => "Qwen3VLMoeForConditionalGeneration",
             Architecture::BitNet(_) => "BitNetForCausalLM",
         }
@@ -1134,6 +1141,15 @@ impl Architecture {
         use crate::kv_cache::KvCacheBuilder;
         use rmlx_kv_quant::KvQuant;
 
+        // Same enforcement as the text entry, and in the same position: reject
+        // before touching MLX thread state, so a refused codec costs nothing.
+        // The `None` fallback below is `for_arch_default`, a no-op returning
+        // K8V8 — K stays 8-bit, so it satisfies every arch invariant by
+        // construction and needs no separate check.
+        if let Some(kq) = kv_quant_override {
+            self.validate_kv_quant(kq)?;
+        }
+
         // Register the thread-local CPU + GPU streams + CommandEncoders once per
         // thread entry point (mirrors the text `generate_greedy` entry). The CPU
         // stream is registered unconditionally because K8V8 `exit_prefill` schedules
@@ -1143,15 +1159,6 @@ impl Architecture {
         rmlx_mlx::ensure_cpu_default_stream();
         if device == Device::Gpu {
             rmlx_mlx::ensure_gpu_default_stream();
-        }
-
-        // Same enforcement as the text entry: check the operator-supplied quant
-        // against the resolved architecture before any KV cache exists. The
-        // `None` fallback below is `for_arch_default`, which is a no-op
-        // returning K8V8 — K stays 8-bit, so it satisfies every arch invariant
-        // by construction and needs no separate check.
-        if let Some(kq) = kv_quant_override {
-            self.validate_kv_quant(kq)?;
         }
 
         match self {

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -763,6 +763,15 @@ impl Architecture {
 
     /// Architecture class name as a static string, matching the canonical
     /// `model_type` identifiers used throughout rMLX (tracing fields, metrics).
+    ///
+    /// This is the **resolved** class — what the loader actually built — not
+    /// the `architectures[0]` string the checkpoint declares. The two can
+    /// disagree, and where they do this one is the truth: both Qwen3.5 arch
+    /// strings share a single loader and model struct, so the sparse-MoE vs
+    /// dense-SwiGLU distinction is recovered from the built layers rather than
+    /// from the declaration. Safety predicates keyed on the architecture (the
+    /// Qwen-MoE K-side codec guard in particular) must use this, because a
+    /// checkpoint's self-declaration is model-side data that nothing validates.
     pub fn arch_class(&self) -> &'static str {
         match self {
             Architecture::Gemma4(_) => "Gemma4ForConditionalGeneration",
@@ -770,10 +779,38 @@ impl Architecture {
             Architecture::Qwen2(_) => "Qwen2ForCausalLM",
             Architecture::Qwen3(_) => "Qwen3ForCausalLM",
             Architecture::Laguna(_) => "LagunaForCausalLM",
-            Architecture::Qwen3_5Moe(_) => "Qwen3_5MoeForConditionalGeneration",
+            Architecture::Qwen3_5Moe(m) => {
+                if m.has_sparse_moe_layers() {
+                    "Qwen3_5MoeForConditionalGeneration"
+                } else {
+                    "Qwen3_5ForConditionalGeneration"
+                }
+            }
             Architecture::Qwen3VlMoe(_) => "Qwen3VLMoeForConditionalGeneration",
             Architecture::BitNet(_) => "BitNetForCausalLM",
         }
+    }
+
+    /// Re-check the arch invariants for `kv_quant` against the **resolved**
+    /// architecture, immediately before it is used to build KV caches.
+    ///
+    /// The startup resolvers validate against the checkpoint's declared
+    /// `architectures[0]`, which is model-side data: a snapshot whose
+    /// declaration disagrees with what the loader built passes those checks
+    /// while running the guarded code path. This is the enforcing copy — it
+    /// asks the loaded model, so no declaration can route around it, and it
+    /// also covers quants that enter after startup (a per-request override).
+    ///
+    /// Arch-agnostic: it delegates to the one shared invariant table, so a
+    /// codec that is legal on this architecture costs a single enum match.
+    pub fn validate_kv_quant(&self, kv_quant: rmlx_kv_quant::KvQuant) -> Result<()> {
+        crate::kv_cache::validate_resolved_kv_quant(self.arch_class(), &kv_quant).map_err(|e| {
+            Error::Config(format!(
+                "KV codec rejected for the architecture this snapshot actually resolves to \
+                 ({}): {e}",
+                self.arch_class()
+            ))
+        })
     }
 
     /// One-line summary string for diagnostics and tracing.
@@ -874,16 +911,7 @@ impl Architecture {
         use crate::kv_cache::KvCacheBuilder;
         use rmlx_kv_quant::KvQuant;
         // Resolve the effective quant: explicit override wins; otherwise ask the builder.
-        let arch_name = match self {
-            Architecture::Gemma4(_) => "Gemma4ForConditionalGeneration",
-            Architecture::Gemma3(_) => "Gemma3ForConditionalGeneration",
-            Architecture::Qwen2(_) => "Qwen2ForCausalLM",
-            Architecture::Qwen3(_) => "Qwen3ForCausalLM",
-            Architecture::Laguna(_) => "LagunaForCausalLM",
-            Architecture::Qwen3_5Moe(_) => "Qwen3_5MoeForConditionalGeneration",
-            Architecture::Qwen3VlMoe(_) => "Qwen3VLMoeForConditionalGeneration",
-            Architecture::BitNet(_) => "BitNetForCausalLM",
-        };
+        let arch_name = self.arch_class();
         // `for_arch_default` is deprecated; callers with a full ModelConfig
         // should use `resolve_default`. This arch-dispatch site has no ModelConfig
         // available (the arch-level generate_greedy gets signals separately); the
@@ -894,6 +922,13 @@ impl Architecture {
         )]
         let kv_quant: KvQuant =
             kv_quant_override.unwrap_or_else(|| KvCacheBuilder::for_arch_default(arch_name));
+
+        // Enforce the arch invariants against the resolved architecture before
+        // a single KV cache is built. The startup resolvers key off the
+        // declared `architectures[0]`; this one asks the loaded model, so a
+        // mismatched declaration cannot route around the guard, and a quant
+        // supplied per-request is checked on the same terms as a launch flag.
+        self.validate_kv_quant(kv_quant)?;
 
         // Register the thread-local CPU + GPU streams + CommandEncoders once per
         // thread entry point. tokio blocking-pool threads start with no MLX stream
@@ -1108,6 +1143,15 @@ impl Architecture {
         rmlx_mlx::ensure_cpu_default_stream();
         if device == Device::Gpu {
             rmlx_mlx::ensure_gpu_default_stream();
+        }
+
+        // Same enforcement as the text entry: check the operator-supplied quant
+        // against the resolved architecture before any KV cache exists. The
+        // `None` fallback below is `for_arch_default`, which is a no-op
+        // returning K8V8 — K stays 8-bit, so it satisfies every arch invariant
+        // by construction and needs no separate check.
+        if let Some(kq) = kv_quant_override {
+            self.validate_kv_quant(kq)?;
         }
 
         match self {

--- a/crates/rmlx-models/src/arch/registry.rs
+++ b/crates/rmlx-models/src/arch/registry.rs
@@ -40,3 +40,27 @@ pub const KNOWN_ARCHS: &[&str] = &[
 pub fn is_arch_supported(arch: &str) -> bool {
     KNOWN_ARCHS.contains(&arch)
 }
+
+/// Declared arch strings that rMLX deliberately reports under a different,
+/// canonical class — an alias, not a mismatch.
+///
+/// `Architecture::arch_class()` reports the resolved class, so for these pairs
+/// the declared and resolved names differ on every load of a perfectly
+/// well-formed snapshot. Their consumers all carry an explicit arm for the
+/// alias, so nothing is keyed on a name it does not handle. Callers that
+/// report a declared-vs-resolved divergence must stay quiet for these, or the
+/// signal is noise on a supported model and gets ignored where it matters.
+///
+/// This is NOT the Qwen3.5 dense/MoE pair: those two names describe genuinely
+/// different models, and a snapshot declaring one while building the other is
+/// the mismatch worth reporting.
+#[inline]
+pub(crate) fn is_declared_arch_alias(declared: &str, resolved: &str) -> bool {
+    matches!(
+        (declared, resolved),
+        (
+            "Gemma4UnifiedForConditionalGeneration",
+            "Gemma4ForConditionalGeneration"
+        )
+    )
+}

--- a/crates/rmlx-models/src/kv_cache/cache_type_tests.rs
+++ b/crates/rmlx-models/src/kv_cache/cache_type_tests.rs
@@ -1470,6 +1470,11 @@ fn validate_resolved_non_moe_rotor_k_side_passes() {
     ] {
         validate_resolved("Gemma4ForConditionalGeneration", &kq).unwrap();
         validate_resolved("Qwen3ForCausalLM", &kq).unwrap();
+        // Dense Qwen3.5 shares a loader and an `Architecture` variant with the
+        // sparse-MoE path, so this string is a value `arch_class()` can now
+        // return. The measured PPL disaster is a sparse-MoE result; a dense
+        // model keeps these codecs.
+        validate_resolved("Qwen3_5ForConditionalGeneration", &kq).unwrap();
     }
 }
 

--- a/crates/rmlx-models/src/kv_cache/cache_type_tests.rs
+++ b/crates/rmlx-models/src/kv_cache/cache_type_tests.rs
@@ -1478,6 +1478,50 @@ fn validate_resolved_non_moe_rotor_k_side_passes() {
     }
 }
 
+/// The two Qwen3.5 arch strings produce OPPOSITE verdicts for every codec the
+/// guard exists to reject.
+///
+/// Weights-free proof that which string reaches `validate_resolved` decides
+/// whether the guard fires at all — so `Architecture::arch_class()` returning
+/// the declared name instead of the resolved one is a correctness bug, not a
+/// labelling nit. The seam that feeds the resolved name in
+/// (`Architecture::generate_greedy`) can only be exercised with a real
+/// snapshot; see `tests/resolved_arch_class.rs` and docs/TESTING.md.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test asserts the dense arm passes — unwrap surfaces an over-broad refusal"
+)]
+fn validate_resolved_qwen3_5_dense_and_moe_strings_diverge() {
+    for kq in [
+        KvQuant::Rotor3Sym,
+        KvQuant::Rotor4Sym,
+        KvQuant::RotorKOnly3,
+        KvQuant::RotorKOnly4,
+        KvQuant::RotorK3Asym {
+            v_bits: 4,
+            v_group_size: 128,
+        },
+        KvQuant::RotorK4Asym {
+            v_bits: 4,
+            v_group_size: 128,
+        },
+        KvQuant::Iso3Sym,
+        KvQuant::Iso4Sym,
+        KvQuant::IsoKOnly3,
+        KvQuant::IsoKOnly4,
+        KvQuant::PlanarK,
+        KvQuant::TurboSym3,
+        KvQuant::TurboSym4,
+    ] {
+        assert!(
+            validate_resolved("Qwen3_5MoeForConditionalGeneration", &kq).is_err(),
+            "{kq} must be rejected on sparse Qwen3.5 MoE"
+        );
+        validate_resolved("Qwen3_5ForConditionalGeneration", &kq).unwrap();
+    }
+}
+
 /// combo_to_kv_quant: (RotorK3, Rotor3) maps to Rotor3Sym; etc.
 #[test]
 #[allow(

--- a/crates/rmlx-models/src/qwen3_5_moe/generate.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/generate.rs
@@ -78,8 +78,13 @@ pub fn generate_greedy<'a>(
 ) -> Result<Vec<crate::decode_loop::ProbeStep>> {
     use crate::decode_loop::ProbeStep;
 
+    // One resolved label for the whole call. This module serves both Qwen3.5
+    // shapes, so a hardcoded string made a dense run emit two different `arch`
+    // values in one run's log — splitting exact-field search on it.
+    let arch_label = model.arch_class();
+
     tracing::info!(
-        arch = "Qwen3_5MoeForConditionalGeneration",
+        arch = arch_label,
         ?kv_quant,
         ?max_ctx_override,
         "generate_greedy: selected KV cache quant"
@@ -214,7 +219,7 @@ pub fn generate_greedy<'a>(
                 rng,
                 penalty_cfg,
                 token_history,
-                arch: "Qwen3_5MoeForConditionalGeneration",
+                arch: arch_label,
                 resolve_pieces: false,
             };
             pipelined_decode(&mut ctx, last_id, &mut steps, |y| {
@@ -259,7 +264,7 @@ pub fn generate_greedy<'a>(
     if let Some((mut kv_caches, mut lin_caches, prefix_len)) = hydrated_tail {
         let tail_len = prompt_ids.len() - prefix_len;
         tracing::info!(
-            arch = "Qwen3_5MoeForConditionalGeneration",
+            arch = arch_label,
             prefix_len,
             tail_len,
             "qwen3_5moe: hydrated-tail hit — forwarding tail from SSD-restored KV"
@@ -342,7 +347,7 @@ pub fn generate_greedy<'a>(
             rng,
             penalty_cfg,
             token_history,
-            arch: "Qwen3_5MoeForConditionalGeneration",
+            arch: arch_label,
             resolve_pieces: false,
         };
 
@@ -506,7 +511,7 @@ pub fn generate_greedy<'a>(
         prompt_ids,
         prefill_chunk,
         device,
-        "Qwen3_5MoeForConditionalGeneration",
+        arch_label,
         |chunk, kv| model.forward_seq_with_cache(chunk, Some(kv), Some(&mut lin_caches), device),
     )?;
 
@@ -531,7 +536,7 @@ pub fn generate_greedy<'a>(
         rng,
         penalty_cfg,
         token_history,
-        arch: "Qwen3_5MoeForConditionalGeneration",
+        arch: arch_label,
         resolve_pieces: false,
     };
 
@@ -637,7 +642,7 @@ pub fn generate_greedy<'a>(
         let prefill_ms = (prefill_total_ns as f64) / 1.0e6;
         tracing::info!(
             target: "decode_profile",
-            arch = "Qwen3_5MoeForConditionalGeneration",
+            arch = arch_label,
             n_steps = 0,
             prefill_ms,
             "decode_profile (prefill-EOS)"
@@ -660,7 +665,7 @@ pub fn generate_greedy<'a>(
     let n = f64::from(stats.decode_steps.max(1));
     tracing::info!(
         target: "decode_profile",
-        arch = "Qwen3_5MoeForConditionalGeneration",
+        arch = arch_label,
         n_steps = stats.decode_steps,
         prefill_ms,
         forward_total_ms = forward_ms,

--- a/crates/rmlx-models/src/qwen3_5_moe/model.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/model.rs
@@ -94,6 +94,20 @@ impl Qwen3_5MoeText {
             .any(|l| matches!(l.mlp, MlpBlock::Moe(_)))
     }
 
+    /// The arch class this instance actually resolved to.
+    ///
+    /// Single source of the dense-vs-MoE name for this family:
+    /// `Architecture::arch_class()` delegates here, and the generate path uses
+    /// it for its `arch` tracing field so one run cannot emit two different
+    /// values for the same model.
+    pub fn arch_class(&self) -> &'static str {
+        if self.has_sparse_moe_layers() {
+            "Qwen3_5MoeForConditionalGeneration"
+        } else {
+            "Qwen3_5ForConditionalGeneration"
+        }
+    }
+
     /// Full-sequence forward pass (no KV cache).
     /// Returns logits for the last position, shape `[1, 1, vocab_size]`.
     pub fn forward_seq(&self, ids: &[u32], device: Device) -> Result<Array> {

--- a/crates/rmlx-models/src/qwen3_5_moe/model.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/model.rs
@@ -17,7 +17,7 @@ use rmlx_core::error::Result;
 use rmlx_mlx::{Array, Device, Dtype};
 
 use super::config::Qwen3_5MoeConfig;
-use super::decoder_layer::DecoderLayer;
+use super::decoder_layer::{DecoderLayer, MlpBlock};
 use super::layers::{Embedding, Linear, RmsNorm};
 use rmlx_kv_quant::{KvCache, LinearAttnCache};
 
@@ -80,6 +80,20 @@ pub struct Qwen3_5MoeText {
 }
 
 impl Qwen3_5MoeText {
+    /// Whether any decoder layer actually resolved to a sparse-MoE MLP block.
+    ///
+    /// This is the *built* truth, not a declaration: the loader selects
+    /// dense-vs-MoE per layer from the checkpoint's tensor witness
+    /// (`mlp.switch_mlp.gate_proj.weight`), so a config that names the wrong
+    /// architecture cannot change the answer. Both Qwen3.5 arch strings share
+    /// this one model struct, so callers that need to distinguish sparse MoE
+    /// from dense SwiGLU must ask here rather than read `architectures[0]`.
+    pub fn has_sparse_moe_layers(&self) -> bool {
+        self.layers
+            .iter()
+            .any(|l| matches!(l.mlp, MlpBlock::Moe(_)))
+    }
+
     /// Full-sequence forward pass (no KV cache).
     /// Returns logits for the last position, shape `[1, 1, vocab_size]`.
     pub fn forward_seq(&self, ids: &[u32], device: Device) -> Result<Array> {

--- a/crates/rmlx-models/src/ssd_tier.rs
+++ b/crates/rmlx-models/src/ssd_tier.rs
@@ -21,6 +21,12 @@ use rmlx_mlx::Device;
 /// `(n_layers, n_kv_heads, head_dim)` are taken from the loaded model's
 /// config and folded into the `layout_key` that the spiller/hydrator carry.
 ///
+/// `arch` must be the **resolved** class (`Architecture::arch_class()`), not
+/// the checkpoint's declared `architectures[0]`: it both selects the per-arch
+/// `PROMPT_CACHE` and salts the `layout_key`, so a declared name that does not
+/// describe the model that was built would pick the wrong cache (or none). The
+/// arms below still tolerate a declared alias for any caller that passes one.
+///
 /// No model identity is threaded here on purpose. The per-arch attach slot
 /// holds one set of parameters and the last load wins, so a per-model value
 /// recorded at attach would be wrong for every other resident model of the
@@ -64,7 +70,10 @@ pub fn attach_at_load(
                 info.device,
             );
         }
-        "Qwen3_5MoeForConditionalGeneration" => {
+        // Both Qwen3.5 shapes share one loader, one model struct and one
+        // PROMPT_CACHE static, so the dense class gets the tier too. Listing
+        // only the MoE name left every dense Qwen3.5 snapshot silently RAM-only.
+        "Qwen3_5MoeForConditionalGeneration" | "Qwen3_5ForConditionalGeneration" => {
             crate::qwen3_5_moe::prompt_cache::PROMPT_CACHE.attach_ssd_tier(
                 &info.namespace,
                 info.kv_quant,

--- a/crates/rmlx-models/tests/resolved_arch_class.rs
+++ b/crates/rmlx-models/tests/resolved_arch_class.rs
@@ -1,0 +1,218 @@
+//! Declared vs resolved architecture, and the KV guard that must key off the
+//! resolved one.
+//!
+//! A checkpoint's `architectures[0]` is model-side data that nothing
+//! validates. The Qwen3.5 loader ignores it for the dense-vs-sparse-MoE
+//! decision — it probes the per-layer tensor witness
+//! (`mlp.switch_mlp.gate_proj.weight`) instead — so the declaration and the
+//! model that actually gets built can disagree. Where they do, any safety
+//! predicate still reading the declaration is reasoning about a model that
+//! does not exist.
+//!
+//! The predicate that matters here is the Qwen-MoE K-side codec guard: rotor /
+//! iso / low-bit-K codecs were measured to destroy perplexity on Qwen sparse
+//! MoE, and the guard rejects them. Keyed on the declaration, a snapshot that
+//! declares dense while shipping MoE tensors runs the disaster path to
+//! completion with no error — the run succeeds and only the output is wrong.
+//!
+//! These tests load real snapshots and are `#[ignore]`d for that reason; they
+//! skip gracefully when the snapshot is absent.
+//!
+//! ```text
+//! RMLX_O_MODELS_ROOT=/path/to/open-models \
+//!   cargo test -p rmlx-models --test resolved_arch_class -- --ignored --test-threads=1
+//! ```
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stderr
+)]
+
+use std::path::{Path, PathBuf};
+
+use rmlx_kv_quant::KvQuant;
+use rmlx_mlx::Device;
+use rmlx_models::arch;
+
+/// Resolve a snapshot by env override first, then by slug under
+/// `RMLX_O_MODELS_ROOT`. Returns `None` (with a SKIP note) when absent.
+fn snapshot(env_key: &str, slug: &str) -> Option<PathBuf> {
+    if let Ok(p) = std::env::var(env_key) {
+        let p = PathBuf::from(p);
+        if p.join("config.json").is_file() {
+            return Some(p);
+        }
+    }
+    if let Ok(root) = std::env::var("RMLX_O_MODELS_ROOT") {
+        let p = PathBuf::from(root).join(slug);
+        if p.join("config.json").is_file() {
+            return Some(p);
+        }
+    }
+    eprintln!("SKIP: snapshot {slug} not found (set {env_key} or RMLX_O_MODELS_ROOT)");
+    None
+}
+
+/// Read `architectures[0]` straight from the snapshot's `config.json`.
+fn declared_arch(model_dir: &Path) -> String {
+    let data = std::fs::read(model_dir.join("config.json")).expect("read config.json");
+    let v: serde_json::Value = serde_json::from_slice(&data).expect("parse config.json");
+    v.get("architectures")
+        .and_then(|a| a.get(0))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_owned()
+}
+
+/// Build a snapshot that is byte-identical to `src` except that
+/// `architectures[0]` is replaced by `declared`. Weights are symlinked, so this
+/// costs no disk and no copy time.
+///
+/// This is the bypass under test: the tensors still say sparse MoE, the
+/// declaration says something else.
+fn relabelled_snapshot(src: &Path, declared: &str, dst: &Path) {
+    std::fs::create_dir_all(dst).expect("create relabelled snapshot dir");
+    for entry in std::fs::read_dir(src).expect("read snapshot dir") {
+        let entry = entry.expect("dir entry");
+        let name = entry.file_name();
+        if name == std::ffi::OsStr::new("config.json") {
+            continue;
+        }
+        std::os::unix::fs::symlink(entry.path(), dst.join(&name)).expect("symlink weight file");
+    }
+    let data = std::fs::read(src.join("config.json")).expect("read config.json");
+    let mut v: serde_json::Value = serde_json::from_slice(&data).expect("parse config.json");
+    v.as_object_mut()
+        .expect("config.json is a JSON object")
+        .insert("architectures".to_owned(), serde_json::json!([declared]));
+    std::fs::write(
+        dst.join("config.json"),
+        serde_json::to_vec_pretty(&v).expect("serialise config.json"),
+    )
+    .expect("write relabelled config.json");
+}
+
+/// Every K-side codec the Qwen-MoE guard exists to reject.
+fn k_side_disaster_codecs() -> Vec<KvQuant> {
+    vec![
+        KvQuant::Rotor3Sym,
+        KvQuant::Rotor4Sym,
+        KvQuant::RotorKOnly3,
+        KvQuant::RotorKOnly4,
+        KvQuant::Iso3Sym,
+        KvQuant::Iso4Sym,
+        KvQuant::IsoKOnly3,
+        KvQuant::IsoKOnly4,
+        KvQuant::PlanarK,
+        KvQuant::TurboSym3,
+        KvQuant::TurboSym4,
+    ]
+}
+
+/// A Qwen3.5 checkpoint with no sparse-MoE tensors must report the dense class,
+/// whatever the enum variant it shares with the MoE path is called.
+///
+/// Both Qwen3.5 arch strings load into one `Architecture` variant, so reporting
+/// the variant's name labelled every dense snapshot as MoE — in tracing, in the
+/// bench header, and in the metrics rows those runs wrote.
+#[test]
+#[ignore = "loads a real multi-GB snapshot"]
+fn dense_qwen3_5_snapshot_resolves_to_the_dense_class() {
+    let Some(dir) = snapshot(
+        "RMLX_TEST_MODEL_ORNITH_9B",
+        "sahilchachra__ornith-1.0-9b-mxfp8-mlx",
+    ) else {
+        return;
+    };
+
+    let model = arch::load_model(&dir, Device::Cpu, &arch::LoadOpts::default()).expect("load");
+
+    assert_eq!(
+        model.arch_class(),
+        "Qwen3_5ForConditionalGeneration",
+        "a checkpoint with no switch_mlp tensors resolves to dense; reporting the \
+         MoE class mislabels it everywhere arch_class() is consumed"
+    );
+
+    // The guard is scoped to sparse MoE, so a genuinely dense model keeps
+    // access to the K-side codecs. This is the half of the behaviour that must
+    // NOT change.
+    for kq in k_side_disaster_codecs() {
+        assert!(
+            model.validate_kv_quant(kq).is_ok(),
+            "{kq} must stay available on a dense Qwen3.5 model"
+        );
+    }
+}
+
+/// The bypass: MoE tensors, dense declaration. The guard must still fire.
+///
+/// Keyed on `architectures[0]` this run completes normally on the measured
+/// PPL-disaster path.
+#[test]
+#[ignore = "loads a real multi-GB snapshot"]
+fn mislabelled_moe_snapshot_cannot_bypass_the_k_side_guard() {
+    let Some(src) = snapshot(
+        "RMLX_TEST_MODEL_QWEN36",
+        "mlx-community__Qwen3.6-35B-A3B-8bit",
+    ) else {
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("declares-dense-ships-moe");
+    relabelled_snapshot(&src, "Qwen3_5ForConditionalGeneration", &dir);
+
+    assert_eq!(
+        declared_arch(&dir),
+        "Qwen3_5ForConditionalGeneration",
+        "test fixture must actually carry the mismatched declaration"
+    );
+
+    let model = arch::load_model(&dir, Device::Cpu, &arch::LoadOpts::default()).expect("load");
+
+    assert_eq!(
+        model.arch_class(),
+        "Qwen3_5MoeForConditionalGeneration",
+        "the resolved class must follow the tensors, not the declaration"
+    );
+
+    for kq in k_side_disaster_codecs() {
+        assert!(
+            model.validate_kv_quant(kq).is_err(),
+            "{kq} reached a sparse-MoE model through a dense declaration"
+        );
+    }
+
+    // K stays 8-bit here, so the guard has nothing to say — a refusal would be
+    // over-broad rather than safe.
+    assert!(model.validate_kv_quant(KvQuant::K8V8).is_ok());
+    assert!(model.validate_kv_quant(KvQuant::K8V4).is_ok());
+}
+
+/// Control: the same guard on a snapshot whose declaration is honest. This is
+/// the configuration that was already covered, and it must not regress.
+#[test]
+#[ignore = "loads a real multi-GB snapshot"]
+fn correctly_declared_moe_snapshot_is_still_guarded() {
+    let Some(dir) = snapshot(
+        "RMLX_TEST_MODEL_QWEN36",
+        "mlx-community__Qwen3.6-35B-A3B-8bit",
+    ) else {
+        return;
+    };
+
+    assert_eq!(declared_arch(&dir), "Qwen3_5MoeForConditionalGeneration");
+
+    let model = arch::load_model(&dir, Device::Cpu, &arch::LoadOpts::default()).expect("load");
+
+    assert_eq!(model.arch_class(), "Qwen3_5MoeForConditionalGeneration");
+    for kq in k_side_disaster_codecs() {
+        assert!(
+            model.validate_kv_quant(kq).is_err(),
+            "{kq} must be rejected"
+        );
+    }
+}

--- a/crates/rmlx-models/tests/resolved_arch_class.rs
+++ b/crates/rmlx-models/tests/resolved_arch_class.rs
@@ -101,6 +101,16 @@ fn k_side_disaster_codecs() -> Vec<KvQuant> {
         KvQuant::Rotor4Sym,
         KvQuant::RotorKOnly3,
         KvQuant::RotorKOnly4,
+        // The payload-bearing rotor variants — the only rotor codecs that
+        // reach the fused-QK kernel, so the reachable half of the family.
+        KvQuant::RotorK3Asym {
+            v_bits: 4,
+            v_group_size: 128,
+        },
+        KvQuant::RotorK4Asym {
+            v_bits: 4,
+            v_group_size: 128,
+        },
         KvQuant::Iso3Sym,
         KvQuant::Iso4Sym,
         KvQuant::IsoKOnly3,

--- a/crates/rmlx-server/src/engine/arch_generator.rs
+++ b/crates/rmlx-server/src/engine/arch_generator.rs
@@ -419,7 +419,11 @@ impl ArchGenerator {
         // the spiller / hydrator are never installed and decode is
         // byte-identical to the RAM-only path. The arch name selects the right
         // per-arch PROMPT_CACHE; archs without a spill/hydrate impl are skipped.
-        let arch_name = cfg.architectures.first().map_or("", String::as_str);
+        // Resolved, not declared: the per-arch PROMPT_CACHE and the layout-key
+        // salt must describe the model that was built. A snapshot whose
+        // declaration disagrees would otherwise select the wrong cache (or
+        // none) while decode runs the other architecture's layout.
+        let arch_name = model.arch_class();
         // layout-key inputs come straight from the loaded model so the
         // SSD tier salts every row with `(arch, n_layers, n_kv_heads, head_dim,
         // kv_quant)`. `attach_at_load` is a no-op when the tier is OFF, so

--- a/crates/rmlx-server/src/engine/arch_generator.rs
+++ b/crates/rmlx-server/src/engine/arch_generator.rs
@@ -201,6 +201,15 @@ impl ArchGenerator {
             },
         )?;
 
+        // Fail fast on a codec the resolved architecture refuses, before the
+        // codec is warmed and an SSD tier is keyed on it. The startup resolvers
+        // ran against the declared arch and cannot see a mismatch; without this
+        // the refusal would land on every request instead, after a startup that
+        // reported success.
+        if let Some(kq) = kv_quant_resolved {
+            model.validate_kv_quant(kq)?;
+        }
+
         // Deterministically warm the resolved KV codec's MSL kernels during
         // this load (preload) window so the first user request does not pay a
         // shader cold-compile. General per-codec (keyed off

--- a/crates/rmlx-server/src/engine/speculative.rs
+++ b/crates/rmlx-server/src/engine/speculative.rs
@@ -445,6 +445,16 @@ impl SpeculativeGenerator {
             _ => mpe.min(4096),
         };
 
+        // Fail fast on a codec the verifier's resolved architecture refuses.
+        // The round loop builds the verifier's KV caches itself rather than
+        // going through `Architecture::generate_greedy`, so without this the
+        // only enforcing check would run per request — every request failing
+        // after a fully successful startup. The verifier is the model whose
+        // caches carry the codec, so it is the one to ask.
+        if let Some(kq) = kv_quant_resolved {
+            dispatcher.verifier.validate_kv_quant(kq)?;
+        }
+
         tracing::info!(
             model_id = %model_id,
             k,
@@ -599,6 +609,16 @@ impl Generator for SpeculativeGenerator {
             );
             Some(ctx_quant)
         };
+        // The round loop below builds the verifier's KV caches directly, so
+        // this is the enforcing check for the speculative path — the seam in
+        // `Architecture::generate_greedy` is never reached from here. It covers
+        // the per-request override, which arrives after startup and is
+        // otherwise unvalidated.
+        if let Some(kq) = kv_quant_override {
+            if let Err(e) = self.dispatcher.verifier.validate_kv_quant(kq) {
+                return Box::pin(stream::once(async move { Err(e) }));
+            }
+        }
         // Issue #26: per-request max-ctx ceiling override (#25 lazy-grow path).
         let max_ctx_override = req.max_ctx_override.or(self.max_ctx_override);
         // F2: capture effective_max_ctx for drainer MetricEvent.ctx_max field.

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -4016,13 +4016,29 @@ The enforcing check is therefore keyed on the **resolved** architecture:
 - `Architecture::arch_class()` reports what the loader built. For the Qwen3.5
   variant it asks `has_sparse_moe_layers()` rather than echoing a fixed string.
 - `Architecture::validate_kv_quant()` re-runs the table against that resolved
-  class at the `generate_greedy` / `generate_image` seam — after load, before
-  any KV cache exists. A declaration cannot route around it, and a quant that
-  arrives after startup (a per-request `kv_quant` override, which the server's
-  resolver does not validate) is checked on the same terms as a launch flag.
+  class, after load and before any KV cache exists.
 - `load_model` emits a `warn!` naming `declared_arch` and `resolved_arch` when
   they differ, because that mismatch invalidates every predicate still keyed on
-  the declared name.
+  the declared name. Deliberate aliases (`registry::is_declared_arch_alias` —
+  today only Gemma4-unified) are exempt and log at `debug!`, so the warning
+  stays meaningful.
+
+The enforcement has to sit on **every path that builds a KV cache**, not on the
+one that reads the architecture. There are two such families, and they do not
+share a call graph:
+
+| Path | Cache built by | Enforced at |
+|---|---|---|
+| Non-speculative | per-arch `generate_greedy` (`gemma4`, `gemma3`, `qwen2`, `qwen3`, `qwen3_5_moe`, `qwen3_vl_moe`, `laguna`, `bitnet`), reached only from `Architecture::generate_greedy` / `generate_image` | those two methods, plus `ArchGenerator::new` at startup |
+| Speculative | `speculative::{mtp,dflash,eagle3,gemma4_assistant,mod}` build the verifier's caches directly — they never call `Architecture::generate_greedy` | `SpeculativeGenerator::new` at startup, and the per-request seam in its `generate` |
+
+Drafter-side caches are constructed with a hardcoded `KvQuant::None`, which
+passes every arch invariant by construction and needs no check.
+
+Startup checks are the fast-feedback copy (`exit 78` / a failed load rather than
+a per-request failure after a successful launch); the per-request checks are the
+enforcing copy, because a `kv_quant` field on a request arrives after startup and
+the server's resolver does not validate it.
 
 The startup resolvers (`rmlx-cli` `resolve_kv_quant`, the server's
 `resolve_kv_quant_for_load`) still read `architectures[0]` — they run before

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -3995,11 +3995,45 @@ inspected and confirmed to reject K-side ≤4-bit codecs on Qwen MoE arches:
 
 None of these K-side ≤4-bit codecs are selected by `resolve_default` for
 Qwen MoE — the `Qwen3_5MoeForConditionalGeneration` arm always returns
-`K8V8`. The guard is intact; no weakening detected during the codec adds.
+`K8V8`. The rejection table itself has not been weakened by the codec adds.
+
+#### What the guard keys off
+
+`validate_resolved` takes an architecture *string*, and which string it is
+handed decides whether the guard can fire at all.
+
+Both Qwen3.5 arch strings (`Qwen3_5MoeForConditionalGeneration` and the dense
+`Qwen3_5ForConditionalGeneration`) load through one loader into one
+`Architecture` variant. The loader does **not** believe the declaration: it
+selects dense-vs-sparse-MoE per layer from the tensor witness
+`mlp.switch_mlp.gate_proj.weight`. So `architectures[0]` and the model that
+actually gets built can disagree, and a checkpoint declaring the dense name
+while shipping MoE tensors used to run every codec in the list above to
+completion — no error, only wrong output.
+
+The enforcing check is therefore keyed on the **resolved** architecture:
+
+- `Architecture::arch_class()` reports what the loader built. For the Qwen3.5
+  variant it asks `has_sparse_moe_layers()` rather than echoing a fixed string.
+- `Architecture::validate_kv_quant()` re-runs the table against that resolved
+  class at the `generate_greedy` / `generate_image` seam — after load, before
+  any KV cache exists. A declaration cannot route around it, and a quant that
+  arrives after startup (a per-request `kv_quant` override, which the server's
+  resolver does not validate) is checked on the same terms as a launch flag.
+- `load_model` emits a `warn!` naming `declared_arch` and `resolved_arch` when
+  they differ, because that mismatch invalidates every predicate still keyed on
+  the declared name.
+
+The startup resolvers (`rmlx-cli` `resolve_kv_quant`, the server's
+`resolve_kv_quant_for_load`) still read `architectures[0]` — they run before
+the model is loaded, so it is the only value available. They stay as the
+fast-feedback path (`exit 78` at launch); they are no longer the only check.
 
 Empirical positive test: `validate_resolved_qwen_moe_low_k_bits_rejected_post_decompose`
 in `crates/rmlx-models/src/kv_cache/cache_type_tests.rs` verifies the
-runtime rejection path.
+runtime rejection path. The declared-vs-resolved bypass is covered by
+`crates/rmlx-models/tests/resolved_arch_class.rs`, which builds a snapshot
+that declares dense while shipping MoE tensors and asserts the guard fires.
 
 ---
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -34,10 +34,18 @@ known limitations for every architecture the server can load.
 
 ## Overview
 
-All architectures are identified by the `architectures[0]` field in
-`config.json`. The loader reads this field at startup (`arch.rs:KNOWN_ARCHS`)
-and dispatches to the matching backend. Unknown values are rejected with an
-error before any weight I/O occurs.
+Architecture **dispatch** keys on the `architectures[0]` field in `config.json`.
+The loader reads this field at startup (`arch.rs:KNOWN_ARCHS`) and picks the
+matching backend. Unknown values are rejected with an error before any weight
+I/O occurs.
+
+That field is a declaration, not a verified fact, and one arch string can cover
+several checkpoint shapes. Where a backend resolves the real shape from the
+weights (the Qwen3.5 dense-vs-MoE split), the authoritative identity is
+`Architecture::arch_class()` on the loaded model, not the declared string —
+`load_model` warns when the two differ. Anything that must be *correct* about
+the model rather than merely route to it (KV codec guards, per-arch caches,
+metrics identity) reads the resolved class.
 
 The generative architectures (`Qwen2`, `Qwen3`, `Qwen3_5Moe`, `Qwen3VlMoe`,
 `Gemma3`, `Gemma4`, `Laguna`) implement `Architecture::generate_greedy` and are
@@ -285,6 +293,15 @@ shard headers for the embedding witness, and selects each layer's MLP block
 (dense SwiGLU vs sparse MoE) by which tensors are present
 (`mlp.switch_mlp.*` → MoE; `mlp.{gate,up,down}_proj` → dense). `num_experts`
 defaults to 0 for dense configs that omit the MoE fields.
+
+**Declared vs resolved.** Because dispatch ignores the declaration, the two can
+disagree. `Architecture::arch_class()` reports the **resolved** class: for this
+variant it asks `has_sparse_moe_layers()` instead of echoing one fixed string,
+so a dense snapshot is labelled `Qwen3_5ForConditionalGeneration` in tracing,
+bench headers and metrics rows rather than being reported as MoE. `load_model`
+warns with `declared_arch` + `resolved_arch` when they differ. Safety
+predicates — the Qwen-MoE K-side codec guard above all — must use the resolved
+class; see `docs/KV_QUANT.md` § "What the guard keys off".
 
 ### Config schema
 
@@ -1445,6 +1462,9 @@ Run `rmlx info --list-cache-types` for all valid tags.
 ### Constraints
 
 - K-side bits < 8 rejected for `Qwen3_5MoeForConditionalGeneration` (PPL disaster).
+  Keyed on the **resolved** arch, so a checkpoint declaring the dense name while
+  shipping `switch_mlp` tensors is rejected too; a genuinely dense Qwen3.5 model
+  keeps these codecs.
 - 2-bit K rejected for all architectures (incoherent attention output).
 - `tq4` / `planar4` are V-side only codecs.
 - `rot_k` is a K-side only codec; requires power-of-two `head_dim`.

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -29,10 +29,18 @@ The tier is **off by default**. It activates when `--kv-ssd-cache-gb > 0` is
 passed at startup. When off, the spill and hydrate hooks are never installed and
 decode is byte-identical to the RAM-only path.
 
-Supported architectures (spill + hydrate wired):
-- `Gemma4ForConditionalGeneration`
+Supported architectures (spill + hydrate wired). These are **resolved** classes
+(`Architecture::arch_class()`), not the checkpoint's declared `architectures[0]`:
+- `Gemma4ForConditionalGeneration` (also serves the 12B unified snapshot, which
+  declares `Gemma4UnifiedForConditionalGeneration` and resolves to this class)
+- `Gemma3ForConditionalGeneration`
+- `Qwen2ForCausalLM`
 - `Qwen3ForCausalLM`
 - `Qwen3_5MoeForConditionalGeneration`
+- `Qwen3_5ForConditionalGeneration` (dense Qwen3.5 — same loader, model struct
+  and `PROMPT_CACHE` static as the sparse-MoE class)
+- `Qwen3VLMoeForConditionalGeneration`
+- `BitNetForCausalLM`
 
 Other architectures silently remain RAM-only when the tier is enabled; the SSD
 flag itself is not an error.
@@ -256,6 +264,22 @@ The key is deterministic across runs and distinct with overwhelming probability
 for every distinct input tuple. It is **not** weight-dependent: reloading the
 same architecture at the same `kv_quant` from a different snapshot yields the
 same `layout_key` and shares the cache, which is correct.
+
+`arch` is the **resolved** class. It was previously the declared
+`architectures[0]`, which could name a model that was not built — the salt is
+supposed to describe the layout, and a declaration is not evidence of one.
+
+> **One-time invalidation.** The 12B unified Gemma4 snapshot declares
+> `Gemma4UnifiedForConditionalGeneration` and resolves to
+> `Gemma4ForConditionalGeneration`, so its `layout_key` changes. Blocks spilled
+> by an earlier version become unreachable and keep counting against the
+> namespace budget until LRU evicts them: expect **one cold pass** for that
+> snapshot after upgrading, then steady state. No error, no action required,
+> and only when the tier is enabled (it is off by default). The alias was not
+> preserved in the salt on purpose — two snapshots that resolve to the same
+> architecture with the same geometry have the same layout, and keeping the
+> declared string here would re-introduce the dependence on an unvalidated,
+> model-side name that keying off the resolved class exists to remove.
 
 The key is one of the three terms of the block-hash seed, built at the call site
 by `rmlx_kv_ssd::hashing::cache_seed`:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -35,6 +35,16 @@ prove the Qwen-MoE K-side codec guard still fires. It symlinks the weights, so
 the fixture costs no disk; it is `#[ignore]`d only because it loads real
 snapshots.
 
+> **Known coverage gap.** The *invariant table* is covered weights-free
+> (`cache_type_tests.rs`, including
+> `validate_resolved_qwen3_5_dense_and_moe_strings_diverge`, which pins that the
+> two Qwen3.5 strings give opposite verdicts). Whether the enforcing call sites
+> actually consult it — `Architecture::generate_greedy` / `generate_image`, the
+> `ArchGenerator` and `SpeculativeGenerator` constructors, and the speculative
+> per-request seam — is exercised **only** by snapshot-gated tests. Deleting one
+> of those calls leaves `cargo test --workspace` and `make ci` green. Run the
+> `--ignored` suites above before trusting a change to those seams.
+
 ## Specialised test-model variables
 
 Some integration tests use dedicated snapshot variables instead of the family

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -18,13 +18,22 @@ The model directory must contain at minimum `config.json` and `tokenizer_config.
 | `RMLX_TEST_MODEL_GEMMA4_PARO` | `z-lab__gemma-4-31B-it-PARO` | `Gemma4ForConditionalGeneration` |
 | `RMLX_TEST_MODEL_MEDGEMMA` | `mlx-community__medgemma-1.5-4b-it-8bit` | `Gemma3ForConditionalGeneration` |
 | `RMLX_TEST_MODEL_QWEN36` | `mlx-community__Qwen3.6-35B-A3B-8bit` | `Qwen3_5MoeForConditionalGeneration` |
-| `RMLX_TEST_MODEL_QWEN36_PARO` | `z-lab__Qwen3.6-27B-PARO` | `Qwen3_5MoeForConditionalGeneration` |
+| `RMLX_TEST_MODEL_QWEN36_PARO` | `z-lab__Qwen3.6-27B-PARO` | `Qwen3_5ForConditionalGeneration` (dense PARO) |
+| `RMLX_TEST_MODEL_ORNITH_9B` | `sahilchachra__ornith-1.0-9b-mxfp8-mlx` | `Qwen3_5ForConditionalGeneration` (dense) |
 | `RMLX_TEST_MODEL_BONSAI` | `prism-ml__Ternary-Bonsai-8B-mlx-2bit` | `Qwen3ForCausalLM` |
 | `RMLX_TEST_MODEL_DR_VENUS` | `z-lab__DR-Venus-*` | `Qwen3ForCausalLM` |
 | `RMLX_TEST_MODEL_JINA_V4` | `jinaai__jina-embeddings-v4` | `JinaVLForEmbedding` |
 | `RMLX_TEST_MODEL_LAGUNA` | `z-lab__Laguna-*` | `LagunaForCausalLM` |
 | `RMLX_TEST_MODEL_READERLM_V2` | `mlx-community__jinaai-ReaderLM-v2` | `Qwen2ForCausalLM` |
 | `RMLX_TEST_MODEL_QWEN3_VL_30B` | `mlx-community__Qwen3-VL-30B-Instruct-*` | `Qwen3VLForConditionalGeneration` |
+
+The `Arch` column is the **resolved** class (`Architecture::arch_class()`), which
+for the Qwen3.5 family follows the checkpoint's tensors rather than its
+`architectures[0]`. `tests/resolved_arch_class.rs` pins that distinction and
+builds a deliberately mislabelled snapshot (dense declaration, MoE tensors) to
+prove the Qwen-MoE K-side codec guard still fires. It symlinks the weights, so
+the fixture costs no disk; it is `#[ignore]`d only because it loads real
+snapshots.
 
 ## Specialised test-model variables
 


### PR DESCRIPTION
Closes #352.

The guard protecting against a measured perplexity disaster (218 → 8641) could be
bypassed. Two ways, one of which the issue did not name and one of which survived the
first round of this fix.

## The issue's premise was half wrong

It reported `ornith-1.0-9b` declaring dense while the loader resolves MoE. Checked
against the tensors: that snapshot has **0** `switch_mlp` tensors and 32 dense
`mlp.gate_proj.weight`. The loader builds it all-dense, its declaration is honest, and
the guard's silence on it was **correct**.

What lied was the *reporting*: `arch_class()` returned the enum variant's name, and
both Qwen3.5 architecture strings share one variant — so every dense Qwen3.5 snapshot
was reported as `Qwen3_5MoeForConditionalGeneration` in tracing, bench headers and
metrics rows.

**The defect is real, and runs the other way.** The loader ignores `architectures[0]`
for dense-vs-MoE — it probes `mlp.switch_mlp.gate_proj.weight` — so the dangerous case
is *declare dense, ship MoE tensors*.

## Three bypasses, each proven by running it

Built the adversarial case rather than arguing it: a symlink farm over a real
256-expert snapshot with only `config.json` changed. Binaries hash-verified distinct,
and the new error string confirmed present in the fixed binary only.

| path | before | after |
|---|---|---|
| mislabelled MoE + `rotor3_sym`, plain decode | **exit 0**, 8 tokens generated | exit 1, refused |
| `--kv-quant rotor3_sym` at launch, speculative (`--draft-kind mtp`) | **HTTP 200 + tokens** | refused at load |
| `{"kv_quant":"rotor3_sym"}` per request, launch `k8v8`, speculative | **HTTP 200 + tokens** | refused |
| legal request, launch `k8v8` | 200 | 200 — not over-broad |
| mislabelled MoE + `k8v8` | — | 93.4 TPS, allowed |

The per-request row is the exact mutation mirror: identical command, identical model,
only the binary differs.

**A wider hole neither the issue nor the first round named:** the server's
`resolve_kv_quant_for_load` never called `validate_resolved` at all, so an explicit
`--kv-quant` or a per-request override reached the model unvalidated on *every*
architecture.

## The audit axis was the actual bug

The first round enumerated 14 *readers of the declared architecture string* and got
that list right — and still shipped a fully bypassable guard, because
`SpeculativeGenerator` reads no architecture string at all. It hands the resolved
codec straight to the MTP / DFlash / Eagle3 paths, which build caches directly. Those
verifiers are Qwen3.5/3.6-MoE — the exact architecture the guard protects.

When the deliverable is "cannot be bypassed", the enumeration has to be over **paths
that construct a KV cache**. Redone on that axis: 56 `KvCache::with_quant*` sites, 20
of them production, in two families that share no call graph.

| family | builds caches in | reached from | enforced at |
|---|---|---|---|
| non-speculative | per-arch `generate_greedy` (8 arches) | **only** `Architecture::generate_greedy` / `generate_image` — verified, all callers are `arch/mod.rs:955–1078`, `:1167`, `:1203` | those two, plus `ArchGenerator::new` |
| speculative | `mtp.rs:675`, `dflash:717`, `eagle3:873`, `gemma4_assistant:756`, `speculative/mod.rs:606,612,1058,1064` | `engine/speculative.rs:848–916` | `SpeculativeGenerator::new` + a per-request seam |
| drafter-internal | `mtp:113,133,819`, `dflash:237,253,883`, `eagle3:337,1155,1560`, `mod:1531` | — | none needed — hardcoded `KvQuant::None`, K stays bf16 |

That table is now in `docs/KV_QUANT.md`, so the axis survives this PR.

## The guard now keys on something that cannot lie

`has_sparse_moe_layers()` reads `MlpBlock::Moe`, built from a per-layer tensor witness
(`w.has("…mlp.switch_mlp.gate_proj.weight")`). The PARO path is always dense and
hard-errors on MoE witnesses. A declaration cannot route around it.

Scope verified as not over-broad: `is_qwen_moe` does not match the dense string, and
every codec `kv_quant_for_ctx` and `preferred_auto_kv` can return is K≥8, so auto mode
gains no new refusals. Refusals are actionable:

```
KV codec rejected for the architecture this snapshot actually resolves to
(Qwen3_5MoeForConditionalGeneration): K-side ≤4-bit on Qwen MoE is PPL-disaster:
--kv-quant rotor3_sym is rejected for Qwen3.5/3.6 MoE. Use '--kv-quant k8v8'
(K stays 8-bit) or a V-only rotor variant ('--kv-quant rotor3' / '--kv-quant rotor4').
```

Validation also moved to load time (`ArchGenerator::new`, `SpeculativeGenerator::new`)
rather than per-request only. In registry mode a refused codec previously gave a clean
startup, a warmed MSL codec that would never run, an SSD tier keyed on it, and then a
100% request failure rate with no startup signal.

## Behaviour changes, both deliberate

**Label.** Five snapshots here (ornith-9b, Qwen3.8-27B, both Bonsai-27B,
Qwen3.6-27B-PARO) are now reported as `Qwen3_5ForConditionalGeneration`. No codec is
newly refused for them. Historical metrics rows say MoE; per the free-form-labels rule
this breaks no validation — verified there is no `arch` column in either migration and
nothing checks it against an enum.

Eight hardcoded `"Qwen3_5MoeForConditionalGeneration"` literals inside
`qwen3_5_moe/generate.rs` were also collapsed to `model.arch_class()`. Without that, a
dense run emitted *two different* `arch=` values in one run's `.jsonl`, splitting exact-field
log search on the very field this change set out to make truthful.

**`layout_key` salt.** The salt's first term moves from the declared string to the
resolved class, which invalidates the SSD `layout_key` for the Gemma4-unified 12B
snapshot. Chosen deliberately: two snapshots that resolve to the same architecture with
the same geometry *have* the same layout, and keeping the declared string there would
re-introduce dependence on the unvalidated model-side name this change exists to
remove. Cost is bounded — one cold pass, self-healing via LRU, and only when the tier
is enabled (off by default). Documented in `docs/SSD_TIER.md` § layout_key Salt.

## Review round

- The mismatch `warn!` fired on **every** load of the correctly-declared Gemma4-unified
  12B, asserting that declared-name checks were unreliable for it — false, since
  `ssd_tier`, `kv_cache` and `prefill_chunk` all carry explicit `Gemma4Unified` arms.
  A safety warning that cries wolf on a supported test-target model trains operators to
  ignore the case that matters. Now suppressed via an explicit alias pair (not a
  heuristic; the Qwen3.5 dense/MoE pair is deliberately *not* in it). Verified on the
  real 12B: 0 mismatch warns.
- `k_side_disaster_codecs()` claimed to be "every K-side codec the guard rejects" but
  omitted `RotorK3Asym` / `RotorK4Asym` — the two payload-bearing variants, and the only
  rotor codecs that reach the fused-QK kernel. Added.
- `ssd_tier.rs` listed only the MoE string, so every dense Qwen3.5 snapshot fell to the
  RAM-only arm despite sharing a prompt cache with the sparse path. Dense arm added; the
  supported-arch list in `docs/SSD_TIER.md` was stale (3 of 7 actual arms) and is
  corrected.
- New weights-free test `validate_resolved_qwen3_5_dense_and_moe_strings_diverge` pins
  that the two strings give *opposite* verdicts for all 13 codecs — the enforcing seam
  itself is otherwise only covered by a snapshot-gated `#[ignore]` test that skips
  silently, which is recorded in `docs/TESTING.md` rather than assumed covered.

## Scoped, not fixed

**Qwen3-VL has the same defect one arm over.** `qwen3_vl_moe/loader.rs:212-214` selects
dense-vs-MoE per layer, so a checkpoint with `num_experts == 0` builds all-dense, is
still labelled MoE, and still has K-side codecs refused. Closing it needs a registered
dense Qwen3-VL class with arms in `ssd_tier`, `tool_parser`, `prefill_chunk` and
`resolve_default`. The `arch_class` doc now names the exception rather than implying it
is closed everywhere.

**Not proven:** the PPL impact of rotor-K on a *dense* Qwen3.5 model. The 218 → 8641
measurement is sparse-MoE only, so the guard's scope stays as measured rather than
widened on speculation.

An incidental rotor-store defect surfaced while testing (`CPU blocks cover 46 tokens
but shape[2] needs 50`) — filed as #378 with its reproduction caveat, since it appeared
only on the intentionally invalid configuration.

## Gates

`make ci` green. `make lint` clean, `cargo fmt --check` clean, 409 + 705 + 503 unit
tests, 3/3 integration. gemma-4-e2b 124.1 TPS, Bonsai-8B 91.1, ornith-9b 56.7 — all
within noise (the change is one enum match per generate call). Scratch `RMLX_HOME` +
`--metrics off` throughout.
