### PR TITLE
fix(mlx): serialise MLX evaluation — a global map raced from parallel threads SIGSEGVs make ci (#371)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,18 @@ jobs:
       # call deep in a shared scaffold. Fixture trees pin that recall.
       - name: the lazy-inputs gate still catches what it is for
         run: make check-no-kernel-input-eval-fixtures
+      # MLX 0.31.x fills a process-global CPU command-encoder map with no
+      # synchronisation, so two threads evaluating at once corrupt it and the
+      # process dies inside MLX with no failing test named. Serialising every
+      # evaluation is the fix; this gate is what keeps a new FFI call from
+      # quietly stepping outside it. Static — the local reproducer is
+      # probabilistic and deliberately not run here.
+      - name: MLX eval FFI calls are made under the evaluation lock
+        run: make check-eval-lock
+      # ...and the gate above is one regex edit from matching nothing and
+      # passing forever. Fixture trees pin its recall, per rule.
+      - name: the eval-lock gate still catches what it is for
+        run: make check-eval-lock-fixtures
 
   msl:
     name: msl kernels (compile + format)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,14 @@ Hard rules:
 - **Hard rule: a test that reaches `Device::Gpu` carries `#[ignore]`.** A shared
   Metal context driven from parallel `cargo test` threads aborts the whole test
   binary ("Rust cannot catch foreign exceptions"), taking every other test in
-  the crate with it. Run them with **`make gpu-test`** (every member crate,
+  the crate with it. **This rule is about Metal only — do not widen it to cover
+  MLX contact generally.** The CPU side has its own, unrelated hazard (MLX
+  0.31.x fills a process-global command-encoder map without synchronisation, so
+  parallel test threads used to SIGSEGV the binary with no failing test named);
+  that one is contained by `EVAL_LOCK` in `rmlx-mlx`, which serialises every
+  evaluation process-wide — not by ignoring CPU tests, which would only stop
+  running them. See `docs/FFI.md`.
+  Run GPU tests with **`make gpu-test`** (every member crate,
   serialized; `CRATE=` / `FILTER=` to narrow), or by hand as
   `cargo test -p <crate> --lib -- --ignored <filter> --test-threads=1`.
   `make gpu-test` is the only step that executes them — `make test` passes no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,9 +203,12 @@ Hard rules:
   MLX contact generally.** The CPU side has its own, unrelated hazard (MLX
   0.31.x fills a process-global command-encoder map without synchronisation, so
   parallel test threads used to SIGSEGV the binary with no failing test named);
-  that one is contained by `EVAL_LOCK` in `rmlx-mlx`, which serialises every
-  evaluation process-wide — not by ignoring CPU tests, which would only stop
-  running them. See `docs/FFI.md`.
+  that one is contained by `EVAL_LOCK` / `with_eval_lock` in `rmlx-mlx`, which
+  serialises every evaluation process-wide — not by ignoring CPU tests, which
+  would only stop running them. `make check-eval-lock` (in `make ci`) fails the
+  build on any MLX eval FFI call made outside the lock; `make eval-lock-stress`
+  is the probabilistic reproducer, deliberately out of `make ci`. See
+  `docs/FFI.md`.
   Run GPU tests with **`make gpu-test`** (every member crate,
   serialized; `CRATE=` / `FILTER=` to narrow), or by hand as
   `cargo test -p <crate> --lib -- --ignored <filter> --test-threads=1`.
@@ -296,6 +299,8 @@ hand — keeps the CI gate and the local gate identical.
 | `make hooks` | Install the git `pre-commit` hook. |
 | `make ci` | `fmt-check + lint + test + deny + audit` — pre-merge gate. |
 | `make ci-perf` | `test-perf` under `release-perf` + the serialized GPU/Metal suite. Requires an idle GPU. Run before merging perf-sensitive or codec-layer changes (~21 min). |
+| `make check-eval-lock` | CI gate (in `make ci`): every MLX eval FFI call is made under the process-wide evaluation lock. |
+| `make eval-lock-stress` | Drive the evaluation-lock reproducer across `RUNS` fresh processes (default 60). Not in `make ci` — it is probabilistic and CPU-heavy. |
 | `make tag` | Create annotated `v<version>` tag from `[workspace.package].version` (single source). |
 | `make release-package` | Build + bundle `dist/rmlx-v<ver>-aarch64-apple-darwin.tar.gz` (+ `.sha256`). |
 | `make release-sha` | Print sha256 of the `v<ver>` GitHub source tarball (`--write` patches the formula). |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ Hard rules:
   serialises every evaluation process-wide — not by ignoring CPU tests, which
   would only stop running them. Two deterministic gates hold it, and they are
   complementary by construction: `make check-eval-lock` fails the build on any
-  MLX eval FFI call made outside the lock (24-symbol reach-set, derived from the
+  MLX eval FFI call made outside the lock (25-symbol reach-set, derived from the
   linked dylibs — **not** just the eval-named ones) but is blind to a lock that
   stopped locking, which `with_eval_lock_serialises_concurrent_callers` catches.
   `make eval-lock-stress` is the probabilistic reproducer, deliberately out of
@@ -302,8 +302,8 @@ hand — keeps the CI gate and the local gate identical.
 | `make hooks` | Install the git `pre-commit` hook. |
 | `make ci` | `fmt-check + lint + test + deny + audit` — pre-merge gate. |
 | `make ci-perf` | `test-perf` under `release-perf` + the serialized GPU/Metal suite. Requires an idle GPU. Run before merging perf-sensitive or codec-layer changes (~21 min). |
-| `make check-eval-lock` | CI gate (in `make ci`): every MLX eval FFI call is made under the process-wide evaluation lock (24-symbol reach-set). |
-| `make check-eval-lock-fixtures` | CI gate (in `make ci`): recall test for the above, 13 synthetic scan roots. |
+| `make check-eval-lock` | CI gate (in `make ci`): every MLX eval FFI call is made under the process-wide evaluation lock (25-symbol reach-set). |
+| `make check-eval-lock-fixtures` | CI gate (in `make ci`): recall test for the above, 26 synthetic scan roots, each asserting which rule fired. |
 | `make eval-lock-stress` | Drive the evaluation-lock reproducer across `RUNS` fresh processes (default 60). Not in `make ci` — probabilistic (~8%/run) and costs ~412 threads. |
 | `make tag` | Create annotated `v<version>` tag from `[workspace.package].version` (single source). |
 | `make release-package` | Build + bundle `dist/rmlx-v<ver>-aarch64-apple-darwin.tar.gz` (+ `.sha256`). |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,10 +205,13 @@ Hard rules:
   parallel test threads used to SIGSEGV the binary with no failing test named);
   that one is contained by `EVAL_LOCK` / `with_eval_lock` in `rmlx-mlx`, which
   serialises every evaluation process-wide — not by ignoring CPU tests, which
-  would only stop running them. `make check-eval-lock` (in `make ci`) fails the
-  build on any MLX eval FFI call made outside the lock; `make eval-lock-stress`
-  is the probabilistic reproducer, deliberately out of `make ci`. See
-  `docs/FFI.md`.
+  would only stop running them. Two deterministic gates hold it, and they are
+  complementary by construction: `make check-eval-lock` fails the build on any
+  MLX eval FFI call made outside the lock (24-symbol reach-set, derived from the
+  linked dylibs — **not** just the eval-named ones) but is blind to a lock that
+  stopped locking, which `with_eval_lock_serialises_concurrent_callers` catches.
+  `make eval-lock-stress` is the probabilistic reproducer, deliberately out of
+  `make ci`. See `docs/FFI.md`.
   Run GPU tests with **`make gpu-test`** (every member crate,
   serialized; `CRATE=` / `FILTER=` to narrow), or by hand as
   `cargo test -p <crate> --lib -- --ignored <filter> --test-threads=1`.
@@ -299,8 +302,9 @@ hand — keeps the CI gate and the local gate identical.
 | `make hooks` | Install the git `pre-commit` hook. |
 | `make ci` | `fmt-check + lint + test + deny + audit` — pre-merge gate. |
 | `make ci-perf` | `test-perf` under `release-perf` + the serialized GPU/Metal suite. Requires an idle GPU. Run before merging perf-sensitive or codec-layer changes (~21 min). |
-| `make check-eval-lock` | CI gate (in `make ci`): every MLX eval FFI call is made under the process-wide evaluation lock. |
-| `make eval-lock-stress` | Drive the evaluation-lock reproducer across `RUNS` fresh processes (default 60). Not in `make ci` — it is probabilistic and CPU-heavy. |
+| `make check-eval-lock` | CI gate (in `make ci`): every MLX eval FFI call is made under the process-wide evaluation lock (24-symbol reach-set). |
+| `make check-eval-lock-fixtures` | CI gate (in `make ci`): recall test for the above, 13 synthetic scan roots. |
+| `make eval-lock-stress` | Drive the evaluation-lock reproducer across `RUNS` fresh processes (default 60). Not in `make ci` — probabilistic (~8%/run) and costs ~412 threads. |
 | `make tag` | Create annotated `v<version>` tag from `[workspace.package].version` (single source). |
 | `make release-package` | Build + bundle `dist/rmlx-v<ver>-aarch64-apple-darwin.tar.gz` (+ `.sha256`). |
 | `make release-sha` | Print sha256 of the `v<ver>` GitHub source tarball (`--write` patches the formula). |

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         file-size-report check-no-inline-tests check-no-scalar-f32-leak \
         check-no-decode-swallow check-gpu-tests-ignored \
         check-gpu-tests-ignored-fixtures \
-        check-eval-lock eval-lock-stress \
+        check-eval-lock check-eval-lock-fixtures eval-lock-stress \
         check-no-kernel-input-eval check-no-kernel-input-eval-fixtures \
         check-metal-compiles check-metal-format
 
@@ -374,6 +374,9 @@ check-no-decode-swallow: ## CI gate: fail if a decode-step failure breaks instea
 check-eval-lock:  ## CI gate: fail if an MLX eval FFI call is made without the process-wide evaluation lock
 	@bash scripts/check_eval_lock.sh
 
+check-eval-lock-fixtures: ## CI gate: recall test for check-eval-lock (synthetic scan roots)
+	@bash scripts/check_eval_lock_fixtures.sh
+
 eval-lock-stress: ## run the evaluation-lock reproducer across RUNS fresh processes (default 60); not in `make ci`
 	@bash scripts/eval_lock_stress.sh $(RUNS)
 
@@ -406,6 +409,7 @@ ci: fmt-check lint test test-capture deny audit ci-metrics ## full pre-merge gat
 	@bash scripts/check_no_scalar_f32_leak.sh
 	@bash scripts/check_no_decode_swallow.sh
 	@bash scripts/check_eval_lock.sh
+	@bash scripts/check_eval_lock_fixtures.sh
 	@bash scripts/check_gpu_tests_ignored.sh
 	@bash scripts/check_gpu_tests_ignored_fixtures.sh
 	@bash scripts/check_no_kernel_input_eval.sh

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         file-size-report check-no-inline-tests check-no-scalar-f32-leak \
         check-no-decode-swallow check-gpu-tests-ignored \
         check-gpu-tests-ignored-fixtures \
+        check-eval-lock eval-lock-stress \
         check-no-kernel-input-eval check-no-kernel-input-eval-fixtures \
         check-metal-compiles check-metal-format
 
@@ -370,6 +371,12 @@ check-no-scalar-f32-leak: ## CI gate: fail if arch-layer code has unguarded scal
 check-no-decode-swallow: ## CI gate: fail if a decode-step failure breaks instead of propagating (would report as finish_reason="length")
 	@bash scripts/check_no_decode_swallow.sh
 
+check-eval-lock:  ## CI gate: fail if an MLX eval FFI call is made without the process-wide evaluation lock
+	@bash scripts/check_eval_lock.sh
+
+eval-lock-stress: ## run the evaluation-lock reproducer across RUNS fresh processes (default 60); not in `make ci`
+	@bash scripts/eval_lock_stress.sh $(RUNS)
+
 check-gpu-tests-ignored: ## CI gate: fail if a GPU-touching test in ANY workspace member lacks #[ignore] (would abort the whole test binary under parallel cargo test)
 	@bash scripts/check_gpu_tests_ignored.sh
 
@@ -398,6 +405,7 @@ ci: fmt-check lint test test-capture deny audit ci-metrics ## full pre-merge gat
 	@bash scripts/check_no_inline_tests.sh
 	@bash scripts/check_no_scalar_f32_leak.sh
 	@bash scripts/check_no_decode_swallow.sh
+	@bash scripts/check_eval_lock.sh
 	@bash scripts/check_gpu_tests_ignored.sh
 	@bash scripts/check_gpu_tests_ignored_fixtures.sh
 	@bash scripts/check_no_kernel_input_eval.sh

--- a/crates/rmlx-mlx/src/compile.rs
+++ b/crates/rmlx-mlx/src/compile.rs
@@ -43,7 +43,7 @@
 
 use rmlx_core::error::{Error, Result};
 
-use crate::{check_status, install_error_handler, sys, Array};
+use crate::{check_status, install_error_handler, sys, with_eval_lock, Array};
 
 // ---------------------------------------------------------------------------
 // Closure — RAII wrapper around mlx_closure
@@ -219,6 +219,21 @@ impl Closure {
     /// Apply this closure to a slice of input arrays.
     ///
     /// Returns the output arrays in a `Vec<Array>`.
+    ///
+    /// Serialised process-wide against every other evaluation — see
+    /// `EVAL_LOCK`. This one is not obvious: applying a closure looks like
+    /// pure graph construction, but building the fused `Compiled` primitive
+    /// bakes scalar constants into the kernel's library name, and that goes
+    /// `print_constant` → `array::item<T>()` → `array::eval()`
+    /// (`mlx/backend/common/compiled.cpp`). So a closure application can reach
+    /// the unsynchronised command-encoder map like any other evaluation.
+    ///
+    /// **Re-entrancy:** the closure body runs on the calling thread, inside
+    /// this FFI call, with the lock held — so a body that itself evaluates
+    /// would self-deadlock on the non-reentrant mutex. No body does today
+    /// (none of the `Closure::from_fn` sites evaluates, and no op wrapper or
+    /// `MetalKernel::apply` does either), and `make check-eval-lock` fails the
+    /// build if one starts to.
     pub fn apply(&self, inputs: &[&Array]) -> Result<Vec<Array>> {
         install_error_handler();
 
@@ -235,7 +250,9 @@ impl Closure {
         }
 
         let mut vec_out = unsafe { sys::mlx_vector_array_new() };
-        let status = unsafe { sys::mlx_closure_apply(&raw mut vec_out, self.inner, vec_in) };
+        let status = with_eval_lock(|| unsafe {
+            sys::mlx_closure_apply(&raw mut vec_out, self.inner, vec_in)
+        });
         unsafe { sys::mlx_vector_array_free(vec_in) };
         unsafe { check_status(status, "Closure::apply") }?;
 

--- a/crates/rmlx-mlx/src/compile.rs
+++ b/crates/rmlx-mlx/src/compile.rs
@@ -229,11 +229,15 @@ impl Closure {
     /// the unsynchronised command-encoder map like any other evaluation.
     ///
     /// **Re-entrancy:** the closure body runs on the calling thread, inside
-    /// this FFI call, with the lock held — so a body that itself evaluates
-    /// would self-deadlock on the non-reentrant mutex. No body does today
-    /// (none of the `Closure::from_fn` sites evaluates, and no op wrapper or
-    /// `MetalKernel::apply` does either), and `make check-eval-lock` fails the
-    /// build if one starts to.
+    /// this FFI call, with the lock held — so a body that *takes the lock
+    /// again* self-deadlocks on the non-reentrant mutex. That ban is broader
+    /// than "must not evaluate": this method takes the lock, so a body which
+    /// applies another compiled closure deadlocks without calling `eval`
+    /// anywhere, and that is the first shape a "fuse two fused kernels"
+    /// refactor produces. No body does either today (no `Closure::from_fn`
+    /// site evaluates or re-applies, and no op wrapper or
+    /// `MetalKernel::apply` takes the lock), and `make check-eval-lock`
+    /// RULE 3 fails the build if one starts to.
     pub fn apply(&self, inputs: &[&Array]) -> Result<Vec<Array>> {
         install_error_handler();
 

--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -74,6 +74,47 @@ thread_local! {
     pub(crate) static LAST_ERROR: Cell<Option<String>> = const { Cell::new(None) };
 }
 
+// ---------------------------------------------------------------------------
+// Evaluation serialisation
+// ---------------------------------------------------------------------------
+//
+// MLX evaluation is not safe to drive from two threads at once, so this crate
+// funnels it through one process-wide lock.
+//
+// The concrete hazard in MLX 0.31.x: a CPU stream's `CommandEncoder` lives in a
+// **process-global** `std::unordered_map<int, CommandEncoder>` that
+// `mlx/backend/cpu/encoder.cpp::get_command_encoder` fills lazily, on the
+// evaluating thread, with **no synchronisation** — while the neighbouring
+// `Scheduler::threads_` map in `mlx/scheduler.h` is mutex-guarded, so the
+// omission is an oversight rather than a contract. Default CPU streams are
+// per-thread (`mlx/stream.cpp::default_stream_storage`), so every thread that
+// evaluates mints its own stream index and performs its own insert into that
+// one shared map. Two inserts in flight together rehash it under a third
+// thread's bucket walk and the process takes SIGSEGV inside MLX, with no Rust
+// frame at fault and nothing to catch. MLX 0.32.0 fixes this by making the map
+// `thread_local`; we do not pin that version (it ships no NAX GEMM kernels),
+// and the lock is harmless there in any case.
+//
+// The lock is held only across the FFI call itself, never across
+// `check_status` — error capture is thread-local, so it needs no protection.
+// Cost is one uncontended mutex acquire per evaluation, against an FFI call
+// that walks a graph and dispatches work; rMLX runs inference on one thread at
+// a time by design, so the lock is a guard against a crash rather than a
+// throughput bottleneck.
+static EVAL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire the process-wide evaluation lock.
+///
+/// The guarded region is a single FFI call with no Rust code that can panic, so
+/// the mutex cannot actually be poisoned; recovering from `PoisonError` rather
+/// than propagating it keeps a structurally-unreachable state from turning a
+/// later evaluation into a spurious failure.
+fn eval_guard() -> std::sync::MutexGuard<'static, ()> {
+    EVAL_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// Install the thread-local error handler. Called once per process, lazily.
 ///
 /// # Safety
@@ -345,34 +386,51 @@ pub fn ensure_gpu_default_stream() {
 /// thread**, so any `Array::eval()` that schedules work on the CPU stream from
 /// this thread finds a registered command encoder.
 ///
-/// This is the CPU analog of [`ensure_gpu_default_stream`]. Since MLX 0.31/0.32
-/// the default CPU/GPU streams are **thread-local** (`mlx/stream.cpp`:
-/// `static thread_local ... default_streams`) and the CPU backend resolves a
-/// stream's `CommandEncoder` through a **thread-local** map first
-/// (`mlx/backend/cpu/encoder.cpp::get_command_encoder`), falling back to a
-/// process-global map and otherwise throwing
-/// "There is no Stream(cpu, N) in current thread." A tokio blocking-pool worker
-/// that never called `mlx::core::new_stream` for the CPU device therefore
-/// faults the first time an op is scheduled on the CPU stream — e.g. the K8V8
+/// This is the CPU analog of [`ensure_gpu_default_stream`]. Since MLX 0.31 the
+/// default CPU/GPU streams are **thread-local** (`mlx/stream.cpp`:
+/// `static thread_local ... default_streams`), so a thread that never
+/// established one — a tokio blocking-pool worker, say — has no CPU stream when
+/// an op is first scheduled on it. That happens on paths like the K8V8
 /// `exit_prefill` quantization, whose reduction MLX evaluates lazily on the CPU
 /// stream even when the model forward runs on the GPU device.
 ///
-/// The mechanism mirrors the GPU guard exactly:
+/// **How the encoder is resolved differs by MLX version, and the two are not
+/// interchangeable:**
+///   - **0.31.x (what we link):** `mlx/backend/cpu/encoder.cpp` keeps one
+///     **process-global** `unordered_map<int, CommandEncoder>` and fills it
+///     lazily on first evaluation with **no synchronisation**. Nothing throws,
+///     and no guard call is needed for correctness — `default_stream(cpu)`
+///     self-registers. What the unsynchronised insert *does* cost is a crash
+///     when two threads evaluate at once; that is contained by `EVAL_LOCK`,
+///     not by this function.
+///   - **0.32.0:** the map became `thread_local` with a process-global
+///     fallback, and an unregistered stream throws
+///     "There is no Stream(cpu, N) in current thread."
+///
+/// So on the linked version this guard is not load-bearing for a thread that
+/// builds and evaluates its own graph; it pins the thread's default CPU stream
+/// so that identity is stable and explicit, and it is what keeps the code
+/// correct if the MLX pin moves to 0.32.0.
+///
+/// The mechanism mirrors the GPU guard:
 ///   1. Create a fresh CPU stream via `mlx_stream_new_device` — which calls
-///      `mlx::core::new_stream` → `cpu::new_stream`, registering a
-///      `CommandEncoder` for this stream index in the calling thread's
-///      thread-local encoder map.
+///      `mlx::core::new_stream`, allocating a new stream index.
 ///   2. Set it as the calling thread's default CPU stream so every subsequent
 ///      `default_stream(cpu)` / `with_stream(Device::Cpu, …)` on this thread
-///      resolves to a stream whose encoder is registered here.
+///      resolves to it.
 ///   3. Store the handle in a thread-local for the thread's lifetime (do NOT
-///      free — that would drop the encoder entry).
+///      free — that would drop the stream and its encoder entry).
 ///
 /// Idempotent — subsequent calls from the same thread are no-ops.
+///
+/// Note the cost this shares with MLX's own lazy path: a stream index is
+/// per-thread and never reclaimed, and MLX backs each one with an OS thread of
+/// its own, so both grow with the number of distinct threads that ever
+/// evaluate.
 pub fn ensure_cpu_default_stream() {
     // Thread-local storage: init flag + stream handle. The handle is held for
-    // the thread's lifetime so the CommandEncoder entry in the thread-local
-    // encoder map stays alive — intentionally leaked on thread exit, same
+    // the thread's lifetime so the stream, and the encoder-map entry keyed on
+    // it, stay alive — intentionally leaked on thread exit, same
     // tradeoff and same bound as `ensure_gpu_default_stream` above: this is
     // only safe because the tokio blocking pool this guards is capped
     // (`max_blocking_threads`) and kept warm (`thread_keep_alive`) by
@@ -816,11 +874,19 @@ impl Array {
     }
 
     /// Force evaluation (MLX is lazy — ops are deferred until materialized).
+    ///
+    /// Serialised process-wide against every other evaluation — see
+    /// `EVAL_LOCK`.
     pub fn eval(&self) -> Result<()> {
         install_error_handler();
-        // SAFETY: inner is a valid mlx_array.
-        let status = unsafe { sys::mlx_array_eval(self.inner) };
-        // SAFETY: called immediately after the C function on the same thread.
+        let status = {
+            let _guard = eval_guard();
+            // SAFETY: inner is a valid mlx_array.
+            unsafe { sys::mlx_array_eval(self.inner) }
+        };
+        // SAFETY: called immediately after the C function on the same thread;
+        // the error slot it reads is thread-local, so releasing the evaluation
+        // lock first cannot lose or cross-wire a message.
         unsafe { check_status(status, "Array::eval") }
     }
 
@@ -831,11 +897,19 @@ impl Array {
     /// Used to pipeline the next decode step's forward pass on the GPU
     /// while the current step's argmax is still being read out (mirrors
     /// mlx-lm's `mx.async_eval` pattern in `generate.py`).
+    ///
+    /// Serialised process-wide against every other evaluation — see
+    /// `EVAL_LOCK`. Only the graph walk and dispatch run under the lock; the
+    /// scheduled work still completes asynchronously after it is released, so
+    /// the pipelining this exists for is preserved.
     pub fn async_eval(&self) -> Result<()> {
         install_error_handler();
         // mlx_async_eval takes a vector_array; build a single-element vec.
         let vec = unsafe { sys::mlx_vector_array_new_value(self.inner) };
-        let status = unsafe { sys::mlx_async_eval(vec) };
+        let status = {
+            let _guard = eval_guard();
+            unsafe { sys::mlx_async_eval(vec) }
+        };
         unsafe { sys::mlx_vector_array_free(vec) };
         unsafe { check_status(status, "Array::async_eval") }
     }

--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -102,9 +102,13 @@ thread_local! {
 // than a throughput bottleneck.
 //
 // **Which C entry points need it.** Not just the eval-named ones: every mlx-c
-// function that reaches `mlx::core::eval_impl` touches the same map. Derived by
-// reverse reachability over the linked dylibs (see `scripts/check_eval_lock.sh`
-// for the exact procedure), the set is 24:
+// function that reaches `mlx::core::eval_impl` touches the same map. The set is
+// **25** — 24 found by reverse reachability over the linked dylibs, plus
+// `mlx_closure_apply`, which that automated pass structurally cannot see
+// because the call goes through a `std::function` vtable. Re-running the
+// procedure at a pin bump yields 24 and no closure entry; that is the pass's
+// blind spot, not a stale guard. `scripts/check_eval_lock.sh` records both
+// passes.
 //
 //   - `mlx_array_eval`, `mlx_async_eval`, `mlx_eval`
 //   - 14 × `mlx_array_item_*` — `array::item<T>()` calls `eval()` first
@@ -119,17 +123,20 @@ thread_local! {
 //     (`mlx/backend/common/compiled.cpp`)
 //
 // The data accessors `mlx_array_data_*` do *not* evaluate and need no lock.
-// Three of these are called here and all three are guarded; the rest are one
-// call away, and adding one unguarded silently reinstates this defect —
+// Three of the 25 are called here and all three are guarded; the other 22 are
+// one call away, and adding one unguarded silently reinstates this defect —
 // `mlx_save_safetensors` is the write side of `rmlx convert`, and
 // `mlx_array_tostring` is what an `impl Debug for Array` would reach for.
 // `make check-eval-lock` fails the build on that, because a doc sentence is
 // not a gate.
 //
 // **Re-entrancy.** The mutex is not reentrant, so nothing running under it may
-// evaluate. That is only a live question for `mlx_closure_apply`, which invokes
-// a Rust closure body on the calling thread while the lock is held. No body
-// evaluates today and the gate enforces it; see `Closure::apply`.
+// *take the lock again* — a broader ban than "must not evaluate", because
+// `Closure::apply` takes it too, so applying one compiled closure from inside
+// another's body deadlocks without calling `eval` anywhere. That is only a live
+// question for `mlx_closure_apply`, which invokes a Rust closure body on the
+// calling thread while the lock is held. No body does it today and the gate's
+// RULE 3 enforces it; see `Closure::apply`.
 static EVAL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Run `f` holding the process-wide evaluation lock.
@@ -143,14 +150,20 @@ static EVAL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 /// remember.
 ///
 /// Poisoning is unreachable here, though not because the guarded region is
-/// Rust-free — it is not. MLX calls back into the error handler installed by
-/// [`install_error_handler`] from *inside* `mlx_array_eval` / `mlx_async_eval`,
-/// and that handler allocates a `String` and writes a thread-local; a compiled
-/// closure body runs under the lock too. What rules poisoning out is that the
-/// callback is an `unsafe extern "C" fn`, and since Rust 1.81 a panic escaping
-/// one aborts the process rather than unwinding. Recovering from `PoisonError`
-/// rather than propagating it keeps that unreachable state from turning a later
-/// evaluation into a spurious failure.
+/// Rust-free — it is not. Two different bits of Rust run under this lock, and
+/// each is contained by a different mechanism:
+///
+/// - The error handler installed by [`install_error_handler`], which MLX calls
+///   from *inside* `mlx_array_eval` / `mlx_async_eval`, allocating a `String`
+///   and writing a thread-local. It is an `unsafe extern "C" fn`, and since
+///   Rust 1.81 a panic escaping one aborts the process rather than unwinding.
+/// - A compiled closure body, run from inside `mlx_closure_apply`. The abort
+///   rule does *not* apply to it, because `rust_closure_callback` wraps the
+///   call in `catch_unwind` and converts a panic into a non-zero return — so
+///   no unwind ever crosses the `MutexGuard` from that direction either.
+///
+/// Recovering from `PoisonError` rather than propagating it keeps that
+/// unreachable state from turning a later evaluation into a spurious failure.
 pub(crate) fn with_eval_lock<T>(f: impl FnOnce() -> T) -> T {
     let _guard = EVAL_LOCK
         .lock()

--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -95,24 +95,42 @@ thread_local! {
 // `thread_local`; we do not pin that version (it ships no NAX GEMM kernels),
 // and the lock is harmless there in any case.
 //
-// The lock is held only across the FFI call itself, never across
-// `check_status` — error capture is thread-local, so it needs no protection.
-// Cost is one uncontended mutex acquire per evaluation, against an FFI call
-// that walks a graph and dispatches work; rMLX runs inference on one thread at
-// a time by design, so the lock is a guard against a crash rather than a
-// throughput bottleneck.
+// Cost is one uncontended mutex acquire + release per evaluation — a CAS and a
+// release store, tens of nanoseconds — against an FFI call that walks a graph
+// and dispatches work in microseconds or more. rMLX runs inference on one
+// thread at a time by design, so the lock is a guard against a crash rather
+// than a throughput bottleneck.
+//
+// **Which C entry points need it.** Not just the two rMLX calls today: every
+// mlx-c function that reaches `mlx::core::eval_impl` touches the same map. In
+// the generated bindings that is `mlx_array_eval`, `mlx_async_eval`,
+// `mlx_eval`, and all 14 `mlx_array_item_*` (each goes through
+// `array::item<T>()`, which calls `eval()` — `mlx/array.h`). The data
+// accessors `mlx_array_data_*` do *not* evaluate and need no lock. Only the
+// first two are called here; the other 15 are one call away, and adding one
+// unguarded silently reinstates this defect. `make check-eval-lock` fails the
+// build on that, because a doc sentence is not a gate.
 static EVAL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Acquire the process-wide evaluation lock.
+/// Run `f` holding the process-wide evaluation lock.
+///
+/// Takes a closure rather than returning the guard on purpose: a
+/// `MutexGuard`-returning helper is only correct if every caller binds it to a
+/// named local, and `let _ = acquire();` — which drops the guard *before* the
+/// FFI call and restores the crash — compiles silently, because `#[must_use]`
+/// does not fire on `let _ =`. This signature makes "held across the FFI call
+/// and nothing else" a property of the API instead of a rule callers have to
+/// remember.
 ///
 /// The guarded region is a single FFI call with no Rust code that can panic, so
 /// the mutex cannot actually be poisoned; recovering from `PoisonError` rather
 /// than propagating it keeps a structurally-unreachable state from turning a
 /// later evaluation into a spurious failure.
-fn eval_guard() -> std::sync::MutexGuard<'static, ()> {
-    EVAL_LOCK
+fn with_eval_lock<T>(f: impl FnOnce() -> T) -> T {
+    let _guard = EVAL_LOCK
         .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    f()
 }
 
 /// Install the thread-local error handler. Called once per process, lazily.
@@ -270,8 +288,8 @@ pub(crate) unsafe fn check_status(status: i32, context: &str) -> Result<()> {
 // on every op invocation. Each call to `mlx_stream_new_device` spawns a new
 // OS worker thread inside MLX. A single Gemma4 forward pass invokes ~42
 // layers × several ops per layer — hundreds of `with_stream` calls per step.
-// After 3–6 decode steps the per-process thread limit (~2 048 on macOS) is
-// exhausted and `pthread_create` returns EAGAIN, manifesting as:
+// After 3–6 decode steps the per-process thread limit is exhausted and
+// `pthread_create` returns EAGAIN, manifesting as:
 //
 // mlx: Array::eval: thread constructor failed: Resource temporarily unavailable
 //
@@ -279,6 +297,15 @@ pub(crate) unsafe fn check_status(status: i32, context: &str) -> Result<()> {
 // return a *reference-counted handle to the already-running default stream*
 // (no new thread). Freeing the handle with `mlx_stream_free` decrements the
 // ref-count — it does NOT tear down the stream or its thread.
+//
+// The ceiling in force at the time of that incident was not recorded; an
+// earlier revision of this comment asserted ~2 048, which is not what this
+// machine reports. Measure before relying on a number:
+// `sysctl kern.num_taskthreads` is the per-task ceiling (16384 here) and
+// `ulimit -u` the per-user process cap. What has not changed is the shape of
+// the bug — MLX never reclaims a stream or the OS thread behind it, so any
+// per-call or per-thread stream creation grows monotonically until it hits
+// whatever the ceiling is.
 
 /// Borrow the process-global default stream for `device`, call `f(stream)`,
 /// release the handle, and return the result.
@@ -879,11 +906,8 @@ impl Array {
     /// `EVAL_LOCK`.
     pub fn eval(&self) -> Result<()> {
         install_error_handler();
-        let status = {
-            let _guard = eval_guard();
-            // SAFETY: inner is a valid mlx_array.
-            unsafe { sys::mlx_array_eval(self.inner) }
-        };
+        // SAFETY: inner is a valid mlx_array.
+        let status = with_eval_lock(|| unsafe { sys::mlx_array_eval(self.inner) });
         // SAFETY: called immediately after the C function on the same thread;
         // the error slot it reads is thread-local, so releasing the evaluation
         // lock first cannot lose or cross-wire a message.
@@ -906,10 +930,7 @@ impl Array {
         install_error_handler();
         // mlx_async_eval takes a vector_array; build a single-element vec.
         let vec = unsafe { sys::mlx_vector_array_new_value(self.inner) };
-        let status = {
-            let _guard = eval_guard();
-            unsafe { sys::mlx_async_eval(vec) }
-        };
+        let status = with_eval_lock(|| unsafe { sys::mlx_async_eval(vec) });
         unsafe { sys::mlx_vector_array_free(vec) };
         unsafe { check_status(status, "Array::async_eval") }
     }

--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -101,15 +101,35 @@ thread_local! {
 // thread at a time by design, so the lock is a guard against a crash rather
 // than a throughput bottleneck.
 //
-// **Which C entry points need it.** Not just the two rMLX calls today: every
-// mlx-c function that reaches `mlx::core::eval_impl` touches the same map. In
-// the generated bindings that is `mlx_array_eval`, `mlx_async_eval`,
-// `mlx_eval`, and all 14 `mlx_array_item_*` (each goes through
-// `array::item<T>()`, which calls `eval()` — `mlx/array.h`). The data
-// accessors `mlx_array_data_*` do *not* evaluate and need no lock. Only the
-// first two are called here; the other 15 are one call away, and adding one
-// unguarded silently reinstates this defect. `make check-eval-lock` fails the
-// build on that, because a doc sentence is not a gate.
+// **Which C entry points need it.** Not just the eval-named ones: every mlx-c
+// function that reaches `mlx::core::eval_impl` touches the same map. Derived by
+// reverse reachability over the linked dylibs (see `scripts/check_eval_lock.sh`
+// for the exact procedure), the set is 24:
+//
+//   - `mlx_array_eval`, `mlx_async_eval`, `mlx_eval`
+//   - 14 × `mlx_array_item_*` — `array::item<T>()` calls `eval()` first
+//     (`mlx/array.h`)
+//   - `mlx_array_tostring` — `operator<<(ostream&, array)` evaluates
+//   - `mlx_save`, `mlx_save_writer`, `mlx_save_safetensors`,
+//     `mlx_save_safetensors_writer`, `mlx_save_gguf`, `mlx_load_gguf` — the
+//     serialisation paths materialise before writing
+//   - `mlx_closure_apply` — indirect: building the fused `Compiled` primitive
+//     bakes scalar constants into the kernel library name via
+//     `print_constant` → `array::item<T>()` → `array::eval()`
+//     (`mlx/backend/common/compiled.cpp`)
+//
+// The data accessors `mlx_array_data_*` do *not* evaluate and need no lock.
+// Three of these are called here and all three are guarded; the rest are one
+// call away, and adding one unguarded silently reinstates this defect —
+// `mlx_save_safetensors` is the write side of `rmlx convert`, and
+// `mlx_array_tostring` is what an `impl Debug for Array` would reach for.
+// `make check-eval-lock` fails the build on that, because a doc sentence is
+// not a gate.
+//
+// **Re-entrancy.** The mutex is not reentrant, so nothing running under it may
+// evaluate. That is only a live question for `mlx_closure_apply`, which invokes
+// a Rust closure body on the calling thread while the lock is held. No body
+// evaluates today and the gate enforces it; see `Closure::apply`.
 static EVAL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Run `f` holding the process-wide evaluation lock.
@@ -122,11 +142,16 @@ static EVAL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 /// and nothing else" a property of the API instead of a rule callers have to
 /// remember.
 ///
-/// The guarded region is a single FFI call with no Rust code that can panic, so
-/// the mutex cannot actually be poisoned; recovering from `PoisonError` rather
-/// than propagating it keeps a structurally-unreachable state from turning a
-/// later evaluation into a spurious failure.
-fn with_eval_lock<T>(f: impl FnOnce() -> T) -> T {
+/// Poisoning is unreachable here, though not because the guarded region is
+/// Rust-free — it is not. MLX calls back into the error handler installed by
+/// [`install_error_handler`] from *inside* `mlx_array_eval` / `mlx_async_eval`,
+/// and that handler allocates a `String` and writes a thread-local; a compiled
+/// closure body runs under the lock too. What rules poisoning out is that the
+/// callback is an `unsafe extern "C" fn`, and since Rust 1.81 a panic escaping
+/// one aborts the process rather than unwinding. Recovering from `PoisonError`
+/// rather than propagating it keeps that unreachable state from turning a later
+/// evaluation into a spurious failure.
+pub(crate) fn with_eval_lock<T>(f: impl FnOnce() -> T) -> T {
     let _guard = EVAL_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);

--- a/crates/rmlx-mlx/src/lib_tests.rs
+++ b/crates/rmlx-mlx/src/lib_tests.rs
@@ -637,7 +637,16 @@ fn cross_thread_eval_resolves_through_the_process_global_encoder_map() {
     assert_eq!(bytes_to_f32(&bytes), vec![4.0f32, 6.0]);
 }
 
-/// Regression gate for the process-global CPU command-encoder map race.
+/// **A reproducer, not a gate.** Read the power figure below before treating a
+/// green run here as evidence of anything: without the lock this fails about
+/// **1 run in 12** (15 failures in 180 runs, measured), so eleven times out of
+/// twelve it would go green with the defect fully present. The gate for this
+/// defect is `make check-eval-lock`, which is deterministic. What this test
+/// adds is an executable demonstration of the mechanism, and a small standing
+/// chance of catching a *semantic* break that a text gate cannot see. To get
+/// real power out of it, run it across many fresh processes — see
+/// `make eval-lock-stress`; repeating the burst inside one process does not
+/// work, because the map only starts cold once.
 ///
 /// The linked MLX resolves a CPU stream's `CommandEncoder` through a
 /// process-global `std::unordered_map<int, CommandEncoder>` that it fills
@@ -656,29 +665,36 @@ fn cross_thread_eval_resolves_through_the_process_global_encoder_map() {
 /// count it grows through, and starting from empty is what puts *all* of those
 /// rehashes inside a single window with hundreds of inserts in flight.
 ///
-/// It passes only because `Array::eval` / `Array::async_eval` hold
-/// `EVAL_LOCK` across the FFI call. Drop that and it crashes the binary.
+/// It passes only because `Array::eval` / `Array::async_eval` evaluate under
+/// `with_eval_lock`. Drop that and it fails as SIGSEGV, SIGTRAP, or an
+/// infinite spin on a bucket chain that became circular — all three were
+/// observed.
 ///
-/// Two honest limits on this as a gate. It is **probabilistic** — measured at
-/// roughly one crash in twenty runs without the lock, so a single green run is
-/// weak evidence and a regression would surface as a rare `make ci` SIGSEGV
-/// rather than a reliable failure. And it covers the **CPU** evaluation path
-/// only: concurrent *GPU* evaluation is not exercised (those tests carry
-/// `#[ignore]` and run serialised), nor are races inside lazy graph
-/// *construction*, which never reaches `eval`.
+/// Scope: the **CPU** evaluation path only. Concurrent *GPU* evaluation is not
+/// exercised (those tests carry `#[ignore]` and run serialised), nor are races
+/// inside lazy graph *construction*, which never reaches `eval`.
 #[test]
 #[allow(
     clippy::needless_collect,
     reason = "the collect is the concurrency: it spawns every thread before the first join, \
               whereas a lazy iterator would spawn and join one at a time and never overlap them"
 )]
-fn concurrent_first_eval_across_threads_does_not_corrupt_encoder_map() {
+fn concurrent_first_eval_reproducer() {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Barrier};
 
-    // Each thread mints one MLX CPU stream and MLX backs every stream with an
-    // OS thread of its own, so this is charged twice against the process thread
-    // limit — still two orders of magnitude below it.
+    // Cost of this number, measured rather than estimated: the binary peaks at
+    // 412 threads running this test versus 4 without it, and MLX 0.31.2 has no
+    // stream-reclaim path, so the streams minted here — and the OS threads
+    // behind them — persist for the life of the test binary. The whole crate
+    // suite peaks at 446 and is still holding ~436 when it finishes, i.e. every
+    // later test in this binary runs in a 400-thread process.
+    //
+    // Headroom against `sysctl kern.num_taskthreads` (16384 on this machine) is
+    // ~40x. That is the real ceiling; the ~2 048 figure this crate used to cite
+    // is unverified, and against it the margin would be only ~5x. Both are
+    // survivable, neither is "two orders of magnitude" — an earlier revision of
+    // this comment claimed that and was wrong in the unsafe direction.
     const THREADS: usize = 400;
 
     // A barrier alone leaves the threads spread over the condvar wake-up. Park

--- a/crates/rmlx-mlx/src/lib_tests.rs
+++ b/crates/rmlx-mlx/src/lib_tests.rs
@@ -595,42 +595,131 @@ fn cpu_guard_alone_handles_scale_reduction_on_worker_thread() {
     assert_eq!(out, vec![8.0f32]);
 }
 
-/// Executable documentation of the *true* fault class behind the
-/// "There is no Stream(cpu, N) in current thread" crash.
+/// Executable statement of the mechanism the evaluation lock exists for: on the
+/// linked MLX the CPU command-encoder map is **process-global**, so an array
+/// built — and therefore stream-bound — on one thread evaluates perfectly well
+/// on another.
 ///
-/// An MLX array whose ops were built on thread A carries that thread's stream
-/// affinity; evaluating it from thread B throws, because MLX ≥0.31 default
-/// streams (from `new_stream`) are usable only on their thread of creation and
-/// the CPU command-encoder map is thread-local. `ensure_cpu_default_stream` on
-/// the eval thread does NOT fix this (it registers a *different* stream). The
-/// only cures are (a) evaluate the array on its building thread (materialised
-/// arrays are then safe to read anywhere), or (b) an MLX `thread_unsafe` stream,
-/// which mlx-c 0.6.0 does not expose.
+/// That is the whole problem. A map every thread can reach is shared mutable
+/// state, and MLX fills it with no synchronisation
+/// (`mlx/backend/cpu/encoder.cpp::get_command_encoder`), which is why
+/// evaluation has to be serialised on our side — see
+/// `concurrent_first_eval_across_threads_does_not_corrupt_encoder_map`.
 ///
-/// Ignored by default: it deliberately provokes an upstream error and is
-/// timing/version sensitive; it exists to pin the mechanism, not to gate CI.
+/// This also pins *which* upstream model is live. MLX 0.32.0 makes that map
+/// `thread_local` and throws "There is no Stream(cpu, N) in current thread."
+/// for exactly this shape, so if the MLX pin moves, this fails loudly here
+/// instead of quietly invalidating the reasoning in `ensure_cpu_default_stream`.
 #[test]
-#[ignore = "documents upstream MLX cross-thread stream limitation; provokes an error on purpose"]
-fn cross_thread_eval_faults_documents_mlx_limit() {
-    // Establish this (main/test) thread's default CPU stream, then build a lazy
-    // op here so it is bound to this thread's stream.
+fn cross_thread_eval_resolves_through_the_process_global_encoder_map() {
+    // Bind this thread's default CPU stream and put its encoder in the map.
     let warm = add(&mk(&[1.0]), &mk(&[1.0]), Device::Cpu).unwrap();
     warm.eval().unwrap();
-    let c = add(&mk(&[1.0, 2.0]), &mk(&[3.0, 4.0]), Device::Cpu).unwrap();
 
-    // Evaluate the here-built array on a different thread → upstream fault.
-    let res = std::thread::spawn(move || c.eval().map_err(|e| format!("{e}")))
-        .join()
-        .expect("worker thread panicked");
-    assert!(
-        res.is_err(),
-        "expected a cross-thread stream fault; got Ok — MLX behaviour changed"
-    );
-    let msg = res.unwrap_err();
-    assert!(
-        msg.contains("no Stream"),
-        "expected a 'There is no Stream(...)' fault, got: {msg}"
-    );
+    // Build here, so the graph carries this thread's stream, then evaluate it
+    // on a thread that never established a CPU stream of its own.
+    let c = add(&mk(&[1.0, 2.0]), &mk(&[3.0, 4.0]), Device::Cpu).unwrap();
+    let result = std::thread::spawn(move || {
+        c.eval().map_err(|e| format!("{e}"))?;
+        c.to_bytes().map_err(|e| format!("{e}"))
+    })
+    .join()
+    .expect("worker thread panicked");
+
+    let bytes = result.unwrap_or_else(|e| {
+        panic!(
+            "cross-thread CPU eval failed: {e}\n\
+             The encoder map is no longer process-global — MLX 0.32.0 makes it \
+             thread_local and throws here. Recheck ensure_cpu_default_stream's \
+             rationale and the evaluation lock against the new pin."
+        )
+    });
+    assert_eq!(bytes_to_f32(&bytes), vec![4.0f32, 6.0]);
+}
+
+/// Regression gate for the process-global CPU command-encoder map race.
+///
+/// The linked MLX resolves a CPU stream's `CommandEncoder` through a
+/// process-global `std::unordered_map<int, CommandEncoder>` that it fills
+/// **lazily, on first evaluation, with no synchronisation**
+/// (`mlx/backend/cpu/encoder.cpp::get_command_encoder`). Its default-CPU-stream
+/// storage is per-thread (`mlx/stream.cpp::default_stream_storage`), so every
+/// thread that evaluates a CPU graph mints its *own* stream index and therefore
+/// performs its *own* insert into that one shared map. Two inserts in flight
+/// together rehash the map underneath a third thread's bucket walk and the
+/// process takes SIGSEGV — the whole test binary dies and libtest reports no
+/// failing test, because no test failed.
+///
+/// `cargo test` runs each test on its own OS thread, so any crate with many
+/// MLX-touching tests reproduces exactly this shape. This test compresses it
+/// into one burst against a cold map: the map rehashes at every prime bucket
+/// count it grows through, and starting from empty is what puts *all* of those
+/// rehashes inside a single window with hundreds of inserts in flight.
+///
+/// It passes only because `Array::eval` / `Array::async_eval` hold
+/// `EVAL_LOCK` across the FFI call. Drop that and it crashes the binary.
+///
+/// Two honest limits on this as a gate. It is **probabilistic** — measured at
+/// roughly one crash in twenty runs without the lock, so a single green run is
+/// weak evidence and a regression would surface as a rare `make ci` SIGSEGV
+/// rather than a reliable failure. And it covers the **CPU** evaluation path
+/// only: concurrent *GPU* evaluation is not exercised (those tests carry
+/// `#[ignore]` and run serialised), nor are races inside lazy graph
+/// *construction*, which never reaches `eval`.
+#[test]
+#[allow(
+    clippy::needless_collect,
+    reason = "the collect is the concurrency: it spawns every thread before the first join, \
+              whereas a lazy iterator would spawn and join one at a time and never overlap them"
+)]
+fn concurrent_first_eval_across_threads_does_not_corrupt_encoder_map() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Barrier};
+
+    // Each thread mints one MLX CPU stream and MLX backs every stream with an
+    // OS thread of its own, so this is charged twice against the process thread
+    // limit — still two orders of magnitude below it.
+    const THREADS: usize = 400;
+
+    // A barrier alone leaves the threads spread over the condvar wake-up. Park
+    // them on a spinning flag instead: they are already running when it flips,
+    // so the inserts land together.
+    let gate = Arc::new(AtomicBool::new(false));
+    let ready = Arc::new(Barrier::new(THREADS + 1));
+
+    let workers: Vec<_> = (0..THREADS)
+        .map(|i| {
+            let gate = Arc::clone(&gate);
+            let ready = Arc::clone(&ready);
+            std::thread::spawn(move || {
+                let v = i as f32;
+                // Build first. MLX ops are lazy, so this only mints this
+                // thread's CPU stream — and stream creation takes an MLX mutex,
+                // which would otherwise stagger the threads apart before they
+                // ever reach the unsynchronised part.
+                let sum = add(&mk(&[v, v]), &mk(&[v, v]), Device::Cpu).expect("cpu add failed");
+                ready.wait();
+                while !gate.load(Ordering::Acquire) {
+                    std::hint::spin_loop();
+                }
+                sum.eval().expect("cpu eval failed");
+                bytes_to_f32(&sum.to_bytes().expect("to_bytes failed"))
+            })
+        })
+        .collect();
+
+    ready.wait();
+    gate.store(true, Ordering::Release);
+
+    for (i, worker) in workers.into_iter().enumerate() {
+        let got = worker.join().expect("worker thread panicked");
+        let want = (i as f32) * 2.0;
+        assert_eq!(
+            got,
+            vec![want, want],
+            "thread {i} read back the wrong values — encoder map or stream state was corrupted"
+        );
+    }
 }
 
 // ── peak-memory bracket ──────────────────────────────────────────────────

--- a/crates/rmlx-mlx/src/lib_tests.rs
+++ b/crates/rmlx-mlx/src/lib_tests.rs
@@ -637,16 +637,79 @@ fn cross_thread_eval_resolves_through_the_process_global_encoder_map() {
     assert_eq!(bytes_to_f32(&bytes), vec![4.0f32, 6.0]);
 }
 
-/// **A reproducer, not a gate.** Read the power figure below before treating a
-/// green run here as evidence of anything: without the lock this fails about
-/// **1 run in 12** (15 failures in 180 runs, measured), so eleven times out of
-/// twelve it would go green with the defect fully present. The gate for this
-/// defect is `make check-eval-lock`, which is deterministic. What this test
-/// adds is an executable demonstration of the mechanism, and a small standing
-/// chance of catching a *semantic* break that a text gate cannot see. To get
-/// real power out of it, run it across many fresh processes — see
-/// `make eval-lock-stress`; repeating the burst inside one process does not
-/// work, because the map only starts cold once.
+/// The deterministic half of the evaluation-lock gate: `with_eval_lock` really
+/// does exclude.
+///
+/// `make check-eval-lock` proves every evaluation FFI call is *written* inside
+/// a `with_eval_lock` closure — a lexical property. It cannot tell whether the
+/// lock actually locks; a `with_eval_lock` that took no lock would satisfy it
+/// completely. This closes that half, and unlike the burst reproducer it is
+/// deterministic: two threads, no MLX, no 400-thread cost, and it fails every
+/// time if mutual exclusion is lost rather than one run in twelve.
+///
+/// The oracle is independent of the lock's implementation — a flag raised and
+/// cleared *inside* the critical section, with each entrant asserting it found
+/// the section empty. It shares no arithmetic with the code under test.
+#[test]
+fn with_eval_lock_serialises_concurrent_callers() {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    static OCCUPIED: AtomicBool = AtomicBool::new(false);
+    static OVERLAPS: AtomicUsize = AtomicUsize::new(0);
+
+    // Long enough that a lost lock overlaps essentially every iteration, short
+    // enough that the whole test stays well under a second.
+    const ITERS: usize = 200;
+    const HOLD: std::time::Duration = std::time::Duration::from_micros(50);
+
+    let worker = || {
+        for _ in 0..ITERS {
+            with_eval_lock(|| {
+                // Entering: the section must have been empty.
+                if OCCUPIED.swap(true, Ordering::SeqCst) {
+                    OVERLAPS.fetch_add(1, Ordering::SeqCst);
+                }
+                std::thread::sleep(HOLD);
+                // Leaving: and must still have been ours.
+                if !OCCUPIED.swap(false, Ordering::SeqCst) {
+                    OVERLAPS.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+        }
+    };
+
+    let a = std::thread::spawn(worker);
+    let b = std::thread::spawn(worker);
+    a.join().expect("thread a panicked");
+    b.join().expect("thread b panicked");
+
+    assert_eq!(
+        OVERLAPS.load(Ordering::SeqCst),
+        0,
+        "two threads were inside with_eval_lock at the same time — the evaluation \
+         lock is not excluding, so every MLX eval FFI call under it is unprotected"
+    );
+}
+
+/// **A reproducer, not a gate — and deliberately out of the default run.**
+/// Without the lock it fails about **1 run in 12** (15 in 180, measured), so
+/// eleven times in twelve it would go green with the defect fully present.
+/// Worse, that figure was measured the way `make eval-lock-stress` runs it:
+/// alone, against a genuinely cold encoder map. Inside a normal `cargo test`
+/// the map is already warm from every other MLX-touching test, so its real
+/// detection chance there is lower still and has never been measured — while
+/// its cost is exact and certain (412 threads peak against 4 without it, ~436
+/// still resident when the suite ends, in a binary whose test order is
+/// nondeterministic). A gate whose cost is measured and whose benefit is not
+/// does not belong in `make ci`.
+///
+/// The gates for this defect are `make check-eval-lock` (every eval FFI call
+/// is made under the lock) and
+/// `with_eval_lock_serialises_concurrent_callers` (the lock actually excludes),
+/// both deterministic. This test is the end-to-end demonstration that the two
+/// of them together prevent the real crash; run it with
+/// `make eval-lock-stress`, which drives it across fresh processes because the
+/// map only starts cold once per process.
 ///
 /// The linked MLX resolves a CPU stream's `CommandEncoder` through a
 /// process-global `std::unordered_map<int, CommandEncoder>` that it fills
@@ -674,6 +737,9 @@ fn cross_thread_eval_resolves_through_the_process_global_encoder_map() {
 /// exercised (those tests carry `#[ignore]` and run serialised), nor are races
 /// inside lazy graph *construction*, which never reaches `eval`.
 #[test]
+// Not a GPU test — CPU only. Ignored because it is probabilistic and costs
+// ~412 threads; `make eval-lock-stress` is its runner and passes `--ignored`.
+#[ignore = "probabilistic reproducer, ~412 threads — run via `make eval-lock-stress`"]
 #[allow(
     clippy::needless_collect,
     reason = "the collect is the concurrency: it spawns every thread before the first join, \

--- a/crates/rmlx-mlx/src/sys.rs
+++ b/crates/rmlx-mlx/src/sys.rs
@@ -16,6 +16,12 @@
 //!   through the safe wrappers in [`super::ops`] and [`super::fast_ops`].
 //! - The `ffi` mod suppresses every clippy and rustdoc lint; that is
 //!   intentional — the generated file is not under our control.
+//! - **`mod ffi` is private, deliberately.** `pub(crate) use ffi::*` below
+//!   re-exports every symbol as `sys::mlx_*`, so that is the single spelling
+//!   for an mlx-c call anywhere in the crate. Making the module itself
+//!   `pub(crate)` would also admit `sys::ffi::mlx_*`, a second spelling of the
+//!   same function that the `check-eval-lock` gate's `sys::mlx_*` anchor does
+//!   not match — an unguarded evaluation could then pass the gate.
 #[allow(
     non_upper_case_globals,
     non_camel_case_types,
@@ -26,7 +32,7 @@
     clippy::all,
     clippy::pedantic
 )]
-pub(crate) mod ffi {
+mod ffi {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -588,14 +588,27 @@ Three consequences worth knowing:
 
 ### Which C entry points need the lock
 
-**Twenty-four**, not the three this workspace happens to call. The set was
-derived by reverse reachability over the linked dylibs — `otool -tvV` on
-`libmlxc.dylib` and `libmlx.dylib`, transitive callers backwards from both
-`mlx::core::eval_impl` and the hazard symbol itself,
-`mlx::core::cpu::get_command_encoder(Stream)`, intersected with the exported
-`mlx_*` C ABI. Both directions agree. The exact procedure is recorded in
-`scripts/check_eval_lock.sh`; **re-run it when the mlx / mlx-c pin moves**
-rather than re-deriving it by eye.
+**Twenty-five**, not the three this workspace happens to call — and they come
+from *two* passes, because one of them is structurally blind to a quarter of
+the problem.
+
+**Pass 1 — automated, direct calls (24 symbols).** Reverse reachability over
+the linked dylibs: `otool -tvV` on `libmlxc.dylib` and `libmlx.dylib`,
+transitive callers backwards from both `mlx::core::eval_impl` and the hazard
+symbol itself `mlx::core::cpu::get_command_encoder(Stream)`, intersected with
+the exported `mlx_*` C ABI. Both directions agree.
+
+**Pass 2 — by hand, indirect dispatch (1 more).** `mlx_closure_apply` reaches
+evaluation through a `std::function` — a `blr` on a vtable slot — which reverse
+reachability over a disassembly does not traverse. It does **not** appear in
+pass 1's output and never will.
+
+> **Re-running pass 1 at a pin bump gives 24, with `mlx_closure_apply` absent.
+> That is the automated pass's blind spot, not a stale entry — do not "correct"
+> the gate by deleting the closure guard.**
+
+The exact procedure, and the other closure-taking entry points to re-audit at a
+pin bump, are recorded in `scripts/check_eval_lock.sh`.
 
 | Entry point | Count | Why it evaluates | Called here |
 |---|---|---|---|
@@ -608,7 +621,7 @@ rather than re-deriving it by eye.
 | `mlx_save`, `mlx_save_writer`, `mlx_save_safetensors`, `mlx_save_safetensors_writer`, `mlx_save_gguf`, `mlx_load_gguf` | 6 | serialisation materialises before writing | no |
 | `mlx_array_data_*` | — | **does not evaluate** — plain pointer accessors | yes, unguarded and correct |
 
-The twenty-one uncalled ones are the live risk. They sit in the bindings one
+The twenty-two uncalled ones are the live risk. They sit in the bindings one
 call away and read as innocuous: `mlx_array_item_float32` looks like a scalar
 accessor, `mlx_array_tostring` is what an `impl Debug for Array` reaches for,
 and `mlx_save_safetensors` is the **write side of `rmlx convert`**, a named
@@ -618,24 +631,36 @@ original bug.
 
 `mlx_closure_apply` is the one that is not obvious in either direction:
 applying a closure looks like pure graph construction, and the evaluation is
-reached through a `std::function` vtable, so it is invisible to a text scan of
-call sites. It is guarded, and because the Rust closure body runs *inside* that
-call with the lock held, a body that evaluated would self-deadlock on the
-non-reentrant mutex. No body does; RULE 3 of the gate keeps it that way.
+reached through a `std::function` vtable, so it is invisible both to a text
+scan of call sites and to pass 1 above. It is guarded, and because the Rust
+closure body runs *inside* that call with the lock held, a body that **takes
+the lock again** self-deadlocks on the non-reentrant mutex. Note that ban is
+broader than "must not evaluate" — `Closure::apply` takes the lock, so a body
+applying another compiled closure deadlocks without calling `eval` anywhere,
+which is the first shape a "fuse two fused kernels" refactor produces. No body
+does either today; RULE 3 of the gate keeps it that way.
 
 ### The three things that hold this together
 
 | | Kind | Catches | Misses |
 |---|---|---|---|
-| `make check-eval-lock` | text gate, deterministic | an unguarded call to any of the 24; a guard dropped from a call site; a closure body that evaluates | a disarmed lock — the lexical structure is unchanged, so it stays green |
+| `make check-eval-lock` | text gate, deterministic | an unguarded call to any of the 25; a guard dropped from a call site; a closure body that takes the lock again | a disarmed lock — the lexical structure is unchanged, so it stays green |
 | `with_eval_lock_serialises_concurrent_callers` | unit test, deterministic | a lock that does not actually exclude | anything about *which* calls take the lock |
 | `make eval-lock-stress` | reproducer driver, probabilistic | the real end-to-end crash | ~1 run in 12 per process, so it needs N≥60 to mean anything |
 
-The first two are in `make ci` and are complementary by construction — each is
-blind to exactly what the other catches; that was verified by mutation, not
-assumed. `make check-eval-lock-fixtures` is the recall test for the first, with
-thirteen synthetic scan roots pinning both its positives and its false-positive
-holes.
+The first two are in `make ci` **and in the hosted `source gates` job**, and are
+complementary by construction — each is blind to exactly what the other
+catches; that was verified by mutation, not assumed.
+
+`make check-eval-lock-fixtures` is the recall test for the first: 26 synthetic
+scan roots, each asserting an exit code **and which rule fired**. Asserting the
+rule is the point — an earlier corpus checked exit codes only, and because every
+must-fail fixture happened to contain no guarded call site, each one tripped
+RULE 2's anti-vacuity branch and exited 1 regardless of the rule under test.
+Deleting RULE 1 or RULE 3 outright left that corpus green. Every RULE 1 / RULE 3
+fixture now ends with a correctly-guarded `guarded_anchor` so the failure is
+attributable. The corpus is itself mutation-tested: 17 mutations of the gate,
+17 killed, 0 survivors.
 
 The stress driver is **not** in `make ci`, and the reproducer it drives carries
 `#[ignore]`. Its measured 8% failure rate was taken the way the driver runs it —

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -556,6 +556,8 @@ methods trigger execution:
 
 **Both are serialised process-wide by `EVAL_LOCK`** (`crates/rmlx-mlx/src/lib.rs`),
 via `with_eval_lock`, which holds the lock across the FFI call and nothing else.
+So is `Closure::apply` — see the reach-set table below for why a closure
+application evaluates.
 MLX evaluation is not safe to drive from two threads at once on the pinned
 0.31.x: the CPU command-encoder table described above is a process-global map
 filled without synchronisation, so two concurrent evaluations rehash it under
@@ -586,34 +588,62 @@ Three consequences worth knowing:
 
 ### Which C entry points need the lock
 
-Every mlx-c function that reaches `mlx::core::eval_impl`, not just the two this
-workspace calls today. From the generated bindings:
+**Twenty-four**, not the three this workspace happens to call. The set was
+derived by reverse reachability over the linked dylibs — `otool -tvV` on
+`libmlxc.dylib` and `libmlx.dylib`, transitive callers backwards from both
+`mlx::core::eval_impl` and the hazard symbol itself,
+`mlx::core::cpu::get_command_encoder(Stream)`, intersected with the exported
+`mlx_*` C ABI. Both directions agree. The exact procedure is recorded in
+`scripts/check_eval_lock.sh`; **re-run it when the mlx / mlx-c pin moves**
+rather than re-deriving it by eye.
 
-| Entry point | Count | Evaluates? | Called here |
+| Entry point | Count | Why it evaluates | Called here |
 |---|---|---|---|
-| `mlx_array_eval` | 1 | yes | yes, guarded |
-| `mlx_async_eval` | 1 | yes | yes, guarded |
-| `mlx_eval` | 1 | yes | no |
-| `mlx_array_item_*` | 14 | yes — via `array::item<T>()`, which calls `eval()` first (`mlx/array.h`) | no |
-| `mlx_array_data_*` | — | **no**, plain pointer accessors | yes, unguarded and correct |
+| `mlx_array_eval` | 1 | directly | yes, guarded |
+| `mlx_async_eval` | 1 | directly | yes, guarded |
+| `mlx_closure_apply` | 1 | **indirectly** — building the fused `Compiled` primitive bakes scalar constants into the kernel library name: `print_constant` → `array::item<T>()` → `array::eval()` (`mlx/backend/common/compiled.cpp`) | yes, guarded |
+| `mlx_eval` | 1 | directly | no |
+| `mlx_array_item_*` | 14 | `array::item<T>()` evaluates before reading (`mlx/array.h`) | no |
+| `mlx_array_tostring` | 1 | `operator<<(ostream&, array)` evaluates | no |
+| `mlx_save`, `mlx_save_writer`, `mlx_save_safetensors`, `mlx_save_safetensors_writer`, `mlx_save_gguf`, `mlx_load_gguf` | 6 | serialisation materialises before writing | no |
+| `mlx_array_data_*` | — | **does not evaluate** — plain pointer accessors | yes, unguarded and correct |
 
-The fifteen uncalled ones are the live risk: they sit in the bindings one call
-away and read as innocuous, `mlx_array_item_float32` most of all. Adding one
-unguarded reinstates this exact defect, with a signature — whole test binary
-dies, no test named — indistinguishable from the original bug.
+The twenty-one uncalled ones are the live risk. They sit in the bindings one
+call away and read as innocuous: `mlx_array_item_float32` looks like a scalar
+accessor, `mlx_array_tostring` is what an `impl Debug for Array` reaches for,
+and `mlx_save_safetensors` is the **write side of `rmlx convert`**, a named
+0.1.0 deliverable. Adding one unguarded reinstates this exact defect, with a
+signature — whole test binary dies, no test named — indistinguishable from the
+original bug.
 
-**`make check-eval-lock` enforces this**, because a doc sentence is not a gate:
-it fails on any call to `sys::mlx_eval` / `sys::mlx_array_item_*`, and on any
-call to the two guarded entry points that is not made under `with_eval_lock`.
-Re-derive the table above when the mlx / mlx-c pin moves — the gate's pattern
-list is hand-maintained and will not flag a newly-added evaluating entry point
-on its own. `scripts/check_eval_lock.sh` documents the rest of its blind spots.
+`mlx_closure_apply` is the one that is not obvious in either direction:
+applying a closure looks like pure graph construction, and the evaluation is
+reached through a `std::function` vtable, so it is invisible to a text scan of
+call sites. It is guarded, and because the Rust closure body runs *inside* that
+call with the lock held, a body that evaluated would self-deadlock on the
+non-reentrant mutex. No body does; RULE 3 of the gate keeps it that way.
 
-**`make eval-lock-stress`** drives the reproducer across N fresh processes
-(default 60) and fails on any non-zero exit. It exists because the in-suite
-reproducer, `concurrent_first_eval_reproducer`, only fails about 1 run in 12
-without the lock — fine as a demonstration, far too weak to gate on. Power
-comes from re-exec, not from looping in-process: the map only starts cold once.
+### The three things that hold this together
+
+| | Kind | Catches | Misses |
+|---|---|---|---|
+| `make check-eval-lock` | text gate, deterministic | an unguarded call to any of the 24; a guard dropped from a call site; a closure body that evaluates | a disarmed lock — the lexical structure is unchanged, so it stays green |
+| `with_eval_lock_serialises_concurrent_callers` | unit test, deterministic | a lock that does not actually exclude | anything about *which* calls take the lock |
+| `make eval-lock-stress` | reproducer driver, probabilistic | the real end-to-end crash | ~1 run in 12 per process, so it needs N≥60 to mean anything |
+
+The first two are in `make ci` and are complementary by construction — each is
+blind to exactly what the other catches; that was verified by mutation, not
+assumed. `make check-eval-lock-fixtures` is the recall test for the first, with
+thirteen synthetic scan roots pinning both its positives and its false-positive
+holes.
+
+The stress driver is **not** in `make ci`, and the reproducer it drives carries
+`#[ignore]`. Its measured 8% failure rate was taken the way the driver runs it —
+alone, against a cold encoder map. Inside a normal `cargo test` the map is
+already warm from other tests, so its detection chance there is lower still and
+was never measured, while its cost is exact: 412 threads peak against 4 without
+it, ~436 still resident at suite end, in a binary whose test order is
+nondeterministic. Measured cost plus unmeasured benefit is not a gate.
 
 **Never `eval()` a kernel's inputs before dispatching it.** `Array::eval()`
 blocks the calling thread until the GPU has produced the array, so an `eval()`

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -381,20 +381,37 @@ ML-semantic effect.
 
 ### Per-thread CPU stream context — `ensure_cpu_default_stream`
 
-The same thread-local-encoder problem exists on the CPU side, independently of
-the GPU one: MLX's CPU backend resolves a stream's `CommandEncoder` through a
-**thread-local** map first
-(`mlx/backend/cpu/encoder.cpp::get_command_encoder`), falling back to a
-process-global map and otherwise throwing `There is no Stream(cpu, N) in
-current thread.` A worker thread whose graph includes a CPU-scheduled op —
-e.g. the K8V8 `exit_prefill` quantization's scale reduction, which MLX places
-on the CPU stream even though the surrounding quantize dispatch runs on the
-GPU device — can fault the same way the GPU path did (issue #206).
+A worker thread whose graph includes a CPU-scheduled op — e.g. the K8V8
+`exit_prefill` quantization's scale reduction, which MLX places on the CPU
+stream even though the surrounding quantize dispatch runs on the GPU device —
+needs a CPU stream of its own, the same way the GPU path did.
+
+**How MLX resolves the CPU encoder is version-specific, and the two versions
+behave oppositely — do not reason from the wrong one:**
+
+| | 0.31.x (**the pinned version**) | 0.32.0 |
+|---|---|---|
+| `cpu::get_command_encoder` map | one **process-global** `unordered_map<int, CommandEncoder>` | `thread_local`, with a process-global fallback |
+| Populated | lazily, on first evaluation, **with no synchronisation** | at stream registration |
+| Unregistered stream | silently inserted | throws `There is no Stream(cpu, N) in current thread.` |
+| Cross-thread eval | succeeds | throws |
+
+Default CPU streams are per-thread either way (`mlx/stream.cpp`:
+`static thread_local ... default_streams`), so on the pinned version every
+thread that evaluates mints its own stream index and inserts into that one
+shared map. That unsynchronised insert is a genuine upstream defect — the
+neighbouring `Scheduler::threads_` map in `mlx/scheduler.h` *is* mutex-guarded —
+and it is what `EVAL_LOCK` (below) contains. MLX 0.32.0 fixes it by making the
+map thread-local; we do not pin that version because its bottle ships no NAX
+GEMM kernels.
 
 `rmlx_mlx::ensure_cpu_default_stream()` is the CPU analog of
 `ensure_gpu_default_stream()`: same mechanism (create a stream, register it as
 the calling thread's default, leak the handle in a thread-local for the
-thread's lifetime), same idempotency guarantee, zero ML-semantic effect.
+thread's lifetime), same idempotency guarantee, zero ML-semantic effect. On
+0.31.x it is not load-bearing for a thread that builds and evaluates its own
+graph — MLX self-registers there — but it pins the thread's stream identity
+explicitly and is what keeps the code correct if the pin moves to 0.32.0.
 
 **Contract:** every blocking-thread inference entry point calls
 `ensure_cpu_default_stream()` **unconditionally** (not gated on the resolved
@@ -423,8 +440,12 @@ unbounded over long serve uptime (which would otherwise eventually exhaust the
 process lifetime regardless.
 
 See `docs/KV_CACHE.md` §5.7.5 and `docs/KV_QUANT.md` for the `exit_prefill`
-mechanism this guards, including the guard's limitation (it registers the
-*worker's own* stream — it does not fix a genuinely cross-thread eval).
+mechanism this guards. Note the guard's scope: it registers the *worker's own*
+stream. On the pinned 0.31.x that is all anyone needs — a cross-thread eval
+resolves through the process-global map and succeeds
+(`cross_thread_eval_resolves_through_the_process_global_encoder_map` pins this).
+On 0.32.0 a cross-thread eval throws and the guard would not help, because it
+registers a different stream than the one the foreign array is bound to.
 
 ### Null sentinel for optional arguments
 
@@ -532,6 +553,29 @@ methods trigger execution:
   to pipeline the next decode step's forward pass on the GPU while the
   current step's argmax is still being read back to the CPU, mirroring
   mlx-lm's `mx.async_eval` pattern in `generate.py`.
+
+**Both are serialised process-wide by `EVAL_LOCK`** (`crates/rmlx-mlx/src/lib.rs`),
+a `Mutex<()>` held across the FFI call and nothing else. MLX evaluation is not
+safe to drive from two threads at once on the pinned 0.31.x: the CPU
+command-encoder table described above is a process-global map filled without
+synchronisation, so two concurrent evaluations rehash it under each other and
+the process takes SIGSEGV inside MLX — no Rust frame at fault, no failing test
+reported, nothing to catch. `cargo test` runs one OS thread per test, which is
+how this reached `make ci` as an intermittent crash of the whole test binary.
+
+Three consequences worth knowing:
+
+- **Cost is one uncontended atomic per evaluation.** rMLX runs inference on one
+  thread at a time by design (and the server has its own `gpu_gate` above that),
+  so the lock is a crash guard, not a throughput bottleneck.
+- **`async_eval` still pipelines.** Only the graph walk and dispatch happen
+  under the lock; the scheduled work completes after it is released.
+- **The lock is not a licence to evaluate concurrently.** It makes concurrent
+  callers correct, not parallel — they serialise.
+
+New FFI entry points that can reach `mlx::core::eval_impl` must take the same
+lock. Today that is exactly `mlx_array_eval` and `mlx_async_eval`; mlx-c's
+data accessors (`mlx_array_data_*`) do not evaluate.
 
 **Never `eval()` a kernel's inputs before dispatching it.** `Array::eval()`
 blocks the calling thread until the GPU has produced the array, so an `eval()`

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -555,27 +555,65 @@ methods trigger execution:
   mlx-lm's `mx.async_eval` pattern in `generate.py`.
 
 **Both are serialised process-wide by `EVAL_LOCK`** (`crates/rmlx-mlx/src/lib.rs`),
-a `Mutex<()>` held across the FFI call and nothing else. MLX evaluation is not
-safe to drive from two threads at once on the pinned 0.31.x: the CPU
-command-encoder table described above is a process-global map filled without
-synchronisation, so two concurrent evaluations rehash it under each other and
-the process takes SIGSEGV inside MLX — no Rust frame at fault, no failing test
-reported, nothing to catch. `cargo test` runs one OS thread per test, which is
-how this reached `make ci` as an intermittent crash of the whole test binary.
+via `with_eval_lock`, which holds the lock across the FFI call and nothing else.
+MLX evaluation is not safe to drive from two threads at once on the pinned
+0.31.x: the CPU command-encoder table described above is a process-global map
+filled without synchronisation, so two concurrent evaluations rehash it under
+each other. The process then dies inside MLX with no Rust frame at fault and
+nothing to catch — observed as SIGSEGV, as SIGTRAP, and as an infinite spin on
+a bucket chain that became circular. libtest names no failing test, because
+none failed. `cargo test` runs one OS thread per test, which is how this
+reached `make ci` as an intermittent crash of a whole test binary.
+
+`with_eval_lock` takes a closure rather than returning a guard on purpose: with
+a guard-returning helper, `let _ = acquire();` would drop the guard before the
+FFI call and silently restore the crash, and `MutexGuard`'s `#[must_use]` does
+not fire on `let _ =`.
 
 Three consequences worth knowing:
 
-- **Cost is one uncontended atomic per evaluation.** rMLX runs inference on one
-  thread at a time by design (and the server has its own `gpu_gate` above that),
-  so the lock is a crash guard, not a throughput bottleneck.
+- **Cost is one uncontended mutex acquire + release per evaluation** — a CAS
+  and a release store, tens of nanoseconds, against an FFI call that walks a
+  graph and dispatches work in microseconds or more. (Order-of-magnitude
+  reasoning, not a measurement; it has not been isolated on a decode bench.)
+  Under contention it would be a futex syscall, but rMLX runs inference on one
+  thread at a time by design and the server holds a 1-permit `gpu_queue` and
+  `gpu_gate` above that, so contention is not the steady state.
 - **`async_eval` still pipelines.** Only the graph walk and dispatch happen
   under the lock; the scheduled work completes after it is released.
 - **The lock is not a licence to evaluate concurrently.** It makes concurrent
   callers correct, not parallel — they serialise.
 
-New FFI entry points that can reach `mlx::core::eval_impl` must take the same
-lock. Today that is exactly `mlx_array_eval` and `mlx_async_eval`; mlx-c's
-data accessors (`mlx_array_data_*`) do not evaluate.
+### Which C entry points need the lock
+
+Every mlx-c function that reaches `mlx::core::eval_impl`, not just the two this
+workspace calls today. From the generated bindings:
+
+| Entry point | Count | Evaluates? | Called here |
+|---|---|---|---|
+| `mlx_array_eval` | 1 | yes | yes, guarded |
+| `mlx_async_eval` | 1 | yes | yes, guarded |
+| `mlx_eval` | 1 | yes | no |
+| `mlx_array_item_*` | 14 | yes — via `array::item<T>()`, which calls `eval()` first (`mlx/array.h`) | no |
+| `mlx_array_data_*` | — | **no**, plain pointer accessors | yes, unguarded and correct |
+
+The fifteen uncalled ones are the live risk: they sit in the bindings one call
+away and read as innocuous, `mlx_array_item_float32` most of all. Adding one
+unguarded reinstates this exact defect, with a signature — whole test binary
+dies, no test named — indistinguishable from the original bug.
+
+**`make check-eval-lock` enforces this**, because a doc sentence is not a gate:
+it fails on any call to `sys::mlx_eval` / `sys::mlx_array_item_*`, and on any
+call to the two guarded entry points that is not made under `with_eval_lock`.
+Re-derive the table above when the mlx / mlx-c pin moves — the gate's pattern
+list is hand-maintained and will not flag a newly-added evaluating entry point
+on its own. `scripts/check_eval_lock.sh` documents the rest of its blind spots.
+
+**`make eval-lock-stress`** drives the reproducer across N fresh processes
+(default 60) and fails on any non-zero exit. It exists because the in-suite
+reproducer, `concurrent_first_eval_reproducer`, only fails about 1 run in 12
+without the lock — fine as a demonstration, far too weak to gate on. Power
+comes from re-exec, not from looping in-process: the map only starts cold once.
 
 **Never `eval()` a kernel's inputs before dispatching it.** `Array::eval()`
 blocks the calling thread until the GPU has produced the array, so an `eval()`

--- a/scripts/check_eval_lock.sh
+++ b/scripts/check_eval_lock.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# scripts/check_eval_lock.sh — CI gate: every FFI call that can reach
+# `mlx::core::eval_impl` must be made under the process-wide evaluation lock.
+#
+# THE BUG THIS PINS
+#   The linked MLX (0.31.x) resolves a CPU stream's `CommandEncoder` through a
+#   *process-global* `std::unordered_map<int, CommandEncoder>` that
+#   `mlx/backend/cpu/encoder.cpp::get_command_encoder` fills lazily, on the
+#   evaluating thread, with no synchronisation. Default CPU streams are
+#   per-thread, so every thread that evaluates mints its own stream index and
+#   performs its own insert into that one shared map. Two inserts in flight
+#   together rehash it under a third thread's bucket walk.
+#
+#   The result is a SIGSEGV (or SIGTRAP, or an infinite spin on a bucket chain
+#   that became circular) *inside MLX*, on a thread named after whichever test
+#   happened to be running. libtest names no failing test, because none failed
+#   — the process died. `cargo test` runs one OS thread per test, so this
+#   reached `make ci` as an intermittent crash of a whole test binary that
+#   never reproduced in isolation and was indistinguishable from a real
+#   regression in the branch under test.
+#
+#   `rmlx_mlx::with_eval_lock` contains it by serialising evaluation
+#   process-wide.
+#
+# WHY A GREP GATE AND NOT A TEST
+#   The reproducer for this (`concurrent_first_eval_reproducer`) is
+#   probabilistic — measured at roughly one failure in twelve runs without the
+#   lock. That is far too weak to gate on: eleven times in twelve, deleting the
+#   lock would go green. The *structural* regressions, though, are exactly the
+#   ones a text gate catches deterministically:
+#
+#     1. Someone drops the lock from a guarded call site.
+#     2. Someone adds a call to one of the other C entry points that evaluate.
+#
+#   Case 2 is the live risk. Only two of the seventeen reachable entry points
+#   are called today; the other fifteen sit in the generated bindings, one call
+#   away, and look completely innocuous — `mlx_array_item_float32` reads like a
+#   scalar accessor, not an evaluation.
+#
+# THE REACH-SET (derived from the generated mlx-c bindings, not guessed)
+#   Reaches `eval_impl`, therefore needs the lock:
+#     - mlx_array_eval          (called here, guarded)
+#     - mlx_async_eval          (called here, guarded)
+#     - mlx_eval                (not called here)
+#     - mlx_array_item_*        (14 of them, not called here) — each goes
+#                               through `array::item<T>()`, which calls
+#                               `eval()` before reading the value; see
+#                               `item()` in mlx/array.h.
+#   Does NOT evaluate, needs no lock:
+#     - mlx_array_data_*        (plain pointer accessors)
+#
+# THE RULES
+#   RULE 1  No call to `sys::mlx_eval(` or `sys::mlx_array_item_*(` anywhere.
+#           These have no guarded wrapper, so any call is unguarded by
+#           construction. If one is genuinely needed, wrap it in
+#           `with_eval_lock` and add it to RULE 2's allowed set here.
+#   RULE 2  Every call to `sys::mlx_array_eval(` / `sys::mlx_async_eval(` must
+#           have `with_eval_lock` within the 3 lines ending at the call, so a
+#           rustfmt line-wrap does not trip it.
+#
+# WHAT THIS GATE CANNOT REACH — know the boundary before trusting it
+#   * It is a text scan. A call made through an alias (`use ... as f; f()`), a
+#     macro expansion, a function pointer or a transmute is invisible to it.
+#   * The reach-set above is hand-derived from the bindings as they are today.
+#     An mlx-c bump that adds a new evaluating entry point will not be flagged
+#     until someone extends RULE 1's pattern list. Re-derive it when the
+#     mlx / mlx-c pin moves.
+#   * It proves lexical adjacency, not that the lock is held at runtime. A
+#     `with_eval_lock` call on a neighbouring but unrelated line would satisfy
+#     it. The closure-taking signature of `with_eval_lock` is what makes that
+#     shape hard to write by accident.
+#   * It says nothing about concurrent *graph construction*, which never
+#     reaches `eval_impl`.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${REPO_ROOT}/crates"
+
+if [ ! -d "${SCAN_DIR}" ]; then
+    echo "check_eval_lock: no crates dir at ${SCAN_DIR}" >&2
+    exit 1
+fi
+
+fail=0
+
+# ---- RULE 1: entry points with no guarded wrapper must not be called -------
+#
+# Anchored on `sys::` + an open paren, so prose in comments and docs that names
+# these functions in backticks does not trip the gate.
+banned_hits="$(grep -rnE 'sys::(mlx_eval|mlx_array_item_[A-Za-z0-9_]*)[[:space:]]*\(' \
+    --include='*.rs' "${SCAN_DIR}" || true)"
+
+if [ -n "${banned_hits}" ]; then
+    fail=1
+    echo "check_eval_lock: RULE 1 — call to an MLX entry point that evaluates but has no guarded wrapper." >&2
+    echo "${banned_hits}" | sed 's/^/  /' >&2
+    echo >&2
+    echo "  These reach mlx::core::eval_impl and therefore the unsynchronised" >&2
+    echo "  process-global CPU command-encoder map. Wrap the call in" >&2
+    echo "  rmlx_mlx::with_eval_lock and add it to this gate's allowed set." >&2
+    echo >&2
+fi
+
+# ---- RULE 2: guarded entry points must be called under the lock ------------
+
+guarded_hits="$(grep -rnE 'sys::(mlx_array_eval|mlx_async_eval)[[:space:]]*\(' \
+    --include='*.rs' "${SCAN_DIR}" || true)"
+
+if [ -z "${guarded_hits}" ]; then
+    fail=1
+    echo "check_eval_lock: RULE 2 — no call to sys::mlx_array_eval / sys::mlx_async_eval found at all." >&2
+    echo "  The gate keys on those call sites; if they were renamed or removed," >&2
+    echo "  this gate is no longer checking anything and must be updated." >&2
+    echo >&2
+fi
+
+while IFS= read -r hit; do
+    [ -z "${hit}" ] && continue
+    file="${hit%%:*}"
+    rest="${hit#*:}"
+    line="${rest%%:*}"
+
+    # Window: the call line and the 3 lines above it, so a rustfmt wrap of
+    # `with_eval_lock(|| unsafe { ... })` across lines still satisfies the gate.
+    start=$(( line > 3 ? line - 3 : 1 ))
+    window="$(sed -n "${start},${line}p" "${file}")"
+
+    if ! printf '%s' "${window}" | grep -q 'with_eval_lock'; then
+        fail=1
+        echo "check_eval_lock: RULE 2 — evaluation FFI call not under the evaluation lock:" >&2
+        echo "  ${file}:${line}" >&2
+        echo "  Wrap it: with_eval_lock(|| unsafe { sys::... })" >&2
+        echo >&2
+    fi
+done <<< "${guarded_hits}"
+
+if [ "${fail}" -ne 0 ]; then
+    echo "check_eval_lock: FAILED" >&2
+    exit 1
+fi
+
+echo "OK: every MLX evaluation FFI call is made under the evaluation lock."

--- a/scripts/check_eval_lock.sh
+++ b/scripts/check_eval_lock.sh
@@ -118,6 +118,19 @@
 #   * It proves lexical structure, not runtime behaviour.
 #   * It says nothing about concurrent *graph construction*, which never
 #     reaches `eval_impl`.
+#
+# AWK PORTABILITY — measured, not reasoned about
+#   This gate and its 26-fixture corpus give identical verdicts under gawk
+#   5.4.1, mawk 1.3.4 and BSD awk 20200816, each under both LC_ALL=C and
+#   LC_ALL=en_US.UTF-8, with all 17 gate mutations killed in all six
+#   combinations. The awk below is POSIX-only on purpose: no `gensub`, no `\s`,
+#   no `{n,m}` intervals (mawk's support is version-dependent) and no octal
+#   escapes in bracket expressions (BSD awk accepts `[\300-\337]`, Linux awk
+#   rejects it outright). `length`/`substr` do go character-based rather than
+#   byte-based under a UTF-8 locale, but `strip()` only ever reconstructs by
+#   concatenation, so its output is byte-identical either way. The scripts call
+#   bare `awk`, so re-checking this means putting a shim named `awk` first on
+#   PATH — there is no AWK= override to reach for.
 
 set -euo pipefail
 

--- a/scripts/check_eval_lock.sh
+++ b/scripts/check_eval_lock.sh
@@ -119,18 +119,39 @@
 #   * It says nothing about concurrent *graph construction*, which never
 #     reaches `eval_impl`.
 #
-# AWK PORTABILITY — measured, not reasoned about
-#   This gate and its 26-fixture corpus give identical verdicts under gawk
-#   5.4.1, mawk 1.3.4 and BSD awk 20200816, each under both LC_ALL=C and
+# INTERPRETER PORTABILITY — measured, not reasoned about
+#   Two external interpreters decide this gate's verdict: `awk` (three scan
+#   helpers below) and `grep` (four call sites below, one more in the fixture
+#   runner). Hosted CI runs GNU builds of both on Linux; this machine's
+#   defaults are neither. So both were measured rather than argued about.
+#
+#   awk — this gate and its 26-fixture corpus give identical verdicts under
+#   gawk 5.4.1, mawk 1.3.4 and BSD awk 20200816, each under both LC_ALL=C and
 #   LC_ALL=en_US.UTF-8, with all 17 gate mutations killed in all six
 #   combinations. The awk below is POSIX-only on purpose: no `gensub`, no `\s`,
 #   no `{n,m}` intervals (mawk's support is version-dependent) and no octal
 #   escapes in bracket expressions (BSD awk accepts `[\300-\337]`, Linux awk
 #   rejects it outright). `length`/`substr` do go character-based rather than
 #   byte-based under a UTF-8 locale, but `strip()` only ever reconstructs by
-#   concatenation, so its output is byte-identical either way. The scripts call
-#   bare `awk`, so re-checking this means putting a shim named `awk` first on
-#   PATH — there is no AWK= override to reach for.
+#   concatenation, so its output is byte-identical either way.
+#
+#   grep — the same two artefacts give byte-identical output and exit code
+#   under BSD grep 2.6.0-FreeBSD and GNU grep 3.12, each under both LC_ALL=C
+#   and LC_ALL=en_US.UTF-8: 4 combinations, plus all 17 mutations killed in
+#   every one of the resulting 68 cells. `BANNED_RE`, `GUARDED_RE` and the
+#   RULE 3 pattern are plain POSIX ERE — no `\s`, no `\d`, no `\b`/`\<` word
+#   boundaries, no `{n,m}` intervals, and no octal escapes in bracket
+#   expressions, which is the same trap the awk paragraph names. `-r` and
+#   `--include` are the only non-POSIX flags used and both engines have them.
+#   The `[A-Za-z0-9_]` ranges are the one locale-collation-sensitive construct
+#   left; the `banned_item` and `banned_save*` fixtures exercise them in both
+#   locales.
+#
+#   Both scripts call bare `awk` and bare `grep`, so re-checking any of this
+#   means putting a shim of that name first on PATH — there is no AWK= or
+#   GREP= override to reach for. Make the shim log which binary it exec'd and
+#   assert on that log: a matrix that silently ran the host default in every
+#   cell proves nothing and looks exactly like one that did not.
 
 set -euo pipefail
 

--- a/scripts/check_eval_lock.sh
+++ b/scripts/check_eval_lock.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # scripts/check_eval_lock.sh — CI gate: every FFI call that can reach
-# `mlx::core::eval_impl` must be made under the process-wide evaluation lock.
+# `mlx::core::eval_impl` must be made under the process-wide evaluation lock,
+# and nothing that runs under that lock may evaluate.
 #
 # THE BUG THIS PINS
 #   The linked MLX (0.31.x) resolves a CPU stream's `CommandEncoder` through a
@@ -24,72 +25,102 @@
 #
 # WHY A GREP GATE AND NOT A TEST
 #   The reproducer for this (`concurrent_first_eval_reproducer`) is
-#   probabilistic — measured at roughly one failure in twelve runs without the
-#   lock. That is far too weak to gate on: eleven times in twelve, deleting the
-#   lock would go green. The *structural* regressions, though, are exactly the
-#   ones a text gate catches deterministically:
+#   probabilistic — roughly one failure in twelve runs without the lock. Far
+#   too weak to gate on: eleven times in twelve, deleting the lock would go
+#   green. The *structural* regressions are the ones a text gate catches
+#   deterministically, and they are the realistic ones:
 #
 #     1. Someone drops the lock from a guarded call site.
-#     2. Someone adds a call to one of the other C entry points that evaluate.
+#     2. Someone adds a call to one of the many other C entry points that
+#        evaluate. This is the live risk — only three of the twenty-four are
+#        called today, and most of the rest look completely innocuous.
+#        `mlx_array_item_float32` reads as a scalar accessor;
+#        `mlx_save_safetensors` is the write side of `rmlx convert`;
+#        `mlx_array_tostring` is what an `impl Debug for Array` reaches for.
+#     3. Someone makes a compiled-closure body evaluate, which self-deadlocks
+#        against the non-reentrant mutex (RULE 3).
 #
-#   Case 2 is the live risk. Only two of the seventeen reachable entry points
-#   are called today; the other fifteen sit in the generated bindings, one call
-#   away, and look completely innocuous — `mlx_array_item_float32` reads like a
-#   scalar accessor, not an evaluation.
+# HOW THE REACH-SET WAS DERIVED — re-run this when the mlx / mlx-c pin moves
+#   It is not guesswork and must not become guesswork. Reverse reachability
+#   over the linked dylibs, computed twice and cross-checked:
 #
-# THE REACH-SET (derived from the generated mlx-c bindings, not guessed)
-#   Reaches `eval_impl`, therefore needs the lock:
-#     - mlx_array_eval          (called here, guarded)
-#     - mlx_async_eval          (called here, guarded)
-#     - mlx_eval                (not called here)
-#     - mlx_array_item_*        (14 of them, not called here) — each goes
-#                               through `array::item<T>()`, which calls
-#                               `eval()` before reading the value; see
-#                               `item()` in mlx/array.h.
-#   Does NOT evaluate, needs no lock:
-#     - mlx_array_data_*        (plain pointer accessors)
+#     otool -tvV "$(brew --prefix mlx-c)/lib/libmlxc.dylib" > /tmp/mlxc.s
+#     otool -tvV "$(brew --prefix mlx)/lib/libmlx.dylib"    > /tmp/mlx.s
+#
+#   Take the transitive closure of callers backwards from BOTH
+#   `mlx::core::eval_impl` and the hazard symbol itself,
+#   `mlx::core::cpu::get_command_encoder(Stream)`, then intersect with the
+#   exported `mlx_*` C ABI. Both directions gave the same 24 below.
+#
+#   Two of the paths are non-obvious and worth restating, because a reader who
+#   only greps for "eval" will miss them:
+#     * `mlx_array_item_*` -> `array::item<T>()` -> `array::eval()`
+#       (visible in `mlx/array.h` — `item()` evaluates before reading).
+#     * `mlx_closure_apply` -> compiled closure body -> `compile_fuse` ->
+#       `Compiled::Compiled` -> `print_constant` -> `array::item<T>()` ->
+#       `array::eval()`. `print_constant` bakes scalar constants into the
+#       kernel library name; see `mlx/backend/common/compiled.cpp`.
 #
 # THE RULES
-#   RULE 1  No call to `sys::mlx_eval(` or `sys::mlx_array_item_*(` anywhere.
-#           These have no guarded wrapper, so any call is unguarded by
-#           construction. If one is genuinely needed, wrap it in
-#           `with_eval_lock` and add it to RULE 2's allowed set here.
-#   RULE 2  Every call to `sys::mlx_array_eval(` / `sys::mlx_async_eval(` must
-#           have `with_eval_lock` within the 3 lines ending at the call, so a
-#           rustfmt line-wrap does not trip it.
+#   RULE 1  No call to an evaluating entry point that has no guarded wrapper.
+#           If one is genuinely needed, wrap it in `with_eval_lock` and move it
+#           from RULE 1's list to RULE 2's.
+#   RULE 2  Every call to a guarded entry point must be lexically inside a
+#           `with_eval_lock` closure: either on the call line itself, or inside
+#           an enclosing block whose opening line calls it.
+#   RULE 3  No `Closure::from_fn` body may evaluate. Those bodies run on the
+#           calling thread *inside* `mlx_closure_apply`, with the lock already
+#           held, so an evaluation there self-deadlocks on a non-reentrant
+#           mutex — a hang, which is one of this defect's own symptoms.
 #
 # WHAT THIS GATE CANNOT REACH — know the boundary before trusting it
-#   * It is a text scan. A call made through an alias (`use ... as f; f()`), a
-#     macro expansion, a function pointer or a transmute is invisible to it.
-#   * The reach-set above is hand-derived from the bindings as they are today.
-#     An mlx-c bump that adds a new evaluating entry point will not be flagged
-#     until someone extends RULE 1's pattern list. Re-derive it when the
-#     mlx / mlx-c pin moves.
-#   * It proves lexical adjacency, not that the lock is held at runtime. A
-#     `with_eval_lock` call on a neighbouring but unrelated line would satisfy
-#     it. The closure-taking signature of `with_eval_lock` is what makes that
-#     shape hard to write by accident.
+#   * It is a text scan. A call reached through an alias (`use ... as f; f()`),
+#     a macro expansion, a function pointer or a transmute is invisible to it.
+#     The one alternate *spelling* that existed — `sys::ffi::mlx_*`, valid
+#     while `mod ffi` was `pub(crate)` — was closed in the code instead of the
+#     regex: `crates/rmlx-mlx/src/sys.rs` now declares `mod ffi` privately, so
+#     `sys::mlx_*` is the only way to name these functions.
+#   * RULE 3 is one level deep. It sees `.eval()` written directly in a closure
+#     body, not an evaluation reached through a helper the body calls. No op
+#     wrapper or `MetalKernel::apply` evaluates today, which is what makes one
+#     level sufficient; that is an assumption, not a proof.
+#   * The reach-set is a snapshot of the current pin. A newly-added evaluating
+#     entry point will not be flagged until someone re-runs the derivation
+#     above and extends RULE 1.
+#   * It proves lexical structure, not runtime behaviour. A `with_eval_lock`
+#     that took no lock would satisfy it. The mutual-exclusion unit test
+#     (`with_eval_lock_serialises_concurrent_callers`) covers that.
 #   * It says nothing about concurrent *graph construction*, which never
 #     reaches `eval_impl`.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SCAN_DIR="${REPO_ROOT}/crates"
+# Optional scan root, so the fixture suite can point the gate at a synthetic
+# tree. Defaults to the real one.
+SCAN_DIR="${1:-${REPO_ROOT}/crates}"
 
 if [ ! -d "${SCAN_DIR}" ]; then
-    echo "check_eval_lock: no crates dir at ${SCAN_DIR}" >&2
+    echo "check_eval_lock: no scan dir at ${SCAN_DIR}" >&2
     exit 1
 fi
+
+# Entry points that evaluate. Split by whether this crate owns a guarded
+# wrapper for them. Anchored on `sys::` + open paren, so prose naming these
+# functions in comments and docs does not trip the gate.
+#
+# `(ffi::)?` is belt-and-braces. The real fix for that spelling is in the code —
+# `sys.rs` declares `mod ffi` privately, so `sys::ffi::mlx_*` does not resolve —
+# but matching it too costs one alternation and keeps the gate honest if that
+# module's visibility is ever widened again.
+BANNED_RE='sys::(ffi::)?(mlx_eval|mlx_array_item_[A-Za-z0-9_]*|mlx_array_tostring|mlx_save[A-Za-z0-9_]*|mlx_load_gguf)[[:space:]]*\('
+GUARDED_RE='sys::(ffi::)?(mlx_array_eval|mlx_async_eval|mlx_closure_apply)[[:space:]]*\('
 
 fail=0
 
 # ---- RULE 1: entry points with no guarded wrapper must not be called -------
-#
-# Anchored on `sys::` + an open paren, so prose in comments and docs that names
-# these functions in backticks does not trip the gate.
-banned_hits="$(grep -rnE 'sys::(mlx_eval|mlx_array_item_[A-Za-z0-9_]*)[[:space:]]*\(' \
-    --include='*.rs' "${SCAN_DIR}" || true)"
+
+banned_hits="$(grep -rnE "${BANNED_RE}" --include='*.rs' "${SCAN_DIR}" || true)"
 
 if [ -n "${banned_hits}" ]; then
     fail=1
@@ -97,23 +128,54 @@ if [ -n "${banned_hits}" ]; then
     echo "${banned_hits}" | sed 's/^/  /' >&2
     echo >&2
     echo "  These reach mlx::core::eval_impl and therefore the unsynchronised" >&2
-    echo "  process-global CPU command-encoder map. Wrap the call in" >&2
-    echo "  rmlx_mlx::with_eval_lock and add it to this gate's allowed set." >&2
+    echo "  process-global CPU command-encoder map. Every mlx-c call belongs in" >&2
+    echo "  the rmlx-mlx crate; wrap it in that crate's with_eval_lock and move" >&2
+    echo "  the symbol into this gate's guarded set." >&2
     echo >&2
 fi
 
 # ---- RULE 2: guarded entry points must be called under the lock ------------
 
-guarded_hits="$(grep -rnE 'sys::(mlx_array_eval|mlx_async_eval)[[:space:]]*\(' \
-    --include='*.rs' "${SCAN_DIR}" || true)"
+guarded_hits="$(grep -rnE "${GUARDED_RE}" --include='*.rs' "${SCAN_DIR}" || true)"
 
 if [ -z "${guarded_hits}" ]; then
     fail=1
-    echo "check_eval_lock: RULE 2 — no call to sys::mlx_array_eval / sys::mlx_async_eval found at all." >&2
+    echo "check_eval_lock: RULE 2 — no call to any guarded MLX entry point found at all." >&2
     echo "  The gate keys on those call sites; if they were renamed or removed," >&2
     echo "  this gate is no longer checking anything and must be updated." >&2
     echo >&2
 fi
+
+# For a hit at line L, pass if `with_eval_lock` appears on L itself or on the
+# opening line of any block enclosing L. Walking *openers* — successively lower
+# indentation — rather than a fixed line window is what makes this immune to
+# both a long comment inside the closure (the window bug this replaced) and to
+# a guarded sibling call earlier in the same function (a sibling is not an
+# enclosing opener, so it never launders a later unguarded call).
+check_guarded() {
+    awk -v target="$1" '
+        NR <= target {
+            line = $0
+            match(line, /^[ \t]*/)
+            ind[NR] = RLENGTH
+            txt[NR] = line
+        }
+        NR == target {
+            if (txt[target] ~ /with_eval_lock/) { print "ok"; exit }
+            cur = ind[target]
+            for (i = target - 1; i >= 1; i--) {
+                if (txt[i] ~ /^[ \t]*$/) continue
+                if (ind[i] < cur) {
+                    if (txt[i] ~ /with_eval_lock/) { print "ok"; exit }
+                    cur = ind[i]
+                    if (cur == 0) break
+                }
+            }
+            print "bad"
+            exit
+        }
+    ' "$2"
+}
 
 while IFS= read -r hit; do
     [ -z "${hit}" ] && continue
@@ -121,12 +183,7 @@ while IFS= read -r hit; do
     rest="${hit#*:}"
     line="${rest%%:*}"
 
-    # Window: the call line and the 3 lines above it, so a rustfmt wrap of
-    # `with_eval_lock(|| unsafe { ... })` across lines still satisfies the gate.
-    start=$(( line > 3 ? line - 3 : 1 ))
-    window="$(sed -n "${start},${line}p" "${file}")"
-
-    if ! printf '%s' "${window}" | grep -q 'with_eval_lock'; then
+    if [ "$(check_guarded "${line}" "${file}")" != "ok" ]; then
         fail=1
         echo "check_eval_lock: RULE 2 — evaluation FFI call not under the evaluation lock:" >&2
         echo "  ${file}:${line}" >&2
@@ -135,9 +192,67 @@ while IFS= read -r hit; do
     fi
 done <<< "${guarded_hits}"
 
+# ---- RULE 3: nothing that runs under the lock may evaluate ----------------
+
+closure_hits="$(grep -rnE 'Closure::from_fn[[:space:]]*\(' --include='*.rs' "${SCAN_DIR}" || true)"
+
+# Brace-match the closure body and look for a direct evaluation inside it.
+check_closure_body() {
+    awk -v start="$1" '
+        NR < start { next }
+        {
+            line = $0
+            if (!started) {
+                p = index(line, "{")
+                if (p == 0) next
+                started = 1
+                rest = substr(line, p)
+            } else {
+                rest = line
+            }
+            if (rest ~ /\.(eval|async_eval|to_bytes)[[:space:]]*\(/) bad = 1
+            n = length(rest)
+            for (i = 1; i <= n; i++) {
+                c = substr(rest, i, 1)
+                if (c == "{") depth++
+                else if (c == "}") {
+                    depth--
+                    # `exit` still runs END in awk, so mark it handled or the
+                    # verdict gets printed twice and every caller reads "bad".
+                    if (depth == 0) { done = 1; print (bad ? "bad" : "ok"); exit }
+                }
+            }
+        }
+        END { if (!done) print (bad ? "bad" : "ok") }
+    ' "$2"
+}
+
+while IFS= read -r hit; do
+    [ -z "${hit}" ] && continue
+    file="${hit%%:*}"
+    rest="${hit#*:}"
+    line="${rest%%:*}"
+
+    # Doc-comment examples are prose, not code.
+    src_line="$(sed -n "${line}p" "${file}")"
+    case "${src_line}" in
+        *"//!"*|*"///"*) continue ;;
+    esac
+
+    if [ "$(check_closure_body "${line}" "${file}")" != "ok" ]; then
+        fail=1
+        echo "check_eval_lock: RULE 3 — a Closure::from_fn body evaluates:" >&2
+        echo "  ${file}:${line}" >&2
+        echo "  That body runs inside mlx_closure_apply with the evaluation lock" >&2
+        echo "  already held, so evaluating there self-deadlocks on a" >&2
+        echo "  non-reentrant mutex. Move the evaluation outside the closure." >&2
+        echo >&2
+    fi
+done <<< "${closure_hits}"
+
 if [ "${fail}" -ne 0 ]; then
     echo "check_eval_lock: FAILED" >&2
     exit 1
 fi
 
-echo "OK: every MLX evaluation FFI call is made under the evaluation lock."
+echo "OK: every MLX evaluation FFI call is made under the evaluation lock (24-symbol reach-set)."

--- a/scripts/check_eval_lock.sh
+++ b/scripts/check_eval_lock.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/check_eval_lock.sh — CI gate: every FFI call that can reach
 # `mlx::core::eval_impl` must be made under the process-wide evaluation lock,
-# and nothing that runs under that lock may evaluate.
+# and nothing that runs under that lock may take it again.
 #
 # THE BUG THIS PINS
 #   The linked MLX (0.31.x) resolves a CPU stream's `CommandEncoder` through a
@@ -26,40 +26,56 @@
 # WHY A GREP GATE AND NOT A TEST
 #   The reproducer for this (`concurrent_first_eval_reproducer`) is
 #   probabilistic — roughly one failure in twelve runs without the lock. Far
-#   too weak to gate on: eleven times in twelve, deleting the lock would go
-#   green. The *structural* regressions are the ones a text gate catches
-#   deterministically, and they are the realistic ones:
+#   too weak to gate on. The *structural* regressions are the ones a text gate
+#   catches deterministically, and they are the realistic ones:
 #
 #     1. Someone drops the lock from a guarded call site.
 #     2. Someone adds a call to one of the many other C entry points that
-#        evaluate. This is the live risk — only three of the twenty-four are
+#        evaluate. This is the live risk — only three of the twenty-five are
 #        called today, and most of the rest look completely innocuous.
 #        `mlx_array_item_float32` reads as a scalar accessor;
 #        `mlx_save_safetensors` is the write side of `rmlx convert`;
 #        `mlx_array_tostring` is what an `impl Debug for Array` reaches for.
-#     3. Someone makes a compiled-closure body evaluate, which self-deadlocks
-#        against the non-reentrant mutex (RULE 3).
+#     3. Someone makes a compiled-closure body take the lock again, which
+#        self-deadlocks against the non-reentrant mutex (RULE 3).
+#
+#   What it does NOT catch is a `with_eval_lock` that stopped locking: the
+#   lexical structure is unchanged, so this gate stays green. That half is
+#   covered by the unit test
+#   `with_eval_lock_serialises_concurrent_callers`. The two are complementary
+#   by construction, verified by mutation — neither alone covers this defect.
 #
 # HOW THE REACH-SET WAS DERIVED — re-run this when the mlx / mlx-c pin moves
-#   It is not guesswork and must not become guesswork. Reverse reachability
-#   over the linked dylibs, computed twice and cross-checked:
+#   It is not guesswork and must not become guesswork. TWO passes, because one
+#   of them is structurally blind to a quarter of the problem.
 #
+#   Pass 1 — automated, direct calls (yields 24 symbols):
 #     otool -tvV "$(brew --prefix mlx-c)/lib/libmlxc.dylib" > /tmp/mlxc.s
 #     otool -tvV "$(brew --prefix mlx)/lib/libmlx.dylib"    > /tmp/mlx.s
-#
 #   Take the transitive closure of callers backwards from BOTH
 #   `mlx::core::eval_impl` and the hazard symbol itself,
 #   `mlx::core::cpu::get_command_encoder(Stream)`, then intersect with the
-#   exported `mlx_*` C ABI. Both directions gave the same 24 below.
+#   exported `mlx_*` C ABI.
 #
-#   Two of the paths are non-obvious and worth restating, because a reader who
-#   only greps for "eval" will miss them:
-#     * `mlx_array_item_*` -> `array::item<T>()` -> `array::eval()`
-#       (visible in `mlx/array.h` — `item()` evaluates before reading).
-#     * `mlx_closure_apply` -> compiled closure body -> `compile_fuse` ->
-#       `Compiled::Compiled` -> `print_constant` -> `array::item<T>()` ->
-#       `array::eval()`. `print_constant` bakes scalar constants into the
-#       kernel library name; see `mlx/backend/common/compiled.cpp`.
+#   Pass 2 — by hand, INDIRECT dispatch (adds 1, for 25 total):
+#   Pass 1 CANNOT see a call made through a `std::function` — the jump is a
+#   `blr` on a vtable slot, so reverse reachability over a disassembly does not
+#   traverse it. `mlx_closure_apply` is exactly that shape and does NOT appear
+#   in pass 1's output. It reaches evaluation anyway:
+#     mlx_closure_apply -> compiled closure body -> compile_fuse ->
+#     Compiled::Compiled -> print_constant -> array::item<T>() -> array::eval()
+#   `print_constant` bakes scalar constants into the kernel library name; see
+#   `mlx/backend/common/compiled.cpp`.
+#
+#   ** If you re-run pass 1 at a pin bump you will get 24 and `mlx_closure_apply`
+#   will be missing. That is the automated pass's blind spot, not a stale
+#   entry — do NOT "correct" the gate by deleting the closure guard. **
+#
+#   Other closure-taking entry points to re-audit the same way at a pin bump,
+#   none called today: `mlx_export_function`, `mlx_imported_function_apply`,
+#   `mlx_vjp`, `mlx_jvp`, `mlx_value_and_grad`, `mlx_custom_function`,
+#   `mlx_checkpoint`. (`mlx_compile` does not invoke the closure;
+#   `mlx_fast_metal_kernel_apply` is lazy.)
 #
 # THE RULES
 #   RULE 1  No call to an evaluating entry point that has no guarded wrapper.
@@ -68,10 +84,15 @@
 #   RULE 2  Every call to a guarded entry point must be lexically inside a
 #           `with_eval_lock` closure: either on the call line itself, or inside
 #           an enclosing block whose opening line calls it.
-#   RULE 3  No `Closure::from_fn` body may evaluate. Those bodies run on the
-#           calling thread *inside* `mlx_closure_apply`, with the lock already
-#           held, so an evaluation there self-deadlocks on a non-reentrant
-#           mutex — a hang, which is one of this defect's own symptoms.
+#   RULE 3  No `Closure::from_fn` body may take the evaluation lock. Those
+#           bodies run on the calling thread *inside* `mlx_closure_apply`, with
+#           the lock already held, so taking it again self-deadlocks on a
+#           non-reentrant mutex — a hang, which is one of this defect's own
+#           symptoms. The ban is on *taking the lock*, which is broader than
+#           "evaluating": `Closure::apply` itself takes it, so a body that
+#           applies another compiled closure deadlocks too. That is not a
+#           hypothetical shape — it is the first thing a "fuse two fused
+#           kernels" refactor produces.
 #
 # WHAT THIS GATE CANNOT REACH — know the boundary before trusting it
 #   * It is a text scan. A call reached through an alias (`use ... as f; f()`),
@@ -80,16 +101,21 @@
 #     while `mod ffi` was `pub(crate)` — was closed in the code instead of the
 #     regex: `crates/rmlx-mlx/src/sys.rs` now declares `mod ffi` privately, so
 #     `sys::mlx_*` is the only way to name these functions.
-#   * RULE 3 is one level deep. It sees `.eval()` written directly in a closure
-#     body, not an evaluation reached through a helper the body calls. No op
-#     wrapper or `MetalKernel::apply` evaluates today, which is what makes one
-#     level sufficient; that is an assumption, not a proof.
-#   * The reach-set is a snapshot of the current pin. A newly-added evaluating
-#     entry point will not be flagged until someone re-runs the derivation
-#     above and extends RULE 1.
-#   * It proves lexical structure, not runtime behaviour. A `with_eval_lock`
-#     that took no lock would satisfy it. The mutual-exclusion unit test
-#     (`with_eval_lock_serialises_concurrent_callers`) covers that.
+#   * RULE 3 only sees bodies written INLINE at the `Closure::from_fn` call.
+#     `Closure::from_fn(named_fn)` moves the body out of reach entirely, and
+#     that is a natural refactor of a one-line delegation like
+#     `gated_delta_msl.rs`'s. It is also one level deep: it sees a lock-taking
+#     call written in the body, not one reached through a helper the body
+#     calls. No op wrapper or `MetalKernel::apply` takes the lock today, which
+#     is what makes one level sufficient — an assumption, not a proof.
+#   * Line comments and double-quoted strings are stripped before matching, so
+#     braces and lock names inside them are inert. Rust RAW strings
+#     (`r#"..."#`), char literals (`'{'`) and block comments (`/* */`) are NOT
+#     handled; an unbalanced brace in one of those would end RULE 3's body scan
+#     early and leave the remainder unscanned.
+#   * The reach-set is a snapshot of the current pin, and pass 1 is blind to
+#     indirect dispatch (see above).
+#   * It proves lexical structure, not runtime behaviour.
 #   * It says nothing about concurrent *graph construction*, which never
 #     reaches `eval_impl`.
 
@@ -116,11 +142,51 @@ fi
 BANNED_RE='sys::(ffi::)?(mlx_eval|mlx_array_item_[A-Za-z0-9_]*|mlx_array_tostring|mlx_save[A-Za-z0-9_]*|mlx_load_gguf)[[:space:]]*\('
 GUARDED_RE='sys::(ffi::)?(mlx_array_eval|mlx_async_eval|mlx_closure_apply)[[:space:]]*\('
 
+# Shared awk helper: drop `//` comments and double-quoted string bodies, so
+# neither a laundering comment nor a brace in a literal can steer the scans.
+STRIP_FN='
+function strip(line,   i, n, c, out, instr, esc) {
+    n = length(line); out = ""; instr = 0; esc = 0
+    for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+        if (instr) {
+            if (esc) { esc = 0; continue }
+            if (c == "\\") { esc = 1; continue }
+            if (c == "\"") { instr = 0 }
+            continue
+        }
+        if (c == "\"") { instr = 1; continue }
+        if (c == "/" && substr(line, i + 1, 1) == "/") break
+        out = out c
+    }
+    return out
+}'
+
+# Drop hits whose match survives only inside a comment or a string literal.
+# All three rules go through this, so "is this a real call site?" is answered
+# the same way everywhere — an inconsistency here is what let a doc comment
+# naming `sys::mlx_eval(v)` fail RULE 1 while the same text was inert to
+# RULE 2 and RULE 3.
+filter_real_calls() {
+    local re="$1" hit file line text stripped
+    while IFS= read -r hit; do
+        [ -z "${hit}" ] && continue
+        file="${hit%%:*}"
+        text="${hit#*:}"
+        line="${text%%:*}"
+        stripped="$(sed -n "${line}p" "${file}" | awk "${STRIP_FN}"'{ print strip($0) }')"
+        if printf '%s\n' "${stripped}" | grep -qE "${re}"; then
+            printf '%s:%s:%s\n' "${file}" "${line}" "${stripped}"
+        fi
+    done
+}
+
 fail=0
 
 # ---- RULE 1: entry points with no guarded wrapper must not be called -------
 
-banned_hits="$(grep -rnE "${BANNED_RE}" --include='*.rs' "${SCAN_DIR}" || true)"
+banned_hits="$(grep -rnE "${BANNED_RE}" --include='*.rs' "${SCAN_DIR}" \
+    | filter_real_calls "${BANNED_RE}" || true)"
 
 if [ -n "${banned_hits}" ]; then
     fail=1
@@ -136,7 +202,8 @@ fi
 
 # ---- RULE 2: guarded entry points must be called under the lock ------------
 
-guarded_hits="$(grep -rnE "${GUARDED_RE}" --include='*.rs' "${SCAN_DIR}" || true)"
+guarded_hits="$(grep -rnE "${GUARDED_RE}" --include='*.rs' "${SCAN_DIR}" \
+    | filter_real_calls "${GUARDED_RE}" || true)"
 
 if [ -z "${guarded_hits}" ]; then
     fail=1
@@ -149,13 +216,15 @@ fi
 # For a hit at line L, pass if `with_eval_lock` appears on L itself or on the
 # opening line of any block enclosing L. Walking *openers* — successively lower
 # indentation — rather than a fixed line window is what makes this immune to
-# both a long comment inside the closure (the window bug this replaced) and to
-# a guarded sibling call earlier in the same function (a sibling is not an
-# enclosing opener, so it never launders a later unguarded call).
+# both a long comment inside the closure and to a guarded sibling call earlier
+# in the same function (a sibling is not an enclosing opener, so it never
+# launders a later unguarded call). Comments are stripped first, so neither a
+# trailing `// with_eval_lock: ...` nor a column-0 comment inside the closure
+# can launder or sever the chain.
 check_guarded() {
-    awk -v target="$1" '
+    awk -v target="$1" "${STRIP_FN}"'
         NR <= target {
-            line = $0
+            line = strip($0)
             match(line, /^[ \t]*/)
             ind[NR] = RLENGTH
             txt[NR] = line
@@ -187,21 +256,25 @@ while IFS= read -r hit; do
         fail=1
         echo "check_eval_lock: RULE 2 — evaluation FFI call not under the evaluation lock:" >&2
         echo "  ${file}:${line}" >&2
-        echo "  Wrap it: with_eval_lock(|| unsafe { sys::... })" >&2
+        echo "  Wrap the call itself in with_eval_lock(|| ...). A comment saying" >&2
+        echo "  the caller already holds the lock does not satisfy this gate and" >&2
+        echo "  is not a substitute for holding it." >&2
         echo >&2
     fi
 done <<< "${guarded_hits}"
 
-# ---- RULE 3: nothing that runs under the lock may evaluate ----------------
+# ---- RULE 3: nothing running under the lock may take it again -------------
 
 closure_hits="$(grep -rnE 'Closure::from_fn[[:space:]]*\(' --include='*.rs' "${SCAN_DIR}" || true)"
 
-# Brace-match the closure body and look for a direct evaluation inside it.
+# Brace-match the closure body (over comment- and string-stripped text) and
+# look for anything that would take the evaluation lock: a direct evaluation,
+# or an application of another compiled closure, which takes it internally.
 check_closure_body() {
-    awk -v start="$1" '
+    awk -v start="$1" "${STRIP_FN}"'
         NR < start { next }
         {
-            line = $0
+            line = strip($0)
             if (!started) {
                 p = index(line, "{")
                 if (p == 0) next
@@ -210,7 +283,8 @@ check_closure_body() {
             } else {
                 rest = line
             }
-            if (rest ~ /\.(eval|async_eval|to_bytes)[[:space:]]*\(/) bad = 1
+            if (rest ~ /(\.|Array::)(eval|async_eval|to_bytes)[[:space:]]*\(/) bad = 1
+            if (rest ~ /\.apply[[:space:]]*\([[:space:]]*&\[/) bad = 1
             n = length(rest)
             for (i = 1; i <= n; i++) {
                 c = substr(rest, i, 1)
@@ -241,11 +315,12 @@ while IFS= read -r hit; do
 
     if [ "$(check_closure_body "${line}" "${file}")" != "ok" ]; then
         fail=1
-        echo "check_eval_lock: RULE 3 — a Closure::from_fn body evaluates:" >&2
+        echo "check_eval_lock: RULE 3 — a Closure::from_fn body takes the evaluation lock:" >&2
         echo "  ${file}:${line}" >&2
-        echo "  That body runs inside mlx_closure_apply with the evaluation lock" >&2
-        echo "  already held, so evaluating there self-deadlocks on a" >&2
-        echo "  non-reentrant mutex. Move the evaluation outside the closure." >&2
+        echo "  That body runs inside mlx_closure_apply with the lock already" >&2
+        echo "  held, so evaluating — or applying another compiled closure," >&2
+        echo "  which takes the lock internally — self-deadlocks on a" >&2
+        echo "  non-reentrant mutex. Move it outside the closure." >&2
         echo >&2
     fi
 done <<< "${closure_hits}"
@@ -255,4 +330,4 @@ if [ "${fail}" -ne 0 ]; then
     exit 1
 fi
 
-echo "OK: every MLX evaluation FFI call is made under the evaluation lock (24-symbol reach-set)."
+echo "OK: every MLX evaluation FFI call is made under the evaluation lock (25-symbol reach-set)."

--- a/scripts/check_eval_lock_fixtures.sh
+++ b/scripts/check_eval_lock_fixtures.sh
@@ -3,25 +3,46 @@
 #
 # A source gate is only worth its runtime if it still fires when the thing it
 # looks for is spelled differently, nested deeper, or hidden behind a comment.
-# Both of that gate's positive rules are one regex edit away from matching
-# nothing and going permanently green, and its anti-vacuity check only covers
+# All three of that gate's rules are one regex edit away from matching nothing
+# and going permanently green, and RULE 2's anti-vacuity check only covers
 # "no call sites at all" — not "the pattern stopped matching the ones that
 # exist". Each fixture below is a synthetic scan root paired with the exit code
-# the gate must produce for it, so a gate change that loses recall fails here
-# instead of passing silently on the real tree.
+# AND THE RULE the gate must produce for it.
 #
-# Several cases pin bugs that were actually present during review:
-#   long_safety_comment  the first version scanned a fixed 3-line window, so a
-#                        4-line SAFETY comment inside the guarded closure — the
-#                        crate's own convention — reported the call unguarded.
-#   guarded_sibling      an enclosing-block scan must not let a guarded call
-#                        earlier in the same function launder a later bare one.
-#   ffi_path_spelling    `sys::ffi::mlx_*` named the same functions and matched
-#                        neither rule.
-#   closure_evals        RULE 3; and an early awk version mis-read every clean
-#                        closure as dirty because `exit` still runs `END`.
+# WHY THE EXPECTED RULE IS CHECKED, NOT JUST THE EXIT CODE
+#   The first version of this corpus asserted exit codes only, and every
+#   must-fail fixture happened to contain no guarded call site — so each one
+#   tripped RULE 2's anti-vacuity branch and exited 1 no matter what the rule
+#   under test did. Measured on that corpus: deleting RULE 1 outright left it
+#   GREEN; deleting RULE 3 outright left it GREEN. It had power over exactly
+#   one rule. Every RULE 1 / RULE 3 fixture now ends with a correctly-guarded
+#   call site (`guarded_anchor`) so RULE 2 is satisfied and the failure is
+#   attributable, and the runner asserts which rule fired.
 #
-# Exit 0 = every fixture produced its expected exit code.
+# Several cases pin bugs that were live during review:
+#   long_safety_comment   a fixed 3-line window read a 4-line SAFETY comment
+#                         inside the guarded closure as unguarded.
+#   guarded_sibling       an enclosing-block scan must not let a guarded call
+#                         earlier in the same fn launder a later bare one.
+#   comment_launder       a trailing `// with_eval_lock: ...` satisfied RULE 2
+#                         — and the old failure message handed the developer
+#                         that exact string to paste.
+#   column0_comment       a column-0 comment inside the closure was read as a
+#                         block opener and severed the guard chain.
+#   ffi_path_spelling     `sys::ffi::mlx_*` named the same functions and
+#                         matched neither rule.
+#   closure_applies       RULE 3's real invariant is "must not take the lock",
+#                         not "must not evaluate": `Closure::apply` takes it,
+#                         so a body applying another compiled closure
+#                         deadlocks without calling .eval() at all.
+#   closure_ufcs_eval     the UFCS `Array::eval(&y)` spelling.
+#   closure_unbalanced_brace_string
+#                         an unbalanced brace in a string literal ended the
+#                         body scan early and hid the evaluation after it.
+#   closure_evals         and an early awk version mis-read every clean closure
+#                         as dirty because `exit` still runs `END`.
+#
+# Exit 0 = every fixture produced its expected exit code and rule.
 
 set -uo pipefail
 
@@ -29,36 +50,60 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GATE="$ROOT/scripts/check_eval_lock.sh"
 FIX="$ROOT/scripts/fixtures/eval_lock"
 
-# fixture | expected-exit | what it proves
+# fixture | expected-exit | expected-rule ("-" when it must pass) | what it proves
 CASES=(
-    "clean|0|guarded call sites in both one-line and block form pass"
-    "long_safety_comment|0|a long comment inside the guarded closure is not a violation"
-    "nested_block|0|the guard counts from two block levels up"
-    "closure_clean|0|a closure body that does not evaluate passes, braces in strings and all"
-    "prose_only|0|comments naming the banned symbols are not call sites"
-    "lock_removed|1|dropping the guard from a call site is caught"
-    "guarded_sibling|1|a guarded call does not launder a bare one later in the same fn"
-    "banned_item|1|sys::mlx_array_item_* is caught"
-    "banned_tostring|1|sys::mlx_array_tostring is caught"
-    "banned_save|1|sys::mlx_save_safetensors — the rmlx convert write side — is caught"
-    "ffi_path_spelling|1|the sys::ffi::mlx_* module path is caught"
-    "closure_evals|1|a Closure::from_fn body that evaluates is caught (self-deadlock)"
-    "empty_tree|1|a scan root with no guarded call sites fails instead of passing vacuously"
+    "clean|0|-|guarded call sites for all three guarded entry points pass"
+    "long_safety_comment|0|-|a long comment inside the guarded closure is not a violation"
+    "nested_block|0|-|the guard counts from two block levels up"
+    "column0_comment|0|-|a column-0 comment inside the closure does not sever the guard chain"
+    "closure_clean|0|-|a body that neither evaluates nor applies passes, MetalKernel::apply included"
+    "prose_only|0|-|parenthesised mentions of the banned symbols in prose are not call sites"
+    "local_fn_lookalike|0|-|a crate-local fn sharing an mlx-c name is not an FFI call (pins the sys:: anchor)"
+
+    "lock_removed|1|RULE 2|dropping the guard from a call site is caught"
+    "lock_removed_async|1|RULE 2|an unguarded sys::mlx_async_eval is caught on its own merits"
+    "lock_removed_closure_apply|1|RULE 2|an unguarded sys::mlx_closure_apply is caught on its own merits"
+    "guarded_sibling|1|RULE 2|a guarded call does not launder a bare one later in the same fn"
+    "comment_launder|1|RULE 2|a trailing comment naming with_eval_lock does not satisfy the guard"
+    "empty_tree|1|RULE 2|a scan root with no guarded call sites fails instead of passing vacuously"
+
+    "banned_eval|1|RULE 1|sys::mlx_eval is caught"
+    "banned_item|1|RULE 1|sys::mlx_array_item_* is caught"
+    "banned_tostring|1|RULE 1|sys::mlx_array_tostring is caught"
+    "banned_save|1|RULE 1|sys::mlx_save_safetensors — the rmlx convert write side — is caught"
+    "banned_save_writer|1|RULE 1|sys::mlx_save_writer is caught"
+    "banned_load_gguf|1|RULE 1|sys::mlx_load_gguf is caught"
+    "ffi_path_spelling|1|RULE 1|the sys::ffi::mlx_* module path is caught"
+
+    "closure_evals|1|RULE 3|a body calling .eval() is caught"
+    "closure_evals_async|1|RULE 3|a body calling .async_eval() is caught"
+    "closure_to_bytes|1|RULE 3|a body calling .to_bytes() is caught"
+    "closure_ufcs_eval|1|RULE 3|the UFCS Array::eval(&y) spelling is caught"
+    "closure_applies|1|RULE 3|a body applying another compiled closure is caught (takes the lock, deadlocks)"
+    "closure_unbalanced_brace_string|1|RULE 3|an unbalanced brace in a string does not hide the evaluation after it"
 )
 
 FAILED=0
 PASSED=0
 
 for case in "${CASES[@]}"; do
-    IFS='|' read -r name want what <<<"$case"
+    IFS='|' read -r name want_exit want_rule what <<<"$case"
     out=$("$GATE" "$FIX/$name" 2>&1)
     got=$?
-    if [ "$got" -eq "$want" ]; then
+
+    ok=1
+    [ "$got" -eq "$want_exit" ] || ok=0
+    if [ "$want_rule" != "-" ]; then
+        printf '%s\n' "$out" | grep -q "$want_rule" || ok=0
+    fi
+
+    if [ "$ok" -eq 1 ]; then
         PASSED=$((PASSED + 1))
-        printf '  ok   %-20s exit=%s — %s\n' "$name" "$got" "$what"
+        printf '  ok   %-32s exit=%s %-7s — %s\n' "$name" "$got" "$want_rule" "$what"
     else
         FAILED=$((FAILED + 1))
-        printf '  FAIL %-20s exit=%s (want %s) — %s\n' "$name" "$got" "$want" "$what"
+        printf '  FAIL %-32s exit=%s (want %s / %s) — %s\n' \
+            "$name" "$got" "$want_exit" "$want_rule" "$what"
         printf '%s\n' "$out" | sed 's/^/       | /'
     fi
 done

--- a/scripts/check_eval_lock_fixtures.sh
+++ b/scripts/check_eval_lock_fixtures.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# scripts/check_eval_lock_fixtures.sh — recall test for `check_eval_lock.sh`.
+#
+# A source gate is only worth its runtime if it still fires when the thing it
+# looks for is spelled differently, nested deeper, or hidden behind a comment.
+# Both of that gate's positive rules are one regex edit away from matching
+# nothing and going permanently green, and its anti-vacuity check only covers
+# "no call sites at all" — not "the pattern stopped matching the ones that
+# exist". Each fixture below is a synthetic scan root paired with the exit code
+# the gate must produce for it, so a gate change that loses recall fails here
+# instead of passing silently on the real tree.
+#
+# Several cases pin bugs that were actually present during review:
+#   long_safety_comment  the first version scanned a fixed 3-line window, so a
+#                        4-line SAFETY comment inside the guarded closure — the
+#                        crate's own convention — reported the call unguarded.
+#   guarded_sibling      an enclosing-block scan must not let a guarded call
+#                        earlier in the same function launder a later bare one.
+#   ffi_path_spelling    `sys::ffi::mlx_*` named the same functions and matched
+#                        neither rule.
+#   closure_evals        RULE 3; and an early awk version mis-read every clean
+#                        closure as dirty because `exit` still runs `END`.
+#
+# Exit 0 = every fixture produced its expected exit code.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE="$ROOT/scripts/check_eval_lock.sh"
+FIX="$ROOT/scripts/fixtures/eval_lock"
+
+# fixture | expected-exit | what it proves
+CASES=(
+    "clean|0|guarded call sites in both one-line and block form pass"
+    "long_safety_comment|0|a long comment inside the guarded closure is not a violation"
+    "nested_block|0|the guard counts from two block levels up"
+    "closure_clean|0|a closure body that does not evaluate passes, braces in strings and all"
+    "prose_only|0|comments naming the banned symbols are not call sites"
+    "lock_removed|1|dropping the guard from a call site is caught"
+    "guarded_sibling|1|a guarded call does not launder a bare one later in the same fn"
+    "banned_item|1|sys::mlx_array_item_* is caught"
+    "banned_tostring|1|sys::mlx_array_tostring is caught"
+    "banned_save|1|sys::mlx_save_safetensors — the rmlx convert write side — is caught"
+    "ffi_path_spelling|1|the sys::ffi::mlx_* module path is caught"
+    "closure_evals|1|a Closure::from_fn body that evaluates is caught (self-deadlock)"
+    "empty_tree|1|a scan root with no guarded call sites fails instead of passing vacuously"
+)
+
+FAILED=0
+PASSED=0
+
+for case in "${CASES[@]}"; do
+    IFS='|' read -r name want what <<<"$case"
+    out=$("$GATE" "$FIX/$name" 2>&1)
+    got=$?
+    if [ "$got" -eq "$want" ]; then
+        PASSED=$((PASSED + 1))
+        printf '  ok   %-20s exit=%s — %s\n' "$name" "$got" "$what"
+    else
+        FAILED=$((FAILED + 1))
+        printf '  FAIL %-20s exit=%s (want %s) — %s\n' "$name" "$got" "$want" "$what"
+        printf '%s\n' "$out" | sed 's/^/       | /'
+    fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "check-eval-lock fixtures: FAIL ($FAILED of $((PASSED + FAILED)))" >&2
+    exit 1
+fi
+
+echo "check-eval-lock fixtures: ok ($PASSED cases)"

--- a/scripts/eval_lock_stress.sh
+++ b/scripts/eval_lock_stress.sh
@@ -71,6 +71,21 @@ if [ -z "${TIMEOUT_BIN}" ]; then
     exit 1
 fi
 
+# Anti-vacuity. libtest exits 0 when a filter selects nothing — it prints
+# "0 passed; 0 failed; N filtered out" and is, to `$?`, indistinguishable from a
+# clean run. Output here goes to /dev/null and only the exit code is read, so a
+# rename, a move out of `lib_tests`, or a change to the `#[ignore]` status would
+# otherwise yield "OK: 60/60 clean" having run the reproducer zero times.
+selected="$("${BIN}" --exact "${TEST_NAME}" --ignored --list 2>/dev/null \
+    | grep -c ': test$' || true)"
+if [ "${selected}" != "1" ]; then
+    echo "eval-lock-stress: filter '${TEST_NAME}' selected ${selected} tests, expected exactly 1." >&2
+    echo "  The reproducer was renamed, moved, or is no longer #[ignore]d." >&2
+    echo "  Update TEST_NAME in this script — a filter that matches nothing" >&2
+    echo "  would make every run exit 0 without executing anything." >&2
+    exit 1
+fi
+
 echo "eval-lock-stress: ${BIN}"
 echo "eval-lock-stress: ${RUNS} fresh processes, ${TMO}s cap each"
 
@@ -78,7 +93,7 @@ ok=0; crash=0; hang=0; other=0
 for i in $(seq 1 "${RUNS}"); do
     set +e
     "${TIMEOUT_BIN}" -s KILL "${TMO}" "${BIN}" --exact "${TEST_NAME}" \
-        --test-threads=1 >/dev/null 2>&1
+        --ignored --test-threads=1 >/dev/null 2>&1
     rc=$?
     set -e
     case "${rc}" in

--- a/scripts/eval_lock_stress.sh
+++ b/scripts/eval_lock_stress.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# scripts/eval_lock_stress.sh — drive the evaluation-lock reproducer across many
+# FRESH PROCESSES and fail on any non-zero exit.
+#
+# WHY A DRIVER AND NOT JUST A TEST
+#   `concurrent_first_eval_reproducer` is probabilistic: without the lock it
+#   fails about 1 run in 12 (15/180 measured). Running it once — which is what
+#   `make ci` does — is therefore weak evidence in the green direction. Its
+#   power comes only from repetition, and specifically from repetition across
+#   *processes*: the defect is an unsynchronised insert into a process-global
+#   hash map, and the map rehashes hardest while it is still growing from
+#   empty. Once a process has populated it, later bursts in that same process
+#   mostly find existing entries and stop inserting. So looping inside the test
+#   buys almost nothing; re-exec does.
+#
+#   At the measured ~8% per-run rate, N=60 gives ~99.3% detection and N=100
+#   ~99.98%. The default below is 60.
+#
+# WHY IT COUNTS TIMEOUTS AS FAILURES
+#   Corruption does not always segfault. Three failure shapes were observed:
+#   SIGSEGV, SIGTRAP, and an infinite spin (a bucket chain that became
+#   circular). The last one hangs forever and would otherwise stall the caller
+#   rather than reporting, so every run is bounded and a timeout is a failure.
+#
+# WHAT THIS CANNOT REACH
+#   Same scope as the test it drives: the CPU evaluation path only. It says
+#   nothing about concurrent GPU evaluation, and nothing about races in lazy
+#   graph construction. It is also a *statistical* instrument — a clean run at
+#   N=60 bounds the failure rate to roughly <5% at 95% confidence, it does not
+#   prove zero.
+#
+# USAGE
+#   bash scripts/eval_lock_stress.sh [RUNS] [TIMEOUT_SECS]
+#   make eval-lock-stress RUNS=100
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNS="${1:-${RUNS:-60}}"
+TMO="${2:-${TIMEOUT_SECS:-60}}"
+TEST_NAME="lib_tests::concurrent_first_eval_reproducer"
+
+cd "${REPO_ROOT}"
+
+echo "eval-lock-stress: building rmlx-mlx test binary"
+
+# Take the path cargo reports for the binary it just built, rather than globbing
+# target/deps — a stale artifact from an earlier build must never be the thing
+# under test. Cargo prints `Executable unittests src/lib.rs (<path>)` on stderr.
+build_out="$(cargo test -p rmlx-mlx --lib --no-run 2>&1)" || {
+    echo "${build_out}" >&2
+    echo "eval-lock-stress: build failed" >&2
+    exit 1
+}
+BIN="$(printf '%s\n' "${build_out}" \
+    | sed -n 's/^ *Executable unittests .*(\(.*\))$/\1/p' | tail -1)"
+
+if [ -z "${BIN}" ] || [ ! -x "${BIN}" ]; then
+    echo "eval-lock-stress: could not resolve the rmlx-mlx test binary from cargo output" >&2
+    printf '%s\n' "${build_out}" >&2
+    exit 1
+fi
+
+# A timeout is mandatory: one of the failure shapes is an infinite spin.
+TIMEOUT_BIN=""
+for cand in timeout gtimeout; do
+    if command -v "${cand}" >/dev/null 2>&1; then TIMEOUT_BIN="$(command -v "${cand}")"; break; fi
+done
+if [ -z "${TIMEOUT_BIN}" ]; then
+    echo "eval-lock-stress: need 'timeout' or 'gtimeout' (brew install coreutils) — a hang is one of the failure shapes and must be bounded" >&2
+    exit 1
+fi
+
+echo "eval-lock-stress: ${BIN}"
+echo "eval-lock-stress: ${RUNS} fresh processes, ${TMO}s cap each"
+
+ok=0; crash=0; hang=0; other=0
+for i in $(seq 1 "${RUNS}"); do
+    set +e
+    "${TIMEOUT_BIN}" -s KILL "${TMO}" "${BIN}" --exact "${TEST_NAME}" \
+        --test-threads=1 >/dev/null 2>&1
+    rc=$?
+    set -e
+    case "${rc}" in
+        0)       ok=$((ok+1)) ;;
+        124|137) hang=$((hang+1)); echo "  run ${i}: HANG (rc=${rc})" ;;
+        *)       if [ "${rc}" -gt 128 ]; then
+                     crash=$((crash+1)); echo "  run ${i}: signal $((rc-128))"
+                 else
+                     other=$((other+1)); echo "  run ${i}: exit ${rc}"
+                 fi ;;
+    esac
+done
+
+fails=$(( crash + hang + other ))
+echo "eval-lock-stress: runs=${RUNS} ok=${ok} crashes=${crash} hangs=${hang} other=${other}"
+
+if [ "${fails}" -ne 0 ]; then
+    echo "eval-lock-stress: FAILED — ${fails}/${RUNS} runs did not exit cleanly." >&2
+    echo "  Evaluation is no longer serialised, or the lock no longer covers" >&2
+    echo "  every path that reaches mlx::core::eval_impl. See docs/FFI.md." >&2
+    exit 1
+fi
+
+echo "OK: ${RUNS}/${RUNS} clean."

--- a/scripts/fixtures/eval_lock/banned_eval/src.rs
+++ b/scripts/fixtures/eval_lock/banned_eval/src.rs
@@ -1,5 +1,5 @@
-pub fn write_snapshot(path: &CStr, arr: &Array) -> Result<()> {
-    let status = unsafe { sys::mlx_save_safetensors(path.as_ptr(), map, meta) };
+pub fn eval_all(v: mlx_vector_array) -> Result<()> {
+    let status = unsafe { sys::mlx_eval(v) };
     Ok(())
 }
 

--- a/scripts/fixtures/eval_lock/banned_item/src.rs
+++ b/scripts/fixtures/eval_lock/banned_item/src.rs
@@ -5,3 +5,8 @@ impl Array {
         out
     }
 }
+
+fn guarded_anchor(a: &Array) -> Result<()> {
+    let s = with_eval_lock(|| unsafe { sys::mlx_array_eval(a.inner) });
+    unsafe { check_status(s, "anchor") }
+}

--- a/scripts/fixtures/eval_lock/banned_item/src.rs
+++ b/scripts/fixtures/eval_lock/banned_item/src.rs
@@ -1,0 +1,7 @@
+impl Array {
+    pub fn to_scalar(&self) -> f32 {
+        let mut out = 0.0f32;
+        unsafe { sys::mlx_array_item_float32(&raw mut out, self.inner) };
+        out
+    }
+}

--- a/scripts/fixtures/eval_lock/banned_load_gguf/src.rs
+++ b/scripts/fixtures/eval_lock/banned_load_gguf/src.rs
@@ -1,5 +1,5 @@
-pub fn write_snapshot(path: &CStr, arr: &Array) -> Result<()> {
-    let status = unsafe { sys::mlx_save_safetensors(path.as_ptr(), map, meta) };
+pub fn read_gguf(path: &CStr) -> Result<()> {
+    let status = unsafe { sys::mlx_load_gguf(&raw mut a, &raw mut b, path.as_ptr()) };
     Ok(())
 }
 

--- a/scripts/fixtures/eval_lock/banned_save/src.rs
+++ b/scripts/fixtures/eval_lock/banned_save/src.rs
@@ -1,0 +1,4 @@
+pub fn write_snapshot(path: &CStr, arr: &Array) -> Result<()> {
+    let status = unsafe { sys::mlx_save_safetensors(path.as_ptr(), map, meta) };
+    Ok(())
+}

--- a/scripts/fixtures/eval_lock/banned_save_writer/src.rs
+++ b/scripts/fixtures/eval_lock/banned_save_writer/src.rs
@@ -1,5 +1,5 @@
-pub fn write_snapshot(path: &CStr, arr: &Array) -> Result<()> {
-    let status = unsafe { sys::mlx_save_safetensors(path.as_ptr(), map, meta) };
+pub fn stream_out(w: mlx_io_writer, a: &Array) -> Result<()> {
+    let status = unsafe { sys::mlx_save_writer(w, a.inner) };
     Ok(())
 }
 

--- a/scripts/fixtures/eval_lock/banned_tostring/src.rs
+++ b/scripts/fixtures/eval_lock/banned_tostring/src.rs
@@ -5,3 +5,8 @@ impl std::fmt::Debug for Array {
         write!(f, "Array")
     }
 }
+
+fn guarded_anchor(a: &Array) -> Result<()> {
+    let s = with_eval_lock(|| unsafe { sys::mlx_array_eval(a.inner) });
+    unsafe { check_status(s, "anchor") }
+}

--- a/scripts/fixtures/eval_lock/banned_tostring/src.rs
+++ b/scripts/fixtures/eval_lock/banned_tostring/src.rs
@@ -1,0 +1,7 @@
+impl std::fmt::Debug for Array {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = unsafe { sys::mlx_string_new() };
+        unsafe { sys::mlx_array_tostring(&raw mut s, self.inner) };
+        write!(f, "Array")
+    }
+}

--- a/scripts/fixtures/eval_lock/clean/src.rs
+++ b/scripts/fixtures/eval_lock/clean/src.rs
@@ -9,4 +9,9 @@ impl Array {
         let status = with_eval_lock(|| unsafe { sys::mlx_async_eval(vec) });
         unsafe { check_status(status, "Array::async_eval") }
     }
+
+    pub fn apply(&self) -> Result<()> {
+        let status = with_eval_lock(|| unsafe { sys::mlx_closure_apply(&raw mut o, c, i) });
+        unsafe { check_status(status, "Closure::apply") }
+    }
 }

--- a/scripts/fixtures/eval_lock/clean/src.rs
+++ b/scripts/fixtures/eval_lock/clean/src.rs
@@ -1,0 +1,12 @@
+impl Array {
+    pub fn eval(&self) -> Result<()> {
+        // SAFETY: inner is a valid mlx_array.
+        let status = with_eval_lock(|| unsafe { sys::mlx_array_eval(self.inner) });
+        unsafe { check_status(status, "Array::eval") }
+    }
+
+    pub fn async_eval(&self) -> Result<()> {
+        let status = with_eval_lock(|| unsafe { sys::mlx_async_eval(vec) });
+        unsafe { check_status(status, "Array::async_eval") }
+    }
+}

--- a/scripts/fixtures/eval_lock/closure_applies/src.rs
+++ b/scripts/fixtures/eval_lock/closure_applies/src.rs
@@ -1,0 +1,16 @@
+fn build() -> Result<Closure> {
+    // The "fuse two fused kernels" refactor. `Closure::apply` takes the eval
+    // lock internally, so applying one from inside a closure body deadlocks —
+    // even though nothing here calls .eval() directly.
+    let raw = Closure::from_fn(move |inputs| -> Result<Vec<Array>> {
+        let inner = swiglu_compiled()?;
+        let outs = inner.apply(&[&x, &x])?;
+        Ok(outs)
+    });
+    Ok(raw)
+}
+
+fn guarded_anchor(a: &Array) -> Result<()> {
+    let s = with_eval_lock(|| unsafe { sys::mlx_array_eval(a.inner) });
+    unsafe { check_status(s, "anchor") }
+}

--- a/scripts/fixtures/eval_lock/closure_clean/src.rs
+++ b/scripts/fixtures/eval_lock/closure_clean/src.rs
@@ -2,11 +2,11 @@ fn build() -> Result<Closure> {
     let raw = Closure::from_fn(move |inputs| -> Result<Vec<Array>> {
         let mut iter = inputs.into_iter();
         let x = iter.next().expect("x");
-        // A brace inside a string must not desync the body scan: "{}"
         let y = add(&x, &x, device)?;
         let y = if y.dtype() == in_dtype { y } else { y.astype(in_dtype, device)? };
+        let outs = kernel.apply(invoke, device)?;
         Ok(vec![y])
     });
-    with_eval_lock(|| unsafe { sys::mlx_closure_apply(&raw mut out, cls, vin) });
+    let status = with_eval_lock(|| unsafe { sys::mlx_closure_apply(&raw mut o, c, i) });
     Ok(raw)
 }

--- a/scripts/fixtures/eval_lock/closure_clean/src.rs
+++ b/scripts/fixtures/eval_lock/closure_clean/src.rs
@@ -1,0 +1,12 @@
+fn build() -> Result<Closure> {
+    let raw = Closure::from_fn(move |inputs| -> Result<Vec<Array>> {
+        let mut iter = inputs.into_iter();
+        let x = iter.next().expect("x");
+        // A brace inside a string must not desync the body scan: "{}"
+        let y = add(&x, &x, device)?;
+        let y = if y.dtype() == in_dtype { y } else { y.astype(in_dtype, device)? };
+        Ok(vec![y])
+    });
+    with_eval_lock(|| unsafe { sys::mlx_closure_apply(&raw mut out, cls, vin) });
+    Ok(raw)
+}

--- a/scripts/fixtures/eval_lock/closure_evals/src.rs
+++ b/scripts/fixtures/eval_lock/closure_evals/src.rs
@@ -1,0 +1,10 @@
+fn build() -> Result<Closure> {
+    let raw = Closure::from_fn(move |inputs| -> Result<Vec<Array>> {
+        let mut iter = inputs.into_iter();
+        let x = iter.next().expect("x");
+        let y = add(&x, &x, device)?;
+        y.eval()?;
+        Ok(vec![y])
+    });
+    Ok(raw)
+}

--- a/scripts/fixtures/eval_lock/closure_evals_async/src.rs
+++ b/scripts/fixtures/eval_lock/closure_evals_async/src.rs
@@ -1,9 +1,7 @@
 fn build() -> Result<Closure> {
     let raw = Closure::from_fn(move |inputs| -> Result<Vec<Array>> {
-        let mut iter = inputs.into_iter();
-        let x = iter.next().expect("x");
         let y = add(&x, &x, device)?;
-        y.eval()?;
+        y.async_eval()?;
         Ok(vec![y])
     });
     Ok(raw)

--- a/scripts/fixtures/eval_lock/closure_to_bytes/src.rs
+++ b/scripts/fixtures/eval_lock/closure_to_bytes/src.rs
@@ -1,9 +1,7 @@
 fn build() -> Result<Closure> {
     let raw = Closure::from_fn(move |inputs| -> Result<Vec<Array>> {
-        let mut iter = inputs.into_iter();
-        let x = iter.next().expect("x");
         let y = add(&x, &x, device)?;
-        y.eval()?;
+        let bytes = y.to_bytes()?;
         Ok(vec![y])
     });
     Ok(raw)

--- a/scripts/fixtures/eval_lock/closure_ufcs_eval/src.rs
+++ b/scripts/fixtures/eval_lock/closure_ufcs_eval/src.rs
@@ -1,9 +1,7 @@
 fn build() -> Result<Closure> {
     let raw = Closure::from_fn(move |inputs| -> Result<Vec<Array>> {
-        let mut iter = inputs.into_iter();
-        let x = iter.next().expect("x");
         let y = add(&x, &x, device)?;
-        y.eval()?;
+        Array::eval(&y)?;
         Ok(vec![y])
     });
     Ok(raw)

--- a/scripts/fixtures/eval_lock/closure_unbalanced_brace_string/src.rs
+++ b/scripts/fixtures/eval_lock/closure_unbalanced_brace_string/src.rs
@@ -1,7 +1,8 @@
 fn build() -> Result<Closure> {
     let raw = Closure::from_fn(move |inputs| -> Result<Vec<Array>> {
-        let mut iter = inputs.into_iter();
-        let x = iter.next().expect("x");
+        // An unbalanced brace inside a string literal must not end the body
+        // scan early and hide the evaluation that follows it.
+        let msg = "trailing brace: }";
         let y = add(&x, &x, device)?;
         y.eval()?;
         Ok(vec![y])

--- a/scripts/fixtures/eval_lock/column0_comment/src.rs
+++ b/scripts/fixtures/eval_lock/column0_comment/src.rs
@@ -1,0 +1,11 @@
+impl Array {
+    pub fn eval(&self) -> Result<()> {
+        let status = with_eval_lock(|| {
+// A column-0 comment inside the closure. rustfmt does not normalise comment
+// indentation, so this shape survives `cargo fmt` and must not be read as a
+// block opener that severs the guard chain.
+            unsafe { sys::mlx_array_eval(self.inner) }
+        });
+        unsafe { check_status(status, "Array::eval") }
+    }
+}

--- a/scripts/fixtures/eval_lock/comment_launder/src.rs
+++ b/scripts/fixtures/eval_lock/comment_launder/src.rs
@@ -1,0 +1,6 @@
+impl Array {
+    pub fn eval(&self) -> Result<()> {
+        let status = unsafe { sys::mlx_array_eval(self.inner) }; // with_eval_lock: caller already holds it
+        unsafe { check_status(status, "Array::eval") }
+    }
+}

--- a/scripts/fixtures/eval_lock/empty_tree/src.rs
+++ b/scripts/fixtures/eval_lock/empty_tree/src.rs
@@ -1,0 +1,1 @@
+pub fn nothing_to_see() -> u32 { 7 }

--- a/scripts/fixtures/eval_lock/ffi_path_spelling/src.rs
+++ b/scripts/fixtures/eval_lock/ffi_path_spelling/src.rs
@@ -1,0 +1,6 @@
+impl Array {
+    pub fn eval(&self) -> Result<()> {
+        let status = unsafe { sys::ffi::mlx_array_eval(self.inner) };
+        unsafe { check_status(status, "Array::eval") }
+    }
+}

--- a/scripts/fixtures/eval_lock/guarded_sibling/src.rs
+++ b/scripts/fixtures/eval_lock/guarded_sibling/src.rs
@@ -1,0 +1,7 @@
+impl Array {
+    pub fn eval_twice(&self) -> Result<()> {
+        let a = with_eval_lock(|| unsafe { sys::mlx_array_eval(self.inner) });
+        let b = unsafe { sys::mlx_array_eval(self.other) };
+        Ok(())
+    }
+}

--- a/scripts/fixtures/eval_lock/local_fn_lookalike/src.rs
+++ b/scripts/fixtures/eval_lock/local_fn_lookalike/src.rs
@@ -1,0 +1,22 @@
+// Crate-local helpers that merely share a name with an mlx-c symbol. They are
+// not FFI calls, so they must not be flagged — that is what the `sys::` anchor
+// on the banned pattern buys, and this fixture is what makes dropping the
+// anchor fail the corpus instead of merely widening it unnoticed.
+fn mlx_eval(v: u32) -> u32 {
+    v + 1
+}
+
+fn mlx_array_tostring(a: u32) -> String {
+    format!("{a}")
+}
+
+pub fn use_them() -> u32 {
+    let a = mlx_eval(7);
+    let _s = mlx_array_tostring(a);
+    a
+}
+
+fn guarded_anchor(a: &Array) -> Result<()> {
+    let s = with_eval_lock(|| unsafe { sys::mlx_array_eval(a.inner) });
+    unsafe { check_status(s, "anchor") }
+}

--- a/scripts/fixtures/eval_lock/lock_removed/src.rs
+++ b/scripts/fixtures/eval_lock/lock_removed/src.rs
@@ -1,0 +1,6 @@
+impl Array {
+    pub fn eval(&self) -> Result<()> {
+        let status = unsafe { sys::mlx_array_eval(self.inner) };
+        unsafe { check_status(status, "Array::eval") }
+    }
+}

--- a/scripts/fixtures/eval_lock/lock_removed_async/src.rs
+++ b/scripts/fixtures/eval_lock/lock_removed_async/src.rs
@@ -1,7 +1,7 @@
 impl Array {
-    pub fn eval_alt(&self) -> Result<()> {
-        let status = unsafe { sys::ffi::mlx_array_item_float32(&raw mut o, self.inner) };
-        Ok(())
+    pub fn async_eval(&self) -> Result<()> {
+        let status = unsafe { sys::mlx_async_eval(vec) };
+        unsafe { check_status(status, "Array::async_eval") }
     }
 }
 

--- a/scripts/fixtures/eval_lock/lock_removed_closure_apply/src.rs
+++ b/scripts/fixtures/eval_lock/lock_removed_closure_apply/src.rs
@@ -1,0 +1,12 @@
+impl Closure {
+    pub fn apply(&self, inputs: &[&Array]) -> Result<Vec<Array>> {
+        let status = unsafe { sys::mlx_closure_apply(&raw mut vec_out, self.inner, vec_in) };
+        unsafe { check_status(status, "Closure::apply") }?;
+        Ok(Vec::new())
+    }
+}
+
+fn guarded_anchor(a: &Array) -> Result<()> {
+    let s = with_eval_lock(|| unsafe { sys::mlx_array_eval(a.inner) });
+    unsafe { check_status(s, "anchor") }
+}

--- a/scripts/fixtures/eval_lock/long_safety_comment/src.rs
+++ b/scripts/fixtures/eval_lock/long_safety_comment/src.rs
@@ -1,0 +1,12 @@
+impl Array {
+    pub fn eval(&self) -> Result<()> {
+        let status = with_eval_lock(|| {
+            // SAFETY: inner is a valid mlx_array handle for the whole call.
+            // The lock is held across exactly this FFI call and nothing else.
+            // Error capture is thread-local, so check_status stays outside.
+            // This comment is deliberately long: it is the crate convention.
+            unsafe { sys::mlx_array_eval(self.inner) }
+        });
+        unsafe { check_status(status, "Array::eval") }
+    }
+}

--- a/scripts/fixtures/eval_lock/nested_block/src.rs
+++ b/scripts/fixtures/eval_lock/nested_block/src.rs
@@ -1,0 +1,11 @@
+impl Array {
+    pub fn eval(&self) -> Result<()> {
+        let status = with_eval_lock(|| {
+            let r = unsafe {
+                sys::mlx_array_eval(self.inner)
+            };
+            r
+        });
+        unsafe { check_status(status, "Array::eval") }
+    }
+}

--- a/scripts/fixtures/eval_lock/prose_only/src.rs
+++ b/scripts/fixtures/eval_lock/prose_only/src.rs
@@ -1,6 +1,8 @@
-//! The reach-set includes `mlx_eval`, every `mlx_array_item_*`,
-//! `mlx_array_tostring`, `mlx_save_safetensors` and `mlx_load_gguf`.
-//! None of those names in prose is a call site.
+//! The reach-set includes sys::mlx_eval(v), every sys::mlx_array_item_float32(p, a),
+//! sys::mlx_array_tostring(s, a), sys::mlx_save_safetensors(p, m, d) and
+//! sys::mlx_load_gguf(a, b, c) — named here with their parentheses on purpose,
+//! so that deleting the `sys::` anchor from the banned pattern does not leave
+//! this fixture silently green.
 impl Array {
     pub fn eval(&self) -> Result<()> {
         let status = with_eval_lock(|| unsafe { sys::mlx_array_eval(self.inner) });

--- a/scripts/fixtures/eval_lock/prose_only/src.rs
+++ b/scripts/fixtures/eval_lock/prose_only/src.rs
@@ -1,0 +1,9 @@
+//! The reach-set includes `mlx_eval`, every `mlx_array_item_*`,
+//! `mlx_array_tostring`, `mlx_save_safetensors` and `mlx_load_gguf`.
+//! None of those names in prose is a call site.
+impl Array {
+    pub fn eval(&self) -> Result<()> {
+        let status = with_eval_lock(|| unsafe { sys::mlx_array_eval(self.inner) });
+        unsafe { check_status(status, "Array::eval") }
+    }
+}


### PR DESCRIPTION
Closes #371.

`make ci` intermittently SIGSEGVs in an MLX-linking test binary, never reproducible in
isolation. **It fired twice more during the work that produced this PR** — on two unrelated
branches, both times as `rmlx_models-d677e2c819f4cd8a (signal: 11, SIGSEGV)` followed by
`make: *** [test] Error 101`, and both times a plain re-run was clean. That is five recorded
occurrences, and the current workaround is "run CI again", which is exactly what makes a gate
untrustworthy.

## Root cause — upstream, and we cannot take the upstream fix

MLX 0.31.2's `mlx/backend/cpu/encoder.cpp` holds a process-global
`std::unordered_map<int, CommandEncoder> encoder_map` with **no mutex**, while default CPU
streams are per-thread. Two threads evaluating concurrently race on that map's internal
structure. Upstream fixed it in 0.32.0 by making the map `thread_local` — but the 0.32.0
bottle ships **zero NAX GEMM kernels**, a 3.8× matmul loss on this hardware, so the brew pin
must stay at 0.31.2 + mlx-c 0.6.0_2. The fix therefore has to be ours.

This was caught live on this host before it was understood: a hung process at 44 minutes and
100% CPU, with `sample` putting **2170 of 2170 frames** in
`mlx::core::cpu::get_command_encoder → __emplace_unique_key_args`.

## What changed

A process-global `EVAL_LOCK`, applied through one `with_eval_lock` wrapper rather than
scattered `lock()` calls, on `mlx_array_eval`, `mlx_async_eval` and `mlx_closure_apply`.
Poison is recovered with `PoisonError::into_inner` — a panicking evaluation does not make the
lock permanently unusable.

`mlx_closure_apply` is in the set because it dispatches through a `std::function`, so it can
reach an eval that reverse-reachability analysis cannot see. That is also why the gate's
reach-set is **25 symbols, not 24**: `otool` cannot follow a `blr` through a function pointer,
so that one had to be added by hand and is documented as such.

## The gate

`scripts/check_eval_lock.sh` makes the convention structural instead of a comment, with three
rules: unguarded eval-reaching entry points are banned, the enclosing block must take the
lock, and a closure body must not take it (which would deadlock). A fixture corpus pins each
rule's failure *reason*, not merely a non-zero exit — an earlier revision of that corpus had
every RULE 1 and RULE 3 case tripping RULE 2's anti-vacuity branch instead, passing for the
wrong reason.

Portability across gawk / mawk / BSD awk and both `LC_ALL=C` and UTF-8 is measured and
recorded, because the hosted `source gates` job runs on Linux while this dev machine has only
BSD awk — a previous gate in this repo passed locally and was rejected outright by the Linux
job.

## Performance: measured, not asserted

The rule was fixed **before** the runs: merge only if the one-sided 95% lower bound on the
prefill-throughput ratio excludes a 1% regression.

| cell | prefill window | comparisons / clusters | point B/A | one-sided 95% LB |
|---|---|---|---:|---:|
| Ternary-Bonsai-27B (GDN) | 4.82 s | 46 / 24 | 0.99868 (−0.13%) | **0.99260** |
| Ternary-Bonsai-8B | 1.38 s | 27 / 14 | 1.00766 (+0.77%) | 0.99997 |
| gemma-4-e2b | 0.17 s | 27 / 14 | 0.99648 (−0.35%) | 0.98897 |

Decode was measured separately and is clean. Token digest `0x9ca2243144245fa8` is identical
across both arms and every round, `contended=False` on all 96 GDN invocations, one settle-gate
loss in 64.

Method notes worth keeping:

- **The baseline is the branch's own parent `61a6b4a1`, not current main.** Comparing against
  main would have imported an unrelated 373-line `sampler.rs` change into the baseline arm.
- Binaries were verified different **by symbol** before any number was trusted:
  `with_eval_lock` 0 in base / 4 in the lock rlib, and the binary tracing marker moves
  `lib.rs:193` → `:290`, exactly the +97-line displacement the `EVAL_LOCK` block inserts.
- The estimator brackets each lock invocation between its temporally nearest base invocations
  and interpolates, bootstrapped clustered by block — robust to the ~19% settle-gate attrition,
  which was lopsided toward the base arm and would otherwise have introduced a selection
  effect.
- **A first GDN round returned an inconclusive 0.97657 and was not merged on it.** It had
  started immediately after two `release-perf` builds and captured the machine's thermal
  transient; a second round at steady state — *with* concurrent `make ci` — halved the standard
  deviation to 1.14%. Thermal steady state dominates background CPU load as a variance source
  here.
- gemma-4-e2b is a **weak instrument** for prefill A/B at 0.17 s and is reported for
  completeness, not as evidence. Instrument quality is set by the length of the measured
  window, not by architecture diversity.

`make ci` green.
