### PR TITLE
fix(kv): stop materialising a packed KV store no decode path reads (#404)

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/fused_qk_dispatch.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/fused_qk_dispatch.rs
@@ -267,16 +267,17 @@ impl KvCache {
             // Seed the rotor table sideband (if applicable) before any
             // encode-chunk runs.
             if codec_is_rotor(codec) {
-                // `seed_rotor_table` hardcodes `head_idx = 0` in its call
-                // to `make_rotor_table`. Assert the active storage's
-                // `head_idx` agrees so future multi-head-KV work cannot
-                // silently desync the shadow's table from the CPU-storage
-                // path's table.
-                debug_assert_eq!(
-                    self.active_storage_rotor_head_idx().unwrap_or(0),
-                    0,
-                    "seed_rotor_table assumes head_idx=0; multi-head KV needs threading head_idx through FusedQkShadow"
-                );
+                // `seed_rotor_table` hardcodes `head_idx = 0` in its call to
+                // `make_rotor_table`. There used to be a `debug_assert_eq!`
+                // here comparing that against the active rotor storage's
+                // `head_idx`. It cannot fire any more and is gone rather than
+                // left to look like cover: `RotorK{3,4}Asym` build no packed
+                // store on a seeded cache, so the storage's `k` is always
+                // `None` on the only path that reaches this — the lookup
+                // returned `None`, `unwrap_or(0)` made it 0, and the assertion
+                // compared 0 against 0. Threading `head_idx` through
+                // `FusedQkShadow` is what multi-head-KV rotor work needs; an
+                // assertion over a buffer that no longer exists is not.
                 seed_rotor_table(
                     self.fused_qk_shadow.as_mut().ok_or_else(|| {
                         Error::Mlx("fused_qk: shadow vanished post-allocate".into())
@@ -461,23 +462,6 @@ impl KvCache {
             reason,
             "fused_qk: skipped"
         );
-    }
-
-    /// Return the rotor K-storage `head_idx` for the active storage variant,
-    /// or `None` when the active storage is not rotor-asym / has no allocated
-    /// K storage. Used by the dispatch path's `debug_assert!` to confirm
-    /// `seed_rotor_table`'s `head_idx=0` hardcode matches reality.
-    ///
-    /// Only the asym variants are listed: the rotor `Sym` / `KOnly` codecs are
-    /// rejected by the kernel-table gate several steps earlier, so this is
-    /// never called with their storage.
-    fn active_storage_rotor_head_idx(&self) -> Option<u32> {
-        use crate::storage::KvStorage;
-        match &self.storage {
-            KvStorage::RotorKAsym3 { k: Some(k), .. } => Some(k.head_idx),
-            KvStorage::RotorKAsym4 { k: Some(k), .. } => Some(k.head_idx),
-            _ => None,
-        }
     }
 
     /// Look up the `max_seq` the shadow should be sized to, taken from the

--- a/crates/rmlx-kv-quant/src/kvcache/rotor3_layer_idx_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/rotor3_layer_idx_tests.rs
@@ -210,17 +210,19 @@ fn rotor3_multi_layer_builder_populates_distinct_tables() {
     let k_data = vec![0.1_f32; n];
     let v_data = vec![0.2_f32; n];
 
-    // Build n_layers caches via the arch-builder pattern, run prefill+exit so
-    // the rotor table is generated on first append.
+    // Build n_layers caches via the arch-builder pattern and append once so the
+    // rotor table is generated. The append is deliberately NOT bracketed by
+    // `enter_prefill`/`exit_prefill`: a prefilled Rotor3 cache decodes off the
+    // bf16 mirror, so `exit_prefill` builds no packed store and there would be
+    // no rotor table to read. The unbracketed append is the same path a
+    // hydrated cache takes, which is where the store is load-bearing.
     let mut caches: Vec<KvCache> = (0..n_layers)
         .map(|i| KvCache::with_quant_max_seq(KvQuant::Rotor3, 1024).with_layer_idx(i))
         .collect();
     for cache in &mut caches {
-        cache.enter_prefill();
         let k = f32_arr(&k_data, &shape);
         let v = f32_arr(&v_data, &shape);
-        cache.update(&k, &v, device).expect("prefill update");
-        cache.exit_prefill(device).expect("exit_prefill");
+        cache.update(&k, &v, device).expect("codec append");
     }
 
     // Read the first rotor (4 floats) from each layer's live storage.

--- a/crates/rmlx-kv-quant/src/kvcache/rotor3_layer_idx_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/rotor3_layer_idx_tests.rs
@@ -200,6 +200,50 @@ fn rotor3_multi_layer_all_distinct() {
 /// pairwise distinct. This catches the layer-threading defect class at the
 /// integration layer: if the builder fails to thread `layer_idx`, every
 /// layer's table collapses to the `layer_idx=0` seed and these assertions fire.
+/// Bracketed counterpart: the same builder, driven through the **production**
+/// prefill path.
+///
+/// The unbracketed test below drives the codec body so a rotor table exists to
+/// compare. That leaves the path a real serve takes untested, which is exactly
+/// the path this change moved — so it is asserted here instead: a prefilled
+/// `Rotor3` cache builds no store at all, and its `layer_idx` still threads
+/// through the builder (the field the table is derived from).
+#[test]
+fn rotor3_multi_layer_prefill_builds_no_store_and_keeps_layer_idx() {
+    let n_layers = 4usize;
+    let device = Device::Cpu;
+    let head_dim = 64i32;
+    let shape = [1i32, 1, 2, head_dim];
+    let n: usize = shape.iter().map(|&x| x as usize).product();
+    let k_data = vec![0.1_f32; n];
+    let v_data = vec![0.2_f32; n];
+
+    for i in 0..n_layers {
+        let mut cache = KvCache::with_quant_max_seq(KvQuant::Rotor3, 1024).with_layer_idx(i);
+        cache.enter_prefill();
+        cache
+            .update(&f32_arr(&k_data, &shape), &f32_arr(&v_data, &shape), device)
+            .expect("prefill update");
+        cache.exit_prefill(device).expect("exit_prefill");
+
+        assert_eq!(
+            cache.layer_idx(),
+            i,
+            "builder must thread layer_idx through the prefill path too"
+        );
+        assert_eq!(
+            cache.storage().resident_bytes(),
+            0,
+            "layer {i}: Rotor3 decodes off the bf16 mirror, so a prefilled cache \
+             must hold no packed store — and therefore no rotor table"
+        );
+        assert!(
+            cache.decode_fp16_kv().is_some(),
+            "layer {i}: the mirror is what decode reads, so it must be live"
+        );
+    }
+}
+
 #[test]
 fn rotor3_multi_layer_builder_populates_distinct_tables() {
     let n_layers = 4usize;

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -2733,6 +2733,16 @@ impl KvCache {
                 total_seq,
                 "exit_prefill: packed store skipped — decode reads the bf16 mirror only"
             );
+            // Not just "build nothing" — drop anything already there. Every
+            // arm below *replaces* the payload, so before this gate a second
+            // prefill on a cache that arrived carrying one (an SSD-hydrated
+            // entry, deep-cloned and tail-extended; `enter_prefill` does not
+            // clear `storage`) overwrote it. Returning early without clearing
+            // would leave a store of the old length beside a mirror of the new
+            // one, and the spill writer prefers the store — so the block would
+            // be written under the full prompt's hash while holding only the
+            // prefix.
+            self.storage.clear_payload();
             if let Some((k_seed, v_seed)) = decode_fp16_pair {
                 self.decode_fp16_k = k_seed;
                 self.decode_fp16_v = v_seed;
@@ -2740,7 +2750,29 @@ impl KvCache {
             return Ok(());
         }
 
+        // REACHABILITY, as of the gate above: only the arms for codecs whose
+        // `materialises_packed_store()` is true run. That is `Mixed`, `RotK`,
+        // `RotKTq4V`, `IsoKOnly3/4`, `RotorKOnly3/4`, `Iso3Sym`, `Iso4Sym`,
+        // `Rotor3Sym`, `Rotor4Sym` — nine of the arms below. The rest are the
+        // bf16-mirror family and the gate returns before them.
+        //
+        // They are kept, not deleted, because they ARE the re-enable path: a
+        // codec that grows a decode kernel over its own packed store flips one
+        // arm in `decode_reads_packed_store` and this bulk encode is what then
+        // fills the buffer that kernel reads (see `docs/KV_CACHE.md` §9.6 —
+        // `planar_flash_decode` and the fused quant-decode work are both
+        // waiting on exactly that flip). The hazard that creates is real: a
+        // flipped predicate re-arms code that has had no execution since. The
+        // pairing guard is
+        // `warm_ttft_cross_codec_tests::exit_prefill_builds_a_store_exactly_when_the_predicate_says_so`,
+        // which sweeps every variant and fails the moment a codec's arm and its
+        // classification disagree.
         match self.quant {
+            // ── mirror-family group: NOT reachable today ────────────────────
+            // The arms from here down that belong to the bf16-mirror family
+            // (`K8V8`, `K8V4`, `Planar*`, `PlanarK`, `K8VTurbo*`, `TurboSym*`,
+            // `Iso3/4`, `Rotor3/4`, `RotorK*Asym`) are behind the gate above.
+            // The nine listed there are the ones that still run.
             KvQuant::K8V8 => {
                 let max_seq = match &self.storage {
                     KvStorage::K8V8 { max_seq, .. } => *max_seq,

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -2605,8 +2605,15 @@ impl KvCache {
                 let sl_start = vec![0i32; 4];
                 let sl_stop: Vec<i32> = [b, kv_h, total_seq, head_dim].into();
                 let sl_strides = vec![1i32; 4];
-                let k_buf = raw_k.slice(&sl_start, &sl_stop, &sl_strides, device)?;
-                let v_buf = raw_v.slice(&sl_start, &sl_stop, &sl_strides, device)?;
+                // `contiguous`: a bare slice stays a strided view over the raw
+                // prefill buffer, which pins the parent and mis-serialises. See
+                // the seed materialisation in the main path below.
+                let k_buf = raw_k
+                    .slice(&sl_start, &sl_stop, &sl_strides, device)?
+                    .contiguous(device)?;
+                let v_buf = raw_v
+                    .slice(&sl_start, &sl_stop, &sl_strides, device)?
+                    .contiguous(device)?;
                 k_buf.eval()?;
                 v_buf.eval()?;
                 self.decode_fp16_k = Some(k_buf);
@@ -2654,18 +2661,31 @@ impl KvCache {
         // a flash kernel over both packed rings. An unread seed is not a small
         // waste: it is `total_seq * B * kv_h * head_dim * 2` bytes per layer per
         // axis, the dominant residency term at long context.
+        //
+        // `contiguous` and not `try_clone`: `k_full` is a slice of the raw
+        // prefill buffer along the sequence axis, and MLX keeps that as a
+        // strided view over the parent allocation — `eval` does not flatten it.
+        // Two things follow that the seed's own contract denies. It is not
+        // compact: the whole `max_seq` parent stays resident behind it until the
+        // first decode step expands the mirror. And anything that reads the
+        // buffer by raw linear offset rather than by stride — `Array::to_bytes`,
+        // which is how the SSD tier serialises it — sees the parent's leading
+        // bytes under the slice's shape, i.e. head 0's whole row window in place
+        // of every head. Materialising row-major here, on the inference thread
+        // that owns the Metal stream, is what makes the seed mean what its shape
+        // says for every later reader.
         let is_bf16_storage = matches!(self.storage, KvStorage::None { .. });
         let need_k_seed = is_bf16_storage || self.quant.feeds_bf16_k_at_decode();
         let need_v_seed = is_bf16_storage || self.quant.feeds_bf16_v_at_decode();
         let k_buf = if need_k_seed {
-            let k = k_full.try_clone()?;
+            let k = k_full.contiguous(device)?;
             k.eval()?;
             Some(k)
         } else {
             None
         };
         let v_buf = if need_v_seed {
-            let v = v_full.try_clone()?;
+            let v = v_full.contiguous(device)?;
             v.eval()?;
             Some(v)
         } else {
@@ -2691,6 +2711,29 @@ impl KvCache {
             if let Some((k_seed, v_seed)) = decode_fp16_pair {
                 // `is_bf16_storage` is true on this path, so both clones above
                 // were materialised — these buffers *are* this codec's storage.
+                self.decode_fp16_k = k_seed;
+                self.decode_fp16_v = v_seed;
+            }
+            return Ok(());
+        }
+
+        // Bulk encode only what something will read. A codec that feeds both
+        // axes from the bf16 mirror and has no decode path over its packed
+        // store would write that store once here and then never touch it again
+        // — a second full copy of the context, per layer, live for the whole
+        // decode window, on top of a mirror that is already bf16-sized. The
+        // classification is the codec's own
+        // (`KvQuant::decode_reads_packed_store`), so this closes the class
+        // rather than a codec at a time; the store is still built for the
+        // families whose decode reads it, and a hydrated cache (which has no
+        // mirror) still gets its store from the SSD block it was read from.
+        if !self.quant.materialises_packed_store() {
+            tracing::debug!(
+                kv_quant = %self.quant,
+                total_seq,
+                "exit_prefill: packed store skipped — decode reads the bf16 mirror only"
+            );
+            if let Some((k_seed, v_seed)) = decode_fp16_pair {
                 self.decode_fp16_k = k_seed;
                 self.decode_fp16_v = v_seed;
             }
@@ -4340,11 +4383,13 @@ impl KvCache {
     /// This is the universal decode shortcut: every quantized `update_<codec>`
     /// (K8V*, Mixed, Planar*, Turbo*, Iso*Sym, Rotor*Sym, RotorK*Asym, …)
     /// early-returns here when `self.decode_fp16_k.is_some()` (always, post
-    /// `exit_prefill`). The per-codec quantizer runs once at `exit_prefill`
-    /// and is then quiescent for the whole decode window — decode-phase K/V
-    /// are bf16. The codec storage buffer is frozen at the prefill length and
-    /// is **not** consulted at decode-read time. See the architectural
-    /// contract + per-codec audit table in `docs/KV_CACHE.md` §9.6.
+    /// `exit_prefill`). Decode-phase K/V are bf16 and the packed store is not
+    /// consulted at decode-read time — which is why, for a codec that reads no
+    /// store at all ([`KvQuant::materialises_packed_store`] is `false`),
+    /// `exit_prefill` does not build one and these mirrors are the cache's
+    /// entire residency. The codecs that *do* read their store never reach
+    /// here for the axes they read. See the architectural contract + per-codec
+    /// audit table in `docs/KV_CACHE.md` §9.6.
     ///
     /// Exceptions: the K-only family (`IsoKOnly*`, `RotorKOnly*`) does NOT
     /// route here for K — it quantizes K every decode step and uses

--- a/crates/rmlx-kv-quant/src/kvcache/warm_ttft_cross_codec_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/warm_ttft_cross_codec_tests.rs
@@ -259,6 +259,108 @@ fn rotor_k_only3_k_codec_seq(cache: &KvCache) -> i32 {
     }
 }
 
+/// Every codec, swept: `exit_prefill` builds a packed store if and only if
+/// `materialises_packed_store()` says so, and the cache's residency matches.
+///
+/// The three hand-written cases below observe `K8V4`, `K8V8` and `PlanarK` in
+/// detail — the codec-specific accessors make them worth keeping. But
+/// `exit_prefill`'s behaviour changed for **18** codecs, and a missed reader in
+/// any of the other 15 is silent by construction: nothing errors, the decode
+/// still works off the mirror, and only the residency moves. So the property is
+/// stated once over `ALL_KV_QUANTS`, with the expectation **derived from the
+/// predicate** rather than listed, which is what makes it exhaustive as new
+/// codecs land.
+///
+/// The residency oracle is a same-shape `KvQuant::None` cache, which shares no
+/// arithmetic with the code under test: a store-free codec must report exactly
+/// what plain bf16 reports.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
+)]
+fn exit_prefill_builds_a_store_exactly_when_the_predicate_says_so() {
+    let device = Device::Cpu;
+
+    let prefill = |quant: KvQuant| -> KvCache {
+        let mut cache = KvCache::with_quant_max_seq(quant, TEST_MAX_SEQ);
+        cache.enter_prefill();
+        let shape = [1i32, TEST_KV_H, TEST_PREFILL_SEQ, TEST_HEAD_DIM];
+        let n: usize = shape.iter().map(|&d| d as usize).product();
+        cache
+            .update(
+                &f32_arr(&vec![0.123f32; n], &shape),
+                &f32_arr(&vec![0.456f32; n], &shape),
+                device,
+            )
+            .expect("prefill chunk");
+        cache.exit_prefill(device).expect("exit_prefill");
+        cache
+    };
+
+    // One decode step on top, because that is where a *missed reader* shows up:
+    // every codec body lazily allocates an empty store and appends to it when
+    // it is reached (`if k.is_none() { *k = Some(..) }`), so a decode path that
+    // still routes into the codec leaves bytes behind even though the prefill
+    // gate built nothing.
+    let decode_once = |cache: &mut KvCache| {
+        let step = [1i32, TEST_KV_H, 1, TEST_HEAD_DIM];
+        let n: usize = step.iter().map(|&d| d as usize).product();
+        cache
+            .update(
+                &f32_arr(&vec![0.789f32; n], &step),
+                &f32_arr(&vec![0.321f32; n], &step),
+                device,
+            )
+            .expect("decode step");
+    };
+
+    let mut bf16_cache = prefill(KvQuant::None);
+    decode_once(&mut bf16_cache);
+    let bf16_bytes = bf16_cache.resident_bytes();
+
+    for &quant in crate::ALL_KV_QUANTS {
+        // `KvQuant::None` takes the else branch and belongs there: it builds no
+        // store and its residency IS the bf16 baseline. Paged storage is a
+        // separate lifecycle selected by a CLI flag, not by the codec, and is
+        // off here.
+        let mut cache = prefill(quant);
+        let store_after_prefill = cache.storage().resident_bytes();
+
+        if quant.materialises_packed_store() {
+            // No decode step here: `Mixed` / `RotK` / `RotKTq4V` refuse
+            // `update()` by contract (they must go through `update_and_sdpa`),
+            // and the property under test on this branch is only that the store
+            // was built.
+            assert!(
+                store_after_prefill > 0,
+                "{quant:?} must build its packed store at exit_prefill — decode \
+                 reads it, or one of its axes has no mirror to read"
+            );
+        } else {
+            decode_once(&mut cache);
+            let store_bytes = cache.storage().resident_bytes();
+            assert_eq!(
+                store_after_prefill, 0,
+                "{quant:?} reads no packed store at decode, so exit_prefill must \
+                 build none — it built {store_after_prefill} bytes"
+            );
+            assert_eq!(
+                store_bytes, 0,
+                "{quant:?} allocated a packed store during decode — some decode \
+                 path still routes into the codec body, so the store it reads is \
+                 the one exit_prefill was told not to build"
+            );
+            assert_eq!(
+                cache.resident_bytes(),
+                bf16_bytes,
+                "{quant:?} holds only its two bf16 mirrors, so its residency must \
+                 equal plain bf16 at the same shape"
+            );
+        }
+    }
+}
+
 #[test]
 fn k8v4_warm_ttft_freezes_codec() {
     assert_shortcut_codec(KvQuant::K8V4, k8_codec_seq);

--- a/crates/rmlx-kv-quant/src/kvcache/warm_ttft_cross_codec_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/warm_ttft_cross_codec_tests.rs
@@ -127,7 +127,15 @@ fn drive_one_decode(cache: &mut KvCache, device: Device) -> DecodeOutcome {
 }
 
 /// Shortcut-codec contract: after one decode step the bf16 K mirror is live
-/// (proves `update_decode_fp16` ran) and the quant codec did NOT advance.
+/// (proves `update_decode_fp16` ran) and the packed store was never built.
+///
+/// The store is what the contract is really about. A codec that mirrors both
+/// axes has no decode path over its packed buffer, so `exit_prefill` building
+/// one would put a second full copy of the context next to a mirror that is
+/// already bf16-sized — and hold it, unread, until the request ends. The three
+/// assertions below are one statement each of that: the store is empty before
+/// decode, still empty after (nothing re-arms it mid-window), and the cache's
+/// whole residency is the two mirrors' filled prefixes and nothing else.
 fn assert_shortcut_codec(quant: KvQuant, codec_seq_after: impl Fn(&KvCache) -> i32) {
     let device = Device::Cpu;
     let mut cache = KvCache::with_quant_max_seq(quant, TEST_MAX_SEQ);
@@ -143,9 +151,15 @@ fn assert_shortcut_codec(quant: KvQuant, codec_seq_after: impl Fn(&KvCache) -> i
 
     let codec_seq_pre_decode = codec_seq_after(&cache);
     assert_eq!(
-        codec_seq_pre_decode, TEST_PREFILL_SEQ,
-        "{quant:?}: exit_prefill should bulk-encode the prefill K to {TEST_PREFILL_SEQ}, \
-         got {codec_seq_pre_decode}"
+        codec_seq_pre_decode, 0,
+        "{quant:?}: exit_prefill must not bulk-encode a packed store that no decode \
+         path reads — got a store of {codec_seq_pre_decode} positions alongside the \
+         bf16 mirror"
+    );
+    assert_eq!(
+        cache.storage().resident_bytes(),
+        0,
+        "{quant:?}: the packed store must hold no bytes at all after exit_prefill"
     );
 
     let step_shape = [1i32, TEST_KV_H, 1, TEST_HEAD_DIM];
@@ -162,15 +176,33 @@ fn assert_shortcut_codec(quant: KvQuant, codec_seq_after: impl Fn(&KvCache) -> i
     );
     let codec_seq_post_decode = codec_seq_after(&cache);
     assert_eq!(
-        codec_seq_post_decode, codec_seq_pre_decode,
-        "{quant:?}: warm-TTFT shortcut violation — quant K codec advanced from \
-         {codec_seq_pre_decode} to {codec_seq_post_decode} on a decode step while \
-         decode_fp16_k was live (the codec must stay frozen; decode reads bf16)"
+        codec_seq_post_decode, 0,
+        "{quant:?}: warm-TTFT shortcut violation — the quant K codec allocated and \
+         advanced to {codec_seq_post_decode} on a decode step while decode_fp16_k was \
+         live (the codec must stay quiescent; decode reads bf16)"
     );
     assert_eq!(
         cache.offset(),
         TEST_PREFILL_SEQ + 1,
         "{quant:?}: offset after one decode step"
+    );
+
+    // Residency is the sharpest form of the claim: the cache holds the two
+    // mirrors' filled prefixes and nothing else. Fails if a store is built, if
+    // a mirror is dropped, or if either is double-counted.
+    let k_seed = cache
+        .decode_fp16_k_for_test()
+        .expect("K mirror is live (asserted above)");
+    let v_seed = cache
+        .decode_fp16_v_for_test()
+        .expect("V mirror is live: this family reads bf16 on both axes");
+    let expected =
+        filled_mirror_bytes(k_seed, cache.offset()) + filled_mirror_bytes(v_seed, cache.offset());
+    assert_eq!(
+        cache.resident_bytes(),
+        expected,
+        "{quant:?}: resident_bytes must equal the two bf16 mirrors' filled prefixes \
+         and nothing else"
     );
 }
 

--- a/crates/rmlx-kv-quant/src/kvcache/warm_ttft_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/warm_ttft_tests.rs
@@ -74,12 +74,17 @@ fn planar_k_warm_ttft_shortcut_quiescent_codec() {
 
     cache.exit_prefill(device).expect("exit_prefill");
 
-    // After exit_prefill the bf16 K seed must be live, AND PlanarK encoder
-    // must have been bulk-loaded with the prefill K codes.
+    // After exit_prefill the bf16 K seed must be live, and the planar K store
+    // must be **unallocated**: decode reads the mirror, so a store built here
+    // would be written once and then held unread for the whole decode window.
+    assert!(
+        cache.decode_fp16_k_for_test().is_some(),
+        "exit_prefill must materialise the bf16 K mirror for PlanarK"
+    );
     let pre_decode_codec_seq = planar_k_codec_seq(&cache);
     assert_eq!(
-        pre_decode_codec_seq, TEST_PREFILL_SEQ,
-        "exit_prefill should bulk-encode prefill K to {TEST_PREFILL_SEQ}, got {pre_decode_codec_seq}"
+        pre_decode_codec_seq, 0,
+        "exit_prefill must not bulk-encode a store no decode path reads, got {pre_decode_codec_seq}"
     );
 
     // Decode step 1.

--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -105,7 +105,9 @@ pub mod turboquant_msl;
 
 pub use kvcache::{KvCache, SharedKv};
 pub use linear_attn::LinearAttnCache;
-pub use quant::{validate_rotor_k_asym_v, KvQuant, KvQuantParseError, KV_MAX_SEQ_DEFAULT};
+pub use quant::{
+    validate_rotor_k_asym_v, KvQuant, KvQuantParseError, ALL_KV_QUANTS, KV_MAX_SEQ_DEFAULT,
+};
 
 // ── Kernel-path selection ────────────────────────────────────────────────────
 //

--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -608,6 +608,107 @@ impl KvQuant {
         }
     }
 
+    /// True when some decode-time read path of this codec consults the packed
+    /// [`crate::storage::KvStorage`] payload.
+    ///
+    /// This is the complement of the two `feeds_bf16_*` predicates, and the
+    /// three together classify what `exit_prefill` has to materialise: a codec
+    /// that feeds both axes from the bf16 mirror **and** never reads its packed
+    /// store at decode gets no packed store at all, because it would be written
+    /// once and then held, unread, for the whole decode window — `O(context)`
+    /// per layer of pure overhead on top of a mirror that is already the same
+    /// size as plain bf16.
+    ///
+    /// `false` does **not** mean "the store is useless": it is still the
+    /// authority for a cache that has no mirror — one reconstructed by
+    /// [`crate::KvCache::from_storage`] (SSD hydrate), or one that never
+    /// bracketed a prefill. It means only that a *seeded* cache never reads it,
+    /// which is exactly the condition under which allocating it is waste.
+    ///
+    /// Which codecs read their store, and where:
+    ///
+    /// * `Mixed` / `RotK` — `update_and_sdpa_mixed` appends to and reads the
+    ///   MLX affine 3-tuples every decode step (`mixed_quantized_sdpa`).
+    /// * `RotKTq4V` — same shape via `update_and_sdpa_rot_k_tq4v`.
+    /// * The K-only re-quantise family (`IsoKOnly3/4`, `RotorKOnly3/4`) —
+    ///   K is appended to the packed store per step and the flash-decode arm
+    ///   reads it back.
+    /// * The fused symmetric family (`Iso3Sym`, `Iso4Sym`, `Rotor3Sym`,
+    ///   `Rotor4Sym`) — decode is a flash kernel over both packed rings.
+    ///
+    /// Everything else decodes off the bf16 mirror alone. That includes the
+    /// codecs whose *other* GPU fast paths look like store reads but are not:
+    /// TurboFlash (`K8V4`) and fused-QK (`K8V4`/`K8V8`/`TurboSym3/4`/
+    /// `RotorK{3,4}Asym`) each maintain their **own** head-major buffer
+    /// re-encoded from the mirror, and `PlanarK`'s fused-QK / flash-decode arm
+    /// is gated on the mirror being *absent*. None of them touches the packed
+    /// store, so no `DispatchPolicy` gate can turn a `false` here into a
+    /// `true` — the classification is a property of the codec alone.
+    ///
+    /// A codec that grows a decode kernel over its own packed store must flip
+    /// its arm here in the same change, or `exit_prefill` will not have built
+    /// the buffer the kernel wants to read.
+    ///
+    /// Exhaustive on purpose, same reasoning as the two `feeds_bf16_*`
+    /// predicates: a new variant must be classified rather than silently
+    /// inherit a value.
+    pub fn decode_reads_packed_store(&self) -> bool {
+        match self {
+            // Quantized-SDPA over the affine 3-tuples, appended per step.
+            KvQuant::Mixed { .. }
+            | KvQuant::RotK { .. }
+            | KvQuant::RotKTq4V
+            // K re-quantised into the packed store every decode step.
+            | KvQuant::IsoKOnly3
+            | KvQuant::IsoKOnly4
+            | KvQuant::RotorKOnly3
+            | KvQuant::RotorKOnly4
+            // Flash decode straight off both packed rings.
+            | KvQuant::Iso3Sym
+            | KvQuant::Iso4Sym
+            | KvQuant::Rotor3Sym
+            | KvQuant::Rotor4Sym => true,
+            // `None` has no packed store to read; the rest are the bf16-mirror
+            // family, whose store is written once at `exit_prefill` and never
+            // read again on a seeded cache.
+            KvQuant::None
+            | KvQuant::K8V4
+            | KvQuant::K8V8
+            | KvQuant::Planar
+            | KvQuant::Planar3
+            | KvQuant::PlanarK
+            | KvQuant::K8VTurbo3
+            | KvQuant::K8VTurbo3Tcq
+            | KvQuant::K8VTurbo2
+            | KvQuant::K8VTurbo2Tcq
+            | KvQuant::TurboSym3
+            | KvQuant::TurboSym4
+            | KvQuant::Iso3
+            | KvQuant::Iso4
+            | KvQuant::Rotor3
+            | KvQuant::Rotor4
+            | KvQuant::RotorK3Asym { .. }
+            | KvQuant::RotorK4Asym { .. } => false,
+        }
+    }
+
+    /// True when `exit_prefill` materialises this codec's packed store.
+    ///
+    /// The store is built when decode reads it ([`Self::decode_reads_packed_store`])
+    /// **or** when either axis decodes without a bf16 mirror to fall back on —
+    /// the second disjunct is what keeps a half-mirrored codec (K quantised, V
+    /// bf16, or the reverse) from losing the side that has no mirror.
+    ///
+    /// This is the predicate the byte estimate and the spill path read; the
+    /// allocation itself is gated on the same three predicates inside
+    /// `exit_prefill`.
+    #[must_use]
+    pub fn materialises_packed_store(&self) -> bool {
+        self.decode_reads_packed_store()
+            || !self.feeds_bf16_k_at_decode()
+            || !self.feeds_bf16_v_at_decode()
+    }
+
     /// True when this codec dispatches at least one custom Metal
     /// (MSL) kernel on its production hot path, so its shaders pay a one-time
     /// cold-compile on first dispatch.
@@ -954,9 +1055,13 @@ impl KvQuant {
     /// - **bf16 decode seed**: a codec keeps a full `seq * head_dim * 2` bf16
     ///   mirror of each axis whose decode reads it —
     ///   [`Self::feeds_bf16_k_at_decode`] for K, [`Self::feeds_bf16_v_at_decode`]
-    ///   for V. This is the warm-TTFT shortcut buffer and is the dominant term
-    ///   that can make a quantized global layer *larger* than bf16. Codecs with
-    ///   a fused decode over both packed axes keep neither.
+    ///   for V. This is the warm-TTFT shortcut buffer. Codecs with a fused
+    ///   decode over both packed axes keep neither.
+    /// - **no packed store**: a codec that mirrors both axes and has no decode
+    ///   path over its store ([`Self::materialises_packed_store`] is `false`)
+    ///   allocates no codes and no scales at all, so its estimate is exactly
+    ///   the two bf16 mirrors — the same bytes as `None`. The codes + scales
+    ///   term applies only to codecs that keep a store something reads.
     ///
     /// `None` (bf16) returns just the two bf16 buffers and no seed.
     ///
@@ -1011,8 +1116,19 @@ impl KvQuant {
                 | KvQuant::RotorK3Asym { .. }
                 | KvQuant::RotorK4Asym { .. }
         );
+        // A codec whose decode never reads its packed store does not allocate
+        // one (`exit_prefill` skips the bulk encode), so the codes + scales
+        // term is zero for it and its resident cost is exactly the mirror.
+        let packs_a_store = self.materialises_packed_store();
         let side_bytes = |bits: u32, retains_seed: bool, side_uses_family: bool| -> u64 {
             if bits >= 16 {
+                return elems.saturating_mul(2);
+            }
+            if !packs_a_store {
+                debug_assert!(
+                    retains_seed,
+                    "a codec with no packed store must read a mirror on every side"
+                );
                 return elems.saturating_mul(2);
             }
             let stored = if side_uses_family && is_iso {

--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -416,6 +416,104 @@ pub enum KvQuant {
     K8VTurbo2Tcq,
 }
 
+/// Every [`KvQuant`] variant, once each, with representative parameters for the
+/// four that carry fields.
+///
+/// It lives here, beside the enum, on purpose: a test that needs to sweep the
+/// codec surface can only be exhaustive if the list it sweeps breaks in the
+/// same file the variant was added to. A list kept in a test crate silently
+/// stops covering the newest codec, which is the shape of gate this repo has
+/// shipped before.
+///
+/// `variants_are_exhaustive` pins the count against a `match` the compiler
+/// checks, so a variant added to the enum and not added here fails there.
+pub const ALL_KV_QUANTS: &[KvQuant] = &[
+    KvQuant::None,
+    KvQuant::K8V4,
+    KvQuant::K8V8,
+    KvQuant::Planar,
+    KvQuant::Planar3,
+    KvQuant::PlanarK,
+    KvQuant::Mixed {
+        k_bits: 8,
+        v_bits: 4,
+        k_group_size: 64,
+        v_group_size: 64,
+    },
+    KvQuant::RotK {
+        v_bits: 8,
+        v_group_size: 64,
+    },
+    KvQuant::RotKTq4V,
+    KvQuant::K8VTurbo3,
+    KvQuant::K8VTurbo3Tcq,
+    KvQuant::K8VTurbo2,
+    KvQuant::K8VTurbo2Tcq,
+    KvQuant::TurboSym3,
+    KvQuant::TurboSym4,
+    KvQuant::Iso3,
+    KvQuant::Iso4,
+    KvQuant::Iso3Sym,
+    KvQuant::Iso4Sym,
+    KvQuant::IsoKOnly3,
+    KvQuant::IsoKOnly4,
+    KvQuant::Rotor3,
+    KvQuant::Rotor4,
+    KvQuant::Rotor3Sym,
+    KvQuant::Rotor4Sym,
+    KvQuant::RotorKOnly3,
+    KvQuant::RotorKOnly4,
+    // `validate_rotor_k_asym_v` accepts (4, 128|64|32) and (3|2, 64) only.
+    KvQuant::RotorK3Asym {
+        v_bits: 4,
+        v_group_size: 64,
+    },
+    KvQuant::RotorK4Asym {
+        v_bits: 4,
+        v_group_size: 64,
+    },
+];
+
+impl KvQuant {
+    /// Discriminant index, used only to prove [`ALL_KV_QUANTS`] names every
+    /// variant. The `match` is exhaustive, so a new variant fails to compile
+    /// here, and the distinct indices make the list's coverage checkable.
+    #[must_use]
+    pub fn variant_index(&self) -> usize {
+        match self {
+            KvQuant::None => 0,
+            KvQuant::K8V4 => 1,
+            KvQuant::K8V8 => 2,
+            KvQuant::Planar => 3,
+            KvQuant::Planar3 => 4,
+            KvQuant::PlanarK => 5,
+            KvQuant::Mixed { .. } => 6,
+            KvQuant::RotK { .. } => 7,
+            KvQuant::RotKTq4V => 8,
+            KvQuant::K8VTurbo3 => 9,
+            KvQuant::K8VTurbo3Tcq => 10,
+            KvQuant::K8VTurbo2 => 11,
+            KvQuant::K8VTurbo2Tcq => 12,
+            KvQuant::TurboSym3 => 13,
+            KvQuant::TurboSym4 => 14,
+            KvQuant::Iso3 => 15,
+            KvQuant::Iso4 => 16,
+            KvQuant::Iso3Sym => 17,
+            KvQuant::Iso4Sym => 18,
+            KvQuant::IsoKOnly3 => 19,
+            KvQuant::IsoKOnly4 => 20,
+            KvQuant::Rotor3 => 21,
+            KvQuant::Rotor4 => 22,
+            KvQuant::Rotor3Sym => 23,
+            KvQuant::Rotor4Sym => 24,
+            KvQuant::RotorKOnly3 => 25,
+            KvQuant::RotorKOnly4 => 26,
+            KvQuant::RotorK3Asym { .. } => 27,
+            KvQuant::RotorK4Asym { .. } => 28,
+        }
+    }
+}
+
 impl KvQuant {
     /// Issue #26: stable per-codec salt for namespacing the in-RAM
     /// prompt/prefix cache key by KV codec.
@@ -652,6 +750,7 @@ impl KvQuant {
     /// Exhaustive on purpose, same reasoning as the two `feeds_bf16_*`
     /// predicates: a new variant must be classified rather than silently
     /// inherit a value.
+    #[must_use]
     pub fn decode_reads_packed_store(&self) -> bool {
         match self {
             // Quantized-SDPA over the affine 3-tuples, appended per step.
@@ -699,9 +798,14 @@ impl KvQuant {
     /// the second disjunct is what keeps a half-mirrored codec (K quantised, V
     /// bf16, or the reverse) from losing the side that has no mirror.
     ///
-    /// This is the predicate the byte estimate and the spill path read; the
-    /// allocation itself is gated on the same three predicates inside
-    /// `exit_prefill`.
+    /// This is the predicate `exit_prefill` gates the allocation on, and the one
+    /// the byte estimate reads. The **spill path does not read it** — it asks
+    /// [`crate::storage::KvStorage::geometry_only_max_seq`], a predicate on the
+    /// other enum, and nothing in the type system couples the two. A codec
+    /// classified `false` here whose storage variant lands in that function's
+    /// "payload is not an `Option`" arm would make the writer stamp a codec
+    /// geometry with no tensors behind it. `a_storeless_codec_always_has_a_geometry_only_storage`
+    /// is the only place that pairing is enforced.
     #[must_use]
     pub fn materialises_packed_store(&self) -> bool {
         self.decode_reads_packed_store()
@@ -1125,10 +1229,14 @@ impl KvQuant {
                 return elems.saturating_mul(2);
             }
             if !packs_a_store {
-                debug_assert!(
-                    retains_seed,
-                    "a codec with no packed store must read a mirror on every side"
-                );
+                // `!materialises_packed_store()` is defined to imply both
+                // `feeds_bf16_*`, which is what `retains_seed` is at both call
+                // sites — so this side is a bf16 mirror and nothing else. The
+                // implication is asserted over every variant by
+                // `a_storeless_codec_mirrors_both_axes`, not by a
+                // `debug_assert` here that could never fire and that
+                // `release-perf` compiles out regardless.
+                let _ = retains_seed;
                 return elems.saturating_mul(2);
             }
             let stored = if side_uses_family && is_iso {

--- a/crates/rmlx-kv-quant/src/quant_tests.rs
+++ b/crates/rmlx-kv-quant/src/quant_tests.rs
@@ -245,14 +245,21 @@ fn windowed_layer_net_saving_is_zero_for_any_codec() {
     }
 }
 
-/// On a **global** layer at small context the scratch-heavy codec is
-/// net-NEGATIVE: it keeps a full bf16 decode seed (warm-TTFT) plus packed codes
-/// and per-group scales, so it is strictly larger than plain bf16. K8V4 on the
-/// Gemma4 e2b global geometry must report a negative saving.
+/// On a **global** layer a codec that keeps a packed store **and** both bf16
+/// mirrors is net-NEGATIVE: the codes and per-group scales are pure addition on
+/// top of a mirror pair that is already exactly bf16-sized. `Mixed` is that
+/// shape — its decode reads the packed 3-tuples, so the store is real, and it
+/// still hands both mirrors to a cross-layer-KV consumer.
 #[test]
-fn global_layer_scratch_heavy_codec_is_net_negative_at_small_ctx() {
+fn global_layer_store_plus_mirror_codec_is_net_negative() {
+    let mixed = KvQuant::Mixed {
+        k_bits: 8,
+        v_bits: 8,
+        k_group_size: 64,
+        v_group_size: 64,
+    };
     // e2b global layer: global_head_dim=256, num_global_key_value_heads=1.
-    let saving = KvQuant::K8V4.estimated_net_saving_per_layer(
+    let saving = mixed.estimated_net_saving_per_layer(
         4096,  // seq
         256,   // head_dim
         1,     // kv_heads
@@ -260,15 +267,48 @@ fn global_layer_scratch_heavy_codec_is_net_negative_at_small_ctx() {
     );
     assert!(
         saving < 0,
-        "K8V4 global layer must be net-negative (bf16 seed + scales > bytes saved); got {saving}"
+        "a store + both-mirror codec must be net-negative (codes + scales on top of \
+         bf16-sized mirrors); got {saving}"
     );
-    // Bonsai-like geometry (head_dim=128, 8 kv heads) is also net-negative for
-    // any K8V* codec that retains the bf16 seed.
-    let saving_bonsai = KvQuant::K8V8.estimated_net_saving_per_layer(2048, 128, 8, false);
+    // Bonsai-like geometry (head_dim=128, 8 kv heads) reports the same sign.
+    let saving_bonsai = mixed.estimated_net_saving_per_layer(2048, 128, 8, false);
     assert!(
         saving_bonsai < 0,
-        "K8V8 global layer with retained bf16 seed must be net-negative; got {saving_bonsai}"
+        "store + both-mirror codec must be net-negative on the dense geometry too; \
+         got {saving_bonsai}"
     );
+}
+
+/// A codec whose decode reads only the bf16 mirrors builds no packed store, so
+/// its estimate is exactly the two mirrors — the same bytes as `None`, at every
+/// context and every geometry. Break-even, never negative: this is the estimate
+/// side of the `exit_prefill` skip, and it would go negative again the moment a
+/// store is materialised for a codec that reads none.
+#[test]
+fn mirror_only_codec_is_exactly_break_even_with_bf16() {
+    for q in [
+        KvQuant::K8V4,
+        KvQuant::K8V8,
+        KvQuant::Planar,
+        KvQuant::Planar3,
+        KvQuant::PlanarK,
+        KvQuant::TurboSym4,
+        KvQuant::Rotor3,
+    ] {
+        assert!(
+            !q.materialises_packed_store(),
+            "{q:?} is expected to be a mirror-only codec"
+        );
+        for (seq, head_dim, kv_heads) in [(512u64, 256u64, 1u64), (8192, 128, 8), (131_072, 128, 8)]
+        {
+            let saving = q.estimated_net_saving_per_layer(seq, head_dim, kv_heads, false);
+            assert_eq!(
+                saving, 0,
+                "{q:?} at seq={seq} head_dim={head_dim} kv_heads={kv_heads}: a mirror-only \
+                 codec holds exactly the bf16 bytes, so the saving is 0"
+            );
+        }
+    }
 }
 
 /// A seed-free K-only codec that carries a sideband-heavy family codec on K
@@ -293,22 +333,28 @@ fn k_only_iso_codec_is_net_negative_from_sidebands() {
     );
 }
 
-/// A both-seed-retaining codec (K8V4 keeps the bf16 K *and* V decode seed on
-/// top of its codes) has a constant per-element overhead, so its net saving is
-/// negative and scales **more** negative with context — there is no crossover
-/// while both seeds are retained. This is the core issue #34 finding: the warm
-/// seed is the dominant term, not the window size.
+/// A codec that keeps both bf16 mirrors **and** a packed store has a constant
+/// per-element overhead, so its net saving is negative and scales **more**
+/// negative with context — there is no crossover while both are retained. The
+/// warm mirror is the dominant term, not the window size.
 #[test]
-fn both_seed_codec_gets_more_negative_with_context() {
-    let small = KvQuant::K8V4.estimated_net_saving_per_layer(512, 256, 1, false);
-    let large = KvQuant::K8V4.estimated_net_saving_per_layer(8192, 256, 1, false);
+fn store_plus_mirror_codec_gets_more_negative_with_context() {
+    let mixed = KvQuant::Mixed {
+        k_bits: 8,
+        v_bits: 8,
+        k_group_size: 64,
+        v_group_size: 64,
+    };
+    let small = mixed.estimated_net_saving_per_layer(512, 256, 1, false);
+    let large = mixed.estimated_net_saving_per_layer(8192, 256, 1, false);
     assert!(
         small < 0 && large < 0,
         "both must be net-negative: small={small} large={large}"
     );
     assert!(
         large < small,
-        "K8V4 retains both bf16 seeds → overhead scales with context (more negative): small={small} large={large}"
+        "retaining both mirrors alongside the store → overhead scales with context \
+         (more negative): small={small} large={large}"
     );
 }
 

--- a/crates/rmlx-kv-quant/src/quant_tests.rs
+++ b/crates/rmlx-kv-quant/src/quant_tests.rs
@@ -9,7 +9,7 @@
 
 use std::str::FromStr;
 
-use super::KvQuant;
+use super::{KvQuant, ALL_KV_QUANTS};
 
 /// Construct one representative instance of every `KvQuant` variant and assert
 /// `KvQuant::from_str(&q.to_string()) == Ok(q)`.
@@ -564,5 +564,83 @@ fn every_parseable_mixed_quantizes_a_side() {
                  it would read as a codec that quantizes nothing"
             );
         }
+    }
+}
+
+// ── The codec surface is swept exhaustively, by construction ─────────────────
+
+/// [`ALL_KV_QUANTS`] names every variant exactly once.
+///
+/// The oracle is `variant_index`, whose `match` the compiler checks: a variant
+/// added to the enum and not to the list leaves a hole in the index set here,
+/// and a variant added to neither fails to compile in `quant.rs`. Every sweep
+/// test below inherits its exhaustiveness from this one.
+#[test]
+fn all_kv_quants_names_every_variant_once() {
+    let mut seen: Vec<usize> = ALL_KV_QUANTS.iter().map(KvQuant::variant_index).collect();
+    seen.sort_unstable();
+    let n = seen.len();
+    seen.dedup();
+    assert_eq!(
+        seen.len(),
+        n,
+        "ALL_KV_QUANTS lists a variant twice: {ALL_KV_QUANTS:?}"
+    );
+    assert_eq!(
+        seen,
+        (0..n).collect::<Vec<_>>(),
+        "ALL_KV_QUANTS must cover every discriminant `variant_index` can return \
+         — a gap means a variant was added to the enum but not to the list"
+    );
+}
+
+/// A codec that builds no packed store must have a storage variant that can
+/// **report** that it holds none.
+///
+/// The two predicates live on different enums and nothing else couples them.
+/// `KvQuant::materialises_packed_store` decides whether `exit_prefill` builds a
+/// payload; `KvStorage::geometry_only_max_seq` is what the spill writer asks
+/// before it stamps a codec geometry. A codec classified `false` whose storage
+/// sits in the "payload is not an `Option`" arm (`Mixed | RotKTq4V | Paged`)
+/// compiles cleanly and makes the writer emit a codec tag with no tensors
+/// behind it — the reader then fails on `missing tensor 'lN.k.codes'`.
+///
+/// The storage is built through the same `KvStorage::new` the cache uses, so
+/// this is the real pairing and not a restatement of either predicate.
+#[test]
+fn a_storeless_codec_always_has_a_geometry_only_storage() {
+    for &q in ALL_KV_QUANTS {
+        if q.materialises_packed_store() {
+            continue;
+        }
+        let storage = crate::storage::KvStorage::new(q, 4096);
+        assert!(
+            storage.geometry_only_max_seq().is_some(),
+            "{q:?} builds no packed store, but its storage cannot report itself \
+             geometry-only — the spill writer would stamp a codec geometry with \
+             no tensors behind it"
+        );
+    }
+}
+
+/// A codec with no packed store reads a bf16 mirror on **both** axes.
+///
+/// `materialises_packed_store` is defined as
+/// `decode_reads_packed_store() || !feeds_bf16_k || !feeds_bf16_v`, so `false`
+/// implies both mirrors — which is what makes the byte estimate's
+/// "return the two mirrors" branch total. Stated over every variant here
+/// instead of as a `debug_assert` inside that branch, where it is both
+/// unreachable and compiled out under `release-perf`.
+#[test]
+fn a_storeless_codec_mirrors_both_axes() {
+    for &q in ALL_KV_QUANTS {
+        if q.materialises_packed_store() {
+            continue;
+        }
+        assert!(
+            q.feeds_bf16_k_at_decode() && q.feeds_bf16_v_at_decode(),
+            "{q:?} has no packed store and no mirror on one axis — that axis has \
+             nowhere to decode from"
+        );
     }
 }

--- a/crates/rmlx-kv-quant/src/storage/cpu_block_truncate_tests.rs
+++ b/crates/rmlx-kv-quant/src/storage/cpu_block_truncate_tests.rs
@@ -548,10 +548,10 @@ fn quant_k_truncate_at_b_gt_1_stays_loud() {
 
 /// A target past what the store covers must not raise `shape[2]`.
 ///
-/// It is reachable, not hypothetical: post-`exit_prefill` the codec store is
-/// frozen at the prefill length while `KvCache::offset` keeps advancing on the
-/// bf16 decode mirror, so a speculative rollback to a position inside the decode
-/// window arrives with `n > shape[2]`. Raising the shape to meet it invents
+/// It is reachable, not hypothetical: a store-backed cache whose codec also
+/// keeps a bf16 mirror advances `KvCache::offset` on paths the store does not
+/// follow, so a speculative rollback to a position inside the decode window
+/// arrives with `n > shape[2]`. Raising the shape to meet it invents
 /// coverage no payload backs — the dequant then reads past the blocks and an SSD
 /// spill persists a header claiming more tokens than its bytes hold.
 ///

--- a/crates/rmlx-kv-quant/src/storage/kv_storage.rs
+++ b/crates/rmlx-kv-quant/src/storage/kv_storage.rs
@@ -1759,6 +1759,66 @@ impl KvStorage {
             }
         }
     }
+
+    /// `Some(max_seq)` when this layer holds **no packed payload**, so the only
+    /// thing there is to persist about it is its geometry.
+    ///
+    /// Three situations reach it, and the SSD spill writer treats them alike:
+    ///
+    /// * a rotating (SWA) layer — its KV lives in the bf16 ring off `storage`,
+    ///   which is not serialisable, so the window is re-established on reuse;
+    /// * a codec whose decode reads only the bf16 mirror
+    ///   ([`crate::KvQuant::materialises_packed_store`] is `false`), so
+    ///   `exit_prefill` built no store to write;
+    /// * [`KvStorage::None`], which never had one.
+    ///
+    /// The K-side slot is the indicator throughout: every two-sided variant
+    /// populates both slots in the same `exit_prefill` statement, so a `None`
+    /// on K means the whole layer is empty. The three variants whose payload is
+    /// not an `Option` — `Mixed`, `RotKTq4V`, `Paged` — always answer `None`
+    /// here: their writers serialise their own empty state, and diverting them
+    /// would change what an unfilled layer of theirs round-trips as.
+    ///
+    /// Exhaustive on purpose: a new variant must be classified, or the writer
+    /// would stamp a codec geometry with no tensors behind it and the reader
+    /// would fail on the first missing tensor.
+    #[must_use]
+    pub fn geometry_only_max_seq(&self) -> Option<i32> {
+        // `k.is_none()` is the test in every arm; a `Some` K means the layer
+        // carries a real payload and belongs to its codec's writer.
+        fn empty<T>(k: Option<&T>, max_seq: i32) -> Option<i32> {
+            k.is_none().then_some(max_seq)
+        }
+        match self {
+            KvStorage::None { max_seq } => Some(*max_seq),
+            KvStorage::K8V4 { k, max_seq, .. }
+            | KvStorage::K8V8 { k, max_seq, .. }
+            | KvStorage::Planar { k, max_seq, .. }
+            | KvStorage::K8VTurbo3 { k, max_seq, .. }
+            | KvStorage::K8VTurbo3Tcq { k, max_seq, .. }
+            | KvStorage::K8VTurbo2 { k, max_seq, .. }
+            | KvStorage::K8VTurbo2Tcq { k, max_seq, .. }
+            | KvStorage::IsoV3 { k, max_seq, .. }
+            | KvStorage::IsoV4 { k, max_seq, .. }
+            | KvStorage::RotorV3 { k, max_seq, .. }
+            | KvStorage::RotorV4 { k, max_seq, .. } => empty(k.as_ref(), *max_seq),
+            KvStorage::TurboSym3 { k, max_seq, .. } => empty(k.as_ref(), *max_seq),
+            KvStorage::TurboSym4 { k, max_seq, .. } => empty(k.as_ref(), *max_seq),
+            KvStorage::PlanarK { k, max_seq } => empty(k.as_ref(), *max_seq),
+            KvStorage::IsoSym3 { k, max_seq, .. } => empty(k.as_ref(), *max_seq),
+            KvStorage::IsoSym4 { k, max_seq, .. } => empty(k.as_ref(), *max_seq),
+            KvStorage::IsoKOnly3 { k, max_seq } => empty(k.as_ref(), *max_seq),
+            KvStorage::IsoKOnly4 { k, max_seq } => empty(k.as_ref(), *max_seq),
+            KvStorage::RotorSym3 { k, max_seq, .. } => empty(k.as_ref(), *max_seq),
+            KvStorage::RotorSym4 { k, max_seq, .. } => empty(k.as_ref(), *max_seq),
+            KvStorage::RotorKOnly3 { k, max_seq } => empty(k.as_ref(), *max_seq),
+            KvStorage::RotorKOnly4 { k, max_seq } => empty(k.as_ref(), *max_seq),
+            KvStorage::RotorKAsym3 { k, max_seq, .. } => empty(k.as_ref(), *max_seq),
+            KvStorage::RotorKAsym4 { k, max_seq, .. } => empty(k.as_ref(), *max_seq),
+            // Payload is not an Option — their own writers handle emptiness.
+            KvStorage::Mixed { .. } | KvStorage::RotKTq4V { .. } | KvStorage::Paged { .. } => None,
+        }
+    }
 }
 
 /// Bytes of an optional store slot; an unpopulated slot (`None`) holds nothing.

--- a/crates/rmlx-kv-quant/src/storage/kv_storage.rs
+++ b/crates/rmlx-kv-quant/src/storage/kv_storage.rs
@@ -1760,6 +1760,110 @@ impl KvStorage {
         }
     }
 
+    /// Drop every packed payload this variant holds, leaving its geometry
+    /// (`max_seq`, bit widths, group sizes) intact.
+    ///
+    /// `exit_prefill` calls this on the path where it decides **not** to build
+    /// a store, and that is not housekeeping: `enter_prefill` does not clear
+    /// `storage`, so a cache that already carries a payload — an SSD-hydrated
+    /// entry that was deep-cloned and tail-extended — would otherwise come out
+    /// of the second prefill holding a store of the *old* length beside a
+    /// mirror of the new one. The spill writer prefers the store whenever it is
+    /// populated, so that block would be written under the full prompt's hash
+    /// while holding only the prefix, and hydrate would hand it back with a
+    /// shorter `offset` and no error anywhere. Clearing at the source removes
+    /// the divergence instead of teaching each reader to detect it.
+    ///
+    /// Exhaustive on purpose: a new payload slot on any variant must be
+    /// classified here, or a stale copy of it survives the skip.
+    pub fn clear_payload(&mut self) {
+        match self {
+            KvStorage::None { .. } => {}
+            KvStorage::K8V4 { k, v, .. }
+            | KvStorage::K8VTurbo3 { k, v, .. }
+            | KvStorage::K8VTurbo3Tcq { k, v, .. }
+            | KvStorage::K8VTurbo2 { k, v, .. }
+            | KvStorage::K8VTurbo2Tcq { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::K8V8 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::Planar { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::PlanarK { k, .. } => *k = None,
+            KvStorage::TurboSym3 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::TurboSym4 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::IsoV3 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::IsoV4 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::IsoSym3 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::IsoSym4 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::IsoKOnly3 { k, .. } => *k = None,
+            KvStorage::IsoKOnly4 { k, .. } => *k = None,
+            KvStorage::RotorV3 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::RotorV4 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::RotorSym3 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::RotorSym4 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::RotorKOnly3 { k, .. } => *k = None,
+            KvStorage::RotorKOnly4 { k, .. } => *k = None,
+            KvStorage::RotorKAsym3 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            KvStorage::RotorKAsym4 { k, v, .. } => {
+                *k = None;
+                *v = None;
+            }
+            // Payload is not an `Option`; each owns a `reset`.
+            KvStorage::Mixed { state, .. } => state.reset(),
+            KvStorage::RotKTq4V { k_state, v, .. } => {
+                k_state.reset();
+                *v = None;
+            }
+            KvStorage::Paged {
+                k, v_k8, v_planar, ..
+            } => {
+                *k = None;
+                *v_k8 = None;
+                *v_planar = None;
+            }
+        }
+    }
+
     /// `Some(max_seq)` when this layer holds **no packed payload**, so the only
     /// thing there is to persist about it is its geometry.
     ///

--- a/crates/rmlx-kv-quant/src/storage/mod.rs
+++ b/crates/rmlx-kv-quant/src/storage/mod.rs
@@ -277,10 +277,10 @@ pub(crate) fn truncate_plan(
 ///
 /// Truncation is monotone-decreasing by contract, and for the turbo / planar /
 /// affine stores that has to be enforced rather than assumed. `n > shape[2]` is
-/// reachable: post-`exit_prefill` the codec store is frozen at the prefill
-/// length while `KvCache::offset` keeps advancing on the bf16 decode mirror, so
-/// a speculative rollback to a position inside the decode window arrives with a
-/// target past the store's own fill. Raising `shape[2]` to meet it invents
+/// reachable: a store-backed cache whose codec also keeps a bf16 mirror advances
+/// `KvCache::offset` on paths the store does not follow, so a speculative
+/// rollback to a position inside the decode window arrives with a target past
+/// the store's own fill. Raising `shape[2]` to meet it invents
 /// coverage that no payload backs — the CPU dequant then reads past the blocks
 /// and the SSD spill persists a store whose header claims more tokens than its
 /// bytes hold.

--- a/crates/rmlx-kv-ssd/src/block_io.rs
+++ b/crates/rmlx-kv-ssd/src/block_io.rs
@@ -318,26 +318,55 @@ pub fn write_caches(
     )
 }
 
-/// Collect the live bf16 K/V buffers of every [`KvStorage::None`] layer, so the
-/// spill writer can persist the unquantised prefix that lives off the storage
-/// buffer (on `KvCache::decode_fp16_{k,v}`). Element `i` is `Some` only for a
-/// `None`-storage layer that actually holds a filled bf16 pair; all other
-/// layers (quantised storage, or an unfilled / SWA-hydrated `None`) are `None`
-/// and spill via their existing geometry-only path.
+/// Collect the live bf16 K/V mirror of every layer that spills geometry-only,
+/// so the writer can persist the unquantised prefix that lives off the storage
+/// buffer (on `KvCache::decode_fp16_{k,v}`).
+///
+/// Element `i` is `Some` only for a layer whose storage holds no packed payload
+/// ([`KvStorage::geometry_only_max_seq`]) and that actually holds a filled bf16
+/// pair. That covers `KvQuant::None`, whose K/V has always lived there, and the
+/// bf16-mirror codecs, whose `exit_prefill` builds no packed store at all —
+/// without this the tier would spill those layers as empty geometry and the
+/// hydrate would come back holding nothing. Layers with a real packed payload,
+/// and rotating (SWA) windows with no mirror to give, are `None` here and spill
+/// through their own path.
+///
+/// # Why this does no tensor work
+///
+/// It runs on the spill **drain** thread, which has no Metal stream: every
+/// array it hands on must already be materialised, in row-major order, at
+/// exactly the length it should be persisted at. `exit_prefill` guarantees the
+/// first two (it stores the seed through `Array::contiguous`). The third is
+/// checked rather than fixed: the writer reads the layer's `seq_len` off the
+/// buffer's own `shape[2]`, so a mirror the decode loop has grown to the
+/// `max_seq` ceiling would persist its zeroed tail as live KV and hydrate a
+/// cache whose offset sits past its real content. Slicing it here would need a
+/// device. Such a layer is refused instead — it spills as geometry-only and
+/// re-prefills on reuse, which is lossy but never wrong.
 fn none_bf16_payloads(kv_caches: &[KvCache]) -> Result<Vec<NoneBf16Seed>> {
     kv_caches
         .iter()
         .map(|c| {
-            if matches!(c.storage(), KvStorage::None { .. }) {
-                match c.decode_fp16_kv() {
-                    // Ref-count clone only (mlx-c is COW); host materialisation
-                    // happens later in `OwnedTensor::from_array`.
-                    Some((k, v)) => Ok(Some((k.try_clone()?, v.try_clone()?))),
-                    None => Ok(None),
-                }
-            } else {
-                Ok(None)
+            if c.storage().geometry_only_max_seq().is_none() {
+                return Ok(None);
             }
+            let Some((k, v)) = c.decode_fp16_kv() else {
+                return Ok(None);
+            };
+            let buf_seq = k.shape().get(2).copied().unwrap_or(0);
+            if c.offset() > 0 && c.offset() < buf_seq {
+                tracing::warn!(
+                    layer = c.layer_idx(),
+                    offset = c.offset(),
+                    buf_seq,
+                    "kv-spill: bf16 mirror is longer than its filled length — spilling \
+                     this layer as geometry-only rather than persisting its zeroed tail"
+                );
+                return Ok(None);
+            }
+            // Ref-count clone only (mlx-c is COW); host materialisation happens
+            // later in `OwnedTensor::from_array`.
+            Ok(Some((k.try_clone()?, v.try_clone()?)))
         })
         .collect()
 }
@@ -585,107 +614,36 @@ fn write_layer(
     device: Device,
     out: &mut Vec<(String, OwnedTensor)>,
 ) -> Result<(String, i32)> {
-    // A K8V4/K8V8/Planar layer whose `k` side has no consolidated quantized
-    // payload (`k: None`) is a rotating SWA layer: its KV lives in the bf16 ring
-    // buffer off-`storage`, not in the quantized `QuantK`. Per the design
-    // (see `KvCache::from_storage` docs) such layers "are not spilled" and are
-    // recorded as geometry-only `None` — the writer would otherwise stamp a
-    // `k8v8` geom with no codes/scales tensors, which the reader then demands
-    // and fails on (`missing tensor 'lN.k.codes'`). Round-trips to a `None`
-    // storage on hydrate; the SWA window is re-established on reuse.
-    if let KvStorage::K8V4 { k, max_seq, .. }
-    | KvStorage::K8V8 { k, max_seq, .. }
-    | KvStorage::Planar { k, max_seq, .. }
-    | KvStorage::K8VTurbo3 { k, max_seq, .. }
-    | KvStorage::K8VTurbo3Tcq { k, max_seq, .. }
-    | KvStorage::K8VTurbo2Tcq { k, max_seq, .. }
-    | KvStorage::K8VTurbo2 { k, max_seq, .. }
-    | KvStorage::IsoV3 { k, max_seq, .. }
-    | KvStorage::IsoV4 { k, max_seq, .. }
-    | KvStorage::RotorV3 { k, max_seq, .. }
-    | KvStorage::RotorV4 { k, max_seq, .. } = storage
-    {
-        if k.is_none() {
+    // A layer with no packed payload has only its geometry to persist. Three
+    // cases arrive here and the treatment is the same for all of them: a
+    // rotating SWA layer (its KV lives in the bf16 ring, which is not
+    // serialisable), a codec whose decode reads only the bf16 mirror so
+    // `exit_prefill` built no store, and `KvStorage::None`, which never had
+    // one. Stamping a codec geometry with no codes/scales tensors behind it
+    // would make the reader fail on `missing tensor 'lN.k.codes'`.
+    //
+    // When the cache handed us its live bf16 mirror, that mirror IS the layer's
+    // KV, so persist it under `l{idx}.{k,v}.bf16` and tag the layer
+    // "none_bf16"; hydrate re-seeds the decode buffers from it and the
+    // reconstructed cache decodes off exactly the bytes the spilling one did.
+    // With no mirror (a rotating window, an unfilled cache) the layer falls
+    // back to geometry-only "none" and the window is re-established on reuse.
+    if let Some(max_seq) = storage.geometry_only_max_seq() {
+        let Some((k, v)) = none_bf16 else {
             return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    // TurboSym3 — K is `QuantKTurbo3` (different type from `QuantK` and
-    // `QuantKTurbo4`). Same SWA round-trip semantics: when k is None, the layer is
-    // a rotating SWA window — record as geometry-only None.
-    if let KvStorage::TurboSym3 { k, max_seq, .. } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    // TurboSym4 — K is `QuantKTurbo4` (different type from `QuantK`) so it
-    // cannot share the or-pattern above. Same SWA round-trip semantics.
-    if let KvStorage::TurboSym4 { k, max_seq, .. } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    // PlanarK — K-only payload; "geometry-only None" when k is None
-    // (rotating ring-buffer SWA layer never initialised).
-    if let KvStorage::PlanarK { k, max_seq } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    // Iso symmetric / K-only — SWA round-trip semantics: when the K-side iso
-    // buffer is None, the layer is a rotating SWA window that does not survive
-    // spill. Record as geometry-only None per the K8V4 precedent.
-    if let KvStorage::IsoSym3 { k, max_seq, .. } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    if let KvStorage::IsoSym4 { k, max_seq, .. } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    if let KvStorage::IsoKOnly3 { k, max_seq } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    if let KvStorage::IsoKOnly4 { k, max_seq } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    // Rotor symmetric / K-only — same SWA-None precheck.
-    if let KvStorage::RotorSym3 { k, max_seq, .. } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    if let KvStorage::RotorSym4 { k, max_seq, .. } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    if let KvStorage::RotorKOnly3 { k, max_seq } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    if let KvStorage::RotorKOnly4 { k, max_seq } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    // RotorKAsym3 / RotorKAsym4 — same SWA-None precheck (K-side is the
-    // load-bearing indicator; V-side QuantV is initialized in lockstep).
-    if let KvStorage::RotorKAsym3 { k, max_seq, .. } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
-    }
-    if let KvStorage::RotorKAsym4 { k, max_seq, .. } = storage {
-        if k.is_none() {
-            return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
-        }
+        };
+        // `seq` is taken as the buffer's filled length, so the caller must hand
+        // over a mirror compacted to `offset` — `none_bf16_payloads` slices it.
+        // A decode-expanded buffer grown to the `max_seq` ceiling with a zeroed
+        // tail must never reach here, or that tail would be persisted as live
+        // KV and the reconstructed offset would be wrong.
+        let seq = k.shape().get(2).copied().unwrap_or(0);
+        out.push((format!("l{idx}.k.bf16"), OwnedTensor::from_array(k)?));
+        out.push((format!("l{idx}.v.bf16"), OwnedTensor::from_array(v)?));
+        return Ok((
+            format!("{{\"tag\":\"none_bf16\",\"max_seq\":{max_seq}}}"),
+            seq,
+        ));
     }
     match storage {
         KvStorage::K8V4 { k, v, max_seq } => {
@@ -711,32 +669,10 @@ fn write_layer(
             let tag = if *bits == 3 { "planar3" } else { "planar" };
             Ok((geom_kv(tag, *max_seq, k_shape(k.as_ref())), seq))
         }
+        // `KvStorage::None` never reaches here — it has no packed payload and
+        // is served by the geometry-only branch above.
         KvStorage::None { max_seq } => {
-            // KvQuant::None keeps its live K/V as bf16 on the parent KvCache
-            // (`decode_fp16_{k,v}`), not in the storage buffer. When the spill
-            // path supplies that pair, persist it under `l{idx}.{k,v}.bf16` and
-            // tag the layer "none_bf16" so hydrate re-seeds the decode buffers
-            // (bf16 round-trips exactly). With no pair (a never-filled cache, or
-            // a hydrated SWA layer whose rotating ring was never serialised) this
-            // falls back to geometry-only "none" — those layers hold no payload.
-            if let Some((k, v)) = none_bf16 {
-                // `seq` is taken as the buffer's filled length. The spill
-                // contract requires the None-path `decode_fp16_k` to be
-                // compacted to `offset` (the state `exit_prefill` leaves it in:
-                // sliced to `[B, kv_h, offset, D]`). A decode-expanded buffer
-                // grown to the `max_seq` ceiling with a zeroed tail must never
-                // reach here, or that tail would be persisted as live KV and the
-                // reconstructed offset would be wrong.
-                let seq = k.shape().get(2).copied().unwrap_or(0);
-                out.push((format!("l{idx}.k.bf16"), OwnedTensor::from_array(k)?));
-                out.push((format!("l{idx}.v.bf16"), OwnedTensor::from_array(v)?));
-                Ok((
-                    format!("{{\"tag\":\"none_bf16\",\"max_seq\":{max_seq}}}"),
-                    seq,
-                ))
-            } else {
-                Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0))
-            }
+            Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0))
         }
         KvStorage::Mixed { state, max_seq } => write_mixed(idx, state, *max_seq, out),
         KvStorage::Paged {

--- a/crates/rmlx-kv-ssd/src/block_io.rs
+++ b/crates/rmlx-kv-ssd/src/block_io.rs
@@ -337,12 +337,18 @@ pub fn write_caches(
 /// array it hands on must already be materialised, in row-major order, at
 /// exactly the length it should be persisted at. `exit_prefill` guarantees the
 /// first two (it stores the seed through `Array::contiguous`). The third is
-/// checked rather than fixed: the writer reads the layer's `seq_len` off the
-/// buffer's own `shape[2]`, so a mirror the decode loop has grown to the
-/// `max_seq` ceiling would persist its zeroed tail as live KV and hydrate a
-/// cache whose offset sits past its real content. Slicing it here would need a
-/// device. Such a layer is refused instead — it spills as geometry-only and
-/// re-prefills on reuse, which is lossy but never wrong.
+/// checked rather than fixed, and the check **fails the whole block** rather
+/// than dropping the layer: the writer reads each layer's `seq_len` off its own
+/// buffer, but `META_SEQ_LEN` is a single max across layers that hydrate then
+/// applies to every reconstructed layer. Dropping one layer's payload would
+/// therefore hand that layer back claiming the block's full offset while
+/// holding nothing — a frozen cache with zero content and no error. Refusing
+/// the block costs one re-prefill; refusing the layer costs correctness.
+/// Compacting the mirror instead would need a device this thread does not have.
+///
+/// The comparison is `!=`, not `<`: a cache whose `offset` runs *past* its
+/// mirror is equally inconsistent, and spilling the short buffer under the
+/// longer claim is the same defect in the other direction.
 fn none_bf16_payloads(kv_caches: &[KvCache]) -> Result<Vec<NoneBf16Seed>> {
     kv_caches
         .iter()
@@ -354,15 +360,15 @@ fn none_bf16_payloads(kv_caches: &[KvCache]) -> Result<Vec<NoneBf16Seed>> {
                 return Ok(None);
             };
             let buf_seq = k.shape().get(2).copied().unwrap_or(0);
-            if c.offset() > 0 && c.offset() < buf_seq {
-                tracing::warn!(
-                    layer = c.layer_idx(),
-                    offset = c.offset(),
-                    buf_seq,
-                    "kv-spill: bf16 mirror is longer than its filled length — spilling \
-                     this layer as geometry-only rather than persisting its zeroed tail"
-                );
-                return Ok(None);
+            if c.offset() != buf_seq {
+                return Err(Error::Mlx(format!(
+                    "kv-spill: layer {} bf16 mirror is {buf_seq} tokens against an \
+                     offset of {}; the block records one seq_len for every layer, so \
+                     spilling this one would hydrate a layer holding nothing at the \
+                     block's length. Refusing the block.",
+                    c.layer_idx(),
+                    c.offset(),
+                )));
             }
             // Ref-count clone only (mlx-c is COW); host materialisation happens
             // later in `OwnedTensor::from_array`.
@@ -632,11 +638,13 @@ fn write_layer(
         let Some((k, v)) = none_bf16 else {
             return Ok((format!("{{\"tag\":\"none\",\"max_seq\":{max_seq}}}"), 0));
         };
-        // `seq` is taken as the buffer's filled length, so the caller must hand
-        // over a mirror compacted to `offset` — `none_bf16_payloads` slices it.
-        // A decode-expanded buffer grown to the `max_seq` ceiling with a zeroed
-        // tail must never reach here, or that tail would be persisted as live
-        // KV and the reconstructed offset would be wrong.
+        // `seq` is the buffer's own length, and the block records one `seq_len`
+        // for every layer — so the mirror handed over must already equal the
+        // cache's `offset`. `none_bf16_payloads` enforces that by REFUSING the
+        // block when it does not (it cannot compact: no device on this thread).
+        // A decode-expanded buffer grown to the `max_seq` ceiling therefore
+        // never reaches here; if it did, its zeroed tail would be persisted as
+        // live KV.
         let seq = k.shape().get(2).copied().unwrap_or(0);
         out.push((format!("l{idx}.k.bf16"), OwnedTensor::from_array(k)?));
         out.push((format!("l{idx}.v.bf16"), OwnedTensor::from_array(v)?));

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -1595,9 +1595,20 @@ fn roundtrip_none_bf16_payload_via_spill_hydrate() {
         let v_ref = to_vec(&v_bf16.astype(Dtype::F32, device).unwrap());
         want.push((k_ref, v_ref));
 
-        let cache = KvCache::with_quant_max_seq(KvQuant::None, 4096)
-            .with_layer_idx(layer as usize)
-            .with_decode_fp16_seed(k_bf16, v_bf16);
+        // Built the way `read_caches` builds a hydrated layer: `from_storage`
+        // carries the offset, `with_decode_fp16_seed` attaches the mirror. The
+        // offset matters — the spill writer records one `seq_len` for the whole
+        // block, so it refuses a cache whose mirror and offset disagree, and a
+        // fixture that leaves the offset at 0 is describing a cache that cannot
+        // arise.
+        let cache = KvCache::from_storage(
+            KvStorage::None { max_seq: 4096 },
+            KvQuant::None,
+            shape[2],
+            layer as usize,
+            DispatchPolicy::default(),
+        )
+        .with_decode_fp16_seed(k_bf16, v_bf16);
         kv_caches.push(cache);
     }
 
@@ -1735,15 +1746,122 @@ fn roundtrip_mirror_codec_spills_and_hydrates_as_bf16() {
     }
 }
 
-/// A mirror grown past its filled length is refused, not persisted with its tail.
+/// A second prefill on a cache that arrived carrying a packed store must not
+/// leave that store behind, or the tier spills a block shorter than the prompt
+/// it is keyed by.
+///
+/// The reachable shape: an SSD-hydrated entry comes back store-backed (that is
+/// what a block written before the mirror codecs moved to `none_bf16` looks
+/// like), the prompt cache deep-clones it, and the request extends the prompt.
+/// `enter_prefill` does not clear `storage`, and every `exit_prefill` arm that
+/// builds a store *replaces* the payload — so a codec that now skips the build
+/// has to clear it instead, or the store survives at the OLD length beside a
+/// mirror at the new one. The spill writer prefers the store whenever it is
+/// populated (`geometry_only_max_seq` is `None` while `k.is_some()`), so the
+/// block would be written under the extended prompt's hash while holding only
+/// the prefix, and `META_SEQ_LEN` is a max across layers, so hydrate hands that
+/// back as the whole cache's offset with no error.
+///
+/// The assertion is on the length the block claims, not on its content: the
+/// re-prefill's own mirror semantics are a separate question, and pinning them
+/// here would make this test fail for a reason it is not about.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn tail_extended_store_backed_cache_does_not_spill_a_short_block() {
+    let device = Device::Cpu;
+    let prefix_shape = [1i32, 2, 32, 128];
+    let n: usize = prefix_shape.iter().map(|&x| x as usize).product();
+
+    // (1) A store-backed cache, the shape `KvCache::from_storage` produces on a
+    // hydrate: payload present, no bf16 mirror. Built by driving the codec body
+    // directly (no prefill bracket), which is the same path a hydrated cache
+    // decodes on.
+    let mut hydrated = KvCache::with_quant_max_seq(KvQuant::K8V8, 4096);
+    hydrated
+        .update(
+            &arr(&lcg(n, 0x1111), &prefix_shape),
+            &arr(&lcg(n, 0x2222), &prefix_shape),
+            device,
+        )
+        .unwrap();
+    let prefix_len = hydrated.offset();
+    assert_eq!(prefix_len, prefix_shape[2], "prefix length");
+    assert!(
+        hydrated.storage().geometry_only_max_seq().is_none(),
+        "precondition: the fixture must actually carry a packed store, or this \
+         test cannot observe it surviving"
+    );
+
+    // (2) The prompt cache deep-clones the entry, and (3) the request extends
+    // the prompt: a second prefill on the clone.
+    let mut reused = hydrated.try_deep_clone().unwrap();
+    let tail_shape = [1i32, 2, 16, 128];
+    let n_tail: usize = tail_shape.iter().map(|&x| x as usize).product();
+    reused.enter_prefill();
+    reused
+        .update(
+            &arr(&lcg(n_tail, 0x3333), &tail_shape),
+            &arr(&lcg(n_tail, 0x4444), &tail_shape),
+            device,
+        )
+        .unwrap();
+    reused.exit_prefill(device).unwrap();
+
+    let extended_len = prefix_shape[2] + tail_shape[2];
+    assert_eq!(reused.offset(), extended_len, "offset after the extension");
+
+    // (4) Spill. The symptom first: the block must describe the cache it came
+    // from. A surviving store makes this the stale prefix length.
+    let path = tmp_path("tail_extended_store");
+    let stale_storage = reused.storage().geometry_only_max_seq().is_none();
+    write_caches(&path, device, MODEL_ID, KvQuant::K8V8, &[reused], &[]).unwrap();
+    let (rebuilt, _lin) = read_caches(
+        &path,
+        device,
+        MODEL_ID,
+        KvQuant::K8V8,
+        DispatchPolicy::default(),
+    )
+    .unwrap();
+    let hydrated_len = rebuilt[0].offset();
+    let mirror_restored = rebuilt[0].decode_fp16_kv().is_some();
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        hydrated_len, extended_len,
+        "the spilled block must hold the whole extended prompt ({extended_len} \
+         tokens), not the stale store's prefix"
+    );
+    assert!(
+        mirror_restored,
+        "the extended cache spills its mirror, so hydrate must re-seed it"
+    );
+    // And the root cause, so a fix that papers over the symptom in the writer
+    // instead of clearing at the source does not satisfy this test.
+    assert!(
+        !stale_storage,
+        "a codec that builds no store must not leave a stale one behind: the \
+         storage still claimed a payload after the second prefill"
+    );
+}
+
+/// A mirror grown past its filled length fails the spill, it is not persisted
+/// with its tail.
 ///
 /// The first decode step expands the mirror from the compact prefill seed to
-/// the `max_seq` ceiling, so from then on the buffer's `shape[2]` is the ceiling
-/// and everything past `offset` is zeros. The writer reads the layer's `seq_len`
-/// off that shape, so persisting the buffer as-is would record the ceiling as
+/// the `max_seq` ceiling, so from then on the buffer's `shape[2]` is the
+/// ceiling and everything past `offset` is zeros. The writer reads the layer's
+/// `seq_len` off that shape, so persisting it as-is would record the ceiling as
 /// live KV and hydrate a cache whose offset sits thousands of tokens past its
-/// real content. Compacting it would need a device the drain thread does not
-/// have, so the layer spills as geometry-only instead: lossy, never wrong.
+/// real content. Compacting it needs a device the drain thread does not have,
+/// so the spill is refused.
 #[test]
 #[allow(
     clippy::indexing_slicing,
@@ -1760,10 +1878,109 @@ fn roundtrip_mirror_codec_spills_and_hydrates_as_bf16() {
 fn decode_expanded_mirror_is_refused_rather_than_spilled_with_its_tail() {
     let device = Device::Cpu;
     const MAX_SEQ: i32 = 4096;
+
+    let cache = expanded_mirror_cache(device, MAX_SEQ);
+    let filled = cache.offset();
+    let (k_live, _) = cache.decode_fp16_kv().expect("mirror is live");
+    assert_eq!(
+        k_live.shape()[2],
+        MAX_SEQ,
+        "precondition: the decode step must have expanded the mirror to the ceiling — \
+         without that this test cannot observe the refusal"
+    );
+    assert_ne!(filled, MAX_SEQ, "precondition: offset is below the ceiling");
+
+    let path = tmp_path("expanded_mirror");
+    let err = write_caches(&path, device, MODEL_ID, KvQuant::K8V8, &[cache], &[])
+        .expect_err("an expanded mirror must not be spilled");
+    assert!(
+        format!("{err}").contains("Refusing the block"),
+        "the refusal must name itself; got: {err}"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// One expanded layer fails the block, it does not quietly drop that layer.
+///
+/// This is the shape the per-layer refusal was dangerous in and the
+/// single-layer test cannot see: `META_SEQ_LEN` is a max across layers and
+/// hydrate applies that one offset to EVERY reconstructed layer, so a block
+/// written with layer 0 compact at `S` and layer 1 dropped would hand layer 1
+/// back claiming `S` tokens while holding nothing at all. Today the arches move
+/// their non-rotating layers in lockstep, so the mixed shape does not arise on
+/// a serve — which is exactly why it has to be pinned here rather than left to
+/// the first caller that breaks the lockstep.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "test assertion: the refusal is the behaviour under test, so a panic with the diagnostic message is the intended outcome"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+fn expanded_mirror_in_one_layer_fails_the_whole_block() {
+    let device = Device::Cpu;
+    const MAX_SEQ: i32 = 4096;
     let shape = [1i32, 2, 32, 128];
     let n: usize = shape.iter().map(|&x| x as usize).product();
 
-    let mut cache = KvCache::with_quant_max_seq(KvQuant::K8V8, MAX_SEQ);
+    // Layer 0: compact — a perfectly spillable mirror.
+    let mut compact = KvCache::with_quant_max_seq(KvQuant::K8V8, MAX_SEQ).with_layer_idx(0);
+    compact.enter_prefill();
+    compact
+        .update(
+            &arr(&lcg(n, 0x1234), &shape),
+            &arr(&lcg(n, 0x5678), &shape),
+            device,
+        )
+        .unwrap();
+    compact.exit_prefill(device).unwrap();
+    assert_eq!(
+        compact.decode_fp16_kv().expect("mirror").0.shape()[2],
+        shape[2],
+        "precondition: layer 0's mirror is compact"
+    );
+
+    // Layer 1: decode-expanded — the one the writer cannot represent.
+    let expanded = expanded_mirror_cache(device, MAX_SEQ).with_layer_idx(1);
+
+    let path = tmp_path("mixed_expanded");
+    let err = write_caches(
+        &path,
+        device,
+        MODEL_ID,
+        KvQuant::K8V8,
+        &[compact, expanded],
+        &[],
+    )
+    .expect_err("one unrepresentable layer must fail the whole block");
+    assert!(
+        format!("{err}").contains("Refusing the block"),
+        "the refusal must name itself; got: {err}"
+    );
+    assert!(
+        !path.exists(),
+        "a refused block must leave no file for the index to point at"
+    );
+}
+
+/// A `K8V8` cache driven through prefill plus one decode step, so its bf16
+/// mirror has been expanded to `max_seq` while `offset` sits below it.
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture setup under a temp dir this test owns; a failure is a broken fixture, not a condition under test"
+)]
+fn expanded_mirror_cache(device: Device, max_seq: i32) -> KvCache {
+    let shape = [1i32, 2, 32, 128];
+    let n: usize = shape.iter().map(|&x| x as usize).product();
+
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::K8V8, max_seq);
     cache.enter_prefill();
     cache
         .update(
@@ -1784,39 +2001,7 @@ fn decode_expanded_mirror_is_refused_rather_than_spilled_with_its_tail() {
             device,
         )
         .unwrap();
-
-    let filled = cache.offset();
-    assert_eq!(filled, shape[2] + 1, "offset after one decode step");
-    let (k_live, _) = cache.decode_fp16_kv().expect("mirror is live");
-    assert_eq!(
-        k_live.shape()[2],
-        MAX_SEQ,
-        "precondition: the decode step must have expanded the mirror to the ceiling — \
-         without that this test cannot observe the refusal"
-    );
-
-    let path = tmp_path("expanded_mirror");
-    write_caches(&path, device, MODEL_ID, KvQuant::K8V8, &[cache], &[]).unwrap();
-    let (hydrated, _lin) = read_caches(
-        &path,
-        device,
-        MODEL_ID,
-        KvQuant::K8V8,
-        DispatchPolicy::default(),
-    )
-    .unwrap();
-    assert_eq!(
-        hydrated[0].offset(),
-        0,
-        "an expanded mirror must spill as geometry-only (seq_len 0), never with the \
-         ceiling recorded as its filled length"
-    );
-    assert!(
-        hydrated[0].decode_fp16_kv().is_none(),
-        "geometry-only means no payload came back"
-    );
-
-    let _ = std::fs::remove_file(&path);
+    cache
 }
 
 /// The hydrate bridge must hand back the caller's `DispatchPolicy`, not the
@@ -2147,6 +2332,82 @@ fn c2_planar_hydrate_round_trip_no_panic() {
 ///    the raw GPU-word bytes as a CPU `PlanarBlocks` and the CPU
 ///    `planar_dequantize` decodes them.
 ///
+/// Bracketed GPU counterpart: a **prefilled** Planar3 cache on the GPU spills
+/// through the bf16 route, and the round trip is exact.
+///
+/// The cross-path test below drives the codec body unbracketed so there are
+/// GPU-encoded codes to cross to the CPU dequant. That is the right subject for
+/// the byte-convention question, but it means the GPU spill/hydrate of a
+/// PREFILLED cache — the shape this change actually moved — would otherwise be
+/// exercised by no gate at all.
+///
+/// Requires Metal / Apple-Silicon GPU.
+#[test]
+#[ignore = "GPU Metal context — run: cargo test -p rmlx-kv-ssd planar3 -- --ignored --test-threads=1"]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "test assertion: a missing bf16 mirror is exactly the failure this test must surface, so a panic with the diagnostic message is the intended outcome"
+)]
+fn planar3_prefilled_gpu_spill_hydrate_is_bf16_and_exact() {
+    let device = Device::Gpu;
+    let shape = [1i32, 2, 128, 128];
+    let n: usize = shape.iter().map(|&x| x as usize).product();
+
+    let mut c = KvCache::with_quant_max_seq(KvQuant::Planar3, 4096);
+    c.enter_prefill();
+    c.update(
+        &arr(&lcg(n, 0xB0B0_1234), &shape),
+        &arr(&lcg(n, 0xB0B0_1234 ^ 0x5EED), &shape),
+        device,
+    )
+    .unwrap();
+    c.exit_prefill(device).unwrap();
+
+    assert_eq!(
+        c.storage().resident_bytes(),
+        0,
+        "a prefilled Planar3 cache decodes off the mirror, so it holds no store"
+    );
+    let (k_live, v_live) = c.decode_fp16_kv().expect("mirror is live after prefill");
+    let want_k = to_vec(&k_live.astype(Dtype::F32, device).unwrap());
+    let want_v = to_vec(&v_live.astype(Dtype::F32, device).unwrap());
+
+    let path = tmp_path("planar3_prefilled");
+    write_caches(&path, device, MODEL_ID, KvQuant::Planar3, &[c], &[]).unwrap();
+    let (rebuilt, _lin) = read_caches(
+        &path,
+        device,
+        MODEL_ID,
+        KvQuant::Planar3,
+        DispatchPolicy::default(),
+    )
+    .unwrap();
+    assert_eq!(rebuilt[0].offset(), shape[2], "spilled length");
+    let (k_hyd, v_hyd) = rebuilt[0]
+        .decode_fp16_kv()
+        .expect("hydrate must re-seed the mirror");
+    assert_eq!(
+        to_vec(&k_hyd.astype(Dtype::F32, device).unwrap()),
+        want_k,
+        "K must round-trip bit-exact through the tier"
+    );
+    assert_eq!(
+        to_vec(&v_hyd.astype(Dtype::F32, device).unwrap()),
+        want_v,
+        "V must round-trip bit-exact through the tier"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
 /// Reference is the GPU's own dequant of the same codes (the GPU codec is
 /// path-fixed — it was correct before and after the fix). The CPU-hydrated V is
 /// compared against it.

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -1659,6 +1659,166 @@ fn roundtrip_none_bf16_payload_via_spill_hydrate() {
     let _ = std::fs::remove_file(&path);
 }
 
+/// A prefilled bf16-mirror cache spills and hydrates **bit-exact**, for
+/// `KvQuant::None` and for a codec that builds no packed store alike.
+///
+/// A mirror-codec's `exit_prefill` builds no packed store, so the mirror is the
+/// whole layer. Persisting geometry alone would hand the tier an empty block —
+/// a silent cache miss dressed as a hit — and persisting a re-quantised store
+/// would make a disk-served prompt-cache hit decode from different numbers than
+/// the RAM one.
+///
+/// The mirror is driven through a real prefill rather than handed in
+/// pre-built, which is what makes it a **slice view** over the prefill buffer.
+/// That is the shape a live cache actually holds and the one the serialiser
+/// mis-reads when it is not materialised row-major first; a fixture that
+/// installs an already-compact array cannot see that failure. `kv_h > 1` for
+/// the same reason — the mis-read costs every head but the first.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "test assertion: a missing bf16 seed is exactly the failure this test must surface, so a panic with the diagnostic message is the intended outcome"
+)]
+fn roundtrip_mirror_codec_spills_and_hydrates_as_bf16() {
+    let device = Device::Cpu;
+    let shape = [1i32, 8, 32, 128];
+    let n: usize = shape.iter().map(|&x| x as usize).product();
+
+    for (label, quant) in [("none", KvQuant::None), ("k8v8", KvQuant::K8V8)] {
+        let mut cache = KvCache::with_quant_max_seq(quant, 4096);
+        cache.enter_prefill();
+        let k = arr(&lcg(n, 0x1357), &shape);
+        let v = arr(&lcg(n, 0x2468), &shape);
+        cache.update(&k, &v, device).unwrap();
+        cache.exit_prefill(device).unwrap();
+
+        let (k_live, v_live) = cache
+            .decode_fp16_kv()
+            .expect("a bf16-mirror cache holds its K/V on the mirror after prefill");
+        let want_k = to_vec(&k_live.astype(Dtype::F32, device).unwrap());
+        let want_v = to_vec(&v_live.astype(Dtype::F32, device).unwrap());
+
+        let path = tmp_path(&format!("mirror_bf16_{label}"));
+        write_caches(&path, device, MODEL_ID, quant, &[cache], &[]).unwrap();
+
+        let (hydrated, _lin) =
+            read_caches(&path, device, MODEL_ID, quant, DispatchPolicy::default()).unwrap();
+        assert_eq!(hydrated.len(), 1, "{label}: layer count");
+        assert_eq!(
+            hydrated[0].offset(),
+            shape[2],
+            "{label}: offset must equal the spilled seq_len"
+        );
+        let (k_hyd, v_hyd) = hydrated[0]
+            .decode_fp16_kv()
+            .expect("a hydrated mirror layer must come back with its bf16 mirror live");
+        assert_eq!(
+            to_vec(&k_hyd.astype(Dtype::F32, device).unwrap()),
+            want_k,
+            "{label}: K must round-trip bit-exact through the tier"
+        );
+        assert_eq!(
+            to_vec(&v_hyd.astype(Dtype::F32, device).unwrap()),
+            want_v,
+            "{label}: V must round-trip bit-exact through the tier"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+/// A mirror grown past its filled length is refused, not persisted with its tail.
+///
+/// The first decode step expands the mirror from the compact prefill seed to
+/// the `max_seq` ceiling, so from then on the buffer's `shape[2]` is the ceiling
+/// and everything past `offset` is zeros. The writer reads the layer's `seq_len`
+/// off that shape, so persisting the buffer as-is would record the ceiling as
+/// live KV and hydrate a cache whose offset sits thousands of tokens past its
+/// real content. Compacting it would need a device the drain thread does not
+/// have, so the layer spills as geometry-only instead: lossy, never wrong.
+#[test]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "test assertion: a missing bf16 seed is exactly the failure this test must surface, so a panic with the diagnostic message is the intended outcome"
+)]
+fn decode_expanded_mirror_is_refused_rather_than_spilled_with_its_tail() {
+    let device = Device::Cpu;
+    const MAX_SEQ: i32 = 4096;
+    let shape = [1i32, 2, 32, 128];
+    let n: usize = shape.iter().map(|&x| x as usize).product();
+
+    let mut cache = KvCache::with_quant_max_seq(KvQuant::K8V8, MAX_SEQ);
+    cache.enter_prefill();
+    cache
+        .update(
+            &arr(&lcg(n, 0x77), &shape),
+            &arr(&lcg(n, 0x88), &shape),
+            device,
+        )
+        .unwrap();
+    cache.exit_prefill(device).unwrap();
+
+    // One decode step: this is what expands the mirror to the ceiling.
+    let step = [1i32, 2, 1, 128];
+    let n_step: usize = step.iter().map(|&x| x as usize).product();
+    cache
+        .update(
+            &arr(&lcg(n_step, 0x99), &step),
+            &arr(&lcg(n_step, 0xAA), &step),
+            device,
+        )
+        .unwrap();
+
+    let filled = cache.offset();
+    assert_eq!(filled, shape[2] + 1, "offset after one decode step");
+    let (k_live, _) = cache.decode_fp16_kv().expect("mirror is live");
+    assert_eq!(
+        k_live.shape()[2],
+        MAX_SEQ,
+        "precondition: the decode step must have expanded the mirror to the ceiling — \
+         without that this test cannot observe the refusal"
+    );
+
+    let path = tmp_path("expanded_mirror");
+    write_caches(&path, device, MODEL_ID, KvQuant::K8V8, &[cache], &[]).unwrap();
+    let (hydrated, _lin) = read_caches(
+        &path,
+        device,
+        MODEL_ID,
+        KvQuant::K8V8,
+        DispatchPolicy::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        hydrated[0].offset(),
+        0,
+        "an expanded mirror must spill as geometry-only (seq_len 0), never with the \
+         ceiling recorded as its filled length"
+    );
+    assert!(
+        hydrated[0].decode_fp16_kv().is_none(),
+        "geometry-only means no payload came back"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
 /// The hydrate bridge must hand back the caller's `DispatchPolicy`, not the
 /// process default.
 ///
@@ -2020,10 +2180,14 @@ fn planar3_v_gpu_spill_cpu_hydrate_cross_path() {
     let v = arr(&lcg(n, 0xF131_AC03 ^ 0x5EED), &shape);
 
     // ── GPU encode via the real Metal planar3 kernel ──────────────────────────
+    //
+    // Deliberately NOT bracketed by `enter_prefill`/`exit_prefill`: a prefilled
+    // Planar3 cache decodes off the bf16 mirror, so `exit_prefill` builds no
+    // packed store and there would be no GPU-encoded codes to spill. The
+    // unbracketed append drives the codec body, which is the state a
+    // store-backed cache is in and the one this crossing exists to exercise.
     let mut c = KvCache::with_quant_max_seq(KvQuant::Planar3, 4096);
-    c.enter_prefill();
     c.update(&k, &v, device).unwrap();
-    c.exit_prefill(device).unwrap();
 
     // GPU reference V reconstruction (codec is identical pre/post fix on GPU).
     let gpu_ref_v = match c.storage() {

--- a/crates/rmlx-kv-ssd/src/hydrate_tests.rs
+++ b/crates/rmlx-kv-ssd/src/hydrate_tests.rs
@@ -57,9 +57,12 @@ fn build_kvcache(seq: i32, seed: u64) -> KvCache {
     let n: usize = shape.iter().map(|&x| x as usize).product();
     let k = arr(&lcg(n, seed), &shape);
     let v = arr(&lcg(n, seed ^ 0xABCD), &shape);
-    c.enter_prefill();
+    // Deliberately NOT bracketed by `enter_prefill`/`exit_prefill`: a prefilled
+    // cache of these codecs decodes off the bf16 mirror, so `exit_prefill`
+    // builds no packed store and there would be nothing to spill as blocks.
+    // The unbracketed append drives the codec body directly, which is the state
+    // a hydrated cache is in and the one these fixtures exist to exercise.
     c.update(&k, &v, device).unwrap();
-    c.exit_prefill(device).unwrap();
     c
 }
 

--- a/crates/rmlx-kv-ssd/src/hydrate_tests.rs
+++ b/crates/rmlx-kv-ssd/src/hydrate_tests.rs
@@ -66,6 +66,63 @@ fn build_kvcache(seq: i32, seed: u64) -> KvCache {
     c
 }
 
+/// Bracketed counterpart to `build_kvcache`: the production prefill path.
+///
+/// `build_kvcache` deliberately skips the prefill bracket so the fixtures below
+/// have a packed store to round-trip. That leaves the path a real serve takes
+/// uncovered in this file, so it is asserted here: a prefilled `K8V8` cache
+/// spills through the bf16 route instead, and the round trip is exact.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn prefilled_cache_spills_through_the_bf16_route_not_the_store() {
+    let device = Device::Cpu;
+    let tmp = TempDir::new().unwrap();
+    let shape = [1i32, 2, 64, 128];
+    let n: usize = shape.iter().map(|&x| x as usize).product();
+
+    let mut cache = KvCache::with_quant_max_seq(QUANT, 4096);
+    cache.enter_prefill();
+    cache
+        .update(
+            &arr(&lcg(n, 0x2468), &shape),
+            &arr(&lcg(n, 0x1357), &shape),
+            device,
+        )
+        .unwrap();
+    cache.exit_prefill(device).unwrap();
+    assert_eq!(
+        cache.storage().resident_bytes(),
+        0,
+        "a prefilled K8V8 cache holds no packed store"
+    );
+
+    let path = tmp.path().join("prefilled.kvb");
+    write_caches(&path, device, MODEL_ID, QUANT, &[cache], &[]).unwrap();
+    let (rebuilt, _lin) =
+        crate::block_io::read_caches(&path, device, MODEL_ID, QUANT, DispatchPolicy::default())
+            .unwrap();
+    assert_eq!(
+        rebuilt[0].offset(),
+        shape[2],
+        "the spilled block must carry the prefill's full length"
+    );
+    assert!(
+        rebuilt[0].decode_fp16_kv().is_some(),
+        "hydrate must re-seed the mirror the block carried"
+    );
+}
+
 /// (a): a block written by `write_caches` + recorded in the index is read
 /// back by `SsdHydrator::lookup`, reconstructing a KV cache whose K dequant
 /// matches the spilled one within the fp tolerance.

--- a/crates/rmlx-kv-ssd/src/hydrate_truncate_tests.rs
+++ b/crates/rmlx-kv-ssd/src/hydrate_truncate_tests.rs
@@ -48,6 +48,52 @@ fn build_kvcache_quant(quant: KvQuant, kv_h: i32, seq: i32, seed: u64) -> KvCach
     c
 }
 
+/// Bracketed counterpart to `build_kvcache_quant`: on the production prefill
+/// path there is no block list to cut, and a truncate is a no-op on it.
+///
+/// The fixtures here drive the codec body directly so a block list exists to
+/// cut. That is the hydrated shape, and it is the right subject — but it leaves
+/// the serve path unasserted in this file. Stated once here: a prefilled cache
+/// of one of these codecs carries no store, so the cut this file is about
+/// cannot mis-fire on it, and the truncate lands on the mirror's offset only.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn a_prefilled_cache_has_no_block_list_to_cut() {
+    let device = Device::Cpu;
+    let shape = [1i32, 2, 64, 128];
+    let n: usize = shape.iter().map(|&x| x as usize).product();
+
+    for quant in [KvQuant::K8V4, KvQuant::K8V8, KvQuant::Planar] {
+        let mut c = KvCache::with_quant_max_seq(quant, 4096);
+        c.enter_prefill();
+        c.update(
+            &arr(&lcg(n, 0x5150), &shape),
+            &arr(&lcg(n, 0x0515), &shape),
+            device,
+        )
+        .unwrap();
+        c.exit_prefill(device).unwrap();
+
+        assert_eq!(
+            c.storage().resident_bytes(),
+            0,
+            "{quant:?}: a prefilled cache carries no packed store, so the block \
+             cut this file exercises has nothing to act on"
+        );
+
+        c.truncate_to(16);
+        assert_eq!(c.offset(), 16, "{quant:?}: truncate moves the cache offset");
+        assert_eq!(
+            c.storage().resident_bytes(),
+            0,
+            "{quant:?}: and still no store afterwards"
+        );
+    }
+}
+
 /// Dequant the V side of a cache to flat head-major `[1, kv_h, S, D]` f32.
 #[allow(
     clippy::expect_used,

--- a/crates/rmlx-kv-ssd/src/hydrate_truncate_tests.rs
+++ b/crates/rmlx-kv-ssd/src/hydrate_truncate_tests.rs
@@ -11,8 +11,10 @@ use super::*;
 // On a normal serve these codecs never read their CPU block list at decode time:
 // `exit_prefill` materialises the bf16 `decode_fp16_{k,v}` seed for every quant
 // whose `feeds_bf16_k_at_decode()` is true, and every quantized `update_<codec>`
-// early-returns into `update_decode_fp16` from then on. The codec store is
-// written once and then frozen at the prefill length.
+// early-returns into `update_decode_fp16` from then on — which is why
+// `exit_prefill` does not build the store for them at all
+// (`KvQuant::materialises_packed_store`). The fixtures below drive the codec
+// body directly, without a prefill bracket, so the store exists to be cut.
 //
 // A hydrated cache is the exception, and it is what makes the block cut
 // observable. `KvCache::from_storage` leaves `decode_fp16_k: None`, so the codec
@@ -37,9 +39,12 @@ fn build_kvcache_quant(quant: KvQuant, kv_h: i32, seq: i32, seed: u64) -> KvCach
     let n: usize = shape.iter().map(|&x| x as usize).product();
     let k = arr(&lcg(n, seed), &shape);
     let v = arr(&lcg(n, seed ^ 0xABCD), &shape);
-    c.enter_prefill();
+    // Deliberately NOT bracketed by `enter_prefill`/`exit_prefill`: a prefilled
+    // cache of these codecs decodes off the bf16 mirror, so `exit_prefill`
+    // builds no packed store and there would be nothing to spill as blocks.
+    // The unbracketed append drives the codec body directly, which is the state
+    // a hydrated cache is in and the one these fixtures exist to exercise.
     c.update(&k, &v, device).unwrap();
-    c.exit_prefill(device).unwrap();
     c
 }
 

--- a/crates/rmlx-kv-ssd/src/ssd_index.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_index.rs
@@ -110,6 +110,16 @@ type Result<T> = std::result::Result<T, SsdKvIndexError>;
 ///   type and the table shape are unchanged; only the stored unit moved, so
 ///   v2 rows must not be left to sit beside v3 rows three orders of magnitude
 ///   away.
+/// - v3 → v4: the **block payload** changed for every bf16-mirror codec
+///   (`K8V4`, `K8V8`, `Planar*`, `PlanarK`, `K8VTurbo*`, `TurboSym*`,
+///   `Iso3/4`, `Rotor3/4`, `RotorK*Asym`). Those layers used to spill codes +
+///   scales under their codec tag and now spill the bf16 mirror under
+///   `none_bf16`, because `exit_prefill` no longer builds a store nothing
+///   reads. Neither the index shape nor the `(hash, layout_key)` key changed,
+///   so a v3 block would still *hit* — and hydrate store-backed, with no bf16
+///   mirror, so the request would decode off dequantised numbers while the
+///   same hit served from RAM decodes bf16. The version is what routes those
+///   namespaces through the wipe instead.
 ///
 /// v2 rows are **convertible** — `UPDATE kv_blocks SET last_used = last_used *
 /// 1000000` is the whole migration. They are wiped anyway, and that is a
@@ -117,7 +127,7 @@ type Result<T> = std::result::Result<T, SsdKvIndexError>;
 /// whose worst loss is one re-prefill per block, and carrying migration code
 /// (plus the branch in the wipe pass that has to let a v2 DB through so it can
 /// be converted) buys nothing a warm cache does not rebuild in minutes.
-pub(crate) const SCHEMA_VERSION: i64 = 3;
+pub(crate) const SCHEMA_VERSION: i64 = 4;
 
 const SCHEMA_PRAGMAS: &str = "
 PRAGMA journal_mode = WAL;

--- a/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
+++ b/crates/rmlx-kv-ssd/src/ssd_tier_tests.rs
@@ -259,6 +259,45 @@ fn wipe_removes_superseded_schema_namespace() {
     );
 }
 
+/// The v3 → v4 transition specifically: a namespace written before the
+/// bf16-mirror codecs moved their block payload must be reclaimed.
+///
+/// This is not covered by `wipe_removes_superseded_schema_namespace`, which
+/// seeds v2 and would keep passing at any later version. It pins the one
+/// transition whose stakes are not merely stranded bytes: a v3 block for
+/// `K8V8` (or any other mirror-family codec) holds codes + scales under its
+/// codec tag, and the `(hash, layout_key)` key did not change — so left in
+/// place it is a live *hit* that hydrates store-backed with no bf16 mirror.
+/// The request then decodes off dequantised numbers while the same prompt
+/// served from RAM decodes bf16, and nothing errors or logs. The version bump
+/// is the only thing standing between that block and a reader.
+///
+/// Mutation check: put `SCHEMA_VERSION` back to 3 and the seeded namespace is
+/// `found == SCHEMA_VERSION`, so the pass skips it and the directory survives.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture setup under a temp dir this test owns; a failure is a broken fixture, not a condition under test"
+)]
+fn wipe_removes_the_pre_none_bf16_block_format_namespace() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let kv_root = tmp.path().to_path_buf();
+    let pre_change = seed_namespace_at_version(&kv_root, "wipe-v3", 3);
+    let current = seed_current_schema_namespace(&kv_root, "keep-current");
+
+    wipe_stale_schema_namespaces(&kv_root);
+
+    assert!(
+        !pre_change.exists(),
+        "a namespace at the pre-`none_bf16` block format must be removed, not \
+         served: its blocks hit under an unchanged key and hydrate store-backed"
+    );
+    assert!(
+        current.exists(),
+        "current-schema namespace must survive the same pass"
+    );
+}
+
 /// A namespace written by a **newer** binary must survive. Two rMLX builds on
 /// one machine at different schema versions is the ordinary case here (a
 /// tap-installed release beside a dev build), and wiping forward means the

--- a/crates/rmlx-models/src/kv_cache/mod.rs
+++ b/crates/rmlx-models/src/kv_cache/mod.rs
@@ -250,13 +250,16 @@ pub struct KvLayerShape {
 /// **increase** resident KV versus plain bf16 on the active layer mix
 /// (issue #34).
 ///
-/// Why this can happen, generally: a quantized codec keeps a warm-TTFT bf16
-/// decode seed (`decode_fp16_k/v`) alongside its packed codes + per-group
+/// Why this can happen, generally: a quantized codec can keep a warm-TTFT bf16
+/// decode seed (`decode_fp16_k/v`) alongside its packed codes and per-group
 /// scales on every **global** layer (see
-/// [`rmlx_kv_quant::KvQuant::feeds_bf16_k_at_decode`]). At small effective
-/// context the codes + scales are pure overhead on top of a buffer the same
-/// size as bf16, so the codec is net-negative. **Windowed layers always run
-/// the bf16 rotating ring regardless of the flag**
+/// [`rmlx_kv_quant::KvQuant::feeds_bf16_k_at_decode`]). Where it does, those
+/// codes and scales are pure overhead on top of a buffer the same size as bf16
+/// and the codec is net-negative. A codec whose decode reads only the mirror
+/// builds no store at all
+/// ([`rmlx_kv_quant::KvQuant::materialises_packed_store`]), so it holds exactly
+/// the bf16 bytes and never reaches this warn.
+/// **Windowed layers always run the bf16 rotating ring regardless of the flag**
 /// (`RotatingKVCache.to_quantized` raises `NotImplementedError` in mlx-lm;
 /// rMLX matches it), so they are a no-op for the codec and contribute zero to
 /// the delta — the net-negative is a property of the global layers only.

--- a/crates/rmlx-models/src/kv_cache/tests.rs
+++ b/crates/rmlx-models/src/kv_cache/tests.rs
@@ -664,42 +664,56 @@ mod tests {
         );
     }
 
-    /// `KvQuant::K8V8` residency is the q8_0 store plus **both** warm-TTFT bf16
-    /// seeds — and the store's real cost (codes *and* per-group scales) exceeds
-    /// the 8-bits-per-element the codec is named for.
+    /// `KvQuant::K8V8` residency after a prefill is **exactly** the two
+    /// warm-TTFT bf16 mirrors — the same bytes a `KvQuant::None` cache of the
+    /// same shape holds — because its decode reads those mirrors and nothing
+    /// reads a packed store, so `exit_prefill` builds none.
+    ///
+    /// The `None` cache is the oracle rather than a byte formula: it shares no
+    /// arithmetic with the accounting under test, and a store built anyway
+    /// (codes *and* per-group scales) shows up immediately as the two totals
+    /// diverging.
     #[test]
     #[allow(
         clippy::expect_used,
         reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
     )]
-    fn resident_bytes_k8v8_counts_store_plus_both_seeds() {
+    fn resident_bytes_k8v8_is_the_two_bf16_mirrors_and_no_store() {
         let device = Device::Cpu;
-        let mut cache = KvCache::with_quant_max_seq(KvQuant::K8V8, 4096);
-        cache.enter_prefill();
-        let k = make_lcg_array(&[1, 4, 256, 128], 0xBEEF).0;
-        let v = make_lcg_array(&[1, 4, 256, 128], 0xCAFE).0;
-        cache.update(&k, &v, device).expect("update must not fail");
-        cache
-            .exit_prefill(device)
-            .expect("exit_prefill must not fail");
+        let shape = [1, 4, 256, 128];
+        let prefilled = |quant| {
+            let mut cache = KvCache::with_quant_max_seq(quant, 4096);
+            cache.enter_prefill();
+            let k = make_lcg_array(&shape, 0xBEEF).0;
+            let v = make_lcg_array(&shape, 0xCAFE).0;
+            cache.update(&k, &v, device).expect("update must not fail");
+            cache
+                .exit_prefill(device)
+                .expect("exit_prefill must not fail");
+            cache
+        };
+        let quantized = prefilled(KvQuant::K8V8);
+        let bf16 = prefilled(KvQuant::None);
 
+        assert_eq!(
+            quantized.storage().resident_bytes(),
+            0,
+            "K8V8 must hold no packed store after prefill — nothing reads it at decode"
+        );
+        assert_eq!(
+            quantized.resident_bytes(),
+            bf16.resident_bytes(),
+            "K8V8 residency must equal plain bf16 at the same shape: both hold two \
+             bf16 mirrors and nothing else"
+        );
+        // And the figure is the mirrors, not zero — a cache that reported
+        // nothing at all would pass the equality above vacuously.
         let seq: u64 = 256;
         let bhd: u64 = 4 * 128; // kv_h=4, head_dim=128 (B=1 implicit)
-        let store = cache.storage().resident_bytes();
-        // Both seeds are live on K8V8 and both are bf16 at the filled length.
-        let seeds = seq * bhd * 2 * 2;
         assert_eq!(
-            cache.resident_bytes(),
-            store + seeds,
-            "K8V8 must report its q8_0 store plus both bf16 seeds"
-        );
-        // The store is the codes *and* their per-group scales: strictly more
-        // than the codec's nominal 8 bits per element for K and V.
-        assert!(
-            store > seq * bhd * 2,
-            "q8_0 store ({store} B) must exceed the nominal 8-bit-per-element figure \
-             ({} B) — the per-group scales are real memory too",
-            seq * bhd * 2
+            quantized.resident_bytes(),
+            seq * bhd * 2 * 2,
+            "the reported bytes must be the two bf16 mirrors at the filled length"
         );
     }
 
@@ -2066,20 +2080,47 @@ mod tests {
         v
     }
 
-    /// A scratch-heavy codec (K8V4) on the windowed+global mix is net-negative:
-    /// the global-layer bf16 seed + scales exceed the bytes saved. The warn
+    /// A codec that keeps a packed store **and** both bf16 mirrors on the
+    /// windowed+global mix is net-negative: the global-layer codes + scales are
+    /// pure addition on top of mirrors that are already bf16-sized. The warn
     /// must fire (total saving < 0) and the windowed layers must contribute 0.
     #[test]
-    fn net_negative_warn_fires_on_scratch_heavy_codec_swa_mix() {
+    fn net_negative_warn_fires_on_store_plus_mirror_codec_swa_mix() {
         let layers = e2b_layer_mix();
         let n_windowed = layers.iter().filter(|l| l.window.is_some()).count();
-        let (saving, n_global, n_win) = kv_codec_net_saving_total(KvQuant::K8V4, &layers, 4096);
+        let mixed = KvQuant::Mixed {
+            k_bits: 8,
+            v_bits: 8,
+            k_group_size: 64,
+            v_group_size: 64,
+        };
+        let (saving, n_global, n_win) = kv_codec_net_saving_total(mixed, &layers, 4096);
         assert_eq!(n_win, n_windowed);
         assert_eq!(n_global, 35 - n_windowed);
         assert!(
             saving < 0,
-            "K8V4 on the SWA+global mix at 4096 ctx must be net-negative (warn fires); got {saving}"
+            "a store + both-mirror codec on the SWA+global mix at 4096 ctx must be \
+             net-negative (warn fires); got {saving}"
         );
+    }
+
+    /// A mirror-only codec never warns on any layer mix or context: it builds no
+    /// packed store, so it holds exactly the bf16 bytes and the saving is 0.
+    /// The advisory used to fire on every one of these runs, which is what the
+    /// operator was being told to work around.
+    #[test]
+    fn net_negative_warn_silent_for_mirror_only_codec() {
+        let layers = e2b_layer_mix();
+        for quant in [KvQuant::K8V4, KvQuant::K8V8, KvQuant::Planar] {
+            for eff_seq in [512, 4096, 131_072] {
+                let (saving, _, _) = kv_codec_net_saving_total(quant, &layers, eff_seq);
+                assert_eq!(
+                    saving, 0,
+                    "{quant:?} at eff_seq={eff_seq} holds exactly the bf16 bytes — the \
+                     net-negative advisory must stay silent"
+                );
+            }
+        }
     }
 
     /// bf16 (`None`) never warns — saving is exactly 0 against its own baseline.

--- a/crates/rmlx-models/tests/ssd_quant_byte_size_table.rs
+++ b/crates/rmlx-models/tests/ssd_quant_byte_size_table.rs
@@ -4,30 +4,25 @@
 //! No model load. No HTTP. No spill drain thread. Pure write_caches + SsdKvIndex
 //! + fs::metadata. Runs in <30 s on CPU. One tempdir per quant variant.
 //!
-//! ## Quant coverage
+//! ## What decides a block's size
 //!
-//! | Variant | Tested | Reason if skipped |
+//! Not the codec name — what the cache actually holds. A codec whose decode
+//! reads only the bf16 mirror builds no packed store (`exit_prefill` skips the
+//! bulk encode), so the only thing there is to persist is that mirror: its
+//! block is bf16 and is byte-identical whatever the flag said. A codec whose
+//! decode reads its packed store spills codes + scales and lands somewhere
+//! else entirely.
+//!
+//! | Variant | Tested | Role |
 //! |---------------------|--------|-------------------|
-//! | K8V8 | YES | reference / 8-bit both sides |
-//! | K8V4 | YES | 8-bit K, 4-bit V (TurboQuant) |
-//! | Planar | YES | 8-bit K, 4-bit V (PlanarQuant rotation codec) |
-//! | Mixed { k8, v4 } | NO | requires internal `MixedKvState` (pub(crate) only) |
-//! | RotK / RotKTq4V | NO | same – internal Hadamard rotation state |
-//! | None (bf16) | NO | KvStorage::None has no codes payload – file is geometry-only |
+//! | K8V8 / K8V4 / Planar | YES | mirror-only — all three spill the same bf16 block |
+//! | IsoKOnly3 | YES | store-keeping control — must NOT land on the bf16 size |
+//! | Mixed / RotK / RotKTq4V | NO | requires internal `MixedKvState` (pub(crate) only) |
+//! | None (bf16) | YES | the oracle the mirror-only trio must match |
 //!
-//! If a future KvQuant variant is added without a row in `TESTED_QUANTS`, the
-//! compile-time exhaustiveness note below is the forcing function to update
-//! this test. See: `assert_all_serializable_quants_are_listed`.
-//!
-//! ## Ratio source-of-truth
-//!
-//! On-disk ratios are derived from the actual storage format (codes + scales +
-//! rotations for Planar), not the naive bits-per-element formula used by
-//! `kv_reduction_ratios_match_table` (which counts codes only). Notably Planar
-//! is LARGER than K8V8 in bytes because it stores per-pair scales (N/2 f32
-//! values) rather than per-group scales — the reduction is in quantization
-//! error quality, not byte count. ±10% tolerance absorbs the safetensors
-//! JSON header overhead (negligible for 256-token blocks).
+//! The control is what keeps this from being a gate that cannot fail: without
+//! it, a writer that emitted a fixed-size stub for every layer would satisfy
+//! the equality half and the formula half alike.
 
 // unsafe_code: mlx-rs Array zero-copy view — slice::from_raw_parts byte-reinterpret for Array::from_bytes in test helpers
 #![allow(unsafe_code)]
@@ -68,24 +63,26 @@ const SEED_K: u64 = 0xDEAD_CAFE_1234_5678;
 /// Seed for the LCG V data (XOR'd from K seed so K ≠ V).
 const SEED_V: u64 = SEED_K ^ 0xABCD_1234;
 
-/// The three quant variants exercised by this integration test.
+/// The mirror-only quants: their decode reads the bf16 mirror on both axes, so
+/// `exit_prefill` builds no packed store and all three spill the same bf16
+/// block. Mixed / RotK / RotKTq4V require `pub(crate)` internal state
+/// (`MixedKvState`, Hadamard rotation) and cannot be driven through the public
+/// `KvCache::enter_prefill` → `update` → `exit_prefill` API.
 ///
-/// Mixed / RotK / RotKTq4V require `pub(crate)` internal state
-/// (`MixedKvState`, Hadamard rotation) and cannot be driven through the
-/// public KvCache::enter_prefill → update → exit_prefill API.
-/// None (bf16) has no codes payload — the `.kvb` contains only geometry
-/// metadata and produces a file that is smaller than K8V4, breaking the
-/// size-ordering assumption.
-///
-/// FORWARD-COMPAT NOTE: When a new KvQuant variant is added, the test
-/// `assert_all_serializable_quants_are_listed` should fail loudly (by design
-/// it prints a reminder). Add the new variant to TESTED_QUANTS or document
-/// why it cannot be exercised here.
-const TESTED_QUANTS: &[(&str, KvQuant)] = &[
+/// FORWARD-COMPAT NOTE: when a new `KvQuant` variant is added,
+/// `assert_all_serializable_quants_are_listed` prints a reminder to classify it
+/// here or in the excluded list.
+const MIRROR_ONLY_QUANTS: &[(&str, KvQuant)] = &[
     ("K8V8", KvQuant::K8V8),
     ("K8V4", KvQuant::K8V4),
     ("Planar", KvQuant::Planar),
 ];
+
+/// Store-keeping control: `IsoKOnly3` re-quantises K into its packed store on
+/// every decode step, so `exit_prefill` builds that store and the block carries
+/// real codes. Its size must differ from the bf16 block — a writer that had
+/// stopped distinguishing the two would pass every other assertion here.
+const STORE_KEEPING_CONTROL: (&str, KvQuant) = ("IsoKOnly3", KvQuant::IsoKOnly3);
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -142,87 +139,134 @@ fn synthetic_hash(quant_label: &str) -> String {
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
-/// Each quant variant must produce a strictly unique on-disk byte size.
-///
-/// DoD criterion: "All quant variants produce strictly distinct byte sizes."
-#[test]
-fn kv_quants_produce_distinct_byte_sizes() {
+/// Write one `.kvb` for `quant` into `dir` and return its size in bytes.
+fn spill_size(dir: &TempDir, label: &str, quant: KvQuant) -> u64 {
     let device = Device::Cpu;
+    let cache = build_kvcache(quant);
+    let hash = synthetic_hash(label);
+    let path = dir.path().join(format!("{hash}.kvb"));
+    rmlx_kv_ssd::write_caches(&path, device, MODEL_ID, quant, &[cache], &[]).unwrap();
+    std::fs::metadata(&path)
+        .unwrap_or_else(|e| panic!("metadata for {label}: {e}"))
+        .len()
+}
+
+/// bf16 payload of one `[B, kv_h, S, D]` K/V pair: two tensors, 2 bytes per
+/// element. Everything above this in the file is the safetensors JSON header.
+fn bf16_payload_bytes() -> u64 {
+    let n: u64 = (BATCH * KV_HEADS * BLOCK_TOKENS * HEAD_DIM) as u64;
+    2 * n * 2
+}
+
+/// The mirror-only quants all spill the **same** bf16 block, byte-identical to
+/// the one a plain `KvQuant::None` cache spills.
+///
+/// This is the on-disk face of the `exit_prefill` store skip: those codecs hold
+/// nothing but the bf16 mirror, so that mirror is the whole layer and it is
+/// what gets persisted. Hydrate then hands the cache back the same bytes it
+/// spilled, which is why a prompt-cache hit served from disk decodes
+/// identically to one served from RAM.
+#[test]
+fn mirror_only_quants_spill_the_same_bf16_block_as_none() {
     let tmp = TempDir::new().unwrap();
+    let baseline = spill_size(&tmp, "None", KvQuant::None);
+    let payload = bf16_payload_bytes();
 
-    let mut sizes: Vec<(&str, u64)> = Vec::new();
-
-    for (label, quant) in TESTED_QUANTS {
-        let cache = build_kvcache(*quant);
-        let hash = synthetic_hash(label);
-        let path = tmp.path().join(format!("{hash}.kvb"));
-
-        rmlx_kv_ssd::write_caches(&path, device, MODEL_ID, *quant, &[cache], &[]).unwrap();
-
-        let byte_size = std::fs::metadata(&path)
-            .unwrap_or_else(|e| panic!("metadata for {label}: {e}"))
-            .len();
-
-        assert!(byte_size > 0, "{label}: .kvb file must not be empty");
-        sizes.push((label, byte_size));
-    }
-
-    // All sizes must be strictly distinct.
-    let unique: HashSet<u64> = sizes.iter().map(|(_, n)| *n).collect();
-    assert_eq!(
-        unique.len(),
-        sizes.len(),
-        "all quant variants must produce unique byte sizes; got: {sizes:?}"
+    assert!(
+        baseline >= payload && baseline < payload + 4096,
+        "the bf16 block must be the two bf16 tensors plus a small header: \
+         got {baseline} B against a {payload} B payload"
     );
 
-    println!("\n── kv_quants_produce_distinct_byte_sizes ────────────────");
-    for (label, sz) in &sizes {
-        println!("  {label:<30} {sz:>10} bytes");
+    println!("\n── mirror_only_quants_spill_the_same_bf16_block_as_none ──");
+    println!("  {:<30} {:>10} bytes", "None (oracle)", baseline);
+    for (label, quant) in MIRROR_ONLY_QUANTS {
+        let size = spill_size(&tmp, label, *quant);
+        println!("  {label:<30} {size:>10} bytes");
+        assert_eq!(
+            size, baseline,
+            "{label} builds no packed store, so its block must be the same bf16 \
+             block `None` spills ({baseline} B); got {size} B"
+        );
     }
 }
 
-/// For every tested quant the on-disk byte size must be within ±10% of the
-/// formula-derived payload ratio relative to K8V8.
+/// The control: a codec whose decode reads its packed store spills that store —
+/// a block that is neither the bf16 block nor an empty geometry stub.
 ///
-/// ## Formula-derived ratios (including codes + scales + rotations overhead)
-///
-/// Shape: [B=1, KV_H=4, S=256, D=128] → total N = 131_072 elements.
-///
-/// | Variant | K payload | V payload | total | ratio/K8V8 |
-/// |---------|---------------|-----------------------------------------------------|----------|------------|
-/// | K8V8 | N + N/128*4 | N + N/128*4 | 270_336 | 1.000× |
-/// | K8V4 | N + N/128*4 | N/2 + N/32*4 | 217_088 | 0.803× |
-/// | Planar | N + N/128*4 | N/2 (codes) + N/2*4 (per-pair scales) + N/4 (rots) | 495_616 | 1.833× |
-///
-/// Note: Planar is LARGER than K8V8 because it uses per-pair scales (N/2 f32
-/// values) instead of per-group scales. The reduction in quantization error
-/// from the Givens rotation codebook is in quality, not in byte count.
-///
-/// The ±10% tolerance absorbs the fixed safetensors JSON header overhead
-/// (~hundreds of bytes) which is negligible for 256-token blocks.
-///
-/// Also verifies: index row `byte_size` column == `fs::metadata().len()`.
+/// Both comparisons are load-bearing. Against the bf16 block it proves the
+/// mirror-only rule did not swallow a codec that needs its codes; against the
+/// unfilled cache's block it proves the codes are actually in the file. Drop
+/// the second and a writer that emitted geometry for every layer would satisfy
+/// the first by landing on 176 bytes.
 #[test]
-fn kv_quant_byte_size_ratios_match_reduction_table() {
+fn store_keeping_quant_spills_its_codes_not_the_bf16_block() {
+    let device = Device::Cpu;
+    let tmp = TempDir::new().unwrap();
+    let bf16_block = spill_size(&tmp, "None", KvQuant::None);
+    let (label, quant) = STORE_KEEPING_CONTROL;
+    assert!(
+        quant.materialises_packed_store(),
+        "{label} must be a store-keeping codec for this control to mean anything"
+    );
+
+    // Geometry-only reference: same codec, never filled, so there is no payload
+    // to write and the file is header + geometry metadata alone.
+    let empty_path = tmp.path().join("empty.kvb");
+    rmlx_kv_ssd::write_caches(
+        &empty_path,
+        device,
+        MODEL_ID,
+        quant,
+        &[KvCache::with_quant_max_seq(quant, 4096)],
+        &[],
+    )
+    .unwrap();
+    let geometry_only = std::fs::metadata(&empty_path).unwrap().len();
+
+    let size = spill_size(&tmp, label, quant);
+    println!("\n── store_keeping_quant_spills_its_codes_not_the_bf16_block ──");
+    println!("  {:<30} {:>10} bytes", "None (bf16 block)", bf16_block);
+    println!(
+        "  {:<30} {:>10} bytes",
+        "unfilled (geometry only)", geometry_only
+    );
+    println!("  {label:<30} {size:>10} bytes");
+    assert_ne!(
+        size, bf16_block,
+        "{label} keeps a packed store, so its block must not be the bf16 block"
+    );
+    // The K codes alone are at least half a byte per element; anything near the
+    // geometry-only size means the payload never reached the file.
+    let n: u64 = (BATCH * KV_HEADS * BLOCK_TOKENS * HEAD_DIM) as u64;
+    assert!(
+        size > geometry_only + n / 2,
+        "{label} must spill its K codes: got {size} B against a {geometry_only} B \
+         geometry-only block for the same codec"
+    );
+}
+
+/// Index bookkeeping: the row's `byte_size` and `kv_quant` columns must match
+/// what was actually written.
+#[test]
+fn index_row_matches_the_file_it_describes() {
     let device = Device::Cpu;
     let tmp = TempDir::new().unwrap();
     let db_path = tmp.path().join("index.db");
     let index = SsdKvIndex::open_at(&db_path).unwrap();
 
-    // ── Write one .kvb per quant, record in the index ─────────────────────
-    let mut quant_sizes: Vec<(&str, KvQuant, u64)> = Vec::new();
-
     // this byte-size proof is layout-agnostic — use a stable
     // placeholder layout_key so the `(hash, layout_key)` PK is well-defined.
     const TEST_LAYOUT_KEY: u64 = 0xb172_e510_5117_5e57;
 
-    for (label, quant) in TESTED_QUANTS {
-        let cache = build_kvcache(*quant);
+    let mut cases: Vec<(&str, KvQuant)> = MIRROR_ONLY_QUANTS.to_vec();
+    cases.push(STORE_KEEPING_CONTROL);
+
+    for (label, quant) in cases {
+        let cache = build_kvcache(quant);
         let hash = synthetic_hash(label);
         let path = tmp.path().join(format!("{hash}.kvb"));
-
-        rmlx_kv_ssd::write_caches(&path, device, MODEL_ID, *quant, &[cache], &[]).unwrap();
-
+        rmlx_kv_ssd::write_caches(&path, device, MODEL_ID, quant, &[cache], &[]).unwrap();
         let byte_size = std::fs::metadata(&path).unwrap().len();
         index
             .record(
@@ -235,19 +279,13 @@ fn kv_quant_byte_size_ratios_match_reduction_table() {
             )
             .unwrap();
 
-        quant_sizes.push((label, *quant, byte_size));
-    }
-
-    // ── Assert index row byte_size == fs::metadata ───────
-    for (label, quant, expected_size) in &quant_sizes {
-        let hash = synthetic_hash(label);
         let row = index
             .lookup(&hash, TEST_LAYOUT_KEY)
             .unwrap()
             .unwrap_or_else(|| panic!("{label}: index row not found after record()"));
         assert_eq!(
-            row.byte_size, *expected_size,
-            "{label}: index byte_size ({}) must match fs::metadata ({expected_size})",
+            row.byte_size, byte_size,
+            "{label}: index byte_size ({}) must match fs::metadata ({byte_size})",
             row.byte_size
         );
         assert_eq!(
@@ -256,98 +294,30 @@ fn kv_quant_byte_size_ratios_match_reduction_table() {
             "{label}: index kv_quant string mismatch"
         );
     }
-
-    // ── Compute ratios vs K8V8 reference ──────────────────────────────────
-    let k8v8_size = quant_sizes
-        .iter()
-        .find(|(l, _, _)| *l == "K8V8")
-        .map(|(_, _, s)| *s)
-        .expect("K8V8 must be in TESTED_QUANTS");
-
-    // Formula-derived expected ratios vs K8V8 for shape [1, 4, 256, 128].
-    // See doc comment above for derivation. These are exact predictions;
-    // ±10% tolerance covers the fixed safetensors header overhead.
-    //
-    // N = B * kv_h * S * D = 1 * 4 * 256 * 128 = 131_072 elements.
-    // K side is q8_0 (8-bit codes + per-128-group f32 scales) for all variants.
-    let n: u64 = (BATCH * KV_HEADS * BLOCK_TOKENS * HEAD_DIM) as u64;
-    let k8v8_formula: u64 = {
-        let k = n + n / 128 * 4; // 8-bit codes + per-128 scales
-        let v = n + n / 128 * 4; // same for V
-        k + v
-    };
-    let k8v4_formula: u64 = {
-        let k = n + n / 128 * 4;
-        let v_codes = n / 2; // 4-bit codes
-        let v_scales = n / 32 * 4; // TurboQuant: per-32-group f32 scales
-        k + v_codes + v_scales
-    };
-    let planar_formula: u64 = {
-        let k = n + n / 128 * 4;
-        let v_codes = n / 2; // 4-bit codes
-        let v_scales_planar = n / 2 * 4; // PlanarQuant: per-PAIR f32 scales
-        let v_rotations = n / 4; // 4 bits per pair, 2 pairs per byte
-        k + v_codes + v_scales_planar + v_rotations
-    };
-
-    let expected_ratio_vs_k8v8 = |label: &str| -> f64 {
-        match label {
-            "K8V8" => k8v8_formula as f64 / k8v8_formula as f64,
-            "K8V4" => k8v4_formula as f64 / k8v8_formula as f64,
-            "Planar" => planar_formula as f64 / k8v8_formula as f64,
-            other => panic!("no formula-derived ratio defined for {other}"),
-        }
-    };
-
-    println!("\n── kv_quant_byte_size_ratios_match_reduction_table ─────");
-    println!(
-        "  {:<30} {:>12} {:>18} {:>18}",
-        "quant", "byte_size", "ratio_vs_K8V8", "formula_vs_K8V8"
-    );
-
-    for (label, _quant, size) in &quant_sizes {
-        let ratio_vs_k8v8 = *size as f64 / k8v8_size as f64;
-        let expected = expected_ratio_vs_k8v8(label);
-        let tol = 0.10; // ±10%: safetensors header is negligible vs payload
-        let diff = (ratio_vs_k8v8 - expected).abs();
-
-        println!(
-            "  {:<30} {:>12} {:>17.4}x {:>17.4}x  diff={:.4}",
-            label, size, ratio_vs_k8v8, expected, diff
-        );
-
-        assert!(
-            diff / expected.abs().max(0.001) < tol,
-            "{label}: observed ratio {ratio_vs_k8v8:.4}× vs formula {expected:.4}× — \
-             relative diff {:.4} exceeds ±{:.0}% tolerance \
-             (formula: k8v8={k8v8_formula}, k8v4={k8v4_formula}, planar={planar_formula})",
-            diff / expected.abs().max(0.001),
-            tol * 100.0
-        );
-    }
 }
 
-/// Forward-compatibility reminder: this is NOT a test that runs assertions.
-/// It prints a notice to ensure a future KvQuant variant triggers an update
-/// to TESTED_QUANTS. If you add a new KvQuant and see this message, add
-/// the variant (or document why it cannot be exercised here).
+/// Forward-compatibility reminder: this is NOT a test that runs assertions
+/// against the writer. It prints a notice to ensure a future KvQuant variant
+/// triggers an update to the lists above.
 #[test]
 fn assert_all_serializable_quants_are_listed() {
-    // The full set of KvQuant variants as of the last update to this test.
-    // Update this set when a new variant is added to the KvQuant enum.
-    // Variants deliberately excluded from TESTED_QUANTS are listed in the
-    // EXCLUDED set with their reason.
-    const TESTED_NAMES: &[&str] = &["K8V8", "K8V4", "Planar"];
+    const TESTED_NAMES: &[&str] = &["K8V8", "K8V4", "Planar", "IsoKOnly3", "None"];
     const EXCLUDED_NAMES: &[&str] = &[
         "Mixed",    // requires pub(crate) MixedKvState
         "RotK",     // requires pub(crate) Hadamard rotation state
         "RotKTq4V", // same as RotK
-        "None",     // KvStorage::None has no codes payload
     ];
 
-    // All known KvQuant variants as of 2026-05-25.
+    // All known KvQuant variants as of the last update to this test.
     const ALL_KNOWN: &[&str] = &[
-        "K8V4", "K8V8", "Planar", "None", "Mixed", "RotK", "RotKTq4V",
+        "K8V4",
+        "K8V8",
+        "Planar",
+        "None",
+        "IsoKOnly3",
+        "Mixed",
+        "RotK",
+        "RotKTq4V",
     ];
 
     let tested: HashSet<&str> = TESTED_NAMES.iter().copied().collect();
@@ -355,7 +325,7 @@ fn assert_all_serializable_quants_are_listed() {
     for name in ALL_KNOWN {
         assert!(
             tested.contains(name) || excluded.contains(name),
-            "KvQuant variant '{name}' is not in TESTED_QUANTS or EXCLUDED_NAMES — \
+            "KvQuant variant '{name}' is not in the tested or excluded lists — \
              please add it to one of the two lists in ssd_quant_byte_size_table.rs"
         );
     }

--- a/crates/rmlx-models/tests/ssd_quant_byte_size_table.rs
+++ b/crates/rmlx-models/tests/ssd_quant_byte_size_table.rs
@@ -1,28 +1,36 @@
-//! Hermetic byte-size proof: same synthetic prompt, different KV-quant flags,
-//! strictly different `.kvb` on-disk sizes in the expected ratios.
+//! Hermetic byte-size proof: same synthetic prompt, every KV-quant flag, and
+//! the assertion that a block's payload is decided by what the cache holds
+//! rather than by which codec was asked for.
 //!
 //! No model load. No HTTP. No spill drain thread. Pure write_caches + SsdKvIndex
-//! + fs::metadata. Runs in <30 s on CPU. One tempdir per quant variant.
+//! + safetensors payload accounting. Runs in ~25 s on CPU.
 //!
 //! ## What decides a block's size
 //!
 //! Not the codec name — what the cache actually holds. A codec whose decode
 //! reads only the bf16 mirror builds no packed store (`exit_prefill` skips the
 //! bulk encode), so the only thing there is to persist is that mirror: its
-//! block is bf16 and is byte-identical whatever the flag said. A codec whose
-//! decode reads its packed store spills codes + scales and lands somewhere
-//! else entirely.
+//! block is bf16 and its payload is byte-identical whatever the flag said. A
+//! codec whose decode reads its packed store spills codes + scales and lands
+//! somewhere else entirely.
 //!
-//! | Variant | Tested | Role |
-//! |---------------------|--------|-------------------|
-//! | K8V8 / K8V4 / Planar | YES | mirror-only — all three spill the same bf16 block |
-//! | IsoKOnly3 | YES | store-keeping control — must NOT land on the bf16 size |
-//! | Mixed / RotK / RotKTq4V | NO | requires internal `MixedKvState` (pub(crate) only) |
-//! | None (bf16) | YES | the oracle the mirror-only trio must match |
+//! | Group | Source | Role |
+//! |---|---|---|
+//! | mirror-only | derived: `!materialises_packed_store()` | every one must spill the same bf16 payload |
+//! | store-keeping | derived: `materialises_packed_store()` | must spill codes, not the bf16 payload and not an empty stub |
+//! | `Mixed` / `RotK` / `RotKTq4V` | `UNDRIVABLE` | needs `pub(crate)` `MixedKvState`; refuses `update()` by contract |
+//! | `None` (bf16) | the oracle | what the mirror-only group must match |
 //!
-//! The control is what keeps this from being a gate that cannot fail: without
-//! it, a writer that emitted a fixed-size stub for every layer would satisfy
-//! the equality half and the formula half alike.
+//! Two things keep this from being a gate that cannot fail. The groups are
+//! **derived from the predicate**, not listed, so a codec added to the enum is
+//! swept on the next run rather than silently skipped; and the store-keeping
+//! group is compared against the *same codec's* unfilled block, so a writer
+//! that emitted geometry for every layer would fail rather than satisfy an
+//! equality by collapsing everything onto one number.
+//!
+//! Sizes are **payloads**, not file lengths: the safetensors header carries
+//! `kv_quant.to_string()`, so whole-file equality would turn a codec rename
+//! into a failure that reads as "the packed store came back".
 
 // unsafe_code: mlx-rs Array zero-copy view — slice::from_raw_parts byte-reinterpret for Array::from_bytes in test helpers
 #![allow(unsafe_code)]
@@ -63,26 +71,45 @@ const SEED_K: u64 = 0xDEAD_CAFE_1234_5678;
 /// Seed for the LCG V data (XOR'd from K seed so K ≠ V).
 const SEED_V: u64 = SEED_K ^ 0xABCD_1234;
 
-/// The mirror-only quants: their decode reads the bf16 mirror on both axes, so
-/// `exit_prefill` builds no packed store and all three spill the same bf16
-/// block. Mixed / RotK / RotKTq4V require `pub(crate)` internal state
-/// (`MixedKvState`, Hadamard rotation) and cannot be driven through the public
-/// `KvCache::enter_prefill` → `update` → `exit_prefill` API.
+/// Codecs this integration test cannot drive, with the reason.
 ///
-/// FORWARD-COMPAT NOTE: when a new `KvQuant` variant is added,
-/// `assert_all_serializable_quants_are_listed` prints a reminder to classify it
-/// here or in the excluded list.
-const MIRROR_ONLY_QUANTS: &[(&str, KvQuant)] = &[
-    ("K8V8", KvQuant::K8V8),
-    ("K8V4", KvQuant::K8V4),
-    ("Planar", KvQuant::Planar),
+/// `Mixed`, `RotK` and `RotKTq4V` need `pub(crate)` internal state
+/// (`MixedKvState`, the Hadamard rotation) that the public
+/// `KvCache::enter_prefill` → `update` → `exit_prefill` API cannot populate;
+/// they also refuse `update()` by contract.
+///
+/// Everything else is classified at runtime off
+/// `KvQuant::materialises_packed_store()`, not off a list kept here — that is
+/// what keeps the coverage check from drifting behind the enum.
+const UNDRIVABLE: &[(&str, &str)] = &[
+    ("mixed_k8g64_v4g64", "requires pub(crate) MixedKvState"),
+    ("rot_k_v8g64", "requires pub(crate) Hadamard rotation state"),
+    ("rot_k_tq4v", "same as rot_k"),
 ];
 
-/// Store-keeping control: `IsoKOnly3` re-quantises K into its packed store on
-/// every decode step, so `exit_prefill` builds that store and the block carries
-/// real codes. Its size must differ from the bf16 block — a writer that had
-/// stopped distinguishing the two would pass every other assertion here.
-const STORE_KEEPING_CONTROL: (&str, KvQuant) = ("IsoKOnly3", KvQuant::IsoKOnly3);
+fn is_undrivable(q: KvQuant) -> bool {
+    let name = q.to_string();
+    UNDRIVABLE.iter().any(|(n, _)| *n == name)
+}
+
+/// Every codec whose decode reads only the bf16 mirror — derived, not listed.
+fn mirror_only_quants() -> Vec<KvQuant> {
+    rmlx_kv_quant::ALL_KV_QUANTS
+        .iter()
+        .copied()
+        .filter(|q| !q.materialises_packed_store() && *q != KvQuant::None && !is_undrivable(*q))
+        .collect()
+}
+
+/// Every codec that keeps a packed store and can be driven through the public
+/// prefill API.
+fn store_keeping_quants() -> Vec<KvQuant> {
+    rmlx_kv_quant::ALL_KV_QUANTS
+        .iter()
+        .copied()
+        .filter(|q| q.materialises_packed_store() && !is_undrivable(*q))
+        .collect()
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -139,16 +166,45 @@ fn synthetic_hash(quant_label: &str) -> String {
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
-/// Write one `.kvb` for `quant` into `dir` and return its size in bytes.
-fn spill_size(dir: &TempDir, label: &str, quant: KvQuant) -> u64 {
+/// Write one `.kvb` for `quant` into `dir` and return its **payload** size in
+/// bytes — the file minus the safetensors header.
+///
+/// The distinction is load-bearing, not pedantry. The header is a JSON blob
+/// carrying `META_KV_QUANT = kv_quant.to_string()`, so `"planar"` writes two
+/// more bytes of metadata than `"k8v8"`. Comparing whole files makes a codec
+/// *rename* — or one more metadata key — flip an equality that is supposed to
+/// be about tensors, and the failure would read as "the packed store came
+/// back" rather than "the header grew". Today they happen to agree only
+/// because safetensors pads the header to an 8-byte multiple and both land in
+/// the same bucket; that is luck, not a property.
+///
+/// Format: the first 8 bytes are a little-endian u64 header length; the payload
+/// is everything after `8 + header_len`.
+fn spill_payload_size(dir: &TempDir, label: &str, quant: KvQuant) -> u64 {
     let device = Device::Cpu;
     let cache = build_kvcache(quant);
     let hash = synthetic_hash(label);
     let path = dir.path().join(format!("{hash}.kvb"));
     rmlx_kv_ssd::write_caches(&path, device, MODEL_ID, quant, &[cache], &[]).unwrap();
-    std::fs::metadata(&path)
+    payload_bytes_of(&path, label)
+}
+
+/// Payload size of a safetensors file: total minus `8 + header_len`.
+fn payload_bytes_of(path: &std::path::Path, label: &str) -> u64 {
+    let total = std::fs::metadata(path)
         .unwrap_or_else(|e| panic!("metadata for {label}: {e}"))
-        .len()
+        .len();
+    let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("read {label}: {e}"));
+    assert!(
+        bytes.len() >= 8,
+        "{label}: file is shorter than the safetensors header-length prefix"
+    );
+    let mut len_le = [0u8; 8];
+    len_le.copy_from_slice(&bytes[..8]);
+    let header_len = u64::from_le_bytes(len_le);
+    total
+        .checked_sub(8 + header_len)
+        .unwrap_or_else(|| panic!("{label}: header claims {header_len} B of a {total} B file"))
 }
 
 /// bf16 payload of one `[B, kv_h, S, D]` K/V pair: two tensors, 2 bytes per
@@ -158,92 +214,104 @@ fn bf16_payload_bytes() -> u64 {
     2 * n * 2
 }
 
-/// The mirror-only quants all spill the **same** bf16 block, byte-identical to
-/// the one a plain `KvQuant::None` cache spills.
+/// Every mirror-only quant spills the **same** bf16 block, byte-identical in
+/// payload to the one a plain `KvQuant::None` cache spills.
 ///
 /// This is the on-disk face of the `exit_prefill` store skip: those codecs hold
 /// nothing but the bf16 mirror, so that mirror is the whole layer and it is
 /// what gets persisted. Hydrate then hands the cache back the same bytes it
 /// spilled, which is why a prompt-cache hit served from disk decodes
 /// identically to one served from RAM.
+///
+/// The set is derived from the predicate, so a codec that joins the family
+/// later is covered without anyone remembering to add it.
 #[test]
 fn mirror_only_quants_spill_the_same_bf16_block_as_none() {
     let tmp = TempDir::new().unwrap();
-    let baseline = spill_size(&tmp, "None", KvQuant::None);
+    let baseline = spill_payload_size(&tmp, "None", KvQuant::None);
     let payload = bf16_payload_bytes();
 
+    assert_eq!(
+        baseline, payload,
+        "the bf16 block's payload must be exactly the two bf16 tensors"
+    );
+
+    let quants = mirror_only_quants();
     assert!(
-        baseline >= payload && baseline < payload + 4096,
-        "the bf16 block must be the two bf16 tensors plus a small header: \
-         got {baseline} B against a {payload} B payload"
+        quants.len() >= 15,
+        "the mirror-only family should be most of the codec surface; got {}",
+        quants.len()
     );
 
     println!("\n── mirror_only_quants_spill_the_same_bf16_block_as_none ──");
     println!("  {:<30} {:>10} bytes", "None (oracle)", baseline);
-    for (label, quant) in MIRROR_ONLY_QUANTS {
-        let size = spill_size(&tmp, label, *quant);
+    for quant in quants {
+        let label = quant.to_string();
+        let size = spill_payload_size(&tmp, &label, quant);
         println!("  {label:<30} {size:>10} bytes");
         assert_eq!(
             size, baseline,
-            "{label} builds no packed store, so its block must be the same bf16 \
-             block `None` spills ({baseline} B); got {size} B"
+            "{label} builds no packed store, so its block must carry the same \
+             bf16 payload `None` spills ({baseline} B); got {size} B"
         );
     }
 }
 
-/// The control: a codec whose decode reads its packed store spills that store —
-/// a block that is neither the bf16 block nor an empty geometry stub.
+/// The controls: every codec that keeps a packed store spills that store — a
+/// block that is neither the bf16 block nor an empty geometry stub.
 ///
 /// Both comparisons are load-bearing. Against the bf16 block it proves the
 /// mirror-only rule did not swallow a codec that needs its codes; against the
-/// unfilled cache's block it proves the codes are actually in the file. Drop
-/// the second and a writer that emitted geometry for every layer would satisfy
-/// the first by landing on 176 bytes.
+/// same codec's unfilled block it proves the codes actually reached the file.
+/// Drop the second and a writer that emitted geometry for every layer would
+/// satisfy the first by landing on the geometry-only size.
 #[test]
-fn store_keeping_quant_spills_its_codes_not_the_bf16_block() {
+fn store_keeping_quants_spill_their_codes_not_the_bf16_block() {
     let device = Device::Cpu;
     let tmp = TempDir::new().unwrap();
-    let bf16_block = spill_size(&tmp, "None", KvQuant::None);
-    let (label, quant) = STORE_KEEPING_CONTROL;
-    assert!(
-        quant.materialises_packed_store(),
-        "{label} must be a store-keeping codec for this control to mean anything"
-    );
-
-    // Geometry-only reference: same codec, never filled, so there is no payload
-    // to write and the file is header + geometry metadata alone.
-    let empty_path = tmp.path().join("empty.kvb");
-    rmlx_kv_ssd::write_caches(
-        &empty_path,
-        device,
-        MODEL_ID,
-        quant,
-        &[KvCache::with_quant_max_seq(quant, 4096)],
-        &[],
-    )
-    .unwrap();
-    let geometry_only = std::fs::metadata(&empty_path).unwrap().len();
-
-    let size = spill_size(&tmp, label, quant);
-    println!("\n── store_keeping_quant_spills_its_codes_not_the_bf16_block ──");
-    println!("  {:<30} {:>10} bytes", "None (bf16 block)", bf16_block);
-    println!(
-        "  {:<30} {:>10} bytes",
-        "unfilled (geometry only)", geometry_only
-    );
-    println!("  {label:<30} {size:>10} bytes");
-    assert_ne!(
-        size, bf16_block,
-        "{label} keeps a packed store, so its block must not be the bf16 block"
-    );
-    // The K codes alone are at least half a byte per element; anything near the
-    // geometry-only size means the payload never reached the file.
+    let bf16_block = spill_payload_size(&tmp, "None", KvQuant::None);
     let n: u64 = (BATCH * KV_HEADS * BLOCK_TOKENS * HEAD_DIM) as u64;
+
+    let quants = store_keeping_quants();
     assert!(
-        size > geometry_only + n / 2,
-        "{label} must spill its K codes: got {size} B against a {geometry_only} B \
-         geometry-only block for the same codec"
+        !quants.is_empty(),
+        "at least one drivable store-keeping codec must exist, or this control \
+         proves nothing"
     );
+
+    println!("\n── store_keeping_quants_spill_their_codes_not_the_bf16_block ──");
+    println!("  {:<30} {:>10} bytes", "None (bf16 block)", bf16_block);
+    for quant in quants {
+        let label = quant.to_string();
+
+        // Geometry-only reference: same codec, never filled, so there is no
+        // payload to write.
+        let empty_path = tmp.path().join(format!("empty_{label}.kvb"));
+        rmlx_kv_ssd::write_caches(
+            &empty_path,
+            device,
+            MODEL_ID,
+            quant,
+            &[KvCache::with_quant_max_seq(quant, 4096)],
+            &[],
+        )
+        .unwrap();
+        let geometry_only = payload_bytes_of(&empty_path, &label);
+
+        let size = spill_payload_size(&tmp, &label, quant);
+        println!("  {label:<30} {size:>10} bytes  (empty {geometry_only} B)");
+        assert_ne!(
+            size, bf16_block,
+            "{label} keeps a packed store, so its block must not be the bf16 block"
+        );
+        // The K codes alone are at least half a byte per element; anything near
+        // the geometry-only size means the payload never reached the file.
+        assert!(
+            size > geometry_only + n / 2,
+            "{label} must spill its codes: got {size} B against a {geometry_only} B \
+             geometry-only block for the same codec"
+        );
+    }
 }
 
 /// Index bookkeeping: the row's `byte_size` and `kv_quant` columns must match
@@ -259,10 +327,14 @@ fn index_row_matches_the_file_it_describes() {
     // placeholder layout_key so the `(hash, layout_key)` PK is well-defined.
     const TEST_LAYOUT_KEY: u64 = 0xb172_e510_5117_5e57;
 
-    let mut cases: Vec<(&str, KvQuant)> = MIRROR_ONLY_QUANTS.to_vec();
-    cases.push(STORE_KEEPING_CONTROL);
+    let cases: Vec<KvQuant> = mirror_only_quants()
+        .into_iter()
+        .chain(store_keeping_quants())
+        .collect();
 
-    for (label, quant) in cases {
+    for quant in cases {
+        let label = quant.to_string();
+        let label = label.as_str();
         let cache = build_kvcache(quant);
         let hash = synthetic_hash(label);
         let path = tmp.path().join(format!("{hash}.kvb"));
@@ -296,45 +368,51 @@ fn index_row_matches_the_file_it_describes() {
     }
 }
 
-/// Forward-compatibility reminder: this is NOT a test that runs assertions
-/// against the writer. It prints a notice to ensure a future KvQuant variant
-/// triggers an update to the lists above.
+/// Coverage check driven off the enum, not off a list this file maintains.
+///
+/// The previous form compared a hand-written `ALL_KNOWN` const against
+/// `TESTED ∪ EXCLUDED`. Adding a `KvQuant` variant does not touch `ALL_KNOWN`,
+/// so it could not fail for the one case it existed to catch — and it had
+/// already drifted 21 variants behind the enum while still printing a
+/// "N/N variants covered" line. Driving it off `ALL_KV_QUANTS`, which lives
+/// beside the enum and is pinned exhaustive by `variant_index`, means a new
+/// codec lands here as an unclassified name on the next run.
 #[test]
-fn assert_all_serializable_quants_are_listed() {
-    const TESTED_NAMES: &[&str] = &["K8V8", "K8V4", "Planar", "IsoKOnly3", "None"];
-    const EXCLUDED_NAMES: &[&str] = &[
-        "Mixed",    // requires pub(crate) MixedKvState
-        "RotK",     // requires pub(crate) Hadamard rotation state
-        "RotKTq4V", // same as RotK
-    ];
+fn every_kv_quant_is_tested_or_explicitly_excluded() {
+    let mut covered: HashSet<String> = mirror_only_quants()
+        .into_iter()
+        .chain(store_keeping_quants())
+        .map(|q| q.to_string())
+        .collect();
+    covered.insert(KvQuant::None.to_string());
 
-    // All known KvQuant variants as of the last update to this test.
-    const ALL_KNOWN: &[&str] = &[
-        "K8V4",
-        "K8V8",
-        "Planar",
-        "None",
-        "IsoKOnly3",
-        "Mixed",
-        "RotK",
-        "RotKTq4V",
-    ];
+    let unclassified: Vec<String> = rmlx_kv_quant::ALL_KV_QUANTS
+        .iter()
+        .map(ToString::to_string)
+        .filter(|name| !covered.contains(name) && !UNDRIVABLE.iter().any(|(n, _)| n == name))
+        .collect();
 
-    let tested: HashSet<&str> = TESTED_NAMES.iter().copied().collect();
-    let excluded: HashSet<&str> = EXCLUDED_NAMES.iter().copied().collect();
-    for name in ALL_KNOWN {
+    // The undrivable list must also stay honest: a name that no longer exists
+    // in the enum is a stale exemption quietly widening the hole.
+    let live: HashSet<String> = rmlx_kv_quant::ALL_KV_QUANTS
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    for (name, _) in UNDRIVABLE {
         assert!(
-            tested.contains(name) || excluded.contains(name),
-            "KvQuant variant '{name}' is not in the tested or excluded lists — \
-             please add it to one of the two lists in ssd_quant_byte_size_table.rs"
+            live.contains(*name),
+            "UNDRIVABLE names '{name}', which is not a KvQuant any more — remove it"
         );
     }
+
+    assert!(
+        unclassified.is_empty(),
+        "these KvQuant variants are neither driven nor excluded here: {unclassified:?}"
+    );
     println!(
-        "\nassert_all_serializable_quants_are_listed: \
-         {}/{} variants covered ({} tested, {} excluded from integration test)",
-        ALL_KNOWN.len(),
-        ALL_KNOWN.len(),
-        TESTED_NAMES.len(),
-        EXCLUDED_NAMES.len()
+        "\nevery_kv_quant_is_tested_or_explicitly_excluded: {} variants, {} driven, {} undrivable",
+        rmlx_kv_quant::ALL_KV_QUANTS.len(),
+        covered.len(),
+        UNDRIVABLE.len()
     );
 }

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -1152,9 +1152,12 @@ per-codec kernel work (#45, #353) and is what flipping
 `decode_reads_packed_store()` would then unlock. Two consumers of the store had
 to stay live and did:
 
-* **A cache with no mirror** — one reconstructed by `KvCache::from_storage`, a
-  `Device::Cpu` run, or any cache that never bracketed a prefill — still builds
-  and reads its store through the codec body. Nothing about those paths changed.
+* **A cache with no mirror** — one reconstructed by `KvCache::from_storage`, or
+  any cache that never bracketed a prefill — still builds and reads its store
+  through the codec body. Nothing about those paths changed. The device is not
+  part of this: the gate in `exit_prefill` has none, and neither do the
+  `feeds_bf16_*` predicates, so a `Device::Cpu` run that brackets a prefill gets
+  the same mirrors and the same absent store as a GPU one.
 * **The SSD tier**, which serialises the store. A mirror-family layer now spills
   its bf16 mirror under the existing `none_bf16` tag instead (see
   `docs/SSD_TIER.md`); hydrate re-seeds the mirror, so a hydrated cache decodes

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -1037,58 +1037,78 @@ collapses that to one `slice_update`. At long context this dominates.
 
 ### Mechanism
 
-* `exit_prefill` quantizes the prefill K/V into the codec storage buffer
-  **and** unconditionally stores a compact bf16 seed on
-  `decode_fp16_k`/`decode_fp16_v` (the generic seed tail after the
-  per-`KvQuant` match, `update.rs:2200`).
+* `exit_prefill` stores a compact bf16 seed on `decode_fp16_k` /
+  `decode_fp16_v` for each axis whose decode reads one
+  (`KvQuant::feeds_bf16_{k,v}_at_decode`).
+* It bulk-encodes the prefill K/V into the codec storage buffer **only when
+  something reads that buffer** — `KvQuant::materialises_packed_store()`,
+  which is `decode_reads_packed_store() || !feeds_bf16_k || !feeds_bf16_v`.
+  For the bf16-mirror family both mirrors serve decode and no decode path
+  touches the store, so no store is built: it would be a second full copy of
+  the context, per layer, held unread for the whole decode window, on top of a
+  mirror that is already exactly bf16-sized. Those codecs' resident KV is
+  therefore identical to `--kv-quant none`, not larger than it.
 * Each `update_<codec>` begins with
   `if self.decode_fp16_k.is_some() { return self.update_decode_fp16(...); }`.
   Once the seed is live (always, post-prefill), the codec is bypassed and
   the decode step appends bf16 K **and** V via one `slice_update`.
-* Consequence: tokens **generated during decode** are never quantized in
-  the codec buffer for the shortcut family — they live only in the bf16
-  mirror. The codec buffer is frozen at the prefill length. This is
-  correct: the codec buffer is not consulted at decode-read time.
+* Consequence: for the mirror family the codec buffer does not exist during
+  the decode window, and tokens generated during decode live only in the bf16
+  mirror. That mirror is the layer, which is also what the SSD tier persists
+  for it (tag `none_bf16`) — so a prompt-cache hit served from disk decodes
+  off the same bytes as one served from RAM.
+
+`decode_reads_packed_store()` is the single place the classification lives. A
+codec that grows a decode kernel over its own packed store flips its arm there
+and `exit_prefill` starts building the buffer again in the same change; that is
+the seam #353 (`planar_flash_decode` dormant behind the live K mirror) has to
+go through.
 
 ### Per-codec audit table
 
 `decode-K` / `decode-V` = the dtype actually fed to SDPA per decode step.
-`codec-at-decode` = does the per-codec quantizer run on each generated
-token? "frozen" = no (bf16 shortcut); "K-only" = K codec runs, V bf16.
+`store` = does `exit_prefill` materialise the packed buffer, i.e. does any
+decode path read it (`KvQuant::decode_reads_packed_store`)?
 
-| Codec (`KvQuant`)        | shortcut? | decode-K | decode-V | codec-at-decode | intentional |
-|--------------------------|-----------|----------|----------|-----------------|-------------|
-| `None` (bf16)            | n/a       | bf16     | bf16     | none            | yes         |
-| `K8V8`                   | yes       | bf16     | bf16     | frozen          | yes         |
-| `K8V4`                   | yes       | bf16     | bf16     | frozen          | yes         |
-| `Mixed{k,v}`             | yes¹      | bf16     | bf16     | frozen          | yes         |
-| `Planar` / `Planar3`     | yes       | bf16     | bf16     | frozen          | yes         |
-| `PlanarK`                | yes²      | bf16     | bf16     | frozen          | yes         |
-| `K8VTurbo2/3` (+`Tcq`)   | yes       | bf16     | bf16     | frozen          | yes         |
-| `TurboSym3` / `TurboSym4`| yes       | bf16     | bf16     | frozen          | yes         |
-| `Iso3` / `Iso4`          | yes       | bf16     | bf16     | frozen          | yes         |
-| `Iso3Sym` / `Iso4Sym`    | yes       | bf16     | bf16     | frozen          | yes         |
-| `Rotor3` / `Rotor4`      | yes       | bf16     | bf16     | frozen          | yes         |
-| `Rotor3Sym` / `Rotor4Sym`| yes       | bf16     | bf16     | frozen          | yes         |
-| `RotorK{3,4}Asym`        | yes       | bf16     | bf16     | frozen          | yes         |
-| `IsoKOnly3` / `IsoKOnly4`| **no**    | **quant**| bf16     | **K-only**      | yes³        |
-| `RotorKOnly3`/`KOnly4`   | **no**    | **quant**| bf16     | **K-only**      | yes³        |
+| Codec (`KvQuant`)        | shortcut? | decode-K | decode-V | store | intentional |
+|--------------------------|-----------|----------|----------|-------|-------------|
+| `None` (bf16)            | n/a       | bf16     | bf16     | n/a   | yes         |
+| `K8V8`                   | yes       | bf16     | bf16     | **no**| yes         |
+| `K8V4`                   | yes       | bf16     | bf16     | **no**| yes¹        |
+| `Mixed{k,v}` / `RotK`    | no²       | quant    | quant    | yes   | yes         |
+| `RotKTq4V`               | no²       | quant    | quant    | yes   | yes         |
+| `Planar` / `Planar3`     | yes       | bf16     | bf16     | **no**| yes         |
+| `PlanarK`                | yes       | bf16     | bf16     | **no**| yes³        |
+| `K8VTurbo2/3` (+`Tcq`)   | yes       | bf16     | bf16     | **no**| yes         |
+| `TurboSym3` / `TurboSym4`| yes       | bf16     | bf16     | **no**| yes¹        |
+| `Iso3` / `Iso4`          | yes       | bf16     | bf16     | **no**| yes         |
+| `Iso3Sym` / `Iso4Sym`    | no        | quant    | quant    | yes   | yes         |
+| `Rotor3` / `Rotor4`      | yes       | bf16     | bf16     | **no**| yes         |
+| `Rotor3Sym` / `Rotor4Sym`| no        | quant    | quant    | yes   | yes         |
+| `RotorK{3,4}Asym`        | yes       | bf16     | bf16     | **no**| yes¹        |
+| `IsoKOnly3` / `IsoKOnly4`| **no**    | **quant**| bf16     | yes   | yes⁴        |
+| `RotorKOnly3`/`KOnly4`   | **no**    | **quant**| bf16     | yes   | yes⁴        |
 
-1. `Mixed`/`RotKTq4V` are driven through `update_and_sdpa` (the direct
-   `update()` arm errors); the bf16 mirror is surfaced to cross-layer-KV
-   consumers via `update_and_sdpa_shared_source` (see §10.2 Mixed note).
-2. PlanarK was the **sole** codec missing the shortcut; it re-encoded K
-   through lossy Lloyd-Max + Givens every decode step, which broke
-   `niah_pflash_bonsai_8k_d50` retrieval. The fix (`b1d9dca`) restored the
-   shortcut to match its siblings. Regression-locked by
-   `warm_ttft_tests.rs`.
-3. The K-only family deliberately keeps K quantized at decode (the K codec
+1. TurboFlash (`K8V4`) and fused-QK (`K8V4`/`K8V8`/`TurboSym3/4`/
+   `RotorK{3,4}Asym`) each maintain their **own** head-major buffer, re-encoded
+   from the bf16 mirror. Neither reads the packed store, so neither
+   `--turbo-flash on` nor `--fused-qk on` puts a store back.
+2. `Mixed`/`RotK`/`RotKTq4V` are driven through `update_and_sdpa` (the direct
+   `update()` arm errors) and read their packed 3-tuples every decode step.
+   The bf16 mirror they *also* keep is surfaced to cross-layer-KV consumers via
+   `update_and_sdpa_shared_source` (see §10.2 Mixed note); on an arch with no
+   such consumer it is unread, which is a residency cost this section does not
+   yet remove.
+3. PlanarK's fused-QK / flash-decode arm is gated on the bf16 K mirror being
+   *absent*, and post-`exit_prefill` it never is — so on a seeded cache PlanarK
+   reads no store either.
+4. The K-only family deliberately keeps K quantized at decode (the K codec
    has no bf16 shortcut in its body) so that the K-side reduction it exists
    to provide is actually realized. V rides the bf16 mirror via
    `update_decode_fp16_v_only` (which must NOT touch `decode_fp16_k`, or it
    would silently re-arm the shortcut and drop K back to bf16). Because the
-   K-only decode body never reads `decode_fp16_k`, `exit_prefill` no longer
-   materialises the bf16 K seed for these variants (gated on
+   K-only decode body never reads `decode_fp16_k`, `exit_prefill` does not
+   materialise the bf16 K seed for these variants (gated on
    `feeds_bf16_k_at_decode()`); only the bf16 V seed is kept. See the F2
    reclaim note below.
 
@@ -1098,7 +1118,7 @@ reads it. For `IsoKOnly*` / `RotorKOnly*` the bf16 K seed was allocated at
 prefill-end and then held, unused, for the entire decode window — wasted RAM
 equal to one bf16 K buffer per K-only layer.
 
-**Fix.** `exit_prefill` now gates the K-seed materialisation (clone + eval **and**
+**Fix.** `exit_prefill` gates the K-seed materialisation (clone + eval **and**
 store) on the predicate [`KvQuant::feeds_bf16_k_at_decode()`], which is `false`
 for the K-only family (`IsoKOnly3/4`, `RotorKOnly3/4`) and `true` for every
 shortcut codec. The `KvStorage::None` bf16-fallback path always forces the K seed
@@ -1114,6 +1134,38 @@ independently and so reflects the dropped buffer. Residency reclaimed for Bonsai
 seed is **absent** and that the reported total is the K store plus the surviving
 V seed and nothing else. `resident_bytes` is the **only** byte diagnostic: it
 reads actual buffer sizes rather than re-deriving from shape fields.
+
+**F3 (packed-store reclaim).** The mirror's counterpart. `exit_prefill` used to
+bulk-encode the packed store for **every** codec, including the whole
+bf16-mirror family whose decode never reads it. The store was written once and
+then held for the entire decode window next to a mirror pair the same size as
+plain bf16, which is why a quantized codec measured **larger** than
+`--kv-quant none` — up to +60% resident KV on `planar`, and monotonically worse
+with context, the opposite of what an operator selects a KV codec for.
+
+**Fix.** The bulk encode is gated on `KvQuant::materialises_packed_store()`
+(above). Decode behaviour and output are unchanged — decode already read only
+the mirror — so this is again pure reclaim, and it makes the mirror family's
+resident KV *equal* to bf16 rather than a multiple of it. It does not make it
+*less* than bf16: that needs the packed store to be readable at decode, which is
+per-codec kernel work (#45, #353) and is what flipping
+`decode_reads_packed_store()` would then unlock. Two consumers of the store had
+to stay live and did:
+
+* **A cache with no mirror** — one reconstructed by `KvCache::from_storage`, a
+  `Device::Cpu` run, or any cache that never bracketed a prefill — still builds
+  and reads its store through the codec body. Nothing about those paths changed.
+* **The SSD tier**, which serialises the store. A mirror-family layer now spills
+  its bf16 mirror under the existing `none_bf16` tag instead (see
+  `docs/SSD_TIER.md`); hydrate re-seeds the mirror, so a hydrated cache decodes
+  off exactly the bytes the spilling one held. That costs ~2× the bytes on disk
+  versus a q8 block and removes a numerical asymmetry: before, a prompt-cache
+  hit served from disk decoded from quantized K/V while the same hit served from
+  RAM decoded from bf16.
+
+The resolve-time net-negative `warn!` follows the same predicate through
+`KvQuant::estimated_resident_bytes_per_layer`, so it no longer fires for the
+mirror family — the condition it warned about is gone rather than silenced.
 
 ### Decision: keep warm-TTFT universal
 
@@ -1153,7 +1205,9 @@ decode-firing path where `decode_fp16_k` is `None`:
 * Speculative / draft-model decode and PPL-eval fixtures that drive
   `update()` without an `exit_prefill` seed.
 * Prompt-cache hydration paths that restore codec state without re-seeding
-  the bf16 mirror.
+  the bf16 mirror. Note this no longer covers the bf16-mirror family: those
+  codecs spill and hydrate as bf16 (`none_bf16`), so a hydrated cache of one
+  comes back seeded, not store-backed.
 
 This is why `--sparse-attn` and `--fused-qk` resolve OFF ("warm-TTFT dormant")
 under Auto: in the normal generate flow the seed is always live, so those
@@ -1167,8 +1221,10 @@ Settled by code + `warm_ttft_cross_codec_tests`: `update_iso3` and
 `update_iso3_sym` (the codecs where the GPU-resident `QuantIsoV3` mirror's
 `append_gpu`/`dequant_gpu` live) both begin with the
 `decode_fp16_k.is_some()` shortcut. In normal generate the seed is live, so
-their per-step `append_gpu`/`dequant_gpu` **never runs** — the iso3 V encode
-fires only once at `exit_prefill` (a single bulk slice) or on a seedless
+their per-step `append_gpu`/`dequant_gpu` **never runs** — and for `Iso3`,
+which reads no store at decode, the bulk `exit_prefill` encode does not run
+either; only `Iso3Sym` (whose flash decode reads both packed rings) still
+encodes at prefill. Otherwise the iso3 V encode fires only on a seedless
 cache. A GPU-resident V mirror therefore **cannot** yield a ≥10% per-token
 TTFT win on iso3 V in the warm-TTFT decode loop; its only beneficiaries are
 the one-shot exit_prefill encode and seedless decode. **Result: NO gain**

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -830,8 +830,9 @@ the rate. Measured, not modelled — `kv_rate_tests.rs` reads the bytes
   reports that directly and its old store sub-term — 5.0 bits per value against
   a measured 22.0, off by 4.4× and wrong in the codec's favour — no longer
   enters the figure for this codec. The 22.0-bit rate still governs a
-  store-backed planar cache: an SSD block written by a `Device::Cpu` or seedless
-  run, and the resident bytes of any future decode path that reads the store.
+  store-backed planar cache: a seedless one (hydrated, or never through a
+  prefill bracket), and the resident bytes of any future decode path that reads
+  the store.
 
 **Arch defaults**: `Gemma3ForConditionalGeneration`;
 `Gemma4ForConditionalGeneration` (dense, hidden_size ≥ 5376); auto-by-ctx at
@@ -3281,9 +3282,15 @@ So the live paths are the ones with **no** bf16 seed:
   The hydrated prefix arrives as a single block, so any trim inside it is a
   mid-block cut. This is the path the round-trip tests in
   `rmlx-kv-ssd/src/hydrate_tests.rs` drive.
-- **A `Device::Cpu` run**, where there is no GPU mirror at all.
 - **Any cache that never bracketed a prefill**, and so never reached
   `exit_prefill` to be seeded.
+
+The device is not one of them. The `exit_prefill` gate has no device arm and
+neither do the `feeds_bf16_*` predicates, so a `Device::Cpu` run that brackets a
+prefill lands on the same mirrors and the same absent store as a GPU one — which
+is what the CPU-device sweep in
+`warm_ttft_cross_codec_tests::exit_prefill_builds_a_store_exactly_when_the_predicate_says_so`
+asserts over every codec.
 
 The store is also still read *without* a decode step in two places, and they
 matter for the codecs that still have one — the K-only and fused-symmetric

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -129,18 +129,28 @@ layers and can never make them larger — the "skip quant on tiny windowed
 layers" condition is therefore already satisfied by the rotating-ring
 exemption, not by an extra gate.
 
-The residual net-negative is on the **global** layers. A quantized global
-layer keeps a warm-TTFT bf16 decode seed (`decode_fp16_k` / `decode_fp16_v`,
-gated by [`KvQuant::feeds_bf16_k_at_decode`]) *alongside* its packed codes and
-per-group scales. At small effective context the codes + scales are pure
-overhead on top of a buffer the same size as bf16, so the codec is strictly
-larger than `--kv-quant none`. Measured on Gemma4 e2b (7 global + 28 windowed
-layers, head_dim 256, 1 KV head) at a 4096-token prompt: `k8v4` ≈ 125.0 MB vs
-`none` ≈ 113.2 MB (`kv_cache_bytes`) — `k8v4` is +11.7 MB on the global layers,
-zero delta on the windowed layers. (These figures predate the global-`none`
-bf16 fix below, where the global `none` K/V were resident as f32; the +11.7 MB
-codec-vs-`none` delta is the same conclusion — the codec adds scales + seed on
-top of the global buffer — and the warn math is unaffected.)
+The residual net-negative is on the **global** layers, and only for the codecs
+that keep a packed store *and* a bf16 mirror. A quantized global layer keeps a
+warm-TTFT bf16 decode seed (`decode_fp16_k` / `decode_fp16_v`, gated by
+[`KvQuant::feeds_bf16_k_at_decode`]); when the codec also builds a packed store,
+the codes + scales are pure overhead on top of a buffer the same size as bf16
+and the codec is strictly larger than `--kv-quant none`.
+
+For the **bf16-mirror family** (`K8V4`, `K8V8`, `Planar*`, `PlanarK`,
+`K8VTurbo*`, `TurboSym*`, `Iso3/4`, `Rotor3/4`, `RotorK*Asym`) that overhead is
+gone: no decode path reads their store, so `exit_prefill` does not build one
+(`KvQuant::materialises_packed_store()`, see `docs/KV_CACHE.md` §9.6 F3). Their
+resident KV is exactly the two bf16 mirrors — the same bytes as
+`--kv-quant none`, at every context and every geometry — and the warn never
+fires for them. It still fires for `Mixed` / `RotK` / `RotKTq4V`, which read
+their packed 3-tuples at decode and keep both mirrors as well, and for the
+K-only re-quantise families' sideband-heavy K store.
+
+Historical note: before that change, measured on Gemma4 e2b (7 global + 28
+windowed layers, head_dim 256, 1 KV head) at a 4096-token prompt, `k8v4` ≈
+125.0 MB vs `none` ≈ 113.2 MB (`kv_cache_bytes`) — `k8v4` was +11.7 MB on the
+global layers, zero delta on the windowed layers. Those two numbers are equal
+now.
 
 rMLX emits one structured `warn!` at request build time when the resolved codec
 is estimated to increase resident KV vs bf16 on the active layer mix:
@@ -150,21 +160,22 @@ WARN KV codec increases resident KV vs bf16 on this layer mix — the
 per-global-layer warm-TTFT bf16 seed plus codec scales exceed the bytes saved
 at this context; windowed layers already run bf16 and are unaffected. Consider
 --kv-quant none if memory is the goal.
-  kv_quant=k8v4 eff_seq=8192 n_global=7 n_windowed=28 est_extra_bytes=51380224
+  kv_quant=mixed_k8g64_v8g64 eff_seq=8192 n_global=7 n_windowed=28 est_extra_bytes=51380224
 ```
 
 The estimate is model-agnostic — keyed only on layer geometry (`head_dim`,
-`kv_heads`, `window`) and codec attributes (`KvQuant::approx_code_bits`,
-the per-group scale cadence, and whether the codec retains a bf16 seed). The
-decision lives in:
+`kv_heads`, `window`) and codec attributes (`KvQuant::approx_code_bits`, the
+per-group scale cadence, whether the codec retains a bf16 seed, and whether it
+materialises a packed store at all). The decision lives in:
 
 - `rmlx_kv_quant::KvQuant::estimated_resident_bytes_per_layer` /
   `estimated_net_saving_per_layer` (codec layer — the per-side byte model;
   windowed layers return saving 0).
 - `rmlx_models::kv_cache::kv_codec_net_saving_total` /
   `warn_if_kv_codec_net_negative` (policy layer — sums the layer mix and emits
-  the warn). Wired into the Gemma4 `generate` path; any arch interleaving
-  windowed + global attention can call it with its own `KvLayerShape` vector.
+  the warn). Wired into the Gemma4, Qwen3 and Qwen3.5-MoE `generate` paths; any
+  arch interleaving windowed + global attention can call it with its own
+  `KvLayerShape` vector.
 
 The warn is **advisory only** — the codec is not changed. Keeping the resolved
 codec is the operator's explicit choice (and forcing bf16 globally would change
@@ -812,21 +823,15 @@ the rate. Measured, not modelled — `kv_rate_tests.rs` reads the bytes
 
 - The perf win above is real and is **not** a memory win on the V axis; it buys
   TPS and quality with resident bytes.
-- `KvQuant::estimated_resident_bytes_per_layer` sizes planar through its generic
-  affine/turbo path. Two distinct numbers, kept apart because conflating them is
-  the same defect this section exists to fix:
-  - Its **store sub-term** (`bits/8` bytes per value plus one `f32` per 32
-    elements) is 5.0 bits per value against a measured 22.0 — the store model is
-    off by 4.4×.
-  - Its **V-side output** is larger, because `Planar` has
-    `feeds_bf16_v_at_decode() == true` and the estimator adds a full
-    `elems * 2` bf16 seed: 5.0 + 16.0 = **21.0** bits per value, against an
-    actual 22.0 + 16.0 = **38.0**. So the number the resolve-time net-saving
-    warn reads is off by 1.8×, not 4.4×.
-
-  Either way it is wrong in the codec's favour. Not corrected here: the fix
-  changes an operator-facing advisory and belongs with a decision about the
-  scale cadence, not with a rate-accounting change.
+- The rate above is the **store's** rate, and on a seeded cache `Planar` no
+  longer keeps a store: nothing reads it at decode, so `exit_prefill` does not
+  build it (`docs/KV_CACHE.md` §9.6 F3) and the layer's resident V is the bf16
+  mirror at 16.0 bits per value. `KvQuant::estimated_resident_bytes_per_layer`
+  reports that directly and its old store sub-term — 5.0 bits per value against
+  a measured 22.0, off by 4.4× and wrong in the codec's favour — no longer
+  enters the figure for this codec. The 22.0-bit rate still governs a
+  store-backed planar cache: an SSD block written by a `Device::Cpu` or seedless
+  run, and the resident bytes of any future decode path that reads the store.
 
 **Arch defaults**: `Gemma3ForConditionalGeneration`;
 `Gemma4ForConditionalGeneration` (dense, hidden_size ≥ 5376); auto-by-ctx at
@@ -3255,19 +3260,19 @@ The GPU half needs no cut and gets none: its dequant slices `[0, shape[2])` and
 its next `append` writes at `prev_seq == shape[2]`, so lowering `shape[2]`
 already makes the rejected region overwritable.
 
-*Second — and this is the binding constraint — the codec store has to be **read**
-after the truncate.* On a normal serve it is not. `exit_prefill` materialises the
-bf16 `decode_fp16_{k,v}` seed for every quant whose `feeds_bf16_k_at_decode()` is
-true (`quant.rs`), which covers `K8V4`, `K8V8`, `Planar`, `Planar3`, `PlanarK`,
-`K8VTurbo2/3`, both TCQ variants and `TurboSym3/4` — i.e. every store this
-section is about. From then on each quantized `update_<codec>` early-returns into
-`update_decode_fp16` at its first line, and `update.rs` states the consequence as
-the architectural contract: *"the codec storage buffer is frozen at the prefill
-length and is not consulted at decode-read time."* The CPU block list is written
-once by `exit_prefill` and never read again on that path, so a plain GPU serve
-**cannot distinguish a correct cut from a no-op cut** — including with
-`--kv-quant k8vturbo3`, whose forced-CPU `QuantV::append` sits below that same
-early return.
+*Second — and this is the binding constraint — the codec store has to **exist and
+be read** after the truncate.* On a normal serve it does neither. `exit_prefill`
+materialises the bf16 `decode_fp16_{k,v}` seed for every quant whose
+`feeds_bf16_k_at_decode()` is true (`quant.rs`), which covers `K8V4`, `K8V8`,
+`Planar`, `Planar3`, `PlanarK`, `K8VTurbo2/3`, both TCQ variants and
+`TurboSym3/4` — i.e. every store this section is about. From then on each
+quantized `update_<codec>` early-returns into `update_decode_fp16` at its first
+line, so the store is not consulted at decode-read time; and because it is not,
+`exit_prefill` no longer builds it at all for those codecs
+(`KvQuant::materialises_packed_store()`, `docs/KV_CACHE.md` §9.6 F3). A plain
+GPU serve therefore **cannot distinguish a correct cut from a no-op cut** —
+there is nothing there to cut — including with `--kv-quant k8vturbo3`, whose
+forced-CPU `QuantV::append` sits below that same early return.
 
 So the live paths are the ones with **no** bf16 seed:
 
@@ -3280,12 +3285,15 @@ So the live paths are the ones with **no** bf16 seed:
 - **Any cache that never bracketed a prefill**, and so never reached
   `exit_prefill` to be seeded.
 
-The store is also still read *without* a decode step in two places that matter
-even on the seeded path: the SSD spill (`write_quant_k` / `write_quant_v`
-serialise `blocks` and report `shape[2]`) and the prompt-cache snapshot
-(`try_deep_clone`). An uncut store spills a header claiming more tokens than its
-bytes hold, which is how the defect propagates from a seeded serve into the
-hydrated cache that later reads it.
+The store is also still read *without* a decode step in two places, and they
+matter for the codecs that still have one — the K-only and fused-symmetric
+families, `Mixed` / `RotK` / `RotKTq4V`, and any hydrated store-backed cache: the
+SSD spill (`write_quant_k` / `write_quant_v` serialise `blocks` and report
+`shape[2]`) and the prompt-cache snapshot (`try_deep_clone`). An uncut store
+spills a header claiming more tokens than its bytes hold, which is how the defect
+propagates from a serve into the hydrated cache that later reads it. For the
+bf16-mirror family that route is closed at the source: there is no store on the
+seeded path to spill.
 
 An earlier revision of this section named `--kv-quant k8vturbo3` on a plain serve
 as the cheapest observable cell. That was wrong for the reason above — device
@@ -3305,10 +3313,10 @@ by `cpu_block_truncate_tests::quant_v_truncate_reads_rows_from_the_shape_product
 
 **Truncation is monotone-decreasing.** All six clamp the target to the store's
 current `shape[2]` (`storage::clamp_truncate_target`). `n > shape[2]` is
-reachable, not hypothetical: post-`exit_prefill` the codec store is frozen at the
-prefill length while `KvCache::offset` keeps advancing on the bf16 mirror, so a
-speculative rollback into the decode window arrives with a target past the
-store's own fill. Raising `shape[2]` to meet it invents coverage no payload
+reachable, not hypothetical: a store-backed cache whose codec also keeps a bf16
+mirror (`Mixed` and the K-only families) advances `KvCache::offset` on paths the
+store does not follow, so a speculative rollback into the decode window arrives
+with a target past the store's own fill. Raising `shape[2]` to meet it invents coverage no payload
 backs — the dequant reads past the blocks and the SSD spill persists a header
 claiming more tokens than its bytes hold.
 

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -135,20 +135,24 @@ binding constraint is not the ring, it is the **bf16 decode seed**.
 `exit_prefill` materialises `decode_fp16_{k,v}` for every quant whose
 `feeds_bf16_k_at_decode()` is true (all of them), and each quantized
 `update_<codec>` then early-returns into `update_decode_fp16` on its first line —
-so post-prefill the codec store is frozen and not read at decode time at all. A
-plain GPU serve therefore cannot observe whether the cut happened, on any of
-these codecs, including the ones whose encode is forced to `Device::Cpu`
-(`K8VTurbo2/3`, both TCQ variants, `TurboSym3`) — that forced-CPU `append` sits
-*below* the same early return.
+so the codec store is not read at decode time at all, and because it is not,
+`exit_prefill` does not build it either (`KvQuant::materialises_packed_store()`;
+see `docs/KV_CACHE.md` §9.6 F3). A plain GPU serve therefore cannot observe
+whether the cut happened, on any of these codecs — there is no store to cut —
+including the ones whose encode is forced to `Device::Cpu` (`K8VTurbo2/3`, both
+TCQ variants, `TurboSym3`) — that forced-CPU `append` sits *below* the same early
+return.
 
 Where it is observable: a **hydrated** cache (`KvCache::from_storage` leaves
 `decode_fp16_k: None`, so the codec arm runs every decode step and the blocks are
 the cache), a `Device::Cpu` run, and any cache that never bracketed a prefill.
-An uncut store is also still *written out* on the seeded path — the SSD spill
+An uncut store is also still *written out* wherever one exists — the SSD spill
 serialises `blocks` against `shape[2]`, and the prompt-cache snapshot clones
-them — which is how the defect travels from a seeded serve into the hydrated
-cache that later reads it. See `rmlx-kv-ssd/src/hydrate_tests.rs` for the
-round-trip that pins this.
+them — which is how the defect travels into the hydrated cache that later reads
+it. That route now applies only to the codecs that keep a store (the K-only and
+fused-symmetric families, `Mixed` / `RotK` / `RotKTq4V`) and to already-hydrated
+store-backed caches; a seeded bf16-mirror cache spills its mirror instead. See
+`rmlx-kv-ssd/src/hydrate_tests.rs` for the round-trip that pins this.
 
 **Scope.** `KvStorage::truncate_to` no longer contains a bare `shape[2] = n` in
 any arm — `K8V4`, `K8V8`, `Planar`, `PlanarK`, `TurboSym3/4`, `K8VTurbo2/3`, both

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -713,25 +713,32 @@ serialized in full.
 
 #### bf16 payload spill (`none_bf16`)
 
-Three kinds of layer hold their live K/V on the parent `KvCache`
+Two kinds of layer hold their live K/V on the parent `KvCache`
 (`decode_fp16_{k,v}`, the buffers `exit_prefill` seeds) rather than in a packed
-store, and all three spill the same way:
+store, and both spill the same way:
 
 * `KvStorage::None` — the `--kv-quant none` path, where those buffers **are**
   the cache;
 * every **bf16-mirror codec** (`K8V4`, `K8V8`, `Planar*`, `PlanarK`,
   `K8VTurbo*`, `TurboSym*`, `Iso3/4`, `Rotor3/4`, `RotorK*Asym`), whose decode
   reads only the mirror and whose `exit_prefill` therefore builds no store at
-  all (`docs/KV_CACHE.md` §9.6 F3);
-* a K8V4/K8V8/Planar row in the table above only when it really carries codes —
-  a hydrated store-backed cache, a `Device::Cpu` run, or a cache that never
-  bracketed a prefill.
+  all (`docs/KV_CACHE.md` §9.6 F3).
 
-The spill bridge (`write_caches`) reads the mirror, clamps it to the cache's
-`offset` (a decode-expanded buffer is grown to the `max_seq` ceiling and its
-tail is zeros — the writer takes the buffer's own `shape[2]` as the layer's
-`seq_len`), materialises it **row-major**, and persists it under `l{i}.k.bf16` /
-`l{i}.v.bf16` with the geometry tag `none_bf16`. On hydrate the reader restores
+The exception is the same codec *with* codes: a K8V4/K8V8/Planar layer that
+really carries a payload — a hydrated store-backed cache, or one that never
+bracketed a prefill — takes its own row in the table above and spills codes.
+The device does not decide this; a `Device::Cpu` run that brackets a prefill
+gets the same absent store as a GPU one.
+
+The spill bridge (`write_caches`) reads the mirror and persists it under
+`l{i}.k.bf16` / `l{i}.v.bf16` with the geometry tag `none_bf16`. It **refuses**
+any mirror longer than the cache's `offset`, failing the whole block rather than
+writing that layer: a decode-expanded buffer is grown to the `max_seq` ceiling
+and its tail is zeros, the writer takes the buffer's own `shape[2]` as the
+layer's `seq_len`, and compacting it would need a device the drain thread does
+not have. The mirror is already row-major — `exit_prefill` stores it through
+`Array::contiguous` — which is what makes the persisted bytes mean what the
+shape says. On hydrate the reader restores
 the pair and re-seeds the reconstructed cache via
 `KvCache::with_decode_fp16_seed`, so an exact-hit SSD replay reads the real K/V
 and decodes off exactly the bytes the spilling cache held — the disk-served
@@ -747,8 +754,9 @@ every head — it reads back as one head of real KV and zeros for the rest, with
 no error anywhere. Pinned by
 `block_io_tests::roundtrip_mirror_codec_spills_and_hydrates_as_bf16`, which
 drives the mirror through a real prefill (a fixture that installs an
-already-compact array cannot see this failure) and by
-`decode_expanded_mirror_spills_only_its_filled_prefix` for the clamp.
+already-compact array cannot see this failure), and by
+`decode_expanded_mirror_is_refused_rather_than_spilled_with_its_tail` and
+`expanded_mirror_in_one_layer_fails_the_whole_block` for the refusal.
 
 Cost: a bf16 block is ~2× the bytes of the q8 block the mirror codecs used to
 write, against the `--kv-ssd-cache-gb` budget. That is the price of the block
@@ -760,10 +768,15 @@ geometry-only `none` tag and re-prefills its prefix on reuse. This is the
 distinguishing signal: presence of `decode_fp16_{k,v}` means real KV exists and
 must travel; absence means there is nothing to persist.
 
-Blocks written before the mirror codecs moved to `none_bf16` remain readable —
-the layer tag is authoritative on read, so a legacy `k8v8` block still hydrates
-as a store-backed cache and decodes through the codec body. It is not corrupt,
-but it is the old numerics for that request until it is re-spilled.
+Blocks written before the mirror codecs moved to `none_bf16` are **not** served.
+The layer tag is authoritative on read, so such a block would hydrate happily as
+a store-backed cache and decode through the codec body — dequantised numbers for
+a request whose RAM-served twin decodes bf16, with nothing to signal it. The
+`(hash, layout_key)` key did not change, so the block would hit. What keeps it
+out is `SsdKvIndex::SCHEMA_VERSION`, bumped to 4 for exactly this transition:
+every pre-change namespace is reclaimed by the `wipe_stale_schema_namespaces`
+pass at model load. Pinned by
+`ssd_tier_tests::wipe_removes_the_pre_none_bf16_block_format_namespace`.
 
 #### SWA layers are not spilled — hydrated entries degrade to re-prefill
 

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -692,13 +692,18 @@ or `BlockIoError::KvQuantMismatch` — never a silently-wrong cache.
 
 ### Tensor layout per KV variant
 
+What a layer writes is decided by what it **holds**, not by the codec name.
+`KvStorage::geometry_only_max_seq()` answers that in one place: a layer with no
+packed payload takes the bf16 / geometry-only route below, everything else its
+codec's tensors.
+
 | `KvStorage` variant | Tensors written |
 |---|---|
 | `K8V4` | `l{i}.k.codes` `l{i}.k.scales` `l{i}.v.codes` `l{i}.v.scales` |
 | `K8V8` | same as K8V4 (V is also q8_0) |
 | `Planar` | K8V4 tensors plus `l{i}.v.rotations` |
-| `None` (filled bf16) | `l{i}.k.bf16` `l{i}.v.bf16` — the off-storage bf16 prefix; geom tag `none_bf16` |
-| `None` (no payload) | geometry only, geom tag `none` — see note below |
+| any variant with **no** packed payload, bf16 mirror live | `l{i}.k.bf16` `l{i}.v.bf16` — the off-storage bf16 prefix; geom tag `none_bf16` |
+| any variant with no packed payload and no mirror | geometry only, geom tag `none` — see note below |
 | `Mixed` | `l{i}.k.codes` `l{i}.k.scales` `l{i}.k.biases` + V equivalents |
 | `Paged` | gathered contiguous codes/scales/rotations + page geometry metadata |
 | `LinearAttn` | `l{i}.conv_state` + `l{i}.delta_state` (recurrent state, whole, never truncated) |
@@ -706,22 +711,59 @@ or `BlockIoError::KvQuantMismatch` — never a silently-wrong cache.
 The round trip is byte-exact on codes. GDN state has no sequence axis and is
 serialized in full.
 
-#### `None` payload spill (bf16)
+#### bf16 payload spill (`none_bf16`)
 
-`KvStorage::None` (the `--kv-quant none` path) does **not** hold its live K/V in
-the storage buffer — the bf16 K/V live on the parent `KvCache`
-(`decode_fp16_{k,v}`, the same buffers `exit_prefill` seeds). The spill bridge
-(`write_caches`) reads those buffers and, when present, persists them under
-`l{i}.k.bf16` / `l{i}.v.bf16` with the geometry tag `none_bf16`. On hydrate the
-reader restores the pair and re-seeds the reconstructed cache via
-`KvCache::with_decode_fp16_seed`, so an exact-hit SSD replay reads the real K/V.
-bf16 round-trips bit-for-bit, so the restored prefix equals the pre-spill value.
+Three kinds of layer hold their live K/V on the parent `KvCache`
+(`decode_fp16_{k,v}`, the buffers `exit_prefill` seeds) rather than in a packed
+store, and all three spill the same way:
 
-A `None` layer with **no** bf16 pair (a never-filled cache, or a hydrated SWA
-layer whose rotating ring was never serialised) falls back to the geometry-only
-`none` tag and re-prefills its prefix on reuse — it carries no spillable payload.
-This is the distinguishing signal: presence of `decode_fp16_{k,v}` means real KV
-exists and must travel; absence means there is nothing to persist.
+* `KvStorage::None` — the `--kv-quant none` path, where those buffers **are**
+  the cache;
+* every **bf16-mirror codec** (`K8V4`, `K8V8`, `Planar*`, `PlanarK`,
+  `K8VTurbo*`, `TurboSym*`, `Iso3/4`, `Rotor3/4`, `RotorK*Asym`), whose decode
+  reads only the mirror and whose `exit_prefill` therefore builds no store at
+  all (`docs/KV_CACHE.md` §9.6 F3);
+* a K8V4/K8V8/Planar row in the table above only when it really carries codes —
+  a hydrated store-backed cache, a `Device::Cpu` run, or a cache that never
+  bracketed a prefill.
+
+The spill bridge (`write_caches`) reads the mirror, clamps it to the cache's
+`offset` (a decode-expanded buffer is grown to the `max_seq` ceiling and its
+tail is zeros — the writer takes the buffer's own `shape[2]` as the layer's
+`seq_len`), materialises it **row-major**, and persists it under `l{i}.k.bf16` /
+`l{i}.v.bf16` with the geometry tag `none_bf16`. On hydrate the reader restores
+the pair and re-seeds the reconstructed cache via
+`KvCache::with_decode_fp16_seed`, so an exact-hit SSD replay reads the real K/V
+and decodes off exactly the bytes the spilling cache held — the disk-served
+prompt-cache hit and the RAM-served one produce the same tokens. bf16
+round-trips bit-for-bit.
+
+The row-major step is load-bearing, not hygiene: a live mirror is normally a
+**slice view** over the larger prefill/decode buffer, and the serialiser reads
+the raw allocation by linear offset (`Array::to_bytes` ignores strides).
+Persisting the view directly writes the parent buffer's leading bytes under the
+slice's shape, which for `kv_h > 1` is head 0's whole row window in place of
+every head — it reads back as one head of real KV and zeros for the rest, with
+no error anywhere. Pinned by
+`block_io_tests::roundtrip_mirror_codec_spills_and_hydrates_as_bf16`, which
+drives the mirror through a real prefill (a fixture that installs an
+already-compact array cannot see this failure) and by
+`decode_expanded_mirror_spills_only_its_filled_prefix` for the clamp.
+
+Cost: a bf16 block is ~2× the bytes of the q8 block the mirror codecs used to
+write, against the `--kv-ssd-cache-gb` budget. That is the price of the block
+meaning the same thing as the RAM cache it came from.
+
+A layer with **no** payload and **no** bf16 pair (a never-filled cache, or a
+hydrated SWA layer whose rotating ring was never serialised) falls back to the
+geometry-only `none` tag and re-prefills its prefix on reuse. This is the
+distinguishing signal: presence of `decode_fp16_{k,v}` means real KV exists and
+must travel; absence means there is nothing to persist.
+
+Blocks written before the mirror codecs moved to `none_bf16` remain readable —
+the layer tag is authoritative on read, so a legacy `k8v8` block still hydrates
+as a store-backed cache and decodes through the codec body. It is not corrupt,
+but it is the old numerics for that request until it is re-spilled.
 
 #### SWA layers are not spilled — hydrated entries degrade to re-prefill
 

--- a/scripts/perf_ceiling.py
+++ b/scripts/perf_ceiling.py
@@ -28,6 +28,9 @@ KV byte accounting mirrors the engine, not a re-invention:
     crates/rmlx-kv-quant/src/quant.rs      KvQuant::decode_reads_packed_store /
         materialises_packed_store -- a codec that reads no store gets none
         built, so its resident KV is the two bf16 mirrors and nothing more.
+        `_DECODE_READS_PACKED_STORE` below is that match transcribed arm for
+        arm; it is a second producer with no gate keeping it in sync, so diff
+        it against the Rust when either moves.
     crates/rmlx-models/src/kv_cache/mod.rs:229  kv_codec_net_saving_total
         (per-layer loop: windowed layers clamp seq to the window and are
         always bf16; global layers take the codec formula)
@@ -267,18 +270,40 @@ def _side_bytes(c: Codec, bits: int, elems: int, n_tokens: int, head_dim: int,
     return stored + (elems * BF16 if retains_seed else 0)
 
 
-def materialises_packed_store(kind: str) -> bool:
-    """Mirror of `KvQuant::materialises_packed_store`.
+# quant.rs -- KvQuant::decode_reads_packed_store. Transcribed ARM FOR ARM from
+# the Rust match so the two can be diffed by eye; do not derive it from the
+# _NO_BF16_* sets, which happen to overlap it today and would silently
+# misclassify the first codec that reads its store AND keeps both mirrors --
+# precisely the case the Rust predicate exists to express.
+_DECODE_READS_PACKED_STORE = {
+    # quantized-SDPA over the affine 3-tuples, appended per step
+    "Mixed", "RotK", "RotKTq4V",
+    # K re-quantised into the packed store every decode step
+    "IsoKOnly3", "IsoKOnly4", "RotorKOnly3", "RotorKOnly4",
+    # flash decode straight off both packed rings
+    "Iso3Sym", "Iso4Sym", "Rotor3Sym", "Rotor4Sym",
+}
 
-    A codec that feeds both axes from the bf16 mirror and has no decode path
-    over its packed store never gets one built: `exit_prefill` skips the bulk
-    encode, so its resident KV is the two mirrors and nothing else. The three
-    membership sets below reproduce `decode_reads_packed_store()` exactly --
-    quantized-SDPA over the affine tuples, K re-quantised per step, and flash
-    decode off both packed rings.
+
+def decode_reads_packed_store(kind: str) -> bool:
+    """Mirror of `KvQuant::decode_reads_packed_store` (quant.rs)."""
+    return kind in _DECODE_READS_PACKED_STORE
+
+
+def materialises_packed_store(kind: str) -> bool:
+    """Mirror of `KvQuant::materialises_packed_store` (quant.rs).
+
+    Rust: `decode_reads_packed_store() || !feeds_bf16_k || !feeds_bf16_v`. A
+    codec that feeds both axes from the bf16 mirror and has no decode path over
+    its packed store never gets one built -- `exit_prefill` skips the bulk
+    encode, so its resident KV is the two mirrors and nothing else.
+
+    This is a SECOND producer of a classification whose first producer is the
+    Rust enum, and nothing gates them against each other. When a codec is added
+    or reclassified, both move together or this roofline is off by a full store
+    per layer, silently, in a direction that flatters the codec.
     """
-    return (kind in _READS_PACKED
-            or kind == "RotKTq4V"
+    return (decode_reads_packed_store(kind)
             or kind in _NO_BF16_K
             or kind in _NO_BF16_V)
 

--- a/scripts/perf_ceiling.py
+++ b/scripts/perf_ceiling.py
@@ -25,6 +25,9 @@ KV byte accounting mirrors the engine, not a re-invention:
     crates/rmlx-kv-quant/src/quant.rs:888  KvQuant::approx_code_bits
     crates/rmlx-kv-quant/src/quant.rs:515  KvQuant::feeds_bf16_k_at_decode
     crates/rmlx-kv-quant/src/quant.rs:575  KvQuant::feeds_bf16_v_at_decode
+    crates/rmlx-kv-quant/src/quant.rs      KvQuant::decode_reads_packed_store /
+        materialises_packed_store -- a codec that reads no store gets none
+        built, so its resident KV is the two bf16 mirrors and nothing more.
     crates/rmlx-models/src/kv_cache/mod.rs:229  kv_codec_net_saving_total
         (per-layer loop: windowed layers clamp seq to the window and are
         always bf16; global layers take the codec formula)
@@ -264,11 +267,30 @@ def _side_bytes(c: Codec, bits: int, elems: int, n_tokens: int, head_dim: int,
     return stored + (elems * BF16 if retains_seed else 0)
 
 
+def materialises_packed_store(kind: str) -> bool:
+    """Mirror of `KvQuant::materialises_packed_store`.
+
+    A codec that feeds both axes from the bf16 mirror and has no decode path
+    over its packed store never gets one built: `exit_prefill` skips the bulk
+    encode, so its resident KV is the two mirrors and nothing else. The three
+    membership sets below reproduce `decode_reads_packed_store()` exactly --
+    quantized-SDPA over the affine tuples, K re-quantised per step, and flash
+    decode off both packed rings.
+    """
+    return (kind in _READS_PACKED
+            or kind == "RotKTq4V"
+            or kind in _NO_BF16_K
+            or kind in _NO_BF16_V)
+
+
 def resident_bytes_per_layer(c: Codec, seq: int, head_dim: int, kv_heads: int,
                              iso_ring: bool = False) -> int:
     """Mirror of `KvQuant::estimated_resident_bytes_per_layer` (quant.rs:966)."""
     elems = seq * head_dim * kv_heads
     if c.kind == "None":
+        return elems * BF16 * 2
+    if not materialises_packed_store(c.kind):
+        # Both mirrors, no store -- byte-identical to `none` at this shape.
         return elems * BF16 * 2
     n_tokens = seq * kv_heads
     k = _side_bytes(c, c.k_bits, elems, n_tokens, head_dim,

--- a/scripts/release_e2e/stage6_perf/kv_codec_matrix.toml
+++ b/scripts/release_e2e/stage6_perf/kv_codec_matrix.toml
@@ -128,7 +128,7 @@ context_length = 32768
 expected_retrieval_pct = 1.0000
 smoke_probe_prompts = ["coherence", "instruction", "multi_turn"]
 skip_reason = ""
-cli_args = "--cache-type-k planar_k4"
+cli_args = "--cache-type-k planar_k4 --cache-type-v bf16"
 niah_filter = "niah_bonsai_32k"
 
 [[entries]]
@@ -256,7 +256,7 @@ context_length = 32768
 expected_retrieval_pct = 1.0000
 smoke_probe_prompts = ["coherence", "instruction", "multi_turn"]
 skip_reason = ""
-cli_args = "--cache-type-k planar_k4"
+cli_args = "--cache-type-k planar_k4 --cache-type-v bf16"
 niah_filter = "niah_gemma4_32k"
 
 [[entries]]
@@ -384,8 +384,8 @@ model = "qwen3.6-moe-8bit"
 context_length = 32768
 expected_retrieval_pct = 1.0000
 smoke_probe_prompts = ["coherence", "instruction", "multi_turn"]
-skip_reason = ""
-cli_args = "--cache-type-k planar_k4"
+skip_reason = "planar-k-qwen-moe-arch-guard: K-side 4-bit is rejected for Qwen3.5/3.6 MoE by cache_type::validate_resolved (PPL disaster); the row can never run"
+cli_args = "--cache-type-k planar_k4 --cache-type-v bf16"
 niah_filter = "niah_qwen36_32k"
 
 [[entries]]


### PR DESCRIPTION
Closes #404.

## Root cause

`exit_prefill` built a packed KV store unconditionally. For the bf16-mirror codec family nothing reads it: the `decode_fp16_k.is_some()` guard at the head of all 21 `update_<codec>` bodies is permanently armed post-prefill, and the two GPU fast paths that look like store readers — TurboFlash and fused-QK — each re-encode their **own** head-major buffer from the mirror, never touching `KvStorage`. So no `DispatchPolicy` gate can make the store live; it is a property of the codec alone.

The store was therefore a second full copy of the context, per layer, held unread for the whole decode window, on top of a mirror that is already exactly bf16-sized.

Gated on a new exhaustive `KvQuant::decode_reads_packed_store()` -> `materialises_packed_store()`, keyed on codec + the existing `feeds_bf16_*` predicates — never on an architecture name. 17 of 27 codecs are covered. Flipping one arm restores the store: that is the seam #45 and #353 go through, so the arms are marked, not deleted.

## Consumer inventory — 2 of 11 stayed live

The store still exists where something reads it: a **mirror-less cache** (`from_storage` hydrate, or a cache that never bracketed a prefill), and **SSD spill**, which is re-routed rather than removed — a mirror-family layer now spills its bf16 mirror under the existing `none_bf16` tag and hydrate re-seeds it. That costs ~2x disk against a q8 block and removes a numerical asymmetry: a disk-served prompt-cache hit used to decode quantized where the RAM-served one decoded bf16.

The other nine were accounting, `Option`-guarded no-ops, or read the mirror already.

## Memory, measured

Residency reaches **exact parity with `none`** at every cell — 2 architectures x 4 contexts, ratio flat 1.0000, replacing a flat 1.33/1.60 on bonsai and a *rising* 1.43 -> 1.92 on gemma:

| arch | ctx | k8v8 | k8v4 | planar |
|---|---|---|---|---|
| bonsai-8b | 4k | 810.7 -> 532.3 | 771.1 -> 532.3 | 978.3 -> 532.3 |
| bonsai-8b | 64k | 13503.2 -> 8899.7 | 12848.4 -> 8899.7 | 16273.9 -> 8899.7 |
| gemma-4-e2b | 4k | 43.4 -> 30.2 | 40.8 -> 30.2 | 54.3 -> 30.2 |
| gemma-4-e2b | 64k | 618.6 -> 409.8 | 577.5 -> 409.8 | 792.6 -> 409.8 |

Peak `metal_gen_alloc_mb` where the store was the peak: bonsai 64k **-4.0 / -3.4 / -6.8 GB**. Output token-ids identical in 8/8 A/B cells. `make smoke-codec-matrix` 25/28 with NIAH 1.0000 at 32k on Bonsai / gemma4-e4b / Qwen3.6-MoE.

**Decode TPS is reported as INCONCLUSIVE**, not as a win. The host never cleared the quiescence gate (`WindowServer` 26-47% plus a foreign build), every cell came back `TAINTED`, and a single unpaired block on this host has ranged 2.5-21% where paired runs held +/-0.75%. Directionally positive with the null control at -1.09%, but no ratio here is usable.

## Scope, stated honestly

The issue's acceptance criteria 1-3 wanted residency *below* `none`, the store actually read, and token-ids diverging from `none`. This change reaches **parity**, which is the ceiling on the cost side; going below requires decode to read the packed store, which is per-codec MSL work (#45, #353) — as the issue itself notes. Reported as parity, not as the target.

## Two correctness holes found in review, on the SSD seam

They compound, and neither errors or logs:

- The skip returned **without clearing an already-populated store**. A store-backed cache that re-enters prefill (legacy SSD hydrate -> deep-clone -> tail-extend) ended with a stale store of length `P` beside a mirror of `P+T`. The spill writer prefers the store, so the block was written under the full prompt's hash while holding only the prefix — and since `META_SEQ_LEN` is a `max` across layers, hydrate handed back the short offset silently. Reproduced end to end: `left: 32 right: 48`.
- `SCHEMA_VERSION` never moved, so pre-change blocks stayed live hits under an identical key — which is what made the above reachable at all. Bumped 3 -> 4; pre-change namespaces now route through the existing wipe pass.

Also fixed: a per-layer spill refusal that could leave other layers hydrating at an offset they had no content for, now fails the whole block; and a pre-existing contiguity corruption on the `none_bf16` path that fails on clean `main`.

## Gates that could not fail

Two were found in the very tests guarding this change and replaced with enum-derived checks: `ALL_KNOWN` was a hand-written const that adding a variant never touches (it was already missing 21 live variants — the byte-size table now drives 26 codecs, not 3), and a whole-file byte comparison that passed only because safetensors happened to pad two different-length headers into the same 8-byte bucket.

A cross-enum invariant had no compiler behind it: `decode_reads_packed_store` and `KvStorage::geometry_only_max_seq` live on different enums, so a new codec could compile cleanly and spill a geometry with no tensors behind it. Now asserted over every variant.

`make ci`: pass. `make ci-perf`: 6 failures, all pre-existing on clean `main` in four known classes (4x `iso_v3_*`, and the two consume-engine goldens), attributed by re-running the same crate and filter in a worktree of the base commit. `rmlx-kv-ssd` is green at 12 GPU tests, up from 11.
