### PR TITLE
fix(ci): the converse GPU-test finding was advisory forever; make it fatal with a declared-route marker (#384)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,21 @@ Hard rules:
   line-leading `// gpu-test-gate: exempt` marker in its own attribute block —
   scoped to that one `#[test]`, not the whole file; **inside a `macro_rules!`
   body that one `#[test]` is every cell the macro generates**, so audit such a
-  marker against all its invocations. A **macro-generated** test is enforced at
+  marker against all its invocations. The **converse is fatal**: an `#[ignore]`
+  whose reason claims a Metal context on a test the classifier can reach no
+  `Device::Gpu` from runs under no gate at all — ignored by `make test`,
+  unclassified by `make gpu-test` — so it fails until one of three dispositions
+  is recorded: declare the route with a line-leading
+  `// gpu-test-gate: metal-unscanned` marker (the exact inverse of `exempt` —
+  dispatches Metal but never names the device: an in-process HTTP handler, or a
+  child process), drop the `#[ignore]` and pass `Device::Cpu`, or reword the
+  `#[ignore]` so it does not claim Metal. A declared test is enforced but
+  deliberately **not** in `--list` — `run_gpu_tests.sh` asserts a Metal
+  validation banner per crate and every declared test is snapshot-gated or drives
+  a child, so listing one would fail the suite over a missing model. This one
+  check keys on the ignore *text*, which is why a Metal-driving test whose reason
+  never says "Metal" or "GPU" stays outside it. A **macro-generated** test is
+  enforced at
   its `macro_rules!` body (one body governs every cell it emits), and a body the
   scanner cannot read back — an assembled fn name, a whole macro on one line, an
   item whose brace never closes, an attribute whose bracket never closes — is a

--- a/crates/rmlx-models/src/paroquant_msl_tests.rs
+++ b/crates/rmlx-models/src/paroquant_msl_tests.rs
@@ -37,6 +37,12 @@ fn to_f32_vec(a: &Array) -> Vec<f32> {
 /// tests below are what force the compile (and one instantiation each of the
 /// `ROWS_PER_TILE` template int); `make check-metal-compiles` is what catches a
 /// syntax error without a GPU.
+///
+/// `paro_rotate_kernel()` lives in the parent module, a regular source file the
+/// `#[ignore]` gate does not scan, and it names no device — it hands MLX a
+/// source string and takes back a handle. So nothing reachable from this body
+/// spells `Device::Gpu` and the gate is told rather than shown.
+// gpu-test-gate: metal-unscanned  registers an MSL kernel via a non-scanned helper.
 #[test]
 #[ignore = "GPU Metal context — run in isolation: cargo test paroquant_msl -- --ignored --test-threads=1"]
 #[allow(

--- a/crates/rmlx-server/tests/embeddings_smoke.rs
+++ b/crates/rmlx-server/tests/embeddings_smoke.rs
@@ -182,8 +182,26 @@ async fn non_embedding_model_is_400() {
 }
 
 // ── GPU shape tests (ignored — single-MLX-process; run in isolation) ──────────
+//
+// Each of these posts to `/v1/embeddings`, and the handler loads the jina
+// encoder and runs the forward under `rmlx_mlx::Device::Gpu` — in THIS process,
+// on a `spawn_blocking` worker, but on the far side of an axum routing table.
+// No source shape in this file names the device and no call graph links the
+// `post(port, "/v1/embeddings", ..)` here to `embeddings()` there, so the
+// `#[ignore]` gate cannot infer the Metal context and each carries the
+// `metal-unscanned` marker instead. See docs/TESTING.md.
+//
+// The marker deliberately does NOT put them in `scripts/run_gpu_tests.sh`:
+// every one is gated on `RMLX_TEST_MODEL_JINA_V4` and returns early without it,
+// so on a machine with no jina snapshot the runner would execute five no-ops,
+// see no Metal validation banner for rmlx-server, and fail the suite over a
+// missing model. They run by hand:
+//
+//   RMLX_TEST_MODEL_JINA_V4=/abs/path/to/jinaai__jina-embeddings-v4 \
+//     cargo test -p rmlx-server --test embeddings_smoke -- --ignored --test-threads=1
 
 /// Valid single-vector request → 200 + OpenAI embeddings shape.
+// gpu-test-gate: metal-unscanned  Metal is entered inside the handler.
 #[tokio::test]
 #[ignore = "GPU Metal: cargo test --test embeddings_smoke valid_single_vector -- --ignored --test-threads=1"]
 async fn valid_single_vector_200_shape() {
@@ -206,6 +224,7 @@ async fn valid_single_vector_200_shape() {
 }
 
 /// `return_multivector:true` toggles the embedding to `[[f32;128];seq]`.
+// gpu-test-gate: metal-unscanned  Metal is entered inside the handler.
 #[tokio::test]
 #[ignore = "GPU Metal: cargo test --test embeddings_smoke return_multivector -- --ignored --test-threads=1"]
 async fn return_multivector_toggles_shape() {
@@ -226,6 +245,13 @@ async fn return_multivector_toggles_shape() {
 }
 
 /// Invalid matryoshka `dimensions` (not in {128,256,512,1024,2048}) → 400.
+///
+/// Unlike the other 400s in this file, this one is NOT a request-validation
+/// rejection: the handler defers `dimensions` to the model's matryoshka set, so
+/// the check runs in `pooling::single_vector` — after the encoder is loaded and
+/// after a full `Device::Gpu` forward. The 400 is the tail of a GPU round trip,
+/// which is why it needs the snapshot and the Metal context.
+// gpu-test-gate: metal-unscanned  Metal is entered inside the handler.
 #[tokio::test]
 #[ignore = "GPU Metal: cargo test --test embeddings_smoke invalid_dimensions -- --ignored --test-threads=1"]
 async fn invalid_dimensions_is_400() {
@@ -248,6 +274,7 @@ const TEST_IMG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAEAAAAAwCAIAAAAuKetIAAAA5UlE
 /// Image input (single-vector): `{"input":{"image":"data:...;base64,..."}}`
 /// → 200 + 2048-d float vector. End-to-end exercise of the M-RoPE + merge +
 /// image-span pooling path (GPU; single-MLX-process).
+// gpu-test-gate: metal-unscanned  Metal is entered inside the handler.
 #[tokio::test]
 #[ignore = "GPU Metal: cargo test --test embeddings_smoke image_single_vector -- --ignored --test-threads=1"]
 async fn image_single_vector_200_shape() {
@@ -271,6 +298,7 @@ async fn image_single_vector_200_shape() {
 
 /// Image input with `return_multivector:true` → `[[f32;128];seq]` (one row
 /// per token of the expanded image sequence).
+// gpu-test-gate: metal-unscanned  Metal is entered inside the handler.
 #[tokio::test]
 #[ignore = "GPU Metal: cargo test --test embeddings_smoke image_multivector -- --ignored --test-threads=1"]
 async fn image_multivector_toggles_shape() {

--- a/crates/rmlx-server/tests/ssd_cache_restart.rs
+++ b/crates/rmlx-server/tests/ssd_cache_restart.rs
@@ -316,6 +316,17 @@ fn ssd_disk_state(rmlx_home: &Path) -> (usize, usize) {
 
 // ── The test ─────────────────────────────────────────────────────────────────
 
+// The Metal context this test needs belongs to the `rmlx serve` CHILD, not to
+// the test binary — this process only speaks HTTP to it — so no source shape
+// here can express the device and the `#[ignore]` gate is told rather than
+// shown. It stays out of `scripts/run_gpu_tests.sh` on top of that: that runner
+// instruments the test process, which dispatches no Metal at all; the test also
+// needs `cargo build -p rmlx-cli` first (`cargo test --tests` does not build the
+// binary), `pkill`s every MLX process on the machine, and spends two 180 s
+// readiness waits. The same spill -> restart -> hydrate chain, over the same two
+// prompts, is covered by `make e2e` phase 2a
+// (`crates/rmlx-cli/tests/e2e/runner.rs`).
+// gpu-test-gate: metal-unscanned  Metal belongs to the spawned serve process.
 #[ignore = "integration: requires RMLX_TEST_MODEL + a real rmlx serve process (Metal)"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn ssd_cache_survives_server_restart() {

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -344,45 +344,132 @@ roots — `src/**/*_tests.rs` *and* bare `src/**/tests.rs` — and the integrati
 binaries under `tests/*.rs`. It runs in `make ci` and in the hosted `source
 gates` job. It keys on the shape (does the test reach `Device::Gpu`, directly,
 through a same-file helper, or via a module-scope `const … = Device::Gpu`?),
-never on the ignore reason's wording, which varies across the tree.
+never on the ignore reason's wording, which varies across the tree. The one
+deliberate exception is the converse check below, which has no shape to key on.
 
 "Test" means `#[test]`, `#[tokio::test]`, and `#[tokio::test(flavor = …)]`. An
 async test attribute is a test attribute; matching only the bare spelling left
 ~107 of them in `rmlx-server` unclassified in both directions.
 
-**Six ignored async tests surface as warnings, and are still run by nothing.**
-Classifying `#[tokio::test]` did not add anything to `--list`, because no
-`rmlx-server` test file names `Device::Gpu` at all — those tests boot a real
-server over HTTP and the device is chosen inside production code the gate does
-not scan. So they land in the non-fatal "claims a Metal context but no
-`Device::Gpu` is reachable" warning instead:
+#### Exempting a device-as-value test
 
-| test | file |
-|---|---|
-| `valid_single_vector_200_shape` | `crates/rmlx-server/tests/embeddings_smoke.rs` |
-| `return_multivector_toggles_shape` | `crates/rmlx-server/tests/embeddings_smoke.rs` |
-| `invalid_dimensions_is_400` | `crates/rmlx-server/tests/embeddings_smoke.rs` |
-| `image_single_vector_200_shape` | `crates/rmlx-server/tests/embeddings_smoke.rs` |
-| `image_multivector_toggles_shape` | `crates/rmlx-server/tests/embeddings_smoke.rs` |
-| `ssd_cache_survives_server_restart` | `crates/rmlx-server/tests/ssd_cache_restart.rs` |
+A pure device-*policy* test — one that passes `Device::Gpu` to a non-mlx function
+as a plain selector value and never dispatches Metal — opts out **per fn** with a
+line-leading `// gpu-test-gate: exempt` marker in its own attribute block. The
+exemption is scoped to that one `#[test]`, not the file, so a Metal-driving test
+added beside it still trips the gate; a copy of the marker inside a fn body
+exempts nothing. A reviewer audits each one.
 
-They are `#[ignore]`d, so `make test` skips them; they are not GPU-classified,
-so `make gpu-test` never selects them. Both statements were true before this
-gate could see them — making them visible does not make them run. Closing that
-needs a decision the gate cannot make for itself: either they reach Metal and
-belong in the runner's population (which means giving the classifier a way to
-see through an HTTP boundary), or they are `#[ignore]`d for a reason other than
-Metal and the ignore text should say so. Until then the warning is the honest
-signal, not noise to be silenced.
+#### An `#[ignore]` that claims Metal and cannot prove it is fatal
 
-Two known edges: (1) a pure device-*policy* test — one that passes `Device::Gpu`
-to a non-mlx function as a plain selector value, never a Metal dispatch — opts
-out **per fn** with a line-leading `// gpu-test-gate: exempt` marker in its own
-attribute block (scoped to that one `#[test]`, so a Metal-driving test added to
-the same file still trips the gate; a copy of the marker inside a fn body does
-not exempt); (2) the reachability seed is file-local, so a test that reaches
-Metal only through a helper defined in another module can draw a non-fatal
-false-positive warning — verify before acting on it.
+An `#[ignore]` whose reason names a Metal context, on a test from which the
+classifier can reach no `Device::Gpu`, runs under **no gate at all**: `make test`
+skips it because it is ignored, and `make gpu-test` skips it because it is not
+classified. It reads as covered at both.
+
+This was a non-fatal warning, on the reasoning that some ignores are legitimately
+non-GPU and that a helper in a non-scanned source file makes a real Metal test
+look GPU-free to a source scanner. Both are true, and neither is a reason to
+leave the finding advisory. An advisory channel with two valid outcomes and no
+way to record which one applies is a channel nothing ever closes; seven tests
+accumulated in it. It is now a hard failure with three dispositions:
+
+1. **It drives Metal by a route the scanner cannot follow** — declare it (below).
+2. **It does not touch the GPU** — drop the `#[ignore]` and pass `Device::Cpu`,
+   so it runs in the default gate again.
+3. **It is ignored for some other reason** — say *that* reason in the `#[ignore]`
+   text instead of claiming Metal.
+
+(3) is a genuine escape hatch and is stated rather than hidden. This one check
+keys on the ignore reason's **wording** — it has to, the absence of a shape to
+key on being the whole problem — so a Metal-driving test whose ignore text never
+says "Metal" or "GPU" is invisible to it. Nothing else in the gate works that
+way.
+
+#### Declaring a Metal route the scanner cannot follow
+
+```rust
+// gpu-test-gate: metal-unscanned  <why the scanner cannot see it>
+#[ignore = "GPU Metal: …"]
+#[tokio::test]
+async fn drives_metal_over_http() { … }
+```
+
+Line-leading, in the fn's own attribute block, scoped to that one `#[test]` —
+the same rules as `// gpu-test-gate: exempt`, of which it is the exact inverse:
+`exempt` says *this names the device but never dispatches*, `metal-unscanned`
+says *this dispatches but never names the device*.
+
+Effect: the test counts as GPU-touching, so the `#[ignore]` rule bites on it —
+deleting the attribute is now a violation, which before the marker it was not.
+It is **not** emitted to `--list`; see the population table below.
+
+Two shapes fail closed rather than being resolved in the author's favour: a
+marker on a test the reachability pass *can* see through (stale — its claim is
+checkable, and keeping it would hold a listable test out of the runner forever),
+and a marker paired with `exempt` (the test both does and does not drive Metal).
+
+#### The seven declared routes, and what actually covers them
+
+Two boundaries defeat a source scanner here, and no extension of it would help:
+an HTTP request resolves through a routing table rather than a call graph, and a
+child process has its own Metal context.
+
+| test | file | route | covered by |
+|---|---|---|---|
+| `valid_single_vector_200_shape` | `crates/rmlx-server/tests/embeddings_smoke.rs` | HTTP → `embeddings()` → `Device::Gpu` | nothing; run by hand |
+| `return_multivector_toggles_shape` | `crates/rmlx-server/tests/embeddings_smoke.rs` | as above | nothing; run by hand |
+| `invalid_dimensions_is_400` | `crates/rmlx-server/tests/embeddings_smoke.rs` | as above | nothing; run by hand |
+| `image_single_vector_200_shape` | `crates/rmlx-server/tests/embeddings_smoke.rs` | as above | nothing; run by hand |
+| `image_multivector_toggles_shape` | `crates/rmlx-server/tests/embeddings_smoke.rs` | as above | nothing; run by hand |
+| `ssd_cache_survives_server_restart` | `crates/rmlx-server/tests/ssd_cache_restart.rs` | spawned `rmlx serve` child | `make e2e` phase 2a covers the same spill → restart → hydrate chain |
+| `paro_kernel_registration` | `crates/rmlx-models/src/paroquant_msl_tests.rs` | `paro_rotate_kernel()` in a non-scanned source file | nothing; the two `paro_rotate_identity_roundtrip_*` cells in `make gpu-test` compile and dispatch the same kernel |
+
+All seven genuinely need Metal — audited against the code, not against their own
+`#[ignore]` text. The five embeddings cells post to `/v1/embeddings`, whose
+handler loads the jina encoder and runs the forward under `Device::Gpu` on a
+`spawn_blocking` worker of the same process. `invalid_dimensions_is_400` looks
+like the file's other request-validation 400s and is not one: the handler defers
+`dimensions` to the model's matryoshka set, so the rejection comes out of
+`pooling::single_vector` *after* a full GPU forward.
+
+**They are enforced but not executed, and that is a runner property, not a
+classifier one.** `run_gpu_tests.sh` asserts per crate that Metal's
+shader-validation banner appeared — a crate that created no Metal device proved
+nothing. Every declared test is snapshot-gated (`RMLX_TEST_MODEL_JINA_V4`,
+`RMLX_TEST_MODEL`) or drives a child, so on a machine without that snapshot the
+runner would execute a handful of early returns, see no banner for the crate, and
+fail the suite over a missing model rather than a defect. `ssd_cache_restart`
+could not be listed on any machine: its Metal is in the child, so the in-process
+instrumentation covers nothing, and it additionally needs `cargo build -p
+rmlx-cli` first (`cargo test --tests` does not build that binary), `pkill`s every
+MLX process, and spends two 180 s readiness waits.
+
+Run the embeddings cells by hand:
+
+```sh
+RMLX_TEST_MODEL_JINA_V4=/abs/path/to/jinaai__jina-embeddings-v4 \
+  cargo test -p rmlx-server --test embeddings_smoke -- --ignored --test-threads=1
+```
+
+`paro_kernel_registration` is the one entry that could be listed as-is —
+`rmlx-models` is already in the runner's population and already produces a
+banner. It is left declared-but-unlisted because moving it needs a GPU run to
+confirm, which is a separate change.
+
+**Three populations, not one.** `--list` (what `make gpu-test` executes) is a
+strict subset of what the gate enforces, and every run prints the difference:
+
+| population | `#[ignore]` enforced | in `--list` | why |
+|---|---|---|---|
+| `Device::Gpu` reachable | yes | yes | the ordinary case |
+| macro-generated | yes, at the `macro_rules!` body | no | cell names exist only after expansion, so no libtest filter selects them |
+| `metal-unscanned` | yes | no | the runner's per-crate banner assertion; see above |
+
+The other known edge: the reachability seed is file-local for unqualified calls,
+so a test that reaches Metal only through a same-named helper in another module
+can draw the fatal converse as a false positive. The marker is the disposition
+for that too — verify the route before adding it.
 
 **Inside a `macro_rules!` body the exemption's blast radius is every cell.** The
 body is one synthetic test, so a single marker line exempts every test that

--- a/scripts/check_gpu_tests_ignored.sh
+++ b/scripts/check_gpu_tests_ignored.sh
@@ -132,12 +132,55 @@
 #     pass `Device::Cpu`, and leave it un-ignored so it keeps running in the
 #     default gate.
 #
-# Also emits a non-fatal WARNING for the converse — a test whose `#[ignore]`
-# claims a Metal context but which never reaches `Device::Gpu`. That is a test
-# that has silently stopped running. It is a warning, not a failure: some
-# ignores are legitimately non-GPU (e.g. "requires mlx runtime"), and a helper
-# in a non-scanned source file (see RESIDUAL) is a legitimate reason a
-# Metal-driving test looks GPU-free to this gate.
+# THE CONVERSE IS FATAL TOO — an `#[ignore]` whose reason claims a Metal
+# context on a test from which no `Device::Gpu` is reachable. Every such test is
+# skipped by `make test` (it is ignored) AND skipped by `make gpu-test` (it is
+# not classified), so it runs nowhere while reading, at both gates, exactly like
+# a test that is covered.
+#
+# It was a non-fatal warning, on the reasoning that some ignores are legitimately
+# non-GPU and that a helper in a non-scanned source file makes a real Metal test
+# look GPU-free here. Both are true and neither is a reason to leave the finding
+# advisory: an advisory channel with two valid outcomes and no way to record
+# which one applies is a channel nothing ever closes. It sat open over six such
+# tests. So the finding now demands a disposition, and there are three:
+#
+#   * the test drives Metal by a route this scanner cannot follow -> declare it
+#     with the `metal-unscanned` marker below;
+#   * the test does not touch the GPU -> drop the `#[ignore]` (and pass
+#     `Device::Cpu`), so it runs in the default gate again;
+#   * the test is ignored for some other reason -> say that reason in the
+#     `#[ignore]` text instead of claiming Metal.
+#
+# The third is a real escape hatch and is stated rather than hidden: this check
+# keys on the ignore reason's WORDING, which is the one place in this gate that
+# does. It has to — there is no shape to key on, that being the whole problem —
+# and the consequence is that a Metal-driving test whose ignore text never says
+# "Metal" or "GPU" is invisible to it.
+#
+# DECLARED METAL ROUTE (`// gpu-test-gate: metal-unscanned`)
+#   The inverse of the exemption below: a line-leading marker in the fn's own
+#   attribute block declaring that the test DOES drive Metal, by a route no
+#   shape in the scanned sources can express. Two such routes exist here:
+#
+#     * an HTTP boundary — the test drives an in-process axum router and the
+#       device is chosen inside `crates/rmlx-server/src/embeddings.rs`, which is
+#       not a scanned file and could not be linked to the test even if it were
+#       (the call goes through a routing table, not a call graph);
+#     * a process boundary — the test spawns `rmlx serve` and the Metal context
+#       belongs to the child.
+#
+#   Effect: the test counts as GPU-touching, so the `#[ignore]` rule bites on it
+#   — deleting the attribute is a violation, which before the marker it was not.
+#   It is NOT emitted to `--list`; see LIST vs ENFORCE. A marker on a test the
+#   scanner CAN see through, and a marker paired with the exemption, are both
+#   hard failures: the first is stale, the second says the test does and does not
+#   drive Metal, and guessing which half to believe is how a marker rots.
+#
+#   Like the exemption, it is opt-in — but not opt-in the way that word usually
+#   means "and therefore forgettable". The fatal rule above is what asks for it:
+#   an `#[ignore]` claiming Metal with nothing to back it fails the gate until
+#   one of the three dispositions is recorded.
 #
 # PER-TEST EXEMPTION (device-as-value false positives)
 #   Detection is by shape: naming `Device::Gpu`. In compute crates that always
@@ -169,6 +212,16 @@
 #   runner's "executed fewer than classified" check. Macro-generated tests are
 #   therefore ENFORCED here and excluded from `--list`; the enforcing run prints
 #   the excluded set so the divergence is stated rather than silent.
+#
+#   A `metal-unscanned` test is excluded for a different reason, and it is a
+#   property of the RUNNER, not of the classifier. `run_gpu_tests.sh` asserts,
+#   per crate, that Metal's shader-validation banner appeared — a crate that
+#   created no Metal device proved nothing and is reported as having run
+#   uninstrumented. Every `metal-unscanned` test in this tree is snapshot-gated
+#   or drives a child process, so a machine without that snapshot would execute
+#   them, watch them all return early, produce no banner, and fail the suite for
+#   a missing model rather than a defect. They are enforced here and listed
+#   nowhere; the excluded set is printed every run alongside the macro one.
 #
 #   That divergence is a real cost and is accepted deliberately for the one
 #   population that has it today, the NIAH long-context cells: they are
@@ -554,6 +607,15 @@ read -r -d '' AWK_DETECT <<'AWK' || true
         attrs = attrs " GATE_EXEMPT"
         next
     }
+    # ── Declared Metal route the scanner cannot follow ──────────────────
+    # The inverse marker: the test DOES drive Metal, across an HTTP or a
+    # process boundary no source shape here can express. Folds into the
+    # pending attribute block on the same terms as the exemption — attaches
+    # to the NEXT fn only, and a copy inside a body declares nothing.
+    !in_fn && /^[[:space:]]*\/\/[[:space:]]*gpu-test-gate:[[:space:]]*metal-unscanned([[:space:]]|$)/ {
+        attrs = attrs " GATE_UNSCANNED"
+        next
+    }
     # ── Comments / doc comments keep the pending attribute block ────────
     /^[[:space:]]*\/\// { next }
 
@@ -769,7 +831,29 @@ read -r -d '' AWK_DETECT <<'AWK' || true
             if (attrs_of[g] !~ /#\[(tokio::)?test[](]/) { continue }
             has_ignore = (attrs_of[g] ~ /#\[ignore/)
             exempt = (attrs_of[g] ~ /GATE_EXEMPT/)
-            if (gpu[g] && !has_ignore && !exempt) {
+            declared = (attrs_of[g] ~ /GATE_UNSCANNED/)
+
+            # Two marker states have no right answer, so both fail closed
+            # rather than this picking one. A marker on a test the reachability
+            # pass CAN see through is stale — its claim is now checkable and
+            # keeping it would hold the test out of `--list` forever. A marker
+            # beside the exemption asserts that the test both does and does not
+            # drive Metal.
+            if (declared && exempt) {
+                printf "U  %s: %s (marked metal-unscanned AND exempt — pick one)\n",
+                    file_of[g], label_of[g]
+                continue
+            }
+            if (declared && gpu[g]) {
+                printf "U  %s: %s (marked metal-unscanned, but Device::Gpu is reachable here)\n",
+                    file_of[g], label_of[g]
+                continue
+            }
+
+            # A declared route counts as GPU-touching for the attribute rule:
+            # deleting the `#[ignore]` from such a test is a violation, which
+            # before the marker existed it was not.
+            if ((gpu[g] || declared) && !has_ignore && !exempt) {
                 printf "V  %s: %s\n", file_of[g], label_of[g]
             }
             # The compliant set: GPU-touching AND ignored. This is exactly the
@@ -788,10 +872,20 @@ read -r -d '' AWK_DETECT <<'AWK' || true
                     printf "T  %s: %s\n", file_of[g], name_of[g]
                 }
             }
+            # A declared route is enforced above but never listed: the runner
+            # asserts a per-crate Metal validation banner, and every test with
+            # this marker is snapshot-gated or drives a child process, so
+            # listing it would fail that assertion on any machine without the
+            # snapshot. Reported, not dropped.
+            if (declared && has_ignore) {
+                printf "N  %s: %s\n", file_of[g], label_of[g]
+            }
             # Converse: an ignore claiming a Metal context on a test that
-            # never reaches one. Warn — the test may have stopped running
-            # (or reaches Metal only via a non-scanned source-file helper).
-            if (!gpu[g] && has_ignore && attrs_of[g] ~ /#\[ignore[^]]*([Mm]etal|GPU)/) {
+            # never reaches one and never declared why. It is skipped by the
+            # default gate (it is ignored) and by the GPU gate (it is not
+            # classified), so it runs nowhere while looking covered at both.
+            if (!gpu[g] && !declared && has_ignore \
+             && attrs_of[g] ~ /#\[ignore[^]]*([Mm]etal|GPU)/) {
                 printf "W  %s: %s\n", file_of[g], label_of[g]
             }
         }
@@ -808,6 +902,7 @@ warnings=""
 gpu_tests=""
 unreadable=""
 macro_generated=""
+declared_unscanned=""
 
 for crate in "${members[@]}"; do
     crate_dir="${REPO_ROOT}/${crate}"
@@ -863,6 +958,7 @@ for crate in "${members[@]}"; do
             "W  "*) warnings="${warnings}  ${line#W  }"$'\n' ;;
             "U  "*) unreadable="${unreadable}  ${line#U  }"$'\n' ;;
             "S  "*) macro_generated="${macro_generated}  ${line#S  }"$'\n' ;;
+            "N  "*) declared_unscanned="${declared_unscanned}  ${line#N  }"$'\n' ;;
             "T  "*) gpu_tests="${gpu_tests}${pkg_name}"$'\t'"${line##*: }"$'\n' ;;
         esac
     done <<< "$out"
@@ -901,6 +997,36 @@ if [ -n "$unreadable" ]; then
     exit 1
 fi
 
+# An `#[ignore]` claiming a Metal context with no reachable `Device::Gpu` and no
+# declared route fails BOTH modes, for the same reason the unreadable case does:
+# such a test is skipped by `make test` because it is ignored and skipped by
+# `make gpu-test` because it is not classified, so it runs nowhere while reading
+# as covered at both gates. This was advisory for a long time and six tests sat
+# in it; an advisory channel with two valid outcomes and no way to record which
+# one applies is a channel nothing ever closes.
+if [ -n "$warnings" ]; then
+    echo "ERROR: #[ignore] claims a Metal context but no Device::Gpu is reachable" >&2
+    echo "       in the scanned roots, and no route was declared:" >&2
+    printf '%s' "$warnings" >&2
+    echo >&2
+    echo "Each of these runs under NO gate: \`make test\` skips it (it is ignored)" >&2
+    echo "and \`make gpu-test\` skips it (it is not classified). Pick the true one:" >&2
+    echo >&2
+    echo "  * it drives Metal through a route this scanner cannot follow — an HTTP" >&2
+    echo "    handler in production source, or a child process — then declare it" >&2
+    echo "    with a line-leading marker in the fn's own attribute block:" >&2
+    echo "      // gpu-test-gate: metal-unscanned  <why the scanner cannot see it>" >&2
+    echo "    It then counts as GPU-touching (the #[ignore] rule bites on it) and" >&2
+    echo "    is deliberately NOT listed for scripts/run_gpu_tests.sh." >&2
+    echo "  * it does not touch the GPU — drop the #[ignore] and pass Device::Cpu," >&2
+    echo "    so it runs in the default gate again." >&2
+    echo "  * it is ignored for some other reason — say THAT reason in the #[ignore]" >&2
+    echo "    text instead of claiming Metal." >&2
+    echo >&2
+    echo "See docs/TESTING.md." >&2
+    exit 1
+fi
+
 # Macro-generated tests are enforced above but excluded from `--list`, so state
 # the divergence every run rather than letting it be a property only the source
 # comments record. Printed BEFORE the `--list` early exit and on stderr: the one
@@ -917,6 +1043,19 @@ if [ -n "$macro_generated" ]; then
     echo >&2
 fi
 
+# The other enforced-but-unlisted population, stated on the same terms and for
+# the same reason: `make gpu-test` calls only `--list`, so an operator reading
+# that run must be told what it does not cover.
+if [ -n "$declared_unscanned" ]; then
+    echo "NOTE: declared-route GPU tests — the #[ignore] rule is ENFORCED on them, but" >&2
+    echo "they are not listed for scripts/run_gpu_tests.sh (that runner asserts a Metal" >&2
+    echo "validation banner per crate, and these are snapshot-gated or drive a child" >&2
+    echo "process, so listing them would fail the suite for a missing model):" >&2
+    printf '%s' "$declared_unscanned" >&2
+    echo "  -> No gate executes these. See docs/TESTING.md for each one's coverage." >&2
+    echo >&2
+fi
+
 if [ "${LIST_MODE}" -eq 1 ]; then
     if [ -z "${gpu_tests}" ]; then
         echo "ERROR: classified 0 GPU-touching #[ignore] tests across ${total_files} files." >&2
@@ -925,18 +1064,6 @@ if [ "${LIST_MODE}" -eq 1 ]; then
     fi
     printf '%s' "${gpu_tests}"
     exit 0
-fi
-
-if [ -n "$warnings" ]; then
-    echo "WARNING (non-fatal): #[ignore] claims a Metal context but no Device::Gpu is reachable in the scanned roots:" >&2
-    printf '%s' "$warnings" >&2
-    echo "  -> If the test truly does not touch the GPU, drop the #[ignore] (and pass" >&2
-    echo "     Device::Cpu) — an ignored CPU test is a test that silently stopped running." >&2
-    echo "  -> But reachability covers only the crate's scanned test roots: a test that" >&2
-    echo "     reaches Metal ONLY through a helper in a non-scanned source file (e.g. a" >&2
-    echo "     kernel-builder in the parent module) is a false positive here and the" >&2
-    echo "     #[ignore] is correct. Verify before removing it." >&2
-    echo >&2
 fi
 
 if [ -n "$violations" ]; then

--- a/scripts/check_gpu_tests_ignored_fixtures.sh
+++ b/scripts/check_gpu_tests_ignored_fixtures.sh
@@ -92,6 +92,8 @@ fi
 
 VIOLATION="ERROR: GPU-touching tests missing the #[ignore]"
 UNREADABLE="ERROR: this gate could not classify part of a scanned file"
+UNDECLARED="ERROR: #[ignore] claims a Metal context"
+DECLARED_NOTE="NOTE: declared-route GPU tests"
 # Pins the file count too, so a fixture that lost its source file cannot pass by
 # scanning nothing.
 CLEAN="OK: every GPU-touching test carries #[ignore] (1 files"
@@ -125,6 +127,14 @@ CASES=(
     "macro_cpu_no_ignore|0|${CLEAN}||NOTE:|a macro body that never reaches the GPU stays un-ignored"
     "macro_gpu_exempt|0|${CLEAN}||NOTE:|the per-test exemption marker works inside a macro body"
     "plain_gpu_ignored|0|${CLEAN}||NOTE:|the compliant non-macro shape stays green"
+    "ignore_metal_undeclared|1|${UNDECLARED}|orphaned_metal_test||an #[ignore] claiming Metal with no reachable device and no declared route is fatal"
+    "unscanned_in_body|1|${UNDECLARED}|marker_inside_body||a declared-route marker among a fn's statements declares nothing"
+    "unscanned_in_body|1|${UNDECLARED}|test_after_body_marker||and does not carry to the next fn"
+    "metal_unscanned_no_ignore|1|${VIOLATION}|declared_without_ignore||a declared route makes the missing #[ignore] a violation"
+    "metal_unscanned_and_exempt|1|${UNREADABLE}|metal-unscanned AND exempt||declaring and exempting the same test fails closed"
+    "metal_unscanned_stale|1|${UNREADABLE}|Device::Gpu is reachable here||a marker the scanner can check for itself is stale, not redundant"
+    "metal_unscanned_declared|0|${CLEAN}||ERROR|a declared route closes the fatal converse"
+    "metal_unscanned_declared|0|${DECLARED_NOTE}|declared_metal_test||and the enforced-but-unlisted test is announced"
 )
 
 FAILED=0
@@ -212,6 +222,45 @@ case "$list_err" in
     *)
         fail "macro_gpu_ignored" "--list did not announce the excluded macro cells on stderr"
         printf '%s\n' "$list_err" | sed 's/^/       | /'
+        ;;
+esac
+
+# The same split for the declared-route marker, and for the same reason: the
+# runner turns a listed name into a libtest filter and executes it, and every
+# declared test is snapshot-gated or drives a child process, so listing one
+# would have the runner execute a no-op, see no Metal validation banner for that
+# crate, and fail the suite over a missing model. Asserting the exact stdout is
+# what stops "declared tests are enforced but unlisted" from quietly becoming
+# either "declared tests are listed" or "plain tests were dropped too".
+want_list=$'fx\tplain_gpu_test'
+got_list=$(bash "$GATE" --list --root "$FIX/metal_unscanned_declared" 2>/dev/null)
+if [ "$got_list" = "$want_list" ]; then
+    PASSED=$((PASSED + 1))
+    printf '  ok   %-22s --list — declared test enforced but not listed; plain test listed\n' \
+        "metal_unscanned_declared"
+else
+    fail "metal_unscanned_declared" "$(printf -- '--list got %q, want %q' "$got_list" "$want_list")"
+fi
+
+# `--list` must refuse an undeclared Metal-claiming #[ignore] exactly as the
+# enforcing path does. `make gpu-test` calls only `--list`, so a check that
+# fires in one mode and not the other leaves the whole GPU suite running over a
+# tree the gate has already judged incomplete.
+#
+# The exit code alone would not assert it: with the check removed the fixture
+# classifies no GPU test at all, so `--list` still exits 1 on its own
+# refuse-to-emit-an-empty-list path. The REASON is what pins this.
+list_rc=0
+list_out=$(bash "$GATE" --list --root "$FIX/ignore_metal_undeclared" 2>&1) || list_rc=$?
+case "${list_rc}:${list_out}" in
+    "1:"*"${UNDECLARED}"*)
+        PASSED=$((PASSED + 1))
+        printf '  ok   %-22s --list — refuses an undeclared Metal-claiming #[ignore] too\n' \
+            "ignore_metal_undeclared"
+        ;;
+    *)
+        fail "ignore_metal_undeclared" "--list exit=$list_rc, and not for the undeclared reason"
+        printf '%s\n' "$list_out" | sed 's/^/       | /'
         ;;
 esac
 

--- a/scripts/fixtures/gpu_tests_ignored/ignore_metal_undeclared/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/ignore_metal_undeclared/Cargo.toml
@@ -1,0 +1,6 @@
+# Synthetic workspace for scripts/check_gpu_tests_ignored_fixtures.sh.
+# Never built — the gate reads only the member list and the package name.
+[workspace]
+members = [
+    "crates/fx",
+]

--- a/scripts/fixtures/gpu_tests_ignored/ignore_metal_undeclared/crates/fx/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/ignore_metal_undeclared/crates/fx/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fx"
+version = "0.0.0"
+edition = "2021"

--- a/scripts/fixtures/gpu_tests_ignored/ignore_metal_undeclared/crates/fx/src/fixture_tests.rs
+++ b/scripts/fixtures/gpu_tests_ignored/ignore_metal_undeclared/crates/fx/src/fixture_tests.rs
@@ -1,0 +1,14 @@
+// The fatal converse: an #[ignore] whose reason claims a Metal context, on a
+// test the scanner can reach no device from, with no declared route.
+//
+// Such a test runs under NO gate — `make test` skips it because it is ignored,
+// `make gpu-test` skips it because it is not classified — so it reads as
+// covered at both while covering nothing. It was advisory for a long time and
+// six tests accumulated in it, which is why the gate now refuses it.
+
+#[ignore = "GPU Metal context"]
+#[test]
+fn orphaned_metal_test() {
+    // The device lives behind an HTTP boundary, but nothing here says so.
+    drive_the_server_over_http();
+}

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_and_exempt/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_and_exempt/Cargo.toml
@@ -1,0 +1,6 @@
+# Synthetic workspace for scripts/check_gpu_tests_ignored_fixtures.sh.
+# Never built — the gate reads only the member list and the package name.
+[workspace]
+members = [
+    "crates/fx",
+]

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_and_exempt/crates/fx/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_and_exempt/crates/fx/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fx"
+version = "0.0.0"
+edition = "2021"

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_and_exempt/crates/fx/src/fixture_tests.rs
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_and_exempt/crates/fx/src/fixture_tests.rs
@@ -1,0 +1,12 @@
+// Both markers on one test: it drives Metal (declared) and it does not
+// (exempt). There is no right answer, so the gate fails closed instead of
+// picking one — silently preferring either half is how a marker rots into a
+// permanent, unreviewed exemption.
+
+// gpu-test-gate: metal-unscanned  the handler picks the device
+// gpu-test-gate: exempt
+#[ignore = "GPU Metal context"]
+#[test]
+fn declared_and_exempt() {
+    post("/v1/embeddings");
+}

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_declared/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_declared/Cargo.toml
@@ -1,0 +1,6 @@
+# Synthetic workspace for scripts/check_gpu_tests_ignored_fixtures.sh.
+# Never built — the gate reads only the member list and the package name.
+[workspace]
+members = [
+    "crates/fx",
+]

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_declared/crates/fx/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_declared/crates/fx/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fx"
+version = "0.0.0"
+edition = "2021"

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_declared/crates/fx/src/fixture_tests.rs
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_declared/crates/fx/src/fixture_tests.rs
@@ -1,0 +1,19 @@
+// Negative control for the declared-route marker, plus the list/enforce split
+// it introduces. The declared test is ENFORCED (its #[ignore] is required) and
+// must stay OUT of `--list`; the plain GPU test beside it must still go in, so
+// a change that starts listing declared tests — or that drops plain ones —
+// shows up as a different stdout rather than as a still-green run.
+
+// gpu-test-gate: metal-unscanned  the handler picks the device
+#[ignore = "GPU Metal context"]
+#[test]
+fn declared_metal_test() {
+    post("/v1/embeddings");
+}
+
+#[ignore = "GPU Metal context"]
+#[test]
+fn plain_gpu_test() {
+    let device = Device::Gpu;
+    run(device);
+}

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_no_ignore/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_no_ignore/Cargo.toml
@@ -1,0 +1,6 @@
+# Synthetic workspace for scripts/check_gpu_tests_ignored_fixtures.sh.
+# Never built — the gate reads only the member list and the package name.
+[workspace]
+members = [
+    "crates/fx",
+]

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_no_ignore/crates/fx/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_no_ignore/crates/fx/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fx"
+version = "0.0.0"
+edition = "2021"

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_no_ignore/crates/fx/src/fixture_tests.rs
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_no_ignore/crates/fx/src/fixture_tests.rs
@@ -1,0 +1,10 @@
+// The marker's enforcement half: a declared route makes the test GPU-touching,
+// so a missing #[ignore] is a violation. Before the marker existed this exact
+// shape was invisible in both directions — never flagged, never listed — and
+// deleting the attribute was caught by nothing.
+
+// gpu-test-gate: metal-unscanned  the handler picks the device
+#[test]
+fn declared_without_ignore() {
+    post("/v1/embeddings");
+}

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_stale/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_stale/Cargo.toml
@@ -1,0 +1,6 @@
+# Synthetic workspace for scripts/check_gpu_tests_ignored_fixtures.sh.
+# Never built — the gate reads only the member list and the package name.
+[workspace]
+members = [
+    "crates/fx",
+]

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_stale/crates/fx/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_stale/crates/fx/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fx"
+version = "0.0.0"
+edition = "2021"

--- a/scripts/fixtures/gpu_tests_ignored/metal_unscanned_stale/crates/fx/src/fixture_tests.rs
+++ b/scripts/fixtures/gpu_tests_ignored/metal_unscanned_stale/crates/fx/src/fixture_tests.rs
@@ -1,0 +1,12 @@
+// A marker whose claim the scanner can now check for itself. The test binds
+// Device::Gpu right here, so nothing needs declaring — and leaving the marker
+// would hold a perfectly listable test out of `--list` forever. Stale markers
+// are the failure mode of every opt-out, so this one fails closed.
+
+// gpu-test-gate: metal-unscanned  the handler picks the device
+#[ignore = "GPU Metal context"]
+#[test]
+fn declared_but_visible() {
+    let device = Device::Gpu;
+    run(device);
+}

--- a/scripts/fixtures/gpu_tests_ignored/unscanned_in_body/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/unscanned_in_body/Cargo.toml
@@ -1,0 +1,6 @@
+# Synthetic workspace for scripts/check_gpu_tests_ignored_fixtures.sh.
+# Never built — the gate reads only the member list and the package name.
+[workspace]
+members = [
+    "crates/fx",
+]

--- a/scripts/fixtures/gpu_tests_ignored/unscanned_in_body/crates/fx/Cargo.toml
+++ b/scripts/fixtures/gpu_tests_ignored/unscanned_in_body/crates/fx/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fx"
+version = "0.0.0"
+edition = "2021"

--- a/scripts/fixtures/gpu_tests_ignored/unscanned_in_body/crates/fx/src/fixture_tests.rs
+++ b/scripts/fixtures/gpu_tests_ignored/unscanned_in_body/crates/fx/src/fixture_tests.rs
@@ -1,0 +1,18 @@
+// The declared-route marker is scoped exactly like the exemption: it must lead
+// its line INSIDE the fn's attribute block. A copy among a fn's statements
+// declares nothing — otherwise a marker could be smuggled in as prose — and it
+// must not carry to the next fn either. Both tests below stay undeclared, so
+// both are reported.
+
+#[ignore = "GPU Metal context"]
+#[test]
+fn marker_inside_body() {
+    // gpu-test-gate: metal-unscanned
+    post("/v1/embeddings");
+}
+
+#[ignore = "GPU Metal context"]
+#[test]
+fn test_after_body_marker() {
+    post("/v1/embeddings");
+}


### PR DESCRIPTION
Closes #384.

The issue offered a choice: either make the six `#[ignore]` "GPU Metal" tests in `rmlx-server`
run somewhere, or drop the misleading attribute. The audit says that is a false choice —
**all six genuinely need Metal**, so dropping the attribute closes nothing.

The real defect is one layer up. The classifier's *converse* finding — an `#[ignore]` claims a
Metal context but no `Device::Gpu` is reachable — was advisory, with two legitimate outcomes
(the attribute lies, or the device is reached somewhere the scanner cannot follow) and no way
to record which applied. So nothing ever closed it and tests accumulated in it.

That warning is now **fatal**, and `// gpu-test-gate: metal-unscanned` is the third
disposition: a written, reviewable declaration that the route to Metal exists but is outside
the scanner's reach. A declared test counts as GPU-touching, so **deleting its `#[ignore]` is
now a violation** where on `main` the same deletion is completely silent.

## The audit — evidence, not the `#[ignore]` text

- Five embeddings cells POST to `/v1/embeddings`; the handler loads jina and runs the forward
  under `Device::Gpu` on a `spawn_blocking` worker. Same process, far side of an axum routing
  table.
- `invalid_dimensions_is_400` **looks like** the file's other request-validation 400s and is
  not one. `embeddings.rs:321-322` defers `dimensions` to the model's matryoshka set, so the
  rejection comes out of `pooling::single_vector` *after* a full GPU forward. Its docstring
  said otherwise; corrected.
- `ssd_cache_survives_server_restart` drives Metal in a spawned `rmlx serve` **child** —
  another process entirely.
- The issue lists six. The fatal rule surfaces a **seventh**: `paro_kernel_registration`,
  which registers an MSL kernel through a non-scanned source helper that never names a device.

## Enforced but still not listed, and why

That is a property of the runner, not the classifier. `run_gpu_tests.sh` asserts Metal's
validation banner *per crate*. Every declared test is snapshot-gated or drives a child, so
listing them would have the runner execute early returns, see no banner for `rmlx-server`, and
fail `make ci-perf` over a missing model rather than over a defect.

`ssd_cache_restart` could not be listed on any machine — Metal is in the child, and it needs
`cargo build -p rmlx-cli`, `pkill`s MLX, and waits twice for 180 s. `make e2e` phase 2a already
covers the identical spill→restart→hydrate chain over the same two prompts.

## Proof

- **Red-first**: with the check made fatal and before the markers, the gate exits 1 naming all
  seven. After the markers, exit 0 with them printed under a NOTE. Confirmed independently
  against current `main`, where the same script names exactly those seven.
- **Enforcement is real**: deleting the `#[ignore]` from `valid_single_vector_200_shape` fails
  the gate on this branch and is silent on `main`.
- **Six mutations**, each red and each naming the right subject: warning back to advisory,
  `declared` dropped from the violation condition, contradiction check dropped, stale-marker
  check dropped, declared emitted to `--list`, `!declared` guard dropped from the converse.
- The `--list` refusal case is pinned on the **reason**, not the exit code — with the check
  removed the fixture still exits 1 through the empty-list path, so an exit-code assertion
  would have passed vacuously.
- **Portability**: 39 fixture cases green under BSD awk, gawk and mawk × `LC_ALL=C` and
  `en_US.UTF-8`, with an identical `--list` digest in all six combinations.
- **No behaviour change**: every `+`/`-` line under `crates/` is a comment or blank — zero
  non-comment lines — and `main`'s classifier run over this tree is byte-identical to its run
  over `main`. `scripts/run_gpu_tests.sh` is untouched.

## What this still cannot reach — the load-bearing assumptions

1. **The converse check keys on the `#[ignore]` reason's wording.** It is the one place this
   gate does that, because there is no shape to key on. A Metal-driving test whose reason never
   says "Metal" or "GPU" is invisible to it, and rewording is a legitimate, undetectable escape.
2. The `Device::Gpu` token heuristic still cannot cross a routing table, a process boundary, a
   proc-macro-generated test, a `macro_rules!` in a non-scanned file, an unqualified cross-file
   call through a glob import, or a helper in a non-scanned regular source file.
3. **The marker is reviewer-audited prose.** It asserts a route; nothing verifies the
   assertion. The two fail-closed misuses — stale, contradictory — are caught. A marker on a
   test that never touches Metal is not.
4. **Seven tests still execute nowhere.** Enforced is not run. The gate now says so on every
   run instead of implying coverage.

The five jina embeddings cells have never executed; their first Metal run is queued
separately. Since this branch changes no executable line, anything that run finds is
pre-existing.

`make ci` green.
