### PR TITLE
fix(sampling): host greedy resolves ties to the lowest id, matching the device (#373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,23 +64,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Greedy decoding picked a different token on the host than on the device
-  whenever the top logits tied.** MLX `argmax` resolves a tie to the lowest
-  token id; the host greedy path (`argmax_with_penalties`, taken whenever a
-  repetition/presence/frequency penalty or a `logit_bias` is set at
-  `temperature == 0`) used `Iterator::max_by`, which returns the *last*
-  maximum — and which also let a `NaN` reset the running best, since
-  `partial_cmp` is `None` against one. So adding a penalty to an otherwise
-  greedy request could change the token on a tied row, and an all-`-inf`
-  (fully constraint-masked) row returned the last id instead of id 0. Host
-  greedy now mirrors the device reduction exactly: strict `>` from a `-inf`
-  seed. Ties are not exotic — BF16 logits carry 8 mantissa bits, so at
-  magnitude 16 any two candidates within 0.125 collapse to the same value.
-  `top_k` gained the same rule (equal probabilities rank by ascending id), so
-  `top_k = 1` is the argmax on tied rows and not only on rows with a unique
-  maximum; previously which of the tied ids survived was decided by pdqsort's
-  pivot choice. The pre-existing tests could not reach this: every one of them
-  used a row with a unique maximum.
+- **Token selection resolved ties differently on the host than on the device,
+  and `top_p` / `top_k` resolved them differently on every call.** MLX `argmax`
+  resolves a tie to the lowest token id. The host greedy path
+  (`argmax_with_penalties`, taken whenever a repetition/presence/frequency
+  penalty or a `logit_bias` is set at `temperature == 0`) used
+  `Iterator::max_by`, which returns the *last* maximum — and which also let a
+  `NaN` reset the running best, since `partial_cmp` is `None` against one. So
+  adding a penalty to an otherwise greedy request could change the token on a
+  tied row, and an all-`-inf` (fully constraint-masked) row returned the last id
+  instead of id 0. `filter_top_k`, `filter_top_p` and `compute_top_logprobs`
+  each left their tied order to a sort's pivot choice or to a selection's swaps.
+  All four now use one rule — equal values rank by lowest token id — so
+  `top_k = 1` is the argmax on a tied row, the `top_p` nucleus is the lowest
+  tied ids rather than a non-contiguous scatter (a 64-wide row with one 0.4 and
+  63 identical tail values at `top_p 0.5` kept `{0, 29, 54..63}`), and logprob
+  rank 0 agrees with the device argmax. `top_p` matters most: it ships set in
+  several `generation_config.json` snapshots, so it is on by default on the
+  served path.
+
+  Ties are not exotic. On a realistic 262144-wide BF16-derived softmax row,
+  259416 of the 262143 adjacent pairs are exactly equal — 8 mantissa bits give
+  0.125 spacing at logit magnitude 16.
+
+  `filter_top_k` / `filter_top_p` implement the rule by sorting packed `u64`
+  keys (inverted IEEE bits above the token id) rather than by sorting indices
+  under a tie-breaking comparator, which fixes a second, pre-existing defect:
+  **a `NaN` probability aborted the decode step.** Folding an unordered pair to
+  `Equal` makes a `NaN` compare equal to everything, which is intransitive, and
+  `sort_unstable_by` panics with "user-provided comparison function does not
+  correctly implement a total order" — reproduced on the shipped comparator at
+  512 and 4096 elements. A `NaN` logit does reach these filters: the softmax
+  propagates it and skips its renormalise. Sorting `u64` makes the order total
+  by construction, so the class is gone rather than narrowed. It is also
+  cheaper: at 262144 wide the packed sort is 2.4 ms against 2.6 ms for the
+  index sort it replaces (and 5.9 ms for the index sort under a tie-breaking
+  comparator), so pinning the tie order costs nothing.
+
+  An all-forbidden constraint mask still falls through to id 0 for device
+  parity, but now emits a `tracing::warn!` at every mask-applying site instead
+  of silently emitting token 0 forever.
+
+  The pre-existing tests could not reach any of this: every row they used had a
+  unique maximum.
 - **Mixed / RotK decode produced wrong output above 8 192 context tokens.** The
   V side of `mixed_quantized_sdpa` diverted to a separate MSL kernel
   (`sparse_v_weighted_sum`) once the cache held 8 192 tokens or more. That

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,16 +141,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a row: it mirrors the device reduction, which skips `NaN` and returns the
   largest real logit, and erroring there would re-create the host/device split
   the tie contract exists to close.
-- **An all-`false` constraint mask produced a stuck stream instead of an
+- **An all-`false` constraint mask would produce a stuck stream instead of an
   error.** No token satisfies the grammar, so every token the selection could
   return violates it — and because the engine state that produced the empty mask
-  persists, the same arbitrary token was emitted for the rest of the generation
-  while the request reported success. All three mask-accepting entry points
-  (`apply_mask_argmax`, `argmax_with_penalties`, `sampling_distribution`) now
-  return `Err`. Logging instead would not have worked: the check sits on the
+  persists, the same arbitrary token would be emitted for the rest of the
+  generation while the request reported success. All three mask-accepting entry
+  points (`apply_mask_argmax`, `argmax_with_penalties`, `sampling_distribution`)
+  now return `Err`. Logging instead would not have worked: the check sits on the
   per-token decode path, so a `warn!` fires once per emitted token and, at a few
   hundred bytes a line, evicts the whole log directory under `RMLX_LOG_CAP_MB`
-  within hours — deleting the evidence it exists to provide.
+  within hours — deleting the evidence it exists to provide. This guard is
+  **unit-tested only and has no demonstrated production trigger**: the
+  all-`false` state was not reachable through the HTTP surface (`{"enum": []}`
+  is rejected at schema parse with HTTP 400 before a mask exists, and byte-level
+  BPE means exotic `const` / single-`enum` values never starve the mask). The
+  constraint engine does engage, so the path is live; the empty-mask state is a
+  future constraint-engine defect being pre-empted, not an observed one.
 - **Mixed / RotK decode produced wrong output above 8 192 context tokens.** The
   V side of `mixed_quantized_sdpa` diverted to a separate MSL kernel
   (`sparse_v_weighted_sum`) once the cache held 8 192 tokens or more. That

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Greedy decoding picked a different token on the host than on the device
+  whenever the top logits tied.** MLX `argmax` resolves a tie to the lowest
+  token id; the host greedy path (`argmax_with_penalties`, taken whenever a
+  repetition/presence/frequency penalty or a `logit_bias` is set at
+  `temperature == 0`) used `Iterator::max_by`, which returns the *last*
+  maximum — and which also let a `NaN` reset the running best, since
+  `partial_cmp` is `None` against one. So adding a penalty to an otherwise
+  greedy request could change the token on a tied row, and an all-`-inf`
+  (fully constraint-masked) row returned the last id instead of id 0. Host
+  greedy now mirrors the device reduction exactly: strict `>` from a `-inf`
+  seed. Ties are not exotic — BF16 logits carry 8 mantissa bits, so at
+  magnitude 16 any two candidates within 0.125 collapse to the same value.
+  `top_k` gained the same rule (equal probabilities rank by ascending id), so
+  `top_k = 1` is the argmax on tied rows and not only on rows with a unique
+  maximum; previously which of the tied ids survived was decided by pdqsort's
+  pivot choice. The pre-existing tests could not reach this: every one of them
+  used a row with a unique maximum.
 - **Mixed / RotK decode produced wrong output above 8 192 context tokens.** The
   V side of `mixed_quantized_sdpa` diverted to a separate MSL kernel
   (`sparse_v_weighted_sum`) once the cache held 8 192 tokens or more. That

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,26 +87,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   259416 of the 262143 adjacent pairs are exactly equal — 8 mantissa bits give
   0.125 spacing at logit magnitude 16.
 
-  `filter_top_k` / `filter_top_p` implement the rule by sorting packed `u64`
-  keys (inverted IEEE bits above the token id) rather than by sorting indices
-  under a tie-breaking comparator, which fixes a second, pre-existing defect:
-  **a `NaN` probability aborted the decode step.** Folding an unordered pair to
-  `Equal` makes a `NaN` compare equal to everything, which is intransitive, and
-  `sort_unstable_by` panics with "user-provided comparison function does not
-  correctly implement a total order" — reproduced on the shipped comparator at
-  512 and 4096 elements. A `NaN` logit does reach these filters: the softmax
-  propagates it and skips its renormalise. Sorting `u64` makes the order total
-  by construction, so the class is gone rather than narrowed. It is also
-  cheaper: at 262144 wide the packed sort is 2.4 ms against 2.6 ms for the
-  index sort it replaces (and 5.9 ms for the index sort under a tie-breaking
-  comparator), so pinning the tie order costs nothing.
+  Neither filter uses a comparator any more, which also removes a pre-existing
+  crash: **a `NaN` probability could abort the decode step.** Folding an
+  unordered pair to `Equal` makes a `NaN` compare equal to everything, which is
+  intransitive, and `sort_unstable_by` panics with "user-provided comparison
+  function does not correctly implement a total order" — reproduced on the
+  shipped comparator. Both filters now order integers under the standard `Ord`,
+  so no comparator exists to be intransitive.
 
-  An all-forbidden constraint mask still falls through to id 0 for device
-  parity, but now emits a `tracing::warn!` at every mask-applying site instead
-  of silently emitting token 0 forever.
+  They do it differently because they have different jobs, and this is also a
+  **speedup on both**. `filter_top_k` partitions (`select_nth_unstable`) over
+  packed `u64` keys — it needs a set, not an order, which is what mlx-lm's
+  `argpartition` says too. `filter_top_p` needs the full ascending order for its
+  cumulative sum, so it sorts the *values alone* and applies the id rule once,
+  to the single tied group the cut lands in; packing the id into that sort key
+  would make every key distinct and destroy the equal-element partition a
+  tie-dense row hands the sort, which measured *slower* than no tie rule at all.
+  At a 262144-token vocabulary, best-of-9 across three runs:
+
+  | Filter | fixture | before | after |
+  |---|---|---:|---:|
+  | `top_k` (k=64) | tie-dense | 2.02–2.13 ms | 0.30–0.33 ms |
+  | `top_k` (k=64) | all-distinct | 3.67–4.31 ms | 0.32–0.41 ms |
+  | `top_p` (0.95) | tie-dense | 2.02–2.06 ms | 1.31–1.34 ms |
+  | `top_p` (0.95) | all-distinct | 3.73–4.32 ms | 2.17–2.68 ms |
+
+  The rank keys use the IEEE total-order flip rather than the raw bit pattern,
+  so they order every `f32`. The raw pattern is monotone only over non-negative
+  values; `probs` are non-negative today, but the failure mode if that stopped
+  holding is a silently wrong token — `-0.0` outranks every positive, so
+  `top_k = 1` on `[-0.0, 0.5, 0.25]` would zero the real maximum and keep
+  `-0.0` — and `release-perf` disables debug assertions, so an assert would not
+  catch it.
 
   The pre-existing tests could not reach any of this: every row they used had a
   unique maximum.
+- **The sampler emitted a constant token, silently, on a `NaN` logits row.**
+  `softmax_scaled` propagated the `NaN` into `probs`; `renormalise` then no-oped
+  (`total > 0.0` is false on `NaN`), `sample_inverse_cdf`'s `total <= 0.0` guard
+  was also false, its `cum > target` never fired, and it returned `last_nonzero`
+  — the same id on every step, **independent of the RNG**, with the request
+  reporting success. Measured on a 16-wide row with one `NaN`: a constant token
+  for every seed tried, against a varied healthy control; with `top_k = 1` the
+  `NaN` took the only surviving slot and the stream collapsed to id 0.
+
+  `softmax_scaled` now returns `Err` when the exponentials do not sum to a
+  finite value, which happens exactly when a logit is `NaN` or `+inf`. This is
+  the decode-step half of the rule the prefill guard already enforces, and it
+  has to live here because that guard is a *prefill* guard: on every
+  test-target architecture it runs once before the loop and never again, so
+  nothing downstream reported a `NaN` arriving at decode step 300. The check is
+  free — `sum` is already computed. Greedy deliberately does **not** refuse such
+  a row: it mirrors the device reduction, which skips `NaN` and returns the
+  largest real logit, and erroring there would re-create the host/device split
+  the tie contract exists to close.
+- **An all-`false` constraint mask produced a stuck stream instead of an
+  error.** No token satisfies the grammar, so every token the selection could
+  return violates it — and because the engine state that produced the empty mask
+  persists, the same arbitrary token was emitted for the rest of the generation
+  while the request reported success. All three mask-accepting entry points
+  (`apply_mask_argmax`, `argmax_with_penalties`, `sampling_distribution`) now
+  return `Err`. Logging instead would not have worked: the check sits on the
+  per-token decode path, so a `warn!` fires once per emitted token and, at a few
+  hundred bytes a line, evicts the whole log directory under `RMLX_LOG_CAP_MB`
+  within hours — deleting the evidence it exists to provide.
 - **Mixed / RotK decode produced wrong output above 8 192 context tokens.** The
   V side of `mixed_quantized_sdpa` diverted to a separate MSL kernel
   (`sparse_v_weighted_sum`) once the cache held 8 192 tokens or more. That

--- a/crates/rmlx-models/src/sampler.rs
+++ b/crates/rmlx-models/src/sampler.rs
@@ -333,7 +333,7 @@ pub fn argmax_with_penalties(
                 logits[i] = f32::NEG_INFINITY;
             }
         }
-        warn_all_forbidden(any_allowed, "argmax_with_penalties", vocab);
+        reject_all_forbidden(any_allowed, "argmax_with_penalties", vocab)?;
     }
 
     // Apply penalties.
@@ -353,20 +353,30 @@ pub fn argmax_with_penalties(
         .map_err(|e| Error::Other(format!("argmax_with_penalties: id array build failed: {e}")))
 }
 
-/// An all-forbidden constraint mask is a constraint-engine defect: no token
-/// satisfies the grammar, so whatever the reduction returns is arbitrary. The
-/// selection still has to return *something* to keep the decode loop's error
-/// channel meaningful, so it falls through to the device-parity answer (id 0),
-/// but the condition is logged rather than swallowed — otherwise the stream
-/// emits token 0 forever with nothing in the run log to explain it.
-fn warn_all_forbidden(any_allowed: bool, site: &'static str, vocab: usize) {
-    if !any_allowed {
-        tracing::warn!(
-            site,
-            vocab,
-            "constraint mask forbids every token; selection falls back to id 0"
-        );
+/// An all-forbidden constraint mask is a constraint-engine defect, not a mode:
+/// no token satisfies the grammar, so every token the selection could return
+/// violates it.
+///
+/// Returning one anyway is the worst option available. It emits an arbitrary
+/// token — id 0, under the device's `-inf`-seeded reduction — and because the
+/// engine state that produced the empty mask is persistent, it emits that same
+/// token for the rest of the generation. The request "succeeds" with a constant
+/// stream. Logging instead of returning is no better at the rate this is
+/// reached: the check sits on the per-token decode path, so a `warn!` fires
+/// once per emitted token and, at a few hundred bytes a line, evicts the whole
+/// log directory under its size cap within hours — deleting the evidence it
+/// exists to provide.
+///
+/// So it errors. One line per request, on the channel the decode loop already
+/// propagates, and the generation stops instead of pretending.
+fn reject_all_forbidden(any_allowed: bool, site: &'static str, vocab: usize) -> Result<()> {
+    if any_allowed {
+        return Ok(());
     }
+    Err(Error::Other(format!(
+        "{site}: constraint mask forbids every one of {vocab} tokens; \
+         no token can satisfy the grammar at this step"
+    )))
 }
 
 /// Index of the maximum of `logits`, resolving ties to the **lowest** index.
@@ -375,12 +385,21 @@ fn warn_all_forbidden(any_allowed: bool, site: &'static str, vocab: usize) {
 /// decode path dispatches on the device. It accumulates with a strict `>` from
 /// a `-inf` seed, which gives three properties the device reduction also has:
 /// equal values never displace the earlier index, a `NaN` never displaces a
-/// real maximum, and a fully constraint-masked (all `-inf`) row yields `0`.
+/// real maximum, and an all-`-inf` row yields `0`.
 ///
 /// The `-inf` seed is the **Metal** reduction's seed, which is the production
 /// stream. MLX's CPU backend seeds with element 0 instead, so the two disagree
 /// on exactly one shape — a `NaN` at index 0 — and no host rule can match both.
 /// Everywhere else the two MLX backends agree with each other and with this.
+///
+/// The all-`-inf` bullet is the weakest of the three, and the `#[ignore]`d
+/// `Device::Gpu` mirror is what checks it: it is the only row where the `-inf`
+/// seed is never displaced, so what a multi-threadgroup Metal arg-reduce
+/// returns is a property of the reduction's seeding rather than of its
+/// comparisons, and the CPU-stream test cannot fail it (MLX's CPU backend
+/// seeds with `in[0]`, so it returns 0 by construction whatever Metal does).
+/// The row is no longer reachable through a constraint mask — that case now
+/// errors — but it stays documented because the function still has to answer.
 ///
 /// Greedy selection must not depend on which side of the FFI boundary it runs,
 /// so host greedy goes through here rather than `Iterator::max_by` — which
@@ -553,7 +572,29 @@ fn logits_to_host_f32(logits_flat: &Array, vocab: usize) -> Result<Vec<f32>> {
 /// Numerically-stable softmax of temperature-scaled logits, in place into a
 /// fresh `Vec<f32>`. `inv_temp = 1.0 / temperature`. Forbidden positions
 /// (already `-inf` from the constraint mask) softmax to exactly `0.0`.
-fn softmax_scaled(logits: &[f32], inv_temp: f32) -> Vec<f32> {
+///
+/// # Refusing an unusable row
+///
+/// Errors when the exponentials do not sum to a finite value, which happens
+/// exactly when a logit is `NaN` or `+inf`. This is the decode-step half of the
+/// rule the prefill guard already enforces — a non-finite logits row must abort
+/// the request, not produce a token — and it has to be enforced here because
+/// the prefill guard is a *prefill* guard: on every test-target architecture it
+/// runs once before the loop and never again, so nothing downstream reports a
+/// `NaN` that appears at decode step 300.
+///
+/// Sampling such a row is not a degraded result, it is a silent one. A `NaN`
+/// propagates to `probs`, then `renormalise` no-ops (its `total > 0.0` guard is
+/// false on `NaN`), then `sample_inverse_cdf`'s `total <= 0.0` guard is also
+/// false, its `cum > target` comparison never fires, and it returns
+/// `last_nonzero` — the same index on every step, **independent of the RNG**.
+/// Measured on a 16-wide row with one `NaN`: the stream is a constant token for
+/// every seed tried, against a healthy varied control.
+///
+/// The check is free: `sum` is already computed, and `NaN`/`+inf` both
+/// propagate into it (`+inf` because the all-`-inf` guard below rewrites `max`
+/// to `0.0`, so an infinite `scaled` stays infinite through the subtraction).
+fn softmax_scaled(logits: &[f32], inv_temp: f32) -> Result<Vec<f32>> {
     let mut max = f32::NEG_INFINITY;
     for &l in logits {
         let s = l * inv_temp;
@@ -579,13 +620,19 @@ fn softmax_scaled(logits: &[f32], inv_temp: f32) -> Vec<f32> {
             e
         })
         .collect();
+    if !sum.is_finite() {
+        return Err(Error::Other(format!(
+            "sampler: logits row is not finite (softmax sum = {sum}); \
+             a NaN or infinite logit cannot be sampled"
+        )));
+    }
     if sum > 0.0 {
         let inv = 1.0 / sum;
         for p in &mut probs {
             *p *= inv;
         }
     }
-    probs
+    Ok(probs)
 }
 
 /// mlx-lm `apply_top_k` (sample_utils.py L130-151): keep the `k` highest
@@ -599,12 +646,15 @@ fn softmax_scaled(logits: &[f32], inv_temp: f32) -> Vec<f32> {
 /// would make which of two equally-likely tokens survives an artefact of
 /// pdqsort's pivot choice.
 ///
-/// The rank order is produced by sorting **packed `u64` keys** rather than by
-/// sorting indices under a custom comparator. See [`rank_key_desc`] for why —
-/// briefly, a comparator that folds an unordered `NaN` pair to `Equal` and then
-/// breaks that "tie" by id is not a total order, and `sort_unstable_by` panics
-/// on it; and at a 262144-token vocabulary the packed sort is measurably
-/// cheaper than an index sort under any comparator.
+/// The `k` survivors are found by **partitioning**, not by sorting: `top_k`
+/// needs a set, not an order, which is what mlx-lm's `argpartition` says too.
+/// Every rank a sort computes past the cut is discarded. Measured at a
+/// 262144-token vocabulary, best-of-9 over three process runs: 2.02–2.37 ms for
+/// the index sort this replaces, 0.30–0.35 ms here.
+///
+/// The partition runs over [`rank_key_desc`] keys, which carry the tie rule, so
+/// the surviving *set* is uniquely determined (all keys are distinct) and does
+/// not depend on the pivot choice.
 #[allow(
     clippy::indexing_slicing,
     reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
@@ -621,75 +671,70 @@ fn filter_top_k(probs: &mut [f32], k: usize) {
         .enumerate()
         .map(|(i, &p)| rank_key_desc(p, i))
         .collect();
-    keys.sort_unstable();
+    keys.select_nth_unstable(k);
     for &key in &keys[k..] {
         probs[key_id(key)] = 0.0;
     }
 }
 
+/// Map an `f32` to a `u32` whose unsigned order is IEEE **total order** —
+/// `-NaN < -inf < .. < -0.0 < +0.0 < .. < +inf < +NaN`.
+///
+/// The standard sign-flip: a non-negative value gets its sign bit set, a
+/// negative value is inverted whole. Three ALU ops, applied once per element
+/// rather than once per comparison.
+///
+/// This is what lets the rank keys carry *every* `f32` instead of resting on a
+/// precondition. The raw bit pattern is only monotone over non-negative values,
+/// and while `probs` are non-negative today, the failure mode if that ever
+/// stopped holding is a silently wrong token rather than a crash: `-0.0`
+/// (pattern `0x8000_0000`) would outrank every positive probability, so
+/// `top_k(1)` on `[-0.0, 0.5, 0.25]` would zero the real maximum and leave
+/// `-0.0` as the sole survivor. A `debug_assert` would not catch it either —
+/// `release-perf` builds with `debug-assertions = false`. Making the key
+/// correct for all inputs costs less than documenting why it is not.
+#[inline]
+fn total_order_bits(p: f32) -> u32 {
+    let b = p.to_bits();
+    b ^ ((((b as i32) >> 31) as u32) | 0x8000_0000)
+}
+
+/// Inverse of [`total_order_bits`].
+#[inline]
+fn from_total_order_bits(o: u32) -> f32 {
+    f32::from_bits(o ^ ((((!o) as i32) >> 31) as u32 | 0x8000_0000))
+}
+
 /// Sort key placing `probs` in **descending** order with ties resolved to the
-/// **lowest** id: the inverted IEEE bit pattern in the high half-word, the
+/// **lowest** id: the inverted total-order bits in the high half-word, the
 /// token id in the low half-word.
 ///
 /// # Why a packed key and not a comparator
 ///
-/// Two independent reasons, both load-bearing.
-///
-/// **It cannot panic.** Sorting `u64` uses the standard `Ord`, so the order is
-/// total by construction. Every `partial_cmp` form is not: folding an unordered
-/// pair to `Equal` makes a `NaN` compare equal to everything, which is already
+/// Sorting or partitioning `u64` uses the standard `Ord`, so the order is total
+/// by construction. Every `partial_cmp` form is not: folding an unordered pair
+/// to `Equal` makes a `NaN` compare equal to everything, which is already
 /// intransitive (`a == NaN`, `NaN == b`, but `a < b`), and adding an id
 /// tiebreak on top turns that into an outright cycle (`i < j`, `j < k`,
-/// `k < i`). `sort_unstable_by` detects either and aborts the decode step —
-/// measured on both shapes at 512 and 4096 elements. `NaN` reaches these
-/// filters whenever a `NaN` logit does: `softmax_scaled` propagates it and
-/// skips its renormalise, whose `sum > 0.0` guard is false on `NaN`.
+/// `k < i`). `sort_unstable_by` detects either and aborts the decode step.
 ///
-/// **It is cheaper.** An index sort dereferences `probs` twice per comparison
-/// at random offsets; sorting the keys is contiguous and compares one integer.
-/// Measured over a 262144-wide BF16-derived softmax row (a realistic served
-/// shape, in which 259416 of the 262143 adjacent pairs are exactly equal, so
-/// the tie path is the common path): 2.58 ms for the untied index sort that
-/// preceded this, 5.92 ms for the same sort under a tie-breaking comparator,
-/// 2.43 ms here.
+/// `NaN` no longer reaches here — `softmax_scaled` refuses a non-finite row —
+/// but the guarantee is kept rather than leaned on, because these two filters
+/// are also reachable directly and a total order costs nothing to hold.
 ///
-/// # Preconditions
+/// # Precondition
 ///
-/// `probs` are non-negative — every element is an `exp` result or a literal
-/// `0.0`, so the IEEE bit pattern is monotone in the value and `-0.0` (whose
-/// pattern would sort above every positive) cannot occur. `id` fits in 32 bits:
-/// it indexes a vocabulary that reaches this crate as an MLX `i32` shape.
-///
-/// A `NaN` sorts above `+inf` because its bit patterns are the largest. That
-/// is a determinism guarantee, not a claim that the rank is meaningful — a
-/// `NaN` logit is a defect the decode loop reports upstream; this only ensures
-/// the sampler survives to let it.
+/// `id` fits in 32 bits: it indexes a vocabulary that reaches this crate as an
+/// MLX `i32` shape, so it cannot exceed `i32::MAX`.
 #[inline]
 fn rank_key_desc(p: f32, id: usize) -> u64 {
-    (u64::from(!p.to_bits()) << 32) | id as u64
-}
-
-/// Sort key placing `probs` in **ascending** order with ties resolved to the
-/// **highest** id. Counterpart to [`rank_key_desc`]; same preconditions.
-///
-/// The inverted id is what makes the *lowest* ids survive a `top_p` cut: that
-/// walk is ascending and drops from the front, so a tied group has to be
-/// ordered highest-id-first for its low ids to outlast the threshold.
-#[inline]
-fn rank_key_asc(p: f32, id: usize) -> u64 {
-    (u64::from(p.to_bits()) << 32) | u64::from(!(id as u32))
+    (u64::from(!total_order_bits(p)) << 32) | u64::from(id as u32)
 }
 
 /// Recover the token id from a [`rank_key_desc`] key.
 #[inline]
 fn key_id(key: u64) -> usize {
     (key & 0xffff_ffff) as usize
-}
-
-/// Recover the token id from a [`rank_key_asc`] key.
-#[inline]
-fn key_id_inverted(key: u64) -> usize {
-    !(key as u32) as usize
 }
 
 /// mlx-lm `apply_top_p` (sample_utils.py L205-237).
@@ -709,18 +754,43 @@ fn key_id_inverted(key: u64) -> usize {
 /// values at `top_p = 0.5`, the unordered version keeps `{0, 29, 54..63}` —
 /// id 29 survives while ids 30..53 are zeroed from a bit-identical value.
 ///
-/// The order comes from sorting packed `u64` keys ([`rank_key_asc`]) rather
-/// than sorting indices under a comparator — both for the total-order
-/// guarantee and for the cost, spelled out on [`rank_key_desc`]. This filter is
-/// the one most exposed to both: `top_p` ships set in several
+/// This filter is the one that matters most: `top_p` ships set in several
 /// `generation_config.json` snapshots, so unlike `top_k` it is on by default on
 /// the served path.
 ///
-/// The drop set is a prefix of the ascending order (probabilities are
-/// non-negative, so `cum` never decreases), and every member of a tied group
-/// contributes the same value, so *how many* elements are dropped does not
-/// depend on the order within a group — only *which ones* does, which is what
-/// the id rule pins.
+/// # Why this is not one sort over (probability, id)
+///
+/// Because that is the slowest of the three options at a real vocabulary, and
+/// it is slow for a reason specific to this data. Served rows are tie-dense —
+/// on a 262144-wide BF16-derived softmax only ~1200 of the 262144 values are
+/// distinct — and a sort over values alone gets to use its equal-element
+/// partition, which is most of its work. Appending the id to break ties makes
+/// every key unique and throws that away, which is a **regression**, not a win:
+/// measured at 262144, best-of-9, 2.02–2.06 ms for the untied index sort this
+/// replaces against 2.26–2.39 ms for a packed (value, id) sort. Splitting the
+/// two concerns gets 1.31–1.42 ms.
+///
+/// So the order is taken over **values only**, and the id rule is applied once,
+/// to the single tied group the cut lands in:
+///
+/// 1. Sort the [`total_order_bits`] of the probabilities. Ties stay ties, so
+///    the equal-partition path survives.
+/// 2. Walk that ascending and find `d`, the number of elements dropped. The
+///    drop set is a *prefix*: probabilities are non-negative, so `cum` never
+///    decreases. And `d` does not depend on the order within a tied group,
+///    because every member contributes the same value to `cum` — only *which*
+///    members are dropped depends on it.
+/// 3. Of the group sitting exactly at the cut value, drop the `m` **highest**
+///    ids, keeping the lowest ones — the same lowest-id-wins rule
+///    [`filter_top_k`] and the device reduction use.
+///
+/// Without step 3 the survivor set is whatever pdqsort's pivot choice produced:
+/// on a row of 64 with one 0.4 and 63 identical tail values at `top_p = 0.5`,
+/// the unordered version keeps `{0, 29, 54..63}` — id 29 survives while ids
+/// 30..53 are zeroed from a bit-identical value.
+///
+/// Every sort and selection here is over integers under the standard `Ord`, so
+/// no comparator exists to be intransitive (see [`rank_key_desc`]).
 #[allow(
     clippy::indexing_slicing,
     reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
@@ -729,21 +799,54 @@ fn filter_top_p(probs: &mut [f32], top_p: f32) {
     if !(top_p > 0.0 && top_p < 1.0) {
         return;
     }
-    // Ascending by probability, ties by descending id.
-    let mut keys: Vec<u64> = probs
-        .iter()
-        .enumerate()
-        .map(|(i, &p)| rank_key_asc(p, i))
-        .collect();
-    keys.sort_unstable();
+    let n = probs.len();
+    let mut ordered: Vec<u32> = probs.iter().map(|&p| total_order_bits(p)).collect();
+    ordered.sort_unstable();
+
+    // Walk ascending; cumulative is inclusive of the current element. Drop
+    // where cum <= threshold (mlx-lm: `mx.where(cumprob > 1 - top_p, ...)`).
     let threshold = 1.0 - top_p;
     let mut cum = 0.0f32;
-    // Walk ascending; cumulative is inclusive of the current element. Keep
-    // where cum > threshold (mlx-lm: `mx.where(cumprob > 1 - top_p, ...)`).
-    for &key in &keys {
-        let i = key_id_inverted(key);
-        cum += probs[i];
+    let mut dropped = 0usize;
+    for (rank, &o) in ordered.iter().enumerate() {
+        cum += from_total_order_bits(o);
         if cum <= threshold {
+            dropped = rank + 1;
+        } else {
+            break;
+        }
+    }
+    if dropped == 0 {
+        return;
+    }
+    if dropped >= n {
+        for p in probs.iter_mut() {
+            *p = 0.0;
+        }
+        return;
+    }
+
+    // Everything below the cut value goes; the group *at* it is split by id.
+    let cut = ordered[dropped - 1];
+    let below = ordered.partition_point(|&o| o < cut);
+    let at_cut_dropped = dropped - below;
+
+    // `tied` comes out of a forward scan, so it is already ascending by id —
+    // no sort or selection is needed to find its highest members, they are its
+    // tail.
+    let mut tied: Vec<usize> = Vec::new();
+    for (i, p) in probs.iter_mut().enumerate() {
+        let o = total_order_bits(*p);
+        if o < cut {
+            *p = 0.0;
+        } else if o == cut {
+            tied.push(i);
+        }
+    }
+    if at_cut_dropped > 0 && at_cut_dropped <= tied.len() {
+        // Keep the lowest ids: drop the highest `at_cut_dropped` of the group.
+        let keep = tied.len() - at_cut_dropped;
+        for &i in &tied[keep..] {
             probs[i] = 0.0;
         }
     }
@@ -925,7 +1028,7 @@ pub fn sampling_distribution(
                 logits[i] = f32::NEG_INFINITY;
             }
         }
-        warn_all_forbidden(any_allowed, "sampling_distribution", vocab);
+        reject_all_forbidden(any_allowed, "sampling_distribution", vocab)?;
     }
 
     if penalty_cfg.penalties_active() {
@@ -941,7 +1044,7 @@ pub fn sampling_distribution(
 
     // temperature > 0 guaranteed by the caller's stochastic branch.
     let inv_temp = 1.0 / sp.temperature;
-    let mut probs = softmax_scaled(&logits, inv_temp);
+    let mut probs = softmax_scaled(&logits, inv_temp)?;
     filter_top_p(&mut probs, sp.top_p);
     filter_min_p(&mut probs, sp.min_p);
     filter_top_k(&mut probs, sp.top_k as usize);
@@ -1095,7 +1198,9 @@ pub struct TokenLogprobs {
 /// an artefact of the selection's swaps. The selection compares on
 /// `(logit, lowest id)`, which is a total order on the remaining candidates —
 /// it therefore does not care that `idx.swap` leaves the unscanned suffix in an
-/// arbitrary order, which a positional tiebreak would.
+/// arbitrary order, which a positional tiebreak would. It is seeded from
+/// outside the candidate set for the same reason [`host_argmax`] is, so a
+/// `NaN` never takes a rank ahead of a real logit.
 #[allow(
     clippy::indexing_slicing,
     reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
@@ -1144,14 +1249,23 @@ pub fn compute_top_logprobs(
     let mut idx: Vec<usize> = (0..vocab).collect();
     let mut top: Vec<(u32, f32)> = Vec::with_capacity(k);
     for slot in 0..k {
-        let mut best = slot;
-        for j in (slot + 1)..vocab {
-            let (lj, lb) = (logits[idx[j]], logits[idx[best]]);
-            if lj > lb || (lj == lb && idx[j] < idx[best]) {
-                best = j;
+        // Seeded from OUTSIDE the candidate set, exactly as `host_argmax` is:
+        // `-inf` for the value, `usize::MAX` for the id. Seeding from the
+        // candidate at `slot` would let a `NaN` sitting there win the rank —
+        // every later `>` and `==` against it is false — and rank 0 would then
+        // disagree with the device `argmax`, which skips `NaN` entirely.
+        let mut best_pos = slot;
+        let mut best_val = f32::NEG_INFINITY;
+        let mut best_id = usize::MAX;
+        for j in slot..vocab {
+            let (lj, id) = (logits[idx[j]], idx[j]);
+            if lj > best_val || (lj == best_val && id < best_id) {
+                best_val = lj;
+                best_id = id;
+                best_pos = j;
             }
         }
-        idx.swap(slot, best);
+        idx.swap(slot, best_pos);
         let id = idx[slot];
         top.push((id as u32, logprob_of(id)));
     }
@@ -1183,9 +1297,9 @@ const NEG_INF_F32_BITS: u32 = 0xFF80_0000u32;
 /// `logits_flat`: `[1, vocab]` array of F32 or BF16. Other dtypes return Err.
 ///
 /// `mask`: `vocab`-length boolean slice. `mask[i] == true` means token `i`
-/// is allowed. At least one entry must be `true`; if all are `false`, the
-/// argmax will return an arbitrary forbidden token (callers must not produce
-/// all-false masks).
+/// is allowed. At least one entry must be `true`; an all-`false` mask returns
+/// `Err` rather than an arbitrary forbidden token — see
+/// [`reject_all_forbidden`].
 ///
 /// The `device` parameter selects the MLX stream for the GPU ops.
 #[inline(never)]
@@ -1211,7 +1325,7 @@ pub fn apply_mask_argmax(logits_flat: &Array, mask: &[bool], device: Device) -> 
             bias_bytes[off..off + 4].copy_from_slice(&neg_inf_bytes);
         }
     }
-    warn_all_forbidden(any_allowed, "apply_mask_argmax", vocab);
+    reject_all_forbidden(any_allowed, "apply_mask_argmax", vocab)?;
     // Allowed entries are already 0.0 (zero_bytes) from vec initialisation.
     let _ = zero_bytes; // suppress unused warning
 

--- a/crates/rmlx-models/src/sampler.rs
+++ b/crates/rmlx-models/src/sampler.rs
@@ -1,3 +1,10 @@
+// LOC-exempt: the selection layer is one contract, not several. Greedy
+// (host + masked), the penalty processors, the three mlx-lm filters, the
+// speculative acceptance path and the logprob ranks all have to resolve a tie
+// the same way the device `argmax` does, and they share the rank-key helpers
+// that encode that rule. Splitting on the obvious seam — filters here,
+// selection there — would put the rule and its enforcement in different files
+// and is exactly how the host and device drifted apart in the first place.
 // unsafe_code: mlx-rs Array zero-copy view — slice::from_raw_parts byte-reinterpret for Array::from_bytes (seed state)
 #![allow(unsafe_code)]
 
@@ -745,14 +752,9 @@ fn key_id(key: u64) -> usize {
 /// Survivors keep their prob; the rest go to `0.0`. No-op unless
 /// `0 < top_p < 1` (mlx-lm `make_sampler` gate).
 ///
-/// Equal probabilities are ranked by **descending** token id. The walk is
-/// ascending and drops from the front, so the ids walked first are the ones
-/// zeroed — ordering a tied group highest-id-first is what leaves the **lowest
-/// ids** in the nucleus, the same lowest-id-wins rule `filter_top_k` and the
-/// device reduction use. Without it the survivor set is whatever pdqsort's
-/// pivot choice produced: on a row of 64 with one 0.4 and 63 identical tail
-/// values at `top_p = 0.5`, the unordered version keeps `{0, 29, 54..63}` —
-/// id 29 survives while ids 30..53 are zeroed from a bit-identical value.
+/// Among equal probabilities the **lowest ids** survive — the same
+/// lowest-id-wins rule [`filter_top_k`] and the device reduction use. That is
+/// the contract; the mechanism is under "Why this is not one sort" below.
 ///
 /// This filter is the one that matters most: `top_p` ships set in several
 /// `generation_config.json` snapshots, so unlike `top_k` it is on by default on
@@ -783,6 +785,10 @@ fn key_id(key: u64) -> usize {
 /// 3. Of the group sitting exactly at the cut value, drop the `m` **highest**
 ///    ids, keeping the lowest ones — the same lowest-id-wins rule
 ///    [`filter_top_k`] and the device reduction use.
+///
+/// Exactly one group can straddle the cut, because the drop set is a prefix of
+/// a sorted order, so `m` is always in `1..=tied.len()`. The range check on it
+/// is defensive and never false.
 ///
 /// Without step 3 the survivor set is whatever pdqsort's pivot choice produced:
 /// on a row of 64 with one 0.4 and 63 identical tail values at `top_p = 0.5`,

--- a/crates/rmlx-models/src/sampler.rs
+++ b/crates/rmlx-models/src/sampler.rs
@@ -342,15 +342,35 @@ pub fn argmax_with_penalties(
         &penalty_cfg.logit_bias,
     );
 
-    // Host argmax.
-    let chosen = logits
-        .iter()
-        .enumerate()
-        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Less))
-        .map_or(0, |(i, _)| i) as i32;
+    // Host argmax, under the same tie rule as the device reduction.
+    let chosen = host_argmax(&logits) as i32;
 
     Array::from_bytes(&chosen.to_le_bytes(), &[1], Dtype::I32)
         .map_err(|e| Error::Other(format!("argmax_with_penalties: id array build failed: {e}")))
+}
+
+/// Index of the maximum of `logits`, resolving ties to the **lowest** index.
+///
+/// This is the host mirror of the MLX `argmax` reduction that every greedy
+/// decode path dispatches on the device. It accumulates with a strict `>` from
+/// a `-inf` seed, which gives three properties the device reduction also has:
+/// equal values never displace the earlier index, a `NaN` never displaces a
+/// real maximum, and a fully constraint-masked (all `-inf`) row yields `0`.
+///
+/// Greedy selection must not depend on which side of the FFI boundary it runs,
+/// so host greedy goes through here rather than `Iterator::max_by` — which
+/// returns the *last* maximum, and which lets a `NaN` reset the running best
+/// because `partial_cmp` is `None` on it.
+fn host_argmax(logits: &[f32]) -> usize {
+    let mut best_idx = 0usize;
+    let mut best_val = f32::NEG_INFINITY;
+    for (i, &l) in logits.iter().enumerate() {
+        if l > best_val {
+            best_val = l;
+            best_idx = i;
+        }
+    }
+    best_idx
 }
 
 // ===========================================================================
@@ -545,6 +565,14 @@ fn softmax_scaled(logits: &[f32], inv_temp: f32) -> Vec<f32> {
 
 /// mlx-lm `apply_top_k` (sample_utils.py L130-151): keep the `k` highest
 /// probabilities, zero the rest. `k == 0` or `k >= len` ⇒ no-op.
+///
+/// Equal probabilities are ranked by ascending token id, so when the cut falls
+/// inside a tied group the **lowest ids** survive. That is what makes `k == 1`
+/// the argmax on every row and not only on rows with a unique maximum — the
+/// same lowest-id-wins rule the device reduction uses. mlx-lm's `argpartition`
+/// leaves the tied order unspecified; leaving it to the sort's internals here
+/// would make which of two equally-likely tokens survives an artefact of
+/// pdqsort's pivot choice.
 #[allow(
     clippy::indexing_slicing,
     reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
@@ -554,14 +582,14 @@ fn filter_top_k(probs: &mut [f32], k: usize) {
     if k == 0 || k >= n {
         return;
     }
-    // Find the k-th largest value via select. Build an index array sorted by
-    // prob descending; the value at rank k-1 is the cutoff. Ties: mlx-lm uses
-    // argpartition (keeps exactly k), so we keep exactly k by index rank.
+    // Build an index array sorted by prob descending, ties by ascending id;
+    // everything from rank k on is zeroed.
     let mut idx: Vec<usize> = (0..n).collect();
     idx.sort_unstable_by(|&a, &b| {
         probs[b]
             .partial_cmp(&probs[a])
             .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.cmp(&b))
     });
     for &i in &idx[k..] {
         probs[i] = 0.0;

--- a/crates/rmlx-models/src/sampler.rs
+++ b/crates/rmlx-models/src/sampler.rs
@@ -325,11 +325,15 @@ pub fn argmax_with_penalties(
                 vocab
             )));
         }
+        let mut any_allowed = false;
         for (i, &allowed) in m.iter().enumerate() {
-            if !allowed {
+            if allowed {
+                any_allowed = true;
+            } else {
                 logits[i] = f32::NEG_INFINITY;
             }
         }
+        warn_all_forbidden(any_allowed, "argmax_with_penalties", vocab);
     }
 
     // Apply penalties.
@@ -349,6 +353,22 @@ pub fn argmax_with_penalties(
         .map_err(|e| Error::Other(format!("argmax_with_penalties: id array build failed: {e}")))
 }
 
+/// An all-forbidden constraint mask is a constraint-engine defect: no token
+/// satisfies the grammar, so whatever the reduction returns is arbitrary. The
+/// selection still has to return *something* to keep the decode loop's error
+/// channel meaningful, so it falls through to the device-parity answer (id 0),
+/// but the condition is logged rather than swallowed — otherwise the stream
+/// emits token 0 forever with nothing in the run log to explain it.
+fn warn_all_forbidden(any_allowed: bool, site: &'static str, vocab: usize) {
+    if !any_allowed {
+        tracing::warn!(
+            site,
+            vocab,
+            "constraint mask forbids every token; selection falls back to id 0"
+        );
+    }
+}
+
 /// Index of the maximum of `logits`, resolving ties to the **lowest** index.
 ///
 /// This is the host mirror of the MLX `argmax` reduction that every greedy
@@ -356,6 +376,11 @@ pub fn argmax_with_penalties(
 /// a `-inf` seed, which gives three properties the device reduction also has:
 /// equal values never displace the earlier index, a `NaN` never displaces a
 /// real maximum, and a fully constraint-masked (all `-inf`) row yields `0`.
+///
+/// The `-inf` seed is the **Metal** reduction's seed, which is the production
+/// stream. MLX's CPU backend seeds with element 0 instead, so the two disagree
+/// on exactly one shape — a `NaN` at index 0 — and no host rule can match both.
+/// Everywhere else the two MLX backends agree with each other and with this.
 ///
 /// Greedy selection must not depend on which side of the FFI boundary it runs,
 /// so host greedy goes through here rather than `Iterator::max_by` — which
@@ -573,6 +598,13 @@ fn softmax_scaled(logits: &[f32], inv_temp: f32) -> Vec<f32> {
 /// leaves the tied order unspecified; leaving it to the sort's internals here
 /// would make which of two equally-likely tokens survives an artefact of
 /// pdqsort's pivot choice.
+///
+/// The rank order is produced by sorting **packed `u64` keys** rather than by
+/// sorting indices under a custom comparator. See [`rank_key_desc`] for why —
+/// briefly, a comparator that folds an unordered `NaN` pair to `Equal` and then
+/// breaks that "tie" by id is not a total order, and `sort_unstable_by` panics
+/// on it; and at a 262144-token vocabulary the packed sort is measurably
+/// cheaper than an index sort under any comparator.
 #[allow(
     clippy::indexing_slicing,
     reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
@@ -582,18 +614,82 @@ fn filter_top_k(probs: &mut [f32], k: usize) {
     if k == 0 || k >= n {
         return;
     }
-    // Build an index array sorted by prob descending, ties by ascending id;
-    // everything from rank k on is zeroed.
-    let mut idx: Vec<usize> = (0..n).collect();
-    idx.sort_unstable_by(|&a, &b| {
-        probs[b]
-            .partial_cmp(&probs[a])
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then(a.cmp(&b))
-    });
-    for &i in &idx[k..] {
-        probs[i] = 0.0;
+    // Descending by probability, ties by ascending id: everything from rank k
+    // on is zeroed, so the survivors of a tied cut are the lowest ids.
+    let mut keys: Vec<u64> = probs
+        .iter()
+        .enumerate()
+        .map(|(i, &p)| rank_key_desc(p, i))
+        .collect();
+    keys.sort_unstable();
+    for &key in &keys[k..] {
+        probs[key_id(key)] = 0.0;
     }
+}
+
+/// Sort key placing `probs` in **descending** order with ties resolved to the
+/// **lowest** id: the inverted IEEE bit pattern in the high half-word, the
+/// token id in the low half-word.
+///
+/// # Why a packed key and not a comparator
+///
+/// Two independent reasons, both load-bearing.
+///
+/// **It cannot panic.** Sorting `u64` uses the standard `Ord`, so the order is
+/// total by construction. Every `partial_cmp` form is not: folding an unordered
+/// pair to `Equal` makes a `NaN` compare equal to everything, which is already
+/// intransitive (`a == NaN`, `NaN == b`, but `a < b`), and adding an id
+/// tiebreak on top turns that into an outright cycle (`i < j`, `j < k`,
+/// `k < i`). `sort_unstable_by` detects either and aborts the decode step —
+/// measured on both shapes at 512 and 4096 elements. `NaN` reaches these
+/// filters whenever a `NaN` logit does: `softmax_scaled` propagates it and
+/// skips its renormalise, whose `sum > 0.0` guard is false on `NaN`.
+///
+/// **It is cheaper.** An index sort dereferences `probs` twice per comparison
+/// at random offsets; sorting the keys is contiguous and compares one integer.
+/// Measured over a 262144-wide BF16-derived softmax row (a realistic served
+/// shape, in which 259416 of the 262143 adjacent pairs are exactly equal, so
+/// the tie path is the common path): 2.58 ms for the untied index sort that
+/// preceded this, 5.92 ms for the same sort under a tie-breaking comparator,
+/// 2.43 ms here.
+///
+/// # Preconditions
+///
+/// `probs` are non-negative — every element is an `exp` result or a literal
+/// `0.0`, so the IEEE bit pattern is monotone in the value and `-0.0` (whose
+/// pattern would sort above every positive) cannot occur. `id` fits in 32 bits:
+/// it indexes a vocabulary that reaches this crate as an MLX `i32` shape.
+///
+/// A `NaN` sorts above `+inf` because its bit patterns are the largest. That
+/// is a determinism guarantee, not a claim that the rank is meaningful — a
+/// `NaN` logit is a defect the decode loop reports upstream; this only ensures
+/// the sampler survives to let it.
+#[inline]
+fn rank_key_desc(p: f32, id: usize) -> u64 {
+    (u64::from(!p.to_bits()) << 32) | id as u64
+}
+
+/// Sort key placing `probs` in **ascending** order with ties resolved to the
+/// **highest** id. Counterpart to [`rank_key_desc`]; same preconditions.
+///
+/// The inverted id is what makes the *lowest* ids survive a `top_p` cut: that
+/// walk is ascending and drops from the front, so a tied group has to be
+/// ordered highest-id-first for its low ids to outlast the threshold.
+#[inline]
+fn rank_key_asc(p: f32, id: usize) -> u64 {
+    (u64::from(p.to_bits()) << 32) | u64::from(!(id as u32))
+}
+
+/// Recover the token id from a [`rank_key_desc`] key.
+#[inline]
+fn key_id(key: u64) -> usize {
+    (key & 0xffff_ffff) as usize
+}
+
+/// Recover the token id from a [`rank_key_asc`] key.
+#[inline]
+fn key_id_inverted(key: u64) -> usize {
+    !(key as u32) as usize
 }
 
 /// mlx-lm `apply_top_p` (sample_utils.py L205-237).
@@ -603,6 +699,28 @@ fn filter_top_k(probs: &mut [f32], k: usize) {
 /// inclusive cumulative probability is **strictly greater than** `1 - top_p`.
 /// Survivors keep their prob; the rest go to `0.0`. No-op unless
 /// `0 < top_p < 1` (mlx-lm `make_sampler` gate).
+///
+/// Equal probabilities are ranked by **descending** token id. The walk is
+/// ascending and drops from the front, so the ids walked first are the ones
+/// zeroed — ordering a tied group highest-id-first is what leaves the **lowest
+/// ids** in the nucleus, the same lowest-id-wins rule `filter_top_k` and the
+/// device reduction use. Without it the survivor set is whatever pdqsort's
+/// pivot choice produced: on a row of 64 with one 0.4 and 63 identical tail
+/// values at `top_p = 0.5`, the unordered version keeps `{0, 29, 54..63}` —
+/// id 29 survives while ids 30..53 are zeroed from a bit-identical value.
+///
+/// The order comes from sorting packed `u64` keys ([`rank_key_asc`]) rather
+/// than sorting indices under a comparator — both for the total-order
+/// guarantee and for the cost, spelled out on [`rank_key_desc`]. This filter is
+/// the one most exposed to both: `top_p` ships set in several
+/// `generation_config.json` snapshots, so unlike `top_k` it is on by default on
+/// the served path.
+///
+/// The drop set is a prefix of the ascending order (probabilities are
+/// non-negative, so `cum` never decreases), and every member of a tied group
+/// contributes the same value, so *how many* elements are dropped does not
+/// depend on the order within a group — only *which ones* does, which is what
+/// the id rule pins.
 #[allow(
     clippy::indexing_slicing,
     reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
@@ -611,19 +729,19 @@ fn filter_top_p(probs: &mut [f32], top_p: f32) {
     if !(top_p > 0.0 && top_p < 1.0) {
         return;
     }
-    let n = probs.len();
-    let mut idx: Vec<usize> = (0..n).collect();
-    // Ascending sort by probability.
-    idx.sort_unstable_by(|&a, &b| {
-        probs[a]
-            .partial_cmp(&probs[b])
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    // Ascending by probability, ties by descending id.
+    let mut keys: Vec<u64> = probs
+        .iter()
+        .enumerate()
+        .map(|(i, &p)| rank_key_asc(p, i))
+        .collect();
+    keys.sort_unstable();
     let threshold = 1.0 - top_p;
     let mut cum = 0.0f32;
     // Walk ascending; cumulative is inclusive of the current element. Keep
     // where cum > threshold (mlx-lm: `mx.where(cumprob > 1 - top_p, ...)`).
-    for &i in &idx {
+    for &key in &keys {
+        let i = key_id_inverted(key);
         cum += probs[i];
         if cum <= threshold {
             probs[i] = 0.0;
@@ -799,11 +917,15 @@ pub fn sampling_distribution(
                 vocab
             )));
         }
+        let mut any_allowed = false;
         for (i, &allowed) in m.iter().enumerate() {
-            if !allowed {
+            if allowed {
+                any_allowed = true;
+            } else {
                 logits[i] = f32::NEG_INFINITY;
             }
         }
+        warn_all_forbidden(any_allowed, "sampling_distribution", vocab);
     }
 
     if penalty_cfg.penalties_active() {
@@ -967,6 +1089,13 @@ pub struct TokenLogprobs {
 /// softmax is numerically stable (subtract max before `exp`). Top-k uses a
 /// partial selection sort over a `(prob, id)` vector — `O(vocab * k)`, fine for
 /// the `k <= 20` OpenAI cap.
+///
+/// Equal logits rank by ascending token id, so rank 0 is the same token the
+/// device `argmax` would return and ranks `1..k` are reproducible rather than
+/// an artefact of the selection's swaps. The selection compares on
+/// `(logit, lowest id)`, which is a total order on the remaining candidates —
+/// it therefore does not care that `idx.swap` leaves the unscanned suffix in an
+/// arbitrary order, which a positional tiebreak would.
 #[allow(
     clippy::indexing_slicing,
     reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
@@ -1017,7 +1146,8 @@ pub fn compute_top_logprobs(
     for slot in 0..k {
         let mut best = slot;
         for j in (slot + 1)..vocab {
-            if logits[idx[j]] > logits[idx[best]] {
+            let (lj, lb) = (logits[idx[j]], logits[idx[best]]);
+            if lj > lb || (lj == lb && idx[j] < idx[best]) {
                 best = j;
             }
         }
@@ -1072,12 +1202,16 @@ pub fn apply_mask_argmax(logits_flat: &Array, mask: &[bool], device: Device) -> 
     let zero_bytes = 0f32.to_le_bytes();
 
     let mut bias_bytes: Vec<u8> = vec![0u8; vocab * 4];
+    let mut any_allowed = false;
     for (i, &allowed) in mask.iter().enumerate() {
-        if !allowed {
+        if allowed {
+            any_allowed = true;
+        } else {
             let off = i * 4;
             bias_bytes[off..off + 4].copy_from_slice(&neg_inf_bytes);
         }
     }
+    warn_all_forbidden(any_allowed, "apply_mask_argmax", vocab);
     // Allowed entries are already 0.0 (zero_bytes) from vec initialisation.
     let _ = zero_bytes; // suppress unused warning
 

--- a/crates/rmlx-models/src/sampler.rs
+++ b/crates/rmlx-models/src/sampler.rs
@@ -368,14 +368,21 @@ pub fn argmax_with_penalties(
 /// token — id 0, under the device's `-inf`-seeded reduction — and because the
 /// engine state that produced the empty mask is persistent, it emits that same
 /// token for the rest of the generation. The request "succeeds" with a constant
-/// stream. Logging instead of returning is no better at the rate this is
-/// reached: the check sits on the per-token decode path, so a `warn!` fires
-/// once per emitted token and, at a few hundred bytes a line, evicts the whole
-/// log directory under its size cap within hours — deleting the evidence it
-/// exists to provide.
+/// stream. Logging instead of returning is no better: the check sits on the
+/// per-token decode path, so a `warn!` fires once per emitted token and, at a
+/// few hundred bytes a line, evicts the whole log directory under its size cap
+/// within hours — deleting the evidence it exists to provide.
 ///
 /// So it errors. One line per request, on the channel the decode loop already
 /// propagates, and the generation stops instead of pretending.
+///
+/// This guard is exercised by unit tests only; no request shape has been shown
+/// to reach it through the served API. An empty `enum` is rejected at schema
+/// parse before a mask is built, and byte-level BPE leaves a continuing byte
+/// for even exotic single-value constraints, so the mask does not starve. The
+/// constraint engine does run on those requests, so the path is live — treat
+/// this as pre-empting a future constraint-engine defect, not as a reproduction
+/// of an observed one.
 fn reject_all_forbidden(any_allowed: bool, site: &'static str, vocab: usize) -> Result<()> {
     if any_allowed {
         return Ok(());

--- a/crates/rmlx-models/src/sampler_tests.rs
+++ b/crates/rmlx-models/src/sampler_tests.rs
@@ -1738,6 +1738,17 @@ fn compute_top_logprobs_skips_nan_like_the_device() {
 /// wrong token, with no panic to notice. `release-perf` disables debug
 /// assertions, so a `debug_assert` on the sign would not catch it either;
 /// the key is made correct instead.
+///
+/// **This guards the key encoding, not a defect that existed on `main`.** The
+/// comparator `main` used happens to order `-0.0` correctly, so this test is
+/// green there; it is red only against a packed key built from the raw
+/// `to_bits()` pattern. Do not count it as regression evidence.
+///
+/// Both halves assert on **bit patterns**, not values. `-0.0 == 0.0` is true in
+/// IEEE, so `assert_eq!(asc[0], 0.0)` passes whether `-0.0` was dropped or left
+/// in place — it cannot see the defect it names. Verified: under the raw-bits
+/// key this row comes back `[-0.0, 0.0, 0.0, 0.6]` and a value comparison is
+/// satisfied by it.
 #[test]
 #[allow(
     clippy::indexing_slicing,
@@ -1752,14 +1763,19 @@ fn rank_keys_order_negative_zero_correctly() {
         "top_k=1 must keep the real maximum, not -0.0"
     );
 
-    // The same through the ascending key, where -0.0 must sort below +0.0.
+    // The same through the ascending order, where -0.0 must sort below +0.0.
     let mut asc = vec![-0.0f32, 0.0, 0.4, 0.6];
     filter_top_p(&mut asc, 0.5);
     assert!(
         asc[3] > 0.0,
         "the dominant id must survive the nucleus, got {asc:?}"
     );
-    assert_eq!(asc[0], 0.0, "-0.0 carries no mass and is dropped");
+    assert_eq!(
+        asc[0].to_bits(),
+        0.0f32.to_bits(),
+        "-0.0 carries no mass and must be zeroed; got bits {:#010x}",
+        asc[0].to_bits()
+    );
 }
 
 // ── Near-zero temperature is sampling, not greedy ────────────────────────

--- a/crates/rmlx-models/src/sampler_tests.rs
+++ b/crates/rmlx-models/src/sampler_tests.rs
@@ -17,6 +17,18 @@ fn materialise(a: &Array) {
     a.eval().expect("materialise: array eval failed");
 }
 
+/// `softmax_scaled` over a row the caller knows is finite. `softmax_scaled`
+/// refuses a `NaN`/`+inf` row, which the tests that use this never build; the
+/// ones that do (`sampling_distribution_refuses_a_nan_logit`) assert on the
+/// error instead of going through here.
+#[allow(
+    clippy::expect_used,
+    reason = "fixture rows in these tests are finite literals; a refusal here is a bug in the fixture and should abort the test"
+)]
+fn softmax_ok(logits: &[f32], inv_temp: f32) -> Vec<f32> {
+    softmax_scaled(logits, inv_temp).expect("softmax_ok: fixture row must be finite")
+}
+
 #[test]
 #[allow(
     clippy::indexing_slicing,
@@ -296,7 +308,7 @@ fn sample_inverse_cdf_all_zero_is_safe() {
 fn softmax_scaled_forbidden_positions_are_zero() {
     // logits with one -inf (constraint-masked) position.
     let logits = vec![1.0f32, f32::NEG_INFINITY, 3.0];
-    let probs = softmax_scaled(&logits, 1.0);
+    let probs = softmax_ok(&logits, 1.0);
     assert_eq!(probs[1], 0.0, "-inf logit ⇒ exactly 0 prob");
     let sum: f32 = probs.iter().sum();
     assert!((sum - 1.0).abs() < 1e-5, "softmax normalised, sum={sum}");
@@ -308,7 +320,7 @@ fn end_to_end_top_k_one_equals_argmax_index() {
     // Combined path: softmax → filters with top_k=1 → inverse-CDF must
     // always return the argmax index for any rng draw.
     let logits = vec![0.2f32, 5.0, 1.0, 4.9, -2.0];
-    let mut probs = softmax_scaled(&logits, 1.0 / 0.8); // temp=0.8
+    let mut probs = softmax_ok(&logits, 1.0 / 0.8); // temp=0.8
     filter_top_p(&mut probs, 1.0); // disabled
     filter_min_p(&mut probs, 0.0); // disabled
     filter_top_k(&mut probs, 1);
@@ -880,7 +892,7 @@ fn top_k_one_collapses_to_greedy() {
 
     // Run with temp=0.8 and top_k=1 — 100 seeds.
     for seed in 0u64..100 {
-        let mut probs = softmax_scaled(&logits, 1.0 / 0.8);
+        let mut probs = softmax_ok(&logits, 1.0 / 0.8);
         filter_top_p(&mut probs, 1.0); // disabled
         filter_min_p(&mut probs, 0.0); // disabled
         filter_top_k(&mut probs, 1);
@@ -893,7 +905,7 @@ fn top_k_one_collapses_to_greedy() {
     }
 
     // Also confirm a different temperature (1.5) gives the same token.
-    let mut probs_hi = softmax_scaled(&logits, 1.0 / 1.5);
+    let mut probs_hi = softmax_ok(&logits, 1.0 / 1.5);
     filter_top_k(&mut probs_hi, 1);
     let mut rng2 = Pcg32::new(0xA7A7);
     let chosen_hi = sample_inverse_cdf(&probs_hi, rng2.next_f32());
@@ -1221,27 +1233,55 @@ fn host_greedy_skips_nan_like_the_device() {
     );
 }
 
-/// A fully constraint-masked row must agree with the device, and must say so
-/// in the run log rather than silently emitting id 0. The row is built by
-/// passing an all-`false` mask (the shape a broken constraint engine actually
-/// produces), not by handing in a pre-built `-inf` row.
+/// An all-`false` constraint mask must be **refused**, on every path that
+/// accepts a mask.
+///
+/// Emitting a token from it is worse than failing: no token satisfies the
+/// grammar, the engine state that produced the empty mask persists, so the
+/// stream would emit that same arbitrary token for the rest of the generation
+/// and the request would report success. The mask is passed as a mask — the
+/// shape a broken constraint engine actually produces — not as a pre-built
+/// `-inf` row.
 #[test]
-#[allow(
-    clippy::unwrap_used,
-    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
-)]
-fn host_greedy_matches_device_argmax_on_an_all_forbidden_mask() {
+fn every_mask_path_refuses_an_all_forbidden_mask() {
     let logits = f32_row(&[0.5, 4.0, 2.0, 9.0, 1.0]);
     let mask = vec![false; 5];
     let cfg = PenaltyConfig::default();
-    let host_id =
-        token_id(&argmax_with_penalties(&logits, Some(&mask), &cfg, &[], Device::Cpu).unwrap());
+    let sp = SamplerConfig {
+        temperature: 0.7,
+        top_p: 1.0,
+        top_k: 0,
+        min_p: 0.0,
+        seed: Some(1),
+        top_logprobs_k: 0,
+    };
+    let mut rng = Pcg32::new(1);
 
-    let device_id = device_argmax(&f32_row(&[f32::NEG_INFINITY; 5]), Device::Cpu);
-    assert_eq!(device_id, 0, "device yields id 0 on an all -inf row");
-    assert_eq!(
-        host_id, device_id,
-        "all-forbidden mask: host greedy picked {host_id}, device argmax picked {device_id}"
+    assert!(
+        argmax_with_penalties(&logits, Some(&mask), &cfg, &[], Device::Cpu).is_err(),
+        "host greedy must refuse an all-forbidden mask"
+    );
+    assert!(
+        apply_mask_argmax(&logits, &mask, Device::Cpu).is_err(),
+        "device greedy must refuse an all-forbidden mask"
+    );
+    assert!(
+        sampling_distribution(&logits, &sp, Some(&mask), &cfg, &[]).is_err(),
+        "the sampling distribution must refuse an all-forbidden mask"
+    );
+    assert!(
+        sample_token_array(&logits, &sp, Some(&mask), &cfg, &[], &mut rng, Device::Cpu).is_err(),
+        "the sampler must refuse an all-forbidden mask"
+    );
+
+    // A mask allowing a single token is not the same shape and must still work.
+    let mut one = vec![false; 5];
+    if let Some(slot) = one.get_mut(2) {
+        *slot = true;
+    }
+    assert!(
+        argmax_with_penalties(&logits, Some(&one), &cfg, &[], Device::Cpu).is_ok(),
+        "a mask with one allowed token must be accepted"
     );
 }
 
@@ -1322,21 +1362,22 @@ fn filter_top_p_breaks_ties_to_lowest_id() {
     );
 }
 
-/// Neither filter may panic when the probability vector holds a `NaN`.
+/// Neither filter may depend on an ordering that is not total, `NaN` included.
 ///
-/// Collapsing an unordered `partial_cmp` to `Equal` and then breaking that
-/// "tie" by id builds a comparator with a cycle, and `sort_unstable_by`
-/// detects it and panics — which would abort a decode step rather than let the
-/// upstream `NaN` guard report it. `NaN` reaches here whenever a `NaN` logit
-/// does: `softmax_scaled` propagates it and skips its renormalise. Lengths
-/// span the point where the sort stops being an insertion sort.
-///
-/// The shipped filters sort packed `u64` keys and so have no user comparator
-/// at all, which makes the panic structurally unreachable rather than merely
-/// absent. This guards the regression back to a comparator form.
+/// A comparator that folds an unordered `partial_cmp` to `Equal` is
+/// intransitive, and `sort_unstable_by` may detect that and panic mid-decode.
+/// But the panic is a *heuristic* detector, so "did it panic?" is a weak
+/// oracle: on the shipped comparator only one of six (filter, length) cells
+/// actually fires. So this asserts the property structurally instead — the
+/// survivor set must equal what the documented rank rule prescribes — which has
+/// power at every length whether the detector fires or not.
 #[test]
-fn filters_do_not_panic_on_nan_probabilities() {
-    for n in [64usize, 512, 4096] {
+#[allow(
+    clippy::indexing_slicing,
+    reason = "probs and the reference order both have length n, and every index used is < n"
+)]
+fn filters_hold_a_total_order_with_nan_present() {
+    for n in [8usize, 64, 512, 4096] {
         let probs: Vec<f32> = (0..n)
             .map(|i| {
                 if i % 7 == 3 {
@@ -1347,15 +1388,47 @@ fn filters_do_not_panic_on_nan_probabilities() {
             })
             .collect();
 
-        let mut k = probs.clone();
-        filter_top_k(&mut k, n / 4);
-        let mut p = probs.clone();
-        filter_top_p(&mut p, 0.95);
-        // Reaching here without a panic is the assertion; keep the results
-        // observable so the calls cannot be optimised away.
-        assert_eq!(k.len(), n, "n={n}: top_k must not resize");
-        assert_eq!(p.len(), n, "n={n}: top_p must not resize");
+        let k = (n / 4).max(1);
+        let mut got_k = probs.clone();
+        filter_top_k(&mut got_k, k);
+        let mut expect_k = probs.clone();
+        for &i in &reference_rank_order(&probs, true)[k..] {
+            expect_k[i] = 0.0;
+        }
+        assert_eq!(
+            survivor_ids(&got_k),
+            survivor_ids(&expect_k),
+            "n={n}: top_k survivors must follow the rank rule with a NaN present"
+        );
+
+        let mut got_p = probs.clone();
+        filter_top_p(&mut got_p, 0.95);
+        let mut expect_p = probs.clone();
+        let mut cum = 0.0f32;
+        for &i in &reference_rank_order(&probs, false) {
+            cum += probs[i];
+            if cum <= 1.0 - 0.95 {
+                expect_p[i] = 0.0;
+            }
+        }
+        assert_eq!(
+            survivor_ids(&got_p),
+            survivor_ids(&expect_p),
+            "n={n}: top_p survivors must follow the rank rule with a NaN present"
+        );
     }
+}
+
+/// Ids whose probability survived a filter. `NaN > 0.0` is false, so a `NaN`
+/// counts as dropped on both sides of a comparison — which is what makes this
+/// a fair oracle rather than one that hides the interesting case.
+fn survivor_ids(probs: &[f32]) -> Vec<usize> {
+    probs
+        .iter()
+        .enumerate()
+        .filter(|&(_, &p)| p > 0.0)
+        .map(|(i, _)| i)
+        .collect()
 }
 
 /// A tie-dense row of the shape the filters actually receive: a BF16-quantised
@@ -1378,7 +1451,7 @@ fn tie_dense_probs(n: usize, seed: u64) -> Vec<f32> {
             f32::from_bits(bits.wrapping_add(0x7fff + lsb) & 0xffff_0000)
         })
         .collect();
-    softmax_scaled(&logits, 1.0 / 0.7)
+    softmax_ok(&logits, 1.0 / 0.7)
 }
 
 /// Reference statement of the documented rank rule, written as a plain
@@ -1469,21 +1542,18 @@ fn filter_top_p_matches_the_reference_rank_rule() {
     }
 }
 
-/// A `NaN` logit must also not panic the whole pipeline, which is the path the
-/// filters are actually reached through.
+/// A non-finite logits row must be **refused**, not sampled.
+///
+/// Sampling one is not a degraded result, it is a silent one. The `NaN` reaches
+/// `probs`, `renormalise` no-ops (`total > 0.0` is false on `NaN`),
+/// `sample_inverse_cdf`'s `total <= 0.0` guard is also false, its `cum > target`
+/// never fires, and it returns `last_nonzero` — the same id every step,
+/// independent of the RNG. The request reports success and streams a constant
+/// token. This asserts refusal on every entry point, and asserts that the
+/// matching finite row is still accepted so the guard is not a blanket reject.
 #[test]
-fn sampling_distribution_survives_a_nan_logit() {
-    let n = 512usize;
-    let data: Vec<f32> = (0..n)
-        .map(|i| {
-            if i == 100 {
-                f32::NAN
-            } else {
-                (i % 13) as f32 * 0.1
-            }
-        })
-        .collect();
-    let logits = f32_row(&data);
+fn a_non_finite_logits_row_is_refused_not_sampled() {
+    let n = 64usize;
     let sp = SamplerConfig {
         temperature: 0.7,
         top_p: 0.95,
@@ -1493,8 +1563,70 @@ fn sampling_distribution_survives_a_nan_logit() {
         top_logprobs_k: 0,
     };
     let nop = PenaltyConfig::default();
-    let probs = sampling_distribution(&logits, &sp, None, &nop, &[]);
-    assert!(probs.is_ok(), "a NaN logit must not abort the sampler");
+
+    let finite: Vec<f32> = (0..n).map(|i| (i % 13) as f32 * 0.1).collect();
+    assert!(
+        sampling_distribution(&f32_row(&finite), &sp, None, &nop, &[]).is_ok(),
+        "the finite control row must still be accepted"
+    );
+
+    for (label, bad) in [("NaN", f32::NAN), ("+inf", f32::INFINITY)] {
+        let mut data = finite.clone();
+        if let Some(slot) = data.get_mut(7) {
+            *slot = bad;
+        }
+        let logits = f32_row(&data);
+        assert!(
+            sampling_distribution(&logits, &sp, None, &nop, &[]).is_err(),
+            "{label} logit: the distribution must be refused"
+        );
+        let mut rng = Pcg32::new(5);
+        assert!(
+            sample_token_array(&logits, &sp, None, &nop, &[], &mut rng, Device::Cpu).is_err(),
+            "{label} logit: the sampler must be refused"
+        );
+    }
+
+    // An all-`-inf` row is a different shape: its softmax sum is a finite 0,
+    // and it must NOT be swept up by the non-finite guard.
+    let masked = vec![f32::NEG_INFINITY; n];
+    assert!(
+        softmax_scaled(&masked, 1.0 / 0.7).is_ok(),
+        "an all -inf row sums to a finite zero and must not be refused here"
+    );
+}
+
+/// The greedy paths deliberately do **not** refuse a `NaN` row: they mirror the
+/// device reduction, which skips `NaN` and returns the largest real logit, and
+/// diverging from it would re-create the host/device split this contract
+/// exists to close. Pinned so the asymmetry is a decision rather than an
+/// oversight — the sampling path refuses because its failure is a constant
+/// stream, the greedy path does not because its answer is the device's.
+#[test]
+fn greedy_does_not_refuse_a_nan_row_but_the_sampler_does() {
+    let logits = f32_row(&[1.0, 3.0, f32::NAN, 2.0]);
+    let nop = PenaltyConfig::default();
+    let sp = SamplerConfig {
+        temperature: 0.7,
+        top_p: 1.0,
+        top_k: 0,
+        min_p: 0.0,
+        seed: Some(2),
+        top_logprobs_k: 0,
+    };
+    assert!(
+        argmax_with_penalties(&logits, None, &nop, &[], Device::Cpu).is_ok(),
+        "host greedy keeps device parity on a NaN row"
+    );
+    assert_eq!(
+        host_greedy(&logits, Device::Cpu),
+        device_argmax(&logits, Device::Cpu),
+        "and agrees with the device on which token that is"
+    );
+    assert!(
+        sampling_distribution(&logits, &sp, None, &nop, &[]).is_err(),
+        "the sampling path refuses the same row"
+    );
 }
 
 /// End-to-end restatement of the same contract on the full host pipeline:
@@ -1567,6 +1699,69 @@ fn compute_top_logprobs_breaks_ties_to_lowest_id() {
     );
 }
 
+/// `top_logprobs` is reported alongside the emitted token, computed from the
+/// same raw logits row the greedy path reduces, so rank 0 must be the token the
+/// device would emit on a `NaN` row too. Seeding the selection from a candidate
+/// rather than from `-inf` breaks exactly this: a `NaN` at the seed position
+/// wins the rank, because every later `>` and `==` against it is false.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "top is built with exactly k = 2 entries immediately above"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
+)]
+fn compute_top_logprobs_skips_nan_like_the_device() {
+    // NaN at index 0 — the seed position of the first selection round.
+    let logits = f32_row(&[f32::NAN, 1.0, 5.0, 2.0]);
+    let out = compute_top_logprobs(&logits, 2, 2).unwrap();
+    let ids: Vec<u32> = out.top.iter().map(|&(id, _)| id).collect();
+    assert_eq!(
+        ids,
+        vec![2, 3],
+        "a NaN must not take a rank ahead of a real logit"
+    );
+    assert_eq!(
+        ids[0],
+        host_greedy(&logits, Device::Cpu),
+        "rank 0 must be the token the greedy path emits"
+    );
+}
+
+/// The rank keys must order every `f32`, not only the non-negative ones the
+/// sampler happens to produce today.
+///
+/// Under a raw bit pattern `-0.0` (`0x8000_0000`) outranks every positive
+/// value, so `top_k(1)` keeps `-0.0` and zeroes the real maximum — a silently
+/// wrong token, with no panic to notice. `release-perf` disables debug
+/// assertions, so a `debug_assert` on the sign would not catch it either;
+/// the key is made correct instead.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "probs is a 3-element literal and every index used is < 3"
+)]
+fn rank_keys_order_negative_zero_correctly() {
+    let mut probs = vec![-0.0f32, 0.5, 0.25];
+    filter_top_k(&mut probs, 1);
+    assert_eq!(
+        survivor_ids(&probs),
+        vec![1],
+        "top_k=1 must keep the real maximum, not -0.0"
+    );
+
+    // The same through the ascending key, where -0.0 must sort below +0.0.
+    let mut asc = vec![-0.0f32, 0.0, 0.4, 0.6];
+    filter_top_p(&mut asc, 0.5);
+    assert!(
+        asc[3] > 0.0,
+        "the dominant id must survive the nucleus, got {asc:?}"
+    );
+    assert_eq!(asc[0], 0.0, "-0.0 carries no mass and is dropped");
+}
+
 // ── Near-zero temperature is sampling, not greedy ────────────────────────
 //
 // These two pin the boundary of the "temperature ~0 behaves like an argmax"
@@ -1585,7 +1780,7 @@ fn compute_top_logprobs_breaks_ties_to_lowest_id() {
 fn near_zero_temperature_underflow_boundary() {
     // Gaps of 0.02 (well past the boundary) and 0.005 (well inside it).
     let logits = vec![10.0f32, 9.98, 9.995];
-    let probs = softmax_scaled(&logits, 1.0 / 1e-4);
+    let probs = softmax_ok(&logits, 1.0 / 1e-4);
     assert_eq!(probs[1], 0.0, "gap 0.02 must underflow to exactly zero");
     assert!(
         probs[2] > 0.0,
@@ -1704,6 +1899,55 @@ fn host_greedy_matches_device_argmax_on_a_bf16_tie_gpu() {
         host_id, device_id,
         "BF16 tie: host greedy picked {host_id}, Metal argmax picked {device_id}"
     );
+}
+
+/// `host_argmax` claims a `NaN` never displaces a real maximum *on the device*.
+/// The CPU test of that claim is weak — MLX's CPU backend seeds its reduction
+/// with `in[0]`, so it skips a mid-row `NaN` for a reason Metal does not share.
+/// This is the mirror that actually checks Metal.
+#[test]
+#[ignore = "reaches Device::Gpu; run via make gpu-test"]
+fn host_greedy_skips_nan_like_the_device_gpu() {
+    let logits = f32_row(&[1.0, 3.0, f32::NAN, 2.0]);
+    let device_id = device_argmax(&logits, Device::Gpu);
+    let host_id = host_greedy(&logits, Device::Gpu);
+    assert_eq!(
+        host_id, device_id,
+        "NaN row: host greedy picked {host_id}, Metal argmax picked {device_id}"
+    );
+    assert_eq!(
+        device_id, 1,
+        "Metal must skip the NaN and take the real max"
+    );
+}
+
+/// The all-`-inf` row is the one shape where the `-inf` seed is never
+/// displaced, so what a multi-threadgroup Metal arg-reduce returns is a
+/// property of its seeding rather than of its comparisons — and the CPU test
+/// **cannot fail**, because MLX's CPU backend seeds with `in[0]` and so returns
+/// 0 by construction whatever Metal does. This is the only check with power
+/// over `host_argmax`'s third documented bullet.
+///
+/// The row is deliberately wide enough to cross the single- to
+/// multi-threadgroup boundary. If this fails, that bullet is wrong and needs
+/// correcting rather than the test.
+#[test]
+#[ignore = "reaches Device::Gpu; run via make gpu-test"]
+fn all_neg_inf_row_agrees_with_metal_gpu() {
+    for width in [8usize, WIDE_VOCAB] {
+        let row = vec![f32::NEG_INFINITY; width];
+        let logits = f32_row(&row);
+        let device_id = device_argmax(&logits, Device::Gpu);
+        let host_id = host_greedy(&logits, Device::Gpu);
+        assert_eq!(
+            host_id, device_id,
+            "width {width}: host greedy picked {host_id}, Metal argmax picked {device_id}"
+        );
+        assert_eq!(
+            device_id, 0,
+            "width {width}: host_argmax documents id 0 for an all -inf row"
+        );
+    }
 }
 
 /// BF16 is the high half-word of the F32 pattern:

--- a/crates/rmlx-models/src/sampler_tests.rs
+++ b/crates/rmlx-models/src/sampler_tests.rs
@@ -982,35 +982,108 @@ fn repetition_penalty_breaks_single_token_loop() {
 // The oracle in this section is MLX's own `argmax`, called through the same
 // FFI the decode loop uses. It shares no arithmetic with the host scan under
 // test: one is a C++/Metal reduction over the array, the other a Rust loop
-// over a host copy. `Device::Cpu` is used only so the tests run in the
-// ordinary (non-`#[ignore]`) suite; MLX's CPU and Metal argmax implement the
-// same tie rule, which the first test pins explicitly.
+// over a host copy.
+//
+// Most of these run on `Device::Cpu` so they land in the ordinary
+// (non-`#[ignore]`) suite. `host_argmax` is written against the **Metal**
+// reduction's seed, so the Metal backend is checked rather than assumed by the
+// `#[ignore]`d `Device::Gpu` mirrors at the end of this section — a CPU-only
+// oracle cannot establish a Metal property.
 
-/// Oracle characterisation: MLX `argmax` resolves an exact tie to the
-/// **lowest** index. Every other test in this section is written against that
-/// fact, so it is pinned here on its own — if a future MLX bump changes the
-/// rule this fails first and names the cause.
-#[test]
+/// Decode the `[1] I32` selection Array into a token id.
 #[allow(
     clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
 )]
 #[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
 )]
+fn token_id(a: &Array) -> u32 {
+    materialise(a);
+    let b = a.to_bytes().unwrap();
+    i32::from_le_bytes(b[..4].try_into().unwrap()) as u32
+}
+
+/// Device `argmax` over a `[1, vocab]` row, on the given stream.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
+)]
+fn device_argmax(logits: &Array, device: Device) -> u32 {
+    token_id(&argmax(logits, -1, device).unwrap())
+}
+
+/// Host greedy over the same row, with no mask and no penalties.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
+)]
+fn host_greedy(logits: &Array, device: Device) -> u32 {
+    let nop = PenaltyConfig::default();
+    token_id(&argmax_with_penalties(logits, None, &nop, &[], device).unwrap())
+}
+
+/// Wrap an f32 row as a `[1, n]` F32 Array.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
+)]
+fn f32_row(data: &[f32]) -> Array {
+    Array::from_bytes(f32_as_bytes(data), &[1, data.len() as i32], Dtype::F32).unwrap()
+}
+
+/// Width of the wide tie fixtures — a real gemma-4 vocabulary.
+const WIDE_VOCAB: usize = 262_144;
+
+/// A `WIDE_VOCAB`-wide row of `0.5` with `12.0` at each of `peaks`.
+fn wide_row_with_peaks(peaks: &[usize]) -> Vec<f32> {
+    let mut row = vec![0.5f32; WIDE_VOCAB];
+    for &p in peaks {
+        if let Some(slot) = row.get_mut(p) {
+            *slot = 12.0;
+        }
+    }
+    row
+}
+
+/// The tied-row shapes the contract has to cover, as `(name, row, expected
+/// lowest-id max)`. Shared by the CPU tests and their `Device::Gpu` mirrors so
+/// the two cannot drift apart.
+///
+/// The wide rows exist because MLX's arg-reduce switches between a single- and
+/// a multi-threadgroup strategy with size, and a tie split across that boundary
+/// is where a parallel reduction's tie rule can break. An 8-wide row cannot
+/// reach that shape.
+fn tie_shapes() -> Vec<(&'static str, Vec<f32>, u32)> {
+    vec![
+        ("narrow", vec![1.0f32, 9.0, 3.0, 2.0, 9.0, 0.0, 9.0, 4.0], 1),
+        (
+            "wide-spread",
+            wide_row_with_peaks(&[7, WIDE_VOCAB / 2, WIDE_VOCAB - 1]),
+            7,
+        ),
+        (
+            "wide-tail-adjacent",
+            wide_row_with_peaks(&[WIDE_VOCAB - 2, WIDE_VOCAB - 1]),
+            (WIDE_VOCAB - 2) as u32,
+        ),
+    ]
+}
+
+/// Oracle characterisation: MLX `argmax` resolves an exact tie to the
+/// **lowest** index, at every width the sampler sees. Every other test in this
+/// section is written against that fact, so it is pinned on its own — if a
+/// future MLX bump changes the rule this fails first and names the cause.
+#[test]
 fn mlx_argmax_breaks_ties_to_lowest_index() {
-    // Three exactly-equal maxima at 1, 4 and 6.
-    let data: [f32; 8] = [1.0, 9.0, 3.0, 2.0, 9.0, 0.0, 9.0, 4.0];
-    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 8], Dtype::F32).unwrap();
-    let idx = argmax(&logits, -1, Device::Cpu).unwrap();
-    materialise(&idx);
-    let b = idx.to_bytes().unwrap();
-    let v = i32::from_le_bytes(b[..4].try_into().unwrap());
-    assert_eq!(
-        v, 1,
-        "MLX argmax must return the first of three tied maxima"
-    );
+    for (name, row, expect) in tie_shapes() {
+        let got = device_argmax(&f32_row(&row), Device::Cpu);
+        assert_eq!(
+            got, expect,
+            "{name}: MLX argmax must return the first of the tied maxima"
+        );
+    }
 }
 
 /// The host greedy path (`temperature == 0` with penalties) must return the
@@ -1018,72 +1091,115 @@ fn mlx_argmax_breaks_ties_to_lowest_index() {
 /// only input where the two reductions can differ, so it is the only input
 /// that tests the contract.
 #[test]
-#[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
-#[allow(
-    clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
-)]
 fn host_greedy_matches_device_argmax_on_a_tie() {
-    let data: [f32; 8] = [1.0, 9.0, 3.0, 2.0, 9.0, 0.0, 9.0, 4.0];
-    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 8], Dtype::F32).unwrap();
-
-    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
-    materialise(&device_idx);
-    let db = device_idx.to_bytes().unwrap();
-    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap());
-
-    let nop = PenaltyConfig::default();
-    let host = argmax_with_penalties(&logits, None, &nop, &[], Device::Cpu).unwrap();
-    materialise(&host);
-    let hb = host.to_bytes().unwrap();
-    let host_id = i32::from_le_bytes(hb[..4].try_into().unwrap());
-
-    assert_eq!(
-        host_id, device_id,
-        "host greedy picked {host_id}, device argmax picked {device_id} on the same row"
-    );
+    for (name, row, _) in tie_shapes() {
+        let logits = f32_row(&row);
+        let device_id = device_argmax(&logits, Device::Cpu);
+        let host_id = host_greedy(&logits, Device::Cpu);
+        assert_eq!(
+            host_id, device_id,
+            "{name}: host greedy picked {host_id}, device argmax picked {device_id}"
+        );
+    }
 }
 
-/// Same contract, but the tie is *created* by a penalty rather than present in
-/// the raw row — the shape a served request actually reaches, since the host
-/// greedy path only runs when a penalty or a logit bias is active.
+/// Same contract, but the tie is *created* by a `logit_bias` rather than
+/// present in the raw row — one of the two shapes a served request actually
+/// reaches, since the host greedy path only runs when a penalty or a bias is
+/// active.
 #[test]
 #[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
-#[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
 )]
 fn host_greedy_matches_device_argmax_when_a_bias_creates_the_tie() {
     // Raw row has a unique max at 0. A +2.0 bias on id 3 lifts it to exactly
     // 5.0 — an exact tie with id 0, no rounding involved.
-    let data: [f32; 6] = [5.0, 1.0, 2.0, 3.0, 0.5, 4.0];
-    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 6], Dtype::F32).unwrap();
+    let logits = f32_row(&[5.0, 1.0, 2.0, 3.0, 0.5, 4.0]);
     let cfg = PenaltyConfig {
         logit_bias: vec![(3, 2.0)],
         ..PenaltyConfig::default()
     };
-    let host = argmax_with_penalties(&logits, None, &cfg, &[], Device::Cpu).unwrap();
-    materialise(&host);
-    let hb = host.to_bytes().unwrap();
-    let host_id = i32::from_le_bytes(hb[..4].try_into().unwrap());
+    let host_id = token_id(&argmax_with_penalties(&logits, None, &cfg, &[], Device::Cpu).unwrap());
 
     // Oracle: apply the same bias on the device and reduce there.
-    let biased: [f32; 6] = [5.0, 1.0, 2.0, 5.0, 0.5, 4.0];
-    let biased_arr = Array::from_bytes(f32_as_bytes(&biased), &[1, 6], Dtype::F32).unwrap();
-    let device_idx = argmax(&biased_arr, -1, Device::Cpu).unwrap();
-    materialise(&device_idx);
-    let db = device_idx.to_bytes().unwrap();
-    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap());
+    let device_id = device_argmax(&f32_row(&[5.0, 1.0, 2.0, 5.0, 0.5, 4.0]), Device::Cpu);
 
     assert_eq!(
         host_id, device_id,
         "bias-induced tie: host greedy picked {host_id}, device argmax picked {device_id}"
+    );
+}
+
+/// The other route: the **repetition penalty**, which is the one the field
+/// report names. `rep_penalty` divides a positive logit by the penalty, and
+/// that division maps distinct f32 values onto equal ones — `1.1f32 / 1.1f32`
+/// is exactly `1.0f32`, so a row holding both `1.1` and `1.0` ties after the
+/// penalty is applied to the first.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
+)]
+fn host_greedy_matches_device_argmax_when_rep_penalty_creates_the_tie() {
+    // id 3 = 1.1 is the unique max. With id 3 in the penalty window and
+    // rep_penalty 1.1, it becomes exactly 1.0 — tied with id 1.
+    let logits = f32_row(&[0.25, 1.0, 0.5, 1.1, 0.75]);
+    let cfg = PenaltyConfig {
+        rep_penalty: 1.1,
+        ..PenaltyConfig::default()
+    };
+    let host_id = token_id(&argmax_with_penalties(&logits, None, &cfg, &[3], Device::Cpu).unwrap());
+
+    // Oracle: the post-penalty row, reduced on the device. Built from the
+    // literal 1.0 rather than by recomputing 1.1 / 1.1, so it shares no
+    // arithmetic with the penalty under test.
+    let device_id = device_argmax(&f32_row(&[0.25, 1.0, 0.5, 1.0, 0.75]), Device::Cpu);
+    assert_eq!(device_id, 1, "post-penalty row ties at ids 1 and 3");
+
+    assert_eq!(
+        host_id, device_id,
+        "rep-penalty tie: host greedy picked {host_id}, device argmax picked {device_id}"
+    );
+}
+
+/// The documented "penalties active, with or without a constraint" sub-case:
+/// a mask and a penalty together, with the tie among the *allowed* ids.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
+)]
+fn host_greedy_matches_device_argmax_with_mask_and_penalties() {
+    // Raw max is id 5. The mask forbids it, leaving ids {1, 2, 4}; a +3.0 bias
+    // on id 4 lifts it from 1.0 to exactly 4.0, tying with the allowed id 1.
+    let logits = f32_row(&[0.5, 4.0, 2.0, 9.0, 1.0, 12.0]);
+    let mask = vec![false, true, true, false, true, false];
+    let cfg = PenaltyConfig {
+        logit_bias: vec![(4, 3.0)],
+        ..PenaltyConfig::default()
+    };
+    let host_id =
+        token_id(&argmax_with_penalties(&logits, Some(&mask), &cfg, &[], Device::Cpu).unwrap());
+
+    // Oracle: the same row with the mask and bias folded in by hand, reduced
+    // on the device.
+    let device_id = device_argmax(
+        &f32_row(&[
+            f32::NEG_INFINITY,
+            4.0,
+            2.0,
+            f32::NEG_INFINITY,
+            4.0,
+            f32::NEG_INFINITY,
+        ]),
+        Device::Cpu,
+    );
+    assert_eq!(device_id, 1, "masked+biased row ties at ids 1 and 4");
+
+    assert_eq!(
+        host_id, device_id,
+        "mask+penalty tie: host greedy picked {host_id}, device argmax picked {device_id}"
     );
 }
 
@@ -1094,112 +1210,38 @@ fn host_greedy_matches_device_argmax_when_a_bias_creates_the_tie() {
 /// its Metal reduction with `-inf`, so a leading `NaN` is the one shape where
 /// MLX's own two backends disagree and no host rule can match both.
 #[test]
-#[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
-#[allow(
-    clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
-)]
 fn host_greedy_skips_nan_like_the_device() {
-    let data: [f32; 4] = [1.0, 3.0, f32::NAN, 2.0];
-    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 4], Dtype::F32).unwrap();
-
-    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
-    materialise(&device_idx);
-    let db = device_idx.to_bytes().unwrap();
-    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap());
+    let logits = f32_row(&[1.0, 3.0, f32::NAN, 2.0]);
+    let device_id = device_argmax(&logits, Device::Cpu);
     assert_eq!(device_id, 1, "device reduction must skip the NaN");
-
-    let nop = PenaltyConfig::default();
-    let host = argmax_with_penalties(&logits, None, &nop, &[], Device::Cpu).unwrap();
-    materialise(&host);
-    let hb = host.to_bytes().unwrap();
-    let host_id = i32::from_le_bytes(hb[..4].try_into().unwrap());
+    let host_id = host_greedy(&logits, Device::Cpu);
     assert_eq!(
         host_id, device_id,
         "NaN row: host greedy picked {host_id}, device argmax picked {device_id}"
     );
 }
 
-/// A fully constraint-masked row (every logit `-inf`) must still agree.
+/// A fully constraint-masked row must agree with the device, and must say so
+/// in the run log rather than silently emitting id 0. The row is built by
+/// passing an all-`false` mask (the shape a broken constraint engine actually
+/// produces), not by handing in a pre-built `-inf` row.
 #[test]
 #[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
-#[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
 )]
-fn host_greedy_matches_device_argmax_on_an_all_neg_inf_row() {
-    let data = [f32::NEG_INFINITY; 5];
-    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 5], Dtype::F32).unwrap();
+fn host_greedy_matches_device_argmax_on_an_all_forbidden_mask() {
+    let logits = f32_row(&[0.5, 4.0, 2.0, 9.0, 1.0]);
+    let mask = vec![false; 5];
+    let cfg = PenaltyConfig::default();
+    let host_id =
+        token_id(&argmax_with_penalties(&logits, Some(&mask), &cfg, &[], Device::Cpu).unwrap());
 
-    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
-    materialise(&device_idx);
-    let db = device_idx.to_bytes().unwrap();
-    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap());
-
-    let nop = PenaltyConfig::default();
-    let host = argmax_with_penalties(&logits, None, &nop, &[], Device::Cpu).unwrap();
-    materialise(&host);
-    let hb = host.to_bytes().unwrap();
-    let host_id = i32::from_le_bytes(hb[..4].try_into().unwrap());
-
+    let device_id = device_argmax(&f32_row(&[f32::NEG_INFINITY; 5]), Device::Cpu);
+    assert_eq!(device_id, 0, "device yields id 0 on an all -inf row");
     assert_eq!(
         host_id, device_id,
-        "all -inf row must agree with the device"
-    );
-}
-
-/// The same contract on a **BF16** row, which is the dtype most snapshots
-/// produce and the dtype the device actually reduces over.
-///
-/// This also settles a standing question about whether the host readback could
-/// itself be the source of a disagreement: `logits_to_host_f32` widens BF16 to
-/// F32 by shifting the pattern into the high half-word, which is exact and
-/// injective, so it can neither create a tie nor break one. A BF16 tie is
-/// still a tie after the readback, and the two paths must agree on it.
-#[test]
-#[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
-#[allow(
-    clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
-)]
-fn host_greedy_matches_device_argmax_on_a_bf16_tie() {
-    // BF16 is the high half-word of the F32 pattern:
-    // 0x3F80 = 1.0, 0x4000 = 2.0, 0x4020 = 2.5, 0x4080 = 4.0.
-    // Tied maxima at index 1 and index 3.
-    let patterns: [u16; 5] = [0x4020, 0x4080, 0x3F80, 0x4080, 0x4000];
-    let mut bytes = Vec::with_capacity(patterns.len() * 2);
-    for p in patterns {
-        bytes.extend_from_slice(&p.to_le_bytes());
-    }
-    let logits = Array::from_bytes(&bytes, &[1, 5], Dtype::Bf16).unwrap();
-
-    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
-    materialise(&device_idx);
-    let db = device_idx.to_bytes().unwrap();
-    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap());
-    assert_eq!(
-        device_id, 1,
-        "device takes the first of the two BF16 maxima"
-    );
-
-    let nop = PenaltyConfig::default();
-    let host = argmax_with_penalties(&logits, None, &nop, &[], Device::Cpu).unwrap();
-    materialise(&host);
-    let hb = host.to_bytes().unwrap();
-    let host_id = i32::from_le_bytes(hb[..4].try_into().unwrap());
-
-    assert_eq!(
-        host_id, device_id,
-        "BF16 tie: host greedy picked {host_id}, device argmax picked {device_id}"
+        "all-forbidden mask: host greedy picked {host_id}, device argmax picked {device_id}"
     );
 }
 
@@ -1212,7 +1254,7 @@ fn host_greedy_matches_device_argmax_on_a_bf16_tie() {
 #[test]
 #[allow(
     clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+    reason = "probs is built with length n immediately above and every index used is < n"
 )]
 fn filter_top_k_breaks_ties_to_lowest_id() {
     let n = 64usize;
@@ -1241,31 +1283,239 @@ fn filter_top_k_breaks_ties_to_lowest_id() {
     );
 }
 
+/// The same rule on `top_p`, which unlike `top_k` is ON by default on the
+/// served path (several `generation_config.json` snapshots ship `top_p`).
+/// `filter_top_p` walks ascending and drops from the front, so a tied group has
+/// to be ordered highest-id-first for the lowest ids to survive the cut.
+///
+/// Shape: one dominant probability plus a long run of bit-identical tail
+/// values, with `top_p` placed so the cut lands inside that run. Without an id
+/// rule the survivor set is a non-contiguous artefact of pdqsort's pivot
+/// choice — `{0, 29, 54..63}`, id 29 surviving while ids 30..53 are zeroed from
+/// the same value. `n = 64` is above the length where `sort_unstable_by`
+/// degenerates to a stable insertion sort and the shape becomes unreachable.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "probs is built with length n immediately above and every index used is < n"
+)]
+fn filter_top_p_breaks_ties_to_lowest_id() {
+    let n = 64usize;
+    let tail = 0.6f32 / 63.0;
+    let mut probs: Vec<f32> = (0..n).map(|i| if i == 0 { 0.4 } else { tail }).collect();
+    filter_top_p(&mut probs, 0.5);
+
+    let survivors: Vec<usize> = (0..n).filter(|&i| probs[i] > 0.0).collect();
+    assert!(
+        survivors.len() > 2,
+        "fixture must put the cut inside the tied run, got {} survivors",
+        survivors.len()
+    );
+    assert_eq!(survivors[0], 0, "the dominant id always survives");
+    // Every survivor drawn from the tied run must be a prefix of it: no gap,
+    // and never a higher id kept while a lower one is dropped.
+    let tied: Vec<usize> = survivors[1..].to_vec();
+    let expected: Vec<usize> = (1..=tied.len()).collect();
+    assert_eq!(
+        tied, expected,
+        "tied survivors must be the lowest ids of the run, contiguously"
+    );
+}
+
+/// Neither filter may panic when the probability vector holds a `NaN`.
+///
+/// Collapsing an unordered `partial_cmp` to `Equal` and then breaking that
+/// "tie" by id builds a comparator with a cycle, and `sort_unstable_by`
+/// detects it and panics — which would abort a decode step rather than let the
+/// upstream `NaN` guard report it. `NaN` reaches here whenever a `NaN` logit
+/// does: `softmax_scaled` propagates it and skips its renormalise. Lengths
+/// span the point where the sort stops being an insertion sort.
+///
+/// The shipped filters sort packed `u64` keys and so have no user comparator
+/// at all, which makes the panic structurally unreachable rather than merely
+/// absent. This guards the regression back to a comparator form.
+#[test]
+fn filters_do_not_panic_on_nan_probabilities() {
+    for n in [64usize, 512, 4096] {
+        let probs: Vec<f32> = (0..n)
+            .map(|i| {
+                if i % 7 == 3 {
+                    f32::NAN
+                } else {
+                    ((i.wrapping_mul(2_654_435_761_usize)) % 1000) as f32 / 1000.0
+                }
+            })
+            .collect();
+
+        let mut k = probs.clone();
+        filter_top_k(&mut k, n / 4);
+        let mut p = probs.clone();
+        filter_top_p(&mut p, 0.95);
+        // Reaching here without a panic is the assertion; keep the results
+        // observable so the calls cannot be optimised away.
+        assert_eq!(k.len(), n, "n={n}: top_k must not resize");
+        assert_eq!(p.len(), n, "n={n}: top_p must not resize");
+    }
+}
+
+/// A tie-dense row of the shape the filters actually receive: a BF16-quantised
+/// logit row, softmaxed. Almost every adjacent pair is exactly equal, so the
+/// tie path is the common path rather than a corner.
+fn tie_dense_probs(n: usize, seed: u64) -> Vec<f32> {
+    let mut s = seed | 1;
+    let mut next = move || {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        s
+    };
+    let logits: Vec<f32> = (0..n)
+        .map(|_| {
+            let l = ((next() % 4000) as f32) / 100.0 - 20.0;
+            // Round to BF16: keep 8 mantissa bits, round-to-nearest-even.
+            let bits = l.to_bits();
+            let lsb = (bits >> 16) & 1;
+            f32::from_bits(bits.wrapping_add(0x7fff + lsb) & 0xffff_0000)
+        })
+        .collect();
+    softmax_scaled(&logits, 1.0 / 0.7)
+}
+
+/// Reference statement of the documented rank rule, written as a plain
+/// comparator over `(probability, id)` pairs.
+///
+/// This is an oracle for the *rule*, deliberately not for the implementation:
+/// the filters sort packed `u64` keys, this sorts tuples with an explicit
+/// comparison. If the bit-packing is wrong in any way — the inversion, the
+/// half-word split, the id width — the two orders diverge.
+fn reference_rank_order(probs: &[f32], descending: bool) -> Vec<usize> {
+    // Sort (probability, id) pairs directly; no indexing back into `probs`.
+    let mut pairs: Vec<(f32, usize)> = probs.iter().copied().zip(0..probs.len()).collect();
+    pairs.sort_by(|&(pa, a), &(pb, b)| {
+        if descending {
+            // Highest probability first; equal probabilities by lowest id.
+            pb.total_cmp(&pa).then(a.cmp(&b))
+        } else {
+            // Lowest probability first; equal probabilities by highest id.
+            pa.total_cmp(&pb).then(b.cmp(&a))
+        }
+    });
+    pairs.into_iter().map(|(_, id)| id).collect()
+}
+
+/// `filter_top_k`'s survivor set must be the first `k` of the reference
+/// descending order, on a row where nearly every value is tied.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "probs and the reference order both have length n, and every index used is < n"
+)]
+fn filter_top_k_matches_the_reference_rank_rule() {
+    let n = 4096usize;
+    for k in [1usize, 7, 64, 1000, 4095] {
+        let probs = tie_dense_probs(n, 0x51ED_1234);
+        let mut expect = reference_rank_order(&probs, true)[..k].to_vec();
+        expect.sort_unstable();
+
+        let mut got_probs = probs.clone();
+        filter_top_k(&mut got_probs, k);
+        let got: Vec<usize> = (0..n).filter(|&i| got_probs[i] > 0.0).collect();
+
+        // Zero-probability survivors are indistinguishable from drops, so
+        // compare only over the ids the reference keeps that carry mass.
+        let expect_nonzero: Vec<usize> = expect.into_iter().filter(|&i| probs[i] > 0.0).collect();
+        assert_eq!(
+            got, expect_nonzero,
+            "k={k}: survivor set must match the rule"
+        );
+    }
+}
+
+/// `filter_top_p`'s survivor set must be the suffix of the reference ascending
+/// order that the cumulative-sum walk keeps.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "probs and the reference order both have length n, and every index used is < n"
+)]
+fn filter_top_p_matches_the_reference_rank_rule() {
+    let n = 4096usize;
+    for top_p in [0.1f32, 0.5, 0.9, 0.95, 0.99] {
+        let probs = tie_dense_probs(n, 0x7A11_9999);
+
+        // Reference: walk the reference ascending order and drop the prefix
+        // whose inclusive cumulative sum stays at or below the threshold.
+        let order = reference_rank_order(&probs, false);
+        let threshold = 1.0 - top_p;
+        let mut cum = 0.0f32;
+        let mut expect: Vec<usize> = Vec::new();
+        for &i in &order {
+            cum += probs[i];
+            if cum > threshold {
+                expect.push(i);
+            }
+        }
+        expect.sort_unstable();
+        let expect_nonzero: Vec<usize> = expect.into_iter().filter(|&i| probs[i] > 0.0).collect();
+
+        let mut got_probs = probs.clone();
+        filter_top_p(&mut got_probs, top_p);
+        let got: Vec<usize> = (0..n).filter(|&i| got_probs[i] > 0.0).collect();
+
+        assert_eq!(
+            got, expect_nonzero,
+            "top_p={top_p}: survivor set must match the rule"
+        );
+    }
+}
+
+/// A `NaN` logit must also not panic the whole pipeline, which is the path the
+/// filters are actually reached through.
+#[test]
+fn sampling_distribution_survives_a_nan_logit() {
+    let n = 512usize;
+    let data: Vec<f32> = (0..n)
+        .map(|i| {
+            if i == 100 {
+                f32::NAN
+            } else {
+                (i % 13) as f32 * 0.1
+            }
+        })
+        .collect();
+    let logits = f32_row(&data);
+    let sp = SamplerConfig {
+        temperature: 0.7,
+        top_p: 0.95,
+        top_k: 20,
+        min_p: 0.0,
+        seed: Some(5),
+        top_logprobs_k: 0,
+    };
+    let nop = PenaltyConfig::default();
+    let probs = sampling_distribution(&logits, &sp, None, &nop, &[]);
+    assert!(probs.is_ok(), "a NaN logit must not abort the sampler");
+}
+
 /// End-to-end restatement of the same contract on the full host pipeline:
 /// `top_k = 1` must reproduce the device argmax for every RNG draw, including
 /// on a row whose maximum is tied. The existing `top_k_one_collapses_to_greedy`
 /// covers only rows with a unique maximum, which is the case that cannot fail.
 #[test]
 #[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
-#[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
 )]
 fn top_k_one_equals_device_argmax_under_a_tie() {
     let n = 64usize;
     let mut data = vec![1.0f32; n];
     for &i in &[5usize, 30, 63] {
-        data[i] = 8.0;
+        if let Some(slot) = data.get_mut(i) {
+            *slot = 8.0;
+        }
     }
-    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, n as i32], Dtype::F32).unwrap();
-
-    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
-    materialise(&device_idx);
-    let db = device_idx.to_bytes().unwrap();
-    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap()) as u32;
+    let logits = f32_row(&data);
+    let device_id = device_argmax(&logits, Device::Cpu);
 
     let sp = SamplerConfig {
         temperature: 0.8,
@@ -1279,9 +1529,7 @@ fn top_k_one_equals_device_argmax_under_a_tie() {
     let mut rng = Pcg32::new(sp.seed_or_default());
     for draw in 0..64 {
         let out = sample_token_array(&logits, &sp, None, &nop, &[], &mut rng, Device::Cpu).unwrap();
-        materialise(&out);
-        let b = out.to_bytes().unwrap();
-        let id = i32::from_le_bytes(b[..4].try_into().unwrap()) as u32;
+        let id = token_id(&out);
         assert_eq!(
             id, device_id,
             "top_k=1 draw {draw}: sampled {id}, device argmax {device_id}"
@@ -1289,10 +1537,41 @@ fn top_k_one_equals_device_argmax_under_a_tie() {
     }
 }
 
+/// `top_logprobs` reports ranks, not a selection, but it must still order
+/// equal logits by ascending id — otherwise rank 0 can disagree with the token
+/// the device argmax chose, and ranks 1..k are an artefact of the selection's
+/// swaps rather than a reproducible answer.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "top is built with exactly k = 3 entries immediately above"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
+)]
+fn compute_top_logprobs_breaks_ties_to_lowest_id() {
+    // Two exactly-equal logits at ids 0 and 2, under a unique max at 3.
+    let logits = f32_row(&[5.0, 7.0, 5.0, 9.0]);
+    let out = compute_top_logprobs(&logits, 3, 3).unwrap();
+    let ids: Vec<u32> = out.top.iter().map(|&(id, _)| id).collect();
+    assert_eq!(
+        ids,
+        vec![3, 1, 0],
+        "equal logits must rank by ascending id (id 0 before id 2)"
+    );
+    assert_eq!(
+        ids[0],
+        device_argmax(&logits, Device::Cpu),
+        "rank 0 must be the token the device argmax would choose"
+    );
+}
+
 // ── Near-zero temperature is sampling, not greedy ────────────────────────
 //
 // These two pin the boundary of the "temperature ~0 behaves like an argmax"
-// shortcut so it cannot be read as a guarantee.
+// shortcut so it cannot be read as a guarantee. They characterise existing
+// behaviour; neither is changed by the tie-break work above.
 
 /// At `temperature = 1e-4` every logit below the maximum by more than about
 /// 0.0104 underflows to exactly zero probability, and every logit closer than
@@ -1301,7 +1580,7 @@ fn top_k_one_equals_device_argmax_under_a_tie() {
 #[test]
 #[allow(
     clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+    reason = "probs has the same length as the 3-element logits literal above it"
 )]
 fn near_zero_temperature_underflow_boundary() {
     // Gaps of 0.02 (well past the boundary) and 0.005 (well inside it).
@@ -1320,29 +1599,23 @@ fn near_zero_temperature_underflow_boundary() {
     );
 }
 
-/// The reported symptom, reproduced without a model: on an **exactly tied**
-/// row the near-zero-temperature host sampler is a uniform draw over the tied
-/// ids, so it disagrees with the device argmax roughly half the time. This is
-/// the sampler behaving correctly — a categorical draw from a two-point
-/// distribution — not a defect, and the host greedy path (which this test does
-/// not touch) is the one that must match the device.
+/// A *sufficient* mechanism for a near-zero-temperature stream to leave the
+/// greedy stream, reproduced without a model: on an **exactly tied** row the
+/// host sampler is a uniform draw over the tied ids, so it disagrees with the
+/// device argmax roughly half the time. This is the sampler behaving correctly
+/// — a categorical draw from a two-point distribution — and it is why a
+/// near-zero temperature is not a valid oracle for the greedy path.
+///
+/// It does **not** establish that this is what happened in any particular
+/// field report; that needs the top-2 logits at the first divergent step.
 #[test]
 #[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
-#[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
 )]
 fn near_zero_temperature_is_a_uniform_draw_over_an_exact_tie() {
-    let data: [f32; 3] = [4.0, 4.0, 1.0];
-    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 3], Dtype::F32).unwrap();
-
-    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
-    materialise(&device_idx);
-    let db = device_idx.to_bytes().unwrap();
-    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap()) as u32;
+    let logits = f32_row(&[4.0, 4.0, 1.0]);
+    let device_id = device_argmax(&logits, Device::Cpu);
     assert_eq!(device_id, 0, "device argmax takes the lowest tied id");
 
     let sp = SamplerConfig {
@@ -1359,9 +1632,7 @@ fn near_zero_temperature_is_a_uniform_draw_over_an_exact_tie() {
     let mut hits_device = 0usize;
     for _ in 0..64 {
         let out = sample_token_array(&logits, &sp, None, &nop, &[], &mut rng, Device::Cpu).unwrap();
-        materialise(&out);
-        let b = out.to_bytes().unwrap();
-        let id = i32::from_le_bytes(b[..4].try_into().unwrap()) as u32;
+        let id = token_id(&out);
         assert!(id < 2, "never the untied low logit, got {id}");
         if id == device_id {
             hits_device += 1;
@@ -1372,5 +1643,98 @@ fn near_zero_temperature_is_a_uniform_draw_over_an_exact_tie() {
     assert!(
         hits_other > 0 && hits_device > 0,
         "an exact tie at temp 1e-4 must split between the tied ids, got {hits_device}/{hits_other}"
+    );
+}
+
+// ── Device::Gpu mirrors ───────────────────────────────────────────────────
+//
+// `host_argmax` mirrors the **Metal** reduction, and the CPU tests above
+// cannot establish a Metal property — MLX's two backends are separate
+// implementations that are already known to differ on one shape (the `-inf`
+// vs `in[0]` seed). These re-run the tie contract on the real stream.
+//
+// `#[ignore]`d per the workspace rule for tests that reach `Device::Gpu`; run
+// via `make gpu-test CRATE=rmlx-models FILTER=tie`.
+
+/// Metal's `argmax` must break ties to the lowest index at every width,
+/// including a width that crosses its multi-threadgroup reduction strategy.
+#[test]
+#[ignore = "reaches Device::Gpu; run via make gpu-test"]
+fn mlx_argmax_breaks_ties_to_lowest_index_gpu() {
+    for (name, row, expect) in tie_shapes() {
+        let got = device_argmax(&f32_row(&row), Device::Gpu);
+        assert_eq!(
+            got, expect,
+            "{name}: Metal argmax must return the first of the tied maxima"
+        );
+    }
+}
+
+/// Host greedy must agree with the Metal reduction on the same tied rows.
+#[test]
+#[ignore = "reaches Device::Gpu; run via make gpu-test"]
+fn host_greedy_matches_device_argmax_on_a_tie_gpu() {
+    for (name, row, _) in tie_shapes() {
+        let logits = f32_row(&row);
+        let device_id = device_argmax(&logits, Device::Gpu);
+        let host_id = host_greedy(&logits, Device::Gpu);
+        assert_eq!(
+            host_id, device_id,
+            "{name}: host greedy picked {host_id}, Metal argmax picked {device_id}"
+        );
+    }
+}
+
+/// The BF16 row, on the dtype and the stream production actually uses.
+/// `logits_to_host_f32` widens BF16 by shifting the pattern into the high
+/// half-word, which is exact and injective, so it can neither create a tie nor
+/// break one — a BF16 tie is still a tie after the readback.
+#[test]
+#[ignore = "reaches Device::Gpu; run via make gpu-test"]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
+)]
+fn host_greedy_matches_device_argmax_on_a_bf16_tie_gpu() {
+    let logits = bf16_tie_row();
+    let device_id = device_argmax(&logits, Device::Gpu);
+    assert_eq!(device_id, 1, "Metal takes the first of the two BF16 maxima");
+    let host_id = host_greedy(&logits, Device::Gpu);
+    assert_eq!(
+        host_id, device_id,
+        "BF16 tie: host greedy picked {host_id}, Metal argmax picked {device_id}"
+    );
+}
+
+/// BF16 is the high half-word of the F32 pattern:
+/// `0x3F80` = 1.0, `0x4000` = 2.0, `0x4020` = 2.5, `0x4080` = 4.0.
+/// Tied maxima at index 1 and index 3.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test fixture: from_bytes with a literal shape, to_bytes/try_into over the fixed 4 bytes of a [1] I32 result, and sampler calls on inputs built in the same fn — all infallible by construction"
+)]
+fn bf16_tie_row() -> Array {
+    let patterns: [u16; 5] = [0x4020, 0x4080, 0x3F80, 0x4080, 0x4000];
+    let mut bytes = Vec::with_capacity(patterns.len() * 2);
+    for p in patterns {
+        bytes.extend_from_slice(&p.to_le_bytes());
+    }
+    Array::from_bytes(&bytes, &[1, 5], Dtype::Bf16).unwrap()
+}
+
+/// The same BF16 contract on the CPU stream, so the ordinary suite still
+/// covers the dtype even though the Metal mirror is `#[ignore]`d.
+#[test]
+fn host_greedy_matches_device_argmax_on_a_bf16_tie() {
+    let logits = bf16_tie_row();
+    let device_id = device_argmax(&logits, Device::Cpu);
+    assert_eq!(
+        device_id, 1,
+        "device takes the first of the two BF16 maxima"
+    );
+    let host_id = host_greedy(&logits, Device::Cpu);
+    assert_eq!(
+        host_id, device_id,
+        "BF16 tie: host greedy picked {host_id}, device argmax picked {device_id}"
     );
 }

--- a/crates/rmlx-models/src/sampler_tests.rs
+++ b/crates/rmlx-models/src/sampler_tests.rs
@@ -976,3 +976,401 @@ fn repetition_penalty_breaks_single_token_loop() {
         "rep_penalty=3.0 must cause at least one non-zero token in {n_steps} greedy steps; got 0"
     );
 }
+
+// ── Greedy tie-break: host selection must mirror the device reduction ─────
+//
+// The oracle in this section is MLX's own `argmax`, called through the same
+// FFI the decode loop uses. It shares no arithmetic with the host scan under
+// test: one is a C++/Metal reduction over the array, the other a Rust loop
+// over a host copy. `Device::Cpu` is used only so the tests run in the
+// ordinary (non-`#[ignore]`) suite; MLX's CPU and Metal argmax implement the
+// same tie rule, which the first test pins explicitly.
+
+/// Oracle characterisation: MLX `argmax` resolves an exact tie to the
+/// **lowest** index. Every other test in this section is written against that
+/// fact, so it is pinned here on its own — if a future MLX bump changes the
+/// rule this fails first and names the cause.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn mlx_argmax_breaks_ties_to_lowest_index() {
+    // Three exactly-equal maxima at 1, 4 and 6.
+    let data: [f32; 8] = [1.0, 9.0, 3.0, 2.0, 9.0, 0.0, 9.0, 4.0];
+    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 8], Dtype::F32).unwrap();
+    let idx = argmax(&logits, -1, Device::Cpu).unwrap();
+    materialise(&idx);
+    let b = idx.to_bytes().unwrap();
+    let v = i32::from_le_bytes(b[..4].try_into().unwrap());
+    assert_eq!(
+        v, 1,
+        "MLX argmax must return the first of three tied maxima"
+    );
+}
+
+/// The host greedy path (`temperature == 0` with penalties) must return the
+/// same token as the device greedy path on the same logits row. A tie is the
+/// only input where the two reductions can differ, so it is the only input
+/// that tests the contract.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn host_greedy_matches_device_argmax_on_a_tie() {
+    let data: [f32; 8] = [1.0, 9.0, 3.0, 2.0, 9.0, 0.0, 9.0, 4.0];
+    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 8], Dtype::F32).unwrap();
+
+    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
+    materialise(&device_idx);
+    let db = device_idx.to_bytes().unwrap();
+    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap());
+
+    let nop = PenaltyConfig::default();
+    let host = argmax_with_penalties(&logits, None, &nop, &[], Device::Cpu).unwrap();
+    materialise(&host);
+    let hb = host.to_bytes().unwrap();
+    let host_id = i32::from_le_bytes(hb[..4].try_into().unwrap());
+
+    assert_eq!(
+        host_id, device_id,
+        "host greedy picked {host_id}, device argmax picked {device_id} on the same row"
+    );
+}
+
+/// Same contract, but the tie is *created* by a penalty rather than present in
+/// the raw row — the shape a served request actually reaches, since the host
+/// greedy path only runs when a penalty or a logit bias is active.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn host_greedy_matches_device_argmax_when_a_bias_creates_the_tie() {
+    // Raw row has a unique max at 0. A +2.0 bias on id 3 lifts it to exactly
+    // 5.0 — an exact tie with id 0, no rounding involved.
+    let data: [f32; 6] = [5.0, 1.0, 2.0, 3.0, 0.5, 4.0];
+    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 6], Dtype::F32).unwrap();
+    let cfg = PenaltyConfig {
+        logit_bias: vec![(3, 2.0)],
+        ..PenaltyConfig::default()
+    };
+    let host = argmax_with_penalties(&logits, None, &cfg, &[], Device::Cpu).unwrap();
+    materialise(&host);
+    let hb = host.to_bytes().unwrap();
+    let host_id = i32::from_le_bytes(hb[..4].try_into().unwrap());
+
+    // Oracle: apply the same bias on the device and reduce there.
+    let biased: [f32; 6] = [5.0, 1.0, 2.0, 5.0, 0.5, 4.0];
+    let biased_arr = Array::from_bytes(f32_as_bytes(&biased), &[1, 6], Dtype::F32).unwrap();
+    let device_idx = argmax(&biased_arr, -1, Device::Cpu).unwrap();
+    materialise(&device_idx);
+    let db = device_idx.to_bytes().unwrap();
+    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap());
+
+    assert_eq!(
+        host_id, device_id,
+        "bias-induced tie: host greedy picked {host_id}, device argmax picked {device_id}"
+    );
+}
+
+/// A `NaN` in the row must not displace a real maximum, and must not reset the
+/// running best — both are properties of the device reduction, which compares
+/// with a strict `>` and therefore skips `NaN` entirely. The `NaN` is placed
+/// away from index 0 on purpose: MLX seeds its CPU reduction with `in[0]` and
+/// its Metal reduction with `-inf`, so a leading `NaN` is the one shape where
+/// MLX's own two backends disagree and no host rule can match both.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn host_greedy_skips_nan_like_the_device() {
+    let data: [f32; 4] = [1.0, 3.0, f32::NAN, 2.0];
+    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 4], Dtype::F32).unwrap();
+
+    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
+    materialise(&device_idx);
+    let db = device_idx.to_bytes().unwrap();
+    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap());
+    assert_eq!(device_id, 1, "device reduction must skip the NaN");
+
+    let nop = PenaltyConfig::default();
+    let host = argmax_with_penalties(&logits, None, &nop, &[], Device::Cpu).unwrap();
+    materialise(&host);
+    let hb = host.to_bytes().unwrap();
+    let host_id = i32::from_le_bytes(hb[..4].try_into().unwrap());
+    assert_eq!(
+        host_id, device_id,
+        "NaN row: host greedy picked {host_id}, device argmax picked {device_id}"
+    );
+}
+
+/// A fully constraint-masked row (every logit `-inf`) must still agree.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn host_greedy_matches_device_argmax_on_an_all_neg_inf_row() {
+    let data = [f32::NEG_INFINITY; 5];
+    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 5], Dtype::F32).unwrap();
+
+    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
+    materialise(&device_idx);
+    let db = device_idx.to_bytes().unwrap();
+    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap());
+
+    let nop = PenaltyConfig::default();
+    let host = argmax_with_penalties(&logits, None, &nop, &[], Device::Cpu).unwrap();
+    materialise(&host);
+    let hb = host.to_bytes().unwrap();
+    let host_id = i32::from_le_bytes(hb[..4].try_into().unwrap());
+
+    assert_eq!(
+        host_id, device_id,
+        "all -inf row must agree with the device"
+    );
+}
+
+/// The same contract on a **BF16** row, which is the dtype most snapshots
+/// produce and the dtype the device actually reduces over.
+///
+/// This also settles a standing question about whether the host readback could
+/// itself be the source of a disagreement: `logits_to_host_f32` widens BF16 to
+/// F32 by shifting the pattern into the high half-word, which is exact and
+/// injective, so it can neither create a tie nor break one. A BF16 tie is
+/// still a tie after the readback, and the two paths must agree on it.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn host_greedy_matches_device_argmax_on_a_bf16_tie() {
+    // BF16 is the high half-word of the F32 pattern:
+    // 0x3F80 = 1.0, 0x4000 = 2.0, 0x4020 = 2.5, 0x4080 = 4.0.
+    // Tied maxima at index 1 and index 3.
+    let patterns: [u16; 5] = [0x4020, 0x4080, 0x3F80, 0x4080, 0x4000];
+    let mut bytes = Vec::with_capacity(patterns.len() * 2);
+    for p in patterns {
+        bytes.extend_from_slice(&p.to_le_bytes());
+    }
+    let logits = Array::from_bytes(&bytes, &[1, 5], Dtype::Bf16).unwrap();
+
+    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
+    materialise(&device_idx);
+    let db = device_idx.to_bytes().unwrap();
+    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap());
+    assert_eq!(
+        device_id, 1,
+        "device takes the first of the two BF16 maxima"
+    );
+
+    let nop = PenaltyConfig::default();
+    let host = argmax_with_penalties(&logits, None, &nop, &[], Device::Cpu).unwrap();
+    materialise(&host);
+    let hb = host.to_bytes().unwrap();
+    let host_id = i32::from_le_bytes(hb[..4].try_into().unwrap());
+
+    assert_eq!(
+        host_id, device_id,
+        "BF16 tie: host greedy picked {host_id}, device argmax picked {device_id}"
+    );
+}
+
+/// `top_k` keeps the `k` highest probabilities; when the cut falls inside a
+/// group of equal probabilities it must keep the **lowest ids**, so that
+/// `top_k == 1` is the argmax on every row and not only on rows with a unique
+/// maximum. The array is longer than the length at which `sort_unstable_by`
+/// degenerates to a stable insertion sort, so the ordering under test is the
+/// real one.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+fn filter_top_k_breaks_ties_to_lowest_id() {
+    let n = 64usize;
+    let tied = [5usize, 30, 63];
+    let mut probs = vec![0.001f32; n];
+    for &i in &tied {
+        probs[i] = 0.3;
+    }
+
+    let mut k1 = probs.clone();
+    filter_top_k(&mut k1, 1);
+    let survivors: Vec<usize> = (0..n).filter(|&i| k1[i] > 0.0).collect();
+    assert_eq!(
+        survivors,
+        vec![5],
+        "top_k=1 must keep only the lowest tied id"
+    );
+
+    let mut k2 = probs.clone();
+    filter_top_k(&mut k2, 2);
+    let survivors2: Vec<usize> = (0..n).filter(|&i| k2[i] > 0.0).collect();
+    assert_eq!(
+        survivors2,
+        vec![5, 30],
+        "top_k=2 must keep the two lowest tied ids"
+    );
+}
+
+/// End-to-end restatement of the same contract on the full host pipeline:
+/// `top_k = 1` must reproduce the device argmax for every RNG draw, including
+/// on a row whose maximum is tied. The existing `top_k_one_collapses_to_greedy`
+/// covers only rows with a unique maximum, which is the case that cannot fail.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn top_k_one_equals_device_argmax_under_a_tie() {
+    let n = 64usize;
+    let mut data = vec![1.0f32; n];
+    for &i in &[5usize, 30, 63] {
+        data[i] = 8.0;
+    }
+    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, n as i32], Dtype::F32).unwrap();
+
+    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
+    materialise(&device_idx);
+    let db = device_idx.to_bytes().unwrap();
+    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap()) as u32;
+
+    let sp = SamplerConfig {
+        temperature: 0.8,
+        top_p: 1.0,
+        top_k: 1,
+        min_p: 0.0,
+        seed: Some(11),
+        top_logprobs_k: 0,
+    };
+    let nop = PenaltyConfig::default();
+    let mut rng = Pcg32::new(sp.seed_or_default());
+    for draw in 0..64 {
+        let out = sample_token_array(&logits, &sp, None, &nop, &[], &mut rng, Device::Cpu).unwrap();
+        materialise(&out);
+        let b = out.to_bytes().unwrap();
+        let id = i32::from_le_bytes(b[..4].try_into().unwrap()) as u32;
+        assert_eq!(
+            id, device_id,
+            "top_k=1 draw {draw}: sampled {id}, device argmax {device_id}"
+        );
+    }
+}
+
+// ── Near-zero temperature is sampling, not greedy ────────────────────────
+//
+// These two pin the boundary of the "temperature ~0 behaves like an argmax"
+// shortcut so it cannot be read as a guarantee.
+
+/// At `temperature = 1e-4` every logit below the maximum by more than about
+/// 0.0104 underflows to exactly zero probability, and every logit closer than
+/// that does not. `exp` in f32 returns exactly 0 below roughly -104, so the
+/// boundary in logit units is 104 * temperature.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+fn near_zero_temperature_underflow_boundary() {
+    // Gaps of 0.02 (well past the boundary) and 0.005 (well inside it).
+    let logits = vec![10.0f32, 9.98, 9.995];
+    let probs = softmax_scaled(&logits, 1.0 / 1e-4);
+    assert_eq!(probs[1], 0.0, "gap 0.02 must underflow to exactly zero");
+    assert!(
+        probs[2] > 0.0,
+        "gap 0.005 must keep non-zero mass, got {}",
+        probs[2]
+    );
+    assert!(
+        probs[0] > 0.99,
+        "maximum keeps essentially all the mass, got {}",
+        probs[0]
+    );
+}
+
+/// The reported symptom, reproduced without a model: on an **exactly tied**
+/// row the near-zero-temperature host sampler is a uniform draw over the tied
+/// ids, so it disagrees with the device argmax roughly half the time. This is
+/// the sampler behaving correctly — a categorical draw from a two-point
+/// distribution — not a defect, and the host greedy path (which this test does
+/// not touch) is the one that must match the device.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn near_zero_temperature_is_a_uniform_draw_over_an_exact_tie() {
+    let data: [f32; 3] = [4.0, 4.0, 1.0];
+    let logits = Array::from_bytes(f32_as_bytes(&data), &[1, 3], Dtype::F32).unwrap();
+
+    let device_idx = argmax(&logits, -1, Device::Cpu).unwrap();
+    materialise(&device_idx);
+    let db = device_idx.to_bytes().unwrap();
+    let device_id = i32::from_le_bytes(db[..4].try_into().unwrap()) as u32;
+    assert_eq!(device_id, 0, "device argmax takes the lowest tied id");
+
+    let sp = SamplerConfig {
+        temperature: 1e-4,
+        top_p: 1.0,
+        top_k: 0,
+        min_p: 0.0,
+        seed: Some(7),
+        top_logprobs_k: 0,
+    };
+    let nop = PenaltyConfig::default();
+    let mut rng = Pcg32::new(sp.seed_or_default());
+    let mut hits_other = 0usize;
+    let mut hits_device = 0usize;
+    for _ in 0..64 {
+        let out = sample_token_array(&logits, &sp, None, &nop, &[], &mut rng, Device::Cpu).unwrap();
+        materialise(&out);
+        let b = out.to_bytes().unwrap();
+        let id = i32::from_le_bytes(b[..4].try_into().unwrap()) as u32;
+        assert!(id < 2, "never the untied low logit, got {id}");
+        if id == device_id {
+            hits_device += 1;
+        } else {
+            hits_other += 1;
+        }
+    }
+    assert!(
+        hits_other > 0 && hits_device > 0,
+        "an exact tie at temp 1e-4 must split between the tied ids, got {hits_device}/{hits_other}"
+    );
+}

--- a/docs/SAMPLING.md
+++ b/docs/SAMPLING.md
@@ -201,9 +201,22 @@ the index sorts these replace:
 | `top_p` (0.95) | tie-dense | 2.02–2.06 ms | 1.31–1.34 ms |
 | `top_p` (0.95) | all-distinct | 3.73–4.32 ms | 2.17–2.68 ms |
 
-So pinning the tie order is a net speedup on every fixture measured, not a cost
-to be justified. Details on `rank_key_desc` and `total_order_bits` in
-`sampler.rs`.
+So pinning the tie order is a net speedup on every *served* distribution
+measured, not a cost to be justified. Details on `rank_key_desc` and
+`total_order_bits` in `sampler.rs`.
+
+**Two shapes are marginally slower**, and neither is a distribution a model
+produces:
+
+| Shape | before | after |
+|---|---:|---:|
+| Perfectly uniform row (every probability identical) | 0.27 ms | 0.40 ms |
+| Heavily constraint-masked row (nearly all mass at `0.0`) | 0.419 ms | 0.474 ms |
+
+Both are cases where the sort it replaces gets a near-free equal-element
+partition over one or two distinct values. The uniform row is also the only
+shape where `filter_top_p`'s `tied` vector grows to the full vocabulary — on a
+realistic tie-dense row it holds 808 entries (6 KiB), and on the masked row one.
 
 The keys use the IEEE total-order flip rather than the raw bit pattern, so they
 order every `f32` including negatives and `-0.0`. The raw pattern is monotone

--- a/docs/SAMPLING.md
+++ b/docs/SAMPLING.md
@@ -127,13 +127,45 @@ Three sub-cases refine the greedy path:
 |---|---|
 | No constraint, no penalties | Pure GPU `argmax` |
 | Constraint mask, no penalties | `apply_mask_argmax` — additive `-inf` bias on GPU, then `argmax` |
-| No constraint, penalties active | `argmax_with_penalties` — GPU→host, penalties, host argmax |
+| Penalties active, with or without a constraint | `argmax_with_penalties` — GPU→host, mask, penalties, host argmax |
 
 `apply_mask_argmax` builds a F32 bias buffer on the host (0.0 for allowed,
 `-inf` for forbidden), wraps it as a `[1, vocab]` MLX array, adds it to the
 logits (GPU op, promotes BF16 to F32 automatically), then calls `argmax`.
 Overhead versus unconstrained: approximately 0.05 ms host-side bias fill for
 a 262K-token vocabulary.
+
+#### Tie-break contract
+
+**Greedy resolves an exact tie to the lowest token id, on the host and on the
+device alike.** MLX's `argmax` accumulates with a strict `>` from a `-inf`
+seed, so an equal value never displaces the earlier index; the host scan in
+`argmax_with_penalties` (`host_argmax`) is written to mirror it exactly. Three
+consequences follow from the same rule and are pinned by tests:
+
+- equal logits → lowest id,
+- a `NaN` never displaces a real maximum,
+- an all-`-inf` row (every token forbidden) yields id 0.
+
+The rule matters because the three greedy sub-cases above must be
+interchangeable: which one a request lands in is decided by whether a
+constraint or a penalty happens to be set, and that must never change the
+token on a row where the top logits tie. `Iterator::max_by` returns the *last*
+maximum and so cannot be used here.
+
+Ties are not exotic. Logits are BF16 on most snapshots, which carries 8 bits
+of mantissa — at a logit magnitude of 16 the spacing is 0.125, so any two
+candidates within that of each other collapse to the same value.
+
+The same lowest-id rule extends to `top_k`: when the cut falls inside a group
+of equal probabilities the lowest ids survive, which is what makes `top_k = 1`
+the argmax on *every* row rather than only on rows with a unique maximum.
+
+There is one shape where no host rule can match the device, because MLX does
+not match itself: MLX seeds its CPU reduction with element 0 and its Metal
+reduction with `-inf`, so a `NaN` at index 0 returns 0 on CPU and the first
+real maximum on Metal. `host_argmax` follows Metal, which is the production
+stream.
 
 ### Temperature scaling and softmax
 
@@ -192,9 +224,15 @@ the threshold so no special floor-of-1 case is needed. No-op when
 Applied after min-p. Mirrors mlx-lm `apply_top_k` (`sample_utils.py`
 L130–151).
 
-Keep exactly the `k` highest-probability tokens; set the rest to 0.0. Ties
-are broken by index rank (descending probability sort, argpartition
-semantics). No-op when `k == 0` or `k >= vocab`.
+Keep exactly the `k` highest-probability tokens; set the rest to 0.0. No-op
+when `k == 0` or `k >= vocab`.
+
+Equal probabilities are ranked by **ascending token id**, so a cut that falls
+inside a tied group keeps the lowest ids — the same rule the device `argmax`
+uses, which is what makes `top_k = 1` reduce to greedy on a tied row as well
+as on an untied one. mlx-lm's `argpartition` leaves the tied order
+unspecified; rMLX pins it rather than inheriting whatever the sort's pivot
+choice produces.
 
 ### Renormalisation
 
@@ -494,29 +532,41 @@ Reading it:
   262144-token vocabulary pays 0.880 ms/step against 0.487 ms/step for the
   151669-token one.
 
-### Host selection is not bit-identical to the GPU argmax
+### A near-zero temperature is still sampling, not greedy
 
-At `--temperature 0.0001` the host categorical sampler is arithmetically an
-argmax (every non-maximal logit underflows to exactly zero), so its token stream
-should match the greedy GPU `argmax` stream. On gemma-4-e2b it does, for all 100
-tokens. On Ternary-Bonsai-8B it agrees through 32 tokens and diverges by 64. The
-divergence is reproducible and every run within a cell agrees, so it is a
-deterministic property of the two paths and not a race.
+`--temperature 0.0001` is often used as a stand-in for greedy on the assumption
+that every non-maximal logit underflows to zero probability. That holds only
+away from a tie, and the boundary is computable: `exp` in f32 returns exactly
+zero below about `-104`, so a logit survives the scaling iff it is within
+`104 * temperature` of the maximum — 0.0104 at `temperature = 1e-4`. Outside
+that band the distribution really is one-hot and the draw really is the argmax.
 
-**The mechanism is not established.** The candidate is tie-breaking: MLX's
-`argmax` returns the first maximal index and Rust's `Iterator::max_by` returns
-the last, so an exact tie in the logits row would select different tokens. But
-that does not predict what was observed. `--repetition-penalty 1.1` is a
-different objective, not another route to the same argmax — it divides positive
-logits of the trailing-20 ids by 1.1 — and its stream, which is selected by
-`max_by`, matched the temperature stream, which is selected by
-`sample_inverse_cdf` (the first index whose cumulative sum passes an RNG draw).
-Under a two-way tie those two agree only by chance. Confirming or discarding the
-hypothesis needs the top-2 logits at the first divergent step, which nothing here
-dumps.
+**Inside it, and at an exact tie, it is not.** On an exactly tied top the
+post-softmax distribution is uniform over the tied ids, and the inverse-CDF
+draw picks among them by the RNG — matching the device `argmax`, which takes
+the lowest tied id, only about `1/k` of the time. That is the categorical
+sampler behaving correctly. A near-zero temperature is therefore **not** a
+valid oracle for the greedy path and must not be used as one; the argument
+"temperature ~0 should match greedy, so a mismatch is a bug" is unsound.
 
-What *is* established: the two paths are not interchangeable oracles on every
-model, which matters to anything that treats one as a reference for the other.
+Ties reach this band routinely on BF16 logits, whose 8-bit mantissa spaces
+values 0.125 apart at magnitude 16. A temperature-`1e-4` stream that tracks
+greedy for 32 tokens and then departs is the expected shape: one tied step is
+enough, and every token after it is conditioned on a different prefix.
+
+The path that *does* owe the device an exact match is greedy — including the
+host greedy variant `argmax_with_penalties`. See the tie-break contract under
+[Greedy](#greedy-temperature--0); it is pinned by tests that compare the host
+scan against MLX's own reduction on tied, `NaN`, and all-`-inf` rows.
+
+**Consequence for a future fused GPU sampler.** The merge gate for one cannot
+be "the token stream matches a near-zero-temperature CPU run", and it cannot be
+"the streams match" for any `temperature > 0` unless the RNG matches too. The
+gate that survives is two-part: on the greedy path, exact token identity
+against the device `argmax` including the lowest-id tie rule; on the stochastic
+path, exact token identity against the CPU path **given the same `Pcg32` draw
+sequence** — a GPU RNG must reproduce `Pcg32` bit-for-bit, or the kernel ships
+behind a dispatch policy with the CPU path retained as the oracle.
 
 ## Special tokens
 
@@ -669,7 +719,11 @@ The captured `TokenLogprobs` struct carries:
 
 **Greedy (`temperature == 0`).** Byte-identical across runs. No RNG is
 consulted. Given fixed weights, a fixed prompt, and the same KV cache state,
-the token sequence is fully determined.
+the token sequence is fully determined — and it is the same sequence in all
+three greedy sub-cases, because they share one tie rule (lowest id wins; see
+[Greedy](#greedy-temperature--0)). Adding a constraint or a penalty moves a
+request between sub-cases, and that move must not change the token on a tied
+row.
 
 **Stochastic (`temperature > 0`).** Deterministic when the seed is fixed.
 The PCG32 RNG is seeded from `SamplerConfig::seed_or_default()`:

--- a/docs/SAMPLING.md
+++ b/docs/SAMPLING.md
@@ -158,6 +158,15 @@ Ties are not exotic — see the measurement under
 on a realistic 262144-wide BF16-derived softmax row, 259416 of 262143 adjacent
 pairs are exactly equal.
 
+**The device half of the rule is confirmed on real streams, not just on
+fixtures.** A census of pure-GPU greedy 512-token generations found exact top-2
+ties at 2 of 275 steps on Ternary-Bonsai-8B and at 4 of 200 on gemma-4-e2b — so
+a tie decides a served token roughly once per fifty, not once per run. On every
+tied step censused, the device emitted the **lower** of the tied ids: 12 of 12.
+That is the observed behaviour `host_argmax` is written to mirror, and it is why
+the rule is stated as lowest-id rather than left to whichever path a request
+happens to take.
+
 **Scope.** The rule covers everything that selects or filters a token:
 
 | Site | Rule |
@@ -251,13 +260,24 @@ channel the decode loop already propagates.
 **An all-`false` constraint mask.** No token satisfies the grammar, so every
 token the selection could return violates it. Returning one anyway is the worst
 option: the engine state that produced the empty mask is persistent, so the
-stream emits the same arbitrary token (id 0) for the rest of the generation and
-the request reports success. Logging instead is no better at the rate this is
-reached — the check sits on the per-token decode path, so a `warn!` would fire
-once per emitted token and, at a few hundred bytes a line, evict the whole log
-directory under `RMLX_LOG_CAP_MB` within hours, deleting the evidence it exists
-to provide. All three mask-accepting entry points (`apply_mask_argmax`,
+stream would emit the same arbitrary token (id 0) for the rest of the generation
+while the request reports success. Logging instead is no better — the check sits
+on the per-token decode path, so a `warn!` would fire once per emitted token
+and, at a few hundred bytes a line, evict the whole log directory under
+`RMLX_LOG_CAP_MB` within hours, deleting the evidence it exists to provide. All
+three mask-accepting entry points (`apply_mask_argmax`,
 `argmax_with_penalties`, `sampling_distribution`) refuse it.
+
+**That guard is unit-tested only; it has no demonstrated production trigger.**
+An attempt to construct an all-forbidden mask through the HTTP surface did not
+find one. `{"enum": []}` is rejected at schema parse with HTTP 400, before any
+mask is built; and because the tokenizer is byte-level BPE, exotic `const` or
+single-`enum` values still leave a byte that continues them, so they never
+starve the mask either. The constraint engine itself does engage on these
+requests, so the guarded path is live — but the all-`false` state was not
+reachable from outside. Read the guard as a defence against a future
+constraint-engine defect, proven by construction in tests and by argument from
+the code path, not as a reproduction of an observed served failure.
 
 **A non-finite logits row, on the sampling path.** `softmax_scaled` errors when
 the exponentials do not sum to a finite value, which happens exactly when a
@@ -667,10 +687,19 @@ Reading it:
 
 At `--temperature 0.0001` the host categorical sampler is *close to* an argmax,
 so its token stream might be expected to match the greedy GPU `argmax` stream.
-On gemma-4-e2b it does, for all 100 tokens. On Ternary-Bonsai-8B it agrees
-through 32 tokens and diverges by 64. The divergence is reproducible and every
-run within a cell agrees, so it is a deterministic property of the two paths
-and not a race.
+It does not. The divergence is reproducible and every run within a cell agrees,
+so it is a deterministic property of the two paths and not a race.
+
+**Which architecture exhibits it is a property of the prompt and the window
+length, not of the architecture, and must not be used to scope the defect.**
+The original filing saw gemma-4-e2b agree with greedy for all 100 tokens while
+Ternary-Bonsai-8B agreed through 32 and diverged by 64. A later run at 512 max
+tokens on a different prompt (`--kv-quant none --max-ctx 4096`, `release-perf`)
+inverted that exactly: Ternary-Bonsai-8B was identical to greedy for all 275
+tokens it emitted, and gemma-4-e2b diverged at step 132. Both observations are
+real and neither is a fact about the model. A window that ends before the first
+tied row shows agreement and nothing more, so an arm that matches is evidence of
+a short window, not of an unaffected architecture.
 
 #### What is proven
 
@@ -704,16 +733,30 @@ and returned the last id rather than 0 on a fully masked row. Fixed, and pinned
 by tests that use MLX's own reduction as the oracle. See the tie-break contract
 under [Greedy](#greedy-temperature--0).
 
-#### What is not proven
+#### The mechanism, established
 
-**The mechanism behind the Bonsai divergence is still unestablished.** The
-temperature-`1e-4` path never enters `argmax_with_penalties`, so the greedy fix
-above cannot have changed that stream — it is a different code path, and the
-observation stands unexplained. The tie mechanism described above is a
-*sufficient* explanation, and it is now known to be reachable, but nothing here
-shows it is the *actual* one. Two other candidates are untested: a near-tie
-inside the 0.0104 window (which produces the same symptom without an exact
-tie), and something outside the sampler entirely.
+**The divergence is the exact-tie mechanism. The residual is closed.** The
+closure condition this section set for itself was the gap between the top two
+logits at the first divergent step, read via `logprobs: true` with
+`top_logprobs: 2` (which reports `logit - lse` per rank): a gap of `0` or below
+`104 * temperature` confirms the tie/near-tie mechanism, a gap well above it
+kills the tie explanation. That was run, on the gemma-4-e2b divergence above.
+
+At step 132 the greedy stream emits 16939 (`▁featured`) and the
+temperature-`1e-4` stream emits 22420 (`▁incorporated`). Both ranks report the
+same logprob, `-1.0606343`, bit for bit — a gap of **exactly `0.0`**. That is an
+exact tie, not a near-tie: the post-softmax distribution over the two ids is
+uniform, the inverse-CDF draw takes whichever the RNG lands on, and the device
+`argmax` takes the lower id. Both paths are correct and there is no third
+mechanism left to look for. The near-tie candidate (a gap inside the 0.0104
+window, same symptom without an exact tie) did not need to be invoked, and
+"something outside the sampler" is excluded by a gap that is identically zero.
+
+One control makes this a measurement rather than a coincidence: the
+temperature-`1e-4` streams are **byte-identical across the two arms** of this
+change. That confirms on real output what the code path already implies — the
+temperature path never enters `argmax_with_penalties`, so the greedy tie fix
+neither introduced this divergence nor masked it.
 
 The original filing also offered `--repetition-penalty 1.1` producing the same
 divergent stream as corroboration. It is not: that flag divides positive logits
@@ -721,20 +764,9 @@ of the trailing-20 ids by 1.1, which is a different objective, not another
 route to the same argmax. Its agreement with the temperature stream is evidence
 for nothing either way.
 
-**What would settle it**, and what to run before treating this as closed: the
-top-2 logits at the first divergent step. Unlike when this was filed, the server
-does dump them — `logprobs: true` with `top_logprobs: 2` reports
-`logit - lse` per rank, and the difference of the top two ranks is the gap. Run
-the greedy and the temperature-`1e-4` cells with that enabled, find the first
-step whose token ids differ, and read the gap:
-
-- gap `== 0` or below `104 * temperature` ⇒ the tie/near-tie mechanism is
-  confirmed and the residual is closed;
-- gap well above that ⇒ the tie explanation is dead, the near-zero-temperature
-  path is picking a token that had no probability mass, and the real cause is
-  still open.
-
-Until that is run, do not record this as fully explained.
+What this does **not** license is treating a near-zero temperature as an oracle
+for greedy. The mechanism is understood; the two streams still legitimately
+differ, for the reasons under [What is proven](#what-is-proven) above.
 
 #### Consequence for a future fused GPU sampler
 

--- a/docs/SAMPLING.md
+++ b/docs/SAMPLING.md
@@ -158,14 +158,21 @@ Ties are not exotic — see the measurement under
 on a realistic 262144-wide BF16-derived softmax row, 259416 of 262143 adjacent
 pairs are exactly equal.
 
-**The device half of the rule is confirmed on real streams, not just on
-fixtures.** A census of pure-GPU greedy 512-token generations found exact top-2
-ties at 2 of 275 steps on Ternary-Bonsai-8B and at 4 of 200 on gemma-4-e2b — so
-a tie decides a served token roughly once per fifty, not once per run. On every
-tied step censused, the device emitted the **lower** of the tied ids: 12 of 12.
-That is the observed behaviour `host_argmax` is written to mirror, and it is why
-the rule is stated as lowest-id rather than left to whichever path a request
-happens to take.
+**The primary evidence for the device half of the rule is the GPU test
+`mlx_argmax_breaks_ties_to_lowest_index_gpu`**, which is mutation-verified: it
+goes red when the rule is inverted, so it is a gate that can actually fail.
+
+A census of real streams **corroborates** it. Two pure-GPU greedy 512-token
+generations contained exact top-2 ties at 2 of 275 steps on Ternary-Bonsai-8B
+(steps 70, 253) and at 4 of 200 on gemma-4-e2b (steps 29, 69, 108, 132). The
+device emitted the **lower** tied id in every one — **6 of 6**, zero exceptions.
+Step 132 of the gemma run is the divergence analysed under
+[Host selection is not bit-identical to the GPU argmax](#host-selection-is-not-bit-identical-to-the-gpu-argmax).
+
+Read that as corroboration, not as the basis of the contract. Six tied steps
+from two runs on a single prompt is a small sample, and every tie in it comes
+from the same pair of greedy streams. What it adds is that the rule holds on
+real logits, which a fixture cannot show; it does not carry the contract alone.
 
 **Scope.** The rule covers everything that selects or filters a token:
 

--- a/docs/SAMPLING.md
+++ b/docs/SAMPLING.md
@@ -172,35 +172,102 @@ It does **not** cover the inverse-CDF draw: a categorical sample from a tied
 distribution is supposed to be random, and forcing it to the lowest id would
 make `temperature > 0` biased.
 
-`filter_top_k` and `filter_top_p` implement the rule by sorting packed `u64`
-keys — inverted IEEE bits in the high half-word, token id in the low one —
-rather than by sorting indices under a comparator. Two reasons, both measured:
+Neither filter uses a comparator. Folding an unordered `NaN` pair to `Equal`
+makes a `NaN` compare equal to everything, which is intransitive, and
+`sort_unstable_by` may detect that and panic with "user-provided comparison
+function does not correctly implement a total order" — mid-decode, aborting the
+step. Adding an id tiebreak on top widens the window rather than closing it.
+Both filters order integers under the standard `Ord` instead, so no comparator
+exists to be intransitive.
 
-- **No comparator can be used safely here.** Folding an unordered `NaN` pair to
-  `Equal` makes a `NaN` compare equal to everything, which is intransitive, and
-  `sort_unstable_by` panics with "user-provided comparison function does not
-  correctly implement a total order" — mid-decode, aborting the step. Adding an
-  id tiebreak on top widens the window rather than closing it. A `NaN` logit
-  does reach these filters: the softmax propagates it and skips its
-  renormalise. Sorting `u64` is total by construction.
-- **It is cheaper.** At 262144 wide: 2.4 ms for the packed sort, 2.6 ms for the
-  index sort it replaces, 5.9 ms for that index sort under a tie-breaking
-  comparator. Pinning the tie order costs nothing.
+They do it differently, because the two have different jobs:
 
-Details on `rank_key_desc` in `sampler.rs`.
+- `filter_top_k` **partitions** `select_nth_unstable` over packed `u64` keys
+  (inverted total-order bits above the token id). It needs a set, not an order,
+  which is what mlx-lm's `argpartition` says too.
+- `filter_top_p` needs the full ascending order for the cumulative sum, so it
+  sorts the **values alone** and applies the id rule once, to the single tied
+  group the cut lands in. Packing the id into the sort key would make every key
+  distinct and destroy the equal-element partition that a tie-dense row hands
+  the sort — that formulation is *slower* than no tie rule at all.
+
+Measured at a 262144-token vocabulary (best-of-9, three process runs), against
+the index sorts these replace:
+
+| Filter | fixture | previous | now |
+|---|---|---:|---:|
+| `top_k` (k=64) | tie-dense (1233 distinct) | 2.02–2.13 ms | 0.30–0.33 ms |
+| `top_k` (k=64) | all-distinct | 3.67–4.31 ms | 0.32–0.41 ms |
+| `top_p` (0.95) | tie-dense | 2.02–2.06 ms | 1.31–1.34 ms |
+| `top_p` (0.95) | all-distinct | 3.73–4.32 ms | 2.17–2.68 ms |
+
+So pinning the tie order is a net speedup on every fixture measured, not a cost
+to be justified. Details on `rank_key_desc` and `total_order_bits` in
+`sampler.rs`.
+
+The keys use the IEEE total-order flip rather than the raw bit pattern, so they
+order every `f32` including negatives and `-0.0`. The raw pattern is monotone
+only over non-negative values, and `probs` are non-negative today — but the
+failure mode if that stopped holding is a silently wrong token (`-0.0` outranks
+every positive, so `top_k = 1` would keep it and zero the real maximum), and
+`release-perf` disables debug assertions, so an assert would not catch it.
 
 **Where MLX does not match itself.** MLX seeds its CPU reduction with element 0
 and its Metal reduction with `-inf`, so a `NaN` at index 0 returns 0 on CPU and
 the first real maximum on Metal. No host rule can match both. `host_argmax`
 follows Metal, which is the production stream; the CPU-stream unit tests avoid
-that one shape, and `#[ignore]`d `Device::Gpu` mirrors re-run the tie cases on
-Metal so the Metal property is checked rather than assumed. Everywhere else the
-two MLX backends agree with each other and with `host_argmax`.
+that one shape. Everywhere else the two MLX backends agree with each other and
+with `host_argmax`.
 
-**An all-forbidden mask is a constraint-engine defect, not a mode.** Falling
-through to id 0 keeps host and device parity, but every mask-applying site now
-emits a `tracing::warn!` when no token is allowed, so the condition appears in
-the run log instead of the stream silently emitting token 0 forever.
+That seeding difference is also why the CPU tests are not sufficient. Three
+`#[ignore]`d `Device::Gpu` mirrors re-run the contract on Metal, one per claim:
+equal-logits-lowest-id, `NaN`-never-displaces, and the all-`-inf` row. The last
+carries the most weight — it is the only shape where the `-inf` seed is never
+displaced, so the answer is a property of the reduction's *seeding* rather than
+of its comparisons, and its CPU test **cannot fail** (MLX's CPU backend returns
+0 by construction whatever Metal does). Until that mirror has run, "an all-`-inf`
+row yields id 0" is a claim about Metal taken from reading MLX's kernel, not a
+measured one. It is no longer reachable through a constraint mask — that case
+errors — but `host_argmax` still has to answer.
+
+### Rows the sampler refuses
+
+Two inputs are defects rather than modes, and both now return `Err` on the
+channel the decode loop already propagates.
+
+**An all-`false` constraint mask.** No token satisfies the grammar, so every
+token the selection could return violates it. Returning one anyway is the worst
+option: the engine state that produced the empty mask is persistent, so the
+stream emits the same arbitrary token (id 0) for the rest of the generation and
+the request reports success. Logging instead is no better at the rate this is
+reached — the check sits on the per-token decode path, so a `warn!` would fire
+once per emitted token and, at a few hundred bytes a line, evict the whole log
+directory under `RMLX_LOG_CAP_MB` within hours, deleting the evidence it exists
+to provide. All three mask-accepting entry points (`apply_mask_argmax`,
+`argmax_with_penalties`, `sampling_distribution`) refuse it.
+
+**A non-finite logits row, on the sampling path.** `softmax_scaled` errors when
+the exponentials do not sum to a finite value, which happens exactly when a
+logit is `NaN` or `+inf`. This is the decode-step half of the rule the prefill
+guard already enforces, and it has to live here because that guard is a
+*prefill* guard: on every test-target architecture it runs once before the loop
+and never again, so nothing downstream reports a `NaN` arriving at decode step
+300. The check is free — `sum` is already computed.
+
+Sampling such a row is silent, not degraded: the `NaN` reaches `probs`,
+`renormalise` no-ops (`total > 0.0` is false on `NaN`), `sample_inverse_cdf`'s
+`total <= 0.0` guard is also false, its `cum > target` never fires, and it
+returns `last_nonzero` — the same id every step, **independent of the RNG**.
+Measured on a 16-wide row with one `NaN`: a constant token for every seed tried,
+against a varied healthy control.
+
+**Greedy deliberately does not refuse a `NaN` row.** It mirrors the device
+reduction, which skips `NaN` and returns the largest real logit; erroring there
+would re-create the host/device split this contract exists to close, since the
+pure-GPU `argmax` cannot refuse anything without an extra per-token reduction.
+The asymmetry is pinned by a test. The sampling path refuses because its failure
+mode is a constant stream; the greedy path does not because its answer is the
+device's.
 
 ### Temperature scaling and softmax
 
@@ -238,17 +305,21 @@ Tokens below the threshold go to 0.0. No-op unless `0 < top_p < 1`.
 The ascending-sort + inclusive-cumsum direction is exact mlx-lm parity and
 is not interchangeable with descending order.
 
-Equal probabilities are ranked by **descending token id**. The walk drops from
-the front, so a tied group has to be ordered highest-id-first for its lowest
-ids to survive the cut — the same lowest-id-wins rule the device `argmax` and
-`top_k` use. Unlike `top_k`, this filter is on by default on the served path:
-several `generation_config.json` snapshots ship a `top_p`. Without the rule the
-survivor set is an artefact of the sort's pivot choice — on a row of 64 with
-one 0.4 and 63 identical tail values at `top_p = 0.5`, the unordered version
-keeps `{0, 29, 54..63}`, id 29 surviving while ids 30..53 are zeroed from a
-bit-identical value. The *number* of survivors is unaffected: probabilities are
-non-negative so the drop set is a prefix, and every member of a tied group
-contributes the same value to the cumulative sum.
+Among equal probabilities the **lowest ids** survive the cut — the same
+lowest-id-wins rule the device `argmax` and `top_k` use. Unlike `top_k`, this
+filter is on by default on the served path: several `generation_config.json`
+snapshots ship a `top_p`. Without the rule the survivor set is an artefact of
+the sort's pivot choice — on a row of 64 with one 0.4 and 63 identical tail
+values at `top_p = 0.5`, the unordered version keeps `{0, 29, 54..63}`, id 29
+surviving while ids 30..53 are zeroed from a bit-identical value.
+
+The *number* of survivors is unaffected by the rule: probabilities are
+non-negative, so the drop set is a prefix of the ascending order, and every
+member of a tied group contributes the same value to the cumulative sum. Only
+*which* members are dropped depends on the order within a group. That is what
+lets the implementation sort the values alone — keeping the equal-element
+partition a tie-dense row hands the sort — and then split just the one tied
+group the cut lands in, dropping its highest ids.
 
 ### Min-p truncation
 

--- a/docs/SAMPLING.md
+++ b/docs/SAMPLING.md
@@ -137,10 +137,10 @@ a 262K-token vocabulary.
 
 #### Tie-break contract
 
-**Greedy resolves an exact tie to the lowest token id, on the host and on the
-device alike.** MLX's `argmax` accumulates with a strict `>` from a `-inf`
-seed, so an equal value never displaces the earlier index; the host scan in
-`argmax_with_penalties` (`host_argmax`) is written to mirror it exactly. Three
+**Selection and filtering resolve an exact tie to the lowest token id, on the
+host and on the device alike.** MLX's `argmax` reduces with a strict `>`, so an
+equal value never displaces the earlier index; the host scan in
+`argmax_with_penalties` (`host_argmax`) is written to mirror it. Three
 consequences follow from the same rule and are pinned by tests:
 
 - equal logits → lowest id,
@@ -153,19 +153,54 @@ constraint or a penalty happens to be set, and that must never change the
 token on a row where the top logits tie. `Iterator::max_by` returns the *last*
 maximum and so cannot be used here.
 
-Ties are not exotic. Logits are BF16 on most snapshots, which carries 8 bits
-of mantissa — at a logit magnitude of 16 the spacing is 0.125, so any two
-candidates within that of each other collapse to the same value.
+Ties are not exotic — see the measurement under
+[Host selection is not bit-identical to the GPU argmax](#host-selection-is-not-bit-identical-to-the-gpu-argmax):
+on a realistic 262144-wide BF16-derived softmax row, 259416 of 262143 adjacent
+pairs are exactly equal.
 
-The same lowest-id rule extends to `top_k`: when the cut falls inside a group
-of equal probabilities the lowest ids survive, which is what makes `top_k = 1`
-the argmax on *every* row rather than only on rows with a unique maximum.
+**Scope.** The rule covers everything that selects or filters a token:
 
-There is one shape where no host rule can match the device, because MLX does
-not match itself: MLX seeds its CPU reduction with element 0 and its Metal
-reduction with `-inf`, so a `NaN` at index 0 returns 0 on CPU and the first
-real maximum on Metal. `host_argmax` follows Metal, which is the production
-stream.
+| Site | Rule |
+|---|---|
+| `argmax` / `apply_mask_argmax` (device) | equal logits → lowest id (MLX's own reduction) |
+| `argmax_with_penalties` (host greedy) | mirrors it via `host_argmax` |
+| `filter_top_k` | equal probabilities → lowest ids survive the cut, so `top_k = 1` is the argmax on tied rows too |
+| `filter_top_p` | equal probabilities → lowest ids survive the nucleus |
+| `compute_top_logprobs` | equal logits → ascending id, so rank 0 is the token `argmax` would pick |
+
+It does **not** cover the inverse-CDF draw: a categorical sample from a tied
+distribution is supposed to be random, and forcing it to the lowest id would
+make `temperature > 0` biased.
+
+`filter_top_k` and `filter_top_p` implement the rule by sorting packed `u64`
+keys — inverted IEEE bits in the high half-word, token id in the low one —
+rather than by sorting indices under a comparator. Two reasons, both measured:
+
+- **No comparator can be used safely here.** Folding an unordered `NaN` pair to
+  `Equal` makes a `NaN` compare equal to everything, which is intransitive, and
+  `sort_unstable_by` panics with "user-provided comparison function does not
+  correctly implement a total order" — mid-decode, aborting the step. Adding an
+  id tiebreak on top widens the window rather than closing it. A `NaN` logit
+  does reach these filters: the softmax propagates it and skips its
+  renormalise. Sorting `u64` is total by construction.
+- **It is cheaper.** At 262144 wide: 2.4 ms for the packed sort, 2.6 ms for the
+  index sort it replaces, 5.9 ms for that index sort under a tie-breaking
+  comparator. Pinning the tie order costs nothing.
+
+Details on `rank_key_desc` in `sampler.rs`.
+
+**Where MLX does not match itself.** MLX seeds its CPU reduction with element 0
+and its Metal reduction with `-inf`, so a `NaN` at index 0 returns 0 on CPU and
+the first real maximum on Metal. No host rule can match both. `host_argmax`
+follows Metal, which is the production stream; the CPU-stream unit tests avoid
+that one shape, and `#[ignore]`d `Device::Gpu` mirrors re-run the tie cases on
+Metal so the Metal property is checked rather than assumed. Everywhere else the
+two MLX backends agree with each other and with `host_argmax`.
+
+**An all-forbidden mask is a constraint-engine defect, not a mode.** Falling
+through to id 0 keeps host and device parity, but every mask-applying site now
+emits a `tracing::warn!` when no token is allowed, so the condition appears in
+the run log instead of the stream silently emitting token 0 forever.
 
 ### Temperature scaling and softmax
 
@@ -202,6 +237,18 @@ Tokens below the threshold go to 0.0. No-op unless `0 < top_p < 1`.
 
 The ascending-sort + inclusive-cumsum direction is exact mlx-lm parity and
 is not interchangeable with descending order.
+
+Equal probabilities are ranked by **descending token id**. The walk drops from
+the front, so a tied group has to be ordered highest-id-first for its lowest
+ids to survive the cut — the same lowest-id-wins rule the device `argmax` and
+`top_k` use. Unlike `top_k`, this filter is on by default on the served path:
+several `generation_config.json` snapshots ship a `top_p`. Without the rule the
+survivor set is an artefact of the sort's pivot choice — on a row of 64 with
+one 0.4 and 63 identical tail values at `top_p = 0.5`, the unordered version
+keeps `{0, 29, 54..63}`, id 29 surviving while ids 30..53 are zeroed from a
+bit-identical value. The *number* of survivors is unaffected: probabilities are
+non-negative so the drop set is a prefix, and every member of a tied group
+contributes the same value to the cumulative sum.
 
 ### Min-p truncation
 
@@ -532,41 +579,88 @@ Reading it:
   262144-token vocabulary pays 0.880 ms/step against 0.487 ms/step for the
   151669-token one.
 
-### A near-zero temperature is still sampling, not greedy
+### Host selection is not bit-identical to the GPU argmax
 
-`--temperature 0.0001` is often used as a stand-in for greedy on the assumption
-that every non-maximal logit underflows to zero probability. That holds only
-away from a tie, and the boundary is computable: `exp` in f32 returns exactly
-zero below about `-104`, so a logit survives the scaling iff it is within
-`104 * temperature` of the maximum — 0.0104 at `temperature = 1e-4`. Outside
-that band the distribution really is one-hot and the draw really is the argmax.
+At `--temperature 0.0001` the host categorical sampler is *close to* an argmax,
+so its token stream might be expected to match the greedy GPU `argmax` stream.
+On gemma-4-e2b it does, for all 100 tokens. On Ternary-Bonsai-8B it agrees
+through 32 tokens and diverges by 64. The divergence is reproducible and every
+run within a cell agrees, so it is a deterministic property of the two paths
+and not a race.
 
-**Inside it, and at an exact tie, it is not.** On an exactly tied top the
-post-softmax distribution is uniform over the tied ids, and the inverse-CDF
-draw picks among them by the RNG — matching the device `argmax`, which takes
-the lowest tied id, only about `1/k` of the time. That is the categorical
-sampler behaving correctly. A near-zero temperature is therefore **not** a
-valid oracle for the greedy path and must not be used as one; the argument
-"temperature ~0 should match greedy, so a mismatch is a bug" is unsound.
+#### What is proven
 
-Ties reach this band routinely on BF16 logits, whose 8-bit mantissa spaces
-values 0.125 apart at magnitude 16. A temperature-`1e-4` stream that tracks
-greedy for 32 tokens and then departs is the expected shape: one tied step is
-enough, and every token after it is conditioned on a different prefix.
+**A near-zero temperature is not an argmax, and is not a valid oracle for
+greedy.** Two separate reasons, both pinned by unit tests:
 
-The path that *does* owe the device an exact match is greedy — including the
-host greedy variant `argmax_with_penalties`. See the tie-break contract under
-[Greedy](#greedy-temperature--0); it is pinned by tests that compare the host
-scan against MLX's own reduction on tied, `NaN`, and all-`-inf` rows.
+- The underflow window is computable. `exp` in f32 returns exactly zero below
+  about `-104`, so a logit keeps non-zero probability iff it is within
+  `104 * temperature` of the maximum — 0.0104 at `temperature = 1e-4`. Inside
+  that window the distribution is genuinely mixed and the draw is genuinely
+  random.
+- At an **exact** tie the post-softmax distribution is uniform over the tied
+  ids, and the inverse-CDF draw picks among them by the RNG. It matches the
+  device `argmax` — which takes the lowest tied id — only about `1/k` of the
+  time. That is a categorical sampler behaving correctly.
 
-**Consequence for a future fused GPU sampler.** The merge gate for one cannot
-be "the token stream matches a near-zero-temperature CPU run", and it cannot be
-"the streams match" for any `temperature > 0` unless the RNG matches too. The
-gate that survives is two-part: on the greedy path, exact token identity
-against the device `argmax` including the lowest-id tie rule; on the stochastic
-path, exact token identity against the CPU path **given the same `Pcg32` draw
-sequence** — a GPU RNG must reproduce `Pcg32` bit-for-bit, or the kernel ships
-behind a dispatch policy with the CPU path retained as the oracle.
+So the argument "temperature ~0 should match greedy, therefore a mismatch is a
+bug" does not hold, and neither does the reverse inference: a mismatch there is
+not evidence of a defect in either path.
+
+**Exact ties are common, not exotic.** Logits are BF16 on most snapshots — 8
+mantissa bits, so 0.125 spacing at magnitude 16. Measured on a 262144-wide
+BF16-derived softmax row, 259416 of the 262143 adjacent pairs are exactly
+equal. Tie behaviour is the common case in this code, which is why the rank
+rules below are pinned rather than left to a sort's internals.
+
+**Host greedy was resolving ties the opposite way from the device.**
+`argmax_with_penalties` selected with `Iterator::max_by` (last maximum wins)
+against MLX `argmax`'s first-maximum-wins, let a `NaN` reset the running best,
+and returned the last id rather than 0 on a fully masked row. Fixed, and pinned
+by tests that use MLX's own reduction as the oracle. See the tie-break contract
+under [Greedy](#greedy-temperature--0).
+
+#### What is not proven
+
+**The mechanism behind the Bonsai divergence is still unestablished.** The
+temperature-`1e-4` path never enters `argmax_with_penalties`, so the greedy fix
+above cannot have changed that stream — it is a different code path, and the
+observation stands unexplained. The tie mechanism described above is a
+*sufficient* explanation, and it is now known to be reachable, but nothing here
+shows it is the *actual* one. Two other candidates are untested: a near-tie
+inside the 0.0104 window (which produces the same symptom without an exact
+tie), and something outside the sampler entirely.
+
+The original filing also offered `--repetition-penalty 1.1` producing the same
+divergent stream as corroboration. It is not: that flag divides positive logits
+of the trailing-20 ids by 1.1, which is a different objective, not another
+route to the same argmax. Its agreement with the temperature stream is evidence
+for nothing either way.
+
+**What would settle it**, and what to run before treating this as closed: the
+top-2 logits at the first divergent step. Unlike when this was filed, the server
+does dump them — `logprobs: true` with `top_logprobs: 2` reports
+`logit - lse` per rank, and the difference of the top two ranks is the gap. Run
+the greedy and the temperature-`1e-4` cells with that enabled, find the first
+step whose token ids differ, and read the gap:
+
+- gap `== 0` or below `104 * temperature` ⇒ the tie/near-tie mechanism is
+  confirmed and the residual is closed;
+- gap well above that ⇒ the tie explanation is dead, the near-zero-temperature
+  path is picking a token that had no probability mass, and the real cause is
+  still open.
+
+Until that is run, do not record this as fully explained.
+
+#### Consequence for a future fused GPU sampler
+
+The merge gate cannot be "the token stream matches a near-zero-temperature CPU
+run", and it cannot be "the streams match" at any `temperature > 0` unless the
+RNG matches too. The gate that survives is two-part: on the greedy path, exact
+token identity against the device `argmax` including the lowest-id tie rule; on
+the stochastic path, exact token identity against the CPU path **given the same
+`Pcg32` draw sequence** — a GPU RNG must reproduce `Pcg32` bit-for-bit, or the
+kernel ships behind a dispatch policy with the CPU path retained as the oracle.
 
 ## Special tokens
 
@@ -712,6 +806,13 @@ The captured `TokenLogprobs` struct carries:
 - `token_logprob` — `ln P(token_id)` under the raw-logit softmax.
 - `top` — the `k` highest-probability `(token_id, logprob)` pairs,
   descending by logprob. May or may not include the chosen token.
+
+Equal logits rank by **ascending token id**, so rank 0 is the token the device
+`argmax` would select and ranks `1..k` are reproducible rather than an artefact
+of the selection's swaps. That makes `top_logprobs: 2` usable as the tie probe
+described under
+[Host selection is not bit-identical to the GPU argmax](#host-selection-is-not-bit-identical-to-the-gpu-argmax):
+`top[0].logprob - top[1].logprob` is the top-2 gap at that step.
 
 ---
 


### PR DESCRIPTION
Closes #373.

`argmax_with_penalties` — the only host greedy path — used `Iterator::max_by`, which returns the **last** maximum, while MLX's `argmax` resolves an exact tie to the **lowest** index on both backends. Whether a request hit it was decided by whether a penalty or `logit_bias` happened to be set, so adding `--repetition-penalty` to an otherwise greedy request could change the emitted token.

The issue's stated symptom turned out not to be that defect: the temperature-1e-4 stream never reaches `max_by`, and at an exact tie a categorical sampler drawing uniformly over the tied ids is working correctly. The right defect was found for the wrong reason, and the residual the issue left open is now closed by measurement (below).

## Two pre-existing defects on `main` found on the way

- **A latent decode-abort.** `main`'s shipped comparator is `partial_cmp(..).unwrap_or(Equal)`, which makes NaN equal to everything and is therefore intransitive; rustc 1.81+ `sort_unstable_by` panics with *"does not correctly implement a total order"*. Randomized sweep, 2520 trials: `filter_top_k` form 284 panics, `filter_top_p` form 296. `softmax_scaled` propagates NaN because its `sum > 0.0` renormalise guard is false on NaN.
- **`compute_top_logprobs`** seeded its scan with a candidate rather than `-inf`, so a NaN at the seed position won rank 0 and disagreed with the emitted token.

## What changed

`filter_top_k` selects a **set**, so it now partitions (`select_nth_unstable`) — which is what mlx-lm's `argpartition`, cited in the same docstring, actually does. `filter_top_p` needs the full order, so it sorts values alone and applies the lowest-id rule once, to the single tied group at the cut. Both are total by construction, so no comparator exists that could panic.

A NaN row now returns `Err` from `softmax_scaled` (free — `sum` was already computed, and it catches `+inf` too). Greedy deliberately does **not** refuse, because its job is to mirror the device reduction; that asymmetry is pinned by a named test rather than left implicit.

## Performance: faster on the path that changed

| filter | fixture (262144-wide) | before | after |
|---|---|---:|---:|
| `top_k` k=64 | tie-dense | 2.02 ms | **0.30 ms** |
| `top_k` k=64 | all-distinct | 3.67 ms | **0.32 ms** |
| `top_p` 0.95 | tie-dense | 2.02 ms | **1.33 ms** |
| `top_p` 0.95 | all-distinct | 3.73 ms | **2.12 ms** |

Two shapes are marginally slower and are named in `docs/SAMPLING.md` rather than omitted: a fully uniform row (0.27 → 0.40 ms) and a heavily constraint-masked row (0.419 → 0.474 ms), both cases where the replaced sort got a near-free equal-element partition over one or two distinct values. Neither is a distribution a model produces.

Real-model, ABBA-interleaved: **+4.5% (Bonsai-8B) to +6.8% (gemma-4-e2b)** on `temperature 0.7 / top_p 0.95`. The unchanged pure-GPU greedy path is flat. Host was at load 8–15, so treat magnitudes as ±3%; the direction survives run order.

## Verification

- **Algorithm:** 342,141 exhaustive differential checks against an independent statement of the global tie rule — every row of length 1–7 over a 4-value alphabet × 8 `top_p` values, plus 8192-wide tie-dense and all-distinct rows. Zero mismatches. Bit helpers verified over **all 2³² patterns** (round-trip exact, monotone in IEEE total order, zero inversions).
- **Real models, both architectures:** greedy token ids byte-identical to `main` at 128 and 512 tokens, with the pure-GPU route proven from the run log rather than assumed. Forced-tie A/B (`logit_bias` 2⁴⁰ on two ids, two id pairs, both key orders): branch emits the lower id **8/8**; `main` emits the higher in 6 of 8 and the lower in 2 — arbitrary, which is the pdqsort-pivot artefact this removes.
- **On real logits:** with `temperature 0 + repetition_penalty 1.1`, `main`'s first divergence from greedy is at a step whose top-2 logprobs are **bit-equal** (Bonsai step 70, −0.6944146 both; gemma step 29, −0.85428756 both) and the branch emits the *device's* id there instead.
- **The open residual is closed with a number.** gemma-4-e2b, temp 0 vs temp 1e-4, 512-token window: first divergence at step 132, top-2 both −1.0606343, **gap exactly 0.0** — this issue's own stated closure condition. The temp-1e-4 streams are byte-identical across arms, confirming the fix cannot and does not change that stream.
- **GPU:** `make gpu-test CRATE=rmlx-models FILTER=gpu` passes 7/7 under Metal shader validation, and two mutations of `host_argmax` turn 3 and 1 tests red respectively — the suite is not vacuous.
- 17 of 26 added tests are red under reversion; 5 are `#[ignore]`d GPU mirrors; 3 are characterisation pins labelled as such in the file. `make ci` green.

## Not proven, and the docs say so

`reject_all_forbidden` has **no demonstrated production trigger**. An all-forbidden constraint mask could not be constructed through the HTTP surface — `{"enum": []}` is rejected at schema parse before any mask exists, and byte-level BPE means exotic `const`/single-`enum` values never starve it. Unit-tested only.

Two pre-existing constraint-engine defects surfaced during the proof run and are filed as #388; both reproduce identically on `61a6b4a1`.

## Corrections recorded on the issue

The issue body's per-architecture attribution is **inverted for this prompt** — Bonsai was identical for all 275 tokens while gemma diverged at 132. Which architecture shows it depends on prompt and window length, not architecture, and must not be used to scope the defect.
