### PR TITLE
fix(metrics): bound observation values so an implausible row cannot win the bests view (#401)

### DIFF
--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -166,8 +166,11 @@ pub(crate) fn compute_phase_timing(
     n_generated: usize,
     prompt_tokens: usize,
 ) -> PhaseTiming {
-    // No callback ever fired: nothing was timed, so nothing is reported.
-    let ttft_ms = (n_generated > 0).then_some(first_cb_s * 1000.0);
+    // No callback ever fired, or it landed at t=0: nothing was timed, so
+    // nothing is reported. Same condition as `prefill_tps` below, which is
+    // derived from this same first-callback timestamp — a state one field
+    // calls unmeasured cannot be a measurement in the other.
+    let ttft_ms = (n_generated > 0 && first_cb_s > 0.0).then_some(first_cb_s * 1000.0);
 
     // Decode window: tokens 2..N over (last_cb - first_cb). Needs >= 2 tokens
     // and a positive window; otherwise fall back to the combined number.
@@ -663,12 +666,13 @@ pub(crate) fn run_baseline(
     println!(
         "baseline: model={model_basename}  load={load_ms:.0}ms  ttft_ms={ttft}  \
          decode_tps={decode}  overall_tps={overall}  prefill_tps={prefill}  \
-         prompt_tokens={prompt_token_count}  peak_rss={rss_mb:.1}MB  \
+         prompt_tokens={prompt_token_count}  peak_rss={rss}MB  \
          metal_peak_mb={metal_peak_mb:.1}  metal_gen_alloc_mb={metal_gen_alloc_mb:.1}",
         ttft = fmt_measurement(ttft_ms, 0, "n/a"),
         decode = fmt_measurement(decode_tps, 3, "n/a"),
         overall = fmt_measurement(overall_tps, 3, "n/a"),
         prefill = fmt_measurement(prefill_tps, 1, "n/a"),
+        rss = fmt_measurement(rss_mb_measured, 1, "n/a"),
     );
 
     // Exact generated token-id sequence, one line, opt-in.
@@ -797,7 +801,7 @@ pub(crate) fn run_baseline(
         }
 
         let row = format!(
-            "{},{},rMLX,{},{},{},{},{},{},{:.0},{},{},{:.1},{}\n",
+            "{},{},rMLX,{},{},{},{},{},{},{:.0},{},{},{},{}\n",
             baseline_csv_escape(run_id),
             ts_utc,
             baseline_csv_escape(model_basename),
@@ -809,7 +813,7 @@ pub(crate) fn run_baseline(
             load_ms,
             fmt_measurement(ttft_ms, 0, ""),
             fmt_measurement(tps, 3, ""),
-            rss_mb,
+            fmt_measurement(rss_mb_measured, 1, ""),
             output_cell,
         );
         csv_file

--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -113,6 +113,17 @@ pub(crate) fn peak_rss_mb() -> f64 {
     }
 }
 
+/// Render an optional measurement, substituting `missing` when a run measured
+/// nothing.
+///
+/// A printed `0.0` reads as a measured zero — to a human, to the scripts that
+/// grep the summary line, and to anything that averages the CSV column. The
+/// substitute is `n/a` on the console and an empty field in CSV, both of which
+/// fail a numeric parse instead of quietly weighting a mean.
+fn fmt_measurement(value: Option<f64>, decimals: usize, missing: &str) -> String {
+    value.map_or_else(|| missing.to_string(), |v| format!("{v:.decimals$}"))
+}
+
 /// Per-phase timing computed from the per-token `step_fn` callback wall-clocks.
 ///
 /// `generate_greedy` invokes `step_fn` once per produced token. The FIRST call
@@ -125,12 +136,17 @@ pub(crate) fn peak_rss_mb() -> f64 {
 /// - `overall_tps` = `n_generated / total_elapsed` — the historical combined
 ///   number (prefill + decode), kept for the `overall_tps` metric.
 /// - `prefill_tps` = `prompt_tokens / ttft_s` — prefill throughput.
+///
+/// Every field is `Option`: a run that produced no token measured no rate, and
+/// `0.0` in that slot is a fabricated measurement — it prints, averages and
+/// (once recorded) wins a `bests` cell exactly like a real throughput of zero.
+/// `None` is the only honest answer, and the recorder writes no row for it.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct PhaseTiming {
-    pub ttft_ms: f64,
-    pub decode_tps: f64,
-    pub overall_tps: f64,
-    pub prefill_tps: f64,
+    pub ttft_ms: Option<f64>,
+    pub decode_tps: Option<f64>,
+    pub overall_tps: Option<f64>,
+    pub prefill_tps: Option<f64>,
 }
 
 /// Compute phase timings from raw inputs.
@@ -150,26 +166,20 @@ pub(crate) fn compute_phase_timing(
     n_generated: usize,
     prompt_tokens: usize,
 ) -> PhaseTiming {
-    let ttft_ms = first_cb_s * 1000.0;
+    // No callback ever fired: nothing was timed, so nothing is reported.
+    let ttft_ms = (n_generated > 0).then_some(first_cb_s * 1000.0);
 
     // Decode window: tokens 2..N over (last_cb - first_cb). Needs >= 2 tokens
     // and a positive window; otherwise fall back to the combined number.
     let decode_window_s = last_cb_s - first_cb_s;
-    let overall_tps = if total_s > 0.0 && n_generated > 0 {
-        n_generated as f64 / total_s
-    } else {
-        0.0
-    };
+    let overall_tps = (total_s > 0.0 && n_generated > 0).then(|| n_generated as f64 / total_s);
     let decode_tps = if n_generated >= 2 && decode_window_s > 0.0 {
-        (n_generated as f64 - 1.0) / decode_window_s
+        Some((n_generated as f64 - 1.0) / decode_window_s)
     } else {
         overall_tps
     };
-    let prefill_tps = if first_cb_s > 0.0 && prompt_tokens > 0 {
-        prompt_tokens as f64 / first_cb_s
-    } else {
-        0.0
-    };
+    let prefill_tps =
+        (first_cb_s > 0.0 && prompt_tokens > 0).then(|| prompt_tokens as f64 / first_cb_s);
 
     PhaseTiming {
         ttft_ms,
@@ -562,16 +572,23 @@ pub(crate) fn run_baseline(
     // Invariant: removing the fixed prefill cost from the denominator can only
     // raise TPS. decode_tps must be >= the combined overall_tps for the run.
     debug_assert!(
-        n_generated < 2 || decode_tps + 1e-9 >= overall_tps,
-        "decode_tps ({decode_tps}) must be >= overall_tps ({overall_tps})"
+        n_generated < 2
+            || match (decode_tps, overall_tps) {
+                (Some(d), Some(o)) => d + 1e-9 >= o,
+                _ => true,
+            },
+        "decode_tps ({decode_tps:?}) must be >= overall_tps ({overall_tps:?})"
     );
 
     // `tps` retains the decode-only number for downstream summary + the
     // `decode_tps_warm` metric column (the corrected, prefill-excluded value).
-    let tps: f64 = decode_tps;
+    let tps: Option<f64> = decode_tps;
 
     // -- Peak RSS (after model + generation memory is committed) ---------------
+    // `peak_rss_mb` returns 0.0 when the platform probe fails. A live process
+    // always occupies memory, so that zero is a failed read, not a reading.
     let rss_mb = peak_rss_mb();
+    let rss_mb_measured = (rss_mb > 0.0).then_some(rss_mb);
 
     // -- First-50-token preview ------------------------------------------------
     let preview: String = steps
@@ -644,10 +661,14 @@ pub(crate) fn run_baseline(
         (0.0, 0.0)
     };
     println!(
-        "baseline: model={model_basename}  load={load_ms:.0}ms  ttft_ms={ttft_ms:.0}  \
-         decode_tps={decode_tps:.3}  overall_tps={overall_tps:.3}  prefill_tps={prefill_tps:.1}  \
+        "baseline: model={model_basename}  load={load_ms:.0}ms  ttft_ms={ttft}  \
+         decode_tps={decode}  overall_tps={overall}  prefill_tps={prefill}  \
          prompt_tokens={prompt_token_count}  peak_rss={rss_mb:.1}MB  \
-         metal_peak_mb={metal_peak_mb:.1}  metal_gen_alloc_mb={metal_gen_alloc_mb:.1}"
+         metal_peak_mb={metal_peak_mb:.1}  metal_gen_alloc_mb={metal_gen_alloc_mb:.1}",
+        ttft = fmt_measurement(ttft_ms, 0, "n/a"),
+        decode = fmt_measurement(decode_tps, 3, "n/a"),
+        overall = fmt_measurement(overall_tps, 3, "n/a"),
+        prefill = fmt_measurement(prefill_tps, 1, "n/a"),
     );
 
     // Exact generated token-id sequence, one line, opt-in.
@@ -693,24 +714,31 @@ pub(crate) fn run_baseline(
         .and_then(|tc| tc.max_position_embeddings)
         .unwrap_or(0);
 
-    let metrics_data: &[(&str, &str, f64)] = &[
-        ("baseline_load_ms", "ms", load_ms),
+    // A phase this run did not measure records nothing — an event row reading
+    // `0` tok/s is indistinguishable from a measured stall.
+    let metrics_data: &[(&str, &str, Option<f64>)] = &[
+        ("baseline_load_ms", "ms", Some(load_ms)),
         ("baseline_ttft_ms", "ms", ttft_ms),
         ("baseline_tps", "tok/s", decode_tps),
         ("baseline_overall_tps", "tok/s", overall_tps),
         ("baseline_prefill_tps", "tok/s", prefill_tps),
-        ("baseline_prompt_tokens", "count", prompt_token_count as f64),
-        ("baseline_peak_rss_mb", "MB", rss_mb),
+        (
+            "baseline_prompt_tokens",
+            "count",
+            Some(prompt_token_count as f64),
+        ),
+        ("baseline_peak_rss_mb", "MB", rss_mb_measured),
     ];
 
-    for (op, unit, value) in metrics_data {
+    for (op, unit, measured) in metrics_data {
+        let Some(value) = *measured else { continue };
         sink.record(&rmlx_metrics::events::Measurement {
             model_path: &abs_path_str,
             quant_mode: &quant_mode,
             stage: "baseline",
             op,
             value_unit: unit,
-            value: *value,
+            value,
             notes: &notes_truncated,
         })
         .map_err(|e| anyhow::anyhow!("metrics record {op}: {e}"))?;
@@ -769,7 +797,7 @@ pub(crate) fn run_baseline(
         }
 
         let row = format!(
-            "{},{},rMLX,{},{},{},{},{},{},{:.0},{:.0},{:.3},{:.1},{}\n",
+            "{},{},rMLX,{},{},{},{},{},{},{:.0},{},{},{:.1},{}\n",
             baseline_csv_escape(run_id),
             ts_utc,
             baseline_csv_escape(model_basename),
@@ -779,8 +807,8 @@ pub(crate) fn run_baseline(
             baseline_csv_escape(device_str),
             prompt_token_count,
             load_ms,
-            ttft_ms,
-            tps,
+            fmt_measurement(ttft_ms, 0, ""),
+            fmt_measurement(tps, 3, ""),
             rss_mb,
             output_cell,
         );
@@ -842,7 +870,7 @@ pub(crate) fn run_baseline(
             decode_tps,
             overall_tps,
             prefill_tps,
-            rss_mb,
+            rss_mb_measured,
             n_generated,
             &preview_64,
             kv_cache_bytes,
@@ -973,11 +1001,11 @@ fn build_run_record(
     prompt_tokens: i64,
     max_tokens: i64,
     load_ms: f64,
-    ttft_ms: f64,
-    decode_tps: f64,
-    overall_tps: f64,
-    prefill_tps: f64,
-    rss_mb: f64,
+    ttft_ms: Option<f64>,
+    decode_tps: Option<f64>,
+    overall_tps: Option<f64>,
+    prefill_tps: Option<f64>,
+    rss_mb: Option<f64>,
     n_generated: usize,
     preview_first_64: &str,
     kv_cache_bytes: u64,
@@ -1021,8 +1049,10 @@ fn build_run_record(
 
     // `decode_tps_warm` now carries the prefill-EXCLUDED steady-state number;
     // `overall_tps` keeps the combined prefill+decode value; `prefill_tps` is
-    // prompt throughput.  `kv_cache_bytes` is omitted when 0 (arch not yet
-    // wired) so the RunRecord schema stays backward-compatible.
+    // prompt throughput.  An unmeasured phase serializes to `null` and the
+    // recorder writes no row for it — the §8.5 way of saying "not measured".
+    // `kv_cache_bytes` is omitted when 0 (arch not yet wired) so the RunRecord
+    // schema stays backward-compatible.
     let mut metrics = vec![
         serde_json::json!({ "name": "decode_tps_warm", "value": decode_tps }),
         serde_json::json!({ "name": "overall_tps",     "value": overall_tps }),

--- a/crates/rmlx-cli/src/commands/baseline_tests.rs
+++ b/crates/rmlx-cli/src/commands/baseline_tests.rs
@@ -121,6 +121,10 @@ fn phase_timing_reports_nothing_when_no_token_was_generated() {
 fn phase_timing_reports_no_prefill_rate_without_a_first_callback() {
     let t = compute_phase_timing(0.0, 0.4, 0.4, 8, 4096);
     assert_eq!(t.prefill_tps, None);
+    assert_eq!(
+        t.ttft_ms, None,
+        "ttft_ms fabricated from the same first-callback state prefill_tps calls unmeasured"
+    );
     assert!(t.decode_tps.is_some(), "decode is still measurable here");
 }
 

--- a/crates/rmlx-cli/src/commands/baseline_tests.rs
+++ b/crates/rmlx-cli/src/commands/baseline_tests.rs
@@ -72,29 +72,56 @@ fn csv_escape_empty_string() {
 
 // -- compute_phase_timing -------------------------------------------------
 
+/// Unwrap a measured phase, failing the test if it reads as unmeasured.
+fn measured(v: Option<f64>, what: &str) -> f64 {
+    v.unwrap_or_else(|| panic!("{what} should be measured, got None"))
+}
+
 #[test]
 fn phase_timing_decode_excludes_prefill() {
     // 100 tokens. First callback (TTFT) at 1.0s; last at 2.0s. Total 2.0s.
     // Decode window = 1.0s over 99 tokens => 99 tps.
     // Overall = 100 / 2.0 = 50 tps.
     let t = compute_phase_timing(1.0, 2.0, 2.0, 100, 4096);
-    assert!((t.ttft_ms - 1000.0).abs() < 1e-6, "ttft {}", t.ttft_ms);
-    assert!(
-        (t.decode_tps - 99.0).abs() < 1e-6,
-        "decode {}",
-        t.decode_tps
-    );
-    assert!(
-        (t.overall_tps - 50.0).abs() < 1e-6,
-        "overall {}",
-        t.overall_tps
-    );
+    let ttft = measured(t.ttft_ms, "ttft_ms");
+    let decode = measured(t.decode_tps, "decode_tps");
+    let overall = measured(t.overall_tps, "overall_tps");
+    let prefill = measured(t.prefill_tps, "prefill_tps");
+    assert!((ttft - 1000.0).abs() < 1e-6, "ttft {ttft}");
+    assert!((decode - 99.0).abs() < 1e-6, "decode {decode}");
+    assert!((overall - 50.0).abs() < 1e-6, "overall {overall}");
     // prefill_tps = 4096 / 1.0
-    assert!(
-        (t.prefill_tps - 4096.0).abs() < 1e-6,
-        "prefill {}",
-        t.prefill_tps
+    assert!((prefill - 4096.0).abs() < 1e-6, "prefill {prefill}");
+}
+
+/// A run that produced no token measured no rate. Reporting `0.0` there is
+/// what put fabricated zero-throughput rows into `observations`, where they
+/// win any cell whose only other rows are also zeros.
+#[test]
+fn phase_timing_reports_nothing_when_no_token_was_generated() {
+    let t = compute_phase_timing(0.0, 0.0, 1.5, 0, 4096);
+    assert_eq!(t.ttft_ms, None, "ttft_ms fabricated on a zero-token run");
+    assert_eq!(
+        t.decode_tps, None,
+        "decode_tps fabricated on a zero-token run"
     );
+    assert_eq!(
+        t.overall_tps, None,
+        "overall_tps fabricated on a zero-token run"
+    );
+    assert_eq!(
+        t.prefill_tps, None,
+        "prefill_tps fabricated on a zero-token run"
+    );
+}
+
+/// The prefill rate needs a first-callback timestamp; without one there is no
+/// denominator, so there is no rate — not a rate of zero.
+#[test]
+fn phase_timing_reports_no_prefill_rate_without_a_first_callback() {
+    let t = compute_phase_timing(0.0, 0.4, 0.4, 8, 4096);
+    assert_eq!(t.prefill_tps, None);
+    assert!(t.decode_tps.is_some(), "decode is still measurable here");
 }
 
 #[test]
@@ -108,11 +135,12 @@ fn phase_timing_decode_gte_overall_invariant() {
         (2.0, 2.01, 2.01, 100), // prefill-dominated: decode still >= overall
     ] {
         let t = compute_phase_timing(first, last, total, n, 4096);
+        let decode = measured(t.decode_tps, "decode_tps");
+        let overall = measured(t.overall_tps, "overall_tps");
         assert!(
-            t.decode_tps + 1e-9 >= t.overall_tps,
-            "decode_tps {} must be >= overall_tps {} (first={first} last={last} total={total} n={n})",
-            t.decode_tps,
-            t.overall_tps
+            decode + 1e-9 >= overall,
+            "decode_tps {decode} must be >= overall_tps {overall} \
+             (first={first} last={last} total={total} n={n})"
         );
     }
 }
@@ -121,7 +149,9 @@ fn phase_timing_decode_gte_overall_invariant() {
 fn phase_timing_single_token_falls_back_to_overall() {
     // With n_generated < 2 there is no decode window; decode_tps == overall.
     let t = compute_phase_timing(0.5, 0.5, 0.5, 1, 4096);
-    assert!((t.decode_tps - t.overall_tps).abs() < 1e-9);
+    let decode = measured(t.decode_tps, "decode_tps");
+    let overall = measured(t.overall_tps, "overall_tps");
+    assert!((decode - overall).abs() < 1e-9);
 }
 
 // -- build_run_record: git_sha provenance -----------------------------------
@@ -156,11 +186,11 @@ fn build_record_git_sha_survives_stamp_json() {
         16,
         8,
         0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
+        Some(120.0),
+        Some(40.0),
+        Some(35.0),
+        Some(500.0),
+        Some(1024.0),
         8,
         "",
         0,
@@ -200,11 +230,11 @@ fn build_record_git_sha_absent_is_null() {
         16,
         8,
         0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
+        Some(120.0),
+        Some(40.0),
+        Some(35.0),
+        Some(500.0),
+        Some(1024.0),
         8,
         "",
         0,
@@ -241,11 +271,11 @@ fn build_record_git_sha_blank_string_is_null() {
         16,
         8,
         0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
+        Some(120.0),
+        Some(40.0),
+        Some(35.0),
+        Some(500.0),
+        Some(1024.0),
         8,
         "",
         0,

--- a/crates/rmlx-cli/src/commands/metrics/admin.rs
+++ b/crates/rmlx-cli/src/commands/metrics/admin.rs
@@ -5,7 +5,7 @@ use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
-use rmlx_metrics::{identity, migrate, registry, schema};
+use rmlx_metrics::{bests_view, identity, migrate, registry, schema};
 use rusqlite::params;
 
 // ---------------------------------------------------------------------------
@@ -95,6 +95,20 @@ pub(super) fn cmd_doctor(db_path: &Path, fix: bool) -> anyhow::Result<()> {
         }
     }
 
+    // ── Check 3b: bests view matches the registry ─────────────────────────────
+    //
+    // The view is generated from the §4 registry, not pinned to a migration
+    // number, so a DB already at the latest schema version can still carry a
+    // definition built from an older registry — including one with no
+    // plausibility filter at all. Checking `user_version` cannot see that.
+    {
+        if bests_view::ensure(&conn).context("ensure bests view")? {
+            println!("[fix] bests view: rebuilt from the §4 metric registry");
+        } else {
+            println!("[ok] bests view: definition matches the §4 metric registry");
+        }
+    }
+
     // ── Check 4: whitelist sweep ──────────────────────────────────────────────
     {
         let checks: &[(&str, &str, &[&str])] = &[
@@ -171,7 +185,7 @@ pub(super) fn cmd_doctor(db_path: &Path, fix: bool) -> anyhow::Result<()> {
 
         // Metric column whitelist check
         {
-            let metric_names: Vec<&str> = registry::METRICS.iter().map(|(n, _, _)| *n).collect();
+            let metric_names: Vec<&str> = registry::METRICS.iter().map(|(n, _, _, _)| *n).collect();
             let placeholders = metric_names
                 .iter()
                 .map(|v| format!("'{v}'"))
@@ -275,6 +289,64 @@ pub(super) fn cmd_doctor(db_path: &Path, fix: bool) -> anyhow::Result<()> {
             println!("[ok] unit sanity: all units match registry");
         } else {
             errors += unit_errors;
+        }
+    }
+
+    // ── Check 6b: value plausibility ──────────────────────────────────────────
+    //
+    // Unit sanity above compares the unit *label* against the registry; it
+    // cannot see a number that is not in that unit at all. This check compares
+    // the number against the registry's plausible window: a rate of exactly
+    // 0.0 (a missing field ingested as a measurement) or a value orders of
+    // magnitude past the hardware (an arithmetic accident) is reported here.
+    //
+    // A warning, not an error, and deliberately so. `observations` is
+    // append-only: the rows this finds predate the ingest gate and cannot be
+    // deleted or corrected — the true value is not recoverable from the row,
+    // only re-measurable. An error here would make every `make ci` on a
+    // machine with history permanently red, which is not a gate but a stuck
+    // light. The gate that can actually fail is `RunRecord::validate`, which
+    // refuses such a value at the door; this check is the report of what it
+    // would now refuse, and the `bests` view already excludes the rows.
+    {
+        let mut plausibility_warnings: u32 = 0;
+        for (metric, _, _, bounds) in registry::METRICS {
+            let (bad, min_bad, max_bad, first_id): (i64, Option<f64>, Option<f64>, Option<i64>) =
+                conn.query_row(
+                    &format!(
+                        "SELECT COUNT(*), MIN(value), MAX(value), MIN(id)
+                           FROM observations
+                          WHERE metric = ?1 AND NOT ({})",
+                        bounds.sql("value")
+                    ),
+                    params![metric],
+                    |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+                )
+                .with_context(|| format!("value-plausibility query for metric '{metric}'"))?;
+
+            if bad > 0 {
+                let (lo, hi, id) = (
+                    min_bad.unwrap_or(f64::NAN),
+                    max_bad.unwrap_or(f64::NAN),
+                    first_id.unwrap_or(-1),
+                );
+                eprintln!(
+                    "[WARN] value plausibility: metric '{metric}' has {bad} row(s) outside {} \
+                     (range {lo} .. {hi}, first observation id={id})",
+                    bounds.describe()
+                );
+                plausibility_warnings += 1;
+            }
+        }
+        if plausibility_warnings == 0 {
+            println!("[ok] value plausibility: all values inside registry bounds");
+        } else {
+            println!(
+                "[warn] {plausibility_warnings} metric(s) carry implausible values — historical \
+                 rows, excluded from the `bests` view, refused by ingest today; re-measure, \
+                 do not repair"
+            );
+            warnings += plausibility_warnings;
         }
     }
 

--- a/crates/rmlx-cli/src/commands/metrics/admin.rs
+++ b/crates/rmlx-cli/src/commands/metrics/admin.rs
@@ -101,9 +101,23 @@ pub(super) fn cmd_doctor(db_path: &Path, fix: bool) -> anyhow::Result<()> {
     // number, so a DB already at the latest schema version can still carry a
     // definition built from an older registry — including one with no
     // plausibility filter at all. Checking `user_version` cannot see that.
+    //
+    // Rebuilding is a repair, so it is gated on `--fix` like every other one:
+    // it changes what `bests`, and therefore `BENCHMARK_CHAMPIONS.md`,
+    // publishes. Without `--fix` the drift is reported and left alone.
     {
-        if bests_view::ensure(&conn).context("ensure bests view")? {
-            println!("[fix] bests view: rebuilt from the §4 metric registry");
+        if fix {
+            if bests_view::ensure(&conn).context("rebuild bests view")? {
+                println!("[fix] bests view: rebuilt from the §4 metric registry");
+            } else {
+                println!("[ok] bests view: definition matches the §4 metric registry");
+            }
+        } else if bests_view::is_stale(&conn).context("check bests view")? {
+            eprintln!(
+                "[WARN] bests view: built from a different metric registry than this binary's — \
+                 champion reads do not match §4.1 until `rmlx metrics doctor --fix` rebuilds it"
+            );
+            warnings += 1;
         } else {
             println!("[ok] bests view: definition matches the §4 metric registry");
         }
@@ -305,9 +319,12 @@ pub(super) fn cmd_doctor(db_path: &Path, fix: bool) -> anyhow::Result<()> {
     // deleted or corrected — the true value is not recoverable from the row,
     // only re-measurable. An error here would make every `make ci` on a
     // machine with history permanently red, which is not a gate but a stuck
-    // light. The gate that can actually fail is `RunRecord::validate`, which
-    // refuses such a value at the door; this check is the report of what it
-    // would now refuse, and the `bests` view already excludes the rows.
+    // light. `RunRecord::validate` is what fails at the door, and its reach is
+    // limited in the same way this check's is: bounds reject a value orders of
+    // magnitude out of range, not a wrong value that lands inside it. The
+    // fabricated `(prompt_tokens - 242) * 1000` form, for instance, stays
+    // under the `prefill_tps` ceiling for any prompt below ~342 tokens. The
+    // producer fix is what closes that; this is defence in depth.
     {
         let mut plausibility_warnings: u32 = 0;
         for (metric, _, _, bounds) in registry::METRICS {

--- a/crates/rmlx-cli/src/commands/metrics/export.rs
+++ b/crates/rmlx-cli/src/commands/metrics/export.rs
@@ -29,7 +29,7 @@ pub(super) fn cmd_export(
         anyhow::bail!("--scope only applies to --markdown");
     }
 
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
 
     let scope = match scope_path {

--- a/crates/rmlx-cli/src/commands/metrics/export.rs
+++ b/crates/rmlx-cli/src/commands/metrics/export.rs
@@ -29,8 +29,8 @@ pub(super) fn cmd_export(
         anyhow::bail!("--scope only applies to --markdown");
     }
 
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
 
     let scope = match scope_path {
         Some(p) => Some(

--- a/crates/rmlx-cli/src/commands/metrics/migrate_cmd.rs
+++ b/crates/rmlx-cli/src/commands/metrics/migrate_cmd.rs
@@ -52,6 +52,7 @@ pub(super) fn cmd_migrate(
         "cbb_csv_parse_failures": report.cbb_csv_parse_failures.len(),
         "records_md_cells_added": report.records_md_cells_added,
         "metrics_dropped_implausible": report.metrics_dropped_implausible,
+        "rows_skipped_all_metrics_implausible": report.rows_skipped_all_metrics_implausible,
     });
     println!("{}", serde_json::to_string(&summary)?);
     Ok(())

--- a/crates/rmlx-cli/src/commands/metrics/migrate_cmd.rs
+++ b/crates/rmlx-cli/src/commands/metrics/migrate_cmd.rs
@@ -51,6 +51,7 @@ pub(super) fn cmd_migrate(
         "cbb_csv_rows_skipped": report.cbb_csv_rows_skipped,
         "cbb_csv_parse_failures": report.cbb_csv_parse_failures.len(),
         "records_md_cells_added": report.records_md_cells_added,
+        "metrics_dropped_implausible": report.metrics_dropped_implausible,
     });
     println!("{}", serde_json::to_string(&summary)?);
     Ok(())

--- a/crates/rmlx-cli/src/commands/metrics/prompts_cmds.rs
+++ b/crates/rmlx-cli/src/commands/metrics/prompts_cmds.rs
@@ -24,8 +24,8 @@ pub(super) fn cmd_prompts(db_path: &Path, action: PromptsAction) -> anyhow::Resu
 }
 
 fn cmd_prompts_list(db_path: &Path) -> anyhow::Result<()> {
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let store = prompts::PromptStore::new(&conn);
     let rows = store.list().map_err(|e| anyhow::anyhow!("{e}"))?;
     if rows.is_empty() {
@@ -55,8 +55,8 @@ fn cmd_prompts_list(db_path: &Path) -> anyhow::Result<()> {
 }
 
 fn cmd_prompts_get(db_path: &Path, name: &str) -> anyhow::Result<()> {
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let store = prompts::PromptStore::new(&conn);
     let row = store
         .find_latest_by_name(name)
@@ -83,8 +83,8 @@ fn cmd_prompts_add(
         pf.notes = Some(notes.to_owned());
     }
 
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let store = prompts::PromptStore::new(&conn);
     let id = store
         .get_or_insert(&pf.name, &pf.body, pf.tokens_approx, pf.notes.as_deref())
@@ -96,8 +96,8 @@ fn cmd_prompts_add(
 fn cmd_prompts_sync(db_path: &Path) -> anyhow::Result<()> {
     let root = repo_root();
     let prompts_dir = root.join("prompts");
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let (inserted, total) =
         prompts::sync_dir(&conn, &prompts_dir).map_err(|e| anyhow::anyhow!("{e}"))?;
     println!("sync: inserted={inserted}, total={total}");
@@ -113,8 +113,8 @@ pub(super) fn cmd_champions(
     backend_filter: Option<&str>,
     jsonl: bool,
 ) -> anyhow::Result<()> {
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let rows = query::champions(&conn, backend_filter).map_err(|e| anyhow::anyhow!("{e}"))?;
 
     if jsonl {

--- a/crates/rmlx-cli/src/commands/metrics/prompts_cmds.rs
+++ b/crates/rmlx-cli/src/commands/metrics/prompts_cmds.rs
@@ -24,7 +24,7 @@ pub(super) fn cmd_prompts(db_path: &Path, action: PromptsAction) -> anyhow::Resu
 }
 
 fn cmd_prompts_list(db_path: &Path) -> anyhow::Result<()> {
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
     let store = prompts::PromptStore::new(&conn);
     let rows = store.list().map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -55,7 +55,7 @@ fn cmd_prompts_list(db_path: &Path) -> anyhow::Result<()> {
 }
 
 fn cmd_prompts_get(db_path: &Path, name: &str) -> anyhow::Result<()> {
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
     let store = prompts::PromptStore::new(&conn);
     let row = store

--- a/crates/rmlx-cli/src/commands/metrics/query_cmds.rs
+++ b/crates/rmlx-cli/src/commands/metrics/query_cmds.rs
@@ -48,8 +48,8 @@ pub(super) fn cmd_best(
     prompt_name: Option<&str>,
     metric: &str,
 ) -> anyhow::Result<()> {
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let pid = resolve_prompt_id(&conn, prompt_id, prompt_name)?;
     let cell = query::Cell {
         backend: backend.to_owned(),
@@ -83,8 +83,8 @@ pub(super) fn cmd_rank(
     backend: Option<&str>,
     limit: usize,
 ) -> anyhow::Result<()> {
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let rows = query::rank(&conn, metric, backend, limit).map_err(|e| anyhow::anyhow!("{e}"))?;
     for r in &rows {
         println!("{}", serde_json::to_string(r)?);
@@ -107,8 +107,8 @@ pub(super) fn cmd_compare(
     _kv_quant: Option<&str>,
 ) -> anyhow::Result<()> {
     let backends: Vec<&str> = backends_csv.split(',').map(str::trim).collect();
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let rows = query::compare(&conn, &backends, metric).map_err(|e| anyhow::anyhow!("{e}"))?;
     for r in &rows {
         println!("{}", serde_json::to_string(r)?);
@@ -134,8 +134,8 @@ pub(super) fn cmd_history(
     metric: Option<&str>,
     since: Option<&str>,
 ) -> anyhow::Result<()> {
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let pid = resolve_prompt_id(&conn, prompt_id, prompt_name)?;
     let cell = query::Cell {
         backend: backend.to_owned(),
@@ -172,8 +172,8 @@ pub(super) fn cmd_timeseries(
     since: Option<&str>,
     bucket_str: &str,
 ) -> anyhow::Result<()> {
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let pid = resolve_prompt_id(&conn, prompt_id, prompt_name)?;
     let cell = query::Cell {
         backend: backend.to_owned(),
@@ -207,8 +207,8 @@ pub(super) fn cmd_regress(
     kv: Option<&str>,
     threshold_pct: f64,
 ) -> anyhow::Result<()> {
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
 
     let result = query::regress(&conn, model, metric, kv, threshold_pct)
         .map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -240,8 +240,8 @@ pub(super) fn cmd_deltas(
     threshold_pct: f64,
     exit_code: bool,
 ) -> anyhow::Result<()> {
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let rows =
         query::deltas(&conn, since_sha, Some(threshold_pct)).map_err(|e| anyhow::anyhow!("{e}"))?;
     for r in &rows {
@@ -287,8 +287,8 @@ pub(super) fn cmd_describe(
         anyhow::bail!("either --observation-id or --run-id is required");
     }
 
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
 
     let updated = if let Some(oid) = observation_id {
         conn.execute(
@@ -323,8 +323,8 @@ pub(super) fn cmd_query(db_path: &Path, sql: &str) -> anyhow::Result<()> {
         );
     }
 
-    let conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
     let mut stmt = conn.prepare(sql).context("prepare SQL")?;
 
     // Column names for header row.

--- a/crates/rmlx-cli/src/commands/metrics/query_cmds.rs
+++ b/crates/rmlx-cli/src/commands/metrics/query_cmds.rs
@@ -48,7 +48,7 @@ pub(super) fn cmd_best(
     prompt_name: Option<&str>,
     metric: &str,
 ) -> anyhow::Result<()> {
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
     let pid = resolve_prompt_id(&conn, prompt_id, prompt_name)?;
     let cell = query::Cell {
@@ -83,7 +83,7 @@ pub(super) fn cmd_rank(
     backend: Option<&str>,
     limit: usize,
 ) -> anyhow::Result<()> {
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
     let rows = query::rank(&conn, metric, backend, limit).map_err(|e| anyhow::anyhow!("{e}"))?;
     for r in &rows {
@@ -107,7 +107,7 @@ pub(super) fn cmd_compare(
     _kv_quant: Option<&str>,
 ) -> anyhow::Result<()> {
     let backends: Vec<&str> = backends_csv.split(',').map(str::trim).collect();
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
     let rows = query::compare(&conn, &backends, metric).map_err(|e| anyhow::anyhow!("{e}"))?;
     for r in &rows {
@@ -134,7 +134,7 @@ pub(super) fn cmd_history(
     metric: Option<&str>,
     since: Option<&str>,
 ) -> anyhow::Result<()> {
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
     let pid = resolve_prompt_id(&conn, prompt_id, prompt_name)?;
     let cell = query::Cell {
@@ -172,7 +172,7 @@ pub(super) fn cmd_timeseries(
     since: Option<&str>,
     bucket_str: &str,
 ) -> anyhow::Result<()> {
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
     let pid = resolve_prompt_id(&conn, prompt_id, prompt_name)?;
     let cell = query::Cell {
@@ -207,7 +207,7 @@ pub(super) fn cmd_regress(
     kv: Option<&str>,
     threshold_pct: f64,
 ) -> anyhow::Result<()> {
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
 
     let result = query::regress(&conn, model, metric, kv, threshold_pct)
@@ -240,7 +240,7 @@ pub(super) fn cmd_deltas(
     threshold_pct: f64,
     exit_code: bool,
 ) -> anyhow::Result<()> {
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
     let rows =
         query::deltas(&conn, since_sha, Some(threshold_pct)).map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -287,7 +287,7 @@ pub(super) fn cmd_describe(
         anyhow::bail!("either --observation-id or --run-id is required");
     }
 
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
 
     let updated = if let Some(oid) = observation_id {
@@ -323,7 +323,7 @@ pub(super) fn cmd_query(db_path: &Path, sql: &str) -> anyhow::Result<()> {
         );
     }
 
-    let conn = schema::open_migrated(db_path)
+    let conn = schema::open_checked(db_path)
         .with_context(|| format!("open DB at {}", db_path.display()))?;
     let mut stmt = conn.prepare(sql).context("prepare SQL")?;
 

--- a/crates/rmlx-cli/src/commands/metrics/record.rs
+++ b/crates/rmlx-cli/src/commands/metrics/record.rs
@@ -154,8 +154,8 @@ pub(super) fn ingest_one(
         return Ok(None);
     }
 
-    let mut conn =
-        schema::open(db_path).with_context(|| format!("open DB at {}", db_path.display()))?;
+    let mut conn = schema::open_migrated(db_path)
+        .with_context(|| format!("open DB at {}", db_path.display()))?;
 
     let inserted_by = RunIdentity::get().inserted_by("rmlx-cli");
     let mut rec = Recorder::new(&mut conn, inserted_by);

--- a/crates/rmlx-metrics/src/bests_view.rs
+++ b/crates/rmlx-metrics/src/bests_view.rs
@@ -1,0 +1,91 @@
+//! The `bests` view — champion per cell (docs/METRICS_DB.md §3.3).
+//!
+//! The view ranks `observations` within each cell partition, so whatever the
+//! largest `higher_better` value in a partition is becomes that cell's
+//! published champion. That is the right rule *for measurements*, and the
+//! wrong rule for anything else: a fabricated stand-in — a rate of `0.0` from
+//! a run that generated no tokens, a prefill "rate" that is really
+//! `prompt_tokens × 1000` — beats every real row it shares a partition with
+//! and then publishes into `BENCHMARK_CHAMPIONS.md`.
+//!
+//! So the view only ranks rows the §4 registry can call a measurement, and the
+//! predicate is *generated from that registry* rather than retyped in SQL:
+//! one definition of "plausible", enforced at ingest by
+//! [`crate::ingest::RunRecord::validate`] and here by the same [`Bounds`] the
+//! validator uses. [`ensure`] rebuilds the view whenever the stored definition
+//! and the registry disagree, so a bounds change propagates on the next open
+//! instead of silently applying to new rows only.
+//!
+//! [`Bounds`]: crate::registry::Bounds
+
+use std::fmt::Write as _;
+
+use rusqlite::Connection;
+
+use crate::error::Result;
+use crate::registry;
+
+/// Renders the `CREATE VIEW` statement for `bests` from the §4 registry.
+///
+/// No parameterization: every fragment comes from the compile-time registry.
+pub fn create_sql() -> String {
+    let mut plausible = String::from("CASE metric\n");
+    for (name, _, _, bounds) in registry::METRICS {
+        // write! to a String is infallible — the unit Ok is discarded.
+        let _ = writeln!(
+            plausible,
+            "                WHEN '{name}' THEN ({})",
+            bounds.sql("value")
+        );
+    }
+    // A metric with no registry entry cannot be bounded, only reported —
+    // `rmlx metrics doctor` fails on it under the metric-whitelist check.
+    plausible.push_str("                ELSE 1\n            END");
+
+    format!(
+        "CREATE VIEW bests AS
+WITH ranked AS (
+    SELECT
+        o.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY backend, model_namespace, model, weight_quant, kv_quant,
+                         ctx_max, prompt_id, metric
+            ORDER BY
+                CASE WHEN direction = 'higher_better' THEN  value END DESC,
+                CASE WHEN direction = 'lower_better'  THEN -value END DESC,
+                ts_utc DESC
+        ) AS rn
+    FROM observations o
+    WHERE {plausible}
+)
+SELECT * FROM ranked WHERE rn = 1"
+    )
+}
+
+/// Recreates `bests` when the stored definition does not match [`create_sql`].
+///
+/// Returns `true` when the view was rebuilt. A view holds no data, so dropping
+/// and recreating it mutates no observation — the append-only contract is
+/// untouched.
+pub fn ensure(conn: &Connection) -> Result<bool> {
+    let want = create_sql();
+
+    let stored: Option<String> = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'bests'",
+            [],
+            |r| r.get(0),
+        )
+        .ok();
+
+    if stored.as_deref() == Some(want.as_str()) {
+        return Ok(false);
+    }
+
+    conn.execute_batch(&format!("DROP VIEW IF EXISTS bests;\n{want};"))?;
+    Ok(true)
+}
+
+#[cfg(test)]
+#[path = "bests_view_tests.rs"]
+mod tests;

--- a/crates/rmlx-metrics/src/bests_view.rs
+++ b/crates/rmlx-metrics/src/bests_view.rs
@@ -25,22 +25,34 @@ use rusqlite::Connection;
 use crate::error::Result;
 use crate::registry;
 
-/// Renders the `CREATE VIEW` statement for `bests` from the §4 registry.
+/// Renders the §4.1 plausibility predicate as a SQLite boolean expression over
+/// `column`, keyed on the row's `metric`.
+///
+/// Every consumer that ranks or aggregates `observations` must `AND` this in.
+/// `bests` does it once, but `deltas`, `regress` and `timeseries` each run
+/// their own SQL over the base table — and a gate that ranks the rows the
+/// champion view refuses is the drift this predicate exists to prevent.
 ///
 /// No parameterization: every fragment comes from the compile-time registry.
-pub fn create_sql() -> String {
-    let mut plausible = String::from("CASE metric\n");
+pub fn plausible_sql(column: &str) -> String {
+    let mut sql = String::from("CASE metric\n");
     for (name, _, _, bounds) in registry::METRICS {
         // write! to a String is infallible — the unit Ok is discarded.
         let _ = writeln!(
-            plausible,
+            sql,
             "                WHEN '{name}' THEN ({})",
-            bounds.sql("value")
+            bounds.sql(column)
         );
     }
     // A metric with no registry entry cannot be bounded, only reported —
     // `rmlx metrics doctor` fails on it under the metric-whitelist check.
-    plausible.push_str("                ELSE 1\n            END");
+    sql.push_str("                ELSE 1\n            END");
+    sql
+}
+
+/// Renders the `CREATE VIEW` statement for `bests` from the §4 registry.
+pub fn create_sql() -> String {
+    let plausible = plausible_sql("value");
 
     format!(
         "CREATE VIEW bests AS
@@ -62,6 +74,30 @@ SELECT * FROM ranked WHERE rn = 1"
     )
 }
 
+/// Reads the stored `CREATE VIEW` text for `bests`, if the view exists.
+///
+/// `None` means *absent*, and nothing else: a locked, damaged or unreadable DB
+/// propagates its error rather than being reported as "stale" and then dropped.
+fn stored_sql(conn: &Connection) -> Result<Option<String>> {
+    match conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'bests'",
+        [],
+        |r| r.get::<_, String>(0),
+    ) {
+        Ok(sql) => Ok(Some(sql)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Whether the stored `bests` definition differs from the registry's.
+///
+/// A read command calls this instead of [`ensure`]: it must know the view is
+/// current, and must not be the thing that changes it.
+pub fn is_stale(conn: &Connection) -> Result<bool> {
+    Ok(stored_sql(conn)?.as_deref() != Some(create_sql().as_str()))
+}
+
 /// Recreates `bests` when the stored definition does not match [`create_sql`].
 ///
 /// Returns `true` when the view was rebuilt. A view holds no data, so dropping
@@ -70,15 +106,7 @@ SELECT * FROM ranked WHERE rn = 1"
 pub fn ensure(conn: &Connection) -> Result<bool> {
     let want = create_sql();
 
-    let stored: Option<String> = conn
-        .query_row(
-            "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'bests'",
-            [],
-            |r| r.get(0),
-        )
-        .ok();
-
-    if stored.as_deref() == Some(want.as_str()) {
+    if stored_sql(conn)?.as_deref() == Some(want.as_str()) {
         return Ok(false);
     }
 

--- a/crates/rmlx-metrics/src/bests_view_tests.rs
+++ b/crates/rmlx-metrics/src/bests_view_tests.rs
@@ -1,0 +1,187 @@
+use rusqlite::Connection;
+use serde_json::json;
+
+use crate::{
+    ingest::{MetricEntry, PromptRef, RunRecord},
+    recorder::Recorder,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+fn test_conn() -> Connection {
+    let mut conn = Connection::open_in_memory().unwrap();
+    crate::migrate::run_pending(&mut conn).unwrap();
+    conn
+}
+
+fn make_run(metric: &str, value: f64, kv_quant: &str) -> RunRecord {
+    RunRecord {
+        schema_version: crate::ingest::RECORD_SCHEMA_VERSION,
+        backend: "rmlx".into(),
+        backend_version: Some("0.1.0".into()),
+        model_namespace: "mlx-community".into(),
+        model: "Qwen3.6-35B-A3B-8bit".into(),
+        weight_quant: "q8_0".into(),
+        kv_quant: kv_quant.into(),
+        ctx_max: 131_072,
+        prompt: PromptRef::ByBody {
+            name: "longctx_128k".into(),
+            body: json!("the quick brown fox"),
+            notes: None,
+            tokens_approx: Some(4),
+        },
+        ts_utc: "2026-05-11T16:06:44Z".into(),
+        git_sha: None,
+        build_profile: Some("release".into()),
+        hardware_tag: "m5_max_128gb".into(),
+        prompt_tokens: Some(131_052),
+        max_tokens: Some(32),
+        temperature: Some(0.0),
+        seed: Some(0),
+        n_warmups: Some(1),
+        n_measure: Some(3),
+        output_first_64: None,
+        notes: None,
+        description: None,
+        metrics: vec![MetricEntry {
+            name: metric.into(),
+            value: Some(value),
+            stddev: None,
+        }],
+    }
+}
+
+/// Clone an existing observation with a new value / kv_quant, bypassing the
+/// ingest validator — the historical rows this view has to survive were
+/// written before any value gate existed, and cannot be re-created through it.
+fn clone_row_with(conn: &Connection, metric: &str, value: f64, kv_quant: &str) {
+    conn.execute(
+        "INSERT INTO observations (
+             backend, model_namespace, model, weight_quant, kv_quant, ctx_max, prompt_id,
+             metric, value, unit, direction, run_id, ts_utc, hardware_tag,
+             inserted_utc, inserted_by
+         )
+         SELECT backend, model_namespace, model, weight_quant, ?1, ctx_max, prompt_id,
+                metric, ?2, unit, direction, run_id, ts_utc, hardware_tag,
+                inserted_utc, inserted_by
+           FROM observations WHERE metric = ?3 LIMIT 1",
+        rusqlite::params![kv_quant, value, metric],
+    )
+    .unwrap();
+}
+
+fn bests_values(conn: &Connection, metric: &str) -> Vec<(String, f64)> {
+    let mut stmt = conn
+        .prepare("SELECT kv_quant, value FROM bests WHERE metric = ?1 ORDER BY kv_quant")
+        .unwrap();
+    let rows = stmt
+        .query_map(rusqlite::params![metric], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    rows
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+/// A 998×-inflated `prefill_tps` row sharing a cell with a real measurement
+/// must not become that cell's champion.
+#[test]
+fn implausible_prefill_row_does_not_win_its_cell() {
+    let mut conn = test_conn();
+    {
+        let mut rec = Recorder::new(&mut conn, "test@0.1.0");
+        rec.record_run(&make_run("prefill_tps", 494.7, "k8v4"))
+            .unwrap();
+    }
+    // (prompt_tokens - 242) * 1000 for a 131_052-token prompt.
+    clone_row_with(&conn, "prefill_tps", 130_810_000.0, "k8v4");
+
+    assert_eq!(
+        bests_values(&conn, "prefill_tps"),
+        vec![("k8v4".to_string(), 494.7)],
+        "the inflated row won the cell"
+    );
+}
+
+/// A cell whose only `prefill_tps` row is `0.0` must leave `bests` entirely —
+/// an upper bound alone would promote the zero into the champion table.
+#[test]
+fn a_cell_whose_only_rate_is_zero_leaves_bests() {
+    let mut conn = test_conn();
+    {
+        let mut rec = Recorder::new(&mut conn, "test@0.1.0");
+        rec.record_run(&make_run("prefill_tps", 494.7, "k8v4"))
+            .unwrap();
+    }
+    clone_row_with(&conn, "prefill_tps", 0.0, "planar");
+
+    let bests = bests_values(&conn, "prefill_tps");
+    assert!(
+        bests.iter().all(|(kv, _)| kv != "planar"),
+        "a zero-rate-only cell published a champion: {bests:?}"
+    );
+    assert_eq!(bests.len(), 1, "the plausible cell must survive: {bests:?}");
+}
+
+/// The bound is per metric, not per number: `0` cache hits is a measurement
+/// and must keep winning its cell. Guards the filter against over-reach.
+#[test]
+fn a_zero_counter_still_wins_its_cell() {
+    let mut conn = test_conn();
+    {
+        let mut rec = Recorder::new(&mut conn, "test@0.1.0");
+        rec.record_run(&make_run("prompt_cache_hits", 0.0, "k8v4"))
+            .unwrap();
+    }
+
+    assert_eq!(
+        bests_values(&conn, "prompt_cache_hits"),
+        vec![("k8v4".to_string(), 0.0)],
+        "a legitimate zero counter was filtered out of bests"
+    );
+}
+
+/// A DB carrying an older `bests` definition is brought in line with the
+/// registry on the next migration run, and left alone once it matches.
+#[test]
+fn ensure_rebuilds_a_stale_definition_exactly_once() {
+    let conn = test_conn();
+
+    conn.execute_batch(
+        "DROP VIEW bests;
+         CREATE VIEW bests AS SELECT * FROM observations",
+    )
+    .unwrap();
+
+    assert!(
+        super::ensure(&conn).unwrap(),
+        "a stale view definition was left in place"
+    );
+    assert!(
+        !super::ensure(&conn).unwrap(),
+        "a current view definition was needlessly rebuilt"
+    );
+
+    let stored: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'bests'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(stored, super::create_sql());
+}
+
+/// Every registry metric contributes a branch, so no metric can be silently
+/// unbounded in the view.
+#[test]
+fn generated_predicate_covers_every_registry_metric() {
+    let sql = super::create_sql();
+    for (name, _, _, _) in crate::registry::METRICS {
+        assert!(
+            sql.contains(&format!("WHEN '{name}' THEN")),
+            "metric '{name}' has no branch in the bests predicate"
+        );
+    }
+}

--- a/crates/rmlx-metrics/src/bests_view_tests.rs
+++ b/crates/rmlx-metrics/src/bests_view_tests.rs
@@ -185,3 +185,26 @@ fn generated_predicate_covers_every_registry_metric() {
         );
     }
 }
+
+/// The rendered branch is what SQLite enforces — pin the text, not just the
+/// presence of the metric's name.
+#[test]
+fn generated_predicate_renders_the_registry_bound() {
+    let sql = super::plausible_sql("value");
+    assert!(
+        sql.contains("WHEN 'prefill_tps' THEN (value > 0.0 AND value <= 100000.0)"),
+        "prefill_tps branch is not the registry's bound:\n{sql}"
+    );
+    assert!(
+        sql.contains("WHEN 'prompt_cache_hits' THEN (value >= 0.0 AND value <= 1000000000000.0)"),
+        "a counter's inclusive floor did not render:\n{sql}"
+    );
+    assert!(sql.trim_end().ends_with("ELSE 1\n            END"));
+}
+
+/// The predicate a read command applies must be the one the view was built
+/// with — that identity is the whole reason it is generated in one place.
+#[test]
+fn read_side_predicate_is_the_view_predicate() {
+    assert!(super::create_sql().contains(&super::plausible_sql("value")));
+}

--- a/crates/rmlx-metrics/src/error.rs
+++ b/crates/rmlx-metrics/src/error.rs
@@ -38,6 +38,26 @@ pub enum Error {
     #[error("unknown metric: '{0}' (not in registry; see docs/METRICS_DB.md §4)")]
     UnknownMetric(String),
 
+    /// The value cannot be a measurement of the metric it is filed under.
+    ///
+    /// A rate of exactly `0.0`, or a value orders of magnitude past what the
+    /// hardware can produce, is a missing or miscomputed field, not a record —
+    /// and once stored it wins the `bests` view and publishes as a champion.
+    /// Emitters must send `null` for a measurement they do not have.
+    #[error(
+        "ingest: {value} is not a plausible '{metric}' — the registry bounds are {bounds} \
+         (see docs/METRICS_DB.md §4). Send null, not a placeholder, for a metric \
+         this run did not measure."
+    )]
+    ImplausibleValue {
+        /// Registry name of the metric the value was filed under.
+        metric: String,
+        /// The value that was rejected.
+        value: f64,
+        /// Human-readable rendering of the plausible window, e.g. `(0, 100000]`.
+        bounds: String,
+    },
+
     /// The direction string is not `"higher_better"` or `"lower_better"`.
     #[error("unknown direction: '{0}' (must be 'higher_better' or 'lower_better')")]
     UnknownDirection(String),

--- a/crates/rmlx-metrics/src/identity_tests.rs
+++ b/crates/rmlx-metrics/src/identity_tests.rs
@@ -68,6 +68,7 @@ fn split_model_path_unknown_namespace_errors() {
         | Error::Schema(_)
         | Error::IdentityModelPath(_)
         | Error::UnknownMetric(_)
+        | Error::ImplausibleValue { .. }
         | Error::UnknownDirection(_)
         | Error::InvalidTimestamp(_)
         | Error::InvalidPrompt(_)
@@ -101,6 +102,7 @@ fn canonicalize_backend_unknown() {
         | Error::Schema(_)
         | Error::IdentityModelPath(_)
         | Error::UnknownMetric(_)
+        | Error::ImplausibleValue { .. }
         | Error::UnknownDirection(_)
         | Error::InvalidTimestamp(_)
         | Error::InvalidPrompt(_)
@@ -148,6 +150,7 @@ fn alias_normalization_non_backend_field_untouched() {
         | Error::Schema(_)
         | Error::IdentityModelPath(_)
         | Error::UnknownMetric(_)
+        | Error::ImplausibleValue { .. }
         | Error::UnknownDirection(_)
         | Error::InvalidTimestamp(_)
         | Error::InvalidPrompt(_)

--- a/crates/rmlx-metrics/src/ingest.rs
+++ b/crates/rmlx-metrics/src/ingest.rs
@@ -268,6 +268,29 @@ pub(crate) enum IdentityPolicy {
 // ── RunRecord impl ────────────────────────────────────────────────────────────
 
 impl RunRecord {
+    /// Drops metric entries the §4 registry cannot read as a measurement,
+    /// returning how many were dropped.
+    ///
+    /// For the *archive* converters only (`migrate::legacy`). Those tools'
+    /// CSV/JSONL exports write `0.0` in a column they did not measure, and a
+    /// whole historical run should not be lost because one column carries
+    /// that placeholder. Live ingest gets no such courtesy: [`Self::validate`]
+    /// rejects the record so the emitter is fixed rather than the number
+    /// quietly dropped.
+    pub(crate) fn drop_implausible_metrics(&mut self) -> usize {
+        let before = self.metrics.len();
+        self.metrics.retain(|entry| match entry.value {
+            Some(value) => match registry::bounds(&entry.name) {
+                Ok(bounds) => bounds.contains(value),
+                // An unregistered name is not this function's business — keep
+                // it so `validate` still rejects it by name.
+                Err(_) => true,
+            },
+            None => true,
+        });
+        before - self.metrics.len()
+    }
+
     /// Validates per §8.5 required fields + §4 metric registry + §5
     /// whitelists (`backend`, `weight_quant`), enforcing the run-identity
     /// contract ([`IdentityPolicy::Enforce`]). `model_namespace`, `model`,
@@ -401,9 +424,23 @@ impl RunRecord {
             return Err(Error::NoMeasurements);
         }
 
-        // every metric name in registry
+        // every metric name in registry, and every value a possible
+        // measurement of it. A null value is a deliberate "not measured" and
+        // is skipped by the recorder; a fabricated stand-in (a zero rate, an
+        // arithmetic accident orders of magnitude out of range) is not, and it
+        // outranks every real row in `bests` the moment it lands.
         for entry in &self.metrics {
             registry::lookup(&entry.name)?;
+            if let Some(value) = entry.value {
+                let bounds = registry::bounds(&entry.name)?;
+                if !bounds.contains(value) {
+                    return Err(Error::ImplausibleValue {
+                        metric: entry.name.clone(),
+                        value,
+                        bounds: bounds.describe(),
+                    });
+                }
+            }
         }
 
         Ok(())

--- a/crates/rmlx-metrics/src/ingest_tests.rs
+++ b/crates/rmlx-metrics/src/ingest_tests.rs
@@ -564,3 +564,59 @@ fn null_value_is_the_way_to_say_not_measured() {
     });
     r.validate().unwrap();
 }
+
+// ── archive-only placeholder drop ─────────────────────────────────────────
+
+#[test]
+fn drop_implausible_metrics_removes_only_the_placeholders() {
+    let mut r = valid_record();
+    r.metrics = vec![
+        MetricEntry {
+            name: "decode_tps_warm".to_string(),
+            value: Some(0.0), // a rate of zero: not a measurement
+            stddev: None,
+        },
+        MetricEntry {
+            name: "prefill_tps".to_string(),
+            value: Some(130_810_000.0), // out of range
+            stddev: None,
+        },
+        MetricEntry {
+            name: "peak_rss_mb".to_string(),
+            value: Some(35_392.0), // real
+            stddev: None,
+        },
+        MetricEntry {
+            name: "prompt_cache_hits".to_string(),
+            value: Some(0.0), // a counter's zero IS a measurement
+            stddev: None,
+        },
+        MetricEntry {
+            name: "ttft_warm_ms".to_string(),
+            value: None, // already "not measured"
+            stddev: None,
+        },
+    ];
+
+    assert_eq!(r.drop_implausible_metrics(), 2);
+    let kept: Vec<&str> = r.metrics.iter().map(|m| m.name.as_str()).collect();
+    assert_eq!(
+        kept,
+        vec!["peak_rss_mb", "prompt_cache_hits", "ttft_warm_ms"],
+        "wrong entries survived the archive drop"
+    );
+    // What survives must then pass the gate.
+    r.validate().unwrap();
+}
+
+#[test]
+fn drop_implausible_metrics_leaves_an_unregistered_name_for_validate() {
+    let mut r = valid_record();
+    r.metrics[0].name = "not_a_metric".to_string();
+    assert_eq!(
+        r.drop_implausible_metrics(),
+        0,
+        "an unknown name is validate's to reject, not this function's to hide"
+    );
+    assert!(matches!(r.validate().unwrap_err(), Error::UnknownMetric(_)));
+}

--- a/crates/rmlx-metrics/src/ingest_tests.rs
+++ b/crates/rmlx-metrics/src/ingest_tests.rs
@@ -488,3 +488,79 @@ fn record_with_model_id_alias_ingests() {
     assert_eq!(r.model, "Ternary-Bonsai-8B-mlx-2bit");
     r.validate().unwrap();
 }
+
+// ── §4 value plausibility ─────────────────────────────────────────────────
+
+#[test]
+fn zero_rate_rejected() {
+    // A run that generated no tokens has no rate to report — the recorder
+    // skips a `null` entry, so an emitter has no reason to send `0.0`.
+    let mut r = valid_record();
+    r.metrics[0].value = Some(0.0);
+    let err = r.validate().unwrap_err();
+    assert!(
+        matches!(err, Error::ImplausibleValue { ref metric, value, .. }
+                 if metric == "decode_tps_warm" && value == 0.0),
+        "expected ImplausibleValue, got {err}"
+    );
+}
+
+#[test]
+fn out_of_range_rate_rejected() {
+    // `(prompt_tokens - 242) * 1000` for a 131k-token prompt: the closed-form
+    // non-rate that this gate exists to stop at the door.
+    let mut r = valid_record();
+    r.metrics[0].name = "prefill_tps".to_string();
+    r.metrics[0].value = Some(130_810_000.0);
+    let err = r.validate().unwrap_err();
+    assert!(
+        matches!(err, Error::ImplausibleValue { ref metric, .. } if metric == "prefill_tps"),
+        "expected ImplausibleValue, got {err}"
+    );
+}
+
+#[test]
+fn non_finite_value_rejected() {
+    let mut r = valid_record();
+    r.metrics[0].value = Some(f64::NAN);
+    assert!(matches!(
+        r.validate().unwrap_err(),
+        Error::ImplausibleValue { .. }
+    ));
+    r.metrics[0].value = Some(f64::INFINITY);
+    assert!(matches!(
+        r.validate().unwrap_err(),
+        Error::ImplausibleValue { .. }
+    ));
+}
+
+#[test]
+fn zero_counter_accepted() {
+    // The floor is per metric: zero cache hits is a measurement, and
+    // rejecting it would drop a valid record.
+    let mut r = valid_record();
+    r.metrics[0].name = "prompt_cache_hits".to_string();
+    r.metrics[0].value = Some(0.0);
+    r.validate().unwrap();
+}
+
+#[test]
+fn zero_duration_accepted() {
+    // Millisecond resolution rounds a sub-millisecond span to zero; that is
+    // a coarse measurement, not a missing one.
+    let mut r = valid_record();
+    r.metrics[0].name = "ttft_warm_ms".to_string();
+    r.metrics[0].value = Some(0.0);
+    r.validate().unwrap();
+}
+
+#[test]
+fn null_value_is_the_way_to_say_not_measured() {
+    let mut r = valid_record();
+    r.metrics.push(MetricEntry {
+        name: "prefill_tps".to_string(),
+        value: None,
+        stddev: None,
+    });
+    r.validate().unwrap();
+}

--- a/crates/rmlx-metrics/src/lib.rs
+++ b/crates/rmlx-metrics/src/lib.rs
@@ -19,6 +19,7 @@
     )
 )]
 
+pub mod bests_view;
 pub mod error;
 pub mod events;
 pub mod export;

--- a/crates/rmlx-metrics/src/migrate/legacy.rs
+++ b/crates/rmlx-metrics/src/migrate/legacy.rs
@@ -81,6 +81,11 @@ pub struct MigrateReport {
 
     /// Number of `BENCHMARK_RECORDS.md` table cells successfully ingested.
     pub records_md_cells_added: usize,
+
+    /// Metric entries dropped because the archive carried a placeholder the §4
+    /// bounds cannot read as a measurement (a `0.0` in a column the exporting
+    /// tool never measured). Counted, not silent.
+    pub metrics_dropped_implausible: usize,
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -236,7 +241,7 @@ fn migrate_jsonl_files(
             }
             report.rmlx_jsonl_rows_total += 1;
 
-            match ingest_jsonl_row(conn, line, is_dirty_file, prompt, opts) {
+            match ingest_jsonl_row(conn, line, is_dirty_file, prompt, opts, report) {
                 Ok(inserted) => {
                     if inserted {
                         report.rmlx_jsonl_rows_inserted += 1;
@@ -271,6 +276,7 @@ fn ingest_jsonl_row(
     is_dirty_file: bool,
     prompt: &LoadedPrompt,
     opts: &MigrateOptions,
+    report: &mut MigrateReport,
 ) -> Result<bool> {
     let row: RmlxJsonlRow =
         serde_json::from_str(line).map_err(|e| Error::Schema(format!("JSONL parse error: {e}")))?;
@@ -334,7 +340,7 @@ fn ingest_jsonl_row(
         });
     }
 
-    let run = RunRecord {
+    let mut run = RunRecord {
         schema_version: RECORD_SCHEMA_VERSION,
         backend: "rmlx".to_string(),
         backend_version: None,
@@ -364,6 +370,12 @@ fn ingest_jsonl_row(
         description: None,
         metrics,
     };
+
+    // Same placeholder convention as the CSV pass — see the note there.
+    report.metrics_dropped_implausible += run.drop_implausible_metrics();
+    if run.metrics.is_empty() {
+        return Ok(false);
+    }
 
     let mut rec = Recorder::legacy_archive(conn, &opts.inserted_by);
     rec.record_run(&run)?;
@@ -594,15 +606,6 @@ fn migrate_cbb_csv(
             });
         }
 
-        // Filter out zero-value task_pass_at_1 that CBB emits when not measured.
-        let metrics: Vec<MetricEntry> = metrics
-            .into_iter()
-            .filter(|m| {
-                m.value
-                    .is_some_and(|v| v != 0.0 || m.name != "task_pass_at_1")
-            })
-            .collect();
-
         if metrics.is_empty() {
             report.cbb_csv_rows_skipped += 1;
             continue;
@@ -612,7 +615,7 @@ fn migrate_cbb_csv(
             "legacy_run_key={legacy_key}; migrated from CBB summary.csv"
         ));
 
-        let run = RunRecord {
+        let mut run = RunRecord {
             schema_version: RECORD_SCHEMA_VERSION,
             backend,
             backend_version,
@@ -637,6 +640,16 @@ fn migrate_cbb_csv(
             description: None,
             metrics,
         };
+
+        // The exporter writes `0.0` in a column it did not measure — that is
+        // what the old `task_pass_at_1 == 0.0` special case was reacting to.
+        // The §4 bounds say which metrics can read zero, so the placeholder is
+        // dropped for all of them, not just the one that was noticed first.
+        report.metrics_dropped_implausible += run.drop_implausible_metrics();
+        if run.metrics.is_empty() {
+            report.cbb_csv_rows_skipped += 1;
+            continue;
+        }
 
         match Recorder::legacy_archive(conn, &opts.inserted_by).record_run(&run) {
             Ok(_) => report.cbb_csv_rows_inserted += 1,

--- a/crates/rmlx-metrics/src/migrate/legacy.rs
+++ b/crates/rmlx-metrics/src/migrate/legacy.rs
@@ -86,6 +86,11 @@ pub struct MigrateReport {
     /// bounds cannot read as a measurement (a `0.0` in a column the exporting
     /// tool never measured). Counted, not silent.
     pub metrics_dropped_implausible: usize,
+
+    /// Rows skipped because *every* one of their metrics was such a
+    /// placeholder. A subset of the per-source `rows_skipped` counters, which
+    /// otherwise cannot tell this apart from an idempotent re-run skip.
+    pub rows_skipped_all_metrics_implausible: usize,
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -374,6 +379,10 @@ fn ingest_jsonl_row(
     // Same placeholder convention as the CSV pass — see the note there.
     report.metrics_dropped_implausible += run.drop_implausible_metrics();
     if run.metrics.is_empty() {
+        // The caller reads `Ok(false)` as "already present, skipped". Count
+        // this case separately so a row that was all placeholders is not
+        // silently filed under idempotency.
+        report.rows_skipped_all_metrics_implausible += 1;
         return Ok(false);
     }
 
@@ -598,7 +607,12 @@ fn migrate_cbb_csv(
                 stddev: None,
             });
         }
-        if let Some(v) = parse_f64(ci_task_pass) {
+        // CBB writes `0.0` in this column when it ran no quality probe at all.
+        // The number alone cannot tell that apart from a graded run that scored
+        // zero — both are a legitimate `task_pass_at_1` value, so the §4.1
+        // bounds cannot drop it and must not. The column convention is only
+        // known here, at the parse site, so the decision stays here.
+        if let Some(v) = parse_f64(ci_task_pass).filter(|v| *v != 0.0) {
             metrics.push(MetricEntry {
                 name: "task_pass_at_1".into(),
                 value: Some(v),
@@ -641,13 +655,14 @@ fn migrate_cbb_csv(
             metrics,
         };
 
-        // The exporter writes `0.0` in a column it did not measure — that is
-        // what the old `task_pass_at_1 == 0.0` special case was reacting to.
-        // The §4 bounds say which metrics can read zero, so the placeholder is
-        // dropped for all of them, not just the one that was noticed first.
+        // The exporter also writes `0.0` in rate columns it never measured.
+        // Those the §4.1 bounds *can* identify — a rate of zero is not a
+        // measurement of anything — so they are dropped generically here,
+        // unlike `task_pass_at_1` above whose zero is a real score.
         report.metrics_dropped_implausible += run.drop_implausible_metrics();
         if run.metrics.is_empty() {
             report.cbb_csv_rows_skipped += 1;
+            report.rows_skipped_all_metrics_implausible += 1;
             continue;
         }
 

--- a/crates/rmlx-metrics/src/migrate/legacy_tests.rs
+++ b/crates/rmlx-metrics/src/migrate/legacy_tests.rs
@@ -127,7 +127,15 @@ fn migrate_one_jsonl_row_inserts_two_metrics() {
     let prompt = load_prompt_file(&prompt_dir.path().join("longctx_4k.json")).unwrap();
     let mut conn = test_conn();
 
-    let inserted = ingest_jsonl_row(&mut conn, &jsonl_row_str(), false, &prompt, &opts).unwrap();
+    let inserted = ingest_jsonl_row(
+        &mut conn,
+        &jsonl_row_str(),
+        false,
+        &prompt,
+        &opts,
+        &mut MigrateReport::default(),
+    )
+    .unwrap();
     assert!(inserted, "first insert must succeed");
 
     let count: i64 = conn
@@ -144,10 +152,26 @@ fn migrate_jsonl_idempotent() {
     let mut conn = test_conn();
     let line = jsonl_row_str();
 
-    let first = ingest_jsonl_row(&mut conn, &line, false, &prompt, &opts).unwrap();
+    let first = ingest_jsonl_row(
+        &mut conn,
+        &line,
+        false,
+        &prompt,
+        &opts,
+        &mut MigrateReport::default(),
+    )
+    .unwrap();
     assert!(first);
 
-    let second = ingest_jsonl_row(&mut conn, &line, false, &prompt, &opts).unwrap();
+    let second = ingest_jsonl_row(
+        &mut conn,
+        &line,
+        false,
+        &prompt,
+        &opts,
+        &mut MigrateReport::default(),
+    )
+    .unwrap();
     assert!(!second, "second insert must be skipped");
 
     let count: i64 = conn
@@ -236,7 +260,14 @@ fn migrate_unknown_namespace_logs_and_skips_row() {
     })
     .to_string();
 
-    let result = ingest_jsonl_row(&mut conn, &line, false, &prompt, &opts);
+    let result = ingest_jsonl_row(
+        &mut conn,
+        &line,
+        false,
+        &prompt,
+        &opts,
+        &mut MigrateReport::default(),
+    );
     assert!(result.is_err(), "unknown namespace must return Err");
 
     let count: i64 = conn

--- a/crates/rmlx-metrics/src/migrate/legacy_tests.rs
+++ b/crates/rmlx-metrics/src/migrate/legacy_tests.rs
@@ -208,13 +208,99 @@ fn migrate_one_csv_row_inserts_multiple_metrics() {
     migrate_cbb_csv(&mut conn, tmp.path(), &prompt, &opts, &mut report).unwrap();
 
     assert_eq!(report.cbb_csv_rows_inserted, 1);
-    // Expect: decode_tps_warm, overall_tps, ttft_warm_ms, itl_p50_ms, itl_p95_ms, peak_rss_mb = 6
-    // (task_pass_at_1=0.0 filtered out, peak_rss_mb=0.0 also filtered for zero)
-    // Actually peak_rss_mb = 0.0 is not filtered by default — check exact count.
-    let count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM observations", [], |r| r.get(0))
+
+    // The row carries 7 parseable metric columns. Two of them are CBB's
+    // "not measured" placeholders and neither may become an observation:
+    // `task_pass_at_1=0.0` (dropped at the parse site — the value alone is a
+    // valid score, only the column convention says otherwise) and
+    // `peak_rss_mb=0.0` (dropped by the §4.1 bounds — a live process has RSS).
+    // Exact counts, not `>=`: a `>=` here passes whether 0 or 3 entries were
+    // dropped, which is the whole thing under test.
+    let names: Vec<String> = {
+        let mut stmt = conn
+            .prepare("SELECT metric FROM observations ORDER BY metric")
+            .unwrap();
+        stmt.query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<String>>>()
+            .unwrap()
+    };
+    assert_eq!(
+        names,
+        vec![
+            "decode_tps_warm",
+            "itl_p50_ms",
+            "itl_p95_ms",
+            "overall_tps",
+            "ttft_warm_ms"
+        ],
+        "unexpected metric set ingested from the CBB CSV row"
+    );
+    assert_eq!(
+        report.metrics_dropped_implausible, 1,
+        "only peak_rss_mb is a bounds drop; task_pass_at_1 never reaches the record"
+    );
+}
+
+/// CBB writes `0.0` in `task_pass_at_1` when it ran no quality probe. The §4.1
+/// bounds cannot catch it — `0.0` pass@1 is a legitimate score for a model that
+/// failed every task — so the parse site must, or the placeholder wins every
+/// all-zero partition in `bests` exactly like the rate zeros do.
+#[test]
+fn csv_zero_task_pass_is_never_ingested() {
+    let prompt_dir = make_prompt_dir();
+    let opts = default_opts_with_prompt_dir(prompt_dir.path());
+    let mut conn = test_conn();
+
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), minimal_csv()).unwrap();
+
+    let prompt = load_prompt_file(&prompt_dir.path().join("longctx_4k.json")).unwrap();
+    let mut report = MigrateReport::default();
+    migrate_cbb_csv(&mut conn, tmp.path(), &prompt, &opts, &mut report).unwrap();
+
+    let zero_scores: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM observations WHERE metric = 'task_pass_at_1'",
+            [],
+            |r| r.get(0),
+        )
         .unwrap();
-    assert!(count >= 4, "expected ≥4 metric rows, got {count}");
+    assert_eq!(
+        zero_scores, 0,
+        "CBB's unmeasured-probe placeholder was ingested as a pass@1 score"
+    );
+}
+
+/// A graded run that genuinely scored zero is a different thing from an
+/// unmeasured one only in the exporter's convention — but a *non-zero* score
+/// must still ingest. Guards the parse-site filter against over-reach.
+#[test]
+fn csv_nonzero_task_pass_still_ingests() {
+    let prompt_dir = make_prompt_dir();
+    let opts = default_opts_with_prompt_dir(prompt_dir.path());
+    let mut conn = test_conn();
+
+    let tmp = NamedTempFile::new().unwrap();
+    // Same row, with a graded (non-zero) score in the task_pass_at_1 column.
+    let graded = minimal_csv().replace("0.0,37.0,0.0,0.0,True", "0.0,37.0,0.0,0.75,True");
+    std::fs::write(tmp.path(), graded).unwrap();
+
+    let prompt = load_prompt_file(&prompt_dir.path().join("longctx_4k.json")).unwrap();
+    let mut report = MigrateReport::default();
+    migrate_cbb_csv(&mut conn, tmp.path(), &prompt, &opts, &mut report).unwrap();
+
+    let score: f64 = conn
+        .query_row(
+            "SELECT value FROM observations WHERE metric = 'task_pass_at_1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(
+        (score - 0.75).abs() < 1e-9,
+        "graded score {score} was dropped"
+    );
 }
 
 #[test]

--- a/crates/rmlx-metrics/src/migrate/schema_runner.rs
+++ b/crates/rmlx-metrics/src/migrate/schema_runner.rs
@@ -6,7 +6,7 @@
 
 use rusqlite::Connection;
 
-use crate::{error::Result, schema::MIGRATIONS, time_util::now_iso8601};
+use crate::{bests_view, error::Result, schema::MIGRATIONS, time_util::now_iso8601};
 
 /// Apply all pending migrations from [`MIGRATIONS`] to `conn`.
 ///
@@ -14,6 +14,10 @@ use crate::{error::Result, schema::MIGRATIONS, time_util::now_iso8601};
 /// every migration whose target version exceeds it, in order. Each migration
 /// executes inside its own transaction. After migration 001 is applied, the
 /// `schema_meta` seed rows are inserted (idempotent via `INSERT OR IGNORE`).
+///
+/// Finally, [`bests_view::ensure`] brings the `bests` view in line with the §4
+/// registry — see that module for why the view is generated rather than
+/// pinned to a migration.
 ///
 /// Returns the number of migrations applied (0 when already up to date).
 pub fn run_pending(conn: &mut Connection) -> Result<u32> {
@@ -40,6 +44,11 @@ pub fn run_pending(conn: &mut Connection) -> Result<u32> {
 
         applied += 1;
     }
+
+    // The `bests` view is generated from the §4 registry, not pinned to a
+    // migration number: a bounds change has to reach existing DBs too, and a
+    // view carries no data to migrate. Cheap no-op when already current.
+    bests_view::ensure(conn)?;
 
     Ok(applied)
 }

--- a/crates/rmlx-metrics/src/migrations/001_init.sql
+++ b/crates/rmlx-metrics/src/migrations/001_init.sql
@@ -71,25 +71,10 @@ CREATE INDEX IF NOT EXISTS obs_run_id_idx    ON observations(run_id);
 CREATE INDEX IF NOT EXISTS obs_backend_idx   ON observations(backend);
 CREATE INDEX IF NOT EXISTS obs_inserted_idx  ON observations(inserted_utc);
 
--- §3.3 bests VIEW — champion per cell via ROW_NUMBER, tie-break newer ts_utc wins
+-- §3.3 bests VIEW — champion per cell.
+-- Not created here: the definition is generated from the §4 metric registry
+-- (it carries the §4.1 plausibility filter, which this file cannot know), and
+-- `migrate::run_pending` installs it via `bests_view::ensure` after the last
+-- migration. Edit `bests_view::create_sql`.
 -- Must remain a VIEW; do NOT convert to a base table (§3.3 note).
 -- No triggers (§3.5).
--- This is the initial definition only. `migrate::run_pending` finishes by
--- calling `bests_view::ensure`, which replaces it with the definition
--- generated from the §4 metric registry (adds the §4.1 plausibility filter).
--- Edit `bests_view::create_sql`, not this statement.
-CREATE VIEW IF NOT EXISTS bests AS
-WITH ranked AS (
-    SELECT
-        o.*,
-        ROW_NUMBER() OVER (
-            PARTITION BY backend, model_namespace, model, weight_quant, kv_quant,
-                         ctx_max, prompt_id, metric
-            ORDER BY
-                CASE WHEN direction = 'higher_better' THEN  value END DESC,
-                CASE WHEN direction = 'lower_better'  THEN -value END DESC,
-                ts_utc DESC
-        ) AS rn
-    FROM observations o
-)
-SELECT * FROM ranked WHERE rn = 1;

--- a/crates/rmlx-metrics/src/migrations/001_init.sql
+++ b/crates/rmlx-metrics/src/migrations/001_init.sql
@@ -74,6 +74,10 @@ CREATE INDEX IF NOT EXISTS obs_inserted_idx  ON observations(inserted_utc);
 -- §3.3 bests VIEW — champion per cell via ROW_NUMBER, tie-break newer ts_utc wins
 -- Must remain a VIEW; do NOT convert to a base table (§3.3 note).
 -- No triggers (§3.5).
+-- This is the initial definition only. `migrate::run_pending` finishes by
+-- calling `bests_view::ensure`, which replaces it with the definition
+-- generated from the §4 metric registry (adds the §4.1 plausibility filter).
+-- Edit `bests_view::create_sql`, not this statement.
 CREATE VIEW IF NOT EXISTS bests AS
 WITH ranked AS (
     SELECT

--- a/crates/rmlx-metrics/src/query/query_tests.rs
+++ b/crates/rmlx-metrics/src/query/query_tests.rs
@@ -390,6 +390,114 @@ fn deltas_no_change_returns_zero_delta() {
     );
 }
 
+/// Clone an existing observation with a new value and timestamp, bypassing the
+/// ingest validator — the rows these gates have to survive were written before
+/// any value gate existed and cannot be re-created through it.
+fn clone_row_with(conn: &Connection, metric: &str, value: f64, ts_utc: &str, git_sha: &str) {
+    conn.execute(
+        "INSERT INTO observations (
+             backend, model_namespace, model, weight_quant, kv_quant, ctx_max, prompt_id,
+             metric, value, unit, direction, run_id, ts_utc, git_sha, hardware_tag,
+             inserted_utc, inserted_by
+         )
+         SELECT backend, model_namespace, model, weight_quant, kv_quant, ctx_max, prompt_id,
+                metric, ?1, unit, direction, run_id, ?2, ?3, hardware_tag,
+                inserted_utc, inserted_by
+           FROM observations WHERE metric = ?4 LIMIT 1",
+        rusqlite::params![value, ts_utc, git_sha, metric],
+    )
+    .unwrap();
+}
+
+/// `deltas --exit-code` is a CI gate that ranks `observations` directly, in its
+/// own SQL. It must refuse the same rows `bests` refuses, or the gate reports a
+/// 998x "improvement" against a real baseline.
+#[test]
+fn deltas_do_not_rank_an_implausible_row() {
+    let mut conn = test_conn();
+    {
+        let mut rec = Recorder::new(&mut conn, "test@0.0.1");
+        rec.record_run(&make_run(
+            "rmlx",
+            "Qwen3.6-35B",
+            "prefill_tps",
+            494.7,
+            "2026-05-01T10:00:00Z",
+            Some("sha_base"),
+        ))
+        .unwrap();
+        rec.record_run(&make_run(
+            "rmlx",
+            "Qwen3.6-35B",
+            "prefill_tps",
+            497.0,
+            "2026-05-05T10:00:00Z",
+            Some("sha_after"),
+        ))
+        .unwrap();
+    }
+    // (prompt_tokens - 242) * 1000, landing after the baseline.
+    clone_row_with(
+        &conn,
+        "prefill_tps",
+        130_810_000.0,
+        "2026-05-06T10:00:00Z",
+        "sha_after",
+    );
+
+    let rows = deltas(&conn, "sha_base", Some(5.0)).unwrap();
+    let row = rows
+        .iter()
+        .find(|r| r.metric == "prefill_tps" && r.cell.model == "Qwen3.6-35B");
+    assert!(
+        row.is_none(),
+        "deltas ranked the implausible row: {:?}",
+        row.map(|r| r.current_value)
+    );
+}
+
+/// A mean is as corruptible as a ranking.
+#[test]
+fn timeseries_mean_excludes_an_implausible_row() {
+    let mut conn = test_conn();
+    {
+        let mut rec = Recorder::new(&mut conn, "test@0.0.1");
+        rec.record_run(&make_run(
+            "rmlx",
+            "Qwen3.6-35B",
+            "prefill_tps",
+            500.0,
+            "2026-05-01T10:00:00Z",
+            None,
+        ))
+        .unwrap();
+    }
+    clone_row_with(
+        &conn,
+        "prefill_tps",
+        130_810_000.0,
+        "2026-05-01T11:00:00Z",
+        "sha_x",
+    );
+
+    let cell = Cell {
+        backend: "rmlx".into(),
+        model_namespace: "mlx-community".into(),
+        model: "Qwen3.6-35B".into(),
+        weight_quant: "mxfp8".into(),
+        kv_quant: "k8v8".into(),
+        ctx_max: 8192,
+        prompt_id: 1,
+    };
+    let points = timeseries(&conn, &cell, "prefill_tps", None, Bucket::Day).unwrap();
+    assert_eq!(points.len(), 1, "expected one day bucket: {points:?}");
+    assert!(
+        (points[0].mean_value - 500.0).abs() < 1e-9,
+        "implausible row entered the mean: {}",
+        points[0].mean_value
+    );
+}
+
 // ── champions ─────────────────────────────────────────────────────────────
 
 /// Seed a minimal two-backend scenario for champion tests:

--- a/crates/rmlx-metrics/src/query/read.rs
+++ b/crates/rmlx-metrics/src/query/read.rs
@@ -284,6 +284,10 @@ pub fn timeseries(
         }
     };
 
+    // A mean is as corruptible as a ranking: one implausible row drags the
+    // bucket it lands in. Same §4.1 predicate as `bests`.
+    let plausible = crate::bests_view::plausible_sql("value");
+
     let mut sql = format!(
         "SELECT {bucket_expr} AS bucket_start,
                 AVG(value)              AS mean_value,
@@ -296,7 +300,8 @@ pub fn timeseries(
            AND kv_quant        = ?5
            AND ctx_max         = ?6
            AND prompt_id       = ?7
-           AND metric          = ?8"
+           AND metric          = ?8
+           AND ({plausible})"
     );
 
     let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![
@@ -392,7 +397,16 @@ pub fn deltas(
     // if a backend was performing better BEFORE the sha than it is in observations
     // recorded AFTER the sha, that signals a regression. When no post-baseline
     // observations exist, we use the all-time current best as "current".
-    let best_in_window_sql = "
+    //
+    // These two rank `observations` directly rather than reading `bests`,
+    // because they rank *within a time window* the view does not know about.
+    // They must therefore carry the same §4.1 plausibility predicate the view
+    // does — `deltas --exit-code` is a CI gate, and a gate that ranks rows the
+    // champion view refuses is worse than no gate.
+    let plausible = crate::bests_view::plausible_sql("value");
+
+    let best_in_window_sql = format!(
+        "
         SELECT value FROM (
             SELECT value,
                 ROW_NUMBER() OVER (
@@ -411,9 +425,12 @@ pub fn deltas(
               AND prompt_id       = ?7
               AND metric          = ?8
               AND ts_utc          <= ?9
-        ) WHERE rn = 1";
+              AND ({plausible})
+        ) WHERE rn = 1"
+    );
 
-    let best_after_sql = "
+    let best_after_sql = format!(
+        "
         SELECT value FROM (
             SELECT value,
                 ROW_NUMBER() OVER (
@@ -432,10 +449,12 @@ pub fn deltas(
               AND prompt_id       = ?7
               AND metric          = ?8
               AND ts_utc          > ?9
-        ) WHERE rn = 1";
+              AND ({plausible})
+        ) WHERE rn = 1"
+    );
 
-    let mut baseline_stmt = conn.prepare(best_in_window_sql)?;
-    let mut after_stmt = conn.prepare(best_after_sql)?;
+    let mut baseline_stmt = conn.prepare(&best_in_window_sql)?;
+    let mut after_stmt = conn.prepare(&best_after_sql)?;
 
     let mut result = Vec::new();
 
@@ -580,25 +599,34 @@ pub fn regress(
     };
 
     // Step 2: find the most-recent observation for this (model, metric).
+    // "Latest" means latest *measurement*: an implausible row here reads as a
+    // 100% regression against the champion and fails the gate on nothing.
+    let plausible = crate::bests_view::plausible_sql("value");
     let latest_value: Option<f64> = if let Some(kv) = kv_quant {
         conn.query_row(
-            "SELECT value FROM observations
-              WHERE instr(model, ?1) > 0
-                AND metric   = ?2
-                AND kv_quant = ?3
-              ORDER BY ts_utc DESC
-              LIMIT 1",
+            &format!(
+                "SELECT value FROM observations
+                  WHERE instr(model, ?1) > 0
+                    AND metric   = ?2
+                    AND kv_quant = ?3
+                    AND ({plausible})
+                  ORDER BY ts_utc DESC
+                  LIMIT 1"
+            ),
             rusqlite::params![model, metric, kv],
             |r| r.get(0),
         )
         .optional()?
     } else {
         conn.query_row(
-            "SELECT value FROM observations
-              WHERE instr(model, ?1) > 0
-                AND metric = ?2
-              ORDER BY ts_utc DESC
-              LIMIT 1",
+            &format!(
+                "SELECT value FROM observations
+                  WHERE instr(model, ?1) > 0
+                    AND metric = ?2
+                    AND ({plausible})
+                  ORDER BY ts_utc DESC
+                  LIMIT 1"
+            ),
             rusqlite::params![model, metric],
             |r| r.get(0),
         )

--- a/crates/rmlx-metrics/src/query/read.rs
+++ b/crates/rmlx-metrics/src/query/read.rs
@@ -714,7 +714,7 @@ pub fn champions(conn: &Connection, backend_filter: Option<&str>) -> Result<Vec<
     for (ns, model, wq, kq) in &distinct_cells {
         let mut metrics_map = std::collections::BTreeMap::new();
 
-        for (metric_name, _, _) in crate::registry::METRICS {
+        for (metric_name, _, _, _) in crate::registry::METRICS {
             let champion: Option<ChampionCell> = if let Some(b) = backend_filter {
                 stmt_with_backend
                     .query_row(rusqlite::params![ns, model, wq, kq, metric_name, b], |r| {

--- a/crates/rmlx-metrics/src/registry.rs
+++ b/crates/rmlx-metrics/src/registry.rs
@@ -122,7 +122,7 @@ impl Bounds {
         format!("{column} {floor} 0.0 AND {column} <= {:?}", self.max)
     }
 
-    /// One-line human description, e.g. `"(0, 100000]"`.
+    /// One-line human description, e.g. `"(0, 100000.0]"`.
     pub fn describe(self) -> String {
         let open = if self.zero_is_measurement { '[' } else { '(' };
         format!("{open}0, {:?}]", self.max)
@@ -162,11 +162,14 @@ pub const METRICS: &[(&str, &str, Direction, Bounds)] = &[
         Direction::HigherBetter,
         Bounds::positive(1e5),
     ),
+    // Same ceiling as `decode_tps_warm`, and not a looser one: `overall_tps`
+    // divides the same token count by a wall clock that also contains prefill,
+    // so it is bounded above by the decode rate by construction.
     (
         "overall_tps",
         "tps",
         Direction::HigherBetter,
-        Bounds::positive(1e5),
+        Bounds::positive(1e4),
     ),
     (
         "ttft_warm_ms",

--- a/crates/rmlx-metrics/src/registry.rs
+++ b/crates/rmlx-metrics/src/registry.rs
@@ -1,14 +1,17 @@
 //! Metric registry per `docs/METRICS_DB.md` §4.
 //!
-//! Maps metric names to `(unit, direction)` pairs. The registry is the
-//! authoritative source for what constitutes a valid metric name and how
-//! to interpret its direction (`Higher` = better, `Lower` = better).
-//! Unregistered metric names are rejected at ingest time.
+//! Maps metric names to `(unit, direction, bounds)` triples. The registry is
+//! the authoritative source for what constitutes a valid metric name, how to
+//! interpret its direction (`Higher` = better, `Lower` = better), and which
+//! values are physically possible measurements of it. Unregistered metric
+//! names, and values outside the bounds, are rejected at ingest time.
 //!
 //! # Public API
 //!
 //! - [`lookup`] — resolve a metric name to its unit string and [`Direction`].
+//! - [`bounds`] — resolve a metric name to its plausible-value [`Bounds`].
 //! - [`Direction`] — `Higher` or `Lower` (better) enum.
+//! - [`Bounds`] — the plausible-value window for one metric.
 //! - [`Coverage`] — enum indicating whether a backend reports a given metric.
 //! - [`coverage`] — check whether a `(backend, metric)` pair has known coverage.
 
@@ -48,83 +51,360 @@ impl Direction {
     }
 }
 
+// ── Bounds ────────────────────────────────────────────────────────────────────
+
+/// The window of values that can be a *measurement* of a metric.
+///
+/// Every metric in the registry counts, times or rates a physical quantity, so
+/// a negative value is never a measurement and the floor is always `0.0`. What
+/// differs per metric is whether that floor is itself a measurement:
+///
+/// * A **rate** cannot be `0.0`. `tokens / seconds` is zero only when no token
+///   was produced, i.e. when there was nothing to measure — the zero is a
+///   missing field wearing a number's clothes.
+/// * A **counter, duration or gauge** can be `0.0` honestly: zero cache hits,
+///   a sub-millisecond span rounded down, a run that allocated no Metal.
+///
+/// The ceiling is the same idea from the other end: a value orders of magnitude
+/// past anything the hardware can do is an arithmetic accident, not a record.
+/// Ceilings are deliberately loose (several × the best value ever recorded) so
+/// they reject fabrications, not fast machines.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "closed value-window struct — a ceiling plus whether zero counts is the whole contract; a signed metric would need a `min` field and a registry-wide review"
+)]
+pub struct Bounds {
+    /// Largest plausible value, inclusive.
+    pub max: f64,
+    /// Whether an exact `0.0` is a measurement rather than a missing field.
+    pub zero_is_measurement: bool,
+}
+
+impl Bounds {
+    /// A quantity whose zero means "nothing was measured" — every rate, plus
+    /// gauges no live run can read as zero (a running process has RSS).
+    pub const fn positive(max: f64) -> Self {
+        Self {
+            max,
+            zero_is_measurement: false,
+        }
+    }
+
+    /// A quantity that can legitimately read `0.0` — counters, durations
+    /// (millisecond resolution rounds sub-ms spans to zero), and gauges that
+    /// a run can genuinely leave at zero.
+    pub const fn non_negative(max: f64) -> Self {
+        Self {
+            max,
+            zero_is_measurement: true,
+        }
+    }
+
+    /// Whether `value` is inside the window. Rejects NaN and infinities.
+    pub fn contains(self, value: f64) -> bool {
+        if !value.is_finite() || value > self.max {
+            return false;
+        }
+        if self.zero_is_measurement {
+            value >= 0.0
+        } else {
+            value > 0.0
+        }
+    }
+
+    /// Renders the window as a SQLite boolean expression over `column`.
+    ///
+    /// Used to build the `bests` view from this registry so the view and the
+    /// ingest gate cannot disagree about what a measurement is.
+    pub fn sql(self, column: &str) -> String {
+        let floor = if self.zero_is_measurement { ">=" } else { ">" };
+        format!("{column} {floor} 0.0 AND {column} <= {:?}", self.max)
+    }
+
+    /// One-line human description, e.g. `"(0, 100000]"`.
+    pub fn describe(self) -> String {
+        let open = if self.zero_is_measurement { '[' } else { '(' };
+        format!("{open}0, {:?}]", self.max)
+    }
+}
+
+/// One hour, in milliseconds — the ceiling for every duration metric. A single
+/// span longer than this is a hung run, not a measurement.
+const MS_CEILING: f64 = 3_600_000.0;
+/// Ceiling for monotonic counters (cache hits, token counts, spike counts).
+const COUNT_CEILING: f64 = 1e12;
+/// Ceiling for byte gauges — 10 TB, well past unified memory on any Mac.
+const BYTES_CEILING: f64 = 1e13;
+/// Ceiling for megabyte gauges — 1 PB expressed in MB.
+const MB_CEILING: f64 = 1e9;
+
 // ── METRICS const ─────────────────────────────────────────────────────────────
 
-/// Canonical metric name → (unit, direction). Add new metrics here AND in §4.
-pub const METRICS: &[(&str, &str, Direction)] = &[
-    ("decode_tps_warm", "tps", Direction::HigherBetter),
-    ("decode_tps_cold", "tps", Direction::HigherBetter),
-    ("prefill_tps", "tps", Direction::HigherBetter),
-    ("overall_tps", "tps", Direction::HigherBetter),
-    ("ttft_warm_ms", "ms", Direction::LowerBetter),
-    ("ttft_cold_ms", "ms", Direction::LowerBetter),
-    ("itl_p50_ms", "ms", Direction::LowerBetter),
-    ("itl_p95_ms", "ms", Direction::LowerBetter),
-    ("step_ms_mean", "ms", Direction::LowerBetter),
-    ("model_load_ms", "ms", Direction::LowerBetter),
-    ("peak_rss_mb", "mb", Direction::LowerBetter),
-    ("metal_peak_alloc_mb", "mb", Direction::LowerBetter),
-    ("kv_cache_bytes", "bytes", Direction::LowerBetter),
-    ("tps_per_gb_ram", "ratio", Direction::HigherBetter),
-    ("task_pass_at_1", "ratio", Direction::HigherBetter),
+/// Canonical metric name → (unit, direction, plausible bounds).
+/// Add new metrics here AND in §4.
+pub const METRICS: &[(&str, &str, Direction, Bounds)] = &[
+    (
+        "decode_tps_warm",
+        "tps",
+        Direction::HigherBetter,
+        Bounds::positive(1e4),
+    ),
+    (
+        "decode_tps_cold",
+        "tps",
+        Direction::HigherBetter,
+        Bounds::positive(1e4),
+    ),
+    (
+        "prefill_tps",
+        "tps",
+        Direction::HigherBetter,
+        Bounds::positive(1e5),
+    ),
+    (
+        "overall_tps",
+        "tps",
+        Direction::HigherBetter,
+        Bounds::positive(1e5),
+    ),
+    (
+        "ttft_warm_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "ttft_cold_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "itl_p50_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "itl_p95_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "step_ms_mean",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "model_load_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "peak_rss_mb",
+        "mb",
+        Direction::LowerBetter,
+        Bounds::positive(MB_CEILING),
+    ),
+    (
+        "metal_peak_alloc_mb",
+        "mb",
+        Direction::LowerBetter,
+        Bounds::non_negative(MB_CEILING),
+    ),
+    (
+        "kv_cache_bytes",
+        "bytes",
+        Direction::LowerBetter,
+        Bounds::non_negative(BYTES_CEILING),
+    ),
+    (
+        "tps_per_gb_ram",
+        "ratio",
+        Direction::HigherBetter,
+        Bounds::positive(1e5),
+    ),
+    (
+        "task_pass_at_1",
+        "ratio",
+        Direction::HigherBetter,
+        Bounds::non_negative(1.0),
+    ),
     // N19: prompt-cache hit/miss/bytes counters.
-    ("prompt_cache_hits", "count", Direction::HigherBetter),
-    ("prompt_cache_misses", "count", Direction::LowerBetter),
-    ("prompt_cache_bytes", "bytes", Direction::LowerBetter),
+    (
+        "prompt_cache_hits",
+        "count",
+        Direction::HigherBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
+    (
+        "prompt_cache_misses",
+        "count",
+        Direction::LowerBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
+    (
+        "prompt_cache_bytes",
+        "bytes",
+        Direction::LowerBetter,
+        Bounds::non_negative(BYTES_CEILING),
+    ),
     // C6: block-level prompt-cache counters (monotonic).
-    ("prompt_cache_block_hits", "count", Direction::HigherBetter),
-    ("prompt_cache_block_misses", "count", Direction::LowerBetter),
+    (
+        "prompt_cache_block_hits",
+        "count",
+        Direction::HigherBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
+    (
+        "prompt_cache_block_misses",
+        "count",
+        Direction::LowerBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
     (
         "prompt_cache_partial_hits",
         "count",
         Direction::HigherBetter,
+        Bounds::non_negative(COUNT_CEILING),
     ),
     // Hot-cache (in-memory prompt-cache LRU) hit + eviction counters.
     (
         "prompt_cache_hot_cache_hits",
         "count",
         Direction::HigherBetter,
+        Bounds::non_negative(COUNT_CEILING),
     ),
     (
         "prompt_cache_hot_cache_evictions",
         "count",
         Direction::LowerBetter,
+        Bounds::non_negative(COUNT_CEILING),
     ),
     // SSD-tier hydrate hits — RAM misses served from the on-disk
     // `.kvb` tier (reader + index). Higher = more cross-process /
     // post-eviction reuse recovered from disk instead of re-prefilled.
-    ("prompt_cache_ssd_hits", "count", Direction::HigherBetter),
+    (
+        "prompt_cache_ssd_hits",
+        "count",
+        Direction::HigherBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
     // Per-phase load-time spans.
-    ("load_mmap_ms", "ms", Direction::LowerBetter),
-    ("load_dequant_ms", "ms", Direction::LowerBetter),
-    ("load_gpu_residency_ms", "ms", Direction::LowerBetter),
-    ("load_first_kernel_ready_ms", "ms", Direction::LowerBetter),
-    ("load_total_ms", "ms", Direction::LowerBetter),
+    (
+        "load_mmap_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "load_dequant_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "load_gpu_residency_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "load_first_kernel_ready_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "load_total_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
     // C5 Slice A: FIFO admission-queue observability (rmlx-only).
-    ("queue_wait_ms", "ms", Direction::LowerBetter),
-    ("queue_depth", "count", Direction::LowerBetter),
+    (
+        "queue_wait_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "queue_depth",
+        "count",
+        Direction::LowerBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
     // F1b: per-request token counts from live HTTP handler (rmlx-only).
     // Suffixed `_live` to distinguish from the bench-config `prompt_tokens` /
     // `completion_tokens` columns on `observations` (those are bench metadata;
     // these are per-request telemetry metrics).
-    ("prompt_tokens_live", "count", Direction::LowerBetter),
-    ("completion_tokens_live", "count", Direction::LowerBetter),
+    (
+        "prompt_tokens_live",
+        "count",
+        Direction::LowerBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
+    (
+        "completion_tokens_live",
+        "count",
+        Direction::LowerBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
     // F9: extended ITL percentile and spike counter (rmlx-only).
     // `itl_p99_ms` — 99th-percentile inter-token latency; emitted alongside
     // the existing itl_p50_ms/itl_p95_ms from `ItlStats`.
     // `itl_spikes` — count of intervals > 3×median per request; diagnostic for
     // GC pauses, Metal pipeline stalls, and other decode-path hiccups.
-    ("itl_p99_ms", "ms", Direction::LowerBetter),
-    ("itl_spikes", "count", Direction::LowerBetter),
+    (
+        "itl_p99_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "itl_spikes",
+        "count",
+        Direction::LowerBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
     // Speculative-decoding metrics. Higher accept_rate = more draft tokens
     // survive verification per round. *_total counters monotonically grow per
     // request and are reset per run. `accepted_per_step` = total_accept /
     // n_rounds (mean draft tokens accepted per verifier step).
-    ("accept_rate", "ratio", Direction::HigherBetter),
-    ("draft_tokens_total", "count", Direction::HigherBetter),
-    ("accept_tokens_total", "count", Direction::HigherBetter),
-    ("draft_rounds_total", "count", Direction::HigherBetter),
-    ("accepted_per_step", "ratio", Direction::HigherBetter),
+    (
+        "accept_rate",
+        "ratio",
+        Direction::HigherBetter,
+        Bounds::non_negative(1.0),
+    ),
+    (
+        "draft_tokens_total",
+        "count",
+        Direction::HigherBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
+    (
+        "accept_tokens_total",
+        "count",
+        Direction::HigherBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
+    (
+        "draft_rounds_total",
+        "count",
+        Direction::HigherBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
+    (
+        "accepted_per_step",
+        "ratio",
+        Direction::HigherBetter,
+        Bounds::non_negative(1e3),
+    ),
     // SSD-tier observability (step2): byte/evict gauges + spill/hydrate timing.
     //
     // `ssd_bytes_used` is LowerBetter: unbounded cache growth is a budget risk.
@@ -132,27 +412,82 @@ pub const METRICS: &[(&str, &str, Direction)] = &[
     // accumulating useful blocks. Either way, *unexpected* size changes are the
     // regression signal — LowerBetter keeps the gate from alerting on a known
     // cache fill (size > 0 is expected) while still flagging runaway growth.
-    ("ssd_bytes_used", "bytes", Direction::LowerBetter),
+    (
+        "ssd_bytes_used",
+        "bytes",
+        Direction::LowerBetter,
+        Bounds::non_negative(BYTES_CEILING),
+    ),
     // More evictions = more cache thrash (LRU budget too tight or write-rate
     // too high). Lower is better.
-    ("ssd_evict_total", "count", Direction::LowerBetter),
+    (
+        "ssd_evict_total",
+        "count",
+        Direction::LowerBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
     // Spill / hydrate raw per-event latency (drain thread / request thread).
     // Each SQLite observation row carries one raw sample; real percentiles come
     // from the Prometheus histogram (rmlx_ssd_spill_us_bucket / rmlx_ssd_hydrate_us_bucket).
     // reason: a single-sample distribution has no meaningful p50 or p99 —
     // emitting the same dur_ms value as both is misleading; removed in H2 fix.
-    ("ssd_spill_ms", "ms", Direction::LowerBetter),
-    ("ssd_hydrate_ms", "ms", Direction::LowerBetter),
+    (
+        "ssd_spill_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "ssd_hydrate_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
     // Spill / hydrate throughput. Higher = faster disk path.
-    ("ssd_spill_mb_per_s", "mb/s", Direction::HigherBetter),
-    ("ssd_hydrate_mb_per_s", "mb/s", Direction::HigherBetter),
+    (
+        "ssd_spill_mb_per_s",
+        "mb/s",
+        Direction::HigherBetter,
+        Bounds::positive(1e6),
+    ),
+    (
+        "ssd_hydrate_mb_per_s",
+        "mb/s",
+        Direction::HigherBetter,
+        Bounds::positive(1e6),
+    ),
     // -- offline perplexity scorer (`rmlx eval ppl`). Op family `ppl`;
     // one `ppl_<corpus>` metric per supported corpus + audit fields.
-    ("ppl_wikitext2", "ppl", Direction::LowerBetter),
-    ("ppl_mean_nll", "nat", Direction::LowerBetter),
-    ("ppl_scored_tokens", "count", Direction::HigherBetter),
-    ("ppl_windows", "count", Direction::HigherBetter),
-    ("ppl_score_ms", "ms", Direction::LowerBetter),
+    (
+        "ppl_wikitext2",
+        "ppl",
+        Direction::LowerBetter,
+        Bounds::positive(1e6),
+    ),
+    (
+        "ppl_mean_nll",
+        "nat",
+        Direction::LowerBetter,
+        Bounds::non_negative(1e3),
+    ),
+    (
+        "ppl_scored_tokens",
+        "count",
+        Direction::HigherBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
+    (
+        "ppl_windows",
+        "count",
+        Direction::HigherBetter,
+        Bounds::non_negative(COUNT_CEILING),
+    ),
+    (
+        "ppl_score_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
     // phase-split TTFT/TPOT metrics. `prefill_duration_ms` reports the
     // wall-clock from generate-entry to first-OK-token (same value as the
     // existing `ttft_{warm,cold}_ms` row, but named as its own op so honest
@@ -162,18 +497,47 @@ pub const METRICS: &[(&str, &str, Direction)] = &[
     // name is the *convention* + an open door for divergence (e.g. tpot
     // might one day exclude tool-calling stalls). `ttft_*_ms` / `itl_*_ms`
     // are kept for backward-compatibility.
-    ("prefill_duration_ms", "ms", Direction::LowerBetter),
-    ("tpot_p50_ms", "ms", Direction::LowerBetter),
-    ("tpot_p95_ms", "ms", Direction::LowerBetter),
-    ("tpot_p99_ms", "ms", Direction::LowerBetter),
+    (
+        "prefill_duration_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "tpot_p50_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "tpot_p95_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
+    (
+        "tpot_p99_ms",
+        "ms",
+        Direction::LowerBetter,
+        Bounds::non_negative(MS_CEILING),
+    ),
 ];
 
 /// Returns `(unit, direction)` for a known metric name.
 pub fn lookup(name: &str) -> Result<(&'static str, Direction)> {
     METRICS
         .iter()
-        .find(|(n, _, _)| *n == name)
-        .map(|(_, u, d)| (*u, *d))
+        .find(|(n, _, _, _)| *n == name)
+        .map(|(_, u, d, _)| (*u, *d))
+        .ok_or_else(|| Error::UnknownMetric(name.to_string()))
+}
+
+/// Returns the plausible-value [`Bounds`] for a known metric name.
+pub fn bounds(name: &str) -> Result<Bounds> {
+    METRICS
+        .iter()
+        .find(|(n, _, _, _)| *n == name)
+        .map(|(_, _, _, b)| *b)
         .ok_or_else(|| Error::UnknownMetric(name.to_string()))
 }
 

--- a/crates/rmlx-metrics/src/registry_tests.rs
+++ b/crates/rmlx-metrics/src/registry_tests.rs
@@ -150,3 +150,56 @@ fn coverage_matrix_includes_all_5_backends() {
         );
     }
 }
+
+// ── Bounds ────────────────────────────────────────────────────────────────
+
+#[test]
+fn bounds_reject_negatives_whatever_the_floor() {
+    assert!(!Bounds::non_negative(10.0).contains(-1.0));
+    assert!(!Bounds::positive(10.0).contains(-1.0));
+    assert!(!Bounds::non_negative(10.0).contains(-0.000_001));
+}
+
+#[test]
+fn bounds_ceiling_is_inclusive() {
+    assert!(Bounds::positive(10.0).contains(10.0));
+    assert!(!Bounds::positive(10.0).contains(10.1));
+    assert!(Bounds::non_negative(10.0).contains(10.0));
+    assert!(!Bounds::non_negative(10.0).contains(f64::MAX));
+}
+
+#[test]
+fn bounds_floor_differs_by_constructor() {
+    assert!(!Bounds::positive(10.0).contains(0.0));
+    assert!(Bounds::positive(10.0).contains(f64::MIN_POSITIVE));
+    assert!(Bounds::non_negative(10.0).contains(0.0));
+}
+
+#[test]
+fn bounds_reject_non_finite() {
+    for b in [Bounds::positive(10.0), Bounds::non_negative(10.0)] {
+        assert!(!b.contains(f64::NAN));
+        assert!(!b.contains(f64::INFINITY));
+        assert!(!b.contains(f64::NEG_INFINITY));
+    }
+}
+
+/// The SQL rendering is what the `bests` view and the `deltas`/`timeseries`
+/// queries actually enforce, so pin the string, not just its shape.
+#[test]
+fn bounds_render_the_floor_they_declare() {
+    assert_eq!(
+        Bounds::positive(1e5).sql("value"),
+        "value > 0.0 AND value <= 100000.0"
+    );
+    assert_eq!(
+        Bounds::non_negative(1e12).sql("value"),
+        "value >= 0.0 AND value <= 1000000000000.0"
+    );
+}
+
+#[test]
+fn bounds_describe_shows_the_open_end() {
+    assert_eq!(Bounds::positive(1e5).describe(), "(0, 100000.0]");
+    assert_eq!(Bounds::non_negative(1.0).describe(), "[0, 1.0]");
+}

--- a/crates/rmlx-metrics/src/registry_tests.rs
+++ b/crates/rmlx-metrics/src/registry_tests.rs
@@ -69,7 +69,7 @@ fn every_spec_metric_present() {
     ];
     for name in spec_names {
         assert!(
-            METRICS.iter().any(|(n, _, _)| *n == name),
+            METRICS.iter().any(|(n, _, _, _)| *n == name),
             "metric '{name}' missing from METRICS"
         );
     }
@@ -121,7 +121,7 @@ fn every_metric_has_valid_unit() {
     let valid_units = [
         "tps", "ms", "mb", "bytes", "ratio", "count", "mb/s", "ppl", "nat",
     ];
-    for (name, unit, _) in METRICS {
+    for (name, unit, _, _) in METRICS {
         assert!(
             valid_units.contains(unit),
             "metric '{name}' has unknown unit '{unit}'"

--- a/crates/rmlx-metrics/src/schema.rs
+++ b/crates/rmlx-metrics/src/schema.rs
@@ -5,7 +5,7 @@
 
 use rusqlite::{Connection, OpenFlags};
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 // ---------------------------------------------------------------------------
 // Embedded migrations (binary-shipped; no filesystem access at runtime).
@@ -48,17 +48,59 @@ pub fn open(path: &std::path::Path) -> Result<Connection> {
     Ok(conn)
 }
 
-/// Open (or create) the DB at `path` read-write with the schema brought up to
-/// date, including the registry-generated `bests` view.
+/// Open the DB at `path` for a command that *writes*, bringing the schema up
+/// to date first (including the registry-generated `bests` view).
 ///
-/// This is what a command that *reads* should use. `open` alone leaves the
-/// caller reading whatever schema the last writer happened to leave behind —
-/// a query command run against a DB older than the binary silently reads a
-/// stale `bests` definition, which is how a champion view keeps publishing
-/// rows the current registry rejects.
+/// Only for writers. A read command must not migrate — see [`open_checked`].
 pub fn open_migrated(path: &std::path::Path) -> Result<Connection> {
     let mut conn = open(path)?;
     crate::migrate::run_pending(&mut conn)?;
+    Ok(conn)
+}
+
+/// Open an existing DB at `path` for a command that only reads, refusing to
+/// run if what it would read is stale.
+///
+/// Two things a read command must not do, both of which `open` alone allows:
+///
+/// * **Create anything.** `Connection::open` creates an empty file for a
+///   mistyped path, and migrating it would then hand back a fully-formed,
+///   empty metrics DB instead of an error. This refuses a path that does not
+///   already exist.
+/// * **Migrate.** `run_pending` ends in a `DROP VIEW` / `CREATE VIEW`, which
+///   would change what `bests` — and therefore `BENCHMARK_CHAMPIONS.md` —
+///   publishes, as a side effect of a query. `<RMLX_HOME>/metrics/legacy/` is
+///   declared read-only archive material and `backups/` holds snapshots; both
+///   are reachable through `--db`.
+///
+/// So staleness is reported instead of silently repaired: if the stored
+/// `bests` definition does not match the §4 registry, the caller is told to
+/// run `rmlx metrics doctor --fix`.
+///
+/// The connection is opened read-write rather than with `open_readonly` on
+/// purpose. A read-only connection to a DB with a non-empty `-wal` must create
+/// the `-shm` file, so it fails outright ("unable to open database file") when
+/// the containing directory is not writable — trading a mutation hazard for an
+/// availability one. Nothing on this path issues a write.
+pub fn open_checked(path: &std::path::Path) -> Result<Connection> {
+    if !path.exists() {
+        return Err(Error::Schema(format!(
+            "no metrics DB at {} — check --db / RMLX_METRICS_DB, or run `rmlx metrics init`",
+            path.display()
+        )));
+    }
+
+    let conn = open(path)?;
+
+    if crate::bests_view::is_stale(&conn)? {
+        return Err(Error::Schema(format!(
+            "the `bests` view in {} was built from a different metric registry than this \
+             binary's, so a champion read here would not match §4.1 — run \
+             `rmlx metrics doctor --fix` to rebuild it",
+            path.display()
+        )));
+    }
+
     Ok(conn)
 }
 

--- a/crates/rmlx-metrics/src/schema.rs
+++ b/crates/rmlx-metrics/src/schema.rs
@@ -48,6 +48,20 @@ pub fn open(path: &std::path::Path) -> Result<Connection> {
     Ok(conn)
 }
 
+/// Open (or create) the DB at `path` read-write with the schema brought up to
+/// date, including the registry-generated `bests` view.
+///
+/// This is what a command that *reads* should use. `open` alone leaves the
+/// caller reading whatever schema the last writer happened to leave behind —
+/// a query command run against a DB older than the binary silently reads a
+/// stale `bests` definition, which is how a champion view keeps publishing
+/// rows the current registry rejects.
+pub fn open_migrated(path: &std::path::Path) -> Result<Connection> {
+    let mut conn = open(path)?;
+    crate::migrate::run_pending(&mut conn)?;
+    Ok(conn)
+}
+
 /// Open an in-memory DB for tests.
 ///
 /// `:memory:` does not persist WAL to disk (journal_mode stays `memory`),

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -935,7 +935,14 @@ Create the schema and seed `schema_meta`. Refuses if the file already exists.
 Verify schema version, integrity, FKs, whitelists, units, directions, and
 value plausibility (every `value` inside its `METRICS_DB.md` §4.1 bounds).
 `--fix` does not touch an implausible value: it is not recoverable from the
-row, only re-measurable.
+row, only re-measurable. It does rebuild the `bests` view when that view was
+generated from an older metric registry — reported as a warning otherwise,
+since the rebuild changes what the champion table publishes.
+
+Read commands (`query`, `best`, `rank`, `history`, `timeseries`, `champions`,
+`export`, `prompts list|get`) never migrate or rebuild anything: they refuse a
+DB that does not exist, and refuse one whose `bests` view is stale, naming
+`doctor --fix` as the repair.
 
 | Flag | Default | Description |
 |---|---|---|

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -932,7 +932,10 @@ Create the schema and seed `schema_meta`. Refuses if the file already exists.
 
 #### `metrics doctor`
 
-Verify schema version, integrity, FKs, whitelists, units, and directions.
+Verify schema version, integrity, FKs, whitelists, units, directions, and
+value plausibility (every `value` inside its `METRICS_DB.md` §4.1 bounds).
+`--fix` does not touch an implausible value: it is not recoverable from the
+row, only re-measurable.
 
 | Flag | Default | Description |
 |---|---|---|

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -193,10 +193,19 @@ SELECT * FROM ranked WHERE rn = 1;
 ```
 
 The `WHERE` is **generated from the §4 registry**, not written by hand:
-`rmlx_metrics::bests_view::create_sql` renders one branch per metric from the
-same `Bounds` the ingest validator enforces, and `migrate::run_pending`
-recreates the view whenever the stored definition and the registry disagree.
-Retyping the bound in SQL is how the view and the gate would drift apart.
+`rmlx_metrics::bests_view::plausible_sql` renders one branch per metric from
+the same `Bounds` the ingest validator enforces. Retyping the bound in SQL is
+how the view and the gate would drift apart, so every consumer that ranks or
+aggregates `observations` in its own SQL — `query::deltas` (the
+`--exit-code` CI gate), `query::regress`, `query::timeseries` — `AND`s in the
+same generated predicate rather than carrying its own copy.
+
+Who installs it: `migrate::run_pending` (i.e. every *writer*) recreates the
+view whenever the stored definition and the registry disagree, and
+`rmlx metrics doctor --fix` does so explicitly. A **read** command never
+rebuilds it — `schema::open_checked` refuses to run against a DB whose view
+was built from a different registry and names the repair. A query must not
+change what the champion table publishes as a side effect of being run.
 
 Rows outside the bound are **excluded, not re-ranked**: the cell falls to the
 best plausible runner-up, and disappears from `bests` when there is none. That
@@ -480,6 +489,12 @@ Ceilings are deliberately loose — several × the best value ever recorded — 
 they reject fabrications, not fast machines. NaN and infinities are outside
 every window.
 
+**What a bound can and cannot catch.** It rejects a value orders of magnitude
+out of range; it cannot detect a wrong value that lands inside the range. The
+fabricated `(prompt_tokens - 242) * 1000` form below stays under the
+`prefill_tps` ceiling for any prompt shorter than ~342 tokens. Bounds are
+defence in depth behind a correct producer, never a substitute for one.
+
 Three places enforce the same bounds, from the same table:
 
 1. **Ingest** — `RunRecord::validate` rejects the whole record with
@@ -492,6 +507,13 @@ Three places enforce the same bounds, from the same table:
    rows cannot be deleted or corrected, and failing on them would make every
    `make ci` run permanently red — a stuck light, not a gate. The gate that
    fails is (1); 6b reports what it would now refuse.
+
+**Where bounds cannot decide.** A placeholder that is indistinguishable from a
+real measurement *as a number* has to be dropped where the convention is known,
+not here. CBB's `summary.csv` writes `task_pass_at_1 = 0.0` when it ran no
+quality probe, and `0.0` pass@1 is also a legitimate score for a model that
+failed every task — so `migrate::legacy` drops that column's zero at the parse
+site, and the §4.1 bound for `task_pass_at_1` deliberately admits `0.0`.
 
 **Archive converters are the one exception.** `rmlx metrics migrate` replays
 another tool's CSV/JSONL exports, which write `0.0` in a column they never
@@ -516,8 +538,12 @@ append-only and nothing is deleted. Two known populations, both excluded from
   upper-only bound would have *promoted* them; the bound has to be two-sided.
 
 Anything anchoring on a recorded rate — a roofline, a champion table, a
-`rmlx metrics rank` — should read `bests`, which already excludes both, rather
-than re-implementing the predicate against `observations`.
+`rmlx metrics rank` — should read `bests`, or one of the `query::*` functions,
+all of which apply the bound already. A consumer that genuinely needs the raw
+distribution (a *median* over a cell's measurements, say, which the one-row-per-cell
+view cannot give) has to carry the predicate itself; it must then be pinned to
+this section by name and reviewed with it. `scripts/perf_ceiling.py`'s
+`prefill_anchor` is the one such consumer in the tree.
 
 **Backend coverage matrix** (which backend can emit which metric — sparse is fine, see §3.3):
 
@@ -1386,10 +1412,11 @@ Runs in this order, exits non-zero on any failure:
 4. Whitelist sweep — `SELECT DISTINCT backend FROM bests EXCEPT VALUES ('rmlx'),('mlx_lm'),(…)` etc. for `backend`, `model_namespace`, `weight_quant`, `kv_quant`, `metric`. Any row outside whitelist = error with PK printed.
 5. Direction sanity — every `metric` value must have correct `direction` per §4 registry. Mismatch = error.
 6. Unit sanity — every `metric` value must have correct `unit` per registry. Mismatch = error.
+3b. `bests` view vs the §4 registry — the view is generated, not pinned to a schema version, so a DB at the latest `user_version` can still carry a definition built from an older registry. Warns; rebuilds only under `--fix`.
 6b. Value plausibility — every `value` must be inside its §4.1 bounds. Unit sanity checks the *label*; this checks the *number*. Reported per metric with a count and the first offending id. **Warning**, never auto-fixed: these rows predate the ingest gate, `observations` is append-only, and the true value is not recoverable — only re-measurable.
 7. Stale-prompt check — prompts referenced from `bests` whose body sha256 doesn't match any `prompts/*.json` file. Warn (not error — a removed prompt file might still have valid history).
 
-`rmlx metrics doctor --fix` attempts safe auto-repairs (re-derives `unit`/`direction` from registry; fixes none of the others, including 6b).
+`rmlx metrics doctor --fix` attempts safe auto-repairs (re-derives `unit`/`direction` from registry, rebuilds the `bests` view from the registry; fixes none of the others, including 6b).
 
 ### 10.5 Concurrency
 

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -177,14 +177,33 @@ WITH ranked AS (
         ROW_NUMBER() OVER (
             PARTITION BY backend, model_namespace, model, weight_quant, kv_quant, ctx_max, prompt_id, metric
             ORDER BY
-                CASE WHEN direction = 'higher_better' THEN value END DESC,
-                CASE WHEN direction = 'lower_better'  THEN value END ASC,
+                CASE WHEN direction = 'higher_better' THEN  value END DESC,
+                CASE WHEN direction = 'lower_better'  THEN -value END DESC,
                 ts_utc DESC                           -- tie-breaker: newer wins
         ) AS rn
     FROM observations o
+    WHERE CASE metric                                 -- §4.1 plausible-value bounds
+              WHEN 'decode_tps_warm' THEN (value > 0.0 AND value <= 10000.0)
+              WHEN 'prompt_cache_hits' THEN (value >= 0.0 AND value <= 1e12)
+              -- … one branch per §4 metric, generated from the registry …
+              ELSE 1
+          END
 )
 SELECT * FROM ranked WHERE rn = 1;
 ```
+
+The `WHERE` is **generated from the §4 registry**, not written by hand:
+`rmlx_metrics::bests_view::create_sql` renders one branch per metric from the
+same `Bounds` the ingest validator enforces, and `migrate::run_pending`
+recreates the view whenever the stored definition and the registry disagree.
+Retyping the bound in SQL is how the view and the gate would drift apart.
+
+Rows outside the bound are **excluded, not re-ranked**: the cell falls to the
+best plausible runner-up, and disappears from `bests` when there is none. That
+is the intended outcome — an absent anchor is honest, an implausible one is
+not. The ranking has no plausibility floor of its own, so without this filter
+the largest number in a partition wins by construction, which is how
+`prefill_tps = (prompt_tokens - 242) * 1000` rows published as champions.
 
 Every column from `observations` is preserved on the champion row, so callers see the full run context that set the record (git_sha, description, etc.).
 
@@ -437,6 +456,68 @@ Source of truth for `observations.metric`, `.unit`, `.direction`. Add to this ta
 | `tpot_p99_ms`                    | `ms`    | `lower_better`  | TPOT 99th percentile over decode-only intervals. Mirrors `itl_p99_ms` in v1. Phase=`Decode`. rmlx-only. |
 
 **Dropped metrics** (vs first draft): `model_disk_gb` (not a perf metric, derivable from `du -sh <model_path>` on demand) and `tps_per_gb_disk` (depends on disk_gb).
+
+### 4.1 Plausible-value bounds
+
+Every registry entry also carries a `Bounds` — the window of values that can be
+a *measurement* of that metric. Per-metric values live in
+`crates/rmlx-metrics/src/registry.rs` (`METRICS`); this section is the policy
+they follow.
+
+Each metric counts, times or rates a physical quantity, so the floor is always
+`0.0` and a negative value is never a measurement. What differs is whether the
+floor is itself a measurement:
+
+| Family | Floor | Ceiling | Why |
+|---|---|---|---|
+| Rates (`tps`, `mb/s`, `tps_per_gb_ram`) | `0` **excluded** | 1e4–1e6 | `tokens / seconds` is zero only when no token was produced — nothing was measured. |
+| Durations (`ms`) | `0` included | 3.6e6 (1 h) | Millisecond resolution rounds a sub-ms span to zero. A single span past an hour is a hung run. |
+| Counters (`count`) | `0` included | 1e12 | Zero cache hits is a real observation. |
+| Gauges (`mb`, `bytes`) | `0` included, except `peak_rss_mb` | 1e9 MB / 1e13 B | A live process always has RSS; a run can genuinely allocate no Metal. |
+| Ratios (`ratio`) | `0` included | 1.0 (or 1e3 for `accepted_per_step`) | Rates of acceptance are honestly zero. |
+
+Ceilings are deliberately loose — several × the best value ever recorded — so
+they reject fabrications, not fast machines. NaN and infinities are outside
+every window.
+
+Three places enforce the same bounds, from the same table:
+
+1. **Ingest** — `RunRecord::validate` rejects the whole record with
+   `ImplausibleValue`. An emitter with no measurement must send `null`; the
+   recorder writes no row for a null and that is the supported way to say
+   "not measured". A placeholder number is not.
+2. **`bests`** — the view does not rank rows outside the bound (§3.3).
+3. **`rmlx metrics doctor`** — check 6b reports rows already in the DB
+   (§10.4). A *warning*, not an error: `observations` is append-only, so those
+   rows cannot be deleted or corrected, and failing on them would make every
+   `make ci` run permanently red — a stuck light, not a gate. The gate that
+   fails is (1); 6b reports what it would now refuse.
+
+**Archive converters are the one exception.** `rmlx metrics migrate` replays
+another tool's CSV/JSONL exports, which write `0.0` in a column they never
+measured. Those entries are dropped rather than failing the whole historical
+run, and counted in the migrate report as `metrics_dropped_implausible`.
+
+#### Known-bad rows already in the DB
+
+Rows written before these gates existed are still there — `observations` is
+append-only and nothing is deleted. Two known populations, both excluded from
+`bests` by the bound and reported by `doctor`:
+
+- **`prefill_tps` ≥ 1e5** — 20 rows from a legacy buffer replay storing
+  `(prompt_tokens - 242) * 1000` under `unit='tps'`. The producing script
+  derived `prefill_s` from `elapsed_s - n_comp / (n_comp / elapsed_s)`, which
+  is identically zero, so it always hit a `0.001 s` floor and reported
+  `prompt_tokens × 1000` as a rate. `value >= 1e5` identifies them; the
+  `notes` string they carry does not, since the emitting code no longer writes
+  it.
+- **rate metrics `= 0.0`** — an early-stopped run recording a fabricated zero
+  instead of nothing. These win any cell whose rows are all zeros, so an
+  upper-only bound would have *promoted* them; the bound has to be two-sided.
+
+Anything anchoring on a recorded rate — a roofline, a champion table, a
+`rmlx metrics rank` — should read `bests`, which already excludes both, rather
+than re-implementing the predicate against `observations`.
 
 **Backend coverage matrix** (which backend can emit which metric — sparse is fine, see §3.3):
 
@@ -1145,7 +1226,7 @@ def record_run(row: dict) -> None:
 | `omlx`      | yes                   | maybe            | yes            |
 | `ollama`    | no                    | no               | yes (HTTP)     |
 
-Each row in the `metrics: []` array with `value: null` is silently skipped. No backend needs to lie about a metric it can't measure.
+Each row in the `metrics: []` array with `value: null` is silently skipped. No backend needs to lie about a metric it can't measure — and it must not: a placeholder `0.0` in place of a `null` is rejected at ingest by the §4.1 bounds, because once stored it ranks and publishes exactly like a measured zero.
 
 ### 8.7 Prompt ownership — rMLX is the source-of-truth
 
@@ -1305,9 +1386,10 @@ Runs in this order, exits non-zero on any failure:
 4. Whitelist sweep — `SELECT DISTINCT backend FROM bests EXCEPT VALUES ('rmlx'),('mlx_lm'),(…)` etc. for `backend`, `model_namespace`, `weight_quant`, `kv_quant`, `metric`. Any row outside whitelist = error with PK printed.
 5. Direction sanity — every `metric` value must have correct `direction` per §4 registry. Mismatch = error.
 6. Unit sanity — every `metric` value must have correct `unit` per registry. Mismatch = error.
+6b. Value plausibility — every `value` must be inside its §4.1 bounds. Unit sanity checks the *label*; this checks the *number*. Reported per metric with a count and the first offending id. **Warning**, never auto-fixed: these rows predate the ingest gate, `observations` is append-only, and the true value is not recoverable — only re-measurable.
 7. Stale-prompt check — prompts referenced from `bests` whose body sha256 doesn't match any `prompts/*.json` file. Warn (not error — a removed prompt file might still have valid history).
 
-`rmlx metrics doctor --fix` attempts safe auto-repairs (re-derives `unit`/`direction` from registry; fixes none of the others).
+`rmlx metrics doctor --fix` attempts safe auto-repairs (re-derives `unit`/`direction` from registry; fixes none of the others, including 6b).
 
 ### 10.5 Concurrency
 
@@ -1472,7 +1554,7 @@ For any future Claude session that touches metrics:
 17. **Prompts owned by rMLX repo** — `rMLX/prompts/*.json` is canonical. CBB symlinks. Content-addressed by sha256, so editing a file = new prompt id; old runs still reference old id. Bench runners include full body in ingest record; recorder hashes + dedups.
 18. **JSON buffer per run** (§8.4) — bench writes `metrics/buffer/pending/<ts>-<uuid>.json`, calls recorder, deletes on success or moves to `failed/` on rejection. Crash recovery via `--replay-pending`.
 19. **`inserted_by` audit field** — every row carries `<tool>@<semver>`. Never NULL. Triage rows by tool when anomalies appear.
-20. **`rmlx metrics doctor`** — run after migrations or before suspect-state operations. Validates schema version, FKs, whitelists, unit/direction sanity.
+20. **`rmlx metrics doctor`** — run after migrations or before suspect-state operations. Validates schema version, FKs, whitelists, unit/direction sanity, and §4.1 value plausibility.
 21. **No parallel writers.** Single MLX process rule already prevents this. PID-flock available as belt-and-braces.
 22. **Atomicity per run** — one `record` invocation = one transaction = all observations from that run land or none do.
 23. **DB is also a Grafana datasource** — the `observations` table is a time-series. Schema choices privilege read-time derivation over write-time pruning specifically to keep history queryable. Never delete observations to "clean up" — that breaks the dashboards.

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -1526,19 +1526,18 @@ Golden-file fixtures: a tiny corpus of legacy JSONL/CSV in `crates/rmlx-metrics/
 
 ### 12.1 Pre-push gate (`make ci`)
 
-`make ci` already runs `fmt-check + lint + test + deny + audit`. Add:
+`make ci` runs `ci-metrics`, which is `rmlx metrics doctor` against
+`<RMLX_HOME>/metrics/runs.db`, skipped when that file is absent. CI never RUNS
+benches (slow, hardware-bound); it validates the DB's structure, identity
+whitelists, unit/direction registry agreement and §4.1 value plausibility.
 
-```makefile
-ci-metrics: ## verify metrics DB sanity (no regressions vs current bests)
-	rmlx metrics doctor
-	rmlx metrics export --markdown > /tmp/RECORDS.md
-	diff -u BENCHMARK_CHAMPIONS.md /tmp/RECORDS.md || \
-		(echo "BENCHMARK_CHAMPIONS.md out of sync — run: rmlx metrics export --markdown > BENCHMARK_CHAMPIONS.md" && exit 1)
-
-ci: fmt-check lint test deny audit ci-metrics
-```
-
-CI never RUNS benches (slow, hardware-bound). It only validates that the committed `BENCHMARK_CHAMPIONS.md` matches what the DB would produce. Stops drift between hand-edits and DB-truth.
+It does **not** diff `BENCHMARK_CHAMPIONS.md`. An earlier draft of this section
+proposed that, and it cannot work: the champions table is a pure function of a
+machine-local, gitignored DB, so the file is gitignored too
+(`.gitignore`, and `make metrics-export` says so on its help line). There is no
+committed copy for CI to compare against, and a per-machine one would differ on
+every host. Regenerate it locally with `make metrics-export` after any change
+that alters what `bests` publishes — for example a §4.1 bounds change.
 
 ### 12.2 Bench-records sweep automation
 

--- a/scripts/bench/final_matrix_bench.sh
+++ b/scripts/bench/final_matrix_bench.sh
@@ -292,9 +292,23 @@ bench_cell() {
         "TIMEOUT" "TIMEOUT" "TIMEOUT" "TIMEOUT" "TIMEOUT" "cell_timeout"; return 0; }
     local ttft_result
     ttft_result="$(completion_request "${TTFT_TOKENS}" "${PROMPT_FILE}" "${MODEL_ID}")" || ttft_result="elapsed_ms=0 completion_tokens=0 prompt_tokens=0 total_tokens=0"
-    local ttft_ms
+    local ttft_ms ttft_prompt_tokens
     ttft_ms="$(echo "${ttft_result}" | grep -oE 'elapsed_ms=[0-9]+' | cut -d= -f2 || echo 0)"
+    ttft_prompt_tokens="$(echo "${ttft_result}" | grep -oE 'prompt_tokens=[0-9]+' | cut -d= -f2 || echo 0)"
     log "  TTFT warm: ${ttft_ms}ms"
+
+    # Prefill rate = prompt tokens / time to the first token, measured by the
+    # max_tokens=1 request above. That request IS the prefill measurement;
+    # there is no way to separate prefill from decode inside a multi-token
+    # request that only reports total elapsed time. Empty when the probe
+    # returned nothing to divide by — an unmeasured rate is recorded as null,
+    # never as a number.
+    local prefill_tps
+    prefill_tps="$(python3 -c "
+ttft_s = ${ttft_ms} / 1000.0
+n_prom = ${ttft_prompt_tokens}
+print(f'{n_prom / ttft_s:.1f}' if ttft_s > 0 and n_prom > 0 else '')
+" 2>/dev/null || echo "")"
 
     # Decode warmup
     log "  Decode warmup..."
@@ -304,7 +318,6 @@ bench_cell() {
 
     # Decode measure runs
     declare -a decode_tps_vals=()
-    declare -a prefill_tps_vals=()
     local run_i
     for run_i in $(seq 1 "${MEASURE_RUNS}"); do
         check_timeout || { write_cell_json "${idx}" "${MODEL_ID}" "${kv_quant}" "${max_ctx}" "${ctx_label}" \
@@ -318,66 +331,40 @@ bench_cell() {
         r_completion="$(echo "${res}" | grep -oE 'completion_tokens=[0-9]+' | cut -d= -f2 || echo 0)"
         r_prompt="$(echo "${res}" | grep -oE 'prompt_tokens=[0-9]+' | cut -d= -f2 || echo 0)"
 
-        # decode TPS = completion_tokens / (elapsed_s - prefill_s)
-        # prefill TPS = prompt_tokens / prefill_s
-        # derive prefill_s by assuming decode rate ~ decode_tps from prior runs,
-        # but for first run estimate prefill_s = elapsed_s - completion_tokens/estimate_decode_tps
-        # Simpler approach: total_s = elapsed_s/1000; decode_s = completion_tokens/decode_tps
-        # We use: prefill_s = elapsed_s - decode_s
-        # decode_tps approximation (iterate): first pass assume decode dominates short responses
-        local tps_raw
-        tps_raw="$(python3 -c "
-elapsed_ms = ${r_elapsed}
+        # Decode rate excludes prefill by subtracting the separately measured
+        # TTFT from the wall clock. The earlier form derived `prefill_s` from
+        # `elapsed_s - n_comp/(n_comp/elapsed_s)`, which is identically zero,
+        # so it always hit the 0.001s floor and reported n_prom*1000 as a rate.
+        local r_decode
+        r_decode="$(python3 -c "
+elapsed_s = ${r_elapsed} / 1000.0
+ttft_s = ${ttft_ms} / 1000.0
 n_comp = ${r_completion}
-n_prom = ${r_prompt}
-# Simple TPS: completion_tokens / elapsed_s (overestimates decode TPS slightly since includes prefill)
-# For 30-token responses vs large prompt, prefill is significant.
-# We compute decode_tps = n_comp / (elapsed_s) as proxy (conservative), and
-# prefill_tps = n_prom / (elapsed_s - n_comp/decode_tps) iteratively.
-elapsed_s = elapsed_ms / 1000.0
-if n_comp > 0 and elapsed_s > 0:
-    # Estimate decode_tps assuming fast decode
-    # Use 2-step: rough decode_tps from total, then refine prefill
-    rough_decode = n_comp / elapsed_s  # over-estimate (includes prefill in denominator)
-    # Use rough decode to estimate prefill time
-    decode_s = n_comp / rough_decode if rough_decode > 0 else 0
-    prefill_s = max(elapsed_s - decode_s, 0.001)
-    prefill_tps = n_prom / prefill_s if prefill_s > 0 else 0
-    # refined decode_tps
-    actual_decode_s = elapsed_s - prefill_s
-    decode_tps = n_comp / actual_decode_s if actual_decode_s > 0.001 else n_comp / elapsed_s
-else:
-    decode_tps = 0.0
-    prefill_tps = 0.0
-print(f'{decode_tps:.2f} {prefill_tps:.1f}')
-" 2>/dev/null || echo "0.00 0.0")"
-        local r_decode r_prefill
-        r_decode="$(echo "${tps_raw}" | awk '{print $1}')"
-        r_prefill="$(echo "${tps_raw}" | awk '{print $2}')"
+decode_s = elapsed_s - ttft_s
+print(f'{(n_comp - 1) / decode_s:.2f}' if n_comp >= 2 and decode_s > 0 else '')
+" 2>/dev/null || echo "")"
         decode_tps_vals+=("${r_decode}")
-        prefill_tps_vals+=("${r_prefill}")
-        log "    decode_tps=${r_decode} prefill_tps=${r_prefill} (elapsed=${r_elapsed}ms comp=${r_completion} prompt=${r_prompt})"
+        log "    decode_tps=${r_decode:-n/a} (elapsed=${r_elapsed}ms comp=${r_completion} prompt=${r_prompt})"
     done
 
-    # Compute mean/stddev
-    local decode_mean decode_stddev prefill_mean
-    read -r decode_mean decode_stddev prefill_mean <<< "$(python3 -c "
+    # Compute mean/stddev over the runs that produced a rate. Runs that did
+    # not are absent, not zero — averaging a zero in would drag the mean.
+    local decode_mean decode_stddev
+    read -r decode_mean decode_stddev <<< "$(python3 -c "
 import math
 dvals = [float(x) for x in '${decode_tps_vals[*]}'.split()]
-pvals = [float(x) for x in '${prefill_tps_vals[*]}'.split()]
 if dvals:
     dmean = sum(dvals)/len(dvals)
     dstd = math.sqrt(sum((v-dmean)**2 for v in dvals)/(len(dvals)-1)) if len(dvals)>1 else 0.0
+    print(f'{dmean:.2f} {dstd:.2f}')
 else:
-    dmean, dstd = 0.0, 0.0
-pmean = sum(pvals)/len(pvals) if pvals else 0.0
-print(f'{dmean:.2f} {dstd:.2f} {pmean:.1f}')
-" 2>/dev/null || echo "0.00 0.00 0.0")"
+    print('  ')
+" 2>/dev/null || echo "  ")"
 
-    log "  Cell ${idx} result: decode=${decode_mean}±${decode_stddev} prefill=${prefill_mean} ttft=${ttft_ms}ms"
+    log "  Cell ${idx} result: decode=${decode_mean:-n/a}±${decode_stddev:-n/a} prefill=${prefill_tps:-n/a} ttft=${ttft_ms}ms"
 
     write_cell_json "${idx}" "${MODEL_ID}" "${kv_quant}" "${max_ctx}" "${ctx_label}" \
-        "${decode_mean}" "${decode_stddev}" "${prefill_mean}" "${ttft_ms}" "ok" ""
+        "${decode_mean}" "${decode_stddev}" "${prefill_tps}" "${ttft_ms}" "ok" ""
 
     # DB ingest buffer record
     local model_dir
@@ -407,6 +394,13 @@ print(f'{dmean:.2f} {dstd:.2f} {pmean:.1f}')
 
     python3 -c "
 import json, os
+
+def num(s):
+    # An unmeasured rate is null in the \u00a78.5 record; the recorder writes no
+    # row for it. A 0.0 here would be stored and ranked as a measurement.
+    s = s.strip()
+    return float(s) if s else None
+
 with open('${PROMPT_FILE}') as f:
     pf = json.load(f)
 prompt_body = pf.get('messages', pf.get('body', str(pf)))
@@ -433,9 +427,9 @@ rec = {
     'notes':           'final-matrix',
     'description':     None,
     'metrics': [
-        {'name': 'decode_tps_warm', 'value': float('${decode_mean}'),  'stddev': float('${decode_stddev}')},
-        {'name': 'prefill_tps',     'value': float('${prefill_mean}'), 'stddev': None},
-        {'name': 'ttft_warm_ms',    'value': float('${ttft_ms}'),      'stddev': None},
+        {'name': 'decode_tps_warm', 'value': num('${decode_mean}'),  'stddev': num('${decode_stddev}')},
+        {'name': 'prefill_tps',     'value': num('${prefill_tps}'),  'stddev': None},
+        {'name': 'ttft_warm_ms',    'value': num('${ttft_ms}'),      'stddev': None},
     ],
 }
 with open('${record_path}', 'w') as f:
@@ -456,6 +450,11 @@ print(f'buffer: ${record_path}')
     # Legacy JSONL
     python3 -c "
 import json, os
+
+def num(s):
+    s = s.strip()
+    return float(s) if s else None
+
 rec = {
     **json.loads(os.environ['RMLX_IDENTITY_JSON']),
     'run_id': '${run_id}',
@@ -463,10 +462,10 @@ rec = {
     'model_path': '${model_path}',
     'kv_quant': '${kv_quant}',
     'max_ctx': int('${max_ctx}'),
-    'decode_tps_mean': float('${decode_mean}'),
-    'decode_tps_stddev': float('${decode_stddev}'),
-    'prefill_tps': float('${prefill_mean}'),
-    'ttft_ms': float('${ttft_ms}'),
+    'decode_tps_mean': num('${decode_mean}'),
+    'decode_tps_stddev': num('${decode_stddev}'),
+    'prefill_tps': num('${prefill_tps}'),
+    'ttft_ms': num('${ttft_ms}'),
     ${GIT_SHA_KV}
     'notes': 'final-matrix',
 }
@@ -528,6 +527,8 @@ def model_short(m):
     return m[:7]
 
 def fmt_val(v, fmt='.1f'):
+    if v is None or str(v).strip() == '':
+        return 'n/a'   # not measured, as opposed to measured-as-zero
     try:
         f = float(v)
         if f == 0.0:

--- a/scripts/bench/gemma_matrix_bench.sh
+++ b/scripts/bench/gemma_matrix_bench.sh
@@ -266,12 +266,14 @@ bench_cell() {
 
     # Prefill TPS from cold TTFT: prefill_tps = prompt_tokens / (cold_ttft_ms / 1000)
     local prefill_tps
+    # Empty, never 0.0, when there is no TTFT to divide by: an unmeasured rate
+    # is recorded as null, and null writes no row.
     prefill_tps="$(python3 -c "
 pt = ${PROMPT_TOKENS}
 ttft_s = ${cold_ttft_ms} / 1000.0
-print(f'{pt/ttft_s:.1f}' if ttft_s > 0 else '0.0')
-" 2>/dev/null || echo "0.0")"
-    log "  Prefill TPS (from cold TTFT): ${prefill_tps}"
+print(f'{pt/ttft_s:.1f}' if ttft_s > 0 and pt > 0 else '')
+" 2>/dev/null || echo "")"
+    log "  Prefill TPS (from cold TTFT): ${prefill_tps:-n/a}"
 
     # Decode warmup
     log "  Decode warmup..."
@@ -297,23 +299,16 @@ print(f'{pt/ttft_s:.1f}' if ttft_s > 0 else '0.0')
         # Decode TPS: total_elapsed - cold_ttft (prefill) = decode time
         local decode_tps
         decode_tps="$(python3 -c "
-elapsed_ms = ${r_elapsed}
+elapsed_s = ${r_elapsed} / 1000.0
 n_comp = ${r_completion}
-cold_ttft_ms = ${cold_ttft_ms}
-elapsed_s = elapsed_ms / 1000.0
-# For decode measure runs, prompt cache is warm (hit), so minimal prefill overhead.
-# Use warm ttft (cache hit time) as the prefill subtraction.
-warm_ttft_ms = ${ttft_ms}
-prefill_s = warm_ttft_ms / 1000.0
-decode_s = max(elapsed_s - prefill_s, 0.001)
-if n_comp > 0 and decode_s > 0:
-    tps = n_comp / decode_s
-else:
-    tps = 0.0
-print(f'{tps:.2f}')
-" 2>/dev/null || echo "0.00")"
+# For decode measure runs the prompt cache is warm (hit), so the warm TTFT is
+# the prefill share to subtract. No floor on the denominator: clamping it to
+# 0.001s is what turned an unmeasurable window into a fabricated rate.
+decode_s = elapsed_s - ${ttft_ms} / 1000.0
+print(f'{n_comp / decode_s:.2f}' if n_comp > 0 and decode_s > 0 else '')
+" 2>/dev/null || echo "")"
         decode_tps_vals+=("${decode_tps}")
-        log "    decode_tps=${decode_tps} (elapsed=${r_elapsed}ms comp=${r_completion} ttft_sub=${ttft_ms}ms)"
+        log "    decode_tps=${decode_tps:-n/a} (elapsed=${r_elapsed}ms comp=${r_completion} ttft_sub=${ttft_ms}ms)"
     done
 
     local decode_mean decode_stddev
@@ -323,12 +318,12 @@ dvals = [float(x) for x in '${decode_tps_vals[*]}'.split()]
 if dvals:
     dmean = sum(dvals)/len(dvals)
     dstd = math.sqrt(sum((v-dmean)**2 for v in dvals)/(len(dvals)-1)) if len(dvals)>1 else 0.0
+    print(f'{dmean:.2f} {dstd:.2f}')
 else:
-    dmean, dstd = 0.0, 0.0
-print(f'{dmean:.2f} {dstd:.2f}')
-" 2>/dev/null || echo "0.00 0.00")"
+    print('  ')
+" 2>/dev/null || echo "  ")"
 
-    log "  Cell ${idx} result: decode=${decode_mean}±${decode_stddev} prefill=${prefill_tps} ttft_cold=${cold_ttft_ms}ms ttft_warm=${ttft_ms}ms"
+    log "  Cell ${idx} result: decode=${decode_mean:-n/a}±${decode_stddev:-n/a} prefill=${prefill_tps:-n/a} ttft_cold=${cold_ttft_ms}ms ttft_warm=${ttft_ms}ms"
 
     write_cell_json "${idx}" "${MODEL_ID}" "${kv_quant}" "${ctx_label}" "${max_ctx}" \
         "${decode_mean}" "${decode_stddev}" "${prefill_tps}" "${cold_ttft_ms}" "ok" "ttft_warm=${ttft_ms}"
@@ -343,6 +338,12 @@ print(f'{dmean:.2f} {dstd:.2f}')
 
     python3 -c "
 import json, os
+
+def num(s):
+    # An unmeasured rate is null in the record; the recorder writes no row for
+    # it. A 0.0 would be stored and ranked as a measurement.
+    s = s.strip()
+    return float(s) if s else None
 with open('${prompt_file}') as f:
     pf = json.load(f)
 prompt_body = pf.get('messages', pf.get('body', str(pf)))
@@ -369,9 +370,9 @@ rec = {
     'notes':           'gemma-matrix-bench',
     'description':     None,
     'metrics': [
-        {'name': 'decode_tps_warm', 'value': float('${decode_mean}'),  'stddev': float('${decode_stddev}')},
-        {'name': 'prefill_tps',     'value': float('${prefill_tps}'),  'stddev': None},
-        {'name': 'ttft_warm_ms',    'value': float('${ttft_ms}'),      'stddev': None},
+        {'name': 'decode_tps_warm', 'value': num('${decode_mean}'),  'stddev': num('${decode_stddev}')},
+        {'name': 'prefill_tps',     'value': num('${prefill_tps}'),  'stddev': None},
+        {'name': 'ttft_warm_ms',    'value': num('${ttft_ms}'),      'stddev': None},
     ],
 }
 with open('${record_path}', 'w') as f:
@@ -391,6 +392,12 @@ print(f'buffer: ${record_path}')
 
     python3 -c "
 import json, os
+
+def num(s):
+    # An unmeasured rate is null in the record; the recorder writes no row for
+    # it. A 0.0 would be stored and ranked as a measurement.
+    s = s.strip()
+    return float(s) if s else None
 rec = {
     **json.loads(os.environ['RMLX_IDENTITY_JSON']),
     'run_id': '${run_id}',
@@ -399,10 +406,10 @@ rec = {
     'kv_quant': '${kv_quant}',
     'max_ctx': int('${max_ctx}'),
     'ctx_label': '${ctx_label}',
-    'decode_tps_mean': float('${decode_mean}'),
-    'decode_tps_stddev': float('${decode_stddev}'),
-    'prefill_tps': float('${prefill_tps}'),
-    'ttft_ms': float('${ttft_ms}'),
+    'decode_tps_mean': num('${decode_mean}'),
+    'decode_tps_stddev': num('${decode_stddev}'),
+    'prefill_tps': num('${prefill_tps}'),
+    'ttft_ms': num('${ttft_ms}'),
     ${GIT_SHA_KV}
     'notes': 'gemma-matrix-bench',
 }

--- a/scripts/bench_cell.sh
+++ b/scripts/bench_cell.sh
@@ -378,7 +378,7 @@ import json, os, sys
 with open(os.environ["PROMPT_FILE"], "r") as f:
     body = json.load(f)
 rec = {
-    **json.loads(os.environ['RMLX_IDENTITY_JSON']),
+    **json.loads(os.environ["RMLX_IDENTITY_JSON"]),
   # "unknown" is a fallback, never provenance — a checkout without .git
   # must not stamp git_sha at all.
   **({"git_sha": os.environ["GIT_SHA_VAL"]} if not os.environ["GIT_SHA_VAL"].startswith("unknown") else {}),
@@ -396,8 +396,11 @@ rec = {
   "n_measure": int(os.environ["N_MEAS_VAL"]),
   "notes": os.environ["NOTES_VAL"],
   "description": os.environ["DESC_VAL"],
+  # A run that failed its throughput threshold measured no throughput. `null`
+  # records the attempt (notes carry status=runtime_fail and the observed tps)
+  # without filing a fabricated 0.0 that would rank as a measurement.
   "metrics": [
-    {"name": "decode_tps_warm", "value": 0.0, "stddev": 0.0},
+    {"name": "decode_tps_warm", "value": None, "stddev": None},
   ],
 }
 json.dump(rec, sys.stdout, indent=2)
@@ -440,10 +443,16 @@ json.dump(rec, sys.stdout, indent=2)
   GIT_SHA_VAL="$GIT_SHA" \
   python3 -c '
 import json, os, sys
+
+def _num(raw):
+    """An empty scrape is a missing measurement, not a zero."""
+    raw = (raw or "").strip()
+    return float(raw) if raw else None
+
 with open(os.environ["PROMPT_FILE"], "r") as f:
     body = json.load(f)
 rec = {
-    **json.loads(os.environ['RMLX_IDENTITY_JSON']),
+    **json.loads(os.environ["RMLX_IDENTITY_JSON"]),
   # "unknown" is a fallback, never provenance — a checkout without .git
   # must not stamp git_sha at all.
   **({"git_sha": os.environ["GIT_SHA_VAL"]} if not os.environ["GIT_SHA_VAL"].startswith("unknown") else {}),
@@ -461,12 +470,15 @@ rec = {
   "n_measure": int(os.environ["N_MEAS_VAL"]),
   "notes": os.environ["NOTES_VAL"],
   "description": os.environ["DESC_VAL"],
+  # `or 0` coerced a scrape that came back empty into a measurement of zero.
+  # A missed RSS scrape is not a 0 MB process, and a zero rate is not a rate:
+  # send null and let the recorder write no row for that metric.
   "metrics": [
-    {"name": "decode_tps_warm", "value": float(os.environ["TPS_VAL"]),
-     "stddev": float(os.environ["STDDEV_VAL"])},
-    {"name": "ttft_warm_ms",    "value": float(os.environ["TTFT_VAL"] or 0)},
-    {"name": "model_load_ms",   "value": float(os.environ["LOAD_VAL"] or 0)},
-    {"name": "peak_rss_mb",     "value": float(os.environ["RSS_VAL"] or 0)},
+    {"name": "decode_tps_warm", "value": _num(os.environ["TPS_VAL"]),
+     "stddev": _num(os.environ["STDDEV_VAL"])},
+    {"name": "ttft_warm_ms",    "value": _num(os.environ["TTFT_VAL"])},
+    {"name": "model_load_ms",   "value": _num(os.environ["LOAD_VAL"])},
+    {"name": "peak_rss_mb",     "value": _num(os.environ["RSS_VAL"])},
   ],
 }
 json.dump(rec, sys.stdout, indent=2)

--- a/scripts/perf_ceiling.py
+++ b/scripts/perf_ceiling.py
@@ -633,10 +633,16 @@ def prefill_flops_per_token(spec: ModelSpec, ctx: int) -> float:
 def prefill_anchor(db: Path, model_basename: str) -> dict | None:
     """Median measured prefill_tps for this model from runs.db, read-only.
 
-    Filters: backend=rmlx, value in (0, 1e5) -- the DB carries legacy rows
-    whose `prefill_tps` value is ~prompt_tokens*1000 and is plainly not a rate
-    (notes: 'ingested from legacy N74 buffer (schema pre-8.5)') -- and
-    ts_utc >= PREFILL_ANCHOR_MIN_TS. Picks the cell with the most rows.
+    Reads `observations`, not `bests`: the anchor is the MEDIAN of a cell's
+    measurements, and the view carries one champion row per cell, which would
+    make the roofline anchor on a best-ever value instead of a typical one.
+    That means this query has to carry the plausibility bound itself, so it is
+    kept identical to METRICS_DB.md §4.1 for `prefill_tps` -- `Bounds::positive(1e5)`,
+    i.e. `value > 0 AND value <= 1e5`. Do not "tighten" it here; change §4.1 and
+    the registry, then mirror it.
+
+    Also filters backend=rmlx and ts_utc >= PREFILL_ANCHOR_MIN_TS. Picks the
+    cell with the most rows.
     """
     if not db.exists():
         return None
@@ -648,7 +654,7 @@ def prefill_anchor(db: Path, model_basename: str) -> dict | None:
         rows = con.execute(
             "SELECT prompt_tokens, value, hardware_tag FROM observations "
             "WHERE metric='prefill_tps' AND backend='rmlx' AND model=? "
-            "AND value>0 AND value<1e5 AND ts_utc>=?",
+            "AND value>0 AND value<=1e5 AND ts_utc>=?",  # §4.1 Bounds::positive(1e5)
             (model_basename, PREFILL_ANCHOR_MIN_TS),
         ).fetchall()
     except sqlite3.Error:


### PR DESCRIPTION
Closes #401.

## Root cause

Nothing between an emitter and the published champion table ever bounded `observations.value`. `registry::METRICS` carried `(unit, direction)` only, `RunRecord::validate` checked metric *names*, doctor Check 6 compared the unit *string*, and the `bests` view ranks by magnitude with no floor — so the largest number in a partition wins by construction.

The 20 rows came from `scripts/bench/final_matrix_bench.sh`, where `decode_s = n_comp / (n_comp / elapsed_s)` is identically `elapsed_s`, so `prefill_s = max(elapsed_s - decode_s, 0.001)` always hit the 0.001 floor and `prefill_tps` reduced to `prompt_tokens x 1000`. The zero half came from `baseline.rs` fabricating `0.0` for every phase of a zero-token run.

## Fix

A per-metric `Bounds` in the registry — a ceiling, plus whether `0.0` is itself a measurement (rates: no; counters and durations: yes) — enforced at three points:

- `RunRecord::validate` rejects at ingest.
- The `bests` view is **generated** from the same table (`bests_view::create_sql`), and the read side (`deltas`, `regress`, `timeseries`) shares the generated predicate via `plausible_sql`, so SQL and gate cannot drift.
- Doctor reports what is already stored, as a warning — the DB is append-only, so an error there could never clear.

Both producers are fixed at source, and the placeholder paths a value bound structurally cannot see are handled where the column convention is known rather than where the number is: `task_pass_at_1 == 0.0` is a legitimate score, so it stays a parse-site decision.

Read-only metrics commands no longer migrate or issue DDL on whatever `--db` points at; they refuse a stale view and name `doctor --fix`.

## Evidence

Every guard was verified red before the fix and mutation-checked after — neutralising each one turned exactly its own test red and left the others green. Highlights:

- View predicate removed: `the inflated row won the cell / left: [("k8v4", 130810000.0)] / right: [("k8v4", 494.7)]`
- Ingest gate removed: `called Result::unwrap_err() on an Ok value`
- Read-path predicate removed: `deltas ranked the implausible row: Some(130810000.0)`
- Phase timing restored: `ttft_ms fabricated on a zero-token run / left: Some(0.0) / right: None`

End-to-end through the real CLI: a pre-fix bench record whose RSS scrape missed lost **every** metric of the cell; post-fix the same run writes 3 observations and reports `skipped_metrics: ["peak_rss_mb"]`.

Champions on a DB copy: prefill cells 170 -> 139 (20 corrupt + 11 fabricated zeros), runners-up promoted. No row deleted or rewritten — the corrupt rows remain, they simply no longer rank.

## Also fixed in branch

`bench_cell.sh` could not write a record at all: inside `python3 -c '...'` the source contained `os.environ['RMLX_IDENTITY_JSON']`, whose quotes closed the shell string, so Python received a bare name and raised `NameError`. Pre-existing.

`docs/METRICS_DB.md` §12.1 claimed CI validates that a *committed* `BENCHMARK_CHAMPIONS.md` matches the DB. That file is gitignored and `ci-metrics` runs `doctor` only.

`make ci`: pass.
