### PR TITLE
fix(kv): reorder each block at its own offset, and repair the iso ring/blocks divergence (#383, #392)

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/iso_flash_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/iso_flash_dispatch_tests.rs
@@ -330,3 +330,61 @@ fn iso4_cpu_append_drops_a_live_gpu_ring() {
     }
     cpu_append_drops_a_live_ring(KvQuant::IsoKOnly4, "iso4");
 }
+
+// ── iso4 V append orientation ────────────────────────────────────────────────
+
+/// The iso4 V **GPU** append must store the chunk the same way the CPU append
+/// does: sequence-major.
+///
+/// `update_iso4` / `update_iso4_sym` used to encode `new_v` head-major, straight
+/// off the model's `[B, kv_h, S, D]` tensor, while `QuantIsoV4::append` reorders
+/// heads↔seq first and `QuantIsoV4::dequant` reorders back. At `kv_h == 1` or
+/// `S == 1` the two coincide, which is why it survived; a multi-token chunk at
+/// `kv_h > 1` — a speculative verify chunk, or a continuation turn's prompt
+/// tokens against a warm cache — was stored transposed and decoded scrambled,
+/// and spilled that way to SSD. Both entries now go through the shared
+/// ring-aware appender, which reorders like every other iso append.
+///
+/// The CPU-appended store is the oracle: it is the one orientation `dequant`
+/// documents and the SSD reader assumes.
+///
+/// Mutation check: encode `new_v` instead of `packed_k_chunk_seq_major(new_v)`
+/// in `iso_gpu_encode_block_retaining`'s caller and this goes red at
+/// `kv_h = 2, S = 3` while staying green at `S = 1`.
+#[test]
+#[ignore = "GPU Metal context — run via `make gpu-test CRATE=rmlx-kv-quant FILTER=iso4_v_gpu_append_matches_cpu_append`"]
+fn iso4_v_gpu_append_matches_cpu_append_at_kv_h_gt_1() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    for (kv_h, seq) in [(1_usize, 3_usize), (2, 1), (2, 3), (3, 4)] {
+        let (b, head_dim) = (1_usize, 8_usize);
+        let shape = [b as i32, kv_h as i32, seq as i32, head_dim as i32];
+        let init = vec![b as i32, kv_h as i32, 0, head_dim as i32];
+        let data = crate::test_utils::batch_head_chunk(b, kv_h, 0, seq, head_dim);
+
+        let mut cpu = crate::storage::QuantIsoV4::new(init.clone(), MAX_SEQ);
+        cpu.append(&data, &shape).expect("cpu append");
+        let oracle = cpu.dequant().expect("cpu dequant");
+
+        // The GPU appender is private to `update`; drive it through the storage
+        // append it now shares, then compare the decoded values.
+        let bytes: Vec<u8> = data.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let arr = Array::from_bytes(&bytes, &shape, Dtype::F32).expect("chunk array");
+        let mut gpu = crate::storage::QuantIsoV4::new(init, MAX_SEQ);
+        super::update::iso4_v_gpu_append_for_test(&mut gpu, &arr, &shape, Device::Gpu, MAX_SEQ)
+            .expect("gpu append");
+        let got = gpu.dequant().expect("gpu-appended dequant");
+
+        assert_eq!(got.len(), oracle.len(), "length at kv_h={kv_h} seq={seq}");
+        let max_abs = got
+            .iter()
+            .zip(oracle.iter())
+            .fold(0.0_f32, |m, (a, c)| m.max((a - c).abs()));
+        assert!(
+            max_abs < 1e-5,
+            "GPU-appended iso4 V vs CPU-appended oracle: max abs error {max_abs} at \
+             kv_h={kv_h} seq={seq} — head↔seq orientation mismatch in the GPU append"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/kvcache/ring_feed_routing_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/ring_feed_routing_tests.rs
@@ -26,7 +26,10 @@
 //! If a call site is changed to bypass its constant, this file stays green and
 //! the matching pair goes red.
 
-use super::{is_ring_only_append, RingFeed, LEGACY_ROTOR_K_ONLY_FEED, LEGACY_ROTOR_SYM_FEED};
+use super::{
+    is_ring_only_append, RingFeed, LEGACY_ISO4_V_FEED, LEGACY_ROTOR_K_ONLY_FEED,
+    LEGACY_ROTOR_SYM_FEED,
+};
 
 /// The arm is chosen by `feed` and `b` only — never by chunk length.
 ///
@@ -112,4 +115,35 @@ fn only_the_k_only_legacy_feed_keeps_the_ring() {
         RingFeed::Maintain,
         "the K-only legacy entry keeps the ring, so a ring-only tail survives a fallback step"
     );
+}
+
+/// The legacy iso4 V entries drop the ring, which is also what routes them
+/// through the sequence-major append.
+///
+/// `update_iso4` / `update_iso4_sym` used to call a bespoke helper that encoded
+/// the chunk **head-major** and touched the ring not at all. `QuantIsoV4::append`
+/// and `QuantIsoV4::dequant` are both sequence-major, so a multi-token chunk at
+/// `kv_h > 1` was stored transposed and decoded scrambled — and a live ring was
+/// left stale underneath it. Both entries now pass this constant to the shared
+/// ring-aware appender, which reconciles the ring, drops it, and stores the
+/// chunk sequence-major like every other iso append.
+///
+/// Same coverage boundary as the rotor pins above: this is a CPU gate on the
+/// constant, not on the encode. The consequence needs Metal and is pinned by
+/// `iso4_v_gpu_append_matches_cpu_append_at_kv_h_gt_1`.
+#[test]
+fn the_legacy_iso4_v_feed_drops_the_ring_and_takes_the_block_path() {
+    assert_eq!(
+        LEGACY_ISO4_V_FEED,
+        RingFeed::Skip,
+        "the legacy iso4 V entries dequantize the whole prefix on the same step, so the CPU \
+         blocks must be the only copy and the ring is dropped"
+    );
+    for shape in [[1_i32, 2, 1, 128], [1, 2, 5, 128], [2, 2, 5, 128]] {
+        assert!(
+            !is_ring_only_append(LEGACY_ISO4_V_FEED, &shape),
+            "the legacy iso4 V feed must reach the block path at shape {shape:?} — that arm \
+             is what reconciles the ring and stores the chunk sequence-major"
+        );
+    }
 }

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -15,7 +15,7 @@ use rmlx_mlx::{zeros, Array, Device, Dtype};
 use crate::storage::{
     iso_n_groups_for, IsoBlocks, KvStorage, QuantIsoK3, QuantIsoK4, QuantIsoV3, QuantIsoV4, QuantK,
     QuantKTurbo3, QuantKTurbo4, QuantPlanarK, QuantPlanarV, QuantRotorV3, QuantRotorV4, QuantV,
-    RotorBlocks, RotorKBlocks, ISO4_GROUP_SIZE, ISO_K3_BITS, ISO_K4_BITS,
+    RotorBlocks, RotorKBlocks, ISO_K3_BITS, ISO_K4_BITS,
 };
 use crate::turbo_flash_msl::{turbo_flash_sdpa, turbo_flash_should_run};
 use crate::KvQuant;
@@ -64,86 +64,6 @@ fn cast_store_bf16(arr: &Array, device: Device) -> Result<Option<Array>> {
     }
 }
 
-/// Encode a KV chunk (`new_kv`, shape `[B, kv_h, S, D]`) via the iso4
-/// MSL kernel and return the resulting CPU [`IsoBlocks`].
-///
-/// Mirrors the CPU codec ([`crate::isoquant::iso_encode_fast`] with
-/// `bits = 4`): the returned block's `n_tokens` equals `B * kv_h * S`, codes
-/// are bit-packed identically (8 vals/u32, dense), and the per-token L2 norm
-/// is preserved (deduplicated from the per-group GPU norm slot).
-///
-/// The kernel is axis-agnostic, so the same helper drives both the V-side
-/// ([`QuantIsoV4`]) and K-side ([`QuantIsoK4`]) appenders.
-///
-/// # Errors
-///
-/// Forwards Metal kernel / shape errors as `Error::Mlx` / `Error::Quant`.
-#[allow(
-    clippy::indexing_slicing,
-    reason = "shape rank guarded to 4 immediately above each indexing site; new_shape[0..=3] are always in-bounds"
-)]
-fn iso4_gpu_encode_block(new_kv: &Array, new_shape: &[i32]) -> Result<IsoBlocks> {
-    if new_shape.len() != 4 {
-        return Err(Error::Mlx(format!(
-            "iso4_gpu_encode_block: expected 4D new_shape, got {new_shape:?}"
-        )));
-    }
-    let b = new_shape[0] as usize;
-    let kv_h = new_shape[1] as usize;
-    let s = new_shape[2] as usize;
-    let head_dim = new_shape[3] as usize;
-    let n_tokens_total = b * kv_h * s;
-    if !head_dim.is_multiple_of(ISO4_GROUP_SIZE) {
-        return Err(Error::Quant(format!(
-            "iso4_gpu_encode_block: head_dim={head_dim} must be a positive multiple of \
-             ISO4_GROUP_SIZE={ISO4_GROUP_SIZE}"
-        )));
-    }
-    let n_groups = head_dim / ISO4_GROUP_SIZE;
-
-    tracing::debug!(
-        target: "rmlx::kv_quant::iso4",
-        n_tokens = n_tokens_total,
-        n_groups,
-        head_dim,
-        "iso4 GPU encode block"
-    );
-
-    let (codes_arr, scales_arr, quats_arr, norms_arr) =
-        crate::isoquant_msl_v4::iso_quantize_v4_gpu(new_kv, head_dim, Device::Gpu)?;
-    let (codes, scales, quaternions, norms) = crate::isoquant_msl_v4::iso4_gpu_outputs_to_cpu(
-        &codes_arr,
-        &scales_arr,
-        &quats_arr,
-        &norms_arr,
-        n_tokens_total,
-        n_groups,
-    )?;
-
-    Ok(IsoBlocks {
-        codes,
-        scales,
-        quaternions,
-        norms,
-        n_tokens: n_tokens_total,
-    })
-}
-
-/// Push a pre-built [`IsoBlocks`] onto a [`QuantIsoV4`] buffer and update
-/// `vs.shape` the same way [`QuantIsoV4::append`] does.
-#[allow(
-    clippy::indexing_slicing,
-    reason = "vs.shape rank-4 guard above each indexing site; new_shape rank validated by upstream encoder helper"
-)]
-fn push_iso4_v_block(vs: &mut QuantIsoV4, block: IsoBlocks, new_shape: &[i32]) {
-    vs.blocks.push(block);
-    if vs.shape.len() != 4 || vs.shape[0] == 0 {
-        vs.shape = new_shape.to_vec();
-    } else {
-        vs.shape[2] += new_shape[2];
-    }
-}
-
 /// Push a pre-built [`IsoBlocks`] onto a [`QuantIsoK4`] buffer and update
 /// `ks.shape` the same way [`QuantIsoK4::append`] does.
 #[allow(
@@ -157,19 +77,6 @@ fn push_iso4_k_block(ks: &mut QuantIsoK4, block: IsoBlocks, new_shape: &[i32]) {
     } else {
         ks.shape[2] += new_shape[2];
     }
-}
-
-/// Convenience wrapper — encode `new_v` via GPU iso4 kernel and append
-/// the resulting block to `vs`. Shared by [`KvCache::update_iso4`] and
-/// [`KvCache::update_iso4_sym`].
-fn iso4_gpu_append_into_blocks(
-    vs: &mut QuantIsoV4,
-    new_v: &Array,
-    new_shape: &[i32],
-) -> Result<()> {
-    let block = iso4_gpu_encode_block(new_v, new_shape)?;
-    push_iso4_v_block(vs, block, new_shape);
-    Ok(())
 }
 
 /// Mirror of [`iso3_gpu_append_into_k_blocks`] for the iso4 codec — see it for
@@ -6916,7 +6823,7 @@ impl KvCache {
         }
         let vs = v.as_mut().unwrap();
         if device == Device::Gpu {
-            iso4_gpu_append_into_blocks(vs, new_v, &new_shape)?;
+            iso4_gpu_append_into_v_blocks(vs, new_v, &new_shape, device, RingFeed::Skip, max_seq)?;
         } else {
             vs.append(&v_f32, &new_shape)?;
         }
@@ -7123,7 +7030,7 @@ impl KvCache {
             return Err(Error::Mlx("IsoSym4 V buffer absent after init".into()));
         };
         if device == Device::Gpu {
-            iso4_gpu_append_into_blocks(vs, new_v, &new_shape)?;
+            iso4_gpu_append_into_v_blocks(vs, new_v, &new_shape, device, RingFeed::Skip, max_seq)?;
         } else {
             vs.append(&v_f32, &new_shape)?;
         }

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -783,6 +783,16 @@ enum RingFeed {
 /// `crate::storage::truncate_plan`.
 const LEGACY_ROTOR_SYM_FEED: RingFeed = RingFeed::Skip;
 
+/// Feed the legacy iso V `update_iso4` / `update_iso4_sym` entries pass.
+///
+/// Named for the same reason as the rotor constants: these entries dequantize
+/// the whole prefix on the same step, so the CPU blocks must carry everything
+/// and the ring is dropped. Passing it also routes the append through
+/// [`iso4_gpu_append_into_v_blocks`], which reconciles a pre-existing ring-only
+/// tail **and** stores the chunk sequence-major — the orientation the CPU
+/// `QuantIsoV4::append` and `QuantIsoV4::dequant` both assume.
+const LEGACY_ISO4_V_FEED: RingFeed = RingFeed::Skip;
+
 /// Feed the legacy rotor K-only `update_*` entries pass.
 ///
 /// Unlike the sym path these keep the ring, so a ring-only tail survives a
@@ -1856,6 +1866,22 @@ fn iso3_gpu_append_into_v_blocks(
     vs.blocks.push(block);
     bump_rotor_k_shape(&mut vs.shape, new_shape);
     Ok(())
+}
+
+/// Test seam onto the iso4 V append the legacy entries use.
+///
+/// The appender is private to this module; the orientation test lives with the
+/// other iso dispatch tests, one module up. Exposing the call rather than
+/// duplicating it is what keeps the test pinned to the production path.
+#[cfg(test)]
+pub(super) fn iso4_v_gpu_append_for_test(
+    vs: &mut QuantIsoV4,
+    new_v: &Array,
+    new_shape: &[i32],
+    device: Device,
+    max_seq: i32,
+) -> Result<()> {
+    iso4_gpu_append_into_v_blocks(vs, new_v, new_shape, device, LEGACY_ISO4_V_FEED, max_seq)
 }
 
 /// Mirror of [`iso3_gpu_append_into_v_blocks`] for [`QuantIsoV4`].
@@ -6823,7 +6849,14 @@ impl KvCache {
         }
         let vs = v.as_mut().unwrap();
         if device == Device::Gpu {
-            iso4_gpu_append_into_v_blocks(vs, new_v, &new_shape, device, RingFeed::Skip, max_seq)?;
+            iso4_gpu_append_into_v_blocks(
+                vs,
+                new_v,
+                &new_shape,
+                device,
+                LEGACY_ISO4_V_FEED,
+                max_seq,
+            )?;
         } else {
             vs.append(&v_f32, &new_shape)?;
         }
@@ -7030,7 +7063,14 @@ impl KvCache {
             return Err(Error::Mlx("IsoSym4 V buffer absent after init".into()));
         };
         if device == Device::Gpu {
-            iso4_gpu_append_into_v_blocks(vs, new_v, &new_shape, device, RingFeed::Skip, max_seq)?;
+            iso4_gpu_append_into_v_blocks(
+                vs,
+                new_v,
+                &new_shape,
+                device,
+                LEGACY_ISO4_V_FEED,
+                max_seq,
+            )?;
         } else {
             vs.append(&v_f32, &new_shape)?;
         }

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -1402,12 +1402,15 @@ fn iso_gpu_encode_block_retaining(
     let head_dim = head_dim_from_shape(new_shape, "iso_gpu_encode_block_retaining")?;
     let (b, kv_h, s) = b_kv_h_new_seq(new_shape)?;
     let n_tokens_total = (b as usize) * (kv_h as usize) * (s as usize);
-    let n_groups = iso_n_groups_for(head_dim);
-    if n_groups == 0 {
-        return Err(Error::Quant(format!(
-            "iso_gpu_encode_block_retaining: head_dim={head_dim} yields no quaternion groups"
-        )));
-    }
+    // Strict form: `iso_n_groups_for` truncates, so a `head_dim` that is not a
+    // whole number of quaternion blocks would silently drop the trailing partial
+    // group. The helper the deleted iso4 encoder used rejected that; keep the
+    // rejection now that this is the shared path.
+    let n_groups = usize::try_from(crate::storage::iso_n_groups_i32(
+        head_dim as i32,
+        "iso_gpu_encode_block_retaining",
+    )?)
+    .map_err(|_| Error::Quant("iso_gpu_encode_block_retaining: n_groups negative".to_owned()))?;
 
     let (codes_arr, scales_arr, quats_arr, norms_arr) = match bits {
         ISO_K3_BITS => crate::isoquant_msl::iso_quantize_v3_gpu(new_k, head_dim, Device::Gpu)?,
@@ -1554,18 +1557,12 @@ fn materialize_iso_k4_ring_tail(ks: &mut QuantIsoK4, device: Device) -> Result<(
 
 /// Mirror of [`materialize_iso_k3_ring_tail`] for [`QuantIsoV3`].
 fn materialize_iso_v3_ring_tail(vs: &mut QuantIsoV3, device: Device) -> Result<()> {
-    if !vs.gpu.is_allocated() {
-        return Ok(());
-    }
-    let rebuilt = match crate::storage::synced_iso_v_blocks(&vs.blocks, &vs.shape, &vs.gpu, device)?
-    {
-        std::borrow::Cow::Owned(full) => Some(full),
-        std::borrow::Cow::Borrowed(_) => None,
-    };
-    if let Some(full) = rebuilt {
-        vs.blocks = full;
-    }
-    Ok(())
+    // One body for the reconcile: the store owns it, because the store is what
+    // has to keep `blocks` and the ring in step. This caller keeps the ring —
+    // its `sync_ring` decides the ring's fate a few lines later — while
+    // `QuantIsoV3::append_gpu` drops it, and that difference is the whole
+    // contract, so it is a parameter rather than two copies that can drift.
+    vs.reconcile_ring(device, crate::storage::RingDisposition::Keep)
 }
 
 /// Mirror of [`materialize_iso_v3_ring_tail`] for [`QuantIsoV4`].

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -106,7 +106,7 @@ fn iso4_gpu_append_into_k_blocks(
         bump_rotor_k_shape(&mut ks.shape, new_shape);
         return Ok(());
     }
-    materialize_iso_k4_ring_tail(ks, device)?;
+    ks.reconcile_ring(device, crate::storage::RingDisposition::Keep)?;
     let block_feed = if feed == RingFeed::Skip {
         RingFeed::Skip
     } else {
@@ -193,7 +193,7 @@ fn iso3_gpu_append_into_k_blocks(
     // legacy sym fallback (Skip). A ring-only feed that reaches here is a `b > 1`
     // chunk — normalise it to Maintain so the shared ring feeder clears the ring
     // for the un-representable batch and the CPU block carries the data.
-    materialize_iso_k3_ring_tail(ks, device)?;
+    ks.reconcile_ring(device, crate::storage::RingDisposition::Keep)?;
     let block_feed = if feed == RingFeed::Skip {
         RingFeed::Skip
     } else {
@@ -1521,66 +1521,6 @@ fn iso_gpu_encode_ring_only(
     })
 }
 
-/// Reconcile a pre-existing ring-only decode tail into `ks.blocks` before a
-/// block-path append — iso mirror of [`materialize_rotor_k3_ring_tail`]. No-op
-/// when `blocks` already cover `shape[2]` (reads no GPU).
-fn materialize_iso_k3_ring_tail(ks: &mut QuantIsoK3, device: Device) -> Result<()> {
-    if !ks.gpu.is_allocated() {
-        return Ok(());
-    }
-    let rebuilt = match crate::storage::synced_iso_v_blocks(&ks.blocks, &ks.shape, &ks.gpu, device)?
-    {
-        std::borrow::Cow::Owned(full) => Some(full),
-        std::borrow::Cow::Borrowed(_) => None,
-    };
-    if let Some(full) = rebuilt {
-        ks.blocks = full;
-    }
-    Ok(())
-}
-
-/// Mirror of [`materialize_iso_k3_ring_tail`] for [`QuantIsoK4`].
-fn materialize_iso_k4_ring_tail(ks: &mut QuantIsoK4, device: Device) -> Result<()> {
-    if !ks.gpu.is_allocated() {
-        return Ok(());
-    }
-    let rebuilt = match crate::storage::synced_iso_v_blocks(&ks.blocks, &ks.shape, &ks.gpu, device)?
-    {
-        std::borrow::Cow::Owned(full) => Some(full),
-        std::borrow::Cow::Borrowed(_) => None,
-    };
-    if let Some(full) = rebuilt {
-        ks.blocks = full;
-    }
-    Ok(())
-}
-
-/// Mirror of [`materialize_iso_k3_ring_tail`] for [`QuantIsoV3`].
-fn materialize_iso_v3_ring_tail(vs: &mut QuantIsoV3, device: Device) -> Result<()> {
-    // One body for the reconcile: the store owns it, because the store is what
-    // has to keep `blocks` and the ring in step. This caller keeps the ring —
-    // its `sync_ring` decides the ring's fate a few lines later — while
-    // `QuantIsoV3::append_gpu` drops it, and that difference is the whole
-    // contract, so it is a parameter rather than two copies that can drift.
-    vs.reconcile_ring(device, crate::storage::RingDisposition::Keep)
-}
-
-/// Mirror of [`materialize_iso_v3_ring_tail`] for [`QuantIsoV4`].
-fn materialize_iso_v4_ring_tail(vs: &mut QuantIsoV4, device: Device) -> Result<()> {
-    if !vs.gpu.is_allocated() {
-        return Ok(());
-    }
-    let rebuilt = match crate::storage::synced_iso_v_blocks(&vs.blocks, &vs.shape, &vs.gpu, device)?
-    {
-        std::borrow::Cow::Owned(full) => Some(full),
-        std::borrow::Cow::Borrowed(_) => None,
-    };
-    if let Some(full) = rebuilt {
-        vs.blocks = full;
-    }
-    Ok(())
-}
-
 /// Append `new_k` into a live `IsoKOnly3` store's GPU ring (+ CPU blocks),
 /// lazily creating the store on first use. No dequant — this is the entry point
 /// the iso flash-decode SDPA path uses.
@@ -1852,7 +1792,7 @@ fn iso3_gpu_append_into_v_blocks(
         bump_rotor_k_shape(&mut vs.shape, new_shape);
         return Ok(());
     }
-    materialize_iso_v3_ring_tail(vs, device)?;
+    vs.reconcile_ring(device, crate::storage::RingDisposition::Keep)?;
     let block_feed = if feed == RingFeed::Skip {
         RingFeed::Skip
     } else {
@@ -1906,7 +1846,7 @@ fn iso4_gpu_append_into_v_blocks(
         bump_rotor_k_shape(&mut vs.shape, new_shape);
         return Ok(());
     }
-    materialize_iso_v4_ring_tail(vs, device)?;
+    vs.reconcile_ring(device, crate::storage::RingDisposition::Keep)?;
     let block_feed = if feed == RingFeed::Skip {
         RingFeed::Skip
     } else {
@@ -6738,7 +6678,7 @@ impl KvCache {
             arr
         } else {
             let t_deq = std::time::Instant::now();
-            let v_recon_f32 = vs.dequant()?;
+            let v_recon_f32 = vs.dequant_on(device)?;
             tracing::trace!(
                 phase = "iso3_dequant_cpu",
                 ms = t_deq.elapsed().as_secs_f64() * 1e3,
@@ -6922,7 +6862,7 @@ impl KvCache {
         let k_full = if device == Device::Gpu {
             ks.dequant_gpu(device)?
         } else {
-            let k_recon_f32 = ks.dequant()?;
+            let k_recon_f32 = ks.dequant_on(device)?;
             f32_vec_to_array(&k_recon_f32, &k_shape)?
         };
 
@@ -6969,7 +6909,7 @@ impl KvCache {
             arr
         } else {
             let t_deq = std::time::Instant::now();
-            let v_recon_f32 = vs.dequant()?;
+            let v_recon_f32 = vs.dequant_on(device)?;
             tracing::trace!(
                 phase = "iso3_dequant_cpu",
                 ms = t_deq.elapsed().as_secs_f64() * 1e3,

--- a/crates/rmlx-kv-quant/src/storage/kv_storage.rs
+++ b/crates/rmlx-kv-quant/src/storage/kv_storage.rs
@@ -52,7 +52,17 @@ pub const ISOV3_LAYOUT_TAG: &str = "iso_v_3";
 /// Layout tag for V-axis IsoQuant 4-bit.
 ///
 /// Single source of truth for the SSD geometry tag.
-pub const ISOV4_LAYOUT_TAG: &str = "iso_v_4";
+// v2: the iso4 V GPU-encode append stored its block head-major while `dequant`
+// reads sequence-major, so a multi-token `kv_h > 1` chunk spilled head-scrambled
+// bytes. The append is fixed, and the tag is bumped because nothing else on disk
+// tells the two layouts apart: the block header carries only
+// `{tag, max_seq, shape}`, and the SSD index key
+// (`FNV_OFFSET ^ layout_key ^ cache_key_salt ^ model_sig`) is derived from the
+// arch, geometry and codec name — none of which move when the orientation of the
+// bytes inside a block does. With the bump a pre-fix entry hits no read arm and
+// fails its hydrate loudly ("unknown layer tag"); without it, it is read back
+// with the new orientation and no error. One cold pass after upgrading.
+pub const ISOV4_LAYOUT_TAG: &str = "iso_v_4_v2";
 
 /// Layout tag for V-axis rotor3 (Cl(3,0) Clifford sandwich).
 ///
@@ -73,7 +83,9 @@ pub const ROTORV4_LAYOUT_TAG: &str = "rotor_v_4";
 pub const ISO_SYM_3_LAYOUT_TAG: &str = "iso_sym_3";
 
 /// Layout tag for symmetric IsoQuant 4-bit K+V.
-pub const ISO_SYM_4_LAYOUT_TAG: &str = "iso_sym_4";
+// v2 for the same reason as `ISOV4_LAYOUT_TAG` — the V half of this storage
+// takes the same append.
+pub const ISO_SYM_4_LAYOUT_TAG: &str = "iso_sym_4_v2";
 
 /// Layout tag for K-only IsoQuant 3-bit (V stays bf16).
 ///

--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -60,7 +60,8 @@ pub use kv_storage::{
     TURBOSYM3_LAYOUT_TAG, TURBOSYM4_LAYOUT_TAG,
 };
 pub use quant_iso_k::{
-    iso_n_groups_for, QuantIsoK3, ISO_K3_BITS, ISO_K3_GROUP_SIZE, ISO_QUAT_BLOCK_SIZE,
+    iso_n_groups_for, iso_n_groups_i32, QuantIsoK3, ISO_K3_BITS, ISO_K3_GROUP_SIZE,
+    ISO_QUAT_BLOCK_SIZE,
 };
 pub use quant_iso_k4::{QuantIsoK4, ISO_K4_BITS, ISO_K4_GROUP_SIZE};
 pub(crate) use quant_iso_v::synced_iso_v_blocks;
@@ -162,6 +163,21 @@ pub const KV_PAGE_SIZE: i32 = 256;
 // the intra-block cut above still refuses. `sdpa::rotor_flash_shape_ok` still
 // refuses `b != 1` because the GPU ring's per-step stride does not interleave
 // batch, which is why no `b > 1` store ever has a ring to rebuild a gap from.
+
+/// What a reconcile does with the GPU ring once the CPU blocks are whole again.
+///
+/// The two callers of [`QuantIsoV3::reconcile_ring`] differ only here, and that
+/// difference is the ring/blocks contract itself: a caller that is about to feed
+/// the ring keeps it, a caller that is not must drop it, because a live ring
+/// that `blocks` have outgrown is the state where the next append writes past
+/// the ring's filled region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RingDisposition {
+    /// Leave the ring allocated — the caller feeds or clears it itself.
+    Keep,
+    /// Drop the ring; the CPU blocks are the authoritative copy from here.
+    Drop,
+}
 
 /// How a block-accumulating KV store must cut its blocks to reach `n`
 /// sequence positions.

--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -144,17 +144,24 @@ pub const KV_PAGE_SIZE: i32 = 256;
 // rejected region overwritable. Only the append-only CPU side has to be cut.
 //
 // The split is confined to `b == 1`, and that is a correctness bound, not a
-// simplification. Every store ends `dequant` with
-// `seq_layout::transpose_seq_heads` over the *concatenation* of its blocks,
-// which reads the buffer as one `[B, S_total, kv_h, D]` run. Each block is
-// only `[B, S_block, kv_h, D]`, so at `b > 1` the concatenation interleaves
-// batch elements and the reading is wrong for any store holding more than one
-// block. Splitting at `b > 1` would turn a mid-block cut from
-// blocks-short-of-`shape[2]` — which the reconciliation guards reject loudly —
-// into a two-block store that decodes silently scrambled. So `b > 1` keeps the
-// whole-block drop and the loud error. `sdpa::rotor_flash_shape_ok` refuses
-// `b != 1` for the same underlying reason, which is also why no `b > 1` store
-// ever has a ring to rebuild the gap from.
+// simplification. The bound is *inside* one block: a block's rows run
+// `[B, S_block, kv_h, D]`, so batch element 1's rows sit after all of batch
+// element 0's. `BlockRows::retain_rows` keeps a **row prefix**, and at `b > 1`
+// a row prefix is not a sequence prefix — it would keep all of batch 0 and
+// none of batch 1. Splitting there would silently drop one batch element's
+// tail instead of cutting every element at the same sequence position, so
+// `b > 1` keeps the whole-block drop, which leaves `blocks` short of
+// `shape[2]` and lets the reconciliation guards abort the request loudly.
+//
+// Reading the *concatenation* of the blocks used to be a second, independent
+// bound: every store ended `dequant` with `seq_layout::transpose_seq_heads`
+// over the concatenation, reading it as one `[B, S_total, kv_h, D]` run, which
+// is wrong at `b > 1` for any store holding more than one block. That is fixed
+// — `seq_layout::transpose_chunked_seq_heads` reorders each block at its own
+// sequence offset — so a multi-block `b > 1` store now decodes correctly; only
+// the intra-block cut above still refuses. `sdpa::rotor_flash_shape_ok` still
+// refuses `b != 1` because the GPU ring's per-step stride does not interleave
+// batch, which is why no `b > 1` store ever has a ring to rebuild a gap from.
 
 /// How a block-accumulating KV store must cut its blocks to reach `n`
 /// sequence positions.
@@ -223,19 +230,20 @@ pub(crate) fn truncate_plan(
             break;
         }
         if b != 1 {
-            // Rows run batch-major, so a sequence prefix is not a row prefix and
-            // the resulting two-block store would decode scrambled rather than
-            // error. Drop the block and let the reconciliation guard report the
-            // gap. See the module note.
+            // A block's rows run batch-major, so a sequence prefix is not a row
+            // prefix: `retain_rows` would keep all of batch 0 and none of batch
+            // 1 instead of cutting every batch element at `keep_seq`. Drop the
+            // block and let the reconciliation guard report the gap. See the
+            // module note.
             tracing::warn!(
                 b,
                 kv_h,
                 kept_seq = acc_seq,
                 target_seq,
-                "KV block truncate: refusing to split a block at b > 1 — the decode path \
-                 reads the block concatenation as one sequence run, so a split store would \
-                 be silently scrambled; dropping the block instead, which leaves the store \
-                 short of its truncation target"
+                "KV block truncate: refusing to split a block at b > 1 — a block's rows run \
+                 batch-major, so keeping a row prefix would cut one batch element and not \
+                 the other; dropping the block instead, which leaves the store short of its \
+                 truncation target"
             );
             break;
         }

--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -276,8 +276,11 @@ pub(crate) fn truncate_plan(
 /// `min(n, shape[2])` could never discard it. What makes the asymmetry safe is
 /// that those stores already **abort loudly** on an over-long target —
 /// `synced_rotor_v_blocks` / `synced_iso_v_blocks` size their ring readback from
-/// `shape[2]` and return `Err` when the ring cannot cover it. The clamp would buy
-/// them nothing. These stores have no ring and no such guard, so for them the
+/// `shape[2]`, and `QuantKGpuRing::packed_view` returns `Err` when that runs past
+/// the ring's fill watermark. (The watermark is what makes this true: `capacity`
+/// is page-rounded and zero-initialised, so bounding on capacity alone accepted a
+/// read into the allocation's zeros and returned a length-correct, silently wrong
+/// tail.) The clamp would buy them nothing. These stores have no ring and no such guard, so for them the
 /// clamp is the only reading that keeps `shape[2] == payload coverage` true.
 pub(crate) fn clamp_truncate_target(shape: &[i32], n: i32) -> i32 {
     let covered = shape.get(2).copied().unwrap_or(0).max(0);

--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -64,7 +64,6 @@ pub use quant_iso_k::{
     ISO_QUAT_BLOCK_SIZE,
 };
 pub use quant_iso_k4::{QuantIsoK4, ISO_K4_BITS, ISO_K4_GROUP_SIZE};
-pub(crate) use quant_iso_v::synced_iso_v_blocks;
 pub use quant_iso_v::{IsoBlocks, QuantIsoV3, ISO3_BITS, ISO3_GROUP_SIZE};
 pub use quant_iso_v4::{QuantIsoV4, ISO4_BITS, ISO4_GROUP_SIZE};
 pub use quant_k::QuantK;

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -387,6 +387,24 @@ impl QuantIsoK3 {
     /// # Errors
     /// Returns an `Error::Mlx` if the underlying [`iso_decode_fast`] fails.
     pub fn dequant(&self) -> Result<Vec<f32>> {
+        // The ring lives on the GPU whenever it is live at all, so that is the
+        // stream its readback belongs on. `dequant_on` exists so a caller that
+        // knows better — a `Device::Cpu` run, or a test that must not touch a
+        // shared Metal context — can say so instead of having this constant
+        // imposed on it.
+        self.dequant_on(Device::Gpu)
+    }
+
+    /// [`Self::dequant`] on an explicit device.
+    ///
+    /// The device selects the stream for the ring readback that reconciles a
+    /// ring-only decode tail; it has no effect on a store whose CPU blocks
+    /// already cover `shape[2]`, which is every store on the CPU append path.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::dequant`].
+    pub fn dequant_on(&self, device: Device) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
             return Err(Error::Mlx(format!(
                 "QuantIsoK3::dequant: malformed shape {:?}",
@@ -402,7 +420,7 @@ impl QuantIsoK3 {
         // (`blocks` trail `shape[2]`), and this rebuilds it on demand rather than
         // decoding a short prefix and zero-padding the gap. Loud on any
         // unrecoverable disagreement.
-        let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?;
+        let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, device)?;
 
         if blocks.is_empty() {
             // Loud on a lost decode tail — see [`super::QuantIsoV3::dequant`].

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -492,59 +492,26 @@ impl QuantIsoK3 {
         // come from the same source.
         let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, device)?;
 
-        let mut codes_bytes: Vec<u8> = Vec::new();
-        let mut scales_bytes: Vec<u8> = Vec::new();
-        let mut quats_bytes: Vec<u8> = Vec::new();
-        let mut norms_bytes: Vec<u8> = Vec::new();
-        let mut total_groups: usize = 0;
+        // Head-major kernel inputs — see [`super::QuantIsoV3::dequant_gpu`] for
+        // why the row order is fixed on the way in rather than reshaped on the
+        // way out.
+        let inputs = super::quant_iso_v::iso_kernel_inputs_head_major(
+            &blocks,
+            &self.shape,
+            n_groups,
+            ISO_K3_GROUP_SIZE,
+            "QuantIsoK3::dequant_gpu",
+        )?;
 
-        for blk in blocks.iter() {
-            for &c in &blk.codes {
-                codes_bytes.extend_from_slice(&c.to_le_bytes());
-            }
-            for &s in &blk.scales {
-                scales_bytes.extend_from_slice(&s.to_le_bytes());
-            }
-            for &q in &blk.quaternions {
-                quats_bytes.extend_from_slice(&q.to_le_bytes());
-            }
-            for &n in &blk.norms {
-                let n_bytes = n.to_le_bytes();
-                for _ in 0..n_groups {
-                    norms_bytes.extend_from_slice(&n_bytes);
-                }
-            }
-            // Checked arithmetic — see V-side mirror.
-            let blk_groups = blk.n_tokens.checked_mul(n_groups).ok_or_else(|| {
-                Error::Quant("dequant_gpu: blk.n_tokens * n_groups overflow".to_owned())
-            })?;
-            total_groups = total_groups
-                .checked_add(blk_groups)
-                .ok_or_else(|| Error::Quant("dequant_gpu: total_groups overflow".to_owned()))?;
-        }
-
-        // Guard against silent shape divergence — see V-side mirror.
-        let declared_total: usize = self.shape.iter().map(|&d| d as usize).product();
-        let actual_total: usize = total_groups.checked_mul(ISO_K3_GROUP_SIZE).ok_or_else(|| {
-            Error::Quant("dequant_gpu: total_groups * ISO_K3_GROUP_SIZE overflow".to_owned())
-        })?;
-        if actual_total != declared_total {
-            return Err(Error::Quant(format!(
-                "dequant_gpu: actual_total={actual_total} (blocks×groups×group_size) != \
-                 declared_total={declared_total} (prod(shape)={:?}); refusing to silently \
-                 truncate/pad",
-                self.shape
-            )));
-        }
-
-        if total_groups == 0 {
+        if inputs.total_groups == 0 {
             return Array::from_bytes(&[][..], &self.shape, Dtype::F32);
         }
 
-        let codes_arr = Array::from_bytes(&codes_bytes, &[total_groups as i32], Dtype::U32)?;
-        let scales_arr = Array::from_bytes(&scales_bytes, &[total_groups as i32], Dtype::F32)?;
-        let quats_arr = Array::from_bytes(&quats_bytes, &[(total_groups * 4) as i32], Dtype::F32)?;
-        let norms_arr = Array::from_bytes(&norms_bytes, &[total_groups as i32], Dtype::F32)?;
+        let n = inputs.total_groups as i32;
+        let codes_arr = Array::from_bytes(&inputs.codes, &[n], Dtype::U32)?;
+        let scales_arr = Array::from_bytes(&inputs.scales, &[n], Dtype::F32)?;
+        let quats_arr = Array::from_bytes(&inputs.quaternions, &[n * 4], Dtype::F32)?;
+        let norms_arr = Array::from_bytes(&inputs.norms, &[n], Dtype::F32)?;
 
         let flat = crate::isoquant_msl::iso_dequantize_v3_gpu(
             &codes_arr,
@@ -555,12 +522,7 @@ impl QuantIsoK3 {
             Dtype::F32,
             device,
         )?;
-
-        // CPU blocks are sequence-major (see `append`): reshape to
-        // `[B, S, kv_h, D]`, then reorder heads↔seq back to `[B, kv_h, S, D]`.
-        let seq_major_shape = [self.shape[0], self.shape[2], self.shape[1], self.shape[3]];
-        let out = flat.reshape(&seq_major_shape, device)?;
-        out.transpose(&[0, 2, 1, 3], device)?.contiguous(device)
+        flat.reshape(&self.shape, device)
     }
 }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -487,13 +487,18 @@ impl QuantIsoK3 {
         }
         let n_groups = head_dim / ISO_K3_GROUP_SIZE;
 
+        // Reconcile the CPU blocks with the GPU ring first — see
+        // [`super::QuantIsoV3::dequant_gpu`] for why both element counts must
+        // come from the same source.
+        let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, device)?;
+
         let mut codes_bytes: Vec<u8> = Vec::new();
         let mut scales_bytes: Vec<u8> = Vec::new();
         let mut quats_bytes: Vec<u8> = Vec::new();
         let mut norms_bytes: Vec<u8> = Vec::new();
         let mut total_groups: usize = 0;
 
-        for blk in &self.blocks {
+        for blk in blocks.iter() {
             for &c in &blk.codes {
                 codes_bytes.extend_from_slice(&c.to_le_bytes());
             }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -381,6 +381,34 @@ impl QuantIsoK3 {
         blocks.iter().map(IsoBlocks::byte_size).sum::<u64>() + gpu.byte_size()
     }
 
+    /// Rebuild any ring-only prefix into the CPU blocks so `blocks` alone cover
+    /// `shape[2]` again, and either keep or drop the ring.
+    ///
+    /// Sibling of [`super::QuantIsoV3::reconcile_ring`] — see it for why the
+    /// disposition is a parameter rather than two copies of this body.
+    ///
+    /// # Errors
+    ///
+    /// Forwards a [`synced_iso_v_blocks`] reconciliation error.
+    pub(crate) fn reconcile_ring(
+        &mut self,
+        device: Device,
+        disposition: super::RingDisposition,
+    ) -> Result<()> {
+        if !self.gpu.is_allocated() {
+            return Ok(());
+        }
+        if let std::borrow::Cow::Owned(full) =
+            synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, device)?
+        {
+            self.blocks = full;
+        }
+        if disposition == super::RingDisposition::Drop {
+            self.gpu.clear();
+        }
+        Ok(())
+    }
+
     /// Dequantize all accumulated K slices into one flat f32 vector of length
     /// `prod(shape)`.
     ///
@@ -528,13 +556,13 @@ impl QuantIsoK3 {
         let n = inputs.total_groups as i32;
         let codes_arr = Array::from_bytes(&inputs.codes, &[n], Dtype::U32)?;
         let scales_arr = Array::from_bytes(&inputs.scales, &[n], Dtype::F32)?;
-        let quats_arr = Array::from_bytes(&inputs.quaternions, &[n * 4], Dtype::F32)?;
         let norms_arr = Array::from_bytes(&inputs.norms, &[n], Dtype::F32)?;
 
+        // Quaternion slot reuse — see [`super::QuantIsoV3::dequant_gpu`].
         let flat = crate::isoquant_msl::iso_dequantize_v3_gpu(
             &codes_arr,
             &scales_arr,
-            &quats_arr,
+            &codes_arr,
             &norms_arr,
             head_dim,
             Dtype::F32,

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -442,12 +442,21 @@ impl QuantIsoK3 {
                 self.shape
             )));
         }
-        // Blocks are sequence-major (see `append`); reorder back to the logical
-        // head-major `[B, kv_h, S, D]`.
+        // Blocks are sequence-major (see `append`), one per append; reorder each
+        // at its own sequence offset back to the logical head-major
+        // `[B, kv_h, S, D]`. Reading the concatenation as a single run would
+        // interleave batch elements once `B > 1`.
         let b = self.shape[0] as usize;
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
-        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
+        let out = super::seq_layout::transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            head_dim,
+            blocks.iter().map(super::BlockRows::rows),
+        )?;
         Ok(out)
     }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k.rs
@@ -66,7 +66,7 @@ pub fn iso_n_groups_for(head_dim: usize) -> usize {
 ///
 /// Returns [`Error::Quant`] when `head_dim` is not a positive multiple of
 /// [`ISO_QUAT_BLOCK_SIZE`].
-pub(crate) fn iso_n_groups_i32(head_dim: i32, what: &str) -> Result<i32> {
+pub fn iso_n_groups_i32(head_dim: i32, what: &str) -> Result<i32> {
     let hd = usize::try_from(head_dim)
         .map_err(|_| Error::Quant(format!("{what}: head_dim={head_dim} must be positive")))?;
     if hd == 0 || !hd.is_multiple_of(ISO_QUAT_BLOCK_SIZE) {

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
@@ -338,12 +338,19 @@ impl QuantIsoK4 {
                 self.shape
             )));
         }
-        // Blocks are sequence-major (see `append`); reorder back to head-major
-        // `[B, kv_h, S, D]`.
+        // Per-block reorder back to head-major `[B, kv_h, S, D]` — see
+        // [`crate::storage::QuantIsoK3::dequant`].
         let b = self.shape[0] as usize;
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
-        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
+        let out = super::seq_layout::transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            head_dim,
+            blocks.iter().map(super::BlockRows::rows),
+        )?;
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4.rs
@@ -285,6 +285,34 @@ impl QuantIsoK4 {
         blocks.iter().map(IsoBlocks::byte_size).sum::<u64>() + gpu.byte_size()
     }
 
+    /// Rebuild any ring-only prefix into the CPU blocks so `blocks` alone cover
+    /// `shape[2]` again, and either keep or drop the ring.
+    ///
+    /// Sibling of [`super::QuantIsoV3::reconcile_ring`] — see it for why the
+    /// disposition is a parameter rather than two copies of this body.
+    ///
+    /// # Errors
+    ///
+    /// Forwards a [`synced_iso_v_blocks`] reconciliation error.
+    pub(crate) fn reconcile_ring(
+        &mut self,
+        device: Device,
+        disposition: super::RingDisposition,
+    ) -> Result<()> {
+        if !self.gpu.is_allocated() {
+            return Ok(());
+        }
+        if let std::borrow::Cow::Owned(full) =
+            synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, device)?
+        {
+            self.blocks = full;
+        }
+        if disposition == super::RingDisposition::Drop {
+            self.gpu.clear();
+        }
+        Ok(())
+    }
+
     /// Dequantize all accumulated K slices into one flat f32 vector.
     ///
     /// # Errors

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4_tests.rs
@@ -230,3 +230,53 @@ fn quant_iso_k4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
         );
     }
 }
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantIsoK4::dequant` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_iso_k4_two_block_decode_matches_one_block_at_b_gt_1() {
+    for b in [1_usize, 2] {
+        let (kv_h, head_dim) = (2_usize, 8_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+
+        let mut one = QuantIsoK4::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 512);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+        )
+        .expect("single append");
+        let oracle = one.dequant().expect("one-block dequant");
+
+        let mut two = QuantIsoK4::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 512);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+        )
+        .expect("append chunk 1");
+        let got = two.dequant().expect("two-block dequant");
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k4_tests.rs
@@ -248,8 +248,8 @@ fn quant_iso_k4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
 /// invisible.
 #[test]
 fn quant_iso_k4_two_block_decode_matches_one_block_at_b_gt_1() {
-    for b in [1_usize, 2] {
-        let (kv_h, head_dim) = (2_usize, 8_usize);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 8_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
 
@@ -276,7 +276,7 @@ fn quant_iso_k4_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
@@ -468,47 +468,68 @@ fn iso_k3_dequant_gpu_reads_a_ring_only_tail() {
 /// `kv_h = 2, head_dim = 8`, which is two quaternion groups per token and hides
 /// anything that scales with `n_groups`. 512 is 128 groups.
 ///
-/// Both readers are checked at that shape: the CPU `dequant` against a
-/// single-append oracle, and the GPU reader's kernel inputs against the same
-/// chunking-independence property the wider test asserts. (The kernel dispatch
-/// itself needs Metal; the inputs are what carry the layout.)
+/// What this pins: that a 128-group store decodes at all, and that the shared
+/// builder's declared-vs-actual accounting agrees on it — the arithmetic that
+/// scales with `n_groups`. At `b = kv_h = 1` it does **not** pin the row
+/// permutation: `head_major_token_order` is the identity there, and so is the
+/// block-concatenation order the branch replaced. Neither does `(1, 2)` —
+/// measured: at `b == 1` concatenation preserves row order across chunk
+/// boundaries for any `kv_h`, so the identity passes both. The `b = 2`
+/// iterations below are what carry the layout at this width. The permutation in
+/// general is pinned by `*_two_block_decode_matches_one_block_at_b_gt_1` and
+/// `seq_layout_tests::head_major_token_order_matches_the_output_reorder`.
 #[test]
 fn iso_k3_single_kv_head_head_dim_512_decodes_the_same_either_chunking() {
-    let (b, kv_h, head_dim) = (1_usize, 1_usize, 512_usize);
-    let n_groups = head_dim / ISO_K3_GROUP_SIZE;
-    let (n0, n1) = (2_usize, 3_usize);
-    let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
-    let init = || vec![b as i32, kv_h as i32, 0, head_dim as i32];
-    let chunk = |s0: usize, n: usize| crate::test_utils::batch_head_chunk(b, kv_h, s0, n, head_dim);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 512_usize;
+        let n_groups = head_dim / ISO_K3_GROUP_SIZE;
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+        let init = || vec![b as i32, kv_h as i32, 0, head_dim as i32];
+        let chunk =
+            |s0: usize, n: usize| crate::test_utils::batch_head_chunk(b, kv_h, s0, n, head_dim);
 
-    let mut one = QuantIsoK3::new(init(), 512);
-    one.append(&chunk(0, n0 + n1), &shape(n0 + n1))
-        .expect("single append");
-    let oracle = one.dequant().expect("one-block dequant");
+        let mut one = QuantIsoK3::new(init(), 512);
+        one.append(&chunk(0, n0 + n1), &shape(n0 + n1))
+            .expect("single append");
+        let oracle = one.dequant().expect("one-block dequant");
 
-    let mut two = QuantIsoK3::new(init(), 512);
-    two.append(&chunk(0, n0), &shape(n0)).expect("chunk 0");
-    two.append(&chunk(n0, n1), &shape(n1)).expect("chunk 1");
-    let got = two.dequant().expect("two-block dequant");
-    assert_eq!(
-        got, oracle,
-        "kv_h = 1, head_dim = 512: two-block decode must equal the one-block oracle"
-    );
+        let mut two = QuantIsoK3::new(init(), 512);
+        two.append(&chunk(0, n0), &shape(n0)).expect("chunk 0");
+        two.append(&chunk(n0, n1), &shape(n1)).expect("chunk 1");
+        let got = two.dequant().expect("two-block dequant");
+        assert_eq!(
+            got, oracle,
+            "head_dim = 512, kv_h={kv_h}: two-block decode must equal the one-block oracle"
+        );
 
-    let build = |blocks: &[crate::storage::IsoBlocks], sh: &[i32]| {
-        crate::storage::quant_iso_v::iso_kernel_inputs_head_major(
-            blocks,
-            sh,
-            n_groups,
-            ISO_K3_GROUP_SIZE,
-            "test",
-        )
-        .expect("well-formed store")
-    };
-    let a = build(&one.blocks, &one.shape);
-    let c = build(&two.blocks, &two.shape);
-    assert_eq!(a.total_groups, c.total_groups, "slot count at head_dim 512");
-    assert_eq!(a.codes, c.codes, "GPU-reader codes at head_dim 512");
-    assert_eq!(a.scales, c.scales, "GPU-reader scales at head_dim 512");
-    assert_eq!(a.norms, c.norms, "GPU-reader norms at head_dim 512");
+        let build = |blocks: &[crate::storage::IsoBlocks], sh: &[i32]| {
+            crate::storage::quant_iso_v::iso_kernel_inputs_head_major(
+                blocks,
+                sh,
+                n_groups,
+                ISO_K3_GROUP_SIZE,
+                "test",
+            )
+            .expect("well-formed store")
+        };
+        let a = build(&one.blocks, &one.shape);
+        let c = build(&two.blocks, &two.shape);
+        assert_eq!(
+            a.total_groups, c.total_groups,
+            "slot count at head_dim 512, kv_h={kv_h}"
+        );
+        assert_eq!(
+            a.codes, c.codes,
+            "GPU-reader codes at head_dim 512, kv_h={kv_h}"
+        );
+        assert_eq!(
+            a.scales, c.scales,
+            "GPU-reader scales at head_dim 512, kv_h={kv_h}"
+        );
+        assert_eq!(
+            a.norms, c.norms,
+            "GPU-reader norms at head_dim 512, kv_h={kv_h}"
+        );
+    }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
@@ -345,8 +345,8 @@ fn quant_iso_k3_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
 /// invisible.
 #[test]
 fn quant_iso_k3_two_block_decode_matches_one_block_at_b_gt_1() {
-    for b in [1_usize, 2] {
-        let (kv_h, head_dim) = (2_usize, 8_usize);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 8_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
 
@@ -373,7 +373,7 @@ fn quant_iso_k3_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}"
         );
     }
 }
@@ -457,4 +457,58 @@ fn iso_k3_dequant_gpu_reads_a_ring_only_tail() {
         shape(n_tokens).to_vec(),
         "dequant_gpu returns the declared [B, kv_h, S, D]"
     );
+}
+
+/// The geometry the codec actually failed on: a single KV head with a wide
+/// `head_dim`.
+///
+/// gemma-4-e2b's global attention layers are `kv_h = 1, head_dim = 512`
+/// (`num_key_value_heads: 1`, `global_head_dim: 512`), and no unit test
+/// constructed that shape for this codec — every other iso fixture here uses
+/// `kv_h = 2, head_dim = 8`, which is two quaternion groups per token and hides
+/// anything that scales with `n_groups`. 512 is 128 groups.
+///
+/// Both readers are checked at that shape: the CPU `dequant` against a
+/// single-append oracle, and the GPU reader's kernel inputs against the same
+/// chunking-independence property the wider test asserts. (The kernel dispatch
+/// itself needs Metal; the inputs are what carry the layout.)
+#[test]
+fn iso_k3_single_kv_head_head_dim_512_decodes_the_same_either_chunking() {
+    let (b, kv_h, head_dim) = (1_usize, 1_usize, 512_usize);
+    let n_groups = head_dim / ISO_K3_GROUP_SIZE;
+    let (n0, n1) = (2_usize, 3_usize);
+    let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+    let init = || vec![b as i32, kv_h as i32, 0, head_dim as i32];
+    let chunk = |s0: usize, n: usize| crate::test_utils::batch_head_chunk(b, kv_h, s0, n, head_dim);
+
+    let mut one = QuantIsoK3::new(init(), 512);
+    one.append(&chunk(0, n0 + n1), &shape(n0 + n1))
+        .expect("single append");
+    let oracle = one.dequant().expect("one-block dequant");
+
+    let mut two = QuantIsoK3::new(init(), 512);
+    two.append(&chunk(0, n0), &shape(n0)).expect("chunk 0");
+    two.append(&chunk(n0, n1), &shape(n1)).expect("chunk 1");
+    let got = two.dequant().expect("two-block dequant");
+    assert_eq!(
+        got, oracle,
+        "kv_h = 1, head_dim = 512: two-block decode must equal the one-block oracle"
+    );
+
+    let build = |blocks: &[crate::storage::IsoBlocks], sh: &[i32]| {
+        crate::storage::quant_iso_v::iso_kernel_inputs_head_major(
+            blocks,
+            sh,
+            n_groups,
+            ISO_K3_GROUP_SIZE,
+            "test",
+        )
+        .expect("well-formed store")
+    };
+    let a = build(&one.blocks, &one.shape);
+    let c = build(&two.blocks, &two.shape);
+    assert_eq!(a.total_groups, c.total_groups, "slot count at head_dim 512");
+    assert_eq!(a.codes, c.codes, "GPU-reader codes at head_dim 512");
+    assert_eq!(a.scales, c.scales, "GPU-reader scales at head_dim 512");
+    assert_eq!(a.norms, c.norms, "GPU-reader norms at head_dim 512");
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
@@ -8,7 +8,7 @@
 use crate::isoquant::{iso_decode_fast, iso_encode_fast};
 use crate::storage::quant_iso_k::{QuantIsoK3, ISO_K3_BITS, ISO_K3_GROUP_SIZE};
 use crate::test_utils::{cosine_similarity_per_row, lcg_data, skip_if_no_gpu_env, TEST_SEED};
-use rmlx_mlx::Device;
+use rmlx_mlx::{Array, Device, Dtype};
 
 #[test]
 fn quant_iso_k3_new_shapes_correct() {
@@ -376,4 +376,85 @@ fn quant_iso_k3_two_block_decode_matches_one_block_at_b_gt_1() {
             "two-block decode must equal the one-block oracle at b={b}"
         );
     }
+}
+
+// ── Ring-only tail is readable by both dequant paths ──────────────────────────
+
+/// `dequant_gpu` must read a store whose decode tail lives only in the GPU ring,
+/// exactly as `dequant` does.
+///
+/// The fused iso-symmetric decode path drops the CPU blocks once the ring is
+/// live, so `blocks` legitimately trail `shape[2]`. `dequant_gpu` used to derive
+/// its element accounting straight from `self.blocks` while `dequant` derived it
+/// from the ring-reconciled list, so the two disagreed on the same store and the
+/// GPU reader rejected it with a blocks-vs-shape mismatch. Both now go through
+/// the one reconciliation.
+///
+/// Mutation check: revert `QuantIsoK3::dequant_gpu` to iterate `self.blocks` and
+/// this fails with `actual_total != declared_total`.
+#[test]
+#[ignore = "GPU Metal context — run via `make gpu-test CRATE=rmlx-kv-quant FILTER=iso_k3_dequant_gpu_reads_a_ring_only_tail`"]
+fn iso_k3_dequant_gpu_reads_a_ring_only_tail() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let (b, kv_h, head_dim) = (1_usize, 2_usize, 8_usize);
+    let n_tokens = 4_usize;
+    let max_seq = 64_i32;
+    let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+    let init = || vec![b as i32, kv_h as i32, 0, head_dim as i32];
+    let data = crate::test_utils::batch_head_chunk(b, kv_h, 0, n_tokens, head_dim);
+
+    let mut oracle_store = QuantIsoK3::new(init(), max_seq);
+    oracle_store
+        .append(&data, &shape(n_tokens))
+        .expect("oracle append");
+    let oracle = oracle_store.dequant().expect("oracle dequant");
+
+    // Ring-only tail: seed the ring from the blocks, then drop the blocks the
+    // way the fused path does.
+    let mut ks = QuantIsoK3::new(init(), max_seq);
+    ks.append(&data, &shape(n_tokens)).expect("cpu append");
+    let last = ks.blocks[0].clone();
+    let codes_b: Vec<u8> = last.codes.iter().flat_map(|c| c.to_le_bytes()).collect();
+    let scales_b: Vec<u8> = last.scales.iter().flat_map(|s| s.to_le_bytes()).collect();
+    let norms_b: Vec<u8> = last.norms.iter().flat_map(|n| n.to_le_bytes()).collect();
+    let codes = Array::from_bytes(&codes_b, &[last.codes.len() as i32], Dtype::U32).expect("codes");
+    let scales =
+        Array::from_bytes(&scales_b, &[last.scales.len() as i32], Dtype::F32).expect("scales");
+    let norms = Array::from_bytes(&norms_b, &[last.norms.len() as i32], Dtype::F32).expect("norms");
+    // `prev_seq = 0`: the ring takes the whole prefix in one append, so nothing
+    // is seeded from the blocks and dropping them leaves the ring as sole copy.
+    ks.gpu_append(
+        &codes,
+        &scales,
+        &norms,
+        kv_h as i32,
+        head_dim as i32,
+        0,
+        n_tokens as i32,
+        max_seq,
+        Device::Gpu,
+    )
+    .expect("ring append");
+    ks.blocks.clear();
+
+    let cpu = ks.dequant().expect("dequant over a ring-only tail");
+    let max_abs = cpu
+        .iter()
+        .zip(oracle.iter())
+        .fold(0.0_f32, |m, (a, c)| m.max((a - c).abs()));
+    assert!(
+        max_abs < 1e-5,
+        "dequant over a ring-only tail: max abs error {max_abs} vs the all-CPU oracle"
+    );
+
+    let gpu_arr = ks
+        .dequant_gpu(Device::Gpu)
+        .expect("dequant_gpu must read the ring-only tail, not reject it");
+    assert_eq!(
+        gpu_arr.shape(),
+        shape(n_tokens).to_vec(),
+        "dequant_gpu returns the declared [B, kv_h, S, D]"
+    );
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_k_tests.rs
@@ -327,3 +327,53 @@ fn quant_iso_k3_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
         );
     }
 }
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantIsoK3::dequant` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_iso_k3_two_block_decode_matches_one_block_at_b_gt_1() {
+    for b in [1_usize, 2] {
+        let (kv_h, head_dim) = (2_usize, 8_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+
+        let mut one = QuantIsoK3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 512);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+        )
+        .expect("single append");
+        let oracle = one.dequant().expect("one-block dequant");
+
+        let mut two = QuantIsoK3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 512);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+        )
+        .expect("append chunk 1");
+        let got = two.dequant().expect("two-block dequant");
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -502,6 +502,33 @@ impl QuantIsoV3 {
         )
     }
 
+    /// Rebuild any ring-only prefix into the CPU blocks and drop the ring, so
+    /// `blocks` alone cover `shape[2]` again.
+    ///
+    /// No-op when the ring was never allocated. Called by every path that
+    /// pushes a CPU block onto a store whose ring may be live: without it the
+    /// pushed block is the *only* block, `blocks` no longer cover `shape[2]`,
+    /// and the ring left behind is stale — the next ring append would write past
+    /// its filled region and `dequant` would read a zeroed gap where the new
+    /// chunk should be. Mirrors what the CPU [`Self::append`] does by clearing.
+    ///
+    /// # Errors
+    ///
+    /// Forwards a [`synced_iso_v_blocks`] reconciliation error — a ring that
+    /// cannot supply the missing prefix is reported, never zero-padded.
+    pub(crate) fn absorb_ring_into_blocks(&mut self, device: Device) -> Result<()> {
+        if !self.gpu.is_allocated() {
+            return Ok(());
+        }
+        if let std::borrow::Cow::Owned(full) =
+            synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, device)?
+        {
+            self.blocks = full;
+        }
+        self.gpu.clear();
+        Ok(())
+    }
+
     /// GPU packed view of the first `kv_seq` positions, or `None` when the ring
     /// is not live (CPU path — caller falls back to `dequant`).
     ///
@@ -688,6 +715,19 @@ impl QuantIsoV3 {
             .ok_or_else(|| {
                 Error::Quant("QuantIsoV3::append_gpu: n_tokens_total overflow".to_owned())
             })?;
+
+        // ── 0. Take the ring's prefix back, then drop the ring. ────────────
+        // This append pushes a CPU block, which makes `blocks` the authoritative
+        // copy of everything accumulated so far. A live ring holds a prefix
+        // `blocks` may no longer carry — the fused decode path drops the blocks
+        // once the ring is live — so the prefix has to come back before the push
+        // or `dequant` / `dequant_gpu` see a store whose blocks cover only this
+        // chunk. Dropping the ring afterwards is the same contract the CPU
+        // `append` states: a ring left behind while `blocks` grow is the
+        // dangerous state, because the next ring append would write past its
+        // filled region and `dequant` would read a zeroed gap. The next
+        // `gpu_append` re-seeds it from `blocks`.
+        self.absorb_ring_into_blocks(device)?;
 
         // ── 1. Dispatch the MSL encode kernel. ─────────────────────────────
         // The codec is per-token-row positional; the GPU mirror accumulates
@@ -1112,6 +1152,15 @@ impl QuantIsoV3 {
             return out.transpose(&[0, 2, 1, 3], device)?.contiguous(device);
         }
 
+        // Reconcile the CPU blocks with the GPU ring first, exactly as
+        // `dequant` does. Both element counts below — the one derived from the
+        // blocks and the one declared by `shape` — must come from the same
+        // source, or a store whose decode tail lives only in the ring is
+        // reported as a shape disagreement instead of being read. `blocks` that
+        // already cover `shape[2]` are borrowed, so the common path pays
+        // nothing.
+        let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, device)?;
+
         // Concatenate all block buffers. CPU codes/scales/quats are already in
         // GPU-kernel layout; per-token norms must be expanded to per-group.
         let mut codes_bytes: Vec<u8> = Vec::new();
@@ -1120,7 +1169,7 @@ impl QuantIsoV3 {
         let mut norms_bytes: Vec<u8> = Vec::new();
         let mut total_groups: usize = 0;
 
-        for blk in &self.blocks {
+        for blk in blocks.iter() {
             for &c in &blk.codes {
                 codes_bytes.extend_from_slice(&c.to_le_bytes());
             }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -1159,7 +1159,7 @@ impl QuantIsoV3 {
             // as one `[B, S, kv_h, D]` run below interleaves batch elements once
             // `B > 1` and more than one chunk landed. Refuse rather than return a
             // scrambled tensor — the block path handles every `B`.
-            if self.shape[0] != 1 && self.shape[2] > 1 {
+            if self.shape[0] != 1 && self.shape[2] != 0 {
                 return Err(Error::Quant(format!(
                     "QuantIsoV3::dequant_gpu: the GPU mirror is b == 1 only (its per-step \
                      stride does not interleave batch), got shape {:?}",
@@ -1231,13 +1231,16 @@ impl QuantIsoV3 {
         // WORDS_PER_GROUP = 1 for ISO3_GROUP_SIZE = 4.
         let codes_arr = Array::from_bytes(&inputs.codes, &[n], Dtype::U32)?;
         let scales_arr = Array::from_bytes(&inputs.scales, &[n], Dtype::F32)?;
-        let quats_arr = Array::from_bytes(&inputs.quaternions, &[n * 4], Dtype::F32)?;
         let norms_arr = Array::from_bytes(&inputs.norms, &[n], Dtype::F32)?;
 
+        // The kernel's quaternion parameter is `_quaternions` and is never bound
+        // as a kernel input (see `iso_dequantize_v3_gpu`); every group uses the
+        // constant `FIXED_QUAT`. Pass `codes_arr` rather than uploading a buffer
+        // the kernel discards — the same reuse the GPU mirror arm above makes.
         let flat = crate::isoquant_msl::iso_dequantize_v3_gpu(
             &codes_arr,
             &scales_arr,
-            &quats_arr,
+            &codes_arr,
             &norms_arr,
             head_dim,
             Dtype::F32,
@@ -1254,16 +1257,22 @@ const ISO_SLOT_BYTES: usize = 4;
 /// Flat kernel inputs for an iso store, with token rows in head-major order.
 ///
 /// Field lengths, in `(token, group)` slots: `codes` and `scales` carry one
-/// entry per slot, `quaternions` four, `norms` one (the per-token norm expanded
-/// to per-group, which is what the kernel indexes).
+/// entry per slot, `norms` one (the per-token norm expanded to per-group, which
+/// is what the kernel indexes).
+///
+/// There is deliberately no quaternion buffer. The dequant kernel takes a
+/// quaternion slot it never dereferences — every group uses the constant
+/// `FIXED_QUAT` — so building one costs `total_groups * 4` f32 of allocation,
+/// memcpy and upload per call for data that is discarded. At the geometry #392
+/// reports (`head_dim = 512`, 128 groups) that is four times the codes buffer,
+/// on a per-decode-step path. The readers pass `codes_arr` for that slot, which
+/// is what the GPU mirror arm in `dequant_gpu` already did.
 #[derive(Debug)]
 pub(crate) struct IsoKernelInputs {
     /// Packed codes, little-endian `u32`.
     pub codes: Vec<u8>,
     /// Per-group scales, little-endian `f32`.
     pub scales: Vec<u8>,
-    /// Per-group quaternions (4 components), little-endian `f32`.
-    pub quaternions: Vec<u8>,
     /// Per-group norms, little-endian `f32`.
     pub norms: Vec<u8>,
     /// `(token, group)` slot count — the kernel's flat length.
@@ -1339,7 +1348,6 @@ pub(crate) fn iso_kernel_inputs_head_major(
     let mut out = IsoKernelInputs {
         codes: vec![0_u8; total_groups * ISO_SLOT_BYTES],
         scales: vec![0_u8; total_groups * ISO_SLOT_BYTES],
-        quaternions: vec![0_u8; total_groups * 4 * ISO_SLOT_BYTES],
         norms: vec![0_u8; total_groups * ISO_SLOT_BYTES],
         total_groups,
     };
@@ -1348,7 +1356,10 @@ pub(crate) fn iso_kernel_inputs_head_major(
     for blk in blocks {
         let rows = super::BlockRows::rows(blk);
         // The scatter below indexes each payload by row; a length that is not a
-        // whole number of rows would silently read across a row boundary.
+        // whole number of rows would silently read across a row boundary. The
+        // quaternion table is checked too even though it is not scattered — a
+        // block whose table disagrees with its row count is malformed whoever
+        // reads it, and the CPU `dequant` does read it.
         let want_codes = rows * n_groups;
         if blk.codes.len() != want_codes
             || blk.scales.len() != want_codes
@@ -1385,12 +1396,6 @@ pub(crate) fn iso_kernel_inputs_head_major(
                 &blk.scales[r * n_groups..(r + 1) * n_groups],
                 f32::to_le_bytes,
             );
-            copy_f32_slots(
-                &mut out.quaternions,
-                dst_token * n_groups * 4,
-                &blk.quaternions[r * n_groups * 4..(r + 1) * n_groups * 4],
-                f32::to_le_bytes,
-            );
             // Per-token → per-group expand: the kernel reads `norms[gid]` with
             // `gid = token * n_groups + grp`, and every group in a token shares
             // the token's norm.
@@ -1407,12 +1412,14 @@ pub(crate) fn iso_kernel_inputs_head_major(
 }
 
 /// Write `src` into `dst` as little-endian 4-byte slots starting at slot
-/// `slot_offset`. Shared by the code / scale / quaternion scatters above.
-#[allow(
-    clippy::indexing_slicing,
-    reason = "dst is sized total_groups slots and slot_offset + src.len() is bounded by the \
-              permutation's range, which head_major_token_order pins to that same count"
-)]
+/// `slot_offset`. Shared by the code and scale scatters above.
+///
+/// `dst` is sized `total_groups` slots and `slot_offset + src.len()` is bounded
+/// by the permutation's range, which `head_major_token_order` pins to that same
+/// count — so the indexing below is in bounds by construction. (Stated as prose
+/// rather than an `#[allow(clippy::indexing_slicing)]`: the module already
+/// allows that lint at the top of the file, so a per-site allow here would read
+/// as an enforced justification while enforcing nothing.)
 fn copy_f32_slots<T: Copy>(dst: &mut [u8], slot_offset: usize, src: &[T], to_le: fn(T) -> [u8; 4]) {
     for (i, &v) in src.iter().enumerate() {
         let at = (slot_offset + i) * 4;

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -502,21 +502,32 @@ impl QuantIsoV3 {
         )
     }
 
-    /// Rebuild any ring-only prefix into the CPU blocks and drop the ring, so
-    /// `blocks` alone cover `shape[2]` again.
+    /// Rebuild any ring-only prefix into the CPU blocks so `blocks` alone cover
+    /// `shape[2]` again, and either keep or drop the ring.
     ///
-    /// No-op when the ring was never allocated. Called by every path that
-    /// pushes a CPU block onto a store whose ring may be live: without it the
-    /// pushed block is the *only* block, `blocks` no longer cover `shape[2]`,
-    /// and the ring left behind is stale — the next ring append would write past
-    /// its filled region and `dequant` would read a zeroed gap where the new
-    /// chunk should be. Mirrors what the CPU [`Self::append`] does by clearing.
+    /// No-op when the ring was never allocated. Every path that pushes a CPU
+    /// block onto a store whose ring may be live goes through here: without it
+    /// the pushed block is the *only* block, `blocks` no longer cover
+    /// `shape[2]`, and the ring left behind is stale — the next ring append
+    /// would write past its filled region and `dequant` would read a gap the
+    /// ring's fill watermark then refuses.
+    ///
+    /// `disposition` is a parameter because it is the one thing the two callers
+    /// disagree on, and having them disagree by carrying separate copies of this
+    /// body is how the two drift apart. [`Self::append_gpu`] drops the ring — it
+    /// does not feed it, so leaving it live is the dangerous state the CPU
+    /// [`Self::append`] avoids by clearing. The append helpers in `kvcache`
+    /// keep it, because their `sync_ring` decides its fate immediately after.
     ///
     /// # Errors
     ///
     /// Forwards a [`synced_iso_v_blocks`] reconciliation error — a ring that
     /// cannot supply the missing prefix is reported, never zero-padded.
-    pub(crate) fn absorb_ring_into_blocks(&mut self, device: Device) -> Result<()> {
+    pub(crate) fn reconcile_ring(
+        &mut self,
+        device: Device,
+        disposition: super::RingDisposition,
+    ) -> Result<()> {
         if !self.gpu.is_allocated() {
             return Ok(());
         }
@@ -525,7 +536,9 @@ impl QuantIsoV3 {
         {
             self.blocks = full;
         }
-        self.gpu.clear();
+        if disposition == super::RingDisposition::Drop {
+            self.gpu.clear();
+        }
         Ok(())
     }
 
@@ -745,7 +758,7 @@ impl QuantIsoV3 {
         // dangerous state, because the next ring append would write past its
         // filled region and `dequant` would read a zeroed gap. The next
         // `gpu_append` re-seeds it from `blocks`.
-        self.absorb_ring_into_blocks(device)?;
+        self.reconcile_ring(device, super::RingDisposition::Drop)?;
 
         // ── 1. Dispatch the MSL encode kernel. ─────────────────────────────
         // The codec is per-token-row positional; the GPU mirror accumulates
@@ -1143,7 +1156,7 @@ impl QuantIsoV3 {
             // as one `[B, S, kv_h, D]` run below interleaves batch elements once
             // `B > 1` and more than one chunk landed. Refuse rather than return a
             // scrambled tensor — the block path handles every `B`.
-            if self.shape[0] != 1 {
+            if self.shape[0] != 1 && self.shape[2] > 1 {
                 return Err(Error::Quant(format!(
                     "QuantIsoV3::dequant_gpu: the GPU mirror is b == 1 only (its per-step \
                      stride does not interleave batch), got shape {:?}",

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -1119,6 +1119,19 @@ impl QuantIsoV3 {
             if s_active == 0 {
                 return Array::from_bytes(&[][..], &self.shape, Dtype::F32);
             }
+            // The mirror is one flat buffer written per chunk at
+            // `prev_seq * words_per_step`, and `words_per_step` folds `b` in, so
+            // the prefix is a run of `[B, S_chunk, kv_h, D]` chunks. Reading it
+            // as one `[B, S, kv_h, D]` run below interleaves batch elements once
+            // `B > 1` and more than one chunk landed. Refuse rather than return a
+            // scrambled tensor — the block path handles every `B`.
+            if self.shape[0] != 1 {
+                return Err(Error::Quant(format!(
+                    "QuantIsoV3::dequant_gpu: the GPU mirror is b == 1 only (its per-step \
+                     stride does not interleave batch), got shape {:?}",
+                    self.shape
+                )));
+            }
             let codes_active = s_active
                 .checked_mul(self.gpu_words_per_step)
                 .ok_or_else(|| Error::Quant("dequant_gpu: codes_active overflow".to_owned()))?;
@@ -1161,78 +1174,31 @@ impl QuantIsoV3 {
         // nothing.
         let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, device)?;
 
-        // Concatenate all block buffers. CPU codes/scales/quats are already in
-        // GPU-kernel layout; per-token norms must be expanded to per-group.
-        let mut codes_bytes: Vec<u8> = Vec::new();
-        let mut scales_bytes: Vec<u8> = Vec::new();
-        let mut quats_bytes: Vec<u8> = Vec::new();
-        let mut norms_bytes: Vec<u8> = Vec::new();
-        let mut total_groups: usize = 0;
+        // Build the kernel inputs with the token rows already in head-major
+        // order, so the flat result *is* `[B, kv_h, S, D]` and needs no
+        // reshape-plus-transpose. Reshaping the whole concatenated decode as one
+        // `[B, S, kv_h, D]` run — what this used to do — is only a valid reading
+        // at `B == 1`, because each block covers only `[B, S_block, kv_h, D]`.
+        let inputs = iso_kernel_inputs_head_major(
+            &blocks,
+            &self.shape,
+            n_groups,
+            ISO3_GROUP_SIZE,
+            "QuantIsoV3::dequant_gpu",
+        )?;
 
-        for blk in blocks.iter() {
-            for &c in &blk.codes {
-                codes_bytes.extend_from_slice(&c.to_le_bytes());
-            }
-            for &s in &blk.scales {
-                scales_bytes.extend_from_slice(&s.to_le_bytes());
-            }
-            for &q in &blk.quaternions {
-                quats_bytes.extend_from_slice(&q.to_le_bytes());
-            }
-            // Per-token → per-group expand (kernel reads norms_in[gid] where
-            // gid = token * n_groups + grp; all groups in a token share the
-            // same norm value).
-            for &n in &blk.norms {
-                let n_bytes = n.to_le_bytes();
-                for _ in 0..n_groups {
-                    norms_bytes.extend_from_slice(&n_bytes);
-                }
-            }
-            // Loudly fail on overflow rather than silently saturating; the
-            // resulting buffer-vs-shape mismatch would otherwise surface as a
-            // confusing kernel-dispatch error downstream.
-            let blk_groups = blk.n_tokens.checked_mul(n_groups).ok_or_else(|| {
-                Error::Quant("dequant_gpu: blk.n_tokens * n_groups overflow".to_owned())
-            })?;
-            total_groups = total_groups
-                .checked_add(blk_groups)
-                .ok_or_else(|| Error::Quant("dequant_gpu: total_groups overflow".to_owned()))?;
-        }
-
-        // Guard against silent shape divergence between `dequant_gpu`
-        // (derives total from concatenated blocks) and `dequant` (pads/truncates
-        // to `prod(shape)`). After `truncate_to` / `reset` / post-hydrate edge
-        // cases the two totals can diverge — refuse to silently reshape rather
-        // than producing a garbage Array.
-        let declared_total: usize = self.shape.iter().map(|&d| d as usize).product();
-        let actual_total: usize = total_groups.checked_mul(ISO3_GROUP_SIZE).ok_or_else(|| {
-            Error::Quant("dequant_gpu: total_groups * ISO3_GROUP_SIZE overflow".to_owned())
-        })?;
-        if actual_total != declared_total {
-            return Err(Error::Quant(format!(
-                "dequant_gpu: actual_total={actual_total} (blocks×groups×group_size) != \
-                 declared_total={declared_total} (prod(shape)={:?}); refusing to silently \
-                 truncate/pad",
-                self.shape
-            )));
-        }
-
-        if total_groups == 0 {
-            // Empty cache — return a zero-length array of the correct rank-4 shape.
-            // (Matches the `dequant()` empty-output behaviour with shape[2] = 0.)
-            // The MEDIUM-1 guard above ensures `prod(shape) == 0` here, so the
-            // empty `from_bytes` call is well-formed.
+        if inputs.total_groups == 0 {
+            // Empty cache — the accounting above already proved `prod(shape)`
+            // is 0, so the empty `from_bytes` is well-formed.
             return Array::from_bytes(&[][..], &self.shape, Dtype::F32);
         }
 
-        let codes_arr = Array::from_bytes(
-            &codes_bytes,
-            &[total_groups as i32], // WORDS_PER_GROUP=1 for ISO3_GS=4
-            Dtype::U32,
-        )?;
-        let scales_arr = Array::from_bytes(&scales_bytes, &[total_groups as i32], Dtype::F32)?;
-        let quats_arr = Array::from_bytes(&quats_bytes, &[(total_groups * 4) as i32], Dtype::F32)?;
-        let norms_arr = Array::from_bytes(&norms_bytes, &[total_groups as i32], Dtype::F32)?;
+        let n = inputs.total_groups as i32;
+        // WORDS_PER_GROUP = 1 for ISO3_GROUP_SIZE = 4.
+        let codes_arr = Array::from_bytes(&inputs.codes, &[n], Dtype::U32)?;
+        let scales_arr = Array::from_bytes(&inputs.scales, &[n], Dtype::F32)?;
+        let quats_arr = Array::from_bytes(&inputs.quaternions, &[n * 4], Dtype::F32)?;
+        let norms_arr = Array::from_bytes(&inputs.norms, &[n], Dtype::F32)?;
 
         let flat = crate::isoquant_msl::iso_dequantize_v3_gpu(
             &codes_arr,
@@ -1243,12 +1209,180 @@ impl QuantIsoV3 {
             Dtype::F32,
             device,
         )?;
+        flat.reshape(&self.shape, device)
+    }
+}
 
-        // CPU blocks are sequence-major (see `append` / `append_gpu`): reshape
-        // to `[B, S, kv_h, D]`, then reorder heads↔seq back to `[B, kv_h, S, D]`.
-        let seq_major_shape = [self.shape[0], self.shape[2], self.shape[1], self.shape[3]];
-        let out = flat.reshape(&seq_major_shape, device)?;
-        out.transpose(&[0, 2, 1, 3], device)?.contiguous(device)
+/// Bytes per little-endian payload slot — every iso payload is 4-byte (`u32`
+/// codes, `f32` scales / quaternions / norms).
+const ISO_SLOT_BYTES: usize = 4;
+
+/// Flat kernel inputs for an iso store, with token rows in head-major order.
+///
+/// Field lengths, in `(token, group)` slots: `codes` and `scales` carry one
+/// entry per slot, `quaternions` four, `norms` one (the per-token norm expanded
+/// to per-group, which is what the kernel indexes).
+#[derive(Debug)]
+pub(crate) struct IsoKernelInputs {
+    /// Packed codes, little-endian `u32`.
+    pub codes: Vec<u8>,
+    /// Per-group scales, little-endian `f32`.
+    pub scales: Vec<u8>,
+    /// Per-group quaternions (4 components), little-endian `f32`.
+    pub quaternions: Vec<u8>,
+    /// Per-group norms, little-endian `f32`.
+    pub norms: Vec<u8>,
+    /// `(token, group)` slot count — the kernel's flat length.
+    pub total_groups: usize,
+}
+
+/// Build the iso dequant kernel's flat inputs from a block list, placing every
+/// token row at its **head-major** `[B, kv_h, S, D]` position.
+///
+/// One derivation for both bit widths and both readers. Two things used to be
+/// written out per store and drifted apart:
+///
+/// * The declared-vs-actual element accounting. `prod(shape)` against
+///   `blocks × groups × group_size` was copied per reader, so the same store
+///   could be accepted by one and rejected by the other.
+/// * The row order. Concatenating the blocks and reshaping the kernel's flat
+///   output as one `[B, S, kv_h, D]` run is only a valid reading at `B == 1`:
+///   each block is `[B, S_block, kv_h, D]`, so at `B > 1` the blocks interleave
+///   and the reshape maps a later block's batch-0 rows onto batch-1 slots.
+///   Permuting the *input* rows instead is exact at every `B` and costs nothing
+///   — the payload is being copied either way, the kernel is per-token
+///   positional, and the result needs no reshape-plus-transpose afterwards.
+///
+/// # Errors
+///
+/// Returns [`Error::Quant`] on a malformed shape, a block whose payload length
+/// disagrees with its row count, chunks that do not partition `shape[2]`, or a
+/// blocks-vs-shape element-count disagreement.
+pub(crate) fn iso_kernel_inputs_head_major(
+    blocks: &[IsoBlocks],
+    shape: &[i32],
+    n_groups: usize,
+    group_size: usize,
+    what: &str,
+) -> Result<IsoKernelInputs> {
+    if shape.len() != 4 {
+        return Err(Error::Quant(format!("{what}: malformed shape {shape:?}")));
+    }
+    let dim = |i: usize| -> usize { shape.get(i).copied().unwrap_or(0).max(0) as usize };
+    let (b, kv_h, s_total) = (dim(0), dim(1), dim(2));
+
+    // Accounting, derived once. `declared` is what the shape claims; `actual` is
+    // what the blocks carry. A disagreement is refused rather than reshaped.
+    let declared: usize = shape.iter().map(|&d| d.max(0) as usize).product();
+    let mut total_groups: usize = 0;
+    for blk in blocks {
+        let blk_groups = super::BlockRows::rows(blk)
+            .checked_mul(n_groups)
+            .ok_or_else(|| Error::Quant(format!("{what}: rows * n_groups overflow")))?;
+        total_groups = total_groups
+            .checked_add(blk_groups)
+            .ok_or_else(|| Error::Quant(format!("{what}: total_groups overflow")))?;
+    }
+    let actual = total_groups
+        .checked_mul(group_size)
+        .ok_or_else(|| Error::Quant(format!("{what}: total_groups * group_size overflow")))?;
+    if actual != declared {
+        return Err(Error::Quant(format!(
+            "{what}: actual_total={actual} (blocks×groups×group_size) != \
+             declared_total={declared} (prod(shape)={shape:?}); refusing to silently \
+             truncate/pad"
+        )));
+    }
+
+    let perm = super::seq_layout::head_major_token_order(
+        b,
+        s_total,
+        kv_h,
+        blocks.iter().map(super::BlockRows::rows),
+    )
+    .map_err(|e| Error::Quant(format!("{what}: {e}")))?;
+
+    let mut out = IsoKernelInputs {
+        codes: vec![0_u8; total_groups * ISO_SLOT_BYTES],
+        scales: vec![0_u8; total_groups * ISO_SLOT_BYTES],
+        quaternions: vec![0_u8; total_groups * 4 * ISO_SLOT_BYTES],
+        norms: vec![0_u8; total_groups * ISO_SLOT_BYTES],
+        total_groups,
+    };
+
+    let mut row = 0usize;
+    for blk in blocks {
+        let rows = super::BlockRows::rows(blk);
+        // The scatter below indexes each payload by row; a length that is not a
+        // whole number of rows would silently read across a row boundary.
+        let want_codes = rows * n_groups;
+        if blk.codes.len() != want_codes
+            || blk.scales.len() != want_codes
+            || blk.quaternions.len() != want_codes * 4
+            || blk.norms.len() != rows
+        {
+            return Err(Error::Quant(format!(
+                "{what}: block payload disagrees with its {rows} rows at n_groups={n_groups} \
+                 (codes {} scales {} quaternions {} norms {}; want {want_codes} {want_codes} {} \
+                 {rows})",
+                blk.codes.len(),
+                blk.scales.len(),
+                blk.quaternions.len(),
+                blk.norms.len(),
+                want_codes * 4,
+            )));
+        }
+        for r in 0..rows {
+            let Some(&dst_token) = perm.get(row + r) else {
+                return Err(Error::Quant(format!(
+                    "{what}: block rows exceed the permutation length {}",
+                    perm.len()
+                )));
+            };
+            copy_f32_slots(
+                &mut out.codes,
+                dst_token * n_groups,
+                &blk.codes[r * n_groups..(r + 1) * n_groups],
+                u32::to_le_bytes,
+            );
+            copy_f32_slots(
+                &mut out.scales,
+                dst_token * n_groups,
+                &blk.scales[r * n_groups..(r + 1) * n_groups],
+                f32::to_le_bytes,
+            );
+            copy_f32_slots(
+                &mut out.quaternions,
+                dst_token * n_groups * 4,
+                &blk.quaternions[r * n_groups * 4..(r + 1) * n_groups * 4],
+                f32::to_le_bytes,
+            );
+            // Per-token → per-group expand: the kernel reads `norms[gid]` with
+            // `gid = token * n_groups + grp`, and every group in a token shares
+            // the token's norm.
+            let n_bytes = blk.norms[r].to_le_bytes();
+            let base = dst_token * n_groups * ISO_SLOT_BYTES;
+            for g in 0..n_groups {
+                let at = base + g * ISO_SLOT_BYTES;
+                out.norms[at..at + ISO_SLOT_BYTES].copy_from_slice(&n_bytes);
+            }
+        }
+        row += rows;
+    }
+    Ok(out)
+}
+
+/// Write `src` into `dst` as little-endian 4-byte slots starting at slot
+/// `slot_offset`. Shared by the code / scale / quaternion scatters above.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "dst is sized total_groups slots and slot_offset + src.len() is bounded by the \
+              permutation's range, which head_major_token_order pins to that same count"
+)]
+fn copy_f32_slots<T: Copy>(dst: &mut [u8], slot_offset: usize, src: &[T], to_le: fn(T) -> [u8; 4]) {
+    for (i, &v) in src.iter().enumerate() {
+        let at = (slot_offset + i) * 4;
+        dst[at..at + 4].copy_from_slice(&to_le(v));
     }
 }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -615,12 +615,21 @@ impl QuantIsoV3 {
                 self.shape
             )));
         }
-        // Blocks are sequence-major (see `append`); reorder the concatenated
-        // decode back to the logical head-major `[B, kv_h, S, D]`.
+        // Blocks are sequence-major (see `append`), one per append; reorder each
+        // at its own sequence offset back to the logical head-major
+        // `[B, kv_h, S, D]`. Reading the concatenation as a single run would
+        // interleave batch elements once `B > 1`.
         let b = self.shape[0] as usize;
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
-        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
+        let out = super::seq_layout::transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            head_dim,
+            blocks.iter().map(super::BlockRows::rows),
+        )?;
         Ok(out)
     }
 
@@ -1242,7 +1251,7 @@ pub(crate) fn synced_iso_v_blocks<'a>(
     let full_seq = shape.get(2).copied().unwrap_or(0).max(0) as usize;
     let head_dim = shape.get(3).copied().unwrap_or(0).max(0) as usize;
     let full_tokens = b * kv_h * full_seq;
-    let blocks_tokens: usize = blocks.iter().map(|blk| blk.n_tokens).sum();
+    let blocks_tokens: usize = blocks.iter().map(super::BlockRows::rows).sum();
 
     if blocks_tokens == full_tokens {
         return Ok(std::borrow::Cow::Borrowed(blocks));

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -508,9 +508,12 @@ impl QuantIsoV3 {
     /// No-op when the ring was never allocated. Every path that pushes a CPU
     /// block onto a store whose ring may be live goes through here: without it
     /// the pushed block is the *only* block, `blocks` no longer cover
-    /// `shape[2]`, and the ring left behind is stale — the next ring append
-    /// would write past its filled region and `dequant` would read a gap the
-    /// ring's fill watermark then refuses.
+    /// `shape[2]`, and the ring left behind is stale. A *read* of that state is
+    /// refused by the ring's fill watermark; an *append* onto it is refused by
+    /// [`QuantKGpuRing::append_encoded`]'s `prev_seq > filled` guard, because
+    /// the write would otherwise zero `[filled, prev_seq)` and then commit a
+    /// watermark that covers it. Both directions have to refuse, or the state
+    /// is only unreachable by convention.
     ///
     /// `disposition` is a parameter because it is the one thing the two callers
     /// disagree on, and having them disagree by carrying separate copies of this

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v.rs
@@ -585,6 +585,24 @@ impl QuantIsoV3 {
     /// Returns an `Error::Mlx` if the underlying [`iso_decode_fast`] fails for
     /// any block.
     pub fn dequant(&self) -> Result<Vec<f32>> {
+        // The ring lives on the GPU whenever it is live at all, so that is the
+        // stream its readback belongs on. `dequant_on` exists so a caller that
+        // knows better — a `Device::Cpu` run, or a test that must not touch a
+        // shared Metal context — can say so instead of having this constant
+        // imposed on it.
+        self.dequant_on(Device::Gpu)
+    }
+
+    /// [`Self::dequant`] on an explicit device.
+    ///
+    /// The device selects the stream for the ring readback that reconciles a
+    /// ring-only decode tail; it has no effect on a store whose CPU blocks
+    /// already cover `shape[2]`, which is every store on the CPU append path.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::dequant`].
+    pub fn dequant_on(&self, device: Device) -> Result<Vec<f32>> {
         if self.shape.len() != 4 {
             return Err(Error::Mlx(format!(
                 "QuantIsoV3::dequant: malformed shape {:?}",
@@ -600,7 +618,7 @@ impl QuantIsoV3 {
         // `shape[2]`), and this rebuilds it on demand rather than decoding a
         // short prefix and zero-padding the gap. Loud on any unrecoverable
         // disagreement.
-        let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, Device::Gpu)?;
+        let blocks = synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, device)?;
 
         if blocks.is_empty() {
             // Empty blocks are valid only when the store genuinely holds no
@@ -1405,7 +1423,18 @@ fn copy_f32_slots<T: Copy>(dst: &mut [u8], slot_offset: usize, src: &[T], to_le:
 /// **Invariant (enforced loudly, never zero-padded):** `blocks` track the ring
 /// exactly, or the ring exists and supplies the tail. Any state where the CPU
 /// blocks fall short of `shape[2]` and the ring cannot make up the difference is
-/// an `Error` — the caller must not fabricate a zeroed gap.
+/// an `Error` — the caller must not fabricate a zeroed gap. The enforcement is
+/// [`QuantKGpuRing`]'s fill watermark: the readback is sized from `shape[2]` and
+/// refused when that runs past what the ring actually wrote. Without it the
+/// ring's page-rounded `capacity` accepted the read and the caller got the
+/// allocation's zeros as a K/V tail — length-correct and silently wrong.
+///
+/// **What it does not cover:** when `blocks` fall short the ring supplies the
+/// *whole* prefix and the existing `blocks` are discarded, not merged. That is
+/// right for the state this exists for — on the fused decode path the ring is a
+/// superset of the blocks — but a caller holding a block the ring never saw
+/// would lose it with no error. No such caller exists today: every block push on
+/// these stores either feeds the ring or drops it first.
 ///
 /// Shared by [`QuantIsoV3`] / [`super::QuantIsoV4`] and the iso K stores
 /// ([`super::QuantIsoK3`] / [`super::QuantIsoK4`]) — the `IsoBlocks` payload and

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
@@ -352,12 +352,19 @@ impl QuantIsoV4 {
                 self.shape
             )));
         }
-        // Blocks are sequence-major (see `append`); reorder back to head-major
-        // `[B, kv_h, S, D]`.
+        // Per-block reorder back to head-major `[B, kv_h, S, D]` — see
+        // [`super::QuantIsoV3::dequant`].
         let b = self.shape[0] as usize;
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
-        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
+        let out = super::seq_layout::transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            head_dim,
+            blocks.iter().map(super::BlockRows::rows),
+        )?;
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v4.rs
@@ -298,6 +298,34 @@ impl QuantIsoV4 {
         blocks.iter().map(IsoBlocks::byte_size).sum::<u64>() + gpu.byte_size()
     }
 
+    /// Rebuild any ring-only prefix into the CPU blocks so `blocks` alone cover
+    /// `shape[2]` again, and either keep or drop the ring.
+    ///
+    /// Sibling of [`super::QuantIsoV3::reconcile_ring`] — see it for why the
+    /// disposition is a parameter rather than two copies of this body.
+    ///
+    /// # Errors
+    ///
+    /// Forwards a [`synced_iso_v_blocks`] reconciliation error.
+    pub(crate) fn reconcile_ring(
+        &mut self,
+        device: Device,
+        disposition: super::RingDisposition,
+    ) -> Result<()> {
+        if !self.gpu.is_allocated() {
+            return Ok(());
+        }
+        if let std::borrow::Cow::Owned(full) =
+            synced_iso_v_blocks(&self.blocks, &self.shape, &self.gpu, device)?
+        {
+            self.blocks = full;
+        }
+        if disposition == super::RingDisposition::Drop {
+            self.gpu.clear();
+        }
+        Ok(())
+    }
+
     /// Dequantize all accumulated V slices into one flat f32 vector of length
     /// `prod(shape)`.
     ///

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v4_tests.rs
@@ -293,8 +293,8 @@ fn quant_iso_v4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
 /// invisible.
 #[test]
 fn quant_iso_v4_two_block_decode_matches_one_block_at_b_gt_1() {
-    for b in [1_usize, 2] {
-        let (kv_h, head_dim) = (2_usize, 8_usize);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 8_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
 
@@ -321,7 +321,7 @@ fn quant_iso_v4_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v4_tests.rs
@@ -275,3 +275,53 @@ fn quant_iso_v4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
         );
     }
 }
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantIsoV4::dequant` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_iso_v4_two_block_decode_matches_one_block_at_b_gt_1() {
+    for b in [1_usize, 2] {
+        let (kv_h, head_dim) = (2_usize, 8_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+
+        let mut one = QuantIsoV4::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 512);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+        )
+        .expect("single append");
+        let oracle = one.dequant().expect("one-block dequant");
+
+        let mut two = QuantIsoV4::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 512);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+        )
+        .expect("append chunk 1");
+        let got = two.dequant().expect("two-block dequant");
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
@@ -860,8 +860,8 @@ fn quant_iso_v3_truncate_mid_block_splits_instead_of_dropping() {
 /// invisible.
 #[test]
 fn quant_iso_v3_two_block_decode_matches_one_block_at_b_gt_1() {
-    for b in [1_usize, 2] {
-        let (kv_h, head_dim) = (2_usize, 8_usize);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 8_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
 
@@ -888,7 +888,7 @@ fn quant_iso_v3_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}"
         );
     }
 }
@@ -927,7 +927,7 @@ fn ring_inputs(blk: &IsoBlocks) -> (Array, Array, Array) {
 /// Runs entirely on `Device::Cpu` — the ring is device-parameterised, so the
 /// state machine reproduces without Metal.
 ///
-/// Mutation check: drop the `absorb_ring_into_blocks` call from
+/// Mutation check: drop the `reconcile_ring` call from
 /// `QuantIsoV3::append_gpu`. The `absorb = false` arm below models exactly that,
 /// and it is what asserts the unfixed store is unreadable; if the fix is
 /// reverted, the `absorb = true` arm goes red for the same reason.
@@ -989,7 +989,7 @@ fn iso_v3_block_append_over_a_live_ring_takes_the_prefix_back() {
 
         // Legacy fallback step: `append_gpu`'s reconcile, then its block push.
         if absorb {
-            vs.absorb_ring_into_blocks(Device::Cpu)
+            vs.reconcile_ring(Device::Cpu, crate::storage::RingDisposition::Drop)
                 .expect("absorb the ring prefix");
             assert!(
                 !vs.gpu.is_allocated(),
@@ -1037,7 +1037,7 @@ fn iso_v3_block_append_over_a_live_ring_takes_the_prefix_back() {
 /// there — which is how `iso3_sym` failed to serve a model whose decode took the
 /// non-fused fallback after the fused path had gone live.
 ///
-/// Mutation check: drop `absorb_ring_into_blocks` from `append_gpu` and the
+/// Mutation check: drop `reconcile_ring` from `append_gpu` and the
 /// `dequant` assertion goes red; revert `dequant_gpu` to iterate `self.blocks`
 /// and the `dequant_gpu` assertion goes red.
 #[test]
@@ -1285,4 +1285,58 @@ fn iso_v3_dequant_gpu_matches_dequant_at_b_gt_1() {
              batch/head scramble in the GPU reader"
         );
     }
+}
+
+/// The geometry the codec actually failed on: a single KV head with a wide
+/// `head_dim`.
+///
+/// gemma-4-e2b's global attention layers are `kv_h = 1, head_dim = 512`
+/// (`num_key_value_heads: 1`, `global_head_dim: 512`), and no unit test
+/// constructed that shape for this codec — every other iso fixture here uses
+/// `kv_h = 2, head_dim = 8`, which is two quaternion groups per token and hides
+/// anything that scales with `n_groups`. 512 is 128 groups.
+///
+/// Both readers are checked at that shape: the CPU `dequant` against a
+/// single-append oracle, and the GPU reader's kernel inputs against the same
+/// chunking-independence property the wider test asserts. (The kernel dispatch
+/// itself needs Metal; the inputs are what carry the layout.)
+#[test]
+fn iso_v3_single_kv_head_head_dim_512_decodes_the_same_either_chunking() {
+    let (b, kv_h, head_dim) = (1_usize, 1_usize, 512_usize);
+    let n_groups = head_dim / ISO3_GROUP_SIZE;
+    let (n0, n1) = (2_usize, 3_usize);
+    let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+    let init = || vec![b as i32, kv_h as i32, 0, head_dim as i32];
+    let chunk = |s0: usize, n: usize| crate::test_utils::batch_head_chunk(b, kv_h, s0, n, head_dim);
+
+    let mut one = QuantIsoV3::new(init());
+    one.append(&chunk(0, n0 + n1), &shape(n0 + n1))
+        .expect("single append");
+    let oracle = one.dequant().expect("one-block dequant");
+
+    let mut two = QuantIsoV3::new(init());
+    two.append(&chunk(0, n0), &shape(n0)).expect("chunk 0");
+    two.append(&chunk(n0, n1), &shape(n1)).expect("chunk 1");
+    let got = two.dequant().expect("two-block dequant");
+    assert_eq!(
+        got, oracle,
+        "kv_h = 1, head_dim = 512: two-block decode must equal the one-block oracle"
+    );
+
+    let build = |blocks: &[IsoBlocks], sh: &[i32]| {
+        crate::storage::quant_iso_v::iso_kernel_inputs_head_major(
+            blocks,
+            sh,
+            n_groups,
+            ISO3_GROUP_SIZE,
+            "test",
+        )
+        .expect("well-formed store")
+    };
+    let a = build(&one.blocks, &one.shape);
+    let c = build(&two.blocks, &two.shape);
+    assert_eq!(a.total_groups, c.total_groups, "slot count at head_dim 512");
+    assert_eq!(a.codes, c.codes, "GPU-reader codes at head_dim 512");
+    assert_eq!(a.scales, c.scales, "GPU-reader scales at head_dim 512");
+    assert_eq!(a.norms, c.norms, "GPU-reader norms at head_dim 512");
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
@@ -959,7 +959,9 @@ fn iso_v3_block_append_over_a_live_ring_takes_the_prefix_back() {
     oracle_store
         .append(&chunk(prefill + 1, 1), &shape(1))
         .expect("oracle fallback step");
-    let oracle = oracle_store.dequant().expect("oracle dequant");
+    let oracle = oracle_store
+        .dequant_on(Device::Cpu)
+        .expect("oracle dequant");
 
     for absorb in [false, true] {
         let mut vs = QuantIsoV3::new(init());
@@ -997,7 +999,7 @@ fn iso_v3_block_append_over_a_live_ring_takes_the_prefix_back() {
         vs.blocks.push(make_block(&chunk(prefill + 1, 1), 1));
         vs.shape[2] += 1;
 
-        let got = vs.dequant();
+        let got = vs.dequant_on(Device::Cpu);
         if absorb {
             assert_eq!(
                 got.expect("dequant after the reconcile"),
@@ -1005,12 +1007,20 @@ fn iso_v3_block_append_over_a_live_ring_takes_the_prefix_back() {
                 "the reconciled store must decode exactly like the all-CPU oracle"
             );
         } else {
-            let unfixed = got.expect("stale-ring dequant returns a plausible tensor");
-            assert_ne!(
-                unfixed, oracle,
-                "premise: without the reconcile the store decodes the stale ring instead \
-                 of the appended chunk. Equality here means this test no longer proves \
-                 the reconcile is load-bearing"
+            // Premise: without the reconcile the store is unreadable, and says
+            // so. The ring holds `prefill + 1` positions while `shape[2]` now
+            // claims `prefill + 2`, so the readback stops inside the ring's
+            // page-rounded zero tail — which the fill watermark refuses rather
+            // than decoding as K/V. (Before that watermark this returned `Ok`
+            // with a zeroed tail: length-correct, silently wrong.)
+            let err = got.expect_err(
+                "premise: a store whose block push skipped the reconcile must be refused. \
+                 An `Ok` here means this test no longer proves the reconcile is load-bearing",
+            );
+            let msg = err.to_string();
+            assert!(
+                msg.contains("exceeds filled="),
+                "the refusal must be the ring fill-watermark guard, got: {msg}"
             );
         }
     }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for [`QuantIsoV3`] (includes GPU-mirror path).
 
 use crate::isoquant::{iso_decode_fast, iso_encode_fast};
-use crate::storage::quant_iso_v::{QuantIsoV3, ISO3_BITS, ISO3_GROUP_SIZE};
+use crate::storage::quant_iso_v::{IsoBlocks, QuantIsoV3, ISO3_BITS, ISO3_GROUP_SIZE};
 use crate::test_utils::{cosine_similarity_per_row, lcg_data, skip_if_no_gpu_env, TEST_SEED};
 use rmlx_mlx::{Array, Device, Dtype};
 
@@ -891,4 +891,220 @@ fn quant_iso_v3_two_block_decode_matches_one_block_at_b_gt_1() {
             "two-block decode must equal the one-block oracle at b={b}"
         );
     }
+}
+
+// ── Block append over a live GPU ring ─────────────────────────────────────────
+
+/// Build the ring's `(codes, scales, norms)` inputs from one CPU-encoded block.
+///
+/// The ring carries per-token norms in exactly the form `iso_encode_fast`
+/// emits, and drops the per-group quaternion table (every group holds the same
+/// `FIXED_QUAT` constant), so this is a straight re-upload.
+fn ring_inputs(blk: &IsoBlocks) -> (Array, Array, Array) {
+    let codes_b: Vec<u8> = blk.codes.iter().flat_map(|c| c.to_le_bytes()).collect();
+    let scales_b: Vec<u8> = blk.scales.iter().flat_map(|s| s.to_le_bytes()).collect();
+    let norms_b: Vec<u8> = blk.norms.iter().flat_map(|n| n.to_le_bytes()).collect();
+    (
+        Array::from_bytes(&codes_b, &[blk.codes.len() as i32], Dtype::U32).expect("codes"),
+        Array::from_bytes(&scales_b, &[blk.scales.len() as i32], Dtype::F32).expect("scales"),
+        Array::from_bytes(&norms_b, &[blk.norms.len() as i32], Dtype::F32).expect("norms"),
+    )
+}
+
+/// A CPU-block append onto a store whose GPU ring is live must take the ring's
+/// prefix back and then drop the ring.
+///
+/// This reproduces the state the fused iso-symmetric decode path leaves behind:
+/// the ring holds every token and the CPU blocks were dropped, because the ring
+/// is the sole resident copy there. The legacy (non-fused) decode fallback then
+/// appends through `QuantIsoV3::append_gpu`, which pushes a CPU block. Without
+/// the reconcile that block is the *only* block — `blocks` cover one chunk while
+/// `shape[2]` counts the whole prefix — and the store is unreadable in both
+/// directions: `dequant_gpu` reports the blocks-derived element count against
+/// the shape-declared one, and `dequant` reads the missing tail out of a ring
+/// that was never told about the new chunk.
+///
+/// Runs entirely on `Device::Cpu` — the ring is device-parameterised, so the
+/// state machine reproduces without Metal.
+///
+/// Mutation check: drop the `absorb_ring_into_blocks` call from
+/// `QuantIsoV3::append_gpu`. The `absorb = false` arm below models exactly that,
+/// and it is what asserts the unfixed store is unreadable; if the fix is
+/// reverted, the `absorb = true` arm goes red for the same reason.
+#[test]
+fn iso_v3_block_append_over_a_live_ring_takes_the_prefix_back() {
+    let (b, kv_h, head_dim) = (1_usize, 2_usize, 8_usize);
+    let prefill = 4_usize;
+    let max_seq = 64_i32;
+    let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+    let init = || vec![b as i32, kv_h as i32, 0, head_dim as i32];
+    let chunk = |s0: usize, n: usize| crate::test_utils::batch_head_chunk(b, kv_h, s0, n, head_dim);
+
+    // One CPU-encoded block for a chunk, via the store's own `append`.
+    let make_block = |data: &[f32], n: usize| -> IsoBlocks {
+        let mut scratch = QuantIsoV3::new(init());
+        scratch.append(data, &shape(n)).expect("scratch append");
+        scratch.blocks.remove(0)
+    };
+
+    // Oracle: every chunk appended on the CPU path, where the ring is cleared
+    // at each append and the blocks are always the whole story.
+    let mut oracle_store = QuantIsoV3::new(init());
+    oracle_store
+        .append(&chunk(0, prefill), &shape(prefill))
+        .expect("oracle prefill");
+    oracle_store
+        .append(&chunk(prefill, 1), &shape(1))
+        .expect("oracle fused step");
+    oracle_store
+        .append(&chunk(prefill + 1, 1), &shape(1))
+        .expect("oracle fallback step");
+    let oracle = oracle_store.dequant().expect("oracle dequant");
+
+    for absorb in [false, true] {
+        let mut vs = QuantIsoV3::new(init());
+        vs.append(&chunk(0, prefill), &shape(prefill))
+            .expect("prefill append");
+
+        // Fused decode step: ring-only append, then the blocks are dropped.
+        let step = make_block(&chunk(prefill, 1), 1);
+        let (codes, scales, norms) = ring_inputs(&step);
+        vs.gpu_append(
+            &codes,
+            &scales,
+            &norms,
+            kv_h as i32,
+            head_dim as i32,
+            prefill as i32,
+            1,
+            max_seq,
+            Device::Cpu,
+        )
+        .expect("ring append");
+        vs.shape[2] = prefill as i32 + 1;
+        vs.blocks.clear();
+        assert!(vs.gpu.is_allocated(), "the ring is the sole copy here");
+
+        // Legacy fallback step: `append_gpu`'s reconcile, then its block push.
+        if absorb {
+            vs.absorb_ring_into_blocks(Device::Cpu)
+                .expect("absorb the ring prefix");
+            assert!(
+                !vs.gpu.is_allocated(),
+                "a store whose blocks are authoritative must not keep a ring"
+            );
+        }
+        vs.blocks.push(make_block(&chunk(prefill + 1, 1), 1));
+        vs.shape[2] += 1;
+
+        let got = vs.dequant();
+        if absorb {
+            assert_eq!(
+                got.expect("dequant after the reconcile"),
+                oracle,
+                "the reconciled store must decode exactly like the all-CPU oracle"
+            );
+        } else {
+            let unfixed = got.expect("stale-ring dequant returns a plausible tensor");
+            assert_ne!(
+                unfixed, oracle,
+                "premise: without the reconcile the store decodes the stale ring instead \
+                 of the appended chunk. Equality here means this test no longer proves \
+                 the reconcile is load-bearing"
+            );
+        }
+    }
+}
+
+/// The same reconcile, driven through the real `append_gpu` on Metal, plus the
+/// `dequant_gpu` half: after a block append over a live ring, **both** readers
+/// must return the all-CPU oracle.
+///
+/// `dequant_gpu` derives its element accounting from the same reconciled block
+/// list `dequant` uses. Before that it counted `self.blocks` directly, so a
+/// store carrying a ring-only tail was rejected with a blocks-vs-shape
+/// disagreement (`actual_total != declared_total`) even though the data was all
+/// there — which is how `iso3_sym` failed to serve a model whose decode took the
+/// non-fused fallback after the fused path had gone live.
+///
+/// Mutation check: drop `absorb_ring_into_blocks` from `append_gpu` and the
+/// `dequant` assertion goes red; revert `dequant_gpu` to iterate `self.blocks`
+/// and the `dequant_gpu` assertion goes red.
+#[test]
+#[ignore = "GPU Metal context — run via `make gpu-test CRATE=rmlx-kv-quant FILTER=iso_v3_append_gpu_over_a_live_ring`"]
+fn iso_v3_append_gpu_over_a_live_ring_is_readable_both_ways() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let (b, kv_h, head_dim) = (1_usize, 2_usize, 8_usize);
+    let prefill = 4_usize;
+    let max_seq = 64_i32;
+    let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+    let init = || vec![b as i32, kv_h as i32, 0, head_dim as i32];
+    let chunk = |s0: usize, n: usize| crate::test_utils::batch_head_chunk(b, kv_h, s0, n, head_dim);
+
+    let mut oracle_store = QuantIsoV3::new(init());
+    oracle_store
+        .append(&chunk(0, prefill), &shape(prefill))
+        .expect("oracle prefill");
+    oracle_store
+        .append(&chunk(prefill, 1), &shape(1))
+        .expect("oracle fused step");
+    oracle_store
+        .append(&chunk(prefill + 1, 1), &shape(1))
+        .expect("oracle fallback step");
+    let oracle = oracle_store.dequant().expect("oracle dequant");
+
+    let mut vs = QuantIsoV3::new(init());
+    vs.append(&chunk(0, prefill), &shape(prefill))
+        .expect("prefill append");
+
+    // Fused decode step: ring-only append, CPU blocks dropped.
+    let mut scratch = QuantIsoV3::new(init());
+    scratch
+        .append(&chunk(prefill, 1), &shape(1))
+        .expect("scratch append");
+    let step = scratch.blocks.remove(0);
+    let (codes, scales, norms) = ring_inputs(&step);
+    vs.gpu_append(
+        &codes,
+        &scales,
+        &norms,
+        kv_h as i32,
+        head_dim as i32,
+        prefill as i32,
+        1,
+        max_seq,
+        Device::Gpu,
+    )
+    .expect("ring append");
+    vs.shape[2] = prefill as i32 + 1;
+    vs.blocks.clear();
+
+    // Legacy fallback step: the real GPU-encode block append.
+    let tail = chunk(prefill + 1, 1);
+    let tail_bytes: Vec<u8> = tail.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let tail_arr = Array::from_bytes(&tail_bytes, &shape(1), Dtype::F32).expect("tail array");
+    vs.append_gpu(&tail_arr, &shape(1), max_seq, Device::Gpu)
+        .expect("append_gpu over a live ring");
+
+    let cpu = vs.dequant().expect("dequant after append_gpu");
+    let max_abs = cpu
+        .iter()
+        .zip(oracle.iter())
+        .fold(0.0_f32, |m, (a, c)| m.max((a - c).abs()));
+    assert!(
+        max_abs < 1e-5,
+        "dequant after a block append over a live ring: max abs error {max_abs} vs the \
+         all-CPU oracle — the ring prefix was not taken back"
+    );
+
+    let gpu_arr = vs
+        .dequant_gpu(Device::Gpu)
+        .expect("dequant_gpu must read the reconciled store, not reject it");
+    assert_eq!(
+        gpu_arr.shape(),
+        shape(prefill + 2).to_vec(),
+        "dequant_gpu returns the declared [B, kv_h, S, D]"
+    );
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
@@ -842,3 +842,53 @@ fn quant_iso_v3_truncate_mid_block_splits_instead_of_dropping() {
         "the split block must reconstruct the retained prefix exactly"
     );
 }
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantIsoV3::dequant` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_iso_v3_two_block_decode_matches_one_block_at_b_gt_1() {
+    for b in [1_usize, 2] {
+        let (kv_h, head_dim) = (2_usize, 8_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+
+        let mut one = QuantIsoV3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32]);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+        )
+        .expect("single append");
+        let oracle = one.dequant().expect("one-block dequant");
+
+        let mut two = QuantIsoV3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32]);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+        )
+        .expect("append chunk 1");
+        let got = two.dequant().expect("two-block dequant");
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
@@ -924,13 +924,20 @@ fn ring_inputs(blk: &IsoBlocks) -> (Array, Array, Array) {
 /// the shape-declared one, and `dequant` reads the missing tail out of a ring
 /// that was never told about the new chunk.
 ///
-/// Runs entirely on `Device::Cpu` — the ring is device-parameterised, so the
-/// state machine reproduces without Metal.
+/// Runs entirely on `Device::Cpu`: the ring is device-parameterised and the one
+/// reader involved is called as `dequant_on(Device::Cpu)`, so nothing here
+/// selects a Metal stream. (`dequant()` defaults to `Device::Gpu`, which is
+/// right for production — the ring lives there — and would have made this a
+/// Metal dispatch running unserialised inside `make test`.)
 ///
-/// Mutation check: drop the `reconcile_ring` call from
-/// `QuantIsoV3::append_gpu`. The `absorb = false` arm below models exactly that,
-/// and it is what asserts the unfixed store is unreadable; if the fix is
-/// reverted, the `absorb = true` arm goes red for the same reason.
+/// Mutation check: this test targets the reconcile and the ring fill watermark,
+/// not the call site. Disabling `QuantKGpuRing::packed_view`'s
+/// `kv_seq > self.filled` refusal reddens the `absorb = false` arm (it returns
+/// `Ok` with a zeroed tail again); breaking `reconcile_ring` itself reddens the
+/// `absorb = true` arm. Deleting the `reconcile_ring` call from
+/// `QuantIsoV3::append_gpu` reddens **neither** — this test drives the state
+/// machine by hand and never invokes `append_gpu`. That deletion is pinned
+/// separately by `append_gpu_reconciles_the_ring_before_it_pushes`.
 #[test]
 fn iso_v3_block_append_over_a_live_ring_takes_the_prefix_back() {
     let (b, kv_h, head_dim) = (1_usize, 2_usize, 8_usize);
@@ -1339,4 +1346,81 @@ fn iso_v3_single_kv_head_head_dim_512_decodes_the_same_either_chunking() {
     assert_eq!(a.codes, c.codes, "GPU-reader codes at head_dim 512");
     assert_eq!(a.scales, c.scales, "GPU-reader scales at head_dim 512");
     assert_eq!(a.norms, c.norms, "GPU-reader norms at head_dim 512");
+}
+
+/// `append_gpu` must reconcile the ring before it pushes — the call site, not
+/// just the helper.
+///
+/// The reconcile itself is proven above; this pins that `append_gpu` performs
+/// it, which nothing on-commit did before. It needs no Metal: the reconcile is
+/// step 0 and the MSL encode is step 1, so a well-formed call on the CPU device
+/// runs the reconcile and then fails at the encode with
+/// `"[metal_kernel] Only supports the GPU"`. That failure is the *expected*
+/// outcome — the assertions are on the state step 0 left behind on the way
+/// there.
+///
+/// (Forcing the early exit with a malformed `head_dim` instead would not work:
+/// that check precedes the reconcile, so the assertions would hold vacuously.)
+///
+/// Mutation check: delete `self.reconcile_ring(device, RingDisposition::Drop)?`
+/// from `QuantIsoV3::append_gpu` and both assertions below go red — the ring is
+/// still live and `blocks` still hold nothing.
+#[test]
+fn append_gpu_reconciles_the_ring_before_it_pushes() {
+    let (b, kv_h, head_dim) = (1_usize, 2_usize, 8_usize);
+    let prefill = 4_usize;
+    let max_seq = 64_i32;
+    let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+    let init = || vec![b as i32, kv_h as i32, 0, head_dim as i32];
+    let chunk = |s0: usize, n: usize| crate::test_utils::batch_head_chunk(b, kv_h, s0, n, head_dim);
+
+    let mut vs = QuantIsoV3::new(init());
+    vs.append(&chunk(0, prefill), &shape(prefill))
+        .expect("prefill append");
+
+    // Fused decode step: ring-only append, then the blocks are dropped — the
+    // state the fused path leaves and the legacy fallback then appends onto.
+    let mut scratch = QuantIsoV3::new(init());
+    scratch
+        .append(&chunk(prefill, 1), &shape(1))
+        .expect("scratch append");
+    let (codes, scales, norms) = ring_inputs(&scratch.blocks[0]);
+    vs.gpu_append(
+        &codes,
+        &scales,
+        &norms,
+        kv_h as i32,
+        head_dim as i32,
+        prefill as i32,
+        1,
+        max_seq,
+        Device::Cpu,
+    )
+    .expect("ring append");
+    vs.shape[2] = prefill as i32 + 1;
+    vs.blocks.clear();
+    assert!(vs.gpu.is_allocated(), "the ring is the sole copy here");
+
+    let tail = chunk(prefill + 1, 1);
+    let bytes: Vec<u8> = tail.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let arr = Array::from_bytes(&bytes, &shape(1), Dtype::F32).expect("tail array");
+    let err = vs
+        .append_gpu(&arr, &shape(1), max_seq, Device::Cpu)
+        .expect_err("the MSL encode cannot run on the CPU device");
+    assert!(
+        err.to_string().contains("Only supports the GPU"),
+        "the append must reach the encode and fail there, not earlier — otherwise the \
+         assertions below would hold vacuously. Got: {err}"
+    );
+
+    assert!(
+        !vs.gpu.is_allocated(),
+        "append_gpu must drop the ring it reconciled"
+    );
+    let rows: usize = vs.blocks.iter().map(crate::storage::BlockRows::rows).sum();
+    assert_eq!(
+        rows,
+        b * kv_h * (prefill + 1),
+        "append_gpu must take the ring's prefix back into blocks before it pushes"
+    );
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
@@ -1206,10 +1206,6 @@ fn iso_v3_kernel_inputs_do_not_depend_on_chunking() {
         );
         assert_eq!(a.codes, c.codes, "codes at b={b} kv_h={kv_h}");
         assert_eq!(a.scales, c.scales, "scales at b={b} kv_h={kv_h}");
-        assert_eq!(
-            a.quaternions, c.quaternions,
-            "quaternions at b={b} kv_h={kv_h}"
-        );
         assert_eq!(a.norms, c.norms, "norms at b={b} kv_h={kv_h}");
     }
 }
@@ -1303,49 +1299,70 @@ fn iso_v3_dequant_gpu_matches_dequant_at_b_gt_1() {
 /// `kv_h = 2, head_dim = 8`, which is two quaternion groups per token and hides
 /// anything that scales with `n_groups`. 512 is 128 groups.
 ///
-/// Both readers are checked at that shape: the CPU `dequant` against a
-/// single-append oracle, and the GPU reader's kernel inputs against the same
-/// chunking-independence property the wider test asserts. (The kernel dispatch
-/// itself needs Metal; the inputs are what carry the layout.)
+/// What this pins: that a 128-group store decodes at all, and that the shared
+/// builder's declared-vs-actual accounting agrees on it — the arithmetic that
+/// scales with `n_groups`. At `b = kv_h = 1` it does **not** pin the row
+/// permutation: `head_major_token_order` is the identity there, and so is the
+/// block-concatenation order the branch replaced. Neither does `(1, 2)` —
+/// measured: at `b == 1` concatenation preserves row order across chunk
+/// boundaries for any `kv_h`, so the identity passes both. The `b = 2`
+/// iterations below are what carry the layout at this width. The permutation in
+/// general is pinned by `*_two_block_decode_matches_one_block_at_b_gt_1` and
+/// `seq_layout_tests::head_major_token_order_matches_the_output_reorder`.
 #[test]
 fn iso_v3_single_kv_head_head_dim_512_decodes_the_same_either_chunking() {
-    let (b, kv_h, head_dim) = (1_usize, 1_usize, 512_usize);
-    let n_groups = head_dim / ISO3_GROUP_SIZE;
-    let (n0, n1) = (2_usize, 3_usize);
-    let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
-    let init = || vec![b as i32, kv_h as i32, 0, head_dim as i32];
-    let chunk = |s0: usize, n: usize| crate::test_utils::batch_head_chunk(b, kv_h, s0, n, head_dim);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 512_usize;
+        let n_groups = head_dim / ISO3_GROUP_SIZE;
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+        let init = || vec![b as i32, kv_h as i32, 0, head_dim as i32];
+        let chunk =
+            |s0: usize, n: usize| crate::test_utils::batch_head_chunk(b, kv_h, s0, n, head_dim);
 
-    let mut one = QuantIsoV3::new(init());
-    one.append(&chunk(0, n0 + n1), &shape(n0 + n1))
-        .expect("single append");
-    let oracle = one.dequant().expect("one-block dequant");
+        let mut one = QuantIsoV3::new(init());
+        one.append(&chunk(0, n0 + n1), &shape(n0 + n1))
+            .expect("single append");
+        let oracle = one.dequant().expect("one-block dequant");
 
-    let mut two = QuantIsoV3::new(init());
-    two.append(&chunk(0, n0), &shape(n0)).expect("chunk 0");
-    two.append(&chunk(n0, n1), &shape(n1)).expect("chunk 1");
-    let got = two.dequant().expect("two-block dequant");
-    assert_eq!(
-        got, oracle,
-        "kv_h = 1, head_dim = 512: two-block decode must equal the one-block oracle"
-    );
+        let mut two = QuantIsoV3::new(init());
+        two.append(&chunk(0, n0), &shape(n0)).expect("chunk 0");
+        two.append(&chunk(n0, n1), &shape(n1)).expect("chunk 1");
+        let got = two.dequant().expect("two-block dequant");
+        assert_eq!(
+            got, oracle,
+            "head_dim = 512, kv_h={kv_h}: two-block decode must equal the one-block oracle"
+        );
 
-    let build = |blocks: &[IsoBlocks], sh: &[i32]| {
-        crate::storage::quant_iso_v::iso_kernel_inputs_head_major(
-            blocks,
-            sh,
-            n_groups,
-            ISO3_GROUP_SIZE,
-            "test",
-        )
-        .expect("well-formed store")
-    };
-    let a = build(&one.blocks, &one.shape);
-    let c = build(&two.blocks, &two.shape);
-    assert_eq!(a.total_groups, c.total_groups, "slot count at head_dim 512");
-    assert_eq!(a.codes, c.codes, "GPU-reader codes at head_dim 512");
-    assert_eq!(a.scales, c.scales, "GPU-reader scales at head_dim 512");
-    assert_eq!(a.norms, c.norms, "GPU-reader norms at head_dim 512");
+        let build = |blocks: &[IsoBlocks], sh: &[i32]| {
+            crate::storage::quant_iso_v::iso_kernel_inputs_head_major(
+                blocks,
+                sh,
+                n_groups,
+                ISO3_GROUP_SIZE,
+                "test",
+            )
+            .expect("well-formed store")
+        };
+        let a = build(&one.blocks, &one.shape);
+        let c = build(&two.blocks, &two.shape);
+        assert_eq!(
+            a.total_groups, c.total_groups,
+            "slot count at head_dim 512, kv_h={kv_h}"
+        );
+        assert_eq!(
+            a.codes, c.codes,
+            "GPU-reader codes at head_dim 512, kv_h={kv_h}"
+        );
+        assert_eq!(
+            a.scales, c.scales,
+            "GPU-reader scales at head_dim 512, kv_h={kv_h}"
+        );
+        assert_eq!(
+            a.norms, c.norms,
+            "GPU-reader norms at head_dim 512, kv_h={kv_h}"
+        );
+    }
 }
 
 /// `append_gpu` must reconcile the ring before it pushes — the call site, not

--- a/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_iso_v_tests.rs
@@ -1108,3 +1108,171 @@ fn iso_v3_append_gpu_over_a_live_ring_is_readable_both_ways() {
         "dequant_gpu returns the declared [B, kv_h, S, D]"
     );
 }
+
+// ── GPU-reader kernel inputs ─────────────────────────────────────────────────
+
+/// Read an f32 `Array` back to a host vector for comparison.
+fn array_to_f32(a: &Array) -> Vec<f32> {
+    let bytes = a.to_bytes().expect("array to bytes");
+    bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+/// The iso dequant kernel's inputs must not depend on how the sequence was
+/// chunked into blocks.
+///
+/// `dequant_gpu` builds them via `iso_kernel_inputs_head_major`, which places
+/// every token row at its head-major `[B, kv_h, S, D]` position. That order is a
+/// function of `(bi, h, s)` alone, so a store built by one append and the same
+/// store built by two must produce **byte-identical** buffers. Reading the
+/// concatenation as one `[B, S, kv_h, D]` run instead — what `dequant_gpu` used
+/// to do with a whole-buffer reshape — is only valid at `B == 1`, so this is the
+/// GPU reader's half of the same bound `dequant` closes.
+///
+/// This is the on-commit gate for that reader: the MSL dispatch itself is
+/// shape-preserving and per-token positional, so if the inputs are right the
+/// output is. `iso_v3_dequant_gpu_matches_dequant_at_b_gt_1` re-proves it
+/// end-to-end on Metal.
+///
+/// What this pins, precisely: that the inputs are **chunking-independent**.
+/// Measured mutation — replace the `perm` lookup in
+/// `iso_kernel_inputs_head_major` with the identity (block-concatenation order,
+/// which is what the whole-buffer reshape assumed) and this goes red at
+/// `b = 2, kv_h = 1` and stays green at both `b = 1` cases, because
+/// concatenation preserves row order across chunk boundaries only when there is
+/// one batch element. It does **not** by itself prove the placement is
+/// head-major — the identity passes it at `b = 1`. That half is pinned by
+/// `seq_layout_tests::head_major_token_order_matches_the_output_reorder` (against
+/// an index-math reference) and `..._is_a_bijection`, and end-to-end on Metal by
+/// `iso_v3_dequant_gpu_matches_dequant_at_b_gt_1`.
+#[test]
+fn iso_v3_kernel_inputs_do_not_depend_on_chunking() {
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 8_usize;
+        let n_groups = head_dim / ISO3_GROUP_SIZE;
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+        let init = || vec![b as i32, kv_h as i32, 0, head_dim as i32];
+        let chunk =
+            |s0: usize, n: usize| crate::test_utils::batch_head_chunk(b, kv_h, s0, n, head_dim);
+
+        let mut one = QuantIsoV3::new(init());
+        one.append(&chunk(0, n0 + n1), &shape(n0 + n1))
+            .expect("single append");
+        let mut two = QuantIsoV3::new(init());
+        two.append(&chunk(0, n0), &shape(n0)).expect("chunk 0");
+        two.append(&chunk(n0, n1), &shape(n1)).expect("chunk 1");
+        assert_eq!(
+            two.blocks.len(),
+            2,
+            "the two-append store really holds 2 blocks"
+        );
+
+        let build = |store: &QuantIsoV3| {
+            crate::storage::quant_iso_v::iso_kernel_inputs_head_major(
+                &store.blocks,
+                &store.shape,
+                n_groups,
+                ISO3_GROUP_SIZE,
+                "test",
+            )
+            .expect("well-formed store")
+        };
+        let a = build(&one);
+        let c = build(&two);
+
+        assert_eq!(
+            a.total_groups, c.total_groups,
+            "slot count at b={b} kv_h={kv_h}"
+        );
+        assert_eq!(a.codes, c.codes, "codes at b={b} kv_h={kv_h}");
+        assert_eq!(a.scales, c.scales, "scales at b={b} kv_h={kv_h}");
+        assert_eq!(
+            a.quaternions, c.quaternions,
+            "quaternions at b={b} kv_h={kv_h}"
+        );
+        assert_eq!(a.norms, c.norms, "norms at b={b} kv_h={kv_h}");
+    }
+}
+
+/// The shared builder's accounting is the one `dequant_gpu` relies on: a block
+/// list that does not cover `prod(shape)` must be refused, not reshaped.
+#[test]
+fn iso_v3_kernel_inputs_refuse_a_blocks_vs_shape_mismatch() {
+    let (b, kv_h, head_dim) = (1_usize, 2_usize, 8_usize);
+    let n_groups = head_dim / ISO3_GROUP_SIZE;
+    let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+    let mut vs = QuantIsoV3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32]);
+    vs.append(
+        &crate::test_utils::batch_head_chunk(b, kv_h, 0, 3, head_dim),
+        &shape(3),
+    )
+    .expect("append");
+    // Claim one more position than the blocks carry.
+    vs.shape[2] = 4;
+    let err = crate::storage::quant_iso_v::iso_kernel_inputs_head_major(
+        &vs.blocks,
+        &vs.shape,
+        n_groups,
+        ISO3_GROUP_SIZE,
+        "QuantIsoV3::dequant_gpu",
+    )
+    .expect_err("blocks short of shape[2] must be refused");
+    assert!(
+        err.to_string().contains("actual_total") && err.to_string().contains("declared_total"),
+        "expected the accounting error, got: {err}"
+    );
+}
+
+/// End-to-end on Metal: `dequant_gpu` must equal `dequant` for a `b > 1` store
+/// holding two blocks.
+///
+/// `dequant_gpu` used to reshape the concatenated kernel output as one
+/// `[B, S, kv_h, D]` run, which interleaves batch elements once more than one
+/// block exists — the same defect `dequant` closed. `synced_iso_v_blocks` hands
+/// this reader a multi-block `Cow::Borrowed` precisely at `b > 1`, because every
+/// ring feed clears the ring when `b != 1`, so the blocks are always
+/// authoritative there.
+///
+/// Mutation check: restore the whole-buffer
+/// `reshape([B, S, kv_h, D]) + transpose(0, 2, 1, 3)` at the end of
+/// `QuantIsoV3::dequant_gpu` and this goes red; the `b = 1` half stays green.
+#[test]
+#[ignore = "GPU Metal context — run via `make gpu-test CRATE=rmlx-kv-quant FILTER=iso_v3_dequant_gpu_matches_dequant_at_b_gt_1`"]
+fn iso_v3_dequant_gpu_matches_dequant_at_b_gt_1() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    for (b, kv_h) in [(1_usize, 2_usize), (2, 1), (2, 2)] {
+        let head_dim = 8_usize;
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+        let chunk =
+            |s0: usize, n: usize| crate::test_utils::batch_head_chunk(b, kv_h, s0, n, head_dim);
+
+        let mut vs = QuantIsoV3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32]);
+        vs.append(&chunk(0, n0), &shape(n0)).expect("chunk 0");
+        vs.append(&chunk(n0, n1), &shape(n1)).expect("chunk 1");
+        assert_eq!(vs.blocks.len(), 2, "two blocks is the case under test");
+
+        let cpu = vs.dequant().expect("cpu dequant");
+        let gpu = vs.dequant_gpu(Device::Gpu).expect("gpu dequant");
+        assert_eq!(
+            gpu.shape(),
+            shape(n0 + n1).to_vec(),
+            "dequant_gpu returns the declared [B, kv_h, S, D] at b={b} kv_h={kv_h}"
+        );
+        let gpu_vals = array_to_f32(&gpu);
+        let max_abs = cpu
+            .iter()
+            .zip(gpu_vals.iter())
+            .fold(0.0_f32, |m, (a, c)| m.max((a - c).abs()));
+        assert!(
+            max_abs < 1e-5,
+            "dequant_gpu vs dequant max abs error {max_abs} at b={b} kv_h={kv_h} — \
+             batch/head scramble in the GPU reader"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k.rs
@@ -453,14 +453,19 @@ impl QuantK {
                 // chunks written at `prev_seq * words_per_step`, and
                 // `words_per_step` folds `b` in. Reading the prefix as one
                 // `[B, S_total, kv_h, D]` run therefore interleaves batch
-                // elements once `B > 1` and more than one sequence position
-                // landed (`S <= 1` is the same order either way, and an emptied
-                // store must still decode to nothing). Refuse
+                // elements once `B > 1`. Unlike the CPU half this arm has no
+                // payload-vs-shape coverage check — the slice is sized *from*
+                // `shape[2]` — so `S == 1` is not evidence that the prefix is a
+                // single `[B, 1, kv_h, D]` chunk: a mid-chunk truncate at
+                // `b > 1` lowers `shape[2]` without touching this buffer. Only
+                // the empty store is exempt, because `truncate_to(0)` (which
+                // `KvStorage::reset` routes through) must still decode to
+                // nothing. Refuse
                 // rather than return a scrambled tensor — the CPU half of this
                 // reader handles every `B` via
                 // `seq_layout::transpose_chunked_seq_heads`, which is what the
                 // block list makes possible and this buffer does not.
-                if self.shape[0] != 1 && self.shape[2] > 1 {
+                if self.shape[0] != 1 && self.shape[2] != 0 {
                     return Err(rmlx_core::error::Error::Quant(format!(
                         "QuantK::dequantize_choice: the flat GPU buffer is b == 1 only \
                          (its per-step stride does not interleave batch), got shape {:?}",
@@ -522,11 +527,13 @@ impl QuantK {
         // fused gate refuses `b != 1`) and a silent scramble here is worth more
         // than the case it costs. Lifting it needs a recorded per-append
         // sequence length on the store.
-        // `s <= 1` needs no boundary: with at most one sequence position the
-        // concatenation order and the head-major order coincide at every `b`,
-        // and an emptied store (`truncate_to(0)`, which `reset` routes through)
+        // Only the empty store is exempt. `s == 1` is not evidence of a single
+        // chunk here either: `truncate_to` lowers `shape[2]` and
+        // `retain_cpu_prefix` refuses to cut the codes at `b != 1`, so a
+        // truncated store can declare one position over a multi-position
+        // payload. `truncate_to(0)` (which `KvStorage::reset` routes through)
         // must still decode to nothing.
-        if b != 1 && s > 1 {
+        if b != 1 && s != 0 {
             return Err(rmlx_core::error::Error::Quant(format!(
                 "QuantK::dequantize_choice: the CPU codes carry no per-append chunk boundary, \
                  so a b > 1 store cannot be reordered to head-major; got shape {:?}",

--- a/crates/rmlx-kv-quant/src/storage/quant_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k.rs
@@ -449,6 +449,24 @@ impl QuantK {
                 // a debugger comparing decode logits against the base commit will
                 // see q8-noise-level deltas, not zero. Pass out_dtype directly:
                 // kernel writes bf16/f16/f32 — no follow-up astype.
+                // The flat GPU buffer is a run of `[B, S_chunk, kv_h, D]`
+                // chunks written at `prev_seq * words_per_step`, and
+                // `words_per_step` folds `b` in. Reading the prefix as one
+                // `[B, S_total, kv_h, D]` run therefore interleaves batch
+                // elements once `B > 1` and more than one sequence position
+                // landed (`S <= 1` is the same order either way, and an emptied
+                // store must still decode to nothing). Refuse
+                // rather than return a scrambled tensor — the CPU half of this
+                // reader handles every `B` via
+                // `seq_layout::transpose_chunked_seq_heads`, which is what the
+                // block list makes possible and this buffer does not.
+                if self.shape[0] != 1 && self.shape[2] > 1 {
+                    return Err(rmlx_core::error::Error::Quant(format!(
+                        "QuantK::dequantize_choice: the flat GPU buffer is b == 1 only \
+                         (its per-step stride does not interleave batch), got shape {:?}",
+                        self.shape
+                    )));
+                }
                 let seq_major_shape = [self.shape[0], s, self.shape[1], self.shape[3]];
                 let out = q8_dequantize_gpu(&codes, &scales, &seq_major_shape, out_dtype, device)?;
                 // Materialize the heads↔seq transpose into a row-major buffer.
@@ -491,6 +509,30 @@ impl QuantK {
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
         let d = self.shape[3] as usize;
+        // `QuantK`'s CPU payload is one flat append-only `codes` / `scales` pair
+        // with no per-append boundary recorded, so the chunked reorder the block
+        // stores use (`seq_layout::transpose_chunked_seq_heads`) has nothing to
+        // partition on. The whole-buffer reorder below is exact for a single
+        // append at any `b`, and for any number of appends at `b == 1`; a
+        // multi-append `b > 1` store reads batch-interleaved and would return
+        // `Ok`. The boundaries are not recoverable after the fact, so this
+        // refuses `b != 1` outright rather than guessing which stores are
+        // single-append — deliberately wider than the defect, because `b > 1`
+        // reaches no production path today (one `KvCache` per request, and every
+        // fused gate refuses `b != 1`) and a silent scramble here is worth more
+        // than the case it costs. Lifting it needs a recorded per-append
+        // sequence length on the store.
+        // `s <= 1` needs no boundary: with at most one sequence position the
+        // concatenation order and the head-major order coincide at every `b`,
+        // and an emptied store (`truncate_to(0)`, which `reset` routes through)
+        // must still decode to nothing.
+        if b != 1 && s > 1 {
+            return Err(rmlx_core::error::Error::Quant(format!(
+                "QuantK::dequantize_choice: the CPU codes carry no per-append chunk boundary, \
+                 so a b > 1 store cannot be reordered to head-major; got shape {:?}",
+                self.shape,
+            )));
+        }
         Ok((transpose_seq_heads(&flat, b, s, kv_h, d), None))
     }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring.rs
@@ -66,6 +66,13 @@ pub struct QuantKGpuRing {
     pub norms_per_step: i32,
     /// Sequence positions the buffers are currently sized for.
     pub capacity: i32,
+    /// Sequence positions actually **written**.
+    ///
+    /// Distinct from `capacity`, which is page-rounded up to `KV_PAGE_SIZE` and
+    /// allocated with `zeros`: reading `[filled, capacity)` hands back the
+    /// allocation's zeros, which decode to a plausible-looking K/V tail rather
+    /// than an error. Every reader bounds on this, not on `capacity`.
+    pub filled: i32,
 }
 
 impl QuantKGpuRing {
@@ -83,6 +90,7 @@ impl QuantKGpuRing {
         self.scales = None;
         self.norms = None;
         self.capacity = 0;
+        self.filled = 0;
     }
 
     /// Resident byte footprint of the ring's GPU buffers.
@@ -104,6 +112,7 @@ impl QuantKGpuRing {
             codes_per_step: _,
             norms_per_step: _,
             capacity: _,
+            filled: _,
         } = self;
         crate::bytes::opt_array_bytes(codes.as_ref())
             + crate::bytes::opt_array_bytes(scales.as_ref())
@@ -196,6 +205,9 @@ impl QuantKGpuRing {
             device,
         )?;
         write_range(&mut self.norms, norms, prev_seq * nps, needed * nps, device)?;
+        // Commit the watermark only after every write landed: a partial append
+        // that raised it would advertise a region the buffers do not hold.
+        self.filled = needed;
         Ok(())
     }
 
@@ -271,6 +283,7 @@ impl QuantKGpuRing {
         write_range(&mut self.codes, &codes_arr, 0, filled_seq * cps, device)?;
         write_range(&mut self.scales, &scales_arr, 0, filled_seq * cps, device)?;
         write_range(&mut self.norms, &norms_arr, 0, filled_seq * nps, device)?;
+        self.filled = filled_seq;
         tracing::debug!(
             filled_seq,
             cap,
@@ -303,6 +316,18 @@ impl QuantKGpuRing {
             return Err(Error::Quant(format!(
                 "QuantKGpuRing::packed_view: kv_seq={kv_seq} exceeds capacity={}",
                 self.capacity
+            )));
+        }
+        // `capacity` is page-rounded and zero-initialised, so a read that stops
+        // inside `[filled, capacity)` is length-correct and silently wrong —
+        // the caller gets a zeroed K/V tail and no error. Bound on what was
+        // actually written. This check precedes every slice, so a rejected read
+        // dispatches nothing.
+        if kv_seq > self.filled {
+            return Err(Error::Quant(format!(
+                "QuantKGpuRing::packed_view: kv_seq={kv_seq} exceeds filled={} \
+                 (capacity={}) — refusing to read the allocation's zeros as K/V",
+                self.filled, self.capacity
             )));
         }
         let cps = self.codes_per_step;
@@ -386,10 +411,15 @@ impl QuantKGpuRing {
             device,
         )?);
         self.capacity = cap;
+        // `regrow` copies exactly `prev_seq` positions, so anything written past
+        // that is gone. Clamp rather than carry a watermark the new buffers do
+        // not back.
+        self.filled = self.filled.min(prev_seq);
         tracing::debug!(
             old_capacity,
             new_capacity = cap,
             prev_seq,
+            filled = self.filled,
             "QuantKGpuRing: ring grown"
         );
         Ok(())

--- a/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring.rs
@@ -174,6 +174,27 @@ impl QuantKGpuRing {
             )));
         }
 
+        // The watermark is a contiguous prefix, not a set. Appending at
+        // `prev_seq` when the ring only holds `filled` positions leaves
+        // `[filled, prev_seq)` as the allocation's zeros, and the
+        // `self.filled = needed` below would then advertise that gap as written
+        // — after which no reader can tell the difference, so the flash-decode
+        // kernel attends a zeroed K/V hole with no error. Enforcing the
+        // watermark on reads alone leaves exactly that state reachable one
+        // append later. A caller whose blocks outgrew the ring must `clear()`
+        // (which every `*_sync_ring` does) or reseed first. Checked before the
+        // alloc/grow below so a rejected append allocates nothing.
+        if self.is_allocated() && prev_seq > self.filled {
+            return Err(Error::Quant(format!(
+                "QuantKGpuRing::append_encoded: prev_seq={prev_seq} exceeds filled={filled} \
+                 (capacity={capacity}) — the ring is stale, so this append would leave \
+                 [{filled}, {prev_seq}) zeroed and then mark it written; clear() the ring \
+                 or reseed it from the CPU blocks first",
+                filled = self.filled,
+                capacity = self.capacity
+            )));
+        }
+
         if !self.is_allocated() {
             // Allocating here and writing only `[prev_seq, needed)` would leave
             // `[0, prev_seq)` zeroed — attention over a zeroed prefix, silently
@@ -437,13 +458,13 @@ fn page_round(needed: i32, max_seq: i32) -> i32 {
 fn regrow(
     old: Option<Array>,
     new_len: i32,
-    filled: i32,
+    copy_seq: i32,
     dtype: Dtype,
     what: &str,
     device: Device,
 ) -> Result<Array> {
     let fresh = zeros(&[new_len], dtype, device)?;
-    if filled <= 0 {
+    if copy_seq <= 0 {
         return Ok(fresh);
     }
     let old = old.ok_or_else(|| {
@@ -451,8 +472,8 @@ fn regrow(
             "QuantKGpuRing::grow: {what} buffer vanished mid-grow (internal invariant)"
         ))
     })?;
-    let prefix = old.slice(&[0], &[filled], &[1], device)?;
-    fresh.slice_update(&prefix, &[0], &[filled], &[1], device)
+    let prefix = old.slice(&[0], &[copy_seq], &[1], device)?;
+    fresh.slice_update(&prefix, &[0], &[copy_seq], &[1], device)
 }
 
 /// `slice_update` `src` into `buf[start..stop]`.

--- a/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_gpu_ring_tests.rs
@@ -455,3 +455,97 @@ fn page_round_covers_needed_and_caps_at_max() {
     // Capped at max_seq, but never below what the caller needs.
     assert_eq!(page_round(300, 300), 300);
 }
+
+// ── The watermark is a prefix, enforced in both directions ───────────────────
+
+/// Appending past `filled` must be refused, not written and then advertised.
+///
+/// `filled` is a contiguous prefix. Writing `[prev_seq, needed)` on a ring that
+/// only holds `filled` positions leaves `[filled, prev_seq)` as the
+/// allocation's zeros, and the `self.filled = needed` at the end of
+/// `append_encoded` would then cover that gap — after which `packed_view`
+/// cannot tell it from written data and the flash-decode kernel attends a
+/// zeroed K/V hole with no error. Enforcing the watermark on reads alone leaves
+/// exactly the state this branch exists to remove reachable one append later.
+///
+/// Runs on `Device::Cpu`: the ring is device-parameterised, and the guard is
+/// checked before any allocation, so nothing here selects a Metal stream.
+///
+/// Mutation check: delete the `prev_seq > self.filled` refusal from
+/// `append_encoded` and the `expect_err` below returns `Ok` instead — the ring
+/// then reports `filled == 5` while positions 2 and 3 hold zeros, and the
+/// `packed_view` assertion that follows stops being reachable at all.
+#[test]
+fn appending_past_the_fill_watermark_is_refused() {
+    let codes: Vec<u32> = (0..CODES_PER_STEP as u32 * 2).collect();
+    let scales: Vec<f32> = vec![0.5; CODES_PER_STEP * 2];
+    let norms: Vec<f32> = vec![7.0; NORMS_PER_STEP * 2];
+
+    let mut ring = QuantKGpuRing::default();
+    ring.append_encoded(
+        &u32_arr(&codes),
+        &f32_arr(&scales),
+        &f32_arr(&norms),
+        KV_H,
+        N_GROUPS,
+        0,
+        2,
+        64,
+        Device::Cpu,
+    )
+    .expect("seed the first two positions");
+    assert_eq!(ring.filled, 2, "two positions written");
+
+    // A stale caller: its blocks reached position 4 while the ring stopped at 2.
+    let one_codes: Vec<u32> = (0..CODES_PER_STEP as u32).collect();
+    let one_scales: Vec<f32> = vec![1.5; CODES_PER_STEP];
+    let one_norms: Vec<f32> = vec![9.0; NORMS_PER_STEP];
+    let err = ring
+        .append_encoded(
+            &u32_arr(&one_codes),
+            &f32_arr(&one_scales),
+            &f32_arr(&one_norms),
+            KV_H,
+            N_GROUPS,
+            4,
+            1,
+            64,
+            Device::Cpu,
+        )
+        .expect_err("appending at prev_seq=4 onto a ring filled to 2 must be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("prev_seq=4") && msg.contains("filled=2"),
+        "the refusal must name both positions, got: {msg}"
+    );
+    assert_eq!(
+        ring.filled, 2,
+        "a rejected append commits nothing — the watermark must not move"
+    );
+
+    // And the read side still refuses the same gap, so neither direction can
+    // hand back the allocation's zeros.
+    let err = ring
+        .packed_view(4, Device::Cpu)
+        .expect_err("reading past filled must be refused too");
+    assert!(
+        err.to_string().contains("exceeds filled="),
+        "expected the read-side watermark guard, got: {err}"
+    );
+
+    // The in-step append still works: the guard keys on the gap, not on being
+    // strict about equality.
+    ring.append_encoded(
+        &u32_arr(&one_codes),
+        &f32_arr(&one_scales),
+        &f32_arr(&one_norms),
+        KV_H,
+        N_GROUPS,
+        2,
+        1,
+        64,
+        Device::Cpu,
+    )
+    .expect("an append that starts exactly at `filled` is the healthy case");
+    assert_eq!(ring.filled, 3, "the healthy append advances the watermark");
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo3.rs
@@ -425,14 +425,19 @@ impl QuantKTurbo3 {
                 // chunks written at `prev_seq * words_per_step`, and
                 // `words_per_step` folds `b` in. Reading the prefix as one
                 // `[B, S_total, kv_h, D]` run therefore interleaves batch
-                // elements once `B > 1` and more than one sequence position
-                // landed (`S <= 1` is the same order either way, and an emptied
-                // store must still decode to nothing). Refuse
+                // elements once `B > 1`. Unlike the CPU half this arm has no
+                // payload-vs-shape coverage check — the slice is sized *from*
+                // `shape[2]` — so `S == 1` is not evidence that the prefix is a
+                // single `[B, 1, kv_h, D]` chunk: a mid-chunk truncate at
+                // `b > 1` lowers `shape[2]` without touching this buffer. Only
+                // the empty store is exempt, because `truncate_to(0)` (which
+                // `KvStorage::reset` routes through) must still decode to
+                // nothing. Refuse
                 // rather than return a scrambled tensor — the CPU half of this
                 // reader handles every `B` via
                 // `seq_layout::transpose_chunked_seq_heads`, which is what the
                 // block list makes possible and this buffer does not.
-                if self.shape[0] != 1 && self.shape[2] > 1 {
+                if self.shape[0] != 1 && self.shape[2] != 0 {
                     return Err(rmlx_core::error::Error::Quant(format!(
                         "QuantKTurbo3::dequantize_choice: the flat GPU buffer is b == 1 only \
                          (its per-step stride does not interleave batch), got shape {:?}",

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo3.rs
@@ -421,6 +421,24 @@ impl QuantKTurbo3 {
                 // `[B, S, kv_h, D]`, then reorder heads↔seq back to the logical
                 // `[B, kv_h, S, D]`. `contiguous` after the output transpose so
                 // raw byte-readers (SSD spill) see the permuted bytes.
+                // The flat GPU buffer is a run of `[B, S_chunk, kv_h, D]`
+                // chunks written at `prev_seq * words_per_step`, and
+                // `words_per_step` folds `b` in. Reading the prefix as one
+                // `[B, S_total, kv_h, D]` run therefore interleaves batch
+                // elements once `B > 1` and more than one sequence position
+                // landed (`S <= 1` is the same order either way, and an emptied
+                // store must still decode to nothing). Refuse
+                // rather than return a scrambled tensor — the CPU half of this
+                // reader handles every `B` via
+                // `seq_layout::transpose_chunked_seq_heads`, which is what the
+                // block list makes possible and this buffer does not.
+                if self.shape[0] != 1 && self.shape[2] > 1 {
+                    return Err(rmlx_core::error::Error::Quant(format!(
+                        "QuantKTurbo3::dequantize_choice: the flat GPU buffer is b == 1 only \
+                         (its per-step stride does not interleave batch), got shape {:?}",
+                        self.shape
+                    )));
+                }
                 let seq_major_shape = [self.shape[0], self.shape[2], self.shape[1], self.shape[3]];
                 let out =
                     turbo_dequantize_v3_gpu(&codes, &scales, &seq_major_shape, out_dtype, device)?;

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo3.rs
@@ -453,7 +453,18 @@ impl QuantKTurbo3 {
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
         let d = self.shape[3] as usize;
-        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, d);
+        // Blocks are sequence-major (see `append`), one per append; reorder each
+        // at its own sequence offset back to head-major `[B, kv_h, S, D]`.
+        // Reading the concatenation as a single run would interleave batch
+        // elements once `B > 1`.
+        let out = super::seq_layout::transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            d,
+            self.blocks.iter().map(super::BlockRows::rows),
+        )?;
         Ok((out, None))
     }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo3_tests.rs
@@ -420,3 +420,70 @@ fn quant_k_turbo3_cpu_msl_parity() {
         "CPU vs MSL max-abs-error = {max_err:.2e} exceeds 1e-5 (codec discrepancy)"
     );
 }
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantKTurbo3::dequantize_choice` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_k_turbo3_two_block_decode_matches_one_block_at_b_gt_1() {
+    for b in [1_usize, 2] {
+        let (kv_h, head_dim) = (2_usize, 32_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let max_seq = 512_i32;
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+        let dummy =
+            |n: usize| rmlx_mlx::zeros(&shape(n), Dtype::F32, Device::Cpu).expect("dummy array");
+        let cpu_dequant = |st: &QuantKTurbo3| {
+            st.dequantize_choice(Device::Cpu, Dtype::F32)
+                .expect("cpu dequant")
+                .0
+        };
+
+        let mut one = QuantKTurbo3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], max_seq);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+            &dummy(n0 + n1),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("single append");
+        let oracle = cpu_dequant(&one);
+
+        let mut two = QuantKTurbo3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], max_seq);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+            &dummy(n0),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+            &dummy(n1),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("append chunk 1");
+        let got = cpu_dequant(&two);
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo3_tests.rs
@@ -438,8 +438,8 @@ fn quant_k_turbo3_cpu_msl_parity() {
 /// invisible.
 #[test]
 fn quant_k_turbo3_two_block_decode_matches_one_block_at_b_gt_1() {
-    for b in [1_usize, 2] {
-        let (kv_h, head_dim) = (2_usize, 32_usize);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 32_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let max_seq = 512_i32;
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
@@ -483,7 +483,7 @@ fn quant_k_turbo3_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo4.rs
@@ -360,6 +360,24 @@ impl QuantKTurbo4 {
                 // `[B, S, kv_h, D]`, then reorder heads↔seq back to the logical
                 // `[B, kv_h, S, D]`. `contiguous` after the output transpose so
                 // raw byte-readers (SSD spill) see the permuted bytes.
+                // The flat GPU buffer is a run of `[B, S_chunk, kv_h, D]`
+                // chunks written at `prev_seq * words_per_step`, and
+                // `words_per_step` folds `b` in. Reading the prefix as one
+                // `[B, S_total, kv_h, D]` run therefore interleaves batch
+                // elements once `B > 1` and more than one sequence position
+                // landed (`S <= 1` is the same order either way, and an emptied
+                // store must still decode to nothing). Refuse
+                // rather than return a scrambled tensor — the CPU half of this
+                // reader handles every `B` via
+                // `seq_layout::transpose_chunked_seq_heads`, which is what the
+                // block list makes possible and this buffer does not.
+                if self.shape[0] != 1 && self.shape[2] > 1 {
+                    return Err(rmlx_core::error::Error::Quant(format!(
+                        "QuantKTurbo4::dequantize_choice: the flat GPU buffer is b == 1 only \
+                         (its per-step stride does not interleave batch), got shape {:?}",
+                        self.shape
+                    )));
+                }
                 let seq_major_shape = [self.shape[0], self.shape[2], self.shape[1], self.shape[3]];
                 let out =
                     turbo_dequantize_v4_gpu(&codes, &scales, &seq_major_shape, out_dtype, device)?;

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo4.rs
@@ -364,14 +364,19 @@ impl QuantKTurbo4 {
                 // chunks written at `prev_seq * words_per_step`, and
                 // `words_per_step` folds `b` in. Reading the prefix as one
                 // `[B, S_total, kv_h, D]` run therefore interleaves batch
-                // elements once `B > 1` and more than one sequence position
-                // landed (`S <= 1` is the same order either way, and an emptied
-                // store must still decode to nothing). Refuse
+                // elements once `B > 1`. Unlike the CPU half this arm has no
+                // payload-vs-shape coverage check — the slice is sized *from*
+                // `shape[2]` — so `S == 1` is not evidence that the prefix is a
+                // single `[B, 1, kv_h, D]` chunk: a mid-chunk truncate at
+                // `b > 1` lowers `shape[2]` without touching this buffer. Only
+                // the empty store is exempt, because `truncate_to(0)` (which
+                // `KvStorage::reset` routes through) must still decode to
+                // nothing. Refuse
                 // rather than return a scrambled tensor — the CPU half of this
                 // reader handles every `B` via
                 // `seq_layout::transpose_chunked_seq_heads`, which is what the
                 // block list makes possible and this buffer does not.
-                if self.shape[0] != 1 && self.shape[2] > 1 {
+                if self.shape[0] != 1 && self.shape[2] != 0 {
                     return Err(rmlx_core::error::Error::Quant(format!(
                         "QuantKTurbo4::dequantize_choice: the flat GPU buffer is b == 1 only \
                          (its per-step stride does not interleave batch), got shape {:?}",

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo4.rs
@@ -392,7 +392,18 @@ impl QuantKTurbo4 {
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
         let d = self.shape[3] as usize;
-        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, d);
+        // Blocks are sequence-major (see `append`), one per append; reorder each
+        // at its own sequence offset back to head-major `[B, kv_h, S, D]`.
+        // Reading the concatenation as a single run would interleave batch
+        // elements once `B > 1`.
+        let out = super::seq_layout::transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            d,
+            self.blocks.iter().map(super::BlockRows::rows),
+        )?;
         Ok((out, None))
     }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo4_tests.rs
@@ -143,3 +143,81 @@ fn gpu_two_append_multi_head_roundtrip() {
         "turbo4 GPU kv_h=2 two-append max abs error {m} — expected q4 noise, not head scramble"
     );
 }
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantKTurbo4::dequantize_choice` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_k_turbo4_two_block_decode_matches_one_block_at_b_gt_1() {
+    for b in [1_usize, 2] {
+        let (kv_h, head_dim) = (2_usize, 32_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let max_seq = 512_i32;
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+        let store = || QuantKTurbo4 {
+            blocks: Vec::new(),
+            gpu_codes_buf: None,
+            gpu_scales_buf: None,
+            gpu_words_per_step: 0,
+            gpu_scales_per_step: 0,
+            gpu_capacity: 0,
+            shape: vec![b as i32, kv_h as i32, 0, head_dim as i32],
+            bits: 4,
+            max_seq: 0,
+        };
+        let dummy =
+            |n: usize| rmlx_mlx::zeros(&shape(n), Dtype::F32, Device::Cpu).expect("dummy array");
+        let cpu_dequant = |st: &QuantKTurbo4| {
+            st.dequantize_choice(Device::Cpu, Dtype::F32)
+                .expect("cpu dequant")
+                .0
+        };
+
+        let mut one = store();
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+            &dummy(n0 + n1),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("single append");
+        let oracle = cpu_dequant(&one);
+
+        let mut two = store();
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+            &dummy(n0),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+            &dummy(n1),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("append chunk 1");
+        let got = cpu_dequant(&two);
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_k_turbo4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_k_turbo4_tests.rs
@@ -161,8 +161,8 @@ fn gpu_two_append_multi_head_roundtrip() {
 /// invisible.
 #[test]
 fn quant_k_turbo4_two_block_decode_matches_one_block_at_b_gt_1() {
-    for b in [1_usize, 2] {
-        let (kv_h, head_dim) = (2_usize, 32_usize);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 32_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let max_seq = 512_i32;
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
@@ -217,7 +217,7 @@ fn quant_k_turbo4_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_k.rs
@@ -412,6 +412,24 @@ impl QuantPlanarK {
                 // `[B, kv_h, S, D]` buffer, so force contiguity. This is the
                 // post-hydrate dequant path, off the steady-state decode hot
                 // path, so the copy is acceptable.
+                // The flat GPU buffer is a run of `[B, S_chunk, kv_h, D]`
+                // chunks written at `prev_seq * words_per_step`, and
+                // `words_per_step` folds `b` in. Reading the prefix as one
+                // `[B, S_total, kv_h, D]` run therefore interleaves batch
+                // elements once `B > 1` and more than one sequence position
+                // landed (`S <= 1` is the same order either way, and an emptied
+                // store must still decode to nothing). Refuse
+                // rather than return a scrambled tensor — the CPU half of this
+                // reader handles every `B` via
+                // `seq_layout::transpose_chunked_seq_heads`, which is what the
+                // block list makes possible and this buffer does not.
+                if self.shape[0] != 1 && self.shape[2] > 1 {
+                    return Err(rmlx_core::error::Error::Quant(format!(
+                        "QuantPlanarK::dequantize_choice: the flat GPU buffer is b == 1 only \
+                         (its per-step stride does not interleave batch), got shape {:?}",
+                        self.shape
+                    )));
+                }
                 let seq_major_shape = [self.shape[0], s, self.shape[1], self.shape[3]];
                 let out = planar_dequantize_v4_gpu(
                     &codes,
@@ -439,11 +457,14 @@ impl QuantPlanarK {
             let slice = planar_dequantize(block)?;
             out.extend_from_slice(&slice);
         }
-        // Blocks must cover `shape[2]` exactly. `transpose_seq_heads` reads only
-        // the first `b * s * kv_h * d` elements, so an over-run used to be
-        // silently cut back — after a mid-block truncate that kept the
-        // *rejected* speculative prefix and dropped the appended correction,
-        // with no error anywhere. A shortfall panicked on an out-of-range index.
+        // Blocks must cover `shape[2]` exactly. `transpose_chunked_seq_heads`
+        // rejects a buffer whose length disagrees with the declared shape in
+        // either direction, but the check is kept here so the error names this
+        // store and its block list rather than the reorder helper. Before both,
+        // an over-run was silently cut back — after a mid-block truncate that
+        // kept the *rejected* speculative prefix and dropped the appended
+        // correction, with no error anywhere — and a shortfall panicked out of
+        // range.
         // `truncate_to` now cuts the blocks; when it cannot (see
         // `super::truncate_plan`) it drops the trailing block whole and leaves
         // the store short on purpose, and that must abort the request here.

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_k.rs
@@ -416,14 +416,19 @@ impl QuantPlanarK {
                 // chunks written at `prev_seq * words_per_step`, and
                 // `words_per_step` folds `b` in. Reading the prefix as one
                 // `[B, S_total, kv_h, D]` run therefore interleaves batch
-                // elements once `B > 1` and more than one sequence position
-                // landed (`S <= 1` is the same order either way, and an emptied
-                // store must still decode to nothing). Refuse
+                // elements once `B > 1`. Unlike the CPU half this arm has no
+                // payload-vs-shape coverage check — the slice is sized *from*
+                // `shape[2]` — so `S == 1` is not evidence that the prefix is a
+                // single `[B, 1, kv_h, D]` chunk: a mid-chunk truncate at
+                // `b > 1` lowers `shape[2]` without touching this buffer. Only
+                // the empty store is exempt, because `truncate_to(0)` (which
+                // `KvStorage::reset` routes through) must still decode to
+                // nothing. Refuse
                 // rather than return a scrambled tensor — the CPU half of this
                 // reader handles every `B` via
                 // `seq_layout::transpose_chunked_seq_heads`, which is what the
                 // block list makes possible and this buffer does not.
-                if self.shape[0] != 1 && self.shape[2] > 1 {
+                if self.shape[0] != 1 && self.shape[2] != 0 {
                     return Err(rmlx_core::error::Error::Quant(format!(
                         "QuantPlanarK::dequantize_choice: the flat GPU buffer is b == 1 only \
                          (its per-step stride does not interleave batch), got shape {:?}",

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_k.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_k.rs
@@ -24,7 +24,7 @@ use crate::planarquant_msl::{planar_dequantize_v4_gpu, planar_quantize_v4_gpu};
 use crate::planarquant::{planar_dequantize, planar_quantize, PlanarBlocks};
 use crate::turboquant::GROUP_SIZE;
 
-use super::seq_layout::{transpose_heads_seq, transpose_seq_heads};
+use super::seq_layout::{transpose_chunked_seq_heads, transpose_heads_seq};
 use super::KV_PAGE_SIZE;
 
 // ── PlanarQuant K storage ─────────────────────────────────────────────────────
@@ -459,7 +459,19 @@ impl QuantPlanarK {
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
         let d = self.shape[3] as usize;
-        Ok((transpose_seq_heads(&out, b, s, kv_h, d), None))
+        // Blocks are sequence-major (see `append`), one per append; reorder each
+        // at its own sequence offset back to head-major `[B, kv_h, S, D]`.
+        // Reading the concatenation as a single run would interleave batch
+        // elements once `B > 1`.
+        let out = transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            d,
+            self.blocks.iter().map(super::BlockRows::rows),
+        )?;
+        Ok((out, None))
     }
 
     /// Return the GPU-resident packed K buffers sliced to the accumulated

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_k_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_k_tests.rs
@@ -444,3 +444,70 @@ fn planar_v4_cpu_roundtrip_8k_bonsai_shape() {
         stats.mean,
     );
 }
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantPlanarK::dequantize_choice` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_planar_k_two_block_decode_matches_one_block_at_b_gt_1() {
+    for b in [1_usize, 2] {
+        let (kv_h, head_dim) = (2_usize, 32_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let max_seq = 512_i32;
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+        let dummy =
+            |n: usize| rmlx_mlx::zeros(&shape(n), Dtype::F32, Device::Cpu).expect("dummy array");
+        let cpu_dequant = |st: &QuantPlanarK| {
+            st.dequantize_choice(Device::Cpu, Dtype::F32)
+                .expect("cpu dequant")
+                .0
+        };
+
+        let mut one = QuantPlanarK::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], max_seq);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+            &dummy(n0 + n1),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("single append");
+        let oracle = cpu_dequant(&one);
+
+        let mut two = QuantPlanarK::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], max_seq);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+            &dummy(n0),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+            &dummy(n1),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("append chunk 1");
+        let got = cpu_dequant(&two);
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_k_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_k_tests.rs
@@ -462,8 +462,8 @@ fn planar_v4_cpu_roundtrip_8k_bonsai_shape() {
 /// invisible.
 #[test]
 fn quant_planar_k_two_block_decode_matches_one_block_at_b_gt_1() {
-    for b in [1_usize, 2] {
-        let (kv_h, head_dim) = (2_usize, 32_usize);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 32_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let max_seq = 512_i32;
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
@@ -507,7 +507,7 @@ fn quant_planar_k_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_v.rs
@@ -422,14 +422,19 @@ impl QuantPlanarV {
                 // chunks written at `prev_seq * words_per_step`, and
                 // `words_per_step` folds `b` in. Reading the prefix as one
                 // `[B, S_total, kv_h, D]` run therefore interleaves batch
-                // elements once `B > 1` and more than one sequence position
-                // landed (`S <= 1` is the same order either way, and an emptied
-                // store must still decode to nothing). Refuse
+                // elements once `B > 1`. Unlike the CPU half this arm has no
+                // payload-vs-shape coverage check — the slice is sized *from*
+                // `shape[2]` — so `S == 1` is not evidence that the prefix is a
+                // single `[B, 1, kv_h, D]` chunk: a mid-chunk truncate at
+                // `b > 1` lowers `shape[2]` without touching this buffer. Only
+                // the empty store is exempt, because `truncate_to(0)` (which
+                // `KvStorage::reset` routes through) must still decode to
+                // nothing. Refuse
                 // rather than return a scrambled tensor — the CPU half of this
                 // reader handles every `B` via
                 // `seq_layout::transpose_chunked_seq_heads`, which is what the
                 // block list makes possible and this buffer does not.
-                if self.shape[0] != 1 && self.shape[2] > 1 {
+                if self.shape[0] != 1 && self.shape[2] != 0 {
                     return Err(rmlx_core::error::Error::Quant(format!(
                         "QuantPlanarV::dequantize_choice: the flat GPU buffer is b == 1 only \
                          (its per-step stride does not interleave batch), got shape {:?}",

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_v.rs
@@ -418,6 +418,24 @@ impl QuantPlanarV {
                 // for raw byte-readers (SSD spill / hydrate); this is the
                 // post-hydrate / chunked-prefill dequant path, off the decode hot
                 // path, so the copy is acceptable.
+                // The flat GPU buffer is a run of `[B, S_chunk, kv_h, D]`
+                // chunks written at `prev_seq * words_per_step`, and
+                // `words_per_step` folds `b` in. Reading the prefix as one
+                // `[B, S_total, kv_h, D]` run therefore interleaves batch
+                // elements once `B > 1` and more than one sequence position
+                // landed (`S <= 1` is the same order either way, and an emptied
+                // store must still decode to nothing). Refuse
+                // rather than return a scrambled tensor — the CPU half of this
+                // reader handles every `B` via
+                // `seq_layout::transpose_chunked_seq_heads`, which is what the
+                // block list makes possible and this buffer does not.
+                if self.shape[0] != 1 && self.shape[2] > 1 {
+                    return Err(rmlx_core::error::Error::Quant(format!(
+                        "QuantPlanarV::dequantize_choice: the flat GPU buffer is b == 1 only \
+                         (its per-step stride does not interleave batch), got shape {:?}",
+                        self.shape
+                    )));
+                }
                 let seq_major_shape = [self.shape[0], s, self.shape[1], self.shape[3]];
                 let out = if self.bits == 3 {
                     planar_dequantize_v3_gpu(&codes, &scales, &rotations, &seq_major_shape, device)?
@@ -527,3 +545,7 @@ impl QuantPlanarV {
         })
     }
 }
+
+#[cfg(test)]
+#[path = "quant_planar_v_tests.rs"]
+mod quant_planar_v_tests;

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_v.rs
@@ -24,7 +24,7 @@ use crate::planarquant_msl::{
 use crate::planarquant::{planar_dequantize, planar_quantize, PlanarBlocks};
 use crate::turboquant::GROUP_SIZE;
 
-use super::seq_layout::{transpose_heads_seq, transpose_seq_heads};
+use super::seq_layout::{transpose_chunked_seq_heads, transpose_heads_seq};
 use super::KV_PAGE_SIZE;
 
 // ── PlanarQuant V storage ─────────────────────────────────────────────────────
@@ -458,7 +458,19 @@ impl QuantPlanarV {
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
         let d = self.shape[3] as usize;
-        Ok((transpose_seq_heads(&out, b, s, kv_h, d), None))
+        // Blocks are sequence-major (see `append`), one per append; reorder each
+        // at its own sequence offset back to head-major `[B, kv_h, S, D]`.
+        // Reading the concatenation as a single run would interleave batch
+        // elements once `B > 1`.
+        let out = transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            d,
+            self.blocks.iter().map(super::BlockRows::rows),
+        )?;
+        Ok((out, None))
     }
 
     /// Truncate the store to `n` sequence positions.

--- a/crates/rmlx-kv-quant/src/storage/quant_planar_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_planar_v_tests.rs
@@ -1,0 +1,97 @@
+//! Tests for [`QuantPlanarV`].
+//!
+//! `QuantPlanarV` accumulates one `PlanarBlocks` per `append` and reorders them
+//! back to head-major on `dequantize_choice`, the same shape as every other
+//! block-list store. It was the one converted store with no sibling test file,
+//! so its call into `seq_layout::transpose_chunked_seq_heads` had no direct
+//! coverage at all — including the `B == 1` equivalence half, where an argument
+//! transposed at the call site (`kv_h` / `d` swapped, or a truncated block list)
+//! would ship green.
+
+use super::QuantPlanarV;
+use rmlx_mlx::{zeros, Device, Dtype};
+
+fn new_planar_v(b: usize, kv_h: usize, d: usize, bits: u8, max_seq: i32) -> QuantPlanarV {
+    QuantPlanarV {
+        blocks: Vec::new(),
+        gpu_codes_buf: None,
+        gpu_scales_buf: None,
+        gpu_rotations_buf: None,
+        gpu_codes_words_per_step: 0,
+        gpu_scales_per_step: 0,
+        gpu_rotations_words_per_step: 0,
+        gpu_capacity: 0,
+        shape: vec![b as i32, kv_h as i32, 0, d as i32],
+        max_seq,
+        bits,
+    }
+}
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two blocks
+/// is not one `[B, S_total, kv_h, D]` run — reading it as one maps the second
+/// block's batch-0 rows onto batch-1 sequence slots. The single-append store
+/// holds exactly one block and therefore concatenates nothing, which is what
+/// makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantPlanarV::dequantize_choice` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_planar_v_two_block_decode_matches_one_block_at_b_gt_1() {
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 32_usize;
+        let (n0, n1) = (2_usize, 3_usize);
+        let max_seq = 512_i32;
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+        let dummy = |n: usize| zeros(&shape(n), Dtype::F32, Device::Cpu).expect("dummy array");
+        let cpu_dequant = |st: &QuantPlanarV| {
+            st.dequantize_choice(Device::Cpu, Dtype::F32)
+                .expect("cpu dequant")
+                .0
+        };
+
+        let mut one = new_planar_v(b, kv_h, head_dim, 4, max_seq);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+            &dummy(n0 + n1),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("single append");
+        let oracle = cpu_dequant(&one);
+
+        let mut two = new_planar_v(b, kv_h, head_dim, 4, max_seq);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+            &dummy(n0),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+            &dummy(n1),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("append chunk 1");
+        assert_eq!(
+            two.blocks.len(),
+            2,
+            "the two-append store really holds 2 blocks"
+        );
+        let got = cpu_dequant(&two);
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
@@ -629,7 +629,7 @@ pub(crate) fn synced_rotor_k_blocks<'a>(
     let full_seq = shape.get(2).copied().unwrap_or(0).max(0) as usize;
     let head_dim = shape.get(3).copied().unwrap_or(0).max(0) as usize;
     let full_tokens = b * kv_h * full_seq;
-    let blocks_tokens: usize = blocks.iter().map(|blk| blk.n_tokens).sum();
+    let blocks_tokens: usize = blocks.iter().map(super::BlockRows::rows).sum();
 
     if blocks_tokens == full_tokens {
         return Ok(Cow::Borrowed(blocks));

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3.rs
@@ -570,12 +570,21 @@ impl QuantRotorK3 {
                 self.shape
             )));
         }
-        // Blocks are sequence-major (see `append`); reorder back to head-major
-        // `[B, kv_h, S, D]`.
+        // Blocks are sequence-major (see `append`), one per append; reorder each
+        // at its own sequence offset back to head-major `[B, kv_h, S, D]`.
+        // Reading the concatenation as a single run would interleave batch
+        // elements once `B > 1`.
         let b = self.shape[0] as usize;
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
-        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
+        let out = super::seq_layout::transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            head_dim,
+            blocks.iter().map(super::BlockRows::rows),
+        )?;
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
@@ -637,3 +637,60 @@ fn quant_rotor_k3_truncate_mid_block_splits_at_this_shape() {
         "the split block must reconstruct the retained token exactly"
     );
 }
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantRotorK3::dequant` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_rotor_k3_two_block_decode_matches_one_block_at_b_gt_1() {
+    // The QJL sideband is read from the process env at each `append`, so a
+    // concurrent env-mutating test could otherwise encode the two stores under
+    // different settings. Hold the lock and pin both settings explicitly — the
+    // per-token sideband has to reorder with its token rows either way.
+    let _guard = crate::test_utils::env_lock();
+    for (b, qjl) in [(1_usize, "0"), (2, "0"), (1, "1"), (2, "1")] {
+        // SAFETY: env lock held — no concurrent env reader/writer in this binary.
+        unsafe { std::env::set_var("RMLX_ROTOR_QJL", qjl) };
+        let (kv_h, head_dim) = (2_usize, 128_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+
+        let mut one = QuantRotorK3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 5);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+        )
+        .expect("single append");
+        let oracle = one.dequant().expect("one-block dequant");
+
+        let mut two = QuantRotorK3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 5);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+        )
+        .expect("append chunk 1");
+        let got = two.dequant().expect("two-block dequant");
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}, qjl={qjl}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k3_tests.rs
@@ -660,10 +660,17 @@ fn quant_rotor_k3_two_block_decode_matches_one_block_at_b_gt_1() {
     // different settings. Hold the lock and pin both settings explicitly — the
     // per-token sideband has to reorder with its token rows either way.
     let _guard = crate::test_utils::env_lock();
-    for (b, qjl) in [(1_usize, "0"), (2, "0"), (1, "1"), (2, "1")] {
+    for (b, kv_h, qjl) in [
+        (1_usize, 1_usize, "0"),
+        (1, 2, "0"),
+        (2, 1, "0"),
+        (2, 2, "0"),
+        (1, 2, "1"),
+        (2, 2, "1"),
+    ] {
         // SAFETY: env lock held — no concurrent env reader/writer in this binary.
         unsafe { std::env::set_var("RMLX_ROTOR_QJL", qjl) };
-        let (kv_h, head_dim) = (2_usize, 128_usize);
+        let head_dim = 128_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
 
@@ -690,7 +697,7 @@ fn quant_rotor_k3_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}, qjl={qjl}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}, qjl={qjl}"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4.rs
@@ -408,12 +408,21 @@ impl QuantRotorK4 {
                 self.shape
             )));
         }
-        // Blocks are sequence-major (see `append`); reorder back to head-major
-        // `[B, kv_h, S, D]`.
+        // Blocks are sequence-major (see `append`), one per append; reorder each
+        // at its own sequence offset back to head-major `[B, kv_h, S, D]`.
+        // Reading the concatenation as a single run would interleave batch
+        // elements once `B > 1`.
         let b = self.shape[0] as usize;
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
-        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
+        let out = super::seq_layout::transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            head_dim,
+            blocks.iter().map(super::BlockRows::rows),
+        )?;
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
@@ -255,10 +255,17 @@ fn quant_rotor_k4_two_block_decode_matches_one_block_at_b_gt_1() {
     // different settings. Hold the lock and pin both settings explicitly — the
     // per-token sideband has to reorder with its token rows either way.
     let _guard = crate::test_utils::env_lock();
-    for (b, qjl) in [(1_usize, "0"), (2, "0"), (1, "1"), (2, "1")] {
+    for (b, kv_h, qjl) in [
+        (1_usize, 1_usize, "0"),
+        (1, 2, "0"),
+        (2, 1, "0"),
+        (2, 2, "0"),
+        (1, 2, "1"),
+        (2, 2, "1"),
+    ] {
         // SAFETY: env lock held — no concurrent env reader/writer in this binary.
         unsafe { std::env::set_var("RMLX_ROTOR_QJL", qjl) };
-        let (kv_h, head_dim) = (2_usize, 128_usize);
+        let head_dim = 128_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
 
@@ -285,7 +292,7 @@ fn quant_rotor_k4_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}, qjl={qjl}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}, qjl={qjl}"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_k4_tests.rs
@@ -232,3 +232,60 @@ fn quant_rotor_k4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
     // SAFETY: env lock still held.
     unsafe { std::env::remove_var("RMLX_ROTOR_QJL") };
 }
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantRotorK4::dequant` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_rotor_k4_two_block_decode_matches_one_block_at_b_gt_1() {
+    // The QJL sideband is read from the process env at each `append`, so a
+    // concurrent env-mutating test could otherwise encode the two stores under
+    // different settings. Hold the lock and pin both settings explicitly — the
+    // per-token sideband has to reorder with its token rows either way.
+    let _guard = crate::test_utils::env_lock();
+    for (b, qjl) in [(1_usize, "0"), (2, "0"), (1, "1"), (2, "1")] {
+        // SAFETY: env lock held — no concurrent env reader/writer in this binary.
+        unsafe { std::env::set_var("RMLX_ROTOR_QJL", qjl) };
+        let (kv_h, head_dim) = (2_usize, 128_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+
+        let mut one = QuantRotorK4::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 5);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+        )
+        .expect("single append");
+        let oracle = one.dequant().expect("one-block dequant");
+
+        let mut two = QuantRotorK4::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 5);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+        )
+        .expect("append chunk 1");
+        let got = two.dequant().expect("two-block dequant");
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}, qjl={qjl}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
@@ -581,7 +581,7 @@ pub(crate) fn synced_rotor_v_blocks<'a>(
     let full_seq = shape.get(2).copied().unwrap_or(0).max(0) as usize;
     let head_dim = shape.get(3).copied().unwrap_or(0).max(0) as usize;
     let full_tokens = b * kv_h * full_seq;
-    let blocks_tokens: usize = blocks.iter().map(|blk| blk.n_tokens).sum();
+    let blocks_tokens: usize = blocks.iter().map(super::BlockRows::rows).sum();
 
     if blocks_tokens == full_tokens {
         return Ok(std::borrow::Cow::Borrowed(blocks));

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3.rs
@@ -520,12 +520,21 @@ impl QuantRotorV3 {
                 self.shape
             )));
         }
-        // Blocks are sequence-major (see `append`); reorder back to head-major
-        // `[B, kv_h, S, D]`.
+        // Blocks are sequence-major (see `append`), one per append; reorder each
+        // at its own sequence offset back to head-major `[B, kv_h, S, D]`.
+        // Reading the concatenation as a single run would interleave batch
+        // elements once `B > 1`.
         let b = self.shape[0] as usize;
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
-        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
+        let out = super::seq_layout::transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            head_dim,
+            blocks.iter().map(super::BlockRows::rows),
+        )?;
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3_tests.rs
@@ -449,8 +449,8 @@ fn quant_rotor_v3_truncate_at_b_gt_1_stays_loud() {
 /// invisible.
 #[test]
 fn quant_rotor_v3_two_block_decode_matches_one_block_at_b_gt_1() {
-    for b in [1_usize, 2] {
-        let (kv_h, head_dim) = (2_usize, 96_usize);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 96_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
 
@@ -477,7 +477,7 @@ fn quant_rotor_v3_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v3_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v3_tests.rs
@@ -343,24 +343,28 @@ fn quant_rotor_v3_truncate_mid_block_splits_instead_of_dropping() {
 
 /// At `b > 1` a mid-block cut must stay **loud**, not become silently wrong.
 ///
-/// The decode path is the constraint. Every rotor/iso store ends `dequant` with
-/// `transpose_seq_heads` over the *concatenation* of its blocks, reading it as
-/// one `[B, S_total, kv_h, D]` run — but each block is only
-/// `[B, S_block, kv_h, D]`, so at `b > 1` the concatenation interleaves batch
-/// elements and any store holding more than one block decodes scrambled. The
-/// first assertion below measures that: a two-block `b = 2` store already
-/// disagrees with a one-block store over the same tokens, on every element
-/// belonging to batch 1.
+/// The constraint is *inside* one block. A block's rows run
+/// `[B, S_block, kv_h, D]`, so batch element 1's rows all sit after batch
+/// element 0's, and `BlockRows::retain_rows` keeps a **row prefix**. At `b > 1`
+/// a row prefix is not a sequence prefix: cutting to `keep_seq` positions would
+/// keep every one of batch 0's rows and none of batch 1's, silently dropping one
+/// batch element's tail instead of cutting both at the same position. The
+/// planner refuses, drops the block whole, and this test pins the resulting
+/// contract: `dequant()` returns `Err`.
 ///
-/// So splitting the trailing block at `b > 1` would produce exactly that
-/// two-block state, converting a `blocks`-short-of-`shape[2]` **error** into
-/// scrambled output with no error at all. The planner refuses, and this test
-/// pins the resulting contract: `dequant()` returns `Err`.
+/// The block *concatenation* used to be a second, independent bound — the
+/// decode read it as one `[B, S_total, kv_h, D]` run, which scrambles at
+/// `b > 1`. That is fixed (`seq_layout::transpose_chunked_seq_heads` reorders
+/// each block at its own sequence offset), and the first assertion below now
+/// pins the *new* premise: a two-block `b = 2` store decodes identically to a
+/// one-block store over the same tokens. Lifting the split refusal therefore
+/// needs a batch-aware `retain_rows`, not a decode change.
 ///
 /// Mutation check: drop the `b != 1` arm in `truncate_plan` and the store splits,
 /// `blocks_tokens == full_tokens`, `synced_rotor_v_blocks` takes its
-/// `Cow::Borrowed` fast return, and `dequant()` returns `Ok` with scrambled
-/// values — the `expect_err` goes RED.
+/// `Cow::Borrowed` fast return, and `dequant()` returns `Ok` — the `expect_err`
+/// goes RED. Re-point `transpose_chunked_seq_heads` in `QuantRotorV3::dequant`
+/// back to `transpose_seq_heads` and the premise assertion goes RED.
 #[test]
 fn quant_rotor_v3_truncate_at_b_gt_1_stays_loud() {
     let (b, kv_h, head_dim) = (2_usize, 2_usize, 96_usize);
@@ -383,8 +387,8 @@ fn quant_rotor_v3_truncate_at_b_gt_1_stays_loud() {
     };
     let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
 
-    // First: establish that multi-block `b > 1` decode really is unreadable, so
-    // the refusal below is a bound and not superstition.
+    // First: establish that multi-block `b > 1` decode is readable, so the
+    // refusal below is pinned to the intra-block row layout and nothing else.
     let mut one_block = QuantRotorV3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 64, 5);
     one_block.append(&chunk(0, 5), &shape(5)).unwrap();
     let dq_one = one_block.dequant().unwrap();
@@ -399,12 +403,11 @@ fn quant_rotor_v3_truncate_at_b_gt_1_stays_loud() {
         .zip(dq_two.iter())
         .filter(|(a, c)| (*a - *c).abs() > 1e-3)
         .count();
-    assert!(
-        scrambled > 0,
-        "premise: a two-block b > 1 store is supposed to decode differently from a \
-         one-block store over the same tokens. If this is now 0 the concatenation \
-         reading was fixed and the b > 1 split may be re-enabled — re-point this test \
-         rather than deleting it"
+    assert_eq!(
+        scrambled, 0,
+        "premise: a two-block b > 1 store decodes identically to a one-block store over \
+         the same tokens. A non-zero count means the per-block reorder regressed — fix \
+         `dequant`, do not weaken this assertion"
     );
 
     // Now the contract: a mid-block cut drops the block and stays loud.
@@ -427,4 +430,54 @@ fn quant_rotor_v3_truncate_at_b_gt_1_stays_loud() {
         msg.contains("CPU blocks cover"),
         "the abort must be the blocks-vs-shape reconciliation error, got: {msg}"
     );
+}
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantRotorV3::dequant` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_rotor_v3_two_block_decode_matches_one_block_at_b_gt_1() {
+    for b in [1_usize, 2] {
+        let (kv_h, head_dim) = (2_usize, 96_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+
+        let mut one = QuantRotorV3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 512, 5);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+        )
+        .expect("single append");
+        let oracle = one.dequant().expect("one-block dequant");
+
+        let mut two = QuantRotorV3::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 512, 5);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+        )
+        .expect("append chunk 1");
+        let got = two.dequant().expect("two-block dequant");
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}"
+        );
+    }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v4.rs
@@ -412,12 +412,21 @@ impl QuantRotorV4 {
                 self.shape
             )));
         }
-        // Blocks are sequence-major (see `append`); reorder back to head-major
-        // `[B, kv_h, S, D]`.
+        // Blocks are sequence-major (see `append`), one per append; reorder each
+        // at its own sequence offset back to head-major `[B, kv_h, S, D]`.
+        // Reading the concatenation as a single run would interleave batch
+        // elements once `B > 1`.
         let b = self.shape[0] as usize;
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
-        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, head_dim);
+        let out = super::seq_layout::transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            head_dim,
+            blocks.iter().map(super::BlockRows::rows),
+        )?;
         Ok(out)
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v4_tests.rs
@@ -264,8 +264,8 @@ fn quant_rotor_v4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
 /// invisible.
 #[test]
 fn quant_rotor_v4_two_block_decode_matches_one_block_at_b_gt_1() {
-    for b in [1_usize, 2] {
-        let (kv_h, head_dim) = (2_usize, 96_usize);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 96_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
 
@@ -292,7 +292,7 @@ fn quant_rotor_v4_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/quant_rotor_v4_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_rotor_v4_tests.rs
@@ -246,3 +246,53 @@ fn quant_rotor_v4_truncate_to_kv_h_gt_1_keeps_exact_prefix() {
         );
     }
 }
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantRotorV4::dequant` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_rotor_v4_two_block_decode_matches_one_block_at_b_gt_1() {
+    for b in [1_usize, 2] {
+        let (kv_h, head_dim) = (2_usize, 96_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+
+        let mut one = QuantRotorV4::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 512, 5);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+        )
+        .expect("single append");
+        let oracle = one.dequant().expect("one-block dequant");
+
+        let mut two = QuantRotorV4::new(vec![b as i32, kv_h as i32, 0, head_dim as i32], 512, 5);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+        )
+        .expect("append chunk 1");
+        let got = two.dequant().expect("two-block dequant");
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_v.rs
@@ -759,7 +759,18 @@ impl QuantV {
         let kv_h = self.shape[1] as usize;
         let s = self.shape[2] as usize;
         let d = self.shape[3] as usize;
-        let out = super::seq_layout::transpose_seq_heads(&out, b, s, kv_h, d);
+        // Blocks are sequence-major (see `append`), one per append; reorder each
+        // at its own sequence offset back to head-major `[B, kv_h, S, D]`.
+        // Reading the concatenation as a single run would interleave batch
+        // elements once `B > 1`.
+        let out = super::seq_layout::transpose_chunked_seq_heads(
+            &out,
+            b,
+            s,
+            kv_h,
+            d,
+            self.blocks.iter().map(super::BlockRows::rows),
+        )?;
         Ok((out, None))
     }
 

--- a/crates/rmlx-kv-quant/src/storage/quant_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_v.rs
@@ -688,14 +688,19 @@ impl QuantV {
                 // chunks written at `prev_seq * words_per_step`, and
                 // `words_per_step` folds `b` in. Reading the prefix as one
                 // `[B, S_total, kv_h, D]` run therefore interleaves batch
-                // elements once `B > 1` and more than one sequence position
-                // landed (`S <= 1` is the same order either way, and an emptied
-                // store must still decode to nothing). Refuse
+                // elements once `B > 1`. Unlike the CPU half this arm has no
+                // payload-vs-shape coverage check — the slice is sized *from*
+                // `shape[2]` — so `S == 1` is not evidence that the prefix is a
+                // single `[B, 1, kv_h, D]` chunk: a mid-chunk truncate at
+                // `b > 1` lowers `shape[2]` without touching this buffer. Only
+                // the empty store is exempt, because `truncate_to(0)` (which
+                // `KvStorage::reset` routes through) must still decode to
+                // nothing. Refuse
                 // rather than return a scrambled tensor — the CPU half of this
                 // reader handles every `B` via
                 // `seq_layout::transpose_chunked_seq_heads`, which is what the
                 // block list makes possible and this buffer does not.
-                if self.shape[0] != 1 && self.shape[2] > 1 {
+                if self.shape[0] != 1 && self.shape[2] != 0 {
                     return Err(rmlx_core::error::Error::Quant(format!(
                         "QuantV::dequantize_choice: the flat GPU buffer is b == 1 only \
                          (its per-step stride does not interleave batch), got shape {:?}",

--- a/crates/rmlx-kv-quant/src/storage/quant_v.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_v.rs
@@ -684,6 +684,24 @@ impl QuantV {
                 // offset; the seq-major reshape on the OUTPUT then needs a final
                 // `contiguous` because raw byte-readers (SSD spill / hydrate)
                 // would otherwise see the un-permuted sequence-major bytes.
+                // The flat GPU buffer is a run of `[B, S_chunk, kv_h, D]`
+                // chunks written at `prev_seq * words_per_step`, and
+                // `words_per_step` folds `b` in. Reading the prefix as one
+                // `[B, S_total, kv_h, D]` run therefore interleaves batch
+                // elements once `B > 1` and more than one sequence position
+                // landed (`S <= 1` is the same order either way, and an emptied
+                // store must still decode to nothing). Refuse
+                // rather than return a scrambled tensor — the CPU half of this
+                // reader handles every `B` via
+                // `seq_layout::transpose_chunked_seq_heads`, which is what the
+                // block list makes possible and this buffer does not.
+                if self.shape[0] != 1 && self.shape[2] > 1 {
+                    return Err(rmlx_core::error::Error::Quant(format!(
+                        "QuantV::dequantize_choice: the flat GPU buffer is b == 1 only \
+                         (its per-step stride does not interleave batch), got shape {:?}",
+                        self.shape
+                    )));
+                }
                 let seq_major_shape = [self.shape[0], self.shape[2], self.shape[1], self.shape[3]];
                 let out = match (
                     self.value_codebook.is_some(),

--- a/crates/rmlx-kv-quant/src/storage/quant_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_v_tests.rs
@@ -281,3 +281,71 @@ fn gpu_single_shot_cold_prefill() {
     let m = check_roundtrip(&out, kv_h, 8, d);
     assert!(m < 0.05, "single-shot cold prefill max abs error {m}");
 }
+
+// ── Batch-axis block-boundary parity ──────────────────────────────────
+
+/// Two appends must decode exactly like one append of the same tokens, at
+/// `B > 1` as well as `B == 1`.
+///
+/// Each block covers `[B, S_block, kv_h, D]`, so the concatenation of two
+/// blocks is not one `[B, S_total, kv_h, D]` run — reading it as one maps the
+/// second block's batch-0 rows onto batch-1 sequence slots. The single-append
+/// store holds exactly one block and therefore concatenates nothing, which is
+/// what makes it the oracle here.
+///
+/// Mutation check: put `seq_layout::transpose_seq_heads` over the whole
+/// concatenation back in `QuantV::dequantize_choice` and this goes red at
+/// `b = 2` while staying green at `b = 1` — which is how the defect stayed
+/// invisible.
+#[test]
+fn quant_v_two_block_decode_matches_one_block_at_b_gt_1() {
+    for b in [1_usize, 2] {
+        let (kv_h, head_dim) = (2_usize, 32_usize);
+        let (n0, n1) = (2_usize, 3_usize);
+        let max_seq = 512_i32;
+        let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
+        let dummy = |n: usize| zeros(&shape(n), Dtype::F32, Device::Cpu).expect("dummy array");
+        let cpu_dequant = |st: &QuantV| {
+            st.dequantize_choice(Device::Cpu, Dtype::F32)
+                .expect("cpu dequant")
+                .0
+        };
+
+        let mut one =
+            QuantV::new_affine_decode(vec![b as i32, kv_h as i32, 0, head_dim as i32], 4, max_seq);
+        one.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0 + n1, head_dim),
+            &shape(n0 + n1),
+            &dummy(n0 + n1),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("single append");
+        let oracle = cpu_dequant(&one);
+
+        let mut two =
+            QuantV::new_affine_decode(vec![b as i32, kv_h as i32, 0, head_dim as i32], 4, max_seq);
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, 0, n0, head_dim),
+            &shape(n0),
+            &dummy(n0),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("append chunk 0");
+        two.append(
+            &crate::test_utils::batch_head_chunk(b, kv_h, n0, n1, head_dim),
+            &shape(n1),
+            &dummy(n1),
+            Device::Cpu,
+            max_seq,
+        )
+        .expect("append chunk 1");
+        let got = cpu_dequant(&two);
+
+        assert_eq!(
+            got, oracle,
+            "two-block decode must equal the one-block oracle at b={b}"
+        );
+    }
+}

--- a/crates/rmlx-kv-quant/src/storage/quant_v_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/quant_v_tests.rs
@@ -299,8 +299,8 @@ fn gpu_single_shot_cold_prefill() {
 /// invisible.
 #[test]
 fn quant_v_two_block_decode_matches_one_block_at_b_gt_1() {
-    for b in [1_usize, 2] {
-        let (kv_h, head_dim) = (2_usize, 32_usize);
+    for (b, kv_h) in [(1_usize, 1_usize), (1, 2), (2, 1), (2, 2)] {
+        let head_dim = 32_usize;
         let (n0, n1) = (2_usize, 3_usize);
         let max_seq = 512_i32;
         let shape = |n: usize| [b as i32, kv_h as i32, n as i32, head_dim as i32];
@@ -345,7 +345,7 @@ fn quant_v_two_block_decode_matches_one_block_at_b_gt_1() {
 
         assert_eq!(
             got, oracle,
-            "two-block decode must equal the one-block oracle at b={b}"
+            "two-block decode must equal the one-block oracle at b={b} kv_h={kv_h}"
         );
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/seq_layout.rs
+++ b/crates/rmlx-kv-quant/src/storage/seq_layout.rs
@@ -32,8 +32,12 @@
 //! onto batch-1 sequence slots — head/batch-scrambled K/V, with no error.
 //! [`transpose_chunked_seq_heads`] is the reorder that knows where the chunks
 //! end; [`transpose_seq_heads`] stays correct only for a buffer that really is
-//! one `[B, S_total, kv_h, D]` run (a single chunk, or a flat store written at
-//! sequence offsets).
+//! one `[B, S_total, kv_h, D]` run — a single chunk at any `B`, or any number of
+//! chunks at `B == 1`. A **flat** store written at sequence offsets is not one
+//! run at `B > 1`: its per-step stride folds `b` in, so the prefix is a run of
+//! `[B, S_chunk, kv_h, D]` chunks with no recorded boundary to partition on.
+//! Those readers refuse `b != 1` rather than reorder — see the
+//! `dequantize_choice` GPU arms and `QuantK`'s CPU arm.
 
 use rmlx_core::error::{Error, Result};
 

--- a/crates/rmlx-kv-quant/src/storage/seq_layout.rs
+++ b/crates/rmlx-kv-quant/src/storage/seq_layout.rs
@@ -21,6 +21,21 @@
 //! the GPU side additionally materializes the transposed view with
 //! `Array::contiguous` before any custom MSL kernel, because such kernels read
 //! their input by raw linear index and ignore MLX lazy-transpose strides.
+//!
+//! # Chunk boundaries matter once `B > 1`
+//!
+//! A store that accumulates one buffer per `append` decodes by concatenating
+//! them. That concatenation is a single `[B, S_total, kv_h, D]` run **only when
+//! `B == 1`**: every chunk is itself `[B, S_chunk, kv_h, D]`, so with more than
+//! one batch element each chunk restarts at batch 0 and the chunks interleave.
+//! Reading the concatenation as one run then maps a later chunk's batch-0 rows
+//! onto batch-1 sequence slots — head/batch-scrambled K/V, with no error.
+//! [`transpose_chunked_seq_heads`] is the reorder that knows where the chunks
+//! end; [`transpose_seq_heads`] stays correct only for a buffer that really is
+//! one `[B, S_total, kv_h, D]` run (a single chunk, or a flat store written at
+//! sequence offsets).
+
+use rmlx_core::error::{Error, Result};
 
 /// Reorder a flat head-major `[B, kv_h, S, D]` buffer to sequence-major
 /// `[B, S, kv_h, D]`. Used by the CPU `append` paths to mirror the GPU
@@ -74,6 +89,87 @@ pub(super) fn transpose_seq_heads(
         }
     }
     out
+}
+
+/// Reorder a **chunked** sequence-major buffer back to head-major
+/// `[B, kv_h, S_total, D]`.
+///
+/// `src` is the concatenation of one `[B, S_chunk, kv_h, D]` buffer per
+/// `append`, in append order; `chunk_rows` is each chunk's row count
+/// (`B * kv_h * S_chunk`) in the same order. Every chunk is reordered at its own
+/// sequence offset, which is what [`transpose_seq_heads`] over the whole
+/// concatenation cannot do once `B > 1` (see the module note).
+///
+/// At `B == 1` this is exactly [`transpose_seq_heads`] over the concatenation —
+/// the sequence axis is then the outermost axis of every chunk, so the chunk
+/// boundaries carry no information.
+///
+/// # Errors
+///
+/// Returns [`Error::Quant`] when the chunks do not partition
+/// `[B, S_total, kv_h, D]`: a wrong total length, a chunk whose row count is not
+/// a whole number of sequence positions, or a chunk list that over- or
+/// under-runs `s_total`.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "every (bi,si,h) base + d is bounded by the length and partition checks above"
+)]
+pub(super) fn transpose_chunked_seq_heads(
+    src: &[f32],
+    b: usize,
+    s_total: usize,
+    kv_h: usize,
+    d: usize,
+    chunk_rows: impl IntoIterator<Item = usize>,
+) -> Result<Vec<f32>> {
+    let total = b * kv_h * s_total * d;
+    if src.len() != total {
+        return Err(Error::Quant(format!(
+            "transpose_chunked_seq_heads: buffer holds {} elems but \
+             [B={b}, kv_h={kv_h}, S={s_total}, D={d}] implies {total}",
+            src.len()
+        )));
+    }
+    let mut out = vec![0.0_f32; total];
+    let rows_per_seq = b * kv_h;
+    if rows_per_seq == 0 || d == 0 {
+        // Nothing to place: `total` is 0, so the empty output is already right.
+        return Ok(out);
+    }
+    let mut s_off = 0usize;
+    let mut src_off = 0usize;
+    for rows in chunk_rows {
+        if !rows.is_multiple_of(rows_per_seq) {
+            return Err(Error::Quant(format!(
+                "transpose_chunked_seq_heads: chunk holds {rows} rows, not a whole number of \
+                 sequence positions at B={b}, kv_h={kv_h}"
+            )));
+        }
+        let s_chunk = rows / rows_per_seq;
+        if s_off + s_chunk > s_total {
+            return Err(Error::Quant(format!(
+                "transpose_chunked_seq_heads: chunks over-run S={s_total} at sequence offset \
+                 {s_off} (+{s_chunk})"
+            )));
+        }
+        for bi in 0..b {
+            for si in 0..s_chunk {
+                for h in 0..kv_h {
+                    let src_base = src_off + ((bi * s_chunk + si) * kv_h + h) * d;
+                    let dst_base = ((bi * kv_h + h) * s_total + s_off + si) * d;
+                    out[dst_base..dst_base + d].copy_from_slice(&src[src_base..src_base + d]);
+                }
+            }
+        }
+        s_off += s_chunk;
+        src_off += rows * d;
+    }
+    if s_off != s_total {
+        return Err(Error::Quant(format!(
+            "transpose_chunked_seq_heads: chunks cover {s_off} sequence positions but S={s_total}"
+        )));
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/crates/rmlx-kv-quant/src/storage/seq_layout.rs
+++ b/crates/rmlx-kv-quant/src/storage/seq_layout.rs
@@ -91,6 +91,102 @@ pub(super) fn transpose_seq_heads(
     out
 }
 
+/// `b * kv_h * s_total * d`, or [`Error::Quant`] when the product overflows.
+///
+/// Callers derive these from `i32` shape fields with a plain `as usize`, so a
+/// malformed shape can reach here as an absurd count. Every other guard in this
+/// module is a typed error; wrapping (or panicking under debug-assertions) on
+/// the size computation alone would be the odd one out.
+fn checked_elems(b: usize, kv_h: usize, s_total: usize, d: usize, what: &str) -> Result<usize> {
+    b.checked_mul(kv_h)
+        .and_then(|v| v.checked_mul(s_total))
+        .and_then(|v| v.checked_mul(d))
+        .ok_or_else(|| {
+            Error::Quant(format!(
+                "{what}: element count overflows usize at \
+                 [B={b}, kv_h={kv_h}, S={s_total}, D={d}]"
+            ))
+        })
+}
+
+/// Head-major `[B, kv_h, S_total, D]` destination index of every **token row**
+/// of a chunked sequence-major block list.
+///
+/// The block stores hold one `[B, S_chunk, kv_h, D]` payload per `append`, so
+/// row `i` of the concatenation identifies `(bi, si, h)` *within its own chunk*.
+/// A reader that wants head-major output has two ways to get there: reorder the
+/// decoded values ([`transpose_chunked_seq_heads`]), or place the payload rows
+/// in head-major order **before** decoding. This returns the permutation for the
+/// second — `perm[i]` is the head-major token index of concatenated row `i`.
+///
+/// The GPU readers take the second route: the iso dequant kernel is per-token
+/// positional (token `t`'s output depends only on token `t`'s codes / scales /
+/// norm), so permuting its input permutes its output identically. Feeding it
+/// head-major rows means the flat result is already `[B, kv_h, S, D]` and needs
+/// no reshape-plus-transpose at all — one less device kernel than reordering
+/// afterwards, and correct at every `B`, which the whole-buffer reshape is not.
+///
+/// # Errors
+///
+/// Returns [`Error::Quant`] when the chunks do not partition
+/// `[B, S_total, kv_h]` — a ragged chunk, or a chunk list that over- or
+/// under-runs `s_total`.
+pub(super) fn head_major_token_order(
+    b: usize,
+    s_total: usize,
+    kv_h: usize,
+    chunk_rows: impl IntoIterator<Item = usize>,
+) -> Result<Vec<usize>> {
+    let total_rows = checked_elems(b, kv_h, s_total, 1, "head_major_token_order")?;
+    let mut perm = vec![0usize; total_rows];
+    let rows_per_seq = b * kv_h;
+    if rows_per_seq == 0 {
+        return Ok(perm);
+    }
+    let mut s_off = 0usize;
+    let mut row = 0usize;
+    for rows in chunk_rows {
+        if !rows.is_multiple_of(rows_per_seq) {
+            return Err(Error::Quant(format!(
+                "head_major_token_order: chunk holds {rows} rows, not a whole number of \
+                 sequence positions at B={b}, kv_h={kv_h}"
+            )));
+        }
+        let s_chunk = rows / rows_per_seq;
+        if s_off + s_chunk > s_total {
+            return Err(Error::Quant(format!(
+                "head_major_token_order: chunks over-run S={s_total} at sequence offset \
+                 {s_off} (+{s_chunk})"
+            )));
+        }
+        for bi in 0..b {
+            for si in 0..s_chunk {
+                for h in 0..kv_h {
+                    // Source row order inside the chunk is `[B, S_chunk, kv_h]`;
+                    // `row` walks it, so no index arithmetic is needed on the
+                    // source side.
+                    let dst = (bi * kv_h + h) * s_total + s_off + si;
+                    let Some(slot) = perm.get_mut(row) else {
+                        return Err(Error::Quant(format!(
+                            "head_major_token_order: chunk rows exceed the {total_rows} rows \
+                             [B={b}, kv_h={kv_h}, S={s_total}] declares"
+                        )));
+                    };
+                    *slot = dst;
+                    row += 1;
+                }
+            }
+        }
+        s_off += s_chunk;
+    }
+    if s_off != s_total {
+        return Err(Error::Quant(format!(
+            "head_major_token_order: chunks cover {s_off} sequence positions but S={s_total}"
+        )));
+    }
+    Ok(perm)
+}
+
 /// Reorder a **chunked** sequence-major buffer back to head-major
 /// `[B, kv_h, S_total, D]`.
 ///
@@ -122,7 +218,7 @@ pub(super) fn transpose_chunked_seq_heads(
     d: usize,
     chunk_rows: impl IntoIterator<Item = usize>,
 ) -> Result<Vec<f32>> {
-    let total = b * kv_h * s_total * d;
+    let total = checked_elems(b, kv_h, s_total, d, "transpose_chunked_seq_heads")?;
     if src.len() != total {
         return Err(Error::Quant(format!(
             "transpose_chunked_seq_heads: buffer holds {} elems but \

--- a/crates/rmlx-kv-quant/src/storage/seq_layout_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/seq_layout_tests.rs
@@ -7,7 +7,7 @@
 //! corrupts a multi-append, multi-head cache, while the sequence-major reorder
 //! round-trips exactly for every append pattern.
 
-use super::{transpose_heads_seq, transpose_seq_heads};
+use super::{transpose_chunked_seq_heads, transpose_heads_seq, transpose_seq_heads};
 
 const B: usize = 1;
 
@@ -122,6 +122,145 @@ fn seq_major_reorder_is_exact_for_all_append_patterns() {
             "fixed path exact for appends={appends:?} kv_h={kv_h} d={d}, got {m}"
         );
     }
+}
+
+// ── Chunked reorder (`B` > 1) ────────────────────────────────────────────────
+
+/// Distinct value per `(batch, head, token, dim)` — the batch axis the
+/// single-`B` helpers above do not exercise.
+fn bval(bi: usize, h: usize, s: usize, d: usize) -> f32 {
+    (bi * 10_000_000 + h * 100_000 + s * 100 + d) as f32
+}
+
+/// Head-major `[B, kv_h, S, D]` reference, built straight from index math — no
+/// reorder helper involved, so it is an independent oracle.
+fn head_major_reference(b: usize, kv_h: usize, s_total: usize, d: usize) -> Vec<f32> {
+    let mut out = vec![0.0_f32; b * kv_h * s_total * d];
+    for bi in 0..b {
+        for h in 0..kv_h {
+            for s in 0..s_total {
+                for dd in 0..d {
+                    out[((bi * kv_h + h) * s_total + s) * d + dd] = bval(bi, h, s, dd);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// The buffer a block-accumulating store decodes to: one sequence-major
+/// `[B, S_chunk, kv_h, D]` chunk per append, concatenated in append order.
+fn chunked_seq_major_buffer(b: usize, kv_h: usize, appends: &[usize], d: usize) -> Vec<f32> {
+    let mut buf = Vec::new();
+    let mut s0 = 0usize;
+    for &n in appends {
+        for bi in 0..b {
+            for s in 0..n {
+                for h in 0..kv_h {
+                    for dd in 0..d {
+                        buf.push(bval(bi, h, s0 + s, dd));
+                    }
+                }
+            }
+        }
+        s0 += n;
+    }
+    buf
+}
+
+#[test]
+fn chunked_reorder_is_exact_at_every_batch_and_split() {
+    for &(b, kv_h, appends, d) in &[
+        (1usize, 1usize, &[3usize][..], 4usize), // degenerate
+        (1, 4, &[2, 1][..], 8),                  // B = 1 multi-chunk (unchanged behaviour)
+        (2, 1, &[5][..], 4),                     // B > 1, single chunk
+        (2, 1, &[2, 3][..], 4),                  // B > 1, two chunks — the defect
+        (2, 2, &[2, 3][..], 4),                  // B > 1, GQA
+        (3, 4, &[1, 1, 1, 2][..], 8),            // per-token decode after a chunk
+    ] {
+        let s_total: usize = appends.iter().sum();
+        let buf = chunked_seq_major_buffer(b, kv_h, appends, d);
+        let got = transpose_chunked_seq_heads(
+            &buf,
+            b,
+            s_total,
+            kv_h,
+            d,
+            appends.iter().map(|&n| b * kv_h * n),
+        )
+        .expect("well-formed chunk partition");
+        assert_eq!(
+            got,
+            head_major_reference(b, kv_h, s_total, d),
+            "chunked reorder must be exact for b={b} kv_h={kv_h} appends={appends:?} d={d}"
+        );
+    }
+}
+
+/// The whole-buffer reorder is what the block stores used to call. It agrees
+/// with the chunked one at `B == 1` and disagrees the moment `B > 1` meets more
+/// than one chunk — this is what makes the chunked helper load-bearing rather
+/// than a rename.
+#[test]
+fn whole_buffer_reorder_only_matches_at_b_1_or_one_chunk() {
+    let d = 4;
+    let agree = |b: usize, kv_h: usize, appends: &[usize]| -> bool {
+        let s_total: usize = appends.iter().sum();
+        let buf = chunked_seq_major_buffer(b, kv_h, appends, d);
+        let whole = transpose_seq_heads(&buf, b, s_total, kv_h, d);
+        let chunked = transpose_chunked_seq_heads(
+            &buf,
+            b,
+            s_total,
+            kv_h,
+            d,
+            appends.iter().map(|&n| b * kv_h * n),
+        )
+        .expect("well-formed chunk partition");
+        whole == chunked
+    };
+    assert!(agree(1, 2, &[2, 3]), "B = 1 multi-chunk: the two agree");
+    assert!(agree(2, 2, &[5]), "single chunk: the two agree at any B");
+    assert!(
+        !agree(2, 1, &[2, 3]),
+        "B > 1 with two chunks: the whole-buffer reorder must disagree — if it does not, \
+         this test no longer proves the chunked helper is needed"
+    );
+    assert!(
+        !agree(3, 2, &[1, 1, 1]),
+        "B > 1 per-token decode: disagrees"
+    );
+}
+
+#[test]
+fn chunked_reorder_rejects_a_partition_that_does_not_add_up() {
+    let (b, kv_h, d) = (2usize, 2usize, 4usize);
+    let buf = chunked_seq_major_buffer(b, kv_h, &[2, 3], d);
+
+    // Chunks cover fewer sequence positions than `s_total` declares.
+    let err = transpose_chunked_seq_heads(&buf, b, 5, kv_h, d, [b * kv_h * 2, b * kv_h * 2])
+        .expect_err("under-running chunks must be rejected");
+    assert!(
+        err.to_string().contains("cover 4 sequence positions"),
+        "expected the coverage error, got: {err}"
+    );
+
+    // A chunk whose row count is not a whole number of sequence positions.
+    let err = transpose_chunked_seq_heads(&buf, b, 5, kv_h, d, [b * kv_h * 2, b * kv_h * 3 - 1, 1])
+        .expect_err("a ragged chunk must be rejected");
+    assert!(
+        err.to_string()
+            .contains("not a whole number of sequence positions"),
+        "expected the ragged-chunk error, got: {err}"
+    );
+
+    // Buffer length disagrees with the declared shape.
+    let err = transpose_chunked_seq_heads(&buf[..buf.len() - d], b, 5, kv_h, d, [b * kv_h * 5])
+        .expect_err("a short buffer must be rejected");
+    assert!(
+        err.to_string().contains("implies"),
+        "expected the length error, got: {err}"
+    );
 }
 
 #[test]

--- a/crates/rmlx-kv-quant/src/storage/seq_layout_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/seq_layout_tests.rs
@@ -7,7 +7,9 @@
 //! corrupts a multi-append, multi-head cache, while the sequence-major reorder
 //! round-trips exactly for every append pattern.
 
-use super::{transpose_chunked_seq_heads, transpose_heads_seq, transpose_seq_heads};
+use super::{
+    head_major_token_order, transpose_chunked_seq_heads, transpose_heads_seq, transpose_seq_heads,
+};
 
 const B: usize = 1;
 
@@ -274,4 +276,91 @@ fn reorder_round_trips_identity() {
     let seq = transpose_heads_seq(&src, B, kv_h, s, d);
     let back = transpose_seq_heads(&seq, B, s, kv_h, d);
     assert_eq!(src, back, "reorder round-trip must be identity");
+}
+
+// ── Head-major token permutation ─────────────────────────────────────────────
+
+/// `head_major_token_order` must agree with `transpose_chunked_seq_heads`: both
+/// are the same reorder, one applied to the payload rows on the way in and one
+/// to the decoded values on the way out. Permuting rows by `perm` and reading
+/// the result as head-major must equal reordering the sequence-major decode.
+///
+/// Mutation check: drop the `s_off` term from the destination index in
+/// `head_major_token_order` and this goes red at every multi-chunk case.
+#[test]
+fn head_major_token_order_matches_the_output_reorder() {
+    for &(b, kv_h, appends, d) in &[
+        (1usize, 1usize, &[3usize][..], 4usize),
+        (1, 4, &[2, 1][..], 8),
+        (2, 1, &[2, 3][..], 4),
+        (2, 2, &[2, 3][..], 4),
+        (3, 4, &[1, 1, 1, 2][..], 8),
+    ] {
+        let s_total: usize = appends.iter().sum();
+        let seq_major = chunked_seq_major_buffer(b, kv_h, appends, d);
+        let rows = appends.iter().map(|&n| b * kv_h * n);
+        let perm = head_major_token_order(b, s_total, kv_h, rows.clone())
+            .expect("well-formed chunk partition");
+
+        // Route A: reorder the decoded values.
+        let via_output = transpose_chunked_seq_heads(&seq_major, b, s_total, kv_h, d, rows)
+            .expect("well-formed chunk partition");
+        // Route B: place each source row at `perm[row]` and read straight off.
+        let mut via_input = vec![0.0_f32; b * kv_h * s_total * d];
+        for (row, &dst) in perm.iter().enumerate() {
+            via_input[dst * d..(dst + 1) * d].copy_from_slice(&seq_major[row * d..(row + 1) * d]);
+        }
+
+        assert_eq!(
+            via_input, via_output,
+            "input permutation and output reorder must agree for b={b} kv_h={kv_h} \
+             appends={appends:?} d={d}"
+        );
+        assert_eq!(
+            via_input,
+            head_major_reference(b, kv_h, s_total, d),
+            "and both must equal the index-math reference"
+        );
+    }
+}
+
+/// The permutation is a bijection onto `[0, B * kv_h * S)` — a duplicate or a
+/// gap would leave one token slot written twice and another holding the
+/// allocation's zeros, which is the silent-corruption shape this whole reorder
+/// exists to avoid.
+#[test]
+fn head_major_token_order_is_a_bijection() {
+    for &(b, kv_h, appends) in &[
+        (2usize, 2usize, &[2usize, 3][..]),
+        (3, 1, &[1, 1, 4][..]),
+        (1, 5, &[7][..]),
+    ] {
+        let s_total: usize = appends.iter().sum();
+        let perm = head_major_token_order(b, s_total, kv_h, appends.iter().map(|&n| b * kv_h * n))
+            .expect("well-formed chunk partition");
+        let mut seen = vec![false; b * kv_h * s_total];
+        assert_eq!(perm.len(), seen.len(), "one entry per token row");
+        for &dst in &perm {
+            assert!(!seen[dst], "destination {dst} written twice");
+            seen[dst] = true;
+        }
+        assert!(seen.iter().all(|&s| s), "every destination slot is written");
+    }
+}
+
+#[test]
+fn head_major_token_order_rejects_a_partition_that_does_not_add_up() {
+    let err = head_major_token_order(2, 5, 2, [8usize, 8])
+        .expect_err("under-running chunks must be rejected");
+    assert!(
+        err.to_string().contains("cover 4 sequence positions"),
+        "expected the coverage error, got: {err}"
+    );
+    let err = head_major_token_order(2, 5, 2, [8usize, 11, 1])
+        .expect_err("a ragged chunk must be rejected");
+    assert!(
+        err.to_string()
+            .contains("not a whole number of sequence positions"),
+        "expected the ragged-chunk error, got: {err}"
+    );
 }

--- a/crates/rmlx-kv-quant/src/storage/truncate_plan_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/truncate_plan_tests.rs
@@ -17,13 +17,15 @@
 //! `blocks` short of `shape[2]` — a state only a live GPU ring can repair. The
 //! planner therefore splits the trailing block instead.
 //!
-//! **`b > 1` must NOT split.** Every store decodes the concatenation of its
-//! blocks as one `[B, S_total, kv_h, D]` run, which is only a valid reading at
-//! `b == 1` or with a single block. Splitting at `b > 1` would replace a loud
-//! blocks-short-of-`shape[2]` error with a silently scrambled two-block store,
-//! so the planner drops the block there and lets the guard report the gap. The
-//! store-level proof of the scrambling is
-//! `quant_rotor_v3_tests::quant_rotor_v3_truncate_at_b_gt_1_stays_loud`.
+//! **`b > 1` must NOT split.** A block's rows run `[B, S_block, kv_h, D]`, so
+//! batch element 1's rows sit after batch element 0's and `retain_rows` keeps a
+//! row prefix. At `b > 1` a row prefix is not a sequence prefix — the cut would
+//! keep all of batch 0 and none of batch 1 — so the planner drops the block
+//! there and lets the reconciliation guard report the gap. The store-level proof
+//! is `quant_rotor_v3_tests::quant_rotor_v3_truncate_at_b_gt_1_stays_loud`,
+//! which also pins that reading the *concatenation* is no longer a second bound
+//! (`seq_layout::transpose_chunked_seq_heads` reorders each block at its own
+//! sequence offset).
 
 use crate::storage::{apply_truncate_plan, retain_rows_in, truncate_plan, BlockRows};
 
@@ -261,11 +263,11 @@ fn whole_block_drop_leaves_the_store_short_of_the_target() {
 
 /// `b > 1` never splits, however cleanly the cut would divide.
 ///
-/// Not a limitation of the planner — a correctness bound imposed by the decode
-/// path. Every store reads its block concatenation as one `[B, S_total, kv_h,
-/// D]` run, which interleaves batch elements once more than one block survives.
-/// Splitting here would replace the loud blocks-short-of-`shape[2]` error with a
-/// silently scrambled store; dropping keeps the error.
+/// Not a limitation of the planner — a correctness bound imposed by the block
+/// layout. A block's rows run `[B, S_block, kv_h, D]`, so `retain_rows`, which
+/// keeps a row prefix, would keep all of batch 0 and none of batch 1 rather than
+/// cutting both at the same sequence position. Dropping the block keeps the loud
+/// blocks-short-of-`shape[2]` error instead.
 #[test]
 fn plan_never_splits_at_batch_gt_1() {
     let (b, kv_h) = (2_usize, 2_usize);
@@ -277,7 +279,7 @@ fn plan_never_splits_at_batch_gt_1() {
     assert_eq!(plan.keep, 0, "the block is dropped, not kept whole");
     assert_eq!(
         plan.partial_rows, None,
-        "no split at b > 1 — the decode path cannot read a multi-block batched store"
+        "no split at b > 1 — a row prefix is not a sequence prefix there"
     );
 
     // The same shape at b == 1 does split, so the refusal is keyed on `b` and

--- a/crates/rmlx-kv-quant/src/test_utils.rs
+++ b/crates/rmlx-kv-quant/src/test_utils.rs
@@ -314,6 +314,36 @@ pub(crate) fn lcg_data(n: usize, seed: u64) -> Vec<f32> {
         .collect()
 }
 
+/// Head-major `[b, kv_h, n, head_dim]` chunk covering sequence positions
+/// `[s0, s0 + n)`, with a distinct pseudo-random row per `(batch, head, token)`.
+///
+/// The fixture exists for one question: does a block-accumulating store decode
+/// the same values whether the sequence arrived as one append or several? Rows
+/// are drawn from [`lcg_data`] with a seed derived from `(batch, head, token)`,
+/// so no two rows repeat and any batch/head/sequence transposition swaps whole
+/// rows rather than perturbing them. Row magnitudes stay in `[-1, 1]` across
+/// every batch element, so no codec sees a batch-dependent dynamic range.
+pub(crate) fn batch_head_chunk(
+    b: usize,
+    kv_h: usize,
+    s0: usize,
+    n: usize,
+    head_dim: usize,
+) -> Vec<f32> {
+    let mut out = vec![0.0_f32; b * kv_h * n * head_dim];
+    for bi in 0..b {
+        for h in 0..kv_h {
+            for si in 0..n {
+                let seed = ((bi as u64 * 977 + h as u64) * 4099 + (s0 + si) as u64) * 65_537 + 1;
+                let row = lcg_data(head_dim, seed);
+                let base = ((bi * kv_h + h) * n + si) * head_dim;
+                out[base..base + head_dim].copy_from_slice(&row);
+            }
+        }
+    }
+    out
+}
+
 /// Generate `n` standard-normal f32 values from the same pinned Knuth LCG as
 /// [`lcg_data`], via Box–Muller.
 ///

--- a/crates/rmlx-kv-ssd/src/block_io.rs
+++ b/crates/rmlx-kv-ssd/src/block_io.rs
@@ -846,7 +846,8 @@ fn write_layer(
         }
         // IsoV4 SSD spill — K side identical to IsoV3 (q8_0); V side uses the
         // same flat IsoBlocks layout. Differentiated only by the geometry tag
-        // (ISOV4_LAYOUT_TAG = "iso_v_4") so the reader picks the 4-bit codec /
+        // (`ISOV4_LAYOUT_TAG`, currently "iso_v_4_v2" — bumped when the GPU
+        // append's byte orientation was fixed) so the reader picks the 4-bit codec /
         // pack on hydrate.
         KvStorage::IsoV4 { k, v, max_seq } => {
             let seq = write_quant_k(idx, "k", k.as_ref(), device, out)?;

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -4035,3 +4035,55 @@ fn rotor_sym_truncate_keeps_ring_tail() {
         }
     }
 }
+
+// ── Layout-tag versioning ────────────────────────────────────────────────────
+
+/// A stored byte layout change must move the tag, because the tag is the only
+/// thing that distinguishes two layouts on disk.
+///
+/// The SSD key is `FNV_OFFSET ^ layout_key ^ cache_key_salt ^ model_sig`, and
+/// `layout_key` is the tag plus geometry (`{"tag":..,"max_seq":..,"shape":[..]}`).
+/// Neither the geometry nor the codec salt changes when the *orientation* of the
+/// bytes inside a block changes, so an entry written under the old layout
+/// hash-matches and is hydrated with the new reader — silently.
+///
+/// The iso4 V append stored head-major blocks while `QuantIsoV4::dequant` reads
+/// sequence-major; fixing the append changed the bytes, so both tags carrying
+/// that payload moved to `_v2`. This pins that they stay moved: reverting either
+/// to its v1 spelling makes pre-fix entries readable again, which is the silent
+/// case.
+///
+/// Deliberately spelled out rather than derived — a test that recomputed the
+/// name from the constant would pass whatever the constant says.
+#[test]
+fn iso4_layout_tags_are_versioned_past_the_head_major_payload() {
+    assert_eq!(
+        ISOV4_LAYOUT_TAG, "iso_v_4_v2",
+        "iso4 V-only entries written before the sequence-major append fix must miss"
+    );
+    assert_eq!(
+        ISO_SYM_4_LAYOUT_TAG, "iso_sym_4_v2",
+        "the V half of iso4-sym takes the same append, so its tag moves with it"
+    );
+    // The iso3 payload orientation never changed — its append always reordered
+    // heads↔seq — so bumping those tags would only throw away valid entries.
+    assert_eq!(ISOV3_LAYOUT_TAG, "iso_v_3", "iso3 V bytes are unchanged");
+    assert_eq!(
+        ISO_SYM_3_LAYOUT_TAG, "iso_sym_3",
+        "iso3-sym bytes are unchanged"
+    );
+    // Every tag stays distinct, or two codecs share a hydrate key.
+    let tags = [
+        ISOV3_LAYOUT_TAG,
+        ISOV4_LAYOUT_TAG,
+        ISO_SYM_3_LAYOUT_TAG,
+        ISO_SYM_4_LAYOUT_TAG,
+        ISO_K_ONLY_3_LAYOUT_TAG,
+        ISO_K_ONLY_4_LAYOUT_TAG,
+    ];
+    for (i, a) in tags.iter().enumerate() {
+        for b in tags.iter().skip(i + 1) {
+            assert_ne!(a, b, "layout tags must be pairwise distinct");
+        }
+    }
+}

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -3060,6 +3060,21 @@ cache — falls through to the legacy `update_*` entries, which pass
 site dequantizes the whole prefix on the same step, so `dequant` would take the
 identical readback if `blocks` were left short.
 
+**How reachable is the divergence?** Narrowly, and it is worth knowing why
+before writing a repro. The state needs a cache whose ring is live *and* whose
+CPU blocks were dropped — which only the fused decode path creates — followed by
+a decode-mode `update()` with `q_seq > 1` on **that same cache**. A warm
+prompt-cache continuation looks like it should qualify (gemma4's `is_prefix`
+flush appends the tail through decode-mode `update` with no enter/exit
+brackets), but it does not: that tail runs against a prompt-cache *clone*, and
+`try_deep_clone` materialises any ring-only tail into blocks and hands back a
+store with no ring at all, so there is nothing to diverge. What does qualify is a
+speculative verify chunk — a multi-token decode step on a live cache. So the
+codec can serve a normal single-request generate loop indefinitely without
+meeting it, which is why it surfaced from a truncation proof matrix rather than
+from serving, and why the guards above are the gate rather than a serve-time
+smoke test.
+
 **Every block push reconciles, and every reader derives its count from the same
 place.** Two holes in that used to be reachable and are now closed. The iso-V
 GPU-encode append (`QuantIsoV3::append_gpu`, the V side of the legacy

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -3125,8 +3125,35 @@ one-block store, while the `b = 1` control matched to the last bit). Every
 block-accumulating CPU store now calls
 `seq_layout::transpose_chunked_seq_heads`, which reorders each block at its own
 sequence offset and is exactly the old whole-buffer reorder when `B == 1`. The
-per-store proof is `*_two_block_decode_matches_one_block_at_b_gt_1` (one per
-store), with the index-math oracle in `seq_layout_tests`.
+per-store proof is `*_two_block_decode_matches_one_block_at_b_gt_1` — one per
+store, all thirteen, each over `(b, kv_h) ∈ {1,2} × {1,2}` — with the index-math
+oracle in `seq_layout_tests`.
+
+The **GPU** readers took the same reorder on the way in rather than the way out.
+`QuantIsoV3::dequant_gpu` / `QuantIsoK3::dequant_gpu` had the identical defect
+(they reshaped the kernel's flat output as one `[B, S, kv_h, D]` run), and it is
+the multi-block case that reaches them: every `*_sync_ring` clears the ring at
+`b != 1`, so `synced_iso_v_blocks` returns a borrowed multi-block list there.
+Both now build their kernel inputs through `iso_kernel_inputs_head_major`, which
+places each token row at its head-major position via
+`seq_layout::head_major_token_order`; the iso dequant kernel is per-token
+positional, so the flat result is already `[B, kv_h, S, D]` and the trailing
+reshape/transpose is gone.
+
+**Where the bound still stands.** Two readers refuse `b != 1` (with `S > 1`)
+rather than reorder:
+
+* The **flat GPU buffers** of the turbo / planar / affine stores (`QuantV`,
+  `QuantKTurbo3/4`, `QuantPlanarK/V`, `QuantK`) and the gated `QuantIsoV3` GPU
+  mirror. Each is a run of `[B, S_chunk, kv_h, D]` chunks written at
+  `prev_seq * words_per_step` with `b` folded into the stride, so the prefix
+  carries no chunk boundary to partition on.
+* `QuantK`'s **CPU** `codes` / `scales`, which are one flat append-only pair with
+  no per-append boundary recorded. The refusal is deliberately wider than the
+  defect — a single-append `b > 1` store would read correctly and is refused
+  anyway — because `b > 1` reaches no production path today and the boundaries
+  are not recoverable after the fact. Lifting it needs a recorded per-append
+  sequence length on the store.
 
 All eight rotor/iso K and V codecs share one crate-internal planner,
 `truncate_plan` in `rmlx-kv-quant/src/storage/mod.rs`, plus a `BlockRows`

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -3060,6 +3060,23 @@ cache — falls through to the legacy `update_*` entries, which pass
 site dequantizes the whole prefix on the same step, so `dequant` would take the
 identical readback if `blocks` were left short.
 
+**Every block push reconciles, and every reader derives its count from the same
+place.** Two holes in that used to be reachable and are now closed. The iso-V
+GPU-encode append (`QuantIsoV3::append_gpu`, the V side of the legacy
+`update_iso3` / `update_iso3_sym` entries) pushed a CPU block without touching a
+live ring, leaving the ring stale *and* the blocks short — it now calls
+`QuantIsoV3::absorb_ring_into_blocks`, which takes the ring's prefix back and
+then drops the ring, matching what the CPU `append` does by clearing. The iso4 V
+side had the same hole in a separate ring-unaware helper; both of its callers now
+go through the ring-aware `iso4_gpu_append_into_v_blocks` with a `Skip` feed, and
+the helper is gone (it also stored its block head-major, unlike every other iso
+append). On the read side `QuantIsoK3::dequant_gpu` and
+`QuantIsoV3::dequant_gpu` counted `self.blocks` directly while their CPU siblings
+counted the ring-reconciled list, so a legitimate ring-only tail was rejected as
+a blocks-vs-shape disagreement (`dequant_gpu: actual_total=... !=
+declared_total=...`); both now start from `synced_iso_v_blocks`, which borrows
+(costs nothing) whenever the blocks already cover `shape[2]`.
+
 **Row vs. sequence units.** Every rotor/iso K and V store's per-append
 `RotorBlocks` / `IsoBlocks` carries `n_tokens` counting **rows**
 (`b * kv_h * seq_of_block`), not sequence positions, but `truncate_to(n)`

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2008,8 +2008,11 @@ the caller reshapes the concatenation head-major `[B, kv_h, S, D]`, a head-major
 per-block store transposes per-head values across a multi-append GQA cache
 (`kv_h > 1`, e.g. the post-SSD-hydrate decode-append path) — the same head
 scramble fixed for `QuantK` / `QuantV`. Each `append` now reorders the
-head-major chunk heads↔seq (`[B, new_seq, kv_h, D]`) before encoding and
-`dequant` reorders back; single-chunk cold prefill is the identity. The codec is
+head-major chunk heads↔seq (`[B, new_seq, kv_h, D]`) before encoding, and
+`dequant` reorders **each block back at its own sequence offset**
+(`seq_layout::transpose_chunked_seq_heads`) — reordering the whole concatenation
+in one pass is only equivalent at `B == 1`; see the `b > 1` note under the
+truncation planner. Single-chunk cold prefill is the identity. The codec is
 per-token-row positional, so the sidebands stay correctly associated: Iso
 per-(token, group) scale/norm and the constant `FIXED_QUAT` quaternion permute
 with the rows; the Rotor static rotor table and QJL projection are
@@ -3082,26 +3085,31 @@ therefore **splits** the trailing block, cutting every per-row buffer — codes,
 per-group scales, per-group quaternions, per-token norms, and the rotor QJL
 sideband — to the accepted row count.
 
-**The split is `b == 1` only, and that is a correctness bound.** Every store
-ends `dequant` with `seq_layout::transpose_seq_heads` over the *concatenation*
-of its blocks, reading it as one `[B, S_total, kv_h, D]` run — but each block is
-only `[B, S_block, kv_h, D]`, so at `b > 1` the concatenation interleaves batch
-elements and any store holding more than one block decodes scrambled. Measured
-on the shipped fixture (`b = 2`, `kv_h = 2`, `head_dim = 96`, 5 positions): a
-two-block store disagrees with a one-block store over the same tokens on **960
-of 1920 elements**, spread across 10 of the 20 rows and straddling both reader
-batch halves — while the `b = 1` control matches to the last bit. Splitting at
-`b > 1` would manufacture that two-block state and convert a **loud**
-blocks-short-of-`shape[2]` error into silently scrambled K/V, so the planner
-drops the block there and lets the reconciliation guard report the gap.
-`sdpa::rotor_flash_shape_ok` refuses `b != 1` for the same underlying reason,
-which is also why a `b > 1` store never has a ring to rebuild from. Pinned by
-`quant_rotor_v3_tests::quant_rotor_v3_truncate_at_b_gt_1_stays_loud`, which
-asserts both halves: that the two-block store really is unreadable, and that a
-`b > 1` mid-block cut therefore returns `Err`.
+**The split is `b == 1` only, and that is a correctness bound.** The bound is
+*inside* one block. A block's rows run `[B, S_block, kv_h, D]`, so batch element
+1's rows all sit after batch element 0's, and `BlockRows::retain_rows` keeps a
+**row prefix**. At `b > 1` a row prefix is not a sequence prefix: a cut to
+`keep_seq` positions would keep every one of batch 0's rows and none of batch
+1's, silently dropping one batch element's tail instead of cutting both at the
+same position. So the planner drops the block there and lets the reconciliation
+guard report the gap. `sdpa::rotor_flash_shape_ok` refuses `b != 1` separately,
+because the GPU ring's per-step stride does not interleave batch — which is also
+why a `b > 1` store never has a ring to rebuild from. Pinned by
+`quant_rotor_v3_tests::quant_rotor_v3_truncate_at_b_gt_1_stays_loud`.
 
-The multi-block `b > 1` decode is broken independently of truncation and is not
-fixed here; the bound above only keeps this change from making it silent.
+Reading the *concatenation* of the blocks used to be a second, independent bound
+and is no longer one. Every store ended `dequant` with
+`seq_layout::transpose_seq_heads` over the concatenation, reading it as one
+`[B, S_total, kv_h, D]` run — but each block is only `[B, S_block, kv_h, D]`, so
+at `b > 1` the concatenation interleaves batch elements and any store holding
+more than one block decoded scrambled (measured on the `b = 2`, `kv_h = 2`,
+`head_dim = 96`, 5-position fixture: **960 of 1920 elements** disagreed with a
+one-block store, while the `b = 1` control matched to the last bit). Every
+block-accumulating CPU store now calls
+`seq_layout::transpose_chunked_seq_heads`, which reorders each block at its own
+sequence offset and is exactly the old whole-buffer reorder when `B == 1`. The
+per-store proof is `*_two_block_decode_matches_one_block_at_b_gt_1` (one per
+store), with the index-math oracle in `seq_layout_tests`.
 
 All eight rotor/iso K and V codecs share one crate-internal planner,
 `truncate_plan` in `rmlx-kv-quant/src/storage/mod.rs`, plus a `BlockRows`

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -3065,8 +3065,12 @@ place.** Two holes in that used to be reachable and are now closed. The iso-V
 GPU-encode append (`QuantIsoV3::append_gpu`, the V side of the legacy
 `update_iso3` / `update_iso3_sym` entries) pushed a CPU block without touching a
 live ring, leaving the ring stale *and* the blocks short — it now calls
-`QuantIsoV3::absorb_ring_into_blocks`, which takes the ring's prefix back and
-then drops the ring, matching what the CPU `append` does by clearing. The iso4 V
+`QuantIsoV3::reconcile_ring(device, RingDisposition::Drop)`, which takes the
+ring's prefix back and then drops the ring, matching what the CPU `append` does
+by clearing. That is one body, shared with `materialize_iso_v3_ring_tail`, which
+passes `RingDisposition::Keep` because its caller's `sync_ring` decides the
+ring's fate immediately after — the disposition is a parameter precisely because
+it is the only thing the two callers disagree on. The iso4 V
 side had the same hole in a separate ring-unaware helper; both of its callers now
 go through the ring-aware `iso4_gpu_append_into_v_blocks` with a `Skip` feed, and
 the helper is gone (it also stored its block head-major, unlike every other iso

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -160,9 +160,10 @@ these six stores: a rollback into the decode window arrives with a target past
 the frozen store's fill, and raising `shape[2]` to meet it would invent coverage
 no payload backs.
 
-The split itself is still `b == 1` only, and that bound is unchanged: at `b > 1`
-the block concatenation is not readable by the decode path, so a mid-block cut
-stays a loud error rather than becoming a scrambled store. What changed is that
+The split itself is still `b == 1` only, and that bound is unchanged: a block's
+rows run `[B, S_block, kv_h, D]`, so keeping a row prefix at `b > 1` would cut
+one batch element and leave the other whole. A mid-block cut therefore stays a
+loud error rather than becoming a half-cut store. What changed is that
 "loud" is now true for the turbo / planar / affine stores too — every CPU dequant
 path checks that its payload decodes to exactly `prod(shape)` and errors with
 `"refusing to zero-pad / truncate"` otherwise. Previously the turbo stores

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -281,6 +281,21 @@ supposed to describe the layout, and a declaration is not evidence of one.
 > declared string here would re-introduce the dependence on an unvalidated,
 > model-side name that keying off the resolved class exists to remove.
 
+> **One-time invalidation (iso4 V).** `layout_key` is derived from
+> `(arch, n_layers, n_kv_heads, head_dim, kv_quant)` and the per-layer block
+> header carries only `{tag, max_seq, shape}`. Neither moves when the byte
+> *orientation* inside a block changes, so a layout change of that kind has to
+> move the **layer tag** or it is invisible on disk. The iso4 V GPU append stored
+> its block head-major while `QuantIsoV4::dequant` reads sequence-major; fixing
+> the append changed the bytes, so `ISOV4_LAYOUT_TAG` and
+> `ISO_SYM_4_LAYOUT_TAG` became `iso_v_4_v2` / `iso_sym_4_v2`. A `.kvb` written
+> before that matches no read arm and fails its hydrate with
+> `unknown layer tag` rather than being decoded with the new orientation —
+> loud, and one cold pass for `--kv-quant iso4` / `iso4_sym` users. Pinned by
+> `block_io_tests::iso4_layout_tags_are_versioned_past_the_head_major_payload`.
+> The iso3 tags are deliberately **not** bumped: that append always reordered
+> heads↔seq, so its bytes are unchanged.
+
 The key is one of the three terms of the block-hash seed, built at the call site
 by `rmlx_kv_ssd::hashing::cache_seed`:
 


### PR DESCRIPTION
Closes #383, closes #392.

**Two distinct defects**, and the evidence separates them rather than assuming:

- **#383 is a read bug** — a whole-buffer reorder over a block concatenation. It is exactly
  correct at `b == 1`, which is every production shape today, so it *cannot* explain #392.
- **#392 is a write/reconcile bug** at `b == 1`. The reported numbers pin it:
  `declared_total = 16896 = 1×1×33×512` against `actual_total = 1024` = 2 tokens. The store's
  CPU blocks held 2 tokens while `shape[2]` said 33 — blocks lost the prefix, which is a
  ring-reconcile failure, not a layout read.

## What changed

`transpose_chunked_seq_heads` reorders each block at its own sequence offset instead of
reading the concatenation as one run; 13 stores now use it, with chunk lengths from
`BlockRows::rows()`. `QuantIsoV3` gained `reconcile_ring`, and the iso4 V GPU append was
routed through the ring-aware helper.

The `dequant_gpu` path — the reader `update_iso3` / `update_iso3_sym` actually use on the GPU
— had the same #383 defect and was missed by the first pass. It is fixed by permuting the
kernel's **input** rows rather than reordering its output: the iso dequant kernel is per-token
positional (`base_out = token * hd + grp * ISO3_GS`, verified against the MSL), so permuting
whole token rows permutes whole `head_dim` output runs identically. The payload was already
copied byte-by-byte, so the permutation is free — and the trailing `reshape + transpose +
contiguous` disappears, leaving one fewer device kernel than before and no host round trip.

A `filled` watermark was added to `QuantKGpuRing`, enforced on **both** reads and writes.
`capacity` is page-rounded, so a readback past the written region returned the allocation's
zeros; and an append at `prev_seq > filled` would have zeroed the gap and then committed a
watermark covering it.

## Three things this branch also fixes, named rather than smuggled

- **The `b > 1` split refusal had a false justification.** `retain_rows` keeps a *row* prefix
  and rows run batch-major, so a row prefix is not a sequence prefix. The gate stays; the
  reason is now true.
- **A third, undeclared correctness fix**: the iso4 V GPU append stored head-major while
  `dequant` reads sequence-major, so `--kv-quant iso4`/`iso4_sym` produced head-scrambled V
  for every multi-token prefill chunk at `kv_h > 1`. Layout tags are bumped to
  `iso_v_4_v2` / `iso_sym_4_v2` so pre-existing `.kvb` entries **miss loudly** instead of
  hydrating scrambled — `layout_key` is tag + geometry only, so nothing else would have
  invalidated them. (The user-facing `--ctv` alias `"iso_v_4"` is a different namespace and
  deliberately unchanged; bumping it blindly would have broken the flag.)
- **The seven flat GPU `dequantize_choice` arms refuse `b != 1`** at `s != 0`. They have no
  payload-vs-shape coverage check, so `s == 1` was never evidence of a single chunk.

## Proof

**CPU, in `make ci`, every mutation measured rather than asserted:**

- 13 stores × `(b, kv_h) ∈ {1,2}²`; the old whole-buffer reorder goes **red at `b=2` and green
  at `b=1`** — reproducing the exact degeneracy that hid the bug.
- `head_major_token_order` proven bijective and equal to an independent index-math oracle.
- Disabling the `filled` guard reddens the ring test; gutting `reconcile_ring` reddens the
  other arm.
- One test found a real bug in the fix itself (a row counter that did not advance within a
  block).

**GPU, fix arm 19/19 PASS, and the second-architecture cell is genuine this time.** An earlier
run's four Bonsai verdicts were vacuous — two warm artifacts were 0 bytes, so `warm == cold`
compared `"" == ""`, because Bonsai-8B is a thinking model and the probe read only
`message.content`. All 8 warm artifacts are now 35 bytes of real output.

- **G5 rotor control clean**: `exceeds filled=` appears **0** times across all 12 fix-arm
  server logs, so the new refusal — which now *aborts* generation where the old code silently
  returned zeros — never false-positives.
- **G2/G3 warm-vs-cold byte equality** on `iso3_sym` and `iso4_sym` × gemma-4-e2b and
  Bonsai-8B. This is the check that catches the *silent* iso4_sym half, where the store returns
  `Ok` while decoding differently.
- **No regression, no silent slow path**: gemma iso3_sym 101.37 vs anchor 100.20, rotor3_sym
  16k 44.55 vs 44.52, k_rotor3 16k 58.44 vs 58.07. The last pair answers whether
  `reconcile_ring`'s unconditional ring drop costs anything when fused and legacy steps
  interleave: it does not.

## The serve-time red half of #392 is UNDEMONSTRATED, and here is why

The base arm exits **4 — INCONCLUSIVE, not passed.** `origin/main` served both turns cleanly
with `kv_quant_resolved=Some(Iso3Sym)` and the `rmlx_iso3_quantize` kernel confirmed in the
log, 0 errors.

That is structural, not a host quirk. The trigger needs a live ring **plus** dropped CPU blocks
— only the fused decode path produces that — and then a decode-mode `update()` with
`q_seq > 1` on that same cache. The two-turn warm-cache probe cannot construct it: gemma4's
`is_prefix` flush has the right shape but runs against a prompt-cache **clone**, and
`try_deep_clone` materialises any ring-only tail into blocks and returns a store with a default
empty ring. A speculative verify chunk would qualify, but no snapshot here pairs a drafter with
a codec that accepts `iso3_sym`. Recorded in `docs/KV_QUANT.md` so it is not re-investigated.

So the #392 fix rests on the CPU tests and their mutations, not on a reproduction.

## Not reached

- `QuantK` (affine q8 K) keeps a flat `codes`/`scales` with no per-append boundary, so a
  multi-append `b > 1` store is **refused, not fixed**.
- `append_gpu`'s call site is gated only by an `#[ignore]` Metal test, not by `make ci` — stated
  in the code rather than overclaimed by a comment.
- Hardcoded `Device::Gpu` remains in `try_deep_clone` on four iso stores and the rotor stores'
  `synced_*`.

`make ci` green.
