### PR TITLE
bench: measure the fused-decode-over-quantised-KV reference on Metal (#415)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,6 +430,7 @@ ci: fmt-check lint test test-capture deny audit ci-metrics ## full pre-merge gat
 	@bash scripts/check_kernel_dtype_contract.sh
 	@bash scripts/check_kernel_dtype_contract_fixtures.sh
 	@bash scripts/perf_ab_selftest.sh
+	@bash scripts/bench_llama_ab_selftest.sh
 	@bash scripts/check_metal_format.sh
 	@bash scripts/check_metal_compiles.sh
 	@bash scripts/file_size_report.sh || true
@@ -601,6 +602,9 @@ canary-ab: mlx-preflight build-perf  ## interleaved A/B of two arms (ARGS='--bin
 
 canary-ab-selftest: ## mutation-check the A/B harness against stub binaries (no GPU, no model)
 	bash scripts/perf_ab_selftest.sh
+
+llama-ab-selftest: ## mutation-check the llama-server A/B harness against a stub server (no GPU, no GGUF)
+	bash scripts/bench_llama_ab_selftest.sh
 
 canary-gate:        ## gate TPS regressions via runs.db (SHA= required; e.g. make canary-gate SHA=3ba8aee)
 	@test -n "$(SHA)" || { echo "ERROR: SHA= required. Usage: make canary-gate SHA=<last-green-sha>"; exit 125; }

--- a/crates/rmlx-metrics/src/identity.rs
+++ b/crates/rmlx-metrics/src/identity.rs
@@ -298,6 +298,7 @@ pub const BACKEND_WHITELIST: &[&str] = &[
     "ollama",
     "vllm",
     "llama_cpp",
+    "llama_cpp_tq",
 ];
 
 /// Allowed values for the `model_namespace` identity column (see docs/METRICS_DB.md §5.1).
@@ -357,9 +358,16 @@ pub fn canonicalize_kv_quant(value: &str) -> Result<String> {
 ///
 /// Handles common variant spellings that bench tools emit:
 /// - `llama.cpp`, `llama-cpp`, `llamacpp` → `llama_cpp`
+/// - `llama-cpp-turboquant`, `llama.cpp-turboquant` → `llama_cpp_tq`
+///
+/// The TurboQuant fork is a **separate backend id**, not a `kv_quant` value on
+/// `llama_cpp`, for the same reason `mlx_lm_tq` is separate from `mlx_lm`: it
+/// is a different build with codecs upstream does not have, and folding it into
+/// the upstream id would put a row under a backend that cannot produce it.
 fn normalize_backend_alias(lower: &str) -> &str {
     match lower {
         "llama.cpp" | "llama-cpp" | "llamacpp" => "llama_cpp",
+        "llama-cpp-turboquant" | "llama.cpp-turboquant" | "llama_cpp_turboquant" => "llama_cpp_tq",
         other => other,
     }
 }

--- a/crates/rmlx-metrics/src/identity_tests.rs
+++ b/crates/rmlx-metrics/src/identity_tests.rs
@@ -139,6 +139,34 @@ fn canonicalize_backend_llamacpp_alias() {
 }
 
 #[test]
+fn canonicalize_backend_llama_cpp_tq_canonical() {
+    let result = canonicalize("backend", "llama_cpp_tq", BACKEND_WHITELIST).unwrap();
+    assert_eq!(result, "llama_cpp_tq");
+}
+
+#[test]
+fn canonicalize_backend_llama_cpp_turboquant_aliases() {
+    for spelling in [
+        "llama-cpp-turboquant",
+        "llama.cpp-turboquant",
+        "llama_cpp_turboquant",
+    ] {
+        let result = canonicalize("backend", spelling, BACKEND_WHITELIST).unwrap();
+        assert_eq!(result, "llama_cpp_tq", "spelling: {spelling}");
+    }
+}
+
+#[test]
+fn canonicalize_backend_turboquant_fork_is_not_upstream() {
+    // The fork ships codecs upstream does not have. Recording its rows under
+    // `llama_cpp` would attribute a turbo KV cell to a build that cannot
+    // produce one, so the two ids must stay distinct.
+    let fork = canonicalize("backend", "llama-cpp-turboquant", BACKEND_WHITELIST).unwrap();
+    let upstream = canonicalize("backend", "llama.cpp", BACKEND_WHITELIST).unwrap();
+    assert_ne!(fork, upstream);
+}
+
+#[test]
 fn alias_normalization_non_backend_field_untouched() {
     // "llama.cpp" is NOT a valid weight_quant — alias only fires for backend field.
     let err = canonicalize("weight_quant", "llama.cpp", WEIGHT_QUANT_WHITELIST).unwrap_err();

--- a/crates/rmlx-metrics/src/registry.rs
+++ b/crates/rmlx-metrics/src/registry.rs
@@ -563,8 +563,49 @@ pub enum Coverage {
     Maybe,
 }
 
+/// The per-backend metric spec: the metrics every wired backend must declare a
+/// [`Coverage`] for, whether `Yes` or `No`.
+///
+/// `coverage()` falls back to `No` for a pair it cannot find, so an omitted row
+/// and a measured "this backend cannot emit that" are the same answer. Naming
+/// the set here is what lets a test tell them apart.
+pub const BACKEND_METRIC_SPEC: &[&str] = &[
+    "decode_tps_warm",
+    "decode_tps_cold",
+    "prefill_tps",
+    "overall_tps",
+    "ttft_warm_ms",
+    "ttft_cold_ms",
+    "itl_p50_ms",
+    "itl_p95_ms",
+    "step_ms_mean",
+    "model_load_ms",
+    "peak_rss_mb",
+    "metal_peak_alloc_mb",
+    "kv_cache_bytes",
+    "tps_per_gb_ram",
+    "task_pass_at_1",
+];
+
+/// Backends in [`crate::identity::BACKEND_WHITELIST`] that deliberately have no
+/// rows in [`COVERAGE_MATRIX`] yet.
+///
+/// This list exists so that adding a backend is a *visible* act. Without it,
+/// a new whitelist entry with no matrix rows makes `coverage()` answer `No` for
+/// every metric — indistinguishable from "measured and genuinely unsupported" —
+/// and nothing fails. Anything added here must be a backend nothing has
+/// recorded yet; the moment it produces a row, wire its metrics instead.
+pub const BACKENDS_WITHOUT_COVERAGE: &[&str] = &[
+    // Declared "(future)" in docs/METRICS_DB.md §5.4; no runner, no rows.
+    "vllm",
+];
+
 /// (backend, metric, coverage). Listed in spec §4 backend coverage matrix.
 /// Used by `rmlx metrics doctor` to flag suspicious gaps.
+///
+/// Every backend in [`crate::identity::BACKEND_WHITELIST`] must appear here for
+/// each metric in [`BACKEND_METRIC_SPEC`], unless it is declared in
+/// [`BACKENDS_WITHOUT_COVERAGE`].
 pub const COVERAGE_MATRIX: &[(&str, &str, Coverage)] = &[
     // ── rmlx ──────────────────────────────────────────────────────────────────
     ("rmlx", "decode_tps_warm", Coverage::Yes),
@@ -653,6 +694,29 @@ pub const COVERAGE_MATRIX: &[(&str, &str, Coverage)] = &[
     ("mlx_lm", "kv_cache_bytes", Coverage::No),
     ("mlx_lm", "tps_per_gb_ram", Coverage::Yes),
     ("mlx_lm", "task_pass_at_1", Coverage::No),
+    // ── mlx_lm_tq (the mlx-lm TurboQuant fork) ────────────────────────────────
+    // Whitelisted and recording since the cross-backend campaigns, but it had no
+    // COVERAGE_MATRIX rows at all until the sweep below was driven off
+    // BACKEND_WHITELIST — so `coverage()` answered No for every metric on the
+    // second-most-recorded backend in the store. Same CBB runner and same
+    // OpenAI-compatible surface as `mlx_lm`, hence the same coverage, except
+    // that its whole reason to exist is a quantised KV cache it does not report
+    // the size of.
+    ("mlx_lm_tq", "decode_tps_warm", Coverage::Yes),
+    ("mlx_lm_tq", "decode_tps_cold", Coverage::Yes),
+    ("mlx_lm_tq", "prefill_tps", Coverage::Yes),
+    ("mlx_lm_tq", "overall_tps", Coverage::Yes),
+    ("mlx_lm_tq", "ttft_warm_ms", Coverage::Yes),
+    ("mlx_lm_tq", "ttft_cold_ms", Coverage::Yes),
+    ("mlx_lm_tq", "itl_p50_ms", Coverage::Yes),
+    ("mlx_lm_tq", "itl_p95_ms", Coverage::Yes),
+    ("mlx_lm_tq", "step_ms_mean", Coverage::Yes),
+    ("mlx_lm_tq", "model_load_ms", Coverage::Yes),
+    ("mlx_lm_tq", "peak_rss_mb", Coverage::Yes),
+    ("mlx_lm_tq", "metal_peak_alloc_mb", Coverage::Yes),
+    ("mlx_lm_tq", "kv_cache_bytes", Coverage::No),
+    ("mlx_lm_tq", "tps_per_gb_ram", Coverage::Yes),
+    ("mlx_lm_tq", "task_pass_at_1", Coverage::No),
     // ── paroquant ─────────────────────────────────────────────────────────────
     ("paroquant", "decode_tps_warm", Coverage::Yes),
     ("paroquant", "decode_tps_cold", Coverage::Yes),
@@ -686,10 +750,13 @@ pub const COVERAGE_MATRIX: &[(&str, &str, Coverage)] = &[
     ("omlx", "tps_per_gb_ram", Coverage::Yes),
     ("omlx", "task_pass_at_1", Coverage::No),
     // ── llama_cpp ─────────────────────────────────────────────────────────────
-    // llama-bench -o json exposes pp (prefill TPS) and tg (decode TPS) natively.
-    // Metal / CPU load time measurable via wall clock around model load.
+    // Two producers feed this backend and they cover different metrics:
+    // `llama_bench_ingest.py` reads `llama-bench -o json` (pp = prefill TPS,
+    // tg = decode TPS, nothing else), and `llama_ab_ingest.py` reads a
+    // `bench_llama_ab.sh` result, which carries the server's own `timings`
+    // plus the KV-buffer total parsed from the server log and sampled peak RSS.
+    // A cell is Yes when EITHER producer can supply it.
     // metal_peak_alloc_mb: no MLX Metal allocator; llama.cpp uses its own pool.
-    // kv_cache_bytes: not directly exposed by llama-bench JSON output.
     // task_pass_at_1: quality probe, not a bench metric.
     ("llama_cpp", "decode_tps_warm", Coverage::Yes),
     ("llama_cpp", "decode_tps_cold", Coverage::Yes),
@@ -703,9 +770,30 @@ pub const COVERAGE_MATRIX: &[(&str, &str, Coverage)] = &[
     ("llama_cpp", "model_load_ms", Coverage::Yes),
     ("llama_cpp", "peak_rss_mb", Coverage::Yes),
     ("llama_cpp", "metal_peak_alloc_mb", Coverage::No),
-    ("llama_cpp", "kv_cache_bytes", Coverage::No),
+    // Yes since the A/B harness landed: `llama_kv_cache: ... KV buffer size`
+    // is on the server's own startup log and is summed per slot. It is not in
+    // `llama-bench` JSON, which is why this cell used to read No.
+    ("llama_cpp", "kv_cache_bytes", Coverage::Yes),
     ("llama_cpp", "tps_per_gb_ram", Coverage::Yes),
     ("llama_cpp", "task_pass_at_1", Coverage::No),
+    // ── llama_cpp_tq (the llama-cpp-turboquant fork) ──────────────────────────
+    // Same server, same log surface, same producer — it differs from upstream
+    // only in the KV codecs it can load, so its coverage is identical.
+    ("llama_cpp_tq", "decode_tps_warm", Coverage::Yes),
+    ("llama_cpp_tq", "decode_tps_cold", Coverage::Yes),
+    ("llama_cpp_tq", "prefill_tps", Coverage::Yes),
+    ("llama_cpp_tq", "overall_tps", Coverage::No),
+    ("llama_cpp_tq", "ttft_warm_ms", Coverage::No),
+    ("llama_cpp_tq", "ttft_cold_ms", Coverage::No),
+    ("llama_cpp_tq", "itl_p50_ms", Coverage::No),
+    ("llama_cpp_tq", "itl_p95_ms", Coverage::No),
+    ("llama_cpp_tq", "step_ms_mean", Coverage::Yes),
+    ("llama_cpp_tq", "model_load_ms", Coverage::Yes),
+    ("llama_cpp_tq", "peak_rss_mb", Coverage::Yes),
+    ("llama_cpp_tq", "metal_peak_alloc_mb", Coverage::No),
+    ("llama_cpp_tq", "kv_cache_bytes", Coverage::Yes),
+    ("llama_cpp_tq", "tps_per_gb_ram", Coverage::Yes),
+    ("llama_cpp_tq", "task_pass_at_1", Coverage::No),
     // ── ollama ────────────────────────────────────────────────────────────────
     ("ollama", "decode_tps_warm", Coverage::Yes),
     ("ollama", "decode_tps_cold", Coverage::Yes),

--- a/crates/rmlx-metrics/src/registry_tests.rs
+++ b/crates/rmlx-metrics/src/registry_tests.rs
@@ -139,15 +139,47 @@ fn coverage_lookup_unknown_pair_is_no() {
     assert_eq!(coverage("xyz", "decode_tps_warm"), Coverage::No);
 }
 
-/// COVERAGE_MATRIX must have at least one row for each of the 5 spec backends.
+/// Every whitelisted backend must be wired into `COVERAGE_MATRIX`, or declared
+/// in `BACKENDS_WITHOUT_COVERAGE`.
+///
+/// The previous version of this test hard-coded "the 5 spec backends", so a
+/// backend added to the whitelist afterwards landed half-wired and silently:
+/// `coverage()` falls back to `No` for an unknown pair, which is
+/// indistinguishable from a measured "this backend cannot emit that metric".
+/// `llama_cpp` and `llama_cpp_tq` both reached the whitelist that way. Driving
+/// the sweep off the whitelist itself is what makes the next one impossible.
 #[test]
-fn coverage_matrix_includes_all_5_backends() {
-    let required = ["rmlx", "mlx_lm", "paroquant", "omlx", "ollama"];
-    for backend in required {
+fn coverage_matrix_covers_every_whitelisted_backend() {
+    for backend in crate::identity::BACKEND_WHITELIST {
+        let has_rows = COVERAGE_MATRIX.iter().any(|(b, _, _)| b == backend);
+        let declared = BACKENDS_WITHOUT_COVERAGE.contains(backend);
         assert!(
-            COVERAGE_MATRIX.iter().any(|(b, _, _)| *b == backend),
-            "backend '{backend}' has no rows in COVERAGE_MATRIX"
+            has_rows != declared,
+            "backend '{backend}': has_rows={has_rows}, declared_uncovered={declared} \
+             — it must be exactly one. Add its COVERAGE_MATRIX rows, or add it to \
+             BACKENDS_WITHOUT_COVERAGE with the reason."
         );
+    }
+}
+
+/// A backend that is wired must be wired for the *whole* metric spec, not a
+/// convenient subset — otherwise a missing cell reads as `No` by fallback.
+#[test]
+fn wired_backends_declare_every_spec_metric() {
+    for backend in crate::identity::BACKEND_WHITELIST {
+        if BACKENDS_WITHOUT_COVERAGE.contains(backend) {
+            continue;
+        }
+        for metric in BACKEND_METRIC_SPEC {
+            assert!(
+                COVERAGE_MATRIX
+                    .iter()
+                    .any(|(b, m, _)| b == backend && m == metric),
+                "backend '{backend}' has no COVERAGE_MATRIX row for spec metric \
+                 '{metric}'; `coverage()` would answer No by fallback, which is \
+                 not the same as a measured No."
+            );
+        }
     }
 }
 

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -3093,7 +3093,7 @@ bytes and within noise on TPS; dropping the gate at the *same* prompt moves
 resident KV by +180 MB and decode 129.8 → 65.9 TPS. The 16k/32k byte deltas
 (+722 MB / +1445 MB, exactly linear in `kv_seq`) are the kernel engaging.
 
-### Cross-backend calibration — ε is a platform number, not an rMLX number
+### Cross-backend calibration — ε is a platform number, not an rMLX number (TAINTED host)
 
 The three rows above are all rMLX kernels, so on their own they cannot separate
 "fused decode over a quant store is hard on this GPU" from "our kernels are
@@ -3103,28 +3103,58 @@ bad". A second, independent implementation now answers that.
 hand-written Metal: TurboQuant K/V blocks read directly inside
 `flash_attn_ext_vec_kturbo*_vturbo*_dk{128,256}_dv{128,256}`, with the WHT
 applied to `q` once per query as a graph op. It was measured against **its own
-upstream merge-base** (`7fc1c4ef7`) at f16 KV — same GGUF, same graph, same
-build flags, so the only variable is the codec and its kernels. ABBA, n=4/arm,
-two models, both `n_q_heads/n_kv_heads = 32/8` → `heads_per_kv = 4`, the same
-ratio as Bonsai-8B:
+upstream merge-base** (`7fc1c4ef7`) at f16 KV — same GGUF file, same graph, same
+build flags, so within one cell the only variable is the codec and its kernels.
+Both models are `n_q_heads/n_kv_heads = 32/8` → `heads_per_kv = 4`, the same
+ratio as Bonsai-8B.
 
-| model | prompt tok | fork turbo3 / upstream f16 decode | ms/step ratio | KV MiB f16 → turbo3 |
-|---|---:|---:|---:|---|
-| Qwen3-8B-Q8_0 | 3 753 | 0.733x | 1.364 | 648.00 → 126.69 |
-| Qwen3-8B-Q8_0 | 7 722 | 0.705x | 1.419 | 2 304.00 → 450.13 |
-| Qwen3-8B-Q8_0 | 31 536 | 0.690x | 1.449 | 5 760.00 → 1 125.13 |
-| Llama-3.1-8B-Instruct-Q8_0 | 61 709 | 0.653x | 1.532 | 8 192.00 → 1 600.13 |
+**Measurement conditions.** Every cell ran `--allow-busy-host` and came back
+**TAINTED** — entry gate 25.6–55.0% of one core, measured windows 29–56%
+(`WindowServer`; `syspolicyd` steady at 32.2–32.5%), and two slots of the 7 722
+run with a `node` process at 139.9%/159.8%. ABBA cancels a *steady* load and the
+arm ranges below are disjoint by far more than the interference, so the
+**separation verdicts survive**; the **absolute TPS does not** and is not quoted
+across runs. Per-slot windows are in each result JSON.
+
+| model | prompt tok | n/arm | fork turbo3 / upstream f16 decode | ms/step ratio | KV MiB f16 → turbo3 | peak RSS B/A |
+|---|---:|---:|---:|---:|---|---:|
+| Qwen3-8B-Q8_0 | 3 753 | 4 | 0.733x | 1.364 | 648.00 → 126.69 | 0.945x |
+| Qwen3-8B-Q8_0 | 7 722 | 4 | 0.705x | 1.419 | 2 304.00 → 450.13 | 0.830x |
+| Qwen3-8B-Q8_0 | 31 536 | 4 | 0.690x | 1.449 | 5 760.00 → 1 125.13 | 0.677x |
+| Llama-3.1-8B-Instruct-Q8_0 | 61 709 | **2** | 0.653x | 1.532 | 8 192.00 → 1 600.13 | 0.607x |
+
+Arm ranges are disjoint in all four cells. **The 61 709 row is n=2/arm**
+(`--pairs 2`), not 4 — it is simultaneously the most extreme ratio, the only
+second-architecture point, and the least-replicated cell. Nothing below is
+derived from it alone. Its stored result JSON records the verdict as
+`SEPARATED`; the harness now labels a disjoint pair at n=2 `SEPARATED-WEAK`, and
+refuses `--pairs 1` outright, because two single-point "ranges" cannot overlap.
 
 `ρ` is exact here and needs no inference: llama.cpp keeps no bf16 mirror, so the
-reported KV buffer *is* what the kernel reads — **ρ = 0.195**, identical to three
-decimal places at every context and on both models. The ms/step ratio is still
-climbing at 62k, so the marginal slope ratio is at least 1.532, giving
-**ε ≤ 0.127**.
+reported KV buffer *is* what the kernel reads. Across all four cells and both
+models **ρ = 0.1953 ± 0.0002** (0.195509 / 0.195369 / 0.195335 / 0.195328) — a
+1.8e-4 spread, which is the codec's block layout reproducing itself exactly.
+
+**ε is derived from the Qwen3-8B series alone.** The `ms/step = a + b·x`
+monotonicity argument is only valid within one `(a, b)` pair, i.e. within one
+model; extending it across the model boundary to the Llama-3.1 row would not be
+a bound at all. Two derivations, both same-model:
+
+* **Drift-free upper bound.** The within-run ms/step ratios rise 1.364 → 1.419 →
+  1.449 and are still climbing, so the marginal slope ratio is at least 1.449 and
+  **ε ≤ 0.135**. This uses only within-run ratios, so host drift cancels.
+* **Two-endpoint slope regression.** Fitting `b` per arm from the 3 753 and
+  31 536 cells gives `b = 0.330`, `b' = 0.536`, slope ratio **1.63** and
+  **ε ≈ 0.120**. This one reads absolute ms across two runs, so it carries the
+  drift caveat.
+
+So ε ∈ **[0.120, 0.135]** for the fork's kernel, and the upper bound is *exactly*
+rMLX's own best measured shell:
 
 | kernel | `heads_per_kv` | geometric ceiling | ε | % of ceiling |
 |---|---|---|---|---|
 | rMLX `iso_flash_decode_symv`, Bonsai-8B | 4 | 0.250 | 0.135 | 54% |
-| `llama-cpp-turboquant` vec-turbo FA, Qwen3-8B / Llama-3.1-8B | 4 | 0.250 | ≤0.127 | ~51% |
+| `llama-cpp-turboquant` vec-turbo FA, Qwen3-8B | 4 | 0.250 | 0.120–0.135 | 48–54% |
 
 **Two independently written Metal kernels, two frameworks, land on the same ε at
 the same `heads_per_kv`.** And for the same structural reason: the fork's vec
@@ -3135,25 +3165,46 @@ The ceiling in the next section is not an rMLX artifact.
 
 Consequences, and they are the load-bearing part of this whole section:
 
-* **ρ = 0.195 > ε ≈ 0.13, so the fork loses too** — by 1.45x–1.53x on ms/step,
-  which is the 0.69x / 0.65x decode ratio measured. rMLX's `turbo_flash` being slower than its
-  generic path is a *degree* of the same result, not a different kind of result.
-  Its ε = 0.041 says our TurboFlash *shell* is ~3x off what is achievable; even
-  a perfect fix of that shell reaches ε ≈ 0.13 and still loses at ρ = 0.195.
-* **The trend runs the wrong way.** 0.733 → 0.705 → 0.690 → 0.653 as context
-  grows 16x across two architectures.
-  A codec whose store is 5x smaller should gain as KV's share of bytes/step
-  rises; it does not, because the per-step dequant work scales with the same
-  `t_seq`. "Measure it at longer context and it will pay" is falsified on the
-  reference implementation, not only on ours.
-* **What the fork does deliver is the memory axis**, cleanly and with coherent
-  output: 0.195x KV and 0.68x–0.83x peak process memory. That is the trade
-  actually on the table — real capacity for ~30% decode — and it is a
-  capacity feature, not a throughput one.
+* **ρ = 0.1953 > ε ≤ 0.135, so the fork loses too** — by 1.45x on ms/step at
+  31 536, which is the 0.690x decode ratio measured. rMLX's `turbo_flash` being
+  slower than its generic path is a *degree* of the same result, not a different
+  kind of result. Its ε = 0.041 says our TurboFlash *shell* is ~3x off what is
+  achievable; even a perfect fix of that shell reaches ε ≈ 0.135 and still loses
+  at ρ = 0.1953.
+* **The trend runs the wrong way**, and this is established on the three
+  **same-model** Qwen3-8B points alone: 0.733 → 0.705 → 0.690 as context grows
+  8.4x. A codec whose store is 5x smaller should gain as KV's share of
+  bytes/step rises; it does not, because the per-step dequant work scales with
+  the same `t_seq`. "Measure it at longer context and it will pay" is falsified
+  on the reference implementation, not only on ours. The Llama-3.1 point at
+  0.653x is *consistent* with the trend but cannot extend it — it changes model
+  and context simultaneously, and there is no short-context Llama-3.1 cell to
+  separate "ratio falls with context" from "Llama-3.1 is worse for this codec".
+* **What the fork does deliver is the memory axis**, and it is monotone with
+  context rather than flat: peak process memory **0.945x / 0.830x / 0.677x /
+  0.607x** at 3 753 / 7 722 / 31 536 / 61 709, against a flat 0.1953x KV buffer.
+  The campaign declared a `≤0.85x` peak-memory criterion in advance; **at 3 753
+  tokens the fork does not clear it** (0.945x), because the KV saving is small
+  beside 8.3 GB of weights until context grows. The trade is real from ~8k up and
+  absent below it.
+* **Coherence was observed only where it was captured, and no quality axis was
+  measured.** Output capture was added to the harness after the 7 722 and 31 536
+  runs, so every slot of those two carries `output_first_64: null`. Where
+  captured (3 753, 61 709, and the confound control) both arms produce fluent,
+  on-topic English. At 61 709 the two arms visibly disagree on extracted facts,
+  which is expected of a lossy KV codec and is *not* evidence either way about
+  quality — no perplexity or task score was run.
 * Its own deepest fusion (`TurboFlash`, a two-pass fused kernel) is **disabled by
   default because it emits garbage on Apple10**, reproduced here on this host.
   Two independent projects disabling their deepest Metal fusion on this GPU
   family is a platform signal.
+
+**Scope of the confound control.** "The only variable is the codec" is licensed
+by a `fork @ f16` vs `merge-base @ f16` cell that returned INCONCLUSIVE with
+fully overlapping ranges (1.013x, n=4/arm) — but that control ran at **one
+context (7 722) on one model (Qwen3-8B)**. The 61 709 Llama-3.1 cell has no
+control of its own, so a long-context-specific or Llama-specific regression among
+the fork's 211 non-upstream commits is unmeasured there.
 
 Method, raw slots and the fork-side detail: `scripts/bench_llama_ab.sh`,
 `scripts/ingest/llama_ab_ingest.py`, results under `$RMLX_HOME/bench/llama_ab/`.

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -3093,6 +3093,71 @@ bytes and within noise on TPS; dropping the gate at the *same* prompt moves
 resident KV by +180 MB and decode 129.8 → 65.9 TPS. The 16k/32k byte deltas
 (+722 MB / +1445 MB, exactly linear in `kv_seq`) are the kernel engaging.
 
+### Cross-backend calibration — ε is a platform number, not an rMLX number
+
+The three rows above are all rMLX kernels, so on their own they cannot separate
+"fused decode over a quant store is hard on this GPU" from "our kernels are
+bad". A second, independent implementation now answers that.
+
+`llama-cpp-turboquant` implements the same idea in a different framework with
+hand-written Metal: TurboQuant K/V blocks read directly inside
+`flash_attn_ext_vec_kturbo*_vturbo*_dk{128,256}_dv{128,256}`, with the WHT
+applied to `q` once per query as a graph op. It was measured against **its own
+upstream merge-base** (`7fc1c4ef7`) at f16 KV — same GGUF, same graph, same
+build flags, so the only variable is the codec and its kernels. ABBA, n=4/arm,
+two models, both `n_q_heads/n_kv_heads = 32/8` → `heads_per_kv = 4`, the same
+ratio as Bonsai-8B:
+
+| model | prompt tok | fork turbo3 / upstream f16 decode | ms/step ratio | KV MiB f16 → turbo3 |
+|---|---:|---:|---:|---|
+| Qwen3-8B-Q8_0 | 3 753 | 0.733x | 1.364 | 648.00 → 126.69 |
+| Qwen3-8B-Q8_0 | 7 722 | 0.705x | 1.419 | 2 304.00 → 450.13 |
+| Qwen3-8B-Q8_0 | 31 536 | 0.690x | 1.449 | 5 760.00 → 1 125.13 |
+| Llama-3.1-8B-Instruct-Q8_0 | 61 709 | 0.653x | 1.532 | 8 192.00 → 1 600.13 |
+
+`ρ` is exact here and needs no inference: llama.cpp keeps no bf16 mirror, so the
+reported KV buffer *is* what the kernel reads — **ρ = 0.195**, identical to three
+decimal places at every context and on both models. The ms/step ratio is still
+climbing at 62k, so the marginal slope ratio is at least 1.532, giving
+**ε ≤ 0.127**.
+
+| kernel | `heads_per_kv` | geometric ceiling | ε | % of ceiling |
+|---|---|---|---|---|
+| rMLX `iso_flash_decode_symv`, Bonsai-8B | 4 | 0.250 | 0.135 | 54% |
+| `llama-cpp-turboquant` vec-turbo FA, Qwen3-8B / Llama-3.1-8B | 4 | 0.250 | ≤0.127 | ~51% |
+
+**Two independently written Metal kernels, two frameworks, land on the same ε at
+the same `heads_per_kv`.** And for the same structural reason: the fork's vec
+dispatch is `dispatch_threadgroups(…, (ne01 + nqptg - 1)/nqptg, ne02, ne03, …)`
+with `ne02` the **query**-head count (`ggml-metal-ops.cpp`), so its
+`heads_per_kv` threadgroups re-read the identical KV bytes exactly as ours do.
+The ceiling in the next section is not an rMLX artifact.
+
+Consequences, and they are the load-bearing part of this whole section:
+
+* **ρ = 0.195 > ε ≈ 0.13, so the fork loses too** — by 1.45x–1.53x on ms/step,
+  which is the 0.69x / 0.65x decode ratio measured. rMLX's `turbo_flash` being slower than its
+  generic path is a *degree* of the same result, not a different kind of result.
+  Its ε = 0.041 says our TurboFlash *shell* is ~3x off what is achievable; even
+  a perfect fix of that shell reaches ε ≈ 0.13 and still loses at ρ = 0.195.
+* **The trend runs the wrong way.** 0.733 → 0.705 → 0.690 → 0.653 as context
+  grows 16x across two architectures.
+  A codec whose store is 5x smaller should gain as KV's share of bytes/step
+  rises; it does not, because the per-step dequant work scales with the same
+  `t_seq`. "Measure it at longer context and it will pay" is falsified on the
+  reference implementation, not only on ours.
+* **What the fork does deliver is the memory axis**, cleanly and with coherent
+  output: 0.195x KV and 0.68x–0.83x peak process memory. That is the trade
+  actually on the table — real capacity for ~30% decode — and it is a
+  capacity feature, not a throughput one.
+* Its own deepest fusion (`TurboFlash`, a two-pass fused kernel) is **disabled by
+  default because it emits garbage on Apple10**, reproduced here on this host.
+  Two independent projects disabling their deepest Metal fusion on this GPU
+  family is a platform signal.
+
+Method, raw slots and the fork-side detail: `scripts/bench_llama_ab.sh`,
+`scripts/ingest/llama_ab_ingest.py`, results under `$RMLX_HOME/bench/llama_ab/`.
+
 ### Why ε is small — grid geometry
 
 Every P1 kernel here indexes its grid by **query** head (`n_bh = b · n_q_heads`)

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -635,7 +635,10 @@ Earlier revisions of this document described `kv_quant` as validated against a f
 
 ### 5.4 `backend` whitelist
 
-Only these strings allowed (extend whitelist by editing this section):
+Only these strings allowed. The list here mirrors
+`rmlx_metrics::identity::BACKEND_WHITELIST` — extend **both**, in the same
+change, or the doc says one thing and the validator does another:
+
 - `rmlx`
 - `mlx_lm` (Apple stock + sampler-fast)
 - `mlx_lm_tq` (TurboQuant fork)
@@ -643,6 +646,19 @@ Only these strings allowed (extend whitelist by editing this section):
 - `omlx`
 - `ollama`
 - `vllm` (future)
+- `llama_cpp` (upstream `ggml-org/llama.cpp`)
+- `llama_cpp_tq` (the `llama-cpp-turboquant` fork)
+
+`canonicalize` normalizes a few spellings before the lookup: `llama.cpp` /
+`llama-cpp` / `llamacpp` → `llama_cpp`, and `llama-cpp-turboquant` /
+`llama.cpp-turboquant` / `llama_cpp_turboquant` → `llama_cpp_tq`.
+
+**A fork is its own backend id, never a `kv_quant` value on the upstream id.**
+`llama_cpp_tq` exists for the same reason `mlx_lm_tq` does: it is a different
+build carrying codecs (`turbo2` / `turbo3` / `turbo4`) that upstream cannot
+load at all. Recording a turbo cell under `llama_cpp` would attribute a
+measurement to a binary that cannot produce it, and `bests` would then rank the
+two builds inside one backend column.
 
 ### 5.5 `hardware_tag`
 

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -545,39 +545,48 @@ view cannot give) has to carry the predicate itself; it must then be pinned to
 this section by name and reviewed with it. `scripts/perf_ceiling.py`'s
 `prefill_anchor` is the one such consumer in the tree.
 
-**Backend coverage matrix** (which backend can emit which metric — sparse is fine, see §3.3):
+**Backend coverage matrix** (which backend can emit which metric — sparse is fine, see §3.3).
 
-| Metric                | rmlx | mlx_lm | paroquant | omlx | ollama |
-|-----------------------|:----:|:------:|:---------:|:----:|:------:|
-| `decode_tps_warm`     | yes  | yes    | yes       | yes  | yes    |
-| `decode_tps_cold`     | yes  | yes    | yes       | yes  | yes    |
-| `prefill_tps`         | yes  | yes    | yes       | yes  | yes    |
-| `overall_tps`         | yes  | yes    | yes       | yes  | yes    |
-| `ttft_warm_ms`        | yes  | yes    | yes       | yes  | yes    |
-| `ttft_cold_ms`        | yes  | yes    | yes       | yes  | yes    |
-| `itl_p50_ms`          | yes  | yes    | yes       | yes  | yes    |
-| `itl_p95_ms`          | yes  | yes    | yes       | yes  | yes    |
-| `step_ms_mean`        | yes  | yes    | yes       | yes  | yes    |
-| `model_load_ms`       | yes  | yes    | yes       | yes  | yes    |
-| `peak_rss_mb`         | yes  | yes    | yes       | yes  | yes    |
-| `metal_peak_alloc_mb` | yes  | yes    | yes       | yes  | no     |
-| `kv_cache_bytes`      | yes  | no     | no        | maybe| no     |
-| `tps_per_gb_ram`      | yes  | yes    | yes       | yes  | yes    |
-| `task_pass_at_1`      | no   | no     | no        | no   | no     |
-| `prompt_cache_block_hits`         | yes | no | no | no | no |
-| `prompt_cache_block_misses`       | yes | no | no | no | no |
-| `prompt_cache_partial_hits`       | yes | no | no | no | no |
-| `queue_wait_ms`                   | yes | no | no | no | no |
-| `queue_depth`                     | yes | no | no | no | no |
-| `prompt_tokens_live`              | yes | no | no | no | no |
-| `completion_tokens_live`          | yes | no | no | no | no |
-| `itl_p99_ms`                      | yes | no | no | no | no |
-| `itl_spikes`                      | yes | no | no | no | no |
-| `accept_rate`                     | yes | no | no | no | no |
-| `draft_tokens_total`              | yes | no | no | no | no |
-| `accept_tokens_total`             | yes | no | no | no | no |
-| `draft_rounds_total`              | yes | no | no | no | no |
-| `accepted_per_step`               | yes | no | no | no | no |
+This table mirrors `rmlx_metrics::registry::COVERAGE_MATRIX`; the columns are
+`identity::BACKEND_WHITELIST` minus the entries declared in
+`BACKENDS_WITHOUT_COVERAGE`. **Adding a backend means adding a column here and a
+block there in the same change** — `coverage()` falls back to `No` for a pair it
+cannot find, so a half-wired backend answers "cannot emit" for everything and
+nothing says otherwise. `mlx_lm_tq`, `llama_cpp` and `llama_cpp_tq` all reached
+the whitelist without coverage rows before the test was driven off the whitelist
+itself.
+
+| Metric                | rmlx | mlx_lm | mlx_lm_tq | paroquant | omlx | ollama | llama_cpp | llama_cpp_tq |
+|-----------------------|:----:|:------:|:---------:|:---------:|:----:|:------:|:---------:|:------------:|
+| `decode_tps_warm`     | yes | yes | yes | yes | yes | yes | yes | yes |
+| `decode_tps_cold`     | yes | yes | yes | yes | yes | yes | yes | yes |
+| `prefill_tps`         | yes | yes | yes | yes | yes | yes | yes | yes |
+| `overall_tps`         | yes | yes | yes | yes | yes | yes | no | no |
+| `ttft_warm_ms`        | yes | yes | yes | yes | yes | yes | no | no |
+| `ttft_cold_ms`        | yes | yes | yes | yes | yes | yes | no | no |
+| `itl_p50_ms`          | yes | yes | yes | yes | yes | yes | no | no |
+| `itl_p95_ms`          | yes | yes | yes | yes | yes | yes | no | no |
+| `step_ms_mean`        | yes | yes | yes | yes | yes | yes | yes | yes |
+| `model_load_ms`       | yes | yes | yes | yes | yes | yes | yes | yes |
+| `peak_rss_mb`         | yes | yes | yes | yes | yes | yes | yes | yes |
+| `metal_peak_alloc_mb` | yes | yes | yes | yes | yes | no | no | no |
+| `kv_cache_bytes`      | yes | no | no | no | maybe | no | yes | yes |
+| `tps_per_gb_ram`      | yes | yes | yes | yes | yes | yes | yes | yes |
+| `task_pass_at_1`      | no | no | no | no | no | no | no | no |
+| `prompt_cache_block_hits`         | yes | no | no | no | no | no | no | no |
+| `prompt_cache_block_misses`       | yes | no | no | no | no | no | no | no |
+| `prompt_cache_partial_hits`       | yes | no | no | no | no | no | no | no |
+| `queue_wait_ms`                   | yes | no | no | no | no | no | no | no |
+| `queue_depth`                     | yes | no | no | no | no | no | no | no |
+| `prompt_tokens_live`              | yes | no | no | no | no | no | no | no |
+| `completion_tokens_live`          | yes | no | no | no | no | no | no | no |
+| `itl_p99_ms`                      | yes | no | no | no | no | no | no | no |
+| `itl_spikes`                      | yes | no | no | no | no | no | no | no |
+| `accept_rate`                     | yes | no | no | no | no | no | no | no |
+| `draft_tokens_total`              | yes | no | no | no | no | no | no | no |
+| `accept_tokens_total`             | yes | no | no | no | no | no | no | no |
+| `draft_rounds_total`              | yes | no | no | no | no | no | no | no |
+| `accepted_per_step`               | yes | no | no | no | no | no | no | no |
 
 `no` = backend genuinely can't measure. `maybe` = backend exposes it but recording path not wired. rMLX TTFT/ITL/kv_cache_bytes are wired via the EventRecorder → `events` table; cold/warm TTFT is distinguished by a first-load flag. Metal peak alloc is also wired.
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -1170,13 +1170,55 @@ Active-param bytes/step vs the 614 GB/s ceiling, compared to decode-only TPS
 | Gemma4-26b MoE | ~3.5 GB active | ~175 TPS | 72.19 | **2.42x** |
 | Qwen3.6-35B-A3B MoE | ~3.5 GB active | ~175 TPS | 94.96 | **1.84x** |
 
-All four sit in a **1.8x–2.7x** band — at/near the healthy 1.5-2x
-ceiling-vs-realized envelope llama.cpp / mlx-lm hit on dense batch-1 decode.
-**ACCEPT** — decode is bandwidth-bound and healthy. This is the headline answer
-to the question "why is decode so low?": it was *not* low — the matrix numbers
-were prefill-contaminated (see the decode-only re-baseline section). The residual ~2x is normal MLX batch-1
-overhead (dispatch + dequant + the gap between realized and peak bandwidth),
-not a defect.
+All four sit in a **1.8x–2.7x** band. **ACCEPT** — decode is bandwidth-bound.
+This is the headline answer to the question "why is decode so low?": it was
+*not* low in the sense first suspected — the matrix numbers were
+prefill-contaminated (see the decode-only re-baseline section). The residual
+~2x is MLX batch-1 overhead (dispatch + dequant + the gap between realized and
+peak bandwidth).
+
+#### H2 addendum — the comparison envelope, now measured locally
+
+This section used to close by calling the 1.8x–2.7x band *"at/near the healthy
+1.5-2x ceiling-vs-realized envelope llama.cpp / mlx-lm hit on dense batch-1
+decode"*. **That envelope was taken from the literature, not measured here, and
+the first local measurement does not support it.**
+
+`llama.cpp` at its own roofline on this host — same 614 GB/s constant, same
+bytes/step arithmetic, `Qwen3-8B-Q8_0` GGUF, Metal, batch 1, decode-only TPS
+from the server's own `timings`, ABBA-interleaved, n=4/arm:
+
+| prompt tokens | bytes/step (weights + f16 KV) | ceiling @614 GB/s | measured decode_tps | ratio vs ceiling |
+|---:|---:|---:|---:|---:|
+| 3 753 | ~9.3 GB | ~66 TPS | 52.05 | **1.27x** |
+| 7 722 | ~9.8 GB | ~62 TPS | 54.89 | **1.14x** |
+| 31 536 | ~13.4 GB | ~46 TPS | 35.25 | **1.30x** |
+
+So llama.cpp realizes **77–88%** of peak bandwidth here, i.e. **1.14x–1.30x**,
+*tighter* than the 1.5–2.0x the old wording attributed to it. rMLX's 1.8x–2.7x
+is therefore **not** "at/near" a neutral backend's envelope on this machine — it
+is roughly 1.5x looser than what a non-MLX runtime achieves on the same GPU.
+That does not by itself make the band a defect (different framework, different
+weight format, different dispatch model — see the equivalence caveat below), but
+it removes the "everyone lands here" justification the sentence was carrying.
+
+**Equivalence caveat, and it is load-bearing.** No file both runtimes can load
+exists: rMLX reads MLX safetensors, llama.cpp reads GGUF. The table above is a
+`q8_0` (block 32, one fp16 scale) model against rMLX's `mxfp8`/affine rows —
+near-equivalent, not identical, and the bytes/step figures differ accordingly.
+Treat a cross-family gap under ~10% as unresolved by this method. What survives
+the caveat is the *shape* of the result: a ~1.5x difference in ceiling-realization
+is far outside any quant-format accounting.
+
+**Cross-run absolute TPS on this host is not comparable; only within-run ABBA
+ratios are.** The 7 722-token cell above reads 54.89 in one run and 49.27 in
+another, same binary, same flags, ~30 min apart — an 11% drift driven by
+foreground desktop load. Every ratio quoted here is between arms *inside one
+ABBA run*; no number here is a cross-run comparison, and none should be made
+into one.
+
+Method and raw slots: `scripts/bench_llama_ab.sh`, results under
+`$RMLX_HOME/bench/llama_ab/`.
 
 ### H3 — MoE routing math — characterized (negligible)
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -127,10 +127,16 @@ is excluded:
 - **Bonsai 8B 2bit**: 15.88 → **115.21**. Ratio ~19x → **2.66x**.
 - **Gemma4-e4b dense**: 27.50 → **72.92**. Ratio ~5.6x → **2.11x**.
 
-All four now sit in the **1.8x–2.7x** band — at or near the healthy
-1.5-2x ceiling-vs-realized envelope llama.cpp / mlx-lm hit on dense models.
-The dramatic "MoE is 40-50x slow" signal was a **bench-harness measurement
-artifact** (prefill in the TPS denominator), not an inference-path defect.
+All four now sit in the **1.8x–2.7x** band. The dramatic "MoE is 40-50x slow"
+signal was a **bench-harness measurement artifact** (prefill in the TPS
+denominator), not an inference-path defect.
+
+That band was previously described here as "at or near the healthy 1.5-2x
+ceiling-vs-realized envelope llama.cpp / mlx-lm hit on dense models". **Do not
+use ratio-vs-ceiling to compare runtimes across models of different size** —
+`ratio = 1 + overhead/ideal_ms`, so the same fixed per-step cost reads larger on
+a smaller model. Measured locally, llama.cpp's absolute per-step overhead
+overlaps rMLX's; the ratio gap is dominated by bytes/step. See the H2 addendum.
 The residual ~2x is plausibly real bandwidth/dispatch overhead; flamegraph
 profiling can still characterize it, but the alarm that motivated the 16-48x
 framing is resolved.
@@ -1177,45 +1183,101 @@ prefill-contaminated (see the decode-only re-baseline section). The residual
 ~2x is MLX batch-1 overhead (dispatch + dequant + the gap between realized and
 peak bandwidth).
 
-#### H2 addendum — the comparison envelope, now measured locally
+#### H2 addendum — the comparison envelope, measured locally (TAINTED host)
 
 This section used to close by calling the 1.8x–2.7x band *"at/near the healthy
 1.5-2x ceiling-vs-realized envelope llama.cpp / mlx-lm hit on dense batch-1
-decode"*. **That envelope was taken from the literature, not measured here, and
-the first local measurement does not support it.**
+decode"*. **That envelope was taken from the literature, not measured here.** The
+first local measurement is below. It does not vindicate the sentence, and it
+does not support the opposite claim either — read on before quoting either.
+
+**Measurement conditions.** Every cell below ran with `bench_llama_ab.sh
+--allow-busy-host` and came back **TAINTED**: the entry gate read 25.6–55.0% of
+one core and individual measured windows 29–56% (`WindowServer`, and
+`syspolicyd` at a steady 32.2–32.5%); two slots of the 7 722 run saw a `node`
+process at 139.9% and 159.8%. ABBA interleaving cancels a *steady* load, so the
+**within-run A/B ratios survive**; the **absolute TPS does not**, and neither
+does anything derived from a single absolute number. Per-slot windows are
+recorded in each result JSON.
 
 `llama.cpp` at its own roofline on this host — same 614 GB/s constant, same
 bytes/step arithmetic, `Qwen3-8B-Q8_0` GGUF, Metal, batch 1, decode-only TPS
-from the server's own `timings`, ABBA-interleaved, n=4/arm:
+from the server's own `timings`:
 
 | prompt tokens | bytes/step (weights + f16 KV) | ceiling @614 GB/s | measured decode_tps | ratio vs ceiling |
 |---:|---:|---:|---:|---:|
-| 3 753 | ~9.3 GB | ~66 TPS | 52.05 | **1.27x** |
-| 7 722 | ~9.8 GB | ~62 TPS | 54.89 | **1.14x** |
-| 31 536 | ~13.4 GB | ~46 TPS | 35.25 | **1.30x** |
+| 3 753 | 9.26 GB | 66.3 TPS | 52.05 | **1.27x** |
+| 7 722 | 9.85 GB | 62.3 TPS | 54.89 / 49.27 | **1.14x / 1.26x** |
+| 31 536 | 13.36 GB | 46.0 TPS | 35.25 | **1.30x** |
 
-So llama.cpp realizes **77–88%** of peak bandwidth here, i.e. **1.14x–1.30x**,
-*tighter* than the 1.5–2.0x the old wording attributed to it. rMLX's 1.8x–2.7x
-is therefore **not** "at/near" a neutral backend's envelope on this machine — it
-is roughly 1.5x looser than what a non-MLX runtime achieves on the same GPU.
-That does not by itself make the band a defect (different framework, different
-weight format, different dispatch model — see the equivalence caveat below), but
-it removes the "everyone lands here" justification the sentence was carrying.
+The 7 722 row carries **two** observations of the same cell, same binary, same
+flags, ~30 min apart. Publishing only the faster one would put an endpoint in
+the band that this very section documents as unreproducible, so both are shown.
+The reproducible band is **1.26x–1.30x**.
+
+##### Ratio-vs-ceiling is not comparable across models of different size
+
+It is tempting to set 1.26x–1.30x against rMLX's 1.8x–2.7x and conclude
+llama.cpp is the more efficient runtime. **That inference is invalid**, and the
+reason generalises well beyond this page.
+
+The ratio is not a scale-free efficiency. By construction
+
+```
+ratio = measured_ms / ideal_ms = 1 + fixed_overhead_ms / ideal_ms
+```
+
+so *the same* fixed per-step cost produces a large ratio on a small model and a
+small ratio on a large one. The two tables are not close in scale: llama.cpp's
+cells move **9.3–13.4 GB/step**, rMLX's H2 rows **2.0–4.0 GB/step** — 2.3x to
+6.7x apart. That difference alone moves the ratio in exactly the observed
+direction, before any question of runtime quality.
+
+The scale-free quantity is the **absolute per-step overhead**,
+`1000/measured_tps − 1000·bytes/614`:
+
+| runtime | cell | bytes/step | ideal ms | measured ms | **overhead ms** | ratio |
+|---|---|---:|---:|---:|---:|---:|
+| llama.cpp | Qwen3-8B-Q8_0 @3 753 | 9.26 GB | 15.09 | 19.21 | **4.12** | 1.27x |
+| llama.cpp | Qwen3-8B-Q8_0 @7 722 | 9.85 GB | 16.04 | 18.22 / 20.30 | **2.18 / 4.26** | 1.14x / 1.26x |
+| llama.cpp | Qwen3-8B-Q8_0 @31 536 | 13.36 GB | 21.76 | 28.37 | **6.61** | 1.30x |
+| rMLX | Qwen3.6-35B-A3B MoE | 3.5 GB | 5.70 | 10.53 | **4.83** | 1.85x |
+| rMLX | Bonsai 8B 2bit | 2.0 GB | 3.26 | 8.68 | **5.42** | 2.66x |
+| rMLX | Gemma4-e4b mxfp8 | 4.0 GB | 6.51 | 13.71 | **7.20** | 2.11x |
+| rMLX | Gemma4-26b MoE | 3.5 GB | 5.70 | 13.85 | **8.15** | 2.43x |
+
+llama.cpp 2.18–6.61 ms against rMLX 4.83–8.15 ms. **The ranges overlap**, so by
+the same rule this repo applies to its own A/B arms the comparison is
+**INCONCLUSIVE**: the medians differ (~4.3 ms vs ~6.3 ms) but no separation is
+demonstrated at n=3 vs n=4, across two frameworks, two weight formats and two
+measurement sessions on a tainted host.
+
+What the data *does* establish:
+
+* The **band difference is dominated by bytes/step, not by runtime efficiency.**
+  A 1.26x-vs-2.4x gap in ratios coexists with overlapping absolute overheads.
+* E2's original sentence is still unsupported — it cited an envelope nobody had
+  measured — but it is **not falsified**, and an earlier revision of this
+  addendum that claimed rMLX was "roughly 1.5x looser" was **wrong**: it compared
+  the non-scale-free quantity across a 2.3–6.7x span in model size.
+* Settling it needs a like-for-like cell — llama.cpp on a model with
+  rMLX-comparable bytes/step, or rMLX on an ~9 GB/step model — on a quiescent
+  host. That has not been run.
 
 **Equivalence caveat, and it is load-bearing.** No file both runtimes can load
-exists: rMLX reads MLX safetensors, llama.cpp reads GGUF. The table above is a
+exists: rMLX reads MLX safetensors, llama.cpp reads GGUF. The tables set a
 `q8_0` (block 32, one fp16 scale) model against rMLX's `mxfp8`/affine rows —
-near-equivalent, not identical, and the bytes/step figures differ accordingly.
-Treat a cross-family gap under ~10% as unresolved by this method. What survives
-the caveat is the *shape* of the result: a ~1.5x difference in ceiling-realization
-is far outside any quant-format accounting.
+near-equivalent, not identical. The rMLX bytes/step figures are themselves the
+rounded estimates this section already published (and `#403` tightens that
+census), so the overhead column inherits their uncertainty. Treat a cross-family
+gap under ~10% as unresolved by this method.
 
-**Cross-run absolute TPS on this host is not comparable; only within-run ABBA
-ratios are.** The 7 722-token cell above reads 54.89 in one run and 49.27 in
-another, same binary, same flags, ~30 min apart — an 11% drift driven by
-foreground desktop load. Every ratio quoted here is between arms *inside one
-ABBA run*; no number here is a cross-run comparison, and none should be made
-into one.
+**Cross-run absolute TPS on this host is not comparable.** The 7 722 cell above
+is the demonstration: 54.89 and 49.27, an 11% drift driven by foreground desktop
+load. Both are published for that reason. Every *ratio* quoted elsewhere in this
+campaign is between two arms *inside one ABBA run*; the roofline tables here are
+the one place absolute numbers appear, and they are why the verdict above is
+INCONCLUSIVE rather than a measurement.
 
 Method and raw slots: `scripts/bench_llama_ab.sh`, results under
 `$RMLX_HOME/bench/llama_ab/`.

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -1,0 +1,158 @@
+# scripts/ — index
+
+Every script in this tree, one line each. **Add a row here when you add a
+script.** An unindexed script is invisible: the next person writes a second one
+that does the same thing, and neither is maintained.
+
+Conventions:
+
+* `make <target>` in the "via" column means the Makefile is the supported entry
+  point — call it that way so the local gate and CI stay identical.
+* "gate" scripts are hard-fail steps of `make ci`. They exist to be run by CI,
+  not by hand, but each is runnable standalone for triage.
+* Shared helpers live in `lib/` and are **sourced, not executed**.
+
+---
+
+## CI gates (`make ci`)
+
+| Script | What it enforces |
+|---|---|
+| `check_eval_lock.sh` | Every MLX eval FFI call is made under the process-wide evaluation lock (25-symbol reach-set). |
+| `check_eval_lock_fixtures.sh` | Recall test for the above — 26 synthetic scan roots, each asserting which rule fired. |
+| `check_gpu_tests_ignored.sh` | A test that reaches `Device::Gpu` carries `#[ignore]`; an `#[ignore]` claiming Metal is reachable or declared. |
+| `check_gpu_tests_ignored_fixtures.sh` | Recall test for the above, asserting each case's failure *reason*. |
+| `check_kernel_dtype_contract.sh` | A custom-Metal-kernel dispatcher returns the caller's dtype, not the kernel's working precision. |
+| `check_kernel_dtype_contract_fixtures.sh` | Recall test for the above. |
+| `check_kv_layer_quants.sh` | The per-layer KV codec vector has one producer; every per-layer cache stack uses it or declares itself uniform. |
+| `check_metal_compiles.sh` | Every `.metal` kernel compiles natively at `-std=metal3.0` and `-std=metal4.0`, and is named by its `probes/kernels.manifest`. |
+| `check_metal_format.sh` | Every `.metal` file is formatted. |
+| `check_no_decode_swallow.sh` | A failed decode step or failed sampler call cannot be swallowed into a silent success. |
+| `check_no_inline_tests.sh` | No inline `#[cfg(test)] mod tests` outside `*_tests.rs` / `tests.rs`. |
+| `check_no_kernel_input_eval.sh` | No blocking `Array::eval()` on a kernel input inside a dispatcher. |
+| `check_no_kernel_input_eval_fixtures.sh` | Recall test for the above. |
+| `check_no_scalar_f32_leak.sh` | No unguarded `scalar_f32(` in the metal-owning crates — the f32 decode-graph promotion class. |
+| `metal_dirs.sh` | The list of directories holding gated `.metal` kernels. Sourced by the metal gates. |
+| `file_size_report.sh` | Advisory (non-failing) LOC report for source files >1000 lines. |
+| `target_size_report.sh` | Advisory (non-failing) `target/` size report. |
+
+## Test execution
+
+| Script | Via | What it does |
+|---|---|---|
+| `run_gpu_tests.sh` | `make gpu-test` | Runs the `#[ignore]` Metal tests per member crate, `--test-threads=1`. |
+| `eval_lock_stress.sh` | `make eval-lock-stress` | Drives the evaluation-lock reproducer across N fresh processes. Deliberately out of `make ci`. |
+| `schema_constraint_canary.sh` | — | Real-model proof for the `json_schema` constrained-decoding path. |
+| `ssd_canary.sh` | — | End-to-end long-session SSD prompt-cache tier canary (see `docs/SSD_CANARY.md`). |
+| `release_e2e/stage6_perf/codec_smoke_runner.sh` | `make smoke-codec-matrix` | KV-codec smoke + NIAH gate matrix. |
+| `release_e2e/stage6_perf/niah_long_context.sh` | — | Needle-in-a-haystack long-context validation driver. |
+| `parity/rmlx-vs-fork.sh` | — | Parity gate: does rMLX agree with the mlx-lm-turboquant fork. |
+| `parity/jina_v4_parity.py` | — | jina-v4 embedding parity against the reference implementation. |
+
+## Perf: A/B and regression
+
+| Script | Via | What it does |
+|---|---|---|
+| `perf_ab.sh` | `perf_canary.sh --ab` | **ABBA-interleaved A/B of two `rmlx baseline` arms.** Host-quiescence gate, arm-distinguishability guard, token-id comparison. |
+| `perf_ab_selftest.sh` | `make perf-ab-selftest` | Mutation check for `perf_ab.sh` — every guard must fail when broken. |
+| `bench_llama_ab.sh` | — | **ABBA-interleaved A/B of two `llama-server` arms** (fork vs upstream, codec vs codec). Same quiescence discipline as `perf_ab.sh`, reported over the server's own `timings` plus KV-buffer and peak-RSS columns. Never writes `runs.db`. |
+| `perf_canary.sh` | `make perf-canary` | Fast decode-TPS canary over the three standard test-target models. |
+| `regression_gate.sh` | — | Compare a committed baseline against the latest canary row. Exit 125 = `git bisect skip`, 1 = regression. |
+| `perf-iter/bench_decode_tps.sh` | — | Per-iteration regression bench for a perf-fix campaign. |
+| `perf-iter/diff_baseline.sh` | — | Compare two perf-iter JSONL files, emit per-cell deltas. |
+| `perf_ceiling.py` | — | Static roofline calculator: bytes/step and the theoretical ceiling from a snapshot's `config.json` + safetensors index. |
+| `sdpa_headdim_bench.py` | — | What MLX's SDPA dispatch costs as a function of `head_dim`. |
+| `aggregate_decode_profile.py` | — | Aggregate per-model `decode_profile` lines from `profile_<MODEL>.txt`. |
+
+## Cross-backend bench cells
+
+| Script | What it does |
+|---|---|
+| `bench_cell.sh` | Per-cell driver for the cross-backend bench. Legacy mode drives the CBB Python harness over an HTTP backend; cache-type mode drives `rmlx baseline` directly and emits one §8.5 RunRecord. |
+| `bench_codec_cell.sh` | Single-codec × single-model bench runner. |
+| `bench_cache_types.sh` | Drive the cache-type combo matrix for one model. |
+| `bench-records-sweep.sh` | 5-model × 4-KV-quant `BENCHMARK_CHAMPIONS` regression sweep. |
+| `spec_bench.sh` | Bench a model in normal vs MTP speculative-decode mode. |
+| `baseline/run_mlx-lm.sh` | Baseline measurement via Apple's stock `mlx-lm` loader. |
+| `baseline/run_mlx-lm-turboquant.sh` | Baseline measurement via the `mlx-lm-turboquant` fork. |
+| `baseline/run_oMLX.sh` | Baseline measurement via the oMLX Python server. |
+| `baseline/group-A-baseline.sh` | Measure the rMLX baseline TPS for the Group-A regression gate. |
+| `baseline/c1-gemma4-cold-equal.sh` | C1 acceptance: gemma4 partial-prefix reuse. |
+| `baseline/d8-phase1-measure.sh` | Quantify the first-dispatch MSL-compile tax. |
+| `autoresearch_run.sh` | Single autoresearch experiment run. |
+
+## Metrics ingest
+
+| Script | What it does |
+|---|---|
+| `ingest/llama_bench_ingest.py` | Convert `llama-bench -o json` rows into the §8.5 universal RunRecord and ingest them. |
+| `ingest/llama_ab_ingest.py` | Promote one accepted `bench_llama_ab.sh` result into two §8.5 RunRecords (one per arm). Refuses a TAINTED run unless told otherwise. |
+| `lib/identity.sh` | Shared §8.5 run-identity (`rmlx metrics identity --json`) for bench scripts. **Source it.** |
+| `lib/prefill_ms.py` | Read `decode_profile{prefill_ms}` back out of an rmlx run log. |
+
+## Profiling / GPU capture
+
+| Script | Via | What it does |
+|---|---|---|
+| `gpu_capture.sh` | `make gpu-capture` | Capture a Metal GPU trace of a bounded steady-state decode window. |
+| `gputrace_preflight.sh` | `make gputrace-preflight` | Check host prerequisites for Apple's GPU tools against a Metal binary. |
+| `gputrace_kernels.sh` | — | List the Metal functions a captured window referenced. |
+| `gputrace_diff.sh` | — | Diff the function sets of two `.gputrace` bundles. |
+| `gputrace_summary.sh` | — | Summarise a `.gputrace` bundle. |
+| `mst_capture.sh` | `make mst-capture` | Record a Metal System Trace of a live `rmlx` run and export the GPU-interval table. |
+| `traces_gc.sh` | `make traces-gc` | Bound how much disk `.rmlx/traces` holds. |
+| `rmlx-capture.entitlements` | — | Entitlements plist for codesigning a capture-enabled binary. |
+
+## Host / environment
+
+| Script | Via | What it does |
+|---|---|---|
+| `mlx_preflight.sh` | `make mlx-preflight` | Verify the linked MLX stack is sane before benching. |
+| `mlx_restore_pin.sh` | `make mlx-restore-pin` | Restore the pinned, nax-capable MLX pair. |
+| `target_gc.sh` | `make target-gc` | Prune stale build profiles from `target/`. |
+| `lib/env.sh` | — | Load repo `.env`, validate `RMLX_O_MODELS_ROOT`. **Source it.** |
+| `lib/cpu_snapshot.sh` | — | Per-process cumulative CPU seconds, for interference gates. **Source it.** |
+| `lib/busiest_between.awk` | — | Which process burned the most CPU between two `cpu_snapshot` files. |
+
+## Release
+
+| Script | Via | What it does |
+|---|---|---|
+| `release/package_binary.sh` | `make release-package` | Build + package the release binary for `aarch64-apple-darwin`. |
+| `release/build_bottle.sh` | — | Build a Homebrew bottle from the installed keg. |
+| `release/source_sha256.sh` | `make release-sha` | Compute the sha256 of a GitHub source tarball and patch the formula. |
+| `release/sync_tap.sh` | `make tap-sync` | Sync `packaging/homebrew/rmlx.rb` into the Homebrew tap. |
+| `release/sign_artifact.sh` | — | Keyless (sigstore) signature for the release tarball. |
+| `release/changelog_section.sh` | — | Print one version's `CHANGELOG.md` section for the GitHub release body. |
+
+## Quality / eval
+
+| Script | What it does |
+|---|---|
+| `eval/wikitext2_ppl.py` | Wikitext-2 perplexity harness for rMLX. |
+| `bench/run_upstream_ppl.py` | Run `mlx_lm.evaluate` wikitext-PPL across the in-scope model set. |
+| `bench/build_ppl_drift_table.py` | Render the PPL × TPS × similarity-drift table. |
+| `bench/extract_outputs.py` | Extract per-(model, backend, quant) greedy-output tuples from CBB `summary.csv`. |
+| `bench/auto_resolution_smoke.py` | 5-model auto-resolution + regression smoke. |
+
+## One-off assets
+
+| Script | What it does |
+|---|---|
+| `gen_lloyd_codebook.py` | Generate Lloyd-Max optimal N(0,1) centroids for the TurboQuant codebook. |
+| `convert_silero_vad.py` | Convert Silero VAD v4 ONNX weights to safetensors. Run once; output is committed. |
+
+## `bench/` — campaign scripts
+
+These are **historical, campaign-scoped** drivers kept for reproducibility of a
+specific report. They hard-code models, contexts and flags for the campaign they
+were written for. Read one before reusing it; prefer extending the general
+drivers above.
+
+`b1_turbo_flash_validate.sh`, `final_matrix_bench.sh`,
+`fullctx_regression_bench.sh`, `gemma_matrix_bench.sh`, `p0b_prefill_bench.sh`,
+`p0b_ttft_only.sh`, `p0b_vg2_niah.sh`, `p1a4_turbo_flash_lock_bench.sh`,
+`p2a_turbo_flash_bench.sh`, `p2c1_remaining_cells.sh`,
+`p2c1_spec_128k_bench.sh`, `t1_final_bench.sh`, `t2_final_bench.sh`,
+`t3_final_bench.sh`, `turboquant_v3_bench.sh`, `vg2_niah_surrogate.sh`,
+`vg2_turbo_flash_lock_qwen35b.sh`, `vg2_turbo_flash_qwen35b.sh`.

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -54,7 +54,8 @@ Conventions:
 | Script | Via | What it does |
 |---|---|---|
 | `perf_ab.sh` | `perf_canary.sh --ab` | **ABBA-interleaved A/B of two `rmlx baseline` arms.** Host-quiescence gate, arm-distinguishability guard, token-id comparison. |
-| `perf_ab_selftest.sh` | `make perf-ab-selftest` | Mutation check for `perf_ab.sh` — every guard must fail when broken. |
+| `perf_ab_selftest.sh` | `make canary-ab-selftest` | Mutation check for `perf_ab.sh` — every guard must fail when broken. |
+| `bench_llama_ab_selftest.sh` | `make llama-ab-selftest` | Mutation check for `bench_llama_ab.sh` against a stub `llama-server` — 13 cases, one per guard. In `make ci`. |
 | `bench_llama_ab.sh` | — | **ABBA-interleaved A/B of two `llama-server` arms** (fork vs upstream, codec vs codec). Same quiescence discipline as `perf_ab.sh`, reported over the server's own `timings` plus KV-buffer and peak-RSS columns. Never writes `runs.db`. |
 | `perf_canary.sh` | `make perf-canary` | Fast decode-TPS canary over the three standard test-target models. |
 | `regression_gate.sh` | — | Compare a committed baseline against the latest canary row. Exit 125 = `git bisect skip`, 1 = regression. |

--- a/scripts/bench_cell.sh
+++ b/scripts/bench_cell.sh
@@ -564,6 +564,20 @@ case "$BACKEND" in
   mlx-lm)
     # Bare Apple stock mlx-lm: no --kv-cache-quantization, so this arm is the
     # unquantised same-framework reference for rMLX, not another codec.
+    #
+    # Because the launcher below cannot express a codec, a quantised KV_QUANT
+    # would be REPORTED and RECORDED while an unquantised run actually happened
+    # -- a row labelled `k8v4` produced with no quantisation at all. Refuse it;
+    # `mlx-lm-turboquant` is the arm that takes a codec.
+    case "$KV_QUANT" in
+      none|auto|bf16|f16) ;;
+      *)
+        echo "[$(date +%T)] CELL FAIL kv-quant-unsupported tag=$TAG backend=mlx-lm kv=$KV_QUANT" >&2
+        echo "  bare mlx-lm serves unquantised KV only; use backend 'mlx-lm-turboquant' for a codec." >&2
+        echo "[$TS_HMS] $TAG | $BACKEND | $KV_QUANT | success=false | coh=false | KV_QUANT_UNSUPPORTED" >>"$PROGRESS"
+        exit 6
+        ;;
+    esac
     "${MLX_LM_ROOT:-../mlx-lm}/.venv/bin/mlx_lm.server" \
         --model "$MODEL_PATH" \
         --port "$PORT" \
@@ -611,8 +625,20 @@ case "$BACKEND" in
     BASE_URL="http://127.0.0.1:$PORT"
     API_KEY=""
     # llama-server serves whatever model it was started with and ignores the
-    # `model` field, so the basename is a label, not a lookup key.
-    HARNESS_MODEL="$(basename "$MODEL_PATH")"
+    # `model` field, so this is a label, not a lookup key. Strip the `.gguf`
+    # extension: the CBB harness derives the recorded `model` column from it,
+    # and `Qwen3-8B-Q8_0.gguf` would become a second champion for the cell that
+    # `scripts/ingest/llama_ab_ingest.py` already records as `Qwen3-8B-Q8_0`.
+    HARNESS_MODEL="$(basename "$MODEL_PATH" .gguf)"
+    # The measured binary's own commit, not the literal "head" the other arms
+    # pass. A version column that says "head" for every run of every build
+    # cannot distinguish two builds, which is the whole point of recording it.
+    BACKEND_VERSION_OVERRIDE="$(git -C "$(dirname "$_LCPP_BIN")/../.." rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    # NOTE: the CBB legacy path still derives `model_namespace` itself, from the
+    # `--model-path` basename, so these cells land under `local` while the A/B
+    # ingest path records them under `hf`. That split lives in the sibling
+    # harness, not here. `bench_llama_ab.sh` + `llama_ab_ingest.py` is the
+    # canonical recorder for GGUF cells; this arm is a smoke/coverage path.
     ;;
   *)
     echo "unknown backend $BACKEND" >&2
@@ -673,7 +699,7 @@ fi
 cd "$CBB"
 HARNESS_ARGS=(
   --backend "$BACKEND"
-  --backend-version "head"
+  --backend-version "${BACKEND_VERSION_OVERRIDE:-head}"
   --base-url "$BASE_URL"
   --model "$HARNESS_MODEL"
   --model-path "$MODEL_PATH"
@@ -710,11 +736,16 @@ if [ -n "$WARM_LINE" ]; then
   WARM_MS=$(echo "$WARM_LINE" | grep -oE "ttft=[0-9.]+ms" | head -1 | sed -E 's/ttft=([0-9.]+)ms/\1/')
   DECODE_TPS=$(echo "$WARM_LINE" | grep -oE "decode=[0-9.]+tps" | head -1 | sed -E 's/decode=([0-9.]+)tps/\1/')
 fi
-# Compute prefill tps = 8192 / (warm_ms/1000) = 8192*1000/warm_ms.
-PREFILL_TPS=0
-if [ -n "$WARM_MS" ] && [ "$(echo "$WARM_MS" | grep -c '^[0-9.]\+$')" -eq 1 ]; then
-  PREFILL_TPS=$(awk -v t="$WARM_MS" 'BEGIN { if (t>0) printf "%.2f", 8192000.0/t; else print "0" }')
-fi
+# Prefill TPS is deliberately NOT computed here. The formula this line used to
+# carry -- 8192000 / warm_ttft_ms -- was fabricated twice over: the 8192 was
+# hard-coded regardless of the real prompt length, and `warm_ttft_ms` is a
+# prompt-cache HIT, so the quotient described a prefill that never ran. It
+# produced ~109 000 and ~88 000 tok/s on the llama.cpp arms. A backend's own
+# `timings.prompt_per_second` is the real figure and is what
+# `scripts/bench_llama_ab.sh` records; nothing downstream of this progress line
+# needs a number here.
+PREFILL_TPS="n/a"
+
 # Success check per harness output.
 if echo "$LINES" | grep -q "success=False"; then SUCCESS=false; fi
 if echo "$LINES" | grep -q "err=other"; then SUCCESS=false; fi

--- a/scripts/bench_cell.sh
+++ b/scripts/bench_cell.sh
@@ -54,7 +54,8 @@ set -uo pipefail
 
 TAG="$1"            # e2b/e4b/26b/31b/31b-paro
 MODEL_PATH="$2"     # abs path to snapshot
-BACKEND="$3"        # rmlx | mlx-lm-turboquant | omlx | paroquant
+BACKEND="$3"        # rmlx | mlx-lm | mlx-lm-turboquant | omlx | paroquant
+                    #   | llama.cpp | llama-cpp-turboquant
 KV_QUANT="$4"       # k8v4|k8v8|planar|mixed | turboquant | native
 BUDGET_MIN="$5"     # int minutes
 MODEL_DISK_GB="$6"  # for harness tps-per-gb
@@ -142,6 +143,7 @@ pkill -f "rmlx serve" 2>/dev/null
 pkill -f mlx_lm 2>/dev/null
 pkill -f paroquant 2>/dev/null
 pkill -f omlx 2>/dev/null
+pkill -f llama-server 2>/dev/null
 sleep 5
 rm -f /tmp/rmlx.*.claim 2>/dev/null
 
@@ -559,6 +561,59 @@ case "$BACKEND" in
     API_KEY=""
     HARNESS_MODEL="$MODEL_PATH"
     ;;
+  mlx-lm)
+    # Bare Apple stock mlx-lm: no --kv-cache-quantization, so this arm is the
+    # unquantised same-framework reference for rMLX, not another codec.
+    "${MLX_LM_ROOT:-../mlx-lm}/.venv/bin/mlx_lm.server" \
+        --model "$MODEL_PATH" \
+        --port "$PORT" \
+        --max-tokens 8192 \
+        --log-level WARNING >"$LOG" 2>&1 &
+    SERVER_PID=$!
+    BASE_URL="http://127.0.0.1:$PORT"
+    API_KEY=""
+    HARNESS_MODEL="$MODEL_PATH"
+    ;;
+  llama.cpp|llama-cpp-turboquant)
+    # GGUF arms. MODEL_PATH is a .gguf file here, not an MLX snapshot dir --
+    # no file exists that both families can load, so a cell against an MLX
+    # backend rests on a stated quant-equivalence assumption (see
+    # docs/PERF_BASELINE.md H2 addendum). The fork-vs-upstream pair does not.
+    #
+    # KV_QUANT is the ggml cache type for both sides; `none` means f16, which
+    # is what upstream calls unquantised KV. `turbo2|turbo3|turbo4` exist only
+    # in the fork, so upstream refuses them at startup rather than silently
+    # running something else.
+    if [ "$BACKEND" = "llama.cpp" ]; then
+      _LCPP_BIN="${LLAMA_CPP_ROOT:-../llama.cpp}/build/bin/llama-server"
+    else
+      _LCPP_BIN="${LLAMA_CPP_TURBOQUANT_ROOT:-../llama-cpp-turboquant}/build/bin/llama-server"
+    fi
+    if [ ! -x "$_LCPP_BIN" ]; then
+      echo "[$(date +%T)] CELL FAIL no-llama-server tag=$TAG backend=$BACKEND path=$_LCPP_BIN" >&2
+      echo "[$TS_HMS] $TAG | $BACKEND | $KV_QUANT | success=false | coh=false | NO_LLAMA_SERVER" >>"$PROGRESS"
+      exit 5
+    fi
+    case "$KV_QUANT" in
+      none|auto) _LCPP_CT="f16" ;;
+      *)         _LCPP_CT="$KV_QUANT" ;;
+    esac
+    "$_LCPP_BIN" \
+        --model "$MODEL_PATH" \
+        --port "$PORT" \
+        --host 127.0.0.1 \
+        -c "$CBB_CTX_MAX" \
+        -np 1 \
+        -fa on \
+        --no-webui \
+        -ctk "$_LCPP_CT" -ctv "$_LCPP_CT" >"$LOG" 2>&1 &
+    SERVER_PID=$!
+    BASE_URL="http://127.0.0.1:$PORT"
+    API_KEY=""
+    # llama-server serves whatever model it was started with and ignores the
+    # `model` field, so the basename is a label, not a lookup key.
+    HARNESS_MODEL="$(basename "$MODEL_PATH")"
+    ;;
   *)
     echo "unknown backend $BACKEND" >&2
     echo "[$TS_HMS] $TAG | $BACKEND | $KV_QUANT | success=false | coh=false | UNKNOWN_BACKEND" >>"$PROGRESS"
@@ -586,7 +641,7 @@ if [ "$READY" -ne 1 ]; then
   echo "[$(date +%T)] CELL FAIL server-not-ready tag=$TAG backend=$BACKEND kv=$KV_QUANT" >&2
   echo "[$(date +%T)] $TAG | $BACKEND | $KV_QUANT | success=false | coh=false | SERVER_NOT_READY" >>"$PROGRESS"
   kill "$SERVER_PID" 2>/dev/null
-  pkill -f "rmlx serve" 2>/dev/null; pkill -f mlx_lm 2>/dev/null; pkill -f omlx 2>/dev/null; pkill -f paroquant 2>/dev/null
+  pkill -f "rmlx serve" 2>/dev/null; pkill -f mlx_lm 2>/dev/null; pkill -f omlx 2>/dev/null; pkill -f paroquant 2>/dev/null; pkill -f llama-server 2>/dev/null
   rm -f /tmp/rmlx.*.claim
   exit 2
 fi
@@ -610,7 +665,7 @@ if [ "$REMAINING" -lt 60 ]; then
   echo "[$(date +%T)] CELL FAIL pre-bench-out-of-budget tag=$TAG" >&2
   echo "[$(date +%T)] $TAG | $BACKEND | $KV_QUANT | success=false | coh=false | OUT_OF_BUDGET" >>"$PROGRESS"
   kill "$SERVER_PID" 2>/dev/null
-  pkill -f "rmlx serve" 2>/dev/null; pkill -f mlx_lm 2>/dev/null; pkill -f omlx 2>/dev/null; pkill -f paroquant 2>/dev/null
+  pkill -f "rmlx serve" 2>/dev/null; pkill -f mlx_lm 2>/dev/null; pkill -f omlx 2>/dev/null; pkill -f paroquant 2>/dev/null; pkill -f llama-server 2>/dev/null
   rm -f /tmp/rmlx.*.claim
   exit 3
 fi
@@ -686,6 +741,7 @@ pkill -f "rmlx serve" 2>/dev/null
 pkill -f mlx_lm 2>/dev/null
 pkill -f omlx 2>/dev/null
 pkill -f paroquant 2>/dev/null
+pkill -f llama-server 2>/dev/null
 sleep 3
 rm -f /tmp/rmlx.*.claim
 

--- a/scripts/bench_llama_ab.sh
+++ b/scripts/bench_llama_ab.sh
@@ -116,7 +116,15 @@ done
 for f in "$BIN_A" "$BIN_B" "$MODEL" "$PROMPT_FILE"; do
 	[ -e "$f" ] || { echo "not found: $f" >&2; exit 125; }
 done
-[ "$PAIRS" -ge 1 ] || { echo "--pairs must be >= 1" >&2; exit 125; }
+# `--pairs 1` gives one slot per arm, so both "ranges" are single points and the
+# overlap test below cannot fire unless the two floats are exactly equal: the
+# verdict would read SEPARATED at the least evidence the harness can collect.
+# Two pairs is the minimum at which a range exists on both sides.
+if [ "$PAIRS" -lt 2 ]; then
+	echo "--pairs must be >= 2: at 1 slot per arm each range is a single point," >&2
+	echo "  so the overlap test cannot fire and every run reads SEPARATED." >&2
+	exit 125
+fi
 
 # ---- arm distinguishability --------------------------------------------------
 # Two arms that are the same build with the same flags produce a difference of
@@ -130,10 +138,49 @@ if [ "$SHA_A" = "$SHA_B" ] && [ "$ARGS_A" = "$ARGS_B" ] && [ "$ENV_A" = "$ENV_B"
 	exit 125
 fi
 
+# ---- arm args must not move what the harness pins -----------------------------
+# `$extra` is appended after the fixed flags, so a later occurrence wins in
+# llama-server's parser. `--args-b "-c 2048"` would run arm B at another context
+# while the report, the result JSON's `n_ctx` and every ingested row still claim
+# `$N_CTX` -- two arms silently become a different experiment, and a wrong
+# `ctx_max` lands in an append-only table. `perf_ab.sh` refuses `--metrics` in
+# arm arguments for exactly this reason.
+PINNED_FLAGS="--model -m --port --host -c --ctx-size -np --parallel -fa --flash-attn -ngl --n-gpu-layers -t --threads"
+refuse_pinned() { # <label> <args>
+	local label="$1" tok
+	for tok in $2; do
+		case " $PINNED_FLAGS " in
+		*" $tok "*)
+			echo "$label sets '$tok', which this harness pins for both arms." >&2
+			echo "  Arm args are appended last, so it would silently win and the" >&2
+			echo "  reported n_ctx / model / dispatch would describe a run that did" >&2
+			echo "  not happen. Use the harness flag instead." >&2
+			exit 125
+			;;
+		esac
+	done
+}
+refuse_pinned --args-a "$ARGS_A"
+refuse_pinned --args-b "$ARGS_B"
+
 CPU_SNAPSHOT_SKIP="$(basename "$BIN_A") $(basename "$BIN_B") llama-server"
 export CPU_SNAPSHOT_SKIP
 # shellcheck source=scripts/lib/cpu_snapshot.sh
 . "${REPO_ROOT}/scripts/lib/cpu_snapshot.sh"
+
+# ---- finding: a stranger already on the port ---------------------------------
+# `llama-server` binds only after it has loaded the model, so a foreign or
+# leftover server on $PORT answers /health immediately while our process is
+# still loading. The measured request would go to the stranger, our process
+# would die on the bind, and BOTH arms would silently measure the same third
+# binary. Refuse the port up front rather than discovering it in the numbers.
+if curl -fsS -m 3 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+	echo "port ${PORT} already answers /health -- something is listening there." >&2
+	echo "  llama-server binds after loading, so this run would measure that" >&2
+	echo "  process instead of its own, on both arms. Free the port or pass" >&2
+	echo "  --port." >&2
+	exit 125
+fi
 
 TMP="$(mktemp -d)"
 cleanup() {
@@ -204,6 +251,17 @@ run_slot() { # <bin> <args> <env> <slotdir>
 		return 1
 	fi
 
+	# Readiness alone does not say WHOSE server answered. Confirm the process
+	# that responds is serving the model this slot launched.
+	local served
+	served="$(curl -fsS -m 5 "http://127.0.0.1:${PORT}/props" 2>/dev/null |
+		python3 -c 'import json,sys; print(json.load(sys.stdin).get("model_path",""))' 2>/dev/null || true)"
+	if [ "$served" != "$MODEL" ]; then
+		kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+		echo "SLOT_FAIL wrong-server: /props reports model '$served', expected '$MODEL'" >&2
+		return 1
+	fi
+
 	# Warmup: a short generation over the same prompt, discarded. It pays the
 	# first-dispatch pipeline compile and the prompt-cache fill so the measured
 	# request times steady-state decode, not Metal's first-use costs.
@@ -232,18 +290,53 @@ run_slot() { # <bin> <args> <env> <slotdir>
 	# The backend's own KV figure. `llama.cpp` prints one line per KV buffer;
 	# summing them is the whole cache, and a codec arm that does not move this
 	# number has not changed what it stores.
-	local kv_mib
-	kv_mib="$(awk '/KV buffer size/ { for (i = 1; i <= NF; i++) if ($i == "MiB") s += $(i-1) } END { printf "%.2f", s+0 }' "$dir/server.log")"
+	# `kv_mib` is half the verdict this harness exists to produce, so a log this
+	# parser cannot read must FAIL the slot. Emitting `0.00` on no match -- a
+	# build that logs GiB, or `2048.00MiB` without the space -- would put a
+	# fabricated zero in the report, the result JSON and `kv_cache_bytes`, where
+	# the §4.1 plausible-value bounds admit 0 as a real gauge reading.
+	local kv_mib kv_hits
+	kv_hits="$(grep -c "KV buffer size" "$dir/server.log" || true)"
+	kv_mib="$(awk '/KV buffer size/ { for (i = 1; i <= NF; i++) if ($i == "MiB") s += $(i-1); n++ } END { if (n == 0 || s <= 0) exit 1; printf "%.2f", s }' "$dir/server.log")" || {
+		echo "SLOT_FAIL kv-buffer-unparsed: ${kv_hits} 'KV buffer size' line(s), no MiB total" >&2
+		return 1
+	}
+
+	# Same rule for resident memory: `ps` returning nothing for every sample
+	# leaves rss_peak at its 0 initialiser, which is not a measurement.
+	if [ "$rss_peak" -le 0 ]; then
+		echo "SLOT_FAIL rss-unsampled: no ps reading for pid $pid during the measured window" >&2
+		return 1
+	fi
 
 	# The generated text goes into the report too. Cross-build output is not
 	# expected to be bit-identical, but a codec that has silently corrupted the
 	# cache produces visible garbage, and a throughput table alone hides it.
-	python3 - "$dir/measure.json" "$kv_mib" "$rss_peak" "$dir/first64" <<'PY'
+	python3 - "$dir/measure.json" "$kv_mib" "$rss_peak" "$dir/first64" "$N_PREDICT" <<'PY'
 import json, sys
 try:
     d = json.load(open(sys.argv[1]))
     t = d["timings"]
-    open(sys.argv[4], "w").write((d.get("content") or "")[:64])
+    want = int(sys.argv[5])
+    # An early EOS or a truncated generation still parses, and its
+    # `predicted_per_second` still enters the median and moves it. A decode
+    # budget that was not spent is not the cell that was asked for.
+    if t["predicted_n"] != want:
+        raise ValueError("decode budget not spent: predicted_n=%s, wanted %d"
+                         % (t["predicted_n"], want))
+    # Zero tokens per second is `tokens / seconds` with a zero numerator --
+    # nothing was measured. It is outside the §4.1 rate window for the same
+    # reason and must not reach the median.
+    if not t["predicted_per_second"] > 0:
+        raise ValueError("predicted_per_second=%s is not a measurement"
+                         % t["predicted_per_second"])
+    text = (d.get("content") or "")[:64]
+    # An empty capture cannot be told apart from "the model emitted only
+    # characters the report strips", and a coherence claim must not rest on
+    # a field that silently reads empty.
+    if not text.strip():
+        raise ValueError("empty generation capture")
+    open(sys.argv[4], "w").write(text)
     print("%.4f %d %d %.4f %s %.1f" % (
         t["predicted_per_second"], t["prompt_n"], t["predicted_n"],
         t["prompt_per_second"], sys.argv[2], float(sys.argv[3]) / 1024.0))
@@ -294,7 +387,13 @@ for arm in $ORDER; do
 	set -- $out
 	tps="$1"; pn="$2"; dn="$3"; ptps="$4"; kv="$5"; rss="$6"
 	win="$(cat "$dir/window")"
+	# The python above refuses to write this file unless the capture was
+	# non-empty, so a missing or blank one here means the contract broke.
 	first64="$(tr -d '|\n' <"$dir/first64" 2>/dev/null || true)"
+	if [ -z "$first64" ]; then
+		echo "slot $SLOT ($label): generation capture is empty" >&2
+		exit 125
+	fi
 	[ "${win%% *}" = "quiet" ] || note_taint "slot $SLOT ($label): $win"
 	echo "  decode ${tps} tok/s | prompt_n ${pn} | predicted ${dn} | kv ${kv} MiB | peak_rss ${rss} MB | host ${win}" >&2
 	echo "  out: ${first64}" >&2
@@ -319,11 +418,18 @@ VERDICT="$(python3 -c '
 import sys
 amin, amed, amax, _ = (float(x) for x in sys.argv[1].split())
 bmin, bmed, bmax, _ = (float(x) for x in sys.argv[2].split())
+n = int(sys.argv[3])
+ratio = bmed / amed
 if amax >= bmin and bmax >= amin:
-    print("INCONCLUSIVE ranges-overlap %.4f" % (bmed / amed))
+    print("INCONCLUSIVE ranges-overlap %.4f" % ratio)
+elif n < 3:
+    # Disjoint ranges built from two points each are disjoint on very little.
+    # Say so rather than letting the strongest word in the vocabulary rest on
+    # the weakest evidence the harness will accept.
+    print("SEPARATED-WEAK n=%d-per-arm %.4f" % (n, ratio))
 else:
-    print("SEPARATED %.4f" % (bmed / amed))
-' "$SA" "$SB")"
+    print("SEPARATED %.4f" % ratio)
+' "$SA" "$SB" "$PAIRS")"
 
 export ROWS
 mkdir -p "$OUT_DIR"

--- a/scripts/bench_llama_ab.sh
+++ b/scripts/bench_llama_ab.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# bench_llama_ab.sh — ABBA-interleaved A/B comparison of two `llama-server` arms.
+#
+# WHY THIS EXISTS
+#
+# `scripts/perf_ab.sh` is the ABBA harness for two `rmlx baseline` arms: it
+# parses that binary's stdout, forbids its `--metrics` flag and compares its
+# token-id line. None of that exists for `llama-server`, whose measurement
+# surface is an HTTP `/completion` response. The measurement *discipline* is
+# the same and is not duplicated here — host quiescence comes from the shared
+# `scripts/lib/cpu_snapshot.sh` + `scripts/lib/busiest_between.awk` pair, on
+# the same cumulative-CPU-seconds criterion and the same default threshold.
+#
+# What is genuinely different, and why this cannot be a flag on perf_ab.sh:
+#
+#   * an arm is a (binary, server flags) pair launched as a daemon, probed for
+#     readiness and shut down again, not a one-shot CLI invocation;
+#   * decode-only throughput is read from the server's own `timings` block,
+#     not from a wall clock the harness holds;
+#   * resident cost is two numbers, not one — the KV buffer size the backend
+#     reports at load, and sampled peak process RSS — because a codec arm that
+#     is faster with the same footprint has not demonstrated anything.
+#
+# DESIGN
+#
+#   * Slots alternate ABBA / BAAB / ABBA …, so monotone drift over the run
+#     contributes equally to both arms. `--pairs N` gives N slots per arm.
+#   * Every slot is a fresh server process. Two servers alive at once would
+#     make each arm's residency the other's memory pressure.
+#   * Foreign CPU use is sampled across each measured window. Anything at or
+#     above `--busy-pct` of one core taints the whole comparison rather than
+#     tilting one arm; a window that could not be sampled taints as well.
+#   * The arms must be distinguishable: identical binary digest AND identical
+#     flags is refused. "A vs B" where both are the same build is the failure
+#     mode that looks most like a result.
+#   * Spread is reported, never hidden. When the two arms' [min,max] ranges
+#     overlap the verdict is INCONCLUSIVE, whatever the medians say.
+#
+# NEVER WRITES TO runs.db. An A/B run is an experiment. Feed an accepted cell
+# to `rmlx metrics record --file` yourself, from the emitted JSON.
+#
+# Exit codes:
+#   0   — ran cleanly; verdict on stdout
+#   125 — not usable: busy host, indistinguishable arms, missing binary or
+#         model, a slot that produced no parseable timing, or TAINTED.
+
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RMLX_HOME="${RMLX_HOME:-${REPO_ROOT}/.rmlx}"
+AWK_BUSIEST="${REPO_ROOT}/scripts/lib/busiest_between.awk"
+
+BIN_A=""; BIN_B=""; ARGS_A=""; ARGS_B=""
+ENV_A=""; ENV_B=""
+LABEL_A="A"; LABEL_B="B"
+MODEL=""; PROMPT_FILE=""
+N_CTX=8192; N_PREDICT=128; PAIRS=2
+PORT=8199; BUSY_PCT=25; ALLOW_BUSY_HOST=false
+READY_TIMEOUT=600
+OUT_DIR="${RMLX_HOME}/bench/llama_ab"
+
+usage() {
+	cat <<'USAGE'
+bench_llama_ab.sh --bin-a P --bin-b P --model GGUF --prompt-file F [options]
+
+  --bin-a/--bin-b PATH     llama-server binary per arm (required)
+  --args-a/--args-b STR    extra server flags per arm, e.g. "-ctk turbo3 -ctv turbo3"
+  --env-a/--env-b STR      extra environment per arm, e.g. "TURBO_FLASH=1". Some
+                           backends gate a kernel on an env knob rather than a
+                           flag; without this such an arm is unreachable.
+  --label-a/--label-b STR  arm label used in the report (default A / B)
+  --model PATH             GGUF weights, identical for both arms (required)
+  --prompt-file PATH       UTF-8 prompt body sent verbatim to /completion (required)
+  --n-ctx N                server context, identical for both arms (default 8192)
+  --n-predict N            decode budget per measured request (default 128)
+  --pairs N                slots per arm; total slots = 2N (default 2, use >=4)
+  --port N                 loopback port for the server (default 8199)
+  --busy-pct N             foreign-CPU taint threshold, % of one core (default 25)
+  --allow-busy-host        start anyway on a busy host; output is marked TAINTED
+  --ready-timeout S        seconds to wait for /health per slot (default 600)
+  --out-dir PATH           JSON result directory (default $RMLX_HOME/bench/llama_ab)
+USAGE
+}
+
+need_value() { [ "$2" -ge 2 ] || { echo "$1 needs a value" >&2; exit 125; }; }
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--bin-a) need_value "$1" $#; BIN_A="$2"; shift 2 ;;
+	--bin-b) need_value "$1" $#; BIN_B="$2"; shift 2 ;;
+	--args-a) need_value "$1" $#; ARGS_A="$2"; shift 2 ;;
+	--args-b) need_value "$1" $#; ARGS_B="$2"; shift 2 ;;
+	--env-a) need_value "$1" $#; ENV_A="$2"; shift 2 ;;
+	--env-b) need_value "$1" $#; ENV_B="$2"; shift 2 ;;
+	--label-a) need_value "$1" $#; LABEL_A="$2"; shift 2 ;;
+	--label-b) need_value "$1" $#; LABEL_B="$2"; shift 2 ;;
+	--model) need_value "$1" $#; MODEL="$2"; shift 2 ;;
+	--prompt-file) need_value "$1" $#; PROMPT_FILE="$2"; shift 2 ;;
+	--n-ctx) need_value "$1" $#; N_CTX="$2"; shift 2 ;;
+	--n-predict) need_value "$1" $#; N_PREDICT="$2"; shift 2 ;;
+	--pairs) need_value "$1" $#; PAIRS="$2"; shift 2 ;;
+	--port) need_value "$1" $#; PORT="$2"; shift 2 ;;
+	--busy-pct) need_value "$1" $#; BUSY_PCT="$2"; shift 2 ;;
+	--allow-busy-host) ALLOW_BUSY_HOST=true; shift ;;
+	--ready-timeout) need_value "$1" $#; READY_TIMEOUT="$2"; shift 2 ;;
+	--out-dir) need_value "$1" $#; OUT_DIR="$2"; shift 2 ;;
+	-h | --help) usage; exit 0 ;;
+	*) echo "unknown argument: $1" >&2; usage >&2; exit 125 ;;
+	esac
+done
+
+[ -n "$BIN_A" ] || { echo "missing required --bin-a" >&2; exit 125; }
+[ -n "$BIN_B" ] || { echo "missing required --bin-b" >&2; exit 125; }
+[ -n "$MODEL" ] || { echo "missing required --model" >&2; exit 125; }
+[ -n "$PROMPT_FILE" ] || { echo "missing required --prompt-file" >&2; exit 125; }
+for f in "$BIN_A" "$BIN_B" "$MODEL" "$PROMPT_FILE"; do
+	[ -e "$f" ] || { echo "not found: $f" >&2; exit 125; }
+done
+[ "$PAIRS" -ge 1 ] || { echo "--pairs must be >= 1" >&2; exit 125; }
+
+# ---- arm distinguishability --------------------------------------------------
+# Two arms that are the same build with the same flags produce a difference of
+# pure noise and a report that reads exactly like a real one. A stash / build /
+# unstash sequence that left the old binary in place is how that happens.
+SHA_A="$(shasum -a 256 "$BIN_A" | awk '{print $1}')"
+SHA_B="$(shasum -a 256 "$BIN_B" | awk '{print $1}')"
+if [ "$SHA_A" = "$SHA_B" ] && [ "$ARGS_A" = "$ARGS_B" ] && [ "$ENV_A" = "$ENV_B" ]; then
+	echo "arms are indistinguishable: same binary digest, same flags, same env." >&2
+	echo "  digest: $SHA_A" >&2
+	exit 125
+fi
+
+CPU_SNAPSHOT_SKIP="$(basename "$BIN_A") $(basename "$BIN_B") llama-server"
+export CPU_SNAPSHOT_SKIP
+# shellcheck source=scripts/lib/cpu_snapshot.sh
+. "${REPO_ROOT}/scripts/lib/cpu_snapshot.sh"
+
+TMP="$(mktemp -d)"
+cleanup() {
+	pkill -f "llama-server .*--port ${PORT}" 2>/dev/null || true
+	rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+host_busiest() { # <before> <after> <window_s> -> "<state> <pct> <comm>"
+	local raw
+	if [ -e "$1.failed" ] || [ -e "$2.failed" ]; then echo "unmeasured - -"; return; fi
+	raw="$(awk -v window="$3" -f "$AWK_BUSIEST" "$1" "$2")"
+	case "${raw%% *}" in
+	unmeasured) echo "unmeasured - -" ;;
+	idle) echo "quiet 0.0 -" ;;
+	*)
+		if awk -v p="$(echo "$raw" | awk '{print $2}')" -v t="$BUSY_PCT" 'BEGIN { exit !(p >= t) }'; then
+			echo "busy ${raw#* }"
+		else
+			echo "quiet ${raw#* }"
+		fi
+		;;
+	esac
+}
+
+snapshot_ok() { cpu_snapshot "$1" && return 0; : >"$1.failed"; return 1; }
+
+# ---- entry gate --------------------------------------------------------------
+snapshot_ok "$TMP/entry_a" || true
+sleep 5
+snapshot_ok "$TMP/entry_b" || true
+ENTRY="$(host_busiest "$TMP/entry_a" "$TMP/entry_b" 5)"
+ENTRY_STATE="${ENTRY%% *}"
+if [ "$ENTRY_STATE" != "quiet" ]; then
+	echo "host is not quiescent: ${ENTRY}" >&2
+	if ! $ALLOW_BUSY_HOST; then
+		echo "  Quiesce the host, or pass --allow-busy-host to see the numbers anyway." >&2
+		exit 125
+	fi
+	echo "  --allow-busy-host: every number below is suspect." >&2
+fi
+
+TAINT=""
+note_taint() { TAINT="${TAINT}$1; "; }
+[ "$ENTRY_STATE" != "quiet" ] && note_taint "entry gate: $ENTRY"
+
+# ---- one slot ----------------------------------------------------------------
+# Emits "<decode_tps> <prompt_n> <predicted_n> <prompt_tps> <kv_mib> <peak_rss_mb>".
+run_slot() { # <bin> <args> <env> <slotdir>
+	local bin="$1" extra="$2" armenv="$3" dir="$4"
+	mkdir -p "$dir"
+	# shellcheck disable=SC2086  # armenv and extra are deliberate word lists
+	env $armenv "$bin" --model "$MODEL" --port "$PORT" --host 127.0.0.1 \
+		-c "$N_CTX" -np 1 -fa on --no-webui \
+		$extra >"$dir/server.log" 2>&1 &
+	local pid=$!
+
+	local deadline=$(( $(date +%s) + READY_TIMEOUT ))
+	local ready=0
+	while [ "$(date +%s)" -lt "$deadline" ]; do
+		sleep 1
+		kill -0 "$pid" 2>/dev/null || break
+		if curl -fsS -m 3 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then ready=1; break; fi
+	done
+	if [ "$ready" -ne 1 ]; then
+		kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+		echo "SLOT_FAIL server-not-ready" >&2
+		return 1
+	fi
+
+	# Warmup: a short generation over the same prompt, discarded. It pays the
+	# first-dispatch pipeline compile and the prompt-cache fill so the measured
+	# request times steady-state decode, not Metal's first-use costs.
+	post_completion "$dir/warmup.json" 8 >/dev/null 2>&1 || true
+
+	local rss_peak=0 rss
+	snapshot_ok "$dir/cpu_before" || true
+	local t0 t1
+	t0="$(python3 -c 'import time; print(time.time())')"
+	post_completion "$dir/measure.json" "$N_PREDICT" >/dev/null 2>&1 &
+	local reqpid=$!
+	while kill -0 "$reqpid" 2>/dev/null; do
+		rss="$(ps -o rss= -p "$pid" 2>/dev/null | tr -d ' ')"
+		[ -n "$rss" ] && [ "$rss" -gt "$rss_peak" ] && rss_peak="$rss"
+		sleep 0.5
+	done
+	wait "$reqpid" 2>/dev/null || true
+	t1="$(python3 -c 'import time; print(time.time())')"
+	snapshot_ok "$dir/cpu_after" || true
+	local window; window="$(awk -v a="$t0" -v b="$t1" 'BEGIN { printf "%.3f", b - a }')"
+	host_busiest "$dir/cpu_before" "$dir/cpu_after" "$window" >"$dir/window"
+
+	kill "$pid" 2>/dev/null || true
+	wait "$pid" 2>/dev/null || true
+
+	# The backend's own KV figure. `llama.cpp` prints one line per KV buffer;
+	# summing them is the whole cache, and a codec arm that does not move this
+	# number has not changed what it stores.
+	local kv_mib
+	kv_mib="$(awk '/KV buffer size/ { for (i = 1; i <= NF; i++) if ($i == "MiB") s += $(i-1) } END { printf "%.2f", s+0 }' "$dir/server.log")"
+
+	# The generated text goes into the report too. Cross-build output is not
+	# expected to be bit-identical, but a codec that has silently corrupted the
+	# cache produces visible garbage, and a throughput table alone hides it.
+	python3 - "$dir/measure.json" "$kv_mib" "$rss_peak" "$dir/first64" <<'PY'
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    t = d["timings"]
+    open(sys.argv[4], "w").write((d.get("content") or "")[:64])
+    print("%.4f %d %d %.4f %s %.1f" % (
+        t["predicted_per_second"], t["prompt_n"], t["predicted_n"],
+        t["prompt_per_second"], sys.argv[2], float(sys.argv[3]) / 1024.0))
+except Exception as exc:  # noqa: BLE001 - any parse failure fails the slot
+    print("PARSE_FAIL %s" % exc, file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+post_completion() { # <outfile> <n_predict>
+	python3 - "$1" "$2" "$PROMPT_FILE" "$PORT" <<'PY'
+import json, sys, urllib.request
+out, npred, pfile, port = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+body = json.dumps({
+    "prompt": open(pfile, encoding="utf-8").read(),
+    "n_predict": npred,
+    "temperature": 0.0,
+    "top_k": 1,
+    "seed": 0,
+    "cache_prompt": False,
+    "stream": False,
+}).encode()
+req = urllib.request.Request("http://127.0.0.1:%s/completion" % port, data=body,
+                             headers={"content-type": "application/json"})
+with urllib.request.urlopen(req, timeout=3600) as r:
+    open(out, "wb").write(r.read())
+PY
+}
+
+# ---- ABBA --------------------------------------------------------------------
+ORDER=""
+for i in $(seq 1 "$PAIRS"); do
+	if [ $((i % 2)) -eq 1 ]; then ORDER="$ORDER A B"; else ORDER="$ORDER B A"; fi
+done
+
+TPS_A=""; TPS_B=""; ROWS=""
+TOTAL=$((PAIRS * 2))
+SLOT=0
+for arm in $ORDER; do
+	SLOT=$((SLOT + 1))
+	if [ "$arm" = "A" ]; then bin="$BIN_A"; extra="$ARGS_A"; armenv="$ENV_A"; label="$LABEL_A"; else bin="$BIN_B"; extra="$ARGS_B"; armenv="$ENV_B"; label="$LABEL_B"; fi
+	dir="$TMP/slot$SLOT"
+	echo "[slot $SLOT/$TOTAL] $label" >&2
+	if ! out="$(run_slot "$bin" "$extra" "$armenv" "$dir")"; then
+		echo "slot $SLOT ($label) produced no measurement" >&2
+		exit 125
+	fi
+	set -- $out
+	tps="$1"; pn="$2"; dn="$3"; ptps="$4"; kv="$5"; rss="$6"
+	win="$(cat "$dir/window")"
+	first64="$(tr -d '|\n' <"$dir/first64" 2>/dev/null || true)"
+	[ "${win%% *}" = "quiet" ] || note_taint "slot $SLOT ($label): $win"
+	echo "  decode ${tps} tok/s | prompt_n ${pn} | predicted ${dn} | kv ${kv} MiB | peak_rss ${rss} MB | host ${win}" >&2
+	echo "  out: ${first64}" >&2
+	ROWS="${ROWS}${arm}|${label}|${tps}|${pn}|${dn}|${ptps}|${kv}|${rss}|${win}|${first64}
+"
+	if [ "$arm" = "A" ]; then TPS_A="$TPS_A $tps"; else TPS_B="$TPS_B $tps"; fi
+done
+
+stats() { # <values...> -> "min median max mean"
+	python3 -c '
+import statistics, sys
+v = sorted(float(x) for x in sys.argv[1:])
+print("%.3f %.3f %.3f %.3f" % (v[0], statistics.median(v), v[-1], statistics.fmean(v)))
+' $1
+}
+# shellcheck disable=SC2086  # word splitting is the intent
+SA="$(stats "$TPS_A")"
+# shellcheck disable=SC2086
+SB="$(stats "$TPS_B")"
+
+VERDICT="$(python3 -c '
+import sys
+amin, amed, amax, _ = (float(x) for x in sys.argv[1].split())
+bmin, bmed, bmax, _ = (float(x) for x in sys.argv[2].split())
+if amax >= bmin and bmax >= amin:
+    print("INCONCLUSIVE ranges-overlap %.4f" % (bmed / amed))
+else:
+    print("SEPARATED %.4f" % (bmed / amed))
+' "$SA" "$SB")"
+
+export ROWS
+mkdir -p "$OUT_DIR"
+# Two forms on purpose: the file name wants a compact stamp, and `ts_utc` in a
+# §8.5 RunRecord must be ISO-8601 UTC. Emitting only the compact one put a
+# string the ingest contract does not accept into every result file.
+TS_FILE="$(date -u +%Y%m%dT%H%M%SZ)"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+RESULT="${OUT_DIR}/${TS_FILE}.json"
+python3 - "$RESULT" "$LABEL_A" "$LABEL_B" "$SHA_A" "$SHA_B" "$ARGS_A" "$ARGS_B" \
+	"$MODEL" "$PROMPT_FILE" "$N_CTX" "$N_PREDICT" "$SA" "$SB" "$VERDICT" "${TAINT%; }" "$TS" \
+	"$ENV_A" "$ENV_B" <<'PY'
+import json, os, sys
+(out, la, lb, sa, sb, aa, ab, model, prompt, nctx, npred, statsa, statsb,
+ verdict, taint, ts, ea, eb) = sys.argv[1:19]
+rows = []
+for line in os.environ.get("ROWS", "").splitlines():
+    if not line.strip():
+        continue
+    f = line.split("|")
+    rows.append({"arm": f[0], "label": f[1], "decode_tps": float(f[2]),
+                 "prompt_n": int(f[3]), "predicted_n": int(f[4]),
+                 "prompt_tps": float(f[5]), "kv_mib": float(f[6]),
+                 "peak_rss_mb": float(f[7]), "host_window": f[8],
+                 "output_first_64": f[9] if len(f) > 9 else ""})
+def st(s):
+    v = [float(x) for x in s.split()]
+    return {"min": v[0], "median": v[1], "max": v[2], "mean": v[3]}
+json.dump({
+    "ts_utc": ts, "model": model, "prompt_file": prompt,
+    "n_ctx": int(nctx), "n_predict": int(npred),
+    "arms": {"A": {"label": la, "sha256": sa, "args": aa, "env": ea, "decode_tps": st(statsa)},
+             "B": {"label": lb, "sha256": sb, "args": ab, "env": eb, "decode_tps": st(statsb)}},
+    "slots": rows, "verdict": verdict, "tainted": taint or None,
+}, open(out, "w"), indent=2)
+PY
+
+echo
+echo "model      $MODEL"
+echo "n_ctx      $N_CTX   n_predict $N_PREDICT   pairs $PAIRS"
+echo "arm A      $LABEL_A  [${SHA_A:0:12}]  ${ARGS_A:-<no extra flags>}  ${ENV_A:+env: $ENV_A}"
+echo "arm B      $LABEL_B  [${SHA_B:0:12}]  ${ARGS_B:-<no extra flags>}  ${ENV_B:+env: $ENV_B}"
+printf 'decode A   min %s  median %s  max %s  mean %s\n' $SA
+printf 'decode B   min %s  median %s  max %s  mean %s\n' $SB
+echo "verdict    $VERDICT   (B/A on medians)"
+echo "result     $RESULT"
+if [ -n "$TAINT" ]; then
+	echo "TAINTED    ${TAINT%; }"
+	exit 125
+fi

--- a/scripts/bench_llama_ab_selftest.sh
+++ b/scripts/bench_llama_ab_selftest.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# bench_llama_ab_selftest.sh — mutation check for `scripts/bench_llama_ab.sh`.
+#
+# Every guard in that harness exists because a specific wrong answer is
+# reachable without it. A guard nobody has watched fail is a comment. This file
+# drives each one to its failure, against a stub `llama-server` — no GPU, no
+# GGUF, no metrics database — and asserts the exit code AND the reason text, so
+# a guard that starts failing for a different reason does not read as passing.
+#
+# Its sibling `perf_ab_selftest.sh` does the same for `perf_ab.sh`.
+#
+# Exit 0 = every case produced its expected exit code and message.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AB="$ROOT/scripts/bench_llama_ab.sh"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/rmlx_llama_ab_selftest.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+MODEL="$WORK/model.gguf"
+PROMPT="$WORK/prompt.txt"
+printf 'weights\n' >"$MODEL"
+printf 'the quick brown fox\n' >"$PROMPT"
+
+# A free port, so a real service on the default never makes a case pass or fail
+# for the wrong reason.
+PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+
+PASS=0
+FAIL=0
+
+# make_stub <name> <tps-csv> <kv-line> <content> [predicted_n] [prompt_n] [props_model]
+#
+# Stands in for `llama-server`: serves /health, /props and /completion over a
+# real socket, prints the KV line the harness parses out of the log, and cycles
+# <tps-csv> across successive processes via a shared counter file so an arm
+# shows a spread rather than a constant.
+make_stub() {
+	local name="$1" tps="$2" kvline="$3" content="$4"
+	local predicted="${5:-4}" promptn="${6:-9}" props="${7:-}"
+	local path="$WORK/$name"
+	cat >"$path" <<STUB
+#!/usr/bin/env bash
+# stub llama-server: $name
+set -eu
+port=""; model=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --port) port="\$2"; shift 2 ;;
+    --model) model="\$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+# The KV line the harness greps out of the server log.
+printf '%s\n' "$kvline"
+n=0
+[ -f "$WORK/${name}.n" ] && n="\$(cat "$WORK/${name}.n")"
+echo \$((n + 1)) >"$WORK/${name}.n"
+props="$props"
+[ -n "\$props" ] || props="\$model"
+export STUB_TPS_CSV="$tps" STUB_N="\$n" STUB_MODEL="\$props"
+export STUB_CONTENT="$content" STUB_PRED="$predicted" STUB_PROMPTN="$promptn"
+exec python3 "$WORK/serve.py" "\$port"
+STUB
+	chmod +x "$path"
+	echo "$path"
+}
+
+cat >"$WORK/serve.py" <<'SERVE'
+import json, os, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+TPS = [float(x) for x in os.environ["STUB_TPS_CSV"].split(",")]
+N = int(os.environ["STUB_N"])
+TPSV = TPS[N % len(TPS)]
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def _send(self, obj):
+        b = json.dumps(obj).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(b)))
+        self.end_headers()
+        self.wfile.write(b)
+    def do_GET(self):
+        if self.path.startswith("/health"):
+            self._send({"status": "ok"})
+        elif self.path.startswith("/props"):
+            self._send({"model_path": os.environ["STUB_MODEL"]})
+        else:
+            self.send_response(404); self.end_headers()
+    def do_POST(self):
+        n = int(self.headers.get("content-length", 0))
+        self.rfile.read(n)
+        self._send({
+            "content": os.environ["STUB_CONTENT"],
+            "timings": {
+                "predicted_per_second": TPSV,
+                "prompt_per_second": 100.0,
+                "prompt_n": int(os.environ["STUB_PROMPTN"]),
+                "predicted_n": int(os.environ["STUB_PRED"]),
+            },
+        })
+
+HTTPServer(("127.0.0.1", int(sys.argv[1])), H).serve_forever()
+SERVE
+
+KV_OK='llama_kv_cache:       MTL0 KV buffer size =   512.00 MiB'
+
+run_ab() { # <extra args...> -> stdout+stderr in $OUT, code in $CODE
+	OUT="$(RMLX_HOME="$WORK/home" bash "$AB" \
+		--model "$MODEL" --prompt-file "$PROMPT" \
+		--port "$PORT" --n-predict 4 --n-ctx 64 \
+		--out-dir "$WORK/home/bench" --ready-timeout 25 \
+		"$@" 2>&1)"
+	CODE=$?
+}
+
+# check <label> <expected-code> <expected-substring>
+check() {
+	local label="$1" want="$2" needle="$3"
+	if [ "$CODE" -eq "$want" ] && printf '%s' "$OUT" | grep -q -- "$needle"; then
+		echo "  PASS  $label"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL  $label (exit $CODE, wanted $want; looking for: $needle)"
+		printf '%s\n' "$OUT" | sed 's/^/        /' | tail -12
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+echo "bench_llama_ab selftest"
+
+# --- guard: indistinguishable arms -------------------------------------------
+STUB_A="$(make_stub a "50,52" "$KV_OK" "hello world")"
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_A" --pairs 2 --allow-busy-host
+check "identical binary + flags + env is refused" 125 "indistinguishable"
+
+# --- guard: --pairs 1 cannot produce a range ---------------------------------
+STUB_B="$(make_stub b "30,31" "$KV_OK" "hello world")"
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_B" --pairs 1 --allow-busy-host
+check "--pairs 1 is refused (overlap test cannot fire)" 125 "pairs must be >= 2"
+
+# --- guard: arm args must not move a harness-pinned flag ---------------------
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_B" --pairs 2 --allow-busy-host \
+	--args-b "-c 2048"
+check "arm args cannot override a pinned flag" 125 "which this harness pins"
+
+# --- guard: a busy port would make both arms measure a stranger --------------
+python3 - "$PORT" <<'SQUAT' &
+import sys, json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_GET(self):
+        b = json.dumps({"status": "ok"}).encode()
+        self.send_response(200); self.send_header("content-length", str(len(b)))
+        self.end_headers(); self.wfile.write(b)
+HTTPServer(("127.0.0.1", int(sys.argv[1])), H).serve_forever()
+SQUAT
+SQUATTER=$!
+sleep 1
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_B" --pairs 2 --allow-busy-host
+check "an occupied port is refused up front" 125 "already answers /health"
+kill "$SQUATTER" 2>/dev/null
+wait "$SQUATTER" 2>/dev/null
+
+# --- guard: a KV line the parser cannot read must fail, not read 0.00 --------
+STUB_NOKV="$(make_stub nokv "30,31" 'llama_kv_cache: KV buffer size = 0.50 GiB' "hello world")"
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_NOKV" --pairs 2 --allow-busy-host
+check "unparseable KV buffer size fails the slot" 125 "kv-buffer-unparsed"
+
+# --- guard: a decode budget that was not spent -------------------------------
+STUB_SHORT="$(make_stub short "30,31" "$KV_OK" "hello world" 2)"
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_SHORT" --pairs 2 --allow-busy-host
+check "truncated generation fails the slot" 125 "decode budget not spent"
+
+# --- guard: zero decode TPS is not a measurement -----------------------------
+STUB_ZERO="$(make_stub zero "0,0" "$KV_OK" "hello world")"
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_ZERO" --pairs 2 --allow-busy-host
+check "predicted_per_second=0 fails the slot" 125 "is not a measurement"
+
+# --- guard: an empty generation capture --------------------------------------
+STUB_EMPTY="$(make_stub empty "30,31" "$KV_OK" "")"
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_EMPTY" --pairs 2 --allow-busy-host
+check "empty generation capture fails the slot" 125 "empty generation capture"
+
+# --- guard: the server that answered must be ours ----------------------------
+STUB_WRONG="$(make_stub wrong "30,31" "$KV_OK" "hello world" 4 9 "/some/other/model.gguf")"
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_WRONG" --pairs 2 --allow-busy-host
+check "a server serving another model fails the slot" 125 "wrong-server"
+
+# --- behaviour: overlapping ranges must read INCONCLUSIVE --------------------
+# Both arms emit the SAME tps sequence from two distinguishable binaries, so
+# the ranges coincide exactly. If this reads SEPARATED the overlap test is
+# inert and every one of this campaign's verdicts is worthless.
+STUB_C="$(make_stub c "50,52" "$KV_OK" "hello world")"
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_C" --pairs 2 --allow-busy-host
+check "identical timings read INCONCLUSIVE" 125 "INCONCLUSIVE ranges-overlap"
+
+# --- behaviour: disjoint ranges at n=2 must be flagged weak ------------------
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_B" --pairs 2 --allow-busy-host
+check "disjoint ranges at n=2 read SEPARATED-WEAK" 125 "SEPARATED-WEAK n=2-per-arm"
+
+# --- behaviour: disjoint ranges at n=3 read SEPARATED ------------------------
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_B" --pairs 3 --allow-busy-host
+check "disjoint ranges at n=3 read SEPARATED" 125 "SEPARATED 0."
+
+# --- the harness must never write runs.db ------------------------------------
+if find "$WORK/home" -name 'runs.db*' -print -quit 2>/dev/null | grep -q .; then
+	echo "  FAIL  harness wrote a metrics DB"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS  no metrics DB written"
+	PASS=$((PASS + 1))
+fi
+
+echo "bench_llama_ab selftest: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/ingest/llama_ab_ingest.py
+++ b/scripts/ingest/llama_ab_ingest.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Ingest a `scripts/bench_llama_ab.sh` result into the rMLX metrics DB.
+
+`bench_llama_ab.sh` deliberately never touches `runs.db` — an A/B run is an
+experiment and the store is append-only. This is the separate, explicit step
+that promotes one accepted comparison into two §8.5 RunRecords, one per arm.
+
+Sibling of `llama_bench_ingest.py`, which reads `llama-bench -o json`. The two
+inputs are unrelated shapes: `llama-bench` measures synthetic token generation
+and registers a placeholder prompt, while this reads real `/completion` timings
+over a real prompt body and carries the resident-memory columns
+(`kv_cache_bytes`, `peak_rss_mb`) that `llama-bench` cannot report at all.
+
+Usage:
+    # Inspect the records without writing anything:
+    python3 scripts/ingest/llama_ab_ingest.py --dry-run RESULT.json \
+        --arm-a-backend llama_cpp --arm-b-backend llama_cpp_tq \
+        --model Qwen3-8B-Q8_0 --weight-quant q8_0 \
+        --arm-a-kv-quant none --arm-b-kv-quant turbo3 \
+        --prompt-name longctx_8k_text --prompt-file PROMPT.txt
+
+    # Write buffer files and ingest them:
+    python3 scripts/ingest/llama_ab_ingest.py --record RESULT.json ...
+
+Every identity field a cross-backend row needs is caller-supplied and none is
+guessed. `backend_version` is free-form for non-rMLX backends (§8.5.1) — pass
+the build commit. A run the harness marked TAINTED is refused unless
+`--accept-tainted` is given, and the taint text is then carried into `notes`:
+promoting a tainted number silently is how an experiment becomes a permanent
+row nobody can take back out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+RMLX_REPO_ROOT = Path(os.environ.get("RMLX_REPO_ROOT", str(_SCRIPT_DIR.parents[1])))
+# Runtime state lives under a single root (CLAUDE.md). `RMLX_HOME` wins; the
+# in-repo `.rmlx/` is the dev default.
+RMLX_HOME = Path(os.environ.get("RMLX_HOME", str(RMLX_REPO_ROOT / ".rmlx")))
+BUFFER_PENDING = RMLX_HOME / "metrics" / "buffer" / "pending"
+
+MIB = 1024 * 1024
+
+
+def _arm_record(
+    result: dict[str, Any],
+    arm: str,
+    args: argparse.Namespace,
+    prompt_body: str,
+) -> dict[str, Any]:
+    """Build one §8.5 RunRecord from one arm of an A/B result."""
+    slots = [s for s in result["slots"] if s["arm"] == arm]
+    if not slots:
+        raise SystemExit(f"no slots for arm {arm} in {args.result}")
+
+    tps = [s["decode_tps"] for s in slots]
+    backend = args.arm_a_backend if arm == "A" else args.arm_b_backend
+    version = args.arm_a_version if arm == "A" else args.arm_b_version
+    kv_quant = args.arm_a_kv_quant if arm == "A" else args.arm_b_kv_quant
+
+    # One measurement per slot, so a single-slot arm has no sample stddev.
+    stddev = statistics.stdev(tps) if len(tps) > 1 else None
+
+    # Every slot of one arm allocates the same KV buffer (same n_ctx, same
+    # codec); differing values mean the arm was not one configuration.
+    kv_mib = {s["kv_mib"] for s in slots}
+    if len(kv_mib) != 1:
+        raise SystemExit(f"arm {arm} slots disagree on kv_mib: {sorted(kv_mib)}")
+
+    notes = (
+        f"bench_llama_ab.sh ABBA n={len(slots)}/arm; "
+        f"decode_tps median over slots, min={min(tps):.3f} max={max(tps):.3f}; "
+        f"verdict={result['verdict']}"
+    )
+    if result.get("tainted"):
+        notes += f"; TAINTED: {result['tainted']}"
+
+    return {
+        "schema_version": 1,
+        "backend": backend,
+        "backend_version": version,
+        "model_namespace": args.model_namespace,
+        "model": args.model,
+        "weight_quant": args.weight_quant,
+        "kv_quant": kv_quant,
+        "ctx_max": result["n_ctx"],
+        "prompt": {"name": args.prompt_name, "body": prompt_body, "notes": args.prompt_notes},
+        "ts_utc": result["ts_utc"].replace("T", "T").replace("Z", "Z"),
+        "git_sha": args.git_sha,
+        "build_profile": "release",
+        "hardware_tag": args.hardware_tag,
+        "prompt_tokens": slots[0]["prompt_n"],
+        "max_tokens": result["n_predict"],
+        "temperature": 0.0,
+        "seed": 0,
+        "n_warmups": 1,
+        "n_measure": len(slots),
+        "output_first_64": slots[0].get("output_first_64") or None,
+        "notes": notes,
+        "description": args.description,
+        "metrics": [
+            {"name": "decode_tps_warm", "value": statistics.median(tps), "stddev": stddev},
+            {
+                "name": "prefill_tps",
+                "value": statistics.median([s["prompt_tps"] for s in slots]),
+            },
+            {"name": "kv_cache_bytes", "value": kv_mib.pop() * MIB},
+            {"name": "peak_rss_mb", "value": statistics.median([s["peak_rss_mb"] for s in slots])},
+        ],
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("result", help="JSON emitted by bench_llama_ab.sh")
+    p.add_argument("--prompt-file", required=True, help="the prompt body that was sent")
+    p.add_argument("--prompt-name", required=True)
+    p.add_argument("--prompt-notes", default=None)
+    p.add_argument("--model", required=True, help="§5.1 model label")
+    p.add_argument("--model-namespace", default="hf")
+    p.add_argument("--weight-quant", required=True, help="§5.2 whitelist value, e.g. q8_0")
+    p.add_argument("--arm-a-backend", required=True, help="§5.4 whitelist value")
+    p.add_argument("--arm-b-backend", required=True)
+    p.add_argument("--arm-a-version", default=None, help="free-form for non-rMLX backends")
+    p.add_argument("--arm-b-version", default=None)
+    p.add_argument("--arm-a-kv-quant", required=True)
+    p.add_argument("--arm-b-kv-quant", required=True)
+    p.add_argument("--hardware-tag", default="m5_max_128gb")
+    p.add_argument("--git-sha", default=None, help="caller-supplied provenance (§8.5.1)")
+    p.add_argument("--description", default=None)
+    p.add_argument("--accept-tainted", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--record", action="store_true", help="ingest via `rmlx metrics record --file`")
+    p.add_argument("--rmlx-bin", default=str(RMLX_REPO_ROOT / "target" / "release" / "rmlx"))
+    args = p.parse_args()
+
+    result = json.loads(Path(args.result).read_text(encoding="utf-8"))
+    if result.get("tainted") and not args.accept_tainted:
+        print(
+            f"refusing: run is TAINTED ({result['tainted']}).\n"
+            "  Re-run on a quiet host, or pass --accept-tainted to record it with the\n"
+            "  taint carried into `notes`.",
+            file=sys.stderr,
+        )
+        return 2
+
+    prompt_body = Path(args.prompt_file).read_text(encoding="utf-8")
+    records = [_arm_record(result, arm, args, prompt_body) for arm in ("A", "B")]
+
+    if args.dry_run:
+        for rec in records:
+            trimmed = dict(rec)
+            trimmed["prompt"] = dict(rec["prompt"], body=f"<{len(prompt_body)} chars>")
+            print(json.dumps(trimmed, indent=2))
+        return 0
+
+    BUFFER_PENDING.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for rec in records:
+        path = BUFFER_PENDING / f"{result['ts_utc']}-{rec['backend']}-{uuid.uuid4().hex[:8]}.json"
+        path.write_text(json.dumps(rec, indent=2), encoding="utf-8")
+        written.append(path)
+        print(f"wrote {path}")
+
+    if not args.record:
+        print("not ingested (pass --record). Inspect the files above first.")
+        return 0
+
+    failed = 0
+    for path in written:
+        proc = subprocess.run(
+            [args.rmlx_bin, "metrics", "record", "--file", str(path)], check=False
+        )
+        if proc.returncode != 0:
+            print(f"ingest FAILED for {path} (exit {proc.returncode})", file=sys.stderr)
+            failed += 1
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ingest/llama_ab_ingest.py
+++ b/scripts/ingest/llama_ab_ingest.py
@@ -48,6 +48,13 @@ RMLX_REPO_ROOT = Path(os.environ.get("RMLX_REPO_ROOT", str(_SCRIPT_DIR.parents[1
 # in-repo `.rmlx/` is the dev default.
 RMLX_HOME = Path(os.environ.get("RMLX_HOME", str(RMLX_REPO_ROOT / ".rmlx")))
 BUFFER_PENDING = RMLX_HOME / "metrics" / "buffer" / "pending"
+# Records are assembled HERE first and only moved into `pending/` for the
+# moment the recorder is actually invoked. Anything sitting in `pending/` is,
+# by contract, work the next `rmlx metrics record --replay-pending` will claim
+# — and that sweep quarantines whatever it cannot ingest into `buffer/failed/`,
+# reporting the reason only on stderr. A "write them and let a human look"
+# mode that stages into the live queue is how an orphaned backlog accumulates.
+STAGING = RMLX_HOME / "bench" / "llama_ab" / "records"
 
 MIB = 1024 * 1024
 
@@ -67,6 +74,9 @@ def _arm_record(
     backend = args.arm_a_backend if arm == "A" else args.arm_b_backend
     version = args.arm_a_version if arm == "A" else args.arm_b_version
     kv_quant = args.arm_a_kv_quant if arm == "A" else args.arm_b_kv_quant
+    # `git_sha` describes the binary that produced the number, so it is per arm.
+    # A single value shared by both would be provenance for neither.
+    per_arm_sha = args.arm_a_git_sha if arm == "A" else args.arm_b_git_sha
 
     # One measurement per slot, so a single-slot arm has no sample stddev.
     stddev = statistics.stdev(tps) if len(tps) > 1 else None
@@ -76,6 +86,19 @@ def _arm_record(
     kv_mib = {s["kv_mib"] for s in slots}
     if len(kv_mib) != 1:
         raise SystemExit(f"arm {arm} slots disagree on kv_mib: {sorted(kv_mib)}")
+
+    # Same rigor for the prompt: differing `prompt_n` across an arm's slots
+    # means the arm was not one configuration, and `prompt_tokens` would then
+    # describe only whichever slot happened to be first.
+    prompt_n = {s["prompt_n"] for s in slots}
+    if len(prompt_n) != 1:
+        raise SystemExit(f"arm {arm} slots disagree on prompt_n: {sorted(prompt_n)}")
+
+    predicted_n = {s["predicted_n"] for s in slots}
+    if len(predicted_n) != 1:
+        raise SystemExit(
+            f"arm {arm} slots disagree on predicted_n: {sorted(predicted_n)}"
+        )
 
     notes = (
         f"bench_llama_ab.sh ABBA n={len(slots)}/arm; "
@@ -95,9 +118,9 @@ def _arm_record(
         "kv_quant": kv_quant,
         "ctx_max": result["n_ctx"],
         "prompt": {"name": args.prompt_name, "body": prompt_body, "notes": args.prompt_notes},
-        "ts_utc": result["ts_utc"].replace("T", "T").replace("Z", "Z"),
-        "git_sha": args.git_sha,
-        "build_profile": "release",
+        "ts_utc": result["ts_utc"],
+        "git_sha": per_arm_sha or args.git_sha,
+        "build_profile": args.build_profile,
         "hardware_tag": args.hardware_tag,
         "prompt_tokens": slots[0]["prompt_n"],
         "max_tokens": result["n_predict"],
@@ -135,8 +158,23 @@ def main() -> int:
     p.add_argument("--arm-b-version", default=None)
     p.add_argument("--arm-a-kv-quant", required=True)
     p.add_argument("--arm-b-kv-quant", required=True)
+    p.add_argument("--arm-a-git-sha", default=None, help="commit of arm A's binary")
+    p.add_argument("--arm-b-git-sha", default=None, help="commit of arm B's binary")
     p.add_argument("--hardware-tag", default="m5_max_128gb")
-    p.add_argument("--git-sha", default=None, help="caller-supplied provenance (§8.5.1)")
+    p.add_argument(
+        "--build-profile",
+        default=None,
+        help="how the measured binary was built, e.g. 'release'. Not guessed: an "
+        "unset value records NULL rather than a plausible-looking default.",
+    )
+    p.add_argument(
+        "--git-sha",
+        default=None,
+        help="caller-supplied provenance (§8.5.1). For a cross-backend arm this is "
+        "the commit of the MEASURED backend, not of rMLX — a column that means "
+        "'the rMLX tree that drove the bench' on some rows and 'the binary under "
+        "test' on others cannot be queried. Pass the arm's own commit, or omit it.",
+    )
     p.add_argument("--description", default=None)
     p.add_argument("--accept-tainted", action="store_true")
     p.add_argument("--dry-run", action="store_true")
@@ -164,25 +202,51 @@ def main() -> int:
             print(json.dumps(trimmed, indent=2))
         return 0
 
-    BUFFER_PENDING.mkdir(parents=True, exist_ok=True)
-    written: list[Path] = []
+    # Compact stamp: every other producer in this tree names buffer files
+    # `YYYYMMDDTHHMMSS...`, and the ISO form puts colons in a filename.
+    stamp = result["ts_utc"].replace("-", "").replace(":", "")
+
+    STAGING.mkdir(parents=True, exist_ok=True)
+    staged: list[Path] = []
     for rec in records:
-        path = BUFFER_PENDING / f"{result['ts_utc']}-{rec['backend']}-{uuid.uuid4().hex[:8]}.json"
+        path = STAGING / f"{stamp}-{rec['backend']}-{uuid.uuid4().hex[:8]}.json"
         path.write_text(json.dumps(rec, indent=2), encoding="utf-8")
-        written.append(path)
-        print(f"wrote {path}")
+        staged.append(path)
+        print(f"staged {path}")
 
     if not args.record:
-        print("not ingested (pass --record). Inspect the files above first.")
+        print(
+            "not ingested (pass --record). The files above are OUTSIDE\n"
+            f"  {BUFFER_PENDING},\n"
+            "  so no --replay-pending sweep can claim them. Inspect, then re-run\n"
+            "  with --record."
+        )
         return 0
 
+    # Move into the live queue one file at a time, immediately before the
+    # recorder claims it, and take it back out either way. Nothing this script
+    # writes is reachable by `--replay-pending` unless that invocation put it
+    # there.
+    BUFFER_PENDING.mkdir(parents=True, exist_ok=True)
     failed = 0
-    for path in written:
-        proc = subprocess.run(
-            [args.rmlx_bin, "metrics", "record", "--file", str(path)], check=False
-        )
+    for path in staged:
+        queued = BUFFER_PENDING / path.name
+        path.rename(queued)
+        try:
+            proc = subprocess.run(
+                [args.rmlx_bin, "metrics", "record", "--file", str(queued)], check=False
+            )
+        finally:
+            # The recorder deletes on success; on failure the file is ours to
+            # retrieve, not the next sweep's to quarantine.
+            if queued.exists():
+                queued.rename(path)
         if proc.returncode != 0:
-            print(f"ingest FAILED for {path} (exit {proc.returncode})", file=sys.stderr)
+            print(
+                f"ingest FAILED for {path} (exit {proc.returncode}); "
+                "record kept in staging, not in the pending queue",
+                file=sys.stderr,
+            )
             failed += 1
     return 1 if failed else 0
 


### PR DESCRIPTION
Closes #415.

The deliverable is evidence, and downstream kernel work (#405, #340) is gated on it.

## The decisive cell

Fork (`llama-cpp-turboquant`) vs upstream `llama.cpp` at the merge-base — same GGUF file, same graph, same flags, same sampling. **The only variable is the KV codec.** No quant-equivalence assumption anywhere in this pair.

| model | prompt tok | n_ctx | upstream f16 | fork turbo3 | ratio | KV MiB | n/arm |
|---|---:|---:|---|---|---:|---|---:|
| Qwen3-8B-Q8_0 | 3 753 | 4 608 | 52.05 | 38.17 | **0.733x** | 648 -> 126.7 | 4 |
| Qwen3-8B-Q8_0 | 7 722 | 16 384 | 54.89 | 38.69 | **0.705x** | 2 304 -> 450.1 | 4 |
| Qwen3-8B-Q8_0 | 31 536 | 40 960 | 35.25 | 24.33 | **0.690x** | 5 760 -> 1 125.1 | 4 |
| Llama-3.1-8B-Q8_0 | 61 709 | 65 536 | 29.82 | 19.47 | **0.653x** | 8 192 -> 1 600.1 | **2** |

Arm ranges disjoint in every cell. Against the issue's pre-declared criteria: throughput >= 0.95x **FAILS** everywhere; memory <= 0.85x **passes at three of four** — at 3 753 the fork is 0.945x and does not clear the bar it was measured against, because the KV saving is small beside 8.3 GB of weights.

**Confound control**: fork@f16 vs merge-base@f16 came back **INCONCLUSIVE, ranges fully overlapping** (1.013x). The fork's 211 non-upstream commits cost nothing measurable, so the gap is the codec. (Control ran at one context on one model; the 62k cell has none.)

## Answer

**Fused decode over a quantised KV store runs correctly on Metal at `dk128_dv128`, and loses ~30% of decode throughput — monotonically worse with context.** "Measure it at longer context and it will pay" is falsified on the three same-model points.

The mechanism is shared with rMLX: the fork's vec dispatch is `dispatch_threadgroups(..., ne01/nqptg, ne02, ...)` with `ne02` the **query**-head count, so `heads_per_kv` threadgroups re-read identical KV. On the Qwen3-8B series that bounds **ε <= 0.135** — exactly rMLX's `iso_flash_decode_symv` (0.135). Since ρ = 0.1953 ± 0.0002 > ε, the trade cannot pay until the **grid geometry** changes; fixing rMLX's `turbo_flash` shell alone (ε = 0.041) still loses.

So ε ≈ 0.13 is a platform constant, not an rMLX deficiency, and the fork is **corroboration, not an existence proof of parity**. Its deeper `TurboFlash` fusion was disabled upstream in `67f076f2e` for corrupt output on Apple10 — reproduced verbatim here (garbage tokens, HTTP 500 on invalid UTF-8), and it was not faster either.

## The issue's E8 is wrong

The fork's base is not `b9082` despite the branch name — `git merge-base` gives `7fc1c4ef7`, 211 upstream commits earlier. Pinning upstream at `b9082` would have injected 211 unrelated commits into the "only the codec differs" claim. `../llama.cpp` is also a shallow checkout that does not contain the merge-base, so the upstream arm was built from a worktree of the fork at that commit — same object store, guaranteed pristine.

Binaries verified distinct: `llama-server` `87562d2c` vs `d01badaa`; 0 vs 12 exported `turbo` symbols; 0 vs 554 `turbo` strings in the embedded Metal library.

## Measurement honesty

**Every cell is TAINTED** and both committed sections now say so. `perf_ab.sh`'s entry gate has never cleared on this host; the real culprit turned out to be **Rancher Desktop's Lima VM at 411% of one core**, which auto-restarted at 806% mid-campaign. Residual `syspolicyd` (~32%) and WindowServer (30-56%) remain above the gate. ABBA cancels steady load, so the separation verdicts survive; the absolute TPS does not. Cross-run absolutes are unusable here — the same binary read 54.89 and 49.27 TPS thirty minutes apart, and both observations are now published rather than the flattering one.

## A correction this branch makes to itself

An earlier revision claimed rMLX's 1.8-2.7x roofline band was "~1.5x looser than a non-MLX runtime". **That was wrong.** Ratio-vs-ceiling is `1 + overhead/ideal_ms` and is not scale-free, and the models compared differ 2.3-6.7x in bytes/step. In absolute per-step overhead the two runtimes overlap — llama.cpp 2.18-6.61 ms against rMLX 4.83-8.15 ms — which is INCONCLUSIVE by the same overlap rule the bench arms are held to. The claim is now recorded as **unsupported but not falsified**, with what a like-for-like cell would require.

## Harness

`scripts/bench_llama_ab.sh` (ABBA, two `llama-server` arms, refuses identical arms, reports spread, says INCONCLUSIVE on overlap, never writes `runs.db`) and `scripts/ingest/llama_ab_ingest.py` (stages outside the pending queue, so nothing it writes is reachable by `--replay-pending` unless written for that invocation).

`scripts/bench_llama_ab_selftest.sh` — 13 cases, stub server, no GPU or GGUF needed, wired into `make ci`. Every guard mutation-checked individually: revert one, exactly its own case goes red and the rest stay green.

| guard reverted | case that turned red |
|---|---|
| `--pairs >= 2` | `--pairs 1 is refused` |
| KV parse emits `0.00` | `unparseable KV buffer size fails the slot` |
| decode-budget assertion | `truncated generation fails the slot` |
| busy-port precheck | `an occupied port is refused up front` |
| empty-capture assertion | `empty generation capture fails the slot` |
| `refuse_pinned` | `arm args cannot override a pinned flag` |
| `/props` identity check | `a server serving another model fails the slot` |

`scripts/INDEX.md` added — 95 scripts, the index the tree never had.

## Also fixed

Widening the coverage test off `BACKEND_WHITELIST` caught a **pre-existing** defect: `mlx_lm_tq` had 402 recorded rows and zero `COVERAGE_MATRIX` entries. Both it and the new backend are wired, `llama_cpp/kv_cache_bytes` flipped to `Yes` (the harness reads it from the server log), and the test now iterates the whitelist so the next backend cannot land half-wired.

40 observation rows recorded via the buffer/ingest path; §4.1 bounds refused nothing. `BENCHMARK_CHAMPIONS.md` regenerated, never hand-edited.

`make ci`: **exit 0** (verified on an untruncated log; an earlier run exited 2 on a lint error introduced by this branch, since fixed).
