### PR TITLE
fix(ci): the attribute capture in check-gpu-tests-ignored latched to end of file (#385)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,8 @@ Hard rules:
   marker against all its invocations. A **macro-generated** test is enforced at
   its `macro_rules!` body (one body governs every cell it emits), and a body the
   scanner cannot read back — an assembled fn name, a whole macro on one line, an
-  item whose brace never closes — is a hard failure rather than a clean scan;
+  item whose brace never closes, an attribute whose bracket never closes — is a
+  hard failure rather than a clean scan;
   those cells are deliberately excluded from `--list` / `make gpu-test`, which
   every run prints. A proc-macro-generated test, and a `macro_rules!` with a
   non-brace delimiter, remain outside the fail-closed net — neither exists in

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -225,7 +225,7 @@ so a `#[ignore]` deleted there fails the gate regardless of how many invocations
 exist. Reachability is traced from the body like any other fn's, so a body that
 reaches Metal one call deep (the shape in the tree today) counts.
 
-Three things are fail-closed rather than skipped, because a shape the parser
+Four things are fail-closed rather than skipped, because a shape the parser
 cannot read looks exactly like a compliant one:
 
 * A `macro_rules!` body that declares more `#[test]` than the gate could read
@@ -235,9 +235,12 @@ cannot read looks exactly like a compliant one:
   `#[test]` — no `fn` line ever follows, so nothing is classifiable.
 * An item whose closing brace is never found, which means the parser lost the
   file at that point and everything after it went unclassified.
+* An **attribute** whose closing `]` is never found, for the same reason: while
+  an attribute capture is latched it consumes every line, `fn` lines included.
 
 Write the generated fn as `fn $name()` on its own line with its attributes above
-it, or extend the classifier.
+it, close the attribute on a line whose last significant character is `]`, or
+extend the classifier.
 
 The first counter is also what stops the original blindness from returning
 quietly. A future edit that narrows the fn-name recognition again does not make
@@ -279,13 +282,59 @@ emitted**: the swallowed `#[test]` was never registered, so nothing looks
 unterminated, and the gate reports `OK` at exit 0 over an un-ignored
 `Device::Gpu` test.
 
-This is **fail-open**, not fail-closed — the one place in this gate that is. It
-is unreachable in the tree today (no scanned file has a where-split signature),
-and the class is tracked in #386 for reconciliation against the compiled `cargo
-test -- --list`, which is what actually closes it. Two fixtures bracket it:
-`trait_where_signature` pins the sub-case where nothing closes the latch (loud),
-and `trait_where_signature_open_hole` pins the open answer so the hole is
-visible in the corpus rather than only in prose.
+This is **fail-open**, not fail-closed. It is unreachable in the tree today (no
+scanned file has a where-split signature), and the class is tracked in #386 for
+reconciliation against the compiled `cargo test -- --list`, which is what
+actually closes it. Two fixtures bracket it: `trait_where_signature` pins the
+sub-case where nothing closes the latch (loud), and
+`trait_where_signature_open_hole` pins the open answer so the hole is visible in
+the corpus rather than only in prose.
+
+It is the only fail-open hole reachable by a shape the parser reads correctly.
+The attribute capture below has a second, narrower one that needs a parse hazard
+first — see the end of that section.
+
+#### The attribute capture
+
+Attributes are the third latching capture, alongside the fn item and the
+`macro_rules!` body, and they carry the same hazard: an attribute that does not
+close on its own line latches, and while latched it consumes every following
+line — `fn` lines included — so a latch that never ends silently unclassifies
+the rest of the file.
+
+The close-test is the same **last significant character** rule the fn arm uses.
+Two narrower spellings of it were each wrong on their own:
+
+* keyed on `)]`, the shape a wrapped `#[cfg(..)]` ends in, it never matched the
+  wrapped **string** form `"]` — which is how `#[ignore = "GPU Metal context: \`
+  wraps, i.e. exactly the remediation this gate's own error message recommends.
+  The documented way to comply was the way to blind it;
+* read from the **raw** line, a trailing comment (`#[test] // why`) hides the
+  closing `]` and latches just as thoroughly.
+
+String state is carried across the line break, so a `//` inside the continued
+payload of a wrapped string is not mistaken for a comment.
+
+Neither recognition rule can be complete, so an attribute still open at a file
+boundary is reported (`U`) rather than passed over.
+
+**What remains open here**, stated rather than papered over: that backstop only
+covers a latch that reaches the end of the file. If any *later, unrelated* line
+bares to `]` — a subsequent `#[test]` is exactly that shape — the latch ends
+there instead. Classification resumes correctly, but the items swallowed in
+between are gone with **no report**. That is fail-open, the same shape as the
+`where`-split hole above, and this parser cannot see it; reconciliation against
+the compiled `cargo test -- --list` is what would.
+
+So the close-test does not buy immunity, it buys reachability. Getting into that
+state now requires one of the two `bare()` hazards below (a raw string, a block
+comment); before, the ordinary wrapped-string spelling was enough — and that
+spelling is the one the gate's own error message recommends.
+
+Three fixtures pin the section: `attr_multiline_ignore` (the wrapped-string
+form closes, and is read as one block rather than merely un-latched),
+`attr_trailing_comment` (a comment after the closing `]` does not latch), and
+`attr_never_closes` (an unterminated attribute is reported, not swallowed).
 
 The trailing-comment scan is string-aware, so neither a URL in a one-line fn
 (`"http://…"`) nor a char literal of any payload form (`b'"'`, `'\x1b'`,
@@ -300,7 +349,8 @@ with a non-ASCII unit, which is what keeps a lifetime tick followed by a nearby
 quote (`<'a>'x'`) from being consumed as though it were a literal. It does
 **not** handle raw strings (the `\` in `r"a\"` is not an escape, and `r#"…"#`
 hashes are not tracked) or block comments: a `/* … */` spanning an item's
-opening line is read literally.
+opening line is read literally. The same scan decides the attribute close-test,
+so those two hazards bound that rule exactly as they bound this one.
 
 Still out of reach on the macro side: a `macro_rules!` with a **non-brace**
 delimiter (`macro_rules! m ( .. );`). Its name is captured so findings are

--- a/scripts/check_gpu_tests_ignored.sh
+++ b/scripts/check_gpu_tests_ignored.sh
@@ -122,6 +122,12 @@
 #   * The test really drives the GPU -> add the attribute:
 #       #[ignore = "GPU Metal context — run in isolation: \
 #                   cargo test <filter> -- --ignored --test-threads=1"]
+#     Wrapping the reason across lines with a trailing `\` is safe: the
+#     attribute capture below closes on the line whose last SIGNIFICANT
+#     character is `]`, which is the `"]` such a continuation ends in. It was
+#     not always so — a close-test keyed on the wrapped-`#[cfg(..)]` shape `)]`
+#     alone left this exact spelling latched for the rest of the file, so the
+#     documented way to comply was the way to blind the gate.
 #   * The test only exercises a guard that returns before any GPU work ->
 #     pass `Device::Cpu`, and leave it un-ignored so it keeps running in the
 #     default gate.
@@ -208,14 +214,40 @@
 #       `trait_where_signature_open_hole` pins the open answer.
 #     * A capture that is still open at a file boundary means the parser lost
 #       the file, so it reports `U` rather than letting the remainder go
-#       unclassified.
+#       unclassified. This holds for all THREE captures — fn item, macro body
+#       and attribute block.
+#
+#   ATTRIBUTES ARE A THIRD CAPTURE, with the same latch hazard. An attribute
+#   that does not close on its own line latches until one does, and while
+#   latched it consumes every line — including every `fn` — so a latch that
+#   never ends silently unclassifies the rest of the file. The close-test is
+#   therefore the same "last SIGNIFICANT character" rule the fn arm uses, not a
+#   match against one wrapped spelling: reading only `)]` (how a wrapped
+#   `#[cfg(..)]` ends) missed the wrapped STRING form `"]`, and reading the raw
+#   line missed any attribute with a trailing comment. The string state is
+#   carried across the line break (`bare()`'s `q0` / `bare_q`), so a `//` in the
+#   continued payload of a wrapped string is not mistaken for a comment.
 #
 #   `bare()` finds the trailing comment with a string-aware scan, so neither a
 #   `//` inside a string literal nor a char literal of any payload form (`b'"'`,
-#   `'\x1b'`, `'\u{FFFD}'`, `'é'`) derails it. Remaining known parse hazards:
+#   `'\x1b'`, `'\u{FFFD}'`, `'é'`) derails it. Remaining known parse hazards,
+#   which apply to the attribute close-test exactly as they do to the fn one:
 #   raw strings (the `\` in `r"a\"` is not an escape, and `r#"…"#` hashes are
 #   not tracked) and block comments — a `/* … */` spanning an item's opening
-#   line is read literally.
+#   line is read literally. An attribute whose closing `]` is hidden behind one
+#   of those latches, and what happens next splits two ways — state both rather
+#   than claim the good one:
+#     * nothing later in the file bares to `]` -> the file boundary reports `U`.
+#       Fail-closed.
+#     * something later does — a subsequent `#[test]` is exactly that shape ->
+#       the latch ends there, classification resumes correctly, and the items
+#       swallowed in between are gone with NO report. Fail-OPEN, the same shape
+#       as the `where`-split hole above, and not detectable from here;
+#       reconciliation against the compiled `cargo test -- --list` is what would
+#       catch it.
+#   What the close-test buys is not immunity but reachability: getting into that
+#   state now requires one of the two `bare()` hazards, where before it needed
+#   only the ordinary wrapped-string spelling.
 #
 #   PORTABLE AWK ONLY — this runs on the developer's BSD awk and on whatever
 #   the Linux CI image provides. Two constructs are out of bounds because they
@@ -351,9 +383,16 @@ read -r -d '' AWK_DETECT <<'AWK' || true
     # the everyday case — is not a comment, and cutting there would end the
     # line in mid-string and flip every decision that reads its last
     # character.
-    function bare(s,   i, n, q, c, rest, w, ascii) {
+    #
+    # `q0` seeds that string state, and `bare_q` reports where the scan ended,
+    # so a caller walking a MULTI-LINE construct can carry the state across the
+    # line break. A string continued with a trailing `\` is still open on the
+    # next line; scanning that line from q=0 would read its payload as code and
+    # cut at the first `//` in it. Callers that read one self-contained line
+    # pass neither and get the old q=0 behaviour exactly.
+    function bare(s, q0,   i, n, q, c, rest, w, ascii) {
         n = length(s)
-        q = 0
+        q = q0 + 0
         for (i = 1; i <= n; i++) {
             c = substr(s, i, 1)
             if (c == "\\" && q) { i++; continue }
@@ -401,6 +440,7 @@ read -r -d '' AWK_DETECT <<'AWK' || true
                 break
             }
         }
+        bare_q = q
         sub(/[[:space:]]+$/, "", s)
         return s
     }
@@ -436,13 +476,32 @@ read -r -d '' AWK_DETECT <<'AWK' || true
         macro_fn_n = 0
     }
 
+    # Tear down an attribute capture whose closing `]` was never found. The
+    # capture is greedy — every later line, including every `fn`, joins the
+    # attribute block — so silence here means the rest of the file was never
+    # classified while the gate reported a clean scan. That is fail-OPEN and it
+    # is the one direction this gate must never take, so an attribute the
+    # close-test could not read is a hard failure, exactly like an unterminated
+    # fn or macro body.
+    function flush_attr() {
+        if (in_attr) {
+            printf "U  %s: %s (attribute never closed — parser lost the file from here)\n",
+                attr_file, attr_label
+        }
+        in_attr = 0
+        attr_q = 0
+        attr_file = ""
+        attr_label = ""
+    }
+
     # New file: reset the per-file parse state and derive this file's module
     # name (directory name for a mod.rs, otherwise the file stem). The module
     # name is how a QUALIFIED cross-file call `module::helper(..)` binds.
     FNR == 1 {
         flush_fn()
         flush_macro()
-        in_attr = 0; attrs = ""; last_macro_name = ""
+        flush_attr()
+        attrs = ""; last_macro_name = ""
         nseg = split(FILENAME, seg, "/")
         base = seg[nseg]
         if (base == "mod.rs" && nseg >= 2) {
@@ -454,9 +513,19 @@ read -r -d '' AWK_DETECT <<'AWK' || true
     }
 
     # ── Multi-line attribute continuation ────────────────────────────────
+    # Closed by the line's SIGNIFICANT text ending in `]`, carrying the string
+    # state across the line break. Keying this on the wrapped-`#[cfg(..)]`
+    # shape `)]` alone reads only one of the two ways an attribute wraps: a
+    # wrapped string argument ends `"]`, never `)]`, so such an attribute never
+    # closed and the capture swallowed the rest of the FILE — every later item
+    # unclassified, and a clean OK printed over them. The `)]` arm is kept
+    # ahead of the general one: it needs no string scan, so it still closes a
+    # wrapped list whose last line the scan below would misread.
     in_attr {
         attrs = attrs " " $0
-        if ($0 ~ /^[[:space:]]*\)\]/) { in_attr = 0 }
+        sig = bare($0, attr_q)
+        attr_q = bare_q
+        if ($0 ~ /^[[:space:]]*\)\]/ || sig ~ /\]$/) { in_attr = 0 }
         next
     }
     # ── Attribute (any indent) ──────────────────────────────────────────
@@ -465,7 +534,17 @@ read -r -d '' AWK_DETECT <<'AWK' || true
         # Count `#[test]`s declared inside a macro body, so the END check can
         # compare them against the test items actually extracted from it.
         if (in_macro && !in_fn && $0 ~ /#\[(tokio::)?test[](]/) { macro_test_n++ }
-        if ($0 !~ /\][[:space:]]*$/) { in_attr = 1 }
+        # Self-contained iff the SIGNIFICANT text closes it. Read from the raw
+        # line, a trailing comment (`#[test] // why`) hides the closing `]` and
+        # latches the capture over the rest of the file — the same fail-open as
+        # the continuation rule above, reached by an easier-to-write shape.
+        if (bare($0) !~ /\]$/) {
+            in_attr = 1
+            attr_q = bare_q
+            attr_file = FILENAME
+            attr_label = $0
+            sub(/^[[:space:]]+/, "", attr_label)
+        }
         next
     }
     # ── Per-test exemption marker (line-leading, in the attr block) ─────
@@ -618,9 +697,10 @@ read -r -d '' AWK_DETECT <<'AWK' || true
 
     END {
         # An item left open by the last file still gets its check — otherwise
-        # an unterminated fn or macro body is a free pass.
+        # an unterminated fn, macro body or attribute is a free pass.
         flush_fn()
         flush_macro()
+        flush_attr()
 
         # ── Seed: fns naming Device::Gpu (literal) or a file-scoped
         #    `const … = Device::Gpu` alias in their own body. Seeds feed a
@@ -799,8 +879,9 @@ fi
 # an unchecked test, and listing over it hands the runner a population that is
 # missing one. This is the same fail-closed rule as "scanned 0 files".
 if [ -n "$unreadable" ]; then
-    echo "ERROR: a macro_rules! body declares #[test] items this gate cannot read" >&2
-    echo "       (or an item never closed, ending classification mid-file):" >&2
+    echo "ERROR: this gate could not classify part of a scanned file" >&2
+    echo "       (an unreadable macro_rules! body, or an item or attribute that" >&2
+    echo "        never closed, ending classification mid-file):" >&2
     printf '%s' "$unreadable" >&2
     echo >&2
     echo "The gate classifies a test-generating macro from its body: it needs an" >&2
@@ -809,13 +890,14 @@ if [ -n "$unreadable" ]; then
     echo "its fn's line, and a whole macro_rules! on one line are all invisible —" >&2
     echo "and an invisible GPU test is exactly what this gate exists to prevent." >&2
     echo >&2
-    echo "A 'fn never closed' finding means the parser lost the file at that item," >&2
-    echo "so everything after it went unclassified. Both are reported rather than" >&2
-    echo "skipped, because a shape this gate cannot read looks exactly like a" >&2
-    echo "compliant one." >&2
+    echo "A 'fn never closed' or 'attribute never closed' finding means the parser" >&2
+    echo "lost the file at that point, so everything after it went unclassified. All" >&2
+    echo "are reported rather than skipped, because a shape this gate cannot read" >&2
+    echo "looks exactly like a compliant one." >&2
     echo >&2
     echo "Write the generated fn as \`fn \$name()\` on its own line with its" >&2
-    echo "attributes above it, or extend the classifier to read the new shape." >&2
+    echo "attributes above it, close the attribute on a line whose last significant" >&2
+    echo "character is \`]\`, or extend the classifier to read the new shape." >&2
     exit 1
 fi
 

--- a/scripts/check_gpu_tests_ignored_fixtures.sh
+++ b/scripts/check_gpu_tests_ignored_fixtures.sh
@@ -91,7 +91,7 @@ if [ -z "${GATE_AWK_SHIM:-}" ]; then
 fi
 
 VIOLATION="ERROR: GPU-touching tests missing the #[ignore]"
-UNREADABLE="ERROR: a macro_rules! body declares #[test] items this gate cannot read"
+UNREADABLE="ERROR: this gate could not classify part of a scanned file"
 # Pins the file count too, so a fixture that lost its source file cannot pass by
 # scanning nothing.
 CLEAN="OK: every GPU-touching test carries #[ignore] (1 files"
@@ -109,6 +109,9 @@ CASES=(
     "trait_where_signature|1|${UNREADABLE}|fn never closed||a where-split signature latches, and is loud ONLY when nothing closes the latch"
     "trait_where_signature_open_hole|0|${CLEAN}||ERROR|KNOWN OPEN HOLE: one nested block closes the latch and the swallowed GPU test is reported clean"
     "fn_never_closes|1|${UNREADABLE}|fn never closed||a capture that cannot terminate is reported, not skipped"
+    "attr_multiline_ignore|1|${VIOLATION}|later_plain_gpu_no_ignore|probe|a wrapped #[ignore = \"..\" ] closes, and is read rather than merely un-latched"
+    "attr_trailing_comment|1|${VIOLATION}|gpu_after_comment_attr||a comment after an attribute's closing ] does not latch the capture"
+    "attr_never_closes|1|${UNREADABLE}|attribute never closed||an attribute capture that cannot terminate is reported, not swallowed"
     "exempt_in_body|1|${VIOLATION}|gpu_marker_inside_body||a marker among a fn's statements exempts nothing"
     "exempt_in_body|1|${VIOLATION}|gpu_after_marker_in_body||and does not carry to the next fn"
     "macro_one_line_no_test|1|${VIOLATION}|gpu_cell!{\$name}||a one-line macro declaring no test is stepped over, not latched"

--- a/scripts/fixtures/gpu_tests_ignored/attr_multiline_ignore/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/attr_multiline_ignore/Cargo.toml
@@ -1,0 +1,6 @@
+# Synthetic workspace for scripts/check_gpu_tests_ignored_fixtures.sh.
+# Never built — the gate reads only the member list and the package name.
+[workspace]
+members = [
+    "crates/fx",
+]

--- a/scripts/fixtures/gpu_tests_ignored/attr_multiline_ignore/crates/fx/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/attr_multiline_ignore/crates/fx/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fx"
+version = "0.0.0"
+edition = "2021"

--- a/scripts/fixtures/gpu_tests_ignored/attr_multiline_ignore/crates/fx/src/fixture_tests.rs
+++ b/scripts/fixtures/gpu_tests_ignored/attr_multiline_ignore/crates/fx/src/fixture_tests.rs
@@ -1,0 +1,20 @@
+// The multi-line `#[ignore = "... \` spelling this gate's own remediation text
+// recommends. Its continuation line ends in `"]`, never in the `)]` that a
+// wrapped `#[cfg(..)]` produces, so a continuation rule keyed only on `)]`
+// leaves the attribute capture latched for the REST OF THE FILE: every later
+// item is swallowed into the attribute block, nothing is classified, and the
+// gate reports a clean scan. The violation below is what that silence hides.
+
+#[ignore = "GPU Metal context — run in isolation: \
+            cargo test probe -- --ignored --test-threads=1"]
+#[test]
+fn probe() {
+    let device = Device::Gpu;
+    run(device);
+}
+
+#[test]
+fn later_plain_gpu_no_ignore() {
+    let device = Device::Gpu;
+    run(device);
+}

--- a/scripts/fixtures/gpu_tests_ignored/attr_never_closes/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/attr_never_closes/Cargo.toml
@@ -1,0 +1,6 @@
+# Synthetic workspace for scripts/check_gpu_tests_ignored_fixtures.sh.
+# Never built — the gate reads only the member list and the package name.
+[workspace]
+members = [
+    "crates/fx",
+]

--- a/scripts/fixtures/gpu_tests_ignored/attr_never_closes/crates/fx/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/attr_never_closes/crates/fx/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fx"
+version = "0.0.0"
+edition = "2021"

--- a/scripts/fixtures/gpu_tests_ignored/attr_never_closes/crates/fx/src/fixture_tests.rs
+++ b/scripts/fixtures/gpu_tests_ignored/attr_never_closes/crates/fx/src/fixture_tests.rs
@@ -1,0 +1,17 @@
+// The fail-closed backstop for the attribute capture, and the reason the
+// close-test is not the whole fix. Recognising more spellings makes the latch
+// rarer; it cannot make it impossible, because the scan has documented limits
+// (raw-string hashes, block comments) and any shape past them looks exactly
+// like an attribute that has not closed yet.
+//
+// So an attribute still open at the end of a file is REPORTED. Without that,
+// the swallowed test below is unclassified and the gate exits 0 saying every
+// GPU test carries #[ignore] — fail-open, which is the one direction this gate
+// must never take. Nothing after the opener bares to a `]`, so nothing closes
+// the capture and the file ends inside it.
+
+#[ignore = "GPU Metal context — this string's closing quote never arrives
+fn swallowed_gpu_test() {
+    let device = Device::Gpu;
+    run(device);
+}

--- a/scripts/fixtures/gpu_tests_ignored/attr_trailing_comment/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/attr_trailing_comment/Cargo.toml
@@ -1,0 +1,6 @@
+# Synthetic workspace for scripts/check_gpu_tests_ignored_fixtures.sh.
+# Never built — the gate reads only the member list and the package name.
+[workspace]
+members = [
+    "crates/fx",
+]

--- a/scripts/fixtures/gpu_tests_ignored/attr_trailing_comment/crates/fx/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/attr_trailing_comment/crates/fx/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fx"
+version = "0.0.0"
+edition = "2021"

--- a/scripts/fixtures/gpu_tests_ignored/attr_trailing_comment/crates/fx/src/fixture_tests.rs
+++ b/scripts/fixtures/gpu_tests_ignored/attr_trailing_comment/crates/fx/src/fixture_tests.rs
@@ -1,0 +1,12 @@
+// The other half of the attribute latch, reached by an easier-to-write shape
+// than a wrapped string: a trailing comment after the closing bracket. Read
+// from the raw line, `#[test] // why` does not end in `]`, so the capture
+// latches and swallows the rest of the file — the test below is never
+// classified and the gate reports a clean scan over it. The close-test reads
+// the line's significant text, so the comment is not part of the decision.
+
+#[test] // an ordinary explanatory comment, not part of the attribute
+fn gpu_after_comment_attr() {
+    let device = Device::Gpu;
+    run(device);
+}


### PR DESCRIPTION
Closes #385.

`scripts/check_gpu_tests_ignored.sh` runs three latching captures. The attribute one closed
only on `^[[:space:]]*\)\]` — the shape a wrapped `#[cfg(..)]` ends in. An attribute whose
argument is a wrapped **string** ends `"]`, never `)]`, so it never closed: the capture then
consumed every following line, `fn` lines included, and the rest of the file went
unclassified while the gate printed `OK: every GPU-touching test carries #[ignore]` and
exited 0.

That spelling is the one the script's own remediation text tells authors to write. The
documented way to comply was the way to blind the gate.

## A second door, not named in the issue

The **opener** tested the raw line (`$0 !~ /\][[:space:]]*$/`), so `#[test] // why not`
latched too — a trailing comment hides the closing `]`. Same silent `OK`, same exit 0,
reached by an easier-to-write shape.

## What changed

- Both close-tests now read the line's significant text through `bare()`, the same
  "last significant character" rule the fn arm already used. The `)]` arm is kept ahead of
  the general one — it needs no string scan, so it still closes a wrapped list whose last
  line the scan would misread.
- `bare(s, q0)` gained an entry quote-state and exports its exit state as `bare_q`, so a
  wrapped string's continuation is scanned as string rather than code and a `//` in the
  payload is not read as a comment. One-argument callers get identical `q = 0` behaviour.
- `flush_attr()` joins `flush_fn()` / `flush_macro()`: an attribute still open at a file
  boundary or at END reports `U`. Recognition can never be complete, so the residual belongs
  on the fail-closed side.
- The `U`-class error text described only macro bodies; generalised, with the fixture
  harness constant updated to match.

## Verification

Red-first, both doors, confirmed against `main` rather than asserted:

| case | `main` | branch |
|---|---|---|
| wrapped `#[ignore = "…\` continuation | `OK …` exit 0 | `ERROR … later_plain_gpu_no_ignore` exit 1 |
| `#[test] // why not` | `OK …` exit 0 | `ERROR … later_plain_gpu_no_ignore` exit 1 |

- **Four mutations, all effective**, asserted on the full case predicate (exit + marker +
  label + forbidden string), not a substring. Removing the continuation `]` arm or reverting
  the opener to the raw line goes red via `flush_attr` — a *different* red, which is the
  defence in depth working. Silencing `flush_attr` goes red on exit code. Making the opener
  never latch goes red because a forbidden probe string appears, which is what proves the
  wrapped attribute is read as one block rather than merely un-latched.
- **Portability**: BSD awk 20200816, GNU Awk 5.4.1, mawk 1.3.4, each under `LC_ALL=C` and
  `en_US.UTF-8`. Full fixture corpus `ok (29 cases)` on all three; 12 real-tree runs, stdout
  **and** stderr byte-identical.
- **Real tree unchanged**: enforce stdout, enforce stderr and `--list` are byte-identical to
  `main`. Mechanism-level survey over the scanned files found 0 opener-decision disagreements
  raw-vs-`bare()`, 0 cases where the new arm fires before `)]`, and 0 EOF latches.
- Reconciled against the compiled test list: every `--list` entry resolves to a compiled
  test, with the single exception of the `shader-validation-canary` cell, which is gated
  behind that non-default feature and is built by name in `run_gpu_tests.sh`.

`make ci` green.

## What this still cannot reach

`flush_attr` only covers a latch that runs to end of file. If a later unrelated line bares
to `]` — a subsequent `#[test]` is exactly that shape — the latch ends there, classification
resumes correctly, and the items swallowed in between are lost with **no report**. That is
fail-open. Reaching it now requires one of `bare()`'s documented hazards first (raw-string
hashes, block comments); before, the ordinary wrapped-string spelling sufficed. Only
reconciliation against `cargo test -- --list` catches that class, which is #386.

The `where`-split fn latch is untouched and `trait_where_signature_open_hole` still pins its
exit-0 answer unchanged.

Two corrections went in alongside: an earlier draft of this branch claimed "nothing
accidentally ends it", which is false; and `docs/TESTING.md` called the `where` hole "the one
place in this gate that is fail-open", which was already untrue when written — the attribute
latch was a second one.
