### PR TITLE
test(kv),docs: Part C is not a KV-ring read — exclude three hypotheses and cancel the proposed campaign (#346)

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/prefill_grow_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/prefill_grow_tests.rs
@@ -34,6 +34,20 @@ fn f32_arr(data: &[f32], shape: &[i32]) -> Array {
     Array::from_bytes(bytes, shape, Dtype::F32).expect("Array::from_bytes")
 }
 
+/// Read an array back as `f32`, whatever its stored dtype.
+///
+/// The prefill ring is stored bf16 (`cast_store_bf16` at the append boundary),
+/// so a byte-level read needs the widening cast first.
+fn read_f32(a: &Array, device: Device) -> Vec<f32> {
+    let f = a.astype(Dtype::F32, device).expect("astype f32");
+    f.eval().expect("eval");
+    f.to_bytes()
+        .expect("to_bytes")
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes(c.try_into().expect("chunks_exact(4) yields 4 bytes")))
+        .collect()
+}
+
 const TEST_KV_H: i32 = 2;
 const TEST_HEAD_DIM: i32 = 64;
 // Use a tiny starting max_seq so we can exceed it cheaply in a unit test.
@@ -267,6 +281,132 @@ fn non_positive_ceiling_means_unbounded() {
     assert_eq!(cache.storage_max_seq_for_test(), 512);
 
     cache.exit_prefill(device).expect("exit_prefill");
+}
+
+/// The slots of the prefill ring no chunk ever writes hold zero, and attention
+/// never sees them.
+///
+/// A prompt whose length is not a power of two leaves `max_seq - offset` slots
+/// unwritten for the whole request. Two properties keep those slots out of the
+/// numerics, and both are pinned here, because violating either one feeds
+/// whatever the allocator last left in that page into SDPA — and a single NaN
+/// or Inf reaching a softmax numerator turns the entire logit row into NaN:
+///
+/// 1. the buffer is allocated with `zeros()`, so an unwritten slot reads 0.0
+///    rather than recycled device memory; and
+/// 2. `update_prefill_raw` hands back `[.., 0..offset, ..]`, so the tail is not
+///    part of the K/V the attention call receives at any prompt length.
+///
+/// Property 2 alone would be enough for correctness; property 1 is what makes
+/// an accidental over-slice benign instead of non-deterministic, so losing
+/// either is worth a failing test.
+#[test]
+fn prefill_ring_tail_is_zeroed_and_never_returned() {
+    let device = Device::Cpu;
+    // 100 tokens into a 128-slot ring: 28 slots stay unwritten.
+    let filled = 100_i32;
+    let max_seq = TEST_INITIAL_MAX_SEQ;
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::None, max_seq);
+    cache.enter_prefill();
+
+    let chunk_shape = [1_i32, TEST_KV_H, filled, TEST_HEAD_DIM];
+    let n_chunk: usize = chunk_shape.iter().map(|&d| d as usize).product();
+    // 1.5 / 2.5 are exact in bf16, so the store's cast is lossless and
+    // "written" vs "never written" stays a bit-exact distinction.
+    let k = f32_arr(&vec![1.5_f32; n_chunk], &chunk_shape);
+    let v = f32_arr(&vec![2.5_f32; n_chunk], &chunk_shape);
+
+    let (k_full, v_full) = cache.update(&k, &v, device).expect("prefill chunk");
+
+    // Property 2 — the attention input is the filled prefix, not the ring.
+    assert_eq!(
+        k_full.shape()[2],
+        filled,
+        "K handed to attention must span the filled prefix, not the ring capacity",
+    );
+    assert_eq!(
+        v_full.shape()[2],
+        filled,
+        "V handed to attention must span the filled prefix, not the ring capacity",
+    );
+    assert!(
+        read_f32(&k_full, device).iter().all(|&x| x == 1.5),
+        "every returned K element is a written one",
+    );
+    assert!(
+        read_f32(&v_full, device).iter().all(|&x| x == 2.5),
+        "every returned V element is a written one",
+    );
+
+    // Property 1 — the unwritten remainder of the ring is zero.
+    let ring = cache
+        .prefill_raw_k
+        .as_ref()
+        .expect("prefill ring allocated on first append");
+    assert_eq!(
+        ring.shape()[2],
+        max_seq,
+        "precondition: the ring is larger than the filled prefix",
+    );
+    let vals = read_f32(ring, device);
+    let row = TEST_HEAD_DIM as usize;
+    let cap = max_seq as usize;
+    let mut tail_dirty = 0_usize;
+    for h in 0..TEST_KV_H as usize {
+        for t in (filled as usize)..cap {
+            let base = (h * cap + t) * row;
+            let slot = vals
+                .get(base..base + row)
+                .expect("ring slot inside the readback");
+            // `!= 0.0` and not a max-of-abs fold: `f32::max` propagates the
+            // *other* operand past a NaN, so a fold would report a clean tail
+            // for exactly the payload this test exists to catch.
+            tail_dirty += slot.iter().filter(|&&x| x != 0.0).count();
+        }
+    }
+    assert_eq!(
+        tail_dirty, 0,
+        "the never-written ring tail must be zero, not recycled device memory",
+    );
+}
+
+/// Prefill append is codec-independent: the K/V attention receives is the same
+/// under `KvQuant::None` and `KvQuant::K8V8`.
+///
+/// While `in_prefill` is set, `KvCache::update` routes every non-rotating cache
+/// to `update_prefill_raw`; the codec dispatch sits behind that branch and no
+/// quantisation happens until `exit_prefill`. So a fault observed *during*
+/// prefill reproducing "at both k8v8 and none" says nothing about the codec —
+/// the two cells execute the same appends over the same bf16 buffer. Pinned so
+/// that a change which started quantising per chunk cannot silently make that
+/// inference valid again while every other test stays green.
+#[test]
+fn prefill_append_is_codec_independent() {
+    let device = Device::Cpu;
+    let chunk_shape = [1_i32, TEST_KV_H, TEST_CHUNK, TEST_HEAD_DIM];
+    let n_chunk: usize = chunk_shape.iter().map(|&d| d as usize).product();
+    // A varied pattern, every value exact in bf16 (quarter steps in [-2, 2)):
+    // a codec running here would round it and the comparison would separate.
+    let pattern: Vec<f32> = (0..n_chunk).map(|i| (i % 16) as f32 * 0.25 - 2.0).collect();
+    let k = f32_arr(&pattern, &chunk_shape);
+    let v = f32_arr(&pattern, &chunk_shape);
+
+    let mut out = Vec::new();
+    for quant in [KvQuant::None, KvQuant::K8V8] {
+        let mut cache = KvCache::with_quant_max_seq(quant, TEST_INITIAL_MAX_SEQ);
+        cache.enter_prefill();
+        let (k_full, v_full) = cache.update(&k, &v, device).expect("prefill chunk");
+        out.push((read_f32(&k_full, device), read_f32(&v_full, device)));
+    }
+
+    let (none_k, none_v) = out.first().expect("None arm recorded");
+    let (k8v8_k, k8v8_v) = out.get(1).expect("K8V8 arm recorded");
+    assert_eq!(none_k, k8v8_k, "prefill K must not depend on the KV codec");
+    assert_eq!(none_v, k8v8_v, "prefill V must not depend on the KV codec");
+    assert_eq!(
+        none_k, &pattern,
+        "prefill K must be the unquantised input (bf16-exact pattern)",
+    );
 }
 
 /// `next_pow2_seq` rounds correctly for a representative spread.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -614,6 +614,13 @@ gemma-4-e2b run has been shown to sample that depressed band, and a campaign
 that never enters it has not sampled the failure regime. Do not pool runs across
 a >5% `prefill_tps` shift, and record the band on every run.
 
+Nor are the two arches equally exposed per run. `enter_prefill` returns early on
+a rotating cache, so gemma-4's sliding-window layers never touch the shared
+`prefill_raw` append at all and only its `full_attention` layers do — where
+every Qwen3-dense layer does. Same number of runs is not the same number of
+draws, and comparing the two by run count overstates what a clean gemma-4-e2b
+record rules out.
+
 `MTL_SHADER_VALIDATION_FAIL_MODE` was tried as a discriminator, on the theory
 that `zerofill` silently dropping a KV store would explain it. **That
 experiment settles nothing**: n=3 per arm, Fisher p = 1.0, no power at any

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -623,9 +623,37 @@ assignment is inverted only for a different hypothesis ("validation drops a
 write the engine needs"). No invalid access is ever reported, and that negative
 *is* load-bearing: the detector was mutation-checked by running the OOB canary
 under both fail modes, and it reported in both. An out-of-bounds access would
-have been caught and was not — which points at an in-bounds read of stale or
-never-written device memory rather than at an OOB write. That is a hypothesis
-under test, not a conclusion; it is tracked outside this document.
+have been caught and was not, which leaves an in-bounds read of stale or
+never-written device memory as the next candidate — but not in a buffer this
+repo owns:
+
+* **The KV ring's never-written tail is not it.** `update_prefill_raw`
+  allocates the ring with `zeros()` on both the lazy-alloc and the grow branch,
+  and hands attention `[.., 0..offset, ..]`. The slots past `offset` hold 0.0
+  and are not part of any SDPA input at any prompt length. Pinned by
+  `prefill_ring_tail_is_zeroed_and_never_returned` (`rmlx-kv-quant`,
+  CPU) — including against a NaN payload, which a max-of-abs fold would have
+  missed.
+* **No rMLX Metal kernel runs before that logit row on this architecture.**
+  While `in_prefill` is set, `KvCache::update` routes every non-rotating cache
+  to `update_prefill_raw`, which is MLX ops only; the codec dispatch sits behind
+  that branch and the fused-QK paths are gated on `q_seq == 1`. Qwen3-dense has
+  no rotating/SWA layers, and neither `.metal` kernel in `rmlx-models`
+  (`gated_delta_step`, `paroquant_rotate`) is on this arch. Every kernel body
+  rMLX dispatches in such a request comes from `exit_prefill`, which runs after
+  the logit graph is already built. The prefill logit row is produced by MLX
+  ops end to end.
+* **"Reproduces at both `k8v8` and `none`" carries no codec information.**
+  Those two cells execute the same appends over the same bf16 buffer during
+  prefill — pinned by `prefill_append_is_codec_independent` — so the pair
+  discriminates nothing. It is consistent with a fault in the shared path and
+  says nothing more.
+
+What remains is an MLX-level mechanism: an MLX op, or the Metal runtime
+underneath it (MLX allocates with `MTLHazardTrackingModeUntracked` and its
+command encoder models read-after-write hazards only — see ml-explore/mlx#3630
+and ml-explore/mlx#3461). Still a hypothesis, and tracked outside this
+document.
 
 Current state: the whole GPU suite — all five crates, `rmlx-kv-quant` included —
 runs clean under validation, zero invalid accesses.


### PR DESCRIPTION
Part C of #346. **Does not close it** — Part C is a research question, not a defect with a
known site — but it removes three wrong answers from the suspect set and cancels an
experiment the issue asks for. No runtime behaviour changes: two CPU regression tests and a
`docs/TESTING.md` correction.

## The issue's Layer-2 hypothesis is false by construction

#346 proposes that the NaN comes from an in-bounds read of the never-written KV-ring tail
(`next_pow2_seq`, 3770 → ring 4096, ~326 unwritten slots), and specifies a 60-run
T-large / T-small GPU campaign to test it. Two facts kill it:

- Lazy alloc (`kvcache/update.rs:2634-2635`) and grow (`:2380-2381`) both use `zeros()` →
  `mlx_zeros`. The tail is 0.0, not recycled memory.
- `update.rs:2655-2659` returns `slice(buf, 0..offset)`. The tail is never in an SDPA input at
  any prompt length.

**The two arms of that experiment differ only in the length of a slice that is then sliced
off.** The GPU time should not be spent.

## No rMLX Metal kernel runs before that logit row on this architecture

While `in_prefill` is set, `KvCache::update` returns at `update.rs:2147-2149` into
`update_prefill_raw`, which is MLX ops only. The codec dispatch is behind that branch
(`:2162-2168`), fused-QK is gated on `q_seq == 1`, Qwen3-dense has no rotating layers, and
neither `rmlx-models` `.metal` kernel is on this arch/checkpoint. Everything rMLX dispatches
comes from `exit_prefill`, which runs *after* the logit graph is built and takes the ring as a
read-only input.

That explains the earlier campaign's zero invalid-access reports structurally, rather than
leaving them an unexplained negative.

## Two premises in the issue are weaker than they read

- **"Reproduces at both `k8v8` and `none`" is vacuous as a codec discriminator** — both cells
  execute the same prefill appends over the same bf16 buffer (`none` force-K8V8s head/tail
  layers only post-prefill).
- **gemma-4-e2b's 0/9 is not counter-evidence.** `enter_prefill` returns early on a rotating
  cache (`update.rs:2680`), so gemma-4's SWA layers never touch the shared append — only its
  `full_attention` layers do, where all 36 Qwen3-dense layers do. Equal run counts are not
  equal draws.

## Tests

Two CPU regressions in `crates/rmlx-kv-quant/src/kvcache/prefill_grow_tests.rs`, pinning the
exclusions so they cannot silently stop being true:

| mutation | result |
|---|---|
| `slice_stop[2] = new_offset` → `max_seq` | **both** red |
| ring allocated NaN instead of `zeros()` | tail test red, codec test green |
| K8V8 skips the `in_prefill` branch | codec test red, tail test green |

One detail worth keeping: the tail check counts elements `!= 0.0` rather than folding a
max-of-abs, because `f32::max` propagates the other operand past a NaN — the first version of
that fold reported a **clean tail under the NaN mutation**. That is the payload the test
exists for.

## Where this leaves Part C

MLX-level. MLX allocates `MTLHazardTrackingModeUntracked` and its command encoder models
read-after-write hazards only, not write-after-read; upstream `ml-explore/mlx#3630` is a real
intermittent-wrong-value bug of that shape, and `#3461` covers buffer lifetime under untracked
mode, filed from this same host. The pin here is 0.31.2. One suspected coupling was ruled out:
`exit_prefill` calls a blocking `eval()` (`update.rs:2792`), so its kernels are not concurrent
with the pending logits graph.

The detector itself is correct (`qwen3.rs:1780-1795`, bf16 via `<< 16`) — the recorded events
were genuine NaN.

**What actually blocks Part C:** no degenerate run has yet been captured with Part A's
instrumentation; the 108-run campaign predates that merge. That one measurement is the
blocker and needs no further code. `nan_count == vocab` would mean the whole hidden row went
NaN; a small count with a finite `max_abs_logit` would mean isolated cells out of `lm_head`, a
different fault.

And a bounded negative campaign **cannot** prove a fix here: the pooled rate is 3/108, but the
three events all came from one 10-run in-band window, so they are not independent draws, and
the band is not controllable. Any campaign is evidence capture, not a gate. That is now
written into `docs/TESTING.md` in place of the open "stale or never-written device memory"
speculation.

`make ci` green. (One run died with `signal: 11` in the `rmlx-models` test binary — the
separately-tracked MLX-linking flake, #371, which fired twice in this session on unrelated
branches; the rerun is clean.)
