### PR TITLE
kv(scope): the long-context codec cell loses, and kv_frac is not a sufficient statistic (#414)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,15 @@ redundant_clone          = "warn"
 # fused-QK) keep bit-exact against their Python/MLX references on purpose.
 # Allow rather than alter reference parity; revisit per-site if ever a hotspot.
 suboptimal_flops         = "allow"
+# clippy 1.98 (2026-08) adds `chunks_exact_to_as_chunks`, which fires on every
+# `chunks_exact(N)` / `chunks_exact_mut(N)` with a literal N — 143 sites across
+# the workspace, most of them the `bytes.chunks_exact(4) -> f32::from_le_bytes`
+# idiom in tensor readers. `as_chunks` is the better form and the migration is
+# mechanical, but it is a whole-workspace edit through weight- and KV-quant code
+# for no behavioural change, so it does not belong as a rider on an unrelated
+# branch. Allowed here so a floating-`stable` toolchain bump does not turn the
+# gate red all at once; do it as its own change and delete this entry.
+chunks_exact_to_as_chunks = "allow"
 needless_collect         = "warn"
 implicit_clone           = "warn"
 needless_pass_by_value   = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,16 @@ suboptimal_flops         = "allow"
 # branch. Allowed here so a floating-`stable` toolchain bump does not turn the
 # gate red all at once; do it as its own change and delete this entry.
 chunks_exact_to_as_chunks = "allow"
+# clippy 1.98 also adds `manual_midpoint`. Its 10 workspace sites are all f32
+# codebook-boundary midpoints in the rotation-KV codecs (iso, planar, rotor,
+# turbo): `(w[0] + w[1]) * 0.5` deciding a quantization threshold. `f32::midpoint`
+# reduces to exactly `(a + b) / 2.` whenever both operands are <= f32::MAX/2 —
+# true of every codebook entry here — so the two forms are bit-identical in range
+# and the lint is about the out-of-range case, which cannot arise. Rewriting
+# threshold arithmetic in codecs held bit-exact against their Python/MLX
+# references is not something to do as a rider on an unrelated branch; same
+# reasoning as `suboptimal_flops` above. Migrate both together, then delete this.
+manual_midpoint          = "allow"
 needless_collect         = "warn"
 implicit_clone           = "warn"
 needless_pass_by_value   = "warn"

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         metrics-champions metrics-champions-rmlx \
         build-perf build-debug test-perf ci-perf gpu-test model-check model-check-full \
         profile-samply profile-samply-debug profile-instruments bench asm perf-iter \
-        canary canary-gate canary-ab canary-ab-selftest \
+        canary canary-gate canary-ab canary-ab-selftest canary-ab-ingest-selftest \
         mlx-preflight mlx-restore-pin target-gc target-size-report profile-gputrace \
         profile-mst \
         build-capture test-capture gputrace-preflight traces-gc \
@@ -430,6 +430,7 @@ ci: fmt-check lint test test-capture deny audit ci-metrics ## full pre-merge gat
 	@bash scripts/check_kernel_dtype_contract.sh
 	@bash scripts/check_kernel_dtype_contract_fixtures.sh
 	@bash scripts/perf_ab_selftest.sh
+	@bash scripts/perf_ab_ingest_selftest.sh
 	@bash scripts/bench_llama_ab_selftest.sh
 	@bash scripts/check_metal_format.sh
 	@bash scripts/check_metal_compiles.sh
@@ -602,6 +603,9 @@ canary-ab: mlx-preflight build-perf  ## interleaved A/B of two arms (ARGS='--bin
 
 canary-ab-selftest: ## mutation-check the A/B harness against stub binaries (no GPU, no model)
 	bash scripts/perf_ab_selftest.sh
+
+canary-ab-ingest-selftest: ## mutation-check the A/B -> runs.db promoter (no GPU, no model, no DB write)
+	bash scripts/perf_ab_ingest_selftest.sh
 
 llama-ab-selftest: ## mutation-check the llama-server A/B harness against a stub server (no GPU, no GGUF)
 	bash scripts/bench_llama_ab_selftest.sh

--- a/crates/rmlx-cli/src/commands/baseline.rs
+++ b/crates/rmlx-cli/src/commands/baseline.rs
@@ -667,12 +667,22 @@ pub(crate) fn run_baseline(
         "baseline: model={model_basename}  load={load_ms:.0}ms  ttft_ms={ttft}  \
          decode_tps={decode}  overall_tps={overall}  prefill_tps={prefill}  \
          prompt_tokens={prompt_token_count}  peak_rss={rss}MB  \
-         metal_peak_mb={metal_peak_mb:.1}  metal_gen_alloc_mb={metal_gen_alloc_mb:.1}",
+         metal_peak_mb={metal_peak_mb:.1}  metal_gen_alloc_mb={metal_gen_alloc_mb:.1}  \
+         kv_cache_bytes={kv_bytes}",
         ttft = fmt_measurement(ttft_ms, 0, "n/a"),
         decode = fmt_measurement(decode_tps, 3, "n/a"),
         overall = fmt_measurement(overall_tps, 3, "n/a"),
         prefill = fmt_measurement(prefill_tps, 1, "n/a"),
         rss = fmt_measurement(rss_mb_measured, 1, "n/a"),
+        // `ReportedZero` above already decided this column is unusable for this
+        // run; printing the literal `0` would read as "this codec's cache is
+        // empty" and average into a residency comparison as a real reading.
+        // `n/a` is the same refusal the rate columns use.
+        kv_bytes = if kv_cache_bytes > 0 {
+            kv_cache_bytes.to_string()
+        } else {
+            "n/a".to_string()
+        },
     );
 
     // Exact generated token-id sequence, one line, opt-in.

--- a/crates/rmlx-mlx/build_support.rs
+++ b/crates/rmlx-mlx/build_support.rs
@@ -196,12 +196,11 @@ fn nax_missing_kernel_lines(
             "MLX at {mlx_prefix} (mlx {mlx_version}, mlx-c {mlx_c_version}) ships no {kernel} \
              kernels in lib/mlx.metallib."
         ),
-        format!(
-            "  Those are the Neural-Accelerator GEMM path, and this is Neural-Accelerator-class \
-             hardware: without them GPU matmul throughput measured ~3.8x lower and prefill \
-             2.2-3.7x slower. Decode is bandwidth-bound and looks normal, so the symptom mimics \
-             a model-code defect."
-        ),
+        "  Those are the Neural-Accelerator GEMM path, and this is Neural-Accelerator-class \
+         hardware: without them GPU matmul throughput measured ~3.8x lower and prefill \
+         2.2-3.7x slower. Decode is bandwidth-bound and looks normal, so the symptom mimics \
+         a model-code defect."
+            .to_string(),
         format!(
             "  rMLX validates against mlx {} + mlx-c {}: on the bottle that pair was checked \
              against, the kernels were present, but bottle contents vary by build runner — the \

--- a/crates/rmlx-models/src/speculative/gemma4_assistant.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant.rs
@@ -570,8 +570,7 @@ fn load_assistant(
     let has_centroids = shards.iter().any(|(_, handle)| {
         handle
             .safetensors()
-            .ok()
-            .is_some_and(|st| st.tensor("masked_embedding.centroids.weight").is_ok())
+            .is_ok_and(|st| st.tensor("masked_embedding.centroids.weight").is_ok())
     });
 
     let centroids = if has_centroids {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -364,7 +364,7 @@ rmlx baseline --model /path/to/snapshot --prompt-tokens 4096 --label "8k-bench"
 ```
 baseline: model=<name>  load=<ms>  ttft_ms=<ms>  decode_tps=<n>  overall_tps=<n>
           prefill_tps=<n>  prompt_tokens=<n>  peak_rss=<n>MB
-          metal_peak_mb=<n>  metal_gen_alloc_mb=<n>
+          metal_peak_mb=<n>  metal_gen_alloc_mb=<n>  kv_cache_bytes=<n>
 ```
 
 `peak_rss` is host RSS from `ps`. The two `metal_*` fields come from a
@@ -373,6 +373,17 @@ most Metal-allocator bytes live at once during generation (it includes the
 resident weights), and `metal_gen_alloc_mb` is that minus what was already live
 when generation started. **Only `metal_gen_alloc_mb` compares between two runs
 of the same model.** Both read `0` where no Metal allocator is present.
+
+`kv_cache_bytes` is the resident KV figure from `KvCache::resident_bytes`
+(defined in docs/METRICS_DB.md §4) — the *filled* prefix of the cache, not an
+allocator peak. It answers a different question from `metal_gen_alloc_mb`, and
+neither substitutes for the other: on some architectures the prefill working
+set, not the cache, is what sets the allocator peak, so a real KV delta can
+show as `+0.0 MB` there. Emitted on stdout so an A/B harness can read residency
+per slot without `--metrics` (which would write to the append-only store);
+`scripts/perf_ab.sh` parses it. It prints `n/a`, never `0`, when the byte
+accounting reported zero — the same refusal the rate columns use, because a
+literal `0` averages into a residency comparison as a cache of no bytes.
 
 #### When there is no summary line
 

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -3265,11 +3265,22 @@ their quant store is not on the decode read path — the mirror is.
 packed store for every codec. It no longer builds one for a codec that reads
 only the mirror (`KvQuant::materialises_packed_store`), so `k8v4`, `tsym3` and
 `planar` now hold two bf16 mirrors and nothing else — resident KV **exactly
-equal to `none`**, byte for byte, at every context. Measured, not derived: at a
-3 770-token prompt `none`, `k8v8`, `k8v4`, `planar` and `tsym3` all report the
-identical `kv_cache_bytes` — **556 941 312** on Ternary-Bonsai-8B (`kv_h = 8`)
-and **31 629 312** on gemma-4-e2b (`kv_h = 1`, shared-KV), 5 codecs × 2
-architectures, no digit apart. What survives is the prefill cost of encoding a store nobody
+equal to `none`**, byte for byte. Measured — 5 codecs × 2 architectures × 2
+contexts, one `rmlx baseline --record` run per cell, 20 rows in `runs.db`.
+Within every cell `none`, `k8v8`, `k8v4`, `planar` and `tsym3` report the
+identical `kv_cache_bytes`:
+
+| model | prompt tok | `kv_cache_bytes`, all 5 codecs |
+|---|---:|---:|
+| Ternary-Bonsai-8B (`kv_h` 8) | 3 770 | 560 480 256 |
+| Ternary-Bonsai-8B | 31 553 | 4 657 250 304 |
+| gemma-4-e2b (`kv_h` 1, shared-KV) | 4 117 | 31 776 768 |
+| gemma-4-e2b | 34 355 | 217 559 040 |
+
+Two contexts is not "every context" — the derivation says it holds at all of
+them because a codec that builds no store has nothing that can scale — but the
+two that were measured are 8× apart and span both `kv_h` regimes. What survives
+is the prefill cost of encoding a store nobody
 reads (`tsym3` TTFT 23.1 s vs `none` 19.2 s at 32k) and the decode-time cost of
 carrying a quantized layer type at all (≈0.041 ms/layer/step — see
 "`--kv-quant none` is a bf16 control").
@@ -3288,7 +3299,9 @@ much of decode any KV-codec change can possibly touch, and
 `scripts/perf_ceiling.py` prints it in the last column of every row.
 
 **It is a property of the (model, context) pair, not of the context.** At a
-4096-token prompt it spans 22× across the release set:
+4096-token prompt it spans 22× across the release set. This table is a **static
+prediction** — `perf_ceiling.py` over `config.json` plus the safetensors index,
+no model launched — unlike the measured cells below it:
 
 | model | 4 096 | 8 192 | 32 768 | 131 072 |
 |---|---:|---:|---:|---:|
@@ -3303,23 +3316,39 @@ second. A 2-bit 8B model at a 4k prompt already puts 22% of its decode bytes on
 the codec axis; a dense 27B at 131k puts 25%.
 
 **A large `kv_frac` is necessary, not sufficient.** Measured on this tree,
-`none` vs `mixed_k8g64_v4g64` ABBA-paired (`scripts/perf_ab.sh`, n=4/arm,
-TAINTED host — see docs/PERF_BASELINE.md for the cells and the taint):
+`none` vs `mixed_k8g64_v4g64` ABBA-paired (`scripts/perf_ab.sh`, n=4/arm; the
+two Qwen3.8 cells untainted at 7.0–7.3 % foreign CPU, the two Bonsai cells
+tainted only by a monitoring process at their entry gate — see
+docs/PERF_BASELINE.md for per-cell conditions and spreads):
 
 | model | prompt tok | `kv_frac` | predicted ceiling B/A | measured decode B/A | measured resident B/A |
 |---|---:|---:|---:|---|---:|
-| Ternary-Bonsai-8B | 3 770 | 0.211 | 1.099 | 0.949 INCONCLUSIVE | 1.287 |
-| Ternary-Bonsai-8B | 31 553 | **0.687** | **1.419** | 1.003 INCONCLUSIVE | 1.293 |
-| Qwen3.8-27B | 3 892 | 0.010 | 1.004 | 1.005 INCONCLUSIVE | 1.219 |
-| Qwen3.8-27B | 130 848 | 0.245 | 1.149 | **0.728 ranges disjoint** | 1.349 |
+| Ternary-Bonsai-8B | 3 770 | 0.211 | 1.099 | 0.975 ranges disjoint | 1.287 |
+| Ternary-Bonsai-8B | 31 553 | **0.687** | **1.419** | 1.002 INCONCLUSIVE | 1.293 |
+| Qwen3.8-27B | 3 892 | 0.010 | 1.004 | 0.977 SEPARATED | 1.219 |
+| Qwen3.8-27B | 130 848 | 0.245 | 1.149 | **0.763 SEPARATED** | 1.349 |
 
 Two rows carry the argument. The Bonsai **31 553** row is the high-`kv_frac`
-end: at 0.687 — the largest any release-set model reaches — a codec that cuts
-the decode KV stream to 0.571× and is predicted +42% moves decode by +0.3%,
-inside the noise, while costing +29% resident KV. The Qwen3.8 **130 848** row
-is the long-context end: `kv_frac` 0.245, predicted +14.9%, measured **−27.2%
-with the arms' per-slot ranges disjoint in the losing direction**, and +35%
-resident.
+end: at 0.687 — the largest any release-set model reaches *at a context this
+tree can serve*; the static table above projects 0.901 for the same model at
+131 072, which no measured cell reaches — a codec that cuts the decode KV
+stream to 0.571× and is predicted +42% moves decode by +0.3%, inside the noise,
+while costing +29% resident KV — a null with the power to have seen a 1%
+effect, since the arm spreads there are 0.04% and 0.15%. The Qwen3.8
+**130 848** row is the long-context
+end: `kv_frac` 0.245, predicted +14.9%, measured **−23.7% with the arms'
+per-slot ranges disjoint in the losing direction**, and +35% resident
+whole-cache — which on that hybrid arch understates the attention-KV ratio,
+1.355 excluding its codec-independent GDN state.
+
+**Scope on arm B.** It is `mixed_k8g64_v4g64` as it stands here: still
+materialising a packed store *and* retaining both bf16 seeds, because the change
+that stopped building a store for a mirror-fed codec excluded the Mixed / RotK
+family (whose decode does read its store). Its **resident** figures are
+therefore pre-seed-elision and say nothing about a seed-elided variant. Its
+**decode** figures need no such variant — returning an unread seed frees memory,
+it does not speed a quantized-matmul decode — so the throughput result stands
+for the family either way.
 
 The byte model is not what is wrong. At those offsets `perf_ceiling.py` puts
 arm A's resident KV at 4 667.3 MB against 4 667.3 MB measured on Bonsai, and on
@@ -3327,9 +3356,9 @@ Qwen3.8 it is exact once the codec-independent GDN recurrent state that arch
 carries (a flat ~152–154 MB, identical on both arms at both contexts) is added
 back. What fails is the conversion of bytes into time — the ε of the section
 above, ≈0.04–0.135 on every path measured — and at the Qwen3.8 long cell the
-packed path does not merely fail to convert: it spends 48.8 ms/step of
-non-bandwidth work against `none`'s 14.7 ms, so halving the byte stream still
-loses.
+packed path does not merely fail to convert: its non-bandwidth per-step cost
+grows 12.0 → 44.2 ms between 3 892 and 130 848 tokens while `none`'s stays flat
+at 10.5 → 14.7, so halving the byte stream still loses.
 
 Read together with the ε table: **`kv_frac` bounds the prize, ε decides how much
 of it is collectable, and ε is the binding term.** State `kv_frac` next to a

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -3258,15 +3258,82 @@ first; judge a store repack on its memory merits, not on an expected decode win.
 `k8v4` and `tsym3` still produce a token digest **bit-identical to `none`** at
 4k / 16k / 32k on both architectures. A q8/q4/turbo3 store cannot reproduce bf16
 output bit-exactly over 64 greedy steps at 32k, so this is direct evidence that
-their quant store is not on the decode read path — the mirror is. They pay for
-the store in resident bytes (+26% and +16% at 32k on Bonsai) and in prefill
-(`tsym3` TTFT 23.1 s vs `none` 19.2 s at 32k) and get nothing back at decode.
+their quant store is not on the decode read path — the mirror is.
+
+**The resident-bytes half of that charge no longer applies.** It used to read
+"+26% and +16% at 32k on Bonsai", from a tree where `exit_prefill` built a
+packed store for every codec. It no longer builds one for a codec that reads
+only the mirror (`KvQuant::materialises_packed_store`), so `k8v4`, `tsym3` and
+`planar` now hold two bf16 mirrors and nothing else — resident KV **exactly
+equal to `none`**, byte for byte, at every context. Measured, not derived: at a
+3 770-token prompt `none`, `k8v8`, `k8v4`, `planar` and `tsym3` all report the
+identical `kv_cache_bytes` — **556 941 312** on Ternary-Bonsai-8B (`kv_h = 8`)
+and **31 629 312** on gemma-4-e2b (`kv_h = 1`, shared-KV), 5 codecs × 2
+architectures, no digit apart. What survives is the prefill cost of encoding a store nobody
+reads (`tsym3` TTFT 23.1 s vs `none` 19.2 s at 32k) and the decode-time cost of
+carrying a quantized layer type at all (≈0.041 ms/layer/step — see
+"`--kv-quant none` is a bf16 control").
 
 That remains a real defect. What the table above rules out is the *specific*
 remedy of pointing a hand-written flash-decode kernel at those stores: it has
 been built twice — TurboFlash for `k8v4`, the iso/rotor flash-decode pair for the
 eight `_sym` / K-only codecs — and both lose, for a reason that is structural and
 now quantified.
+
+### `kv_frac` bounds a codec claim — and is not a statement about context
+
+`kv_frac` is the KV share of a decode step's byte stream,
+`kv_bytes_step / (weight_bytes_step + kv_bytes_step)`. It is the ceiling on how
+much of decode any KV-codec change can possibly touch, and
+`scripts/perf_ceiling.py` prints it in the last column of every row.
+
+**It is a property of the (model, context) pair, not of the context.** At a
+4096-token prompt it spans 22× across the release set:
+
+| model | 4 096 | 8 192 | 32 768 | 131 072 |
+|---|---:|---:|---:|---:|
+| Qwen3.8-27B-mxfp8 (26.4 GB/step of weights) | 0.010 | 0.020 | 0.075 | 0.245 |
+| Qwen3.6-35B-A3B-8bit (MoE, 3.1 GB/step) | 0.026 | 0.051 | 0.177 | 0.462 |
+| gemma-4-e2b-mxfp8 (SWA on most layers) | 0.030 | 0.053 | 0.170 | 0.445 |
+| Ternary-Bonsai-8B-2bit (2.1 GB/step) | **0.221** | **0.362** | **0.694** | 0.901 |
+
+So "measured at 4k" and "measured where the codec axis is near-zero" are not
+the same qualifier, and a claim scoped by the first is not scoped by the
+second. A 2-bit 8B model at a 4k prompt already puts 22% of its decode bytes on
+the codec axis; a dense 27B at 131k puts 25%.
+
+**A large `kv_frac` is necessary, not sufficient.** Measured on this tree,
+`none` vs `mixed_k8g64_v4g64` ABBA-paired (`scripts/perf_ab.sh`, n=4/arm,
+TAINTED host — see docs/PERF_BASELINE.md for the cells and the taint):
+
+| model | prompt tok | `kv_frac` | predicted ceiling B/A | measured decode B/A | measured resident B/A |
+|---|---:|---:|---:|---|---:|
+| Ternary-Bonsai-8B | 3 770 | 0.211 | 1.099 | 0.949 INCONCLUSIVE | 1.287 |
+| Ternary-Bonsai-8B | 31 553 | **0.687** | **1.419** | 1.003 INCONCLUSIVE | 1.293 |
+| Qwen3.8-27B | 3 892 | 0.010 | 1.004 | 1.005 INCONCLUSIVE | 1.219 |
+| Qwen3.8-27B | 130 848 | 0.245 | 1.149 | **0.728 ranges disjoint** | 1.349 |
+
+Two rows carry the argument. The Bonsai **31 553** row is the high-`kv_frac`
+end: at 0.687 — the largest any release-set model reaches — a codec that cuts
+the decode KV stream to 0.571× and is predicted +42% moves decode by +0.3%,
+inside the noise, while costing +29% resident KV. The Qwen3.8 **130 848** row
+is the long-context end: `kv_frac` 0.245, predicted +14.9%, measured **−27.2%
+with the arms' per-slot ranges disjoint in the losing direction**, and +35%
+resident.
+
+The byte model is not what is wrong. At those offsets `perf_ceiling.py` puts
+arm A's resident KV at 4 667.3 MB against 4 667.3 MB measured on Bonsai, and on
+Qwen3.8 it is exact once the codec-independent GDN recurrent state that arch
+carries (a flat ~152–154 MB, identical on both arms at both contexts) is added
+back. What fails is the conversion of bytes into time — the ε of the section
+above, ≈0.04–0.135 on every path measured — and at the Qwen3.8 long cell the
+packed path does not merely fail to convert: it spends 48.8 ms/step of
+non-bandwidth work against `none`'s 14.7 ms, so halving the byte stream still
+loses.
+
+Read together with the ε table: **`kv_frac` bounds the prize, ε decides how much
+of it is collectable, and ε is the binding term.** State `kv_frac` next to a
+codec cell so a reader can see the bound; do not infer an effect from it.
 
 ---
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -474,10 +474,29 @@ sampled at all (empty or failed `ps`, or a window below the CPU counter's
 references against each other. An arm that is fast and wrong fails the
 invocation that made it look fast.
 
+**Residency is reported next to throughput.** Decode TPS alone cannot express a
+KV-codec question: a codec that costs memory and buys no speed reads as a null
+result if throughput is the only column. Each slot therefore contributes two
+memory figures, and they answer different questions.
+`metal_gen_alloc_mb` is the generation-scoped allocator peak — the prefill
+working set, not the cache, can be what sets it, and then a real KV delta shows
+there as `+0.0 MB`. Measured both ways in the cells below: at a 4 096-token
+prompt it reads `+0.0 MB` on Ternary-Bonsai-8B and on Qwen3.8-27B against
+cache deltas of +28.7 % and +21.9 %, while the same Bonsai pair at 32 768 does
+resolve it (+2 500 MB). Whether the cache is the allocator peak is an
+arch-and-shape question, not a property of the instrument.
+`kv_cache_bytes` is `KvCache::resident_bytes` off the
+`baseline` summary line and is the cache itself. Where a slot's KV accounting
+refused, the column reads `n/a` for that whole arm — never `0`, which would
+divide into a residency ratio as a cache of no bytes.
+
 **Never writes `runs.db`.** Every slot runs `--metrics off`, so the file is
 never opened, and `--metrics` is refused in arm arguments so it cannot be
 turned back on. An A/B run exercises arms built to be thrown away; a row in the
-append-only store cannot be taken back out.
+append-only store cannot be taken back out. Promoting an accepted comparison is
+a separate, explicit step: `scripts/ingest/perf_ab_ingest.py` turns one result
+file into two §8.5 RunRecords (`decode_tps_warm`, `kv_cache_bytes`), refuses a
+TAINTED run unless told otherwise, and carries the taint text into `notes`.
 
 It does write elsewhere. The result lands in
 `$RMLX_HOME/bench/perf_ab/<timestamp>.json` alongside the recorded host
@@ -565,6 +584,122 @@ decode_tps (the bf16 q/k/v compute is cheaper than the prior f32 path); Gemma4
 and Qwen3.6 (separate arch files) are unchanged. On the `none` path the gain
 widens with context as KV bandwidth dominates: Bonsai `none` decode_tps
 ~101→~135 at 4 k, ~48→~83 at 16 k, ~19→~38 at 64 k.
+
+## Codec cells across context — `none` vs `mixed_k8g64_v4g64` (TAINTED host, 2026-08-20)
+
+**Every cell in this section is TAINTED and none of it is a clean measurement.**
+`perf_ab.sh`'s quiescence gate never cleared on this host: a virtual-machine
+helper sat at 113–384 % of a core throughout, WindowServer at 30–56 %, and all
+8 of 8 slots in every run are marked contended. The runs are ABBA-interleaved,
+so a *within-run* ratio still cancels a drift that is monotone across the run,
+and the pre-declared disjoint-range criterion still decides SEPARATED vs
+INCONCLUSIVE. Nothing here may be quoted as an absolute TPS anchor, and no
+number here may be compared against a number from a different run.
+
+Why the section exists: every earlier codec cell in this file and in
+`docs/KV_QUANT.md` was taken at 4 096–32 768 tokens, and the standing objection
+to that basis is that `kv_frac` — the KV share of a decode step's byte stream —
+rises steeply with context, so a short cell cannot see a codec difference "even
+in principle". `kv_frac` is stated next to every row below so that bound is
+visible rather than assumed. It is a **(model, context)** quantity, not a
+context one; see docs/KV_QUANT.md, "`kv_frac` bounds a codec claim".
+
+Shape: `rmlx baseline`, `release-perf` build `sha256:c26e0d8a3ac43996`,
+`--max-tokens 100`, 1 untimed warmup + 8 slots per model (n=4 per arm),
+`--allow-busy-host --allow-token-divergence`. Arm A is `--kv-quant none` (true
+bf16 on every layer), arm B `--kv-quant mixed_k8g64_v4g64` (affine 8-bit K /
+4-bit V, and one of the two codec families whose decode genuinely reads its
+packed store). `kv_frac` and the predicted ceilings are
+`scripts/perf_ceiling.py` on the same snapshot.
+
+`kv_frac` and the predicted ceilings are evaluated at the **measured** cache
+offset (`prompt_tokens + max_tokens - 1`), not at the fixture's nominal size.
+
+| model | prompt tok | `kv_frac` (A) | predicted ceiling B/A | decode B/A (median) | A range | B range | verdict | resident KV A → B | resident B/A |
+|---|---:|---:|---:|---:|---|---|---|---|---:|
+| Ternary-Bonsai-8B-2bit | 3 770 | 0.211 | 1.099 | 0.949 | 125.72–134.86 | 125.21–127.53 | INCONCLUSIVE | 570.5 → 734.1 MB | 1.287 |
+| Ternary-Bonsai-8B-2bit | 31 553 | **0.687** | **1.419** | 1.003 | 65.07–67.82 | 65.03–68.06 | INCONCLUSIVE | 4 667.3 → 6 032.9 MB | 1.293 |
+| Qwen3.8-27B-mxfp8 | 3 892 | 0.010 | 1.004 | 1.005 | 17.73–17.97 | 17.58–18.04 | INCONCLUSIVE | 415.5 → 506.5 MB | 1.219 |
+| Qwen3.8-27B-mxfp8 | 130 848 | 0.245 | 1.149 | **0.728** | 13.94–14.12 | 9.45–10.70 | **ranges disjoint** | 8 735.7 → 11 784.2 MB | 1.349 |
+
+**What the 130 848-token Qwen3.8 row settles.** This is the cell that a
+long-context codec claim was supposed to be decided on: `kv_frac` 0.245, a
+predicted **+14.9 %** ceiling for arm B, and 20× the paired noise floor between
+the arms. Measured, arm B is **27.2 % slower**, with the two arms' per-slot
+ranges disjoint in the losing direction (every `none` slot faster than every
+`mixed` slot), and it holds **35 % more** resident KV and 6 034 MB more
+generation-scoped allocation. Both halves of the pre-declared long-context
+falsifier fire: resident above 0.60× and decode below 0.95×. The
+"measure it at 128 k and the codec will pay" hypothesis is not merely
+unsupported here — the sign is wrong.
+
+This cell is also the least contended of the four: the entry gate refused at
+114 %, but only 4 of 8 slots were flagged (worst 35.8 % WindowServer) and the
+comparison window as a whole read 22.8 %, *under* the 25 % threshold. It is
+still reported as TAINTED, and still may not be read as an absolute anchor.
+
+**Why `none` losing is not a roofline story.** Arm A's non-bandwidth per-step
+term is essentially flat across a 33× context change — 12.65 ms at 3 892 tokens,
+14.70 ms at 130 848 — so `none` decode really is bandwidth-dominated at 131 k
+(1.26× its 57.02 ms floor). Arm B halves the KV byte stream and still loses,
+because its own per-step cost is not flat: 98.55 ms measured against a 49.76 ms
+floor, 1.98×, i.e. 48.79 ms of non-bandwidth work against arm A's 14.70. The
+packed path does not fail to convert bytes into time; at this shape it spends
+more time than the bytes were worth.
+
+**What the 31 553-token Bonsai row settles.** 0.687 is the largest `kv_frac`
+any model in the release set reaches at a context this tree can serve. Arm B
+cuts the decode KV stream to 0.571× of arm A's and the roofline predicts +42 %.
+Measured: **+0.3 %, ranges fully overlapping** — no measured effect — while
+resident KV goes *up* 29 %. So the short-context basis was not what made the
+earlier codec cells come back null: the null survives at the high-`kv_frac` end
+of the same axis.
+
+**The byte model is not what fails; it is exact where it is complete.** At the
+measured offsets `perf_ceiling.py` puts arm A's resident KV at 570.5 MB and
+4 667.3 MB on Bonsai — the measured figures, to the digit — and arm B within
+0.5 % and 0.06 %. What does not hold is the conversion of saved bytes into
+saved time: the ε of docs/KV_QUANT.md, "Fused flash-decode over a quant store",
+measured at 0.041–0.135 on every path tried so far.
+
+**The Qwen3.8 resident ratio is diluted, not smaller.** That arch is hybrid:
+48 of its 64 layers hold a fixed-size GDN recurrent state the codec never
+touches, and `kv_cache_bytes` sums it. `perf_ceiling.py` deliberately excludes
+it, and the gap between its prediction and the measurement is that state — the
+*same constant* at both contexts and on both arms:
+
+| prompt tok | arm | predicted (attention KV) | measured | gap |
+|---:|---|---:|---:|---:|
+| 3 892 | `none` | 261.6 MB | 415.5 MB | +153.9 |
+| 3 892 | `mixed` | 354.5 MB | 506.5 MB | +152.0 |
+| 130 848 | `none` | 8 581.7 MB | 8 735.7 MB | +154.0 |
+| 130 848 | `mixed` | 11 632.3 MB | 11 784.2 MB | +151.9 |
+
+Read the whole-cache ratio on a hybrid arch as a lower bound on the
+attention-KV ratio (1.219 measured against 1.355 attention-only at 3 892; 1.349
+against 1.355 at 130 848), the same way the `--kv-quant none` section reads
+Qwen3.6-35B's 1.060× against its 1.109× attention-only figure.
+
+**Decode moves away from the roofline as context grows.** Same runs, arm A,
+against `perf_ceiling.py`'s bandwidth-bound floor for the same cell:
+
+| model | prompt tok | measured ms/step | roofline ms/step | ratio | non-bandwidth ms/step |
+|---|---:|---:|---:|---:|---:|
+| Ternary-Bonsai-8B-2bit | 3 770 | 7.55 | 4.40 | 1.72× | 3.15 |
+| Ternary-Bonsai-8B-2bit | 31 553 | 15.01 | 11.07 | 1.36× | 3.94 |
+| Qwen3.8-27B-mxfp8 | 3 892 | 56.11 | 43.47 | 1.29× | 12.65 |
+| Qwen3.8-27B-mxfp8 | 130 848 | 71.72 | 57.02 | 1.26× | 14.70 |
+
+Compare the last column, not the ratio: ratio-vs-roofline is
+`1 + overhead/ideal_ms` and is therefore *not* scale-free, so it cannot be
+compared across models of different size — the same fixed per-step cost reads
+large on a small model and small on a large one. Within one model the
+comparison is valid, and within each model the non-bandwidth term is roughly
+flat — Bonsai 3.15 → 3.94 ms across an 8× context change, Qwen3.8 12.65 →
+14.70 ms across 33×. Both models' `none` decode really is bandwidth-dominated
+at their long cell. That is what makes the null load-bearing: the regime where
+a byte cut *should* convert is the regime measured, on two architectures, and
+it did not convert on either.
 
 ## Host-sampler cost — PROVISIONAL, NOT AN ANCHOR (2026-08-16)
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -585,82 +585,97 @@ and Qwen3.6 (separate arch files) are unchanged. On the `none` path the gain
 widens with context as KV bandwidth dominates: Bonsai `none` decode_tps
 ~101→~135 at 4 k, ~48→~83 at 16 k, ~19→~38 at 64 k.
 
-## Codec cells across context — `none` vs `mixed_k8g64_v4g64` (TAINTED host, 2026-08-20)
+## Codec cells across context — `none` vs `mixed_k8g64_v4g64` (2026-08-21)
 
-**Every cell in this section is TAINTED and none of it is a clean measurement.**
-`perf_ab.sh`'s quiescence gate never cleared on this host: a virtual-machine
-helper sat at 113–384 % of a core throughout, WindowServer at 30–56 %, and all
-8 of 8 slots in every run are marked contended. The runs are ABBA-interleaved,
-so a *within-run* ratio still cancels a drift that is monotone across the run,
-and the pre-declared disjoint-range criterion still decides SEPARATED vs
-INCONCLUSIVE. Nothing here may be quoted as an absolute TPS anchor, and no
-number here may be compared against a number from a different run.
-
-Why the section exists: every earlier codec cell in this file and in
+Why this section exists: every earlier codec cell in this file and in
 `docs/KV_QUANT.md` was taken at 4 096–32 768 tokens, and the standing objection
 to that basis is that `kv_frac` — the KV share of a decode step's byte stream —
 rises steeply with context, so a short cell cannot see a codec difference "even
-in principle". `kv_frac` is stated next to every row below so that bound is
-visible rather than assumed. It is a **(model, context)** quantity, not a
-context one; see docs/KV_QUANT.md, "`kv_frac` bounds a codec claim".
+in principle". `kv_frac` is stated next to every row so that bound is visible
+rather than assumed. It is a **(model, context)** quantity, not a context one;
+see docs/KV_QUANT.md, "`kv_frac` bounds a codec claim".
+
+**Host conditions, per cell.** The two Qwen3.8 cells ran with the busiest
+foreign process at **7.0–7.3 % of a core** for their whole comparison and are
+**not tainted**. The two Bonsai cells are marked TAINTED for a single, named,
+non-physical reason: a monitoring `grep` polling for run completion landed
+inside the harness's 1-second entry sample and read 102 %. Their comparison
+windows read 7.1 %. Earlier runs of these same four cells, on the same binary,
+were tainted for a real reason — a container runtime's virtual-machine helper at
+113–384 % of a core, which is not ours to stop on this machine — and those
+numbers are superseded here; only the residency figures were unaffected, and
+they came back bit-identical across both campaigns.
 
 Shape: `rmlx baseline`, `release-perf` build `sha256:c26e0d8a3ac43996`,
 `--max-tokens 100`, 1 untimed warmup + 8 slots per model (n=4 per arm),
 `--allow-busy-host --allow-token-divergence`. Arm A is `--kv-quant none` (true
 bf16 on every layer), arm B `--kv-quant mixed_k8g64_v4g64` (affine 8-bit K /
-4-bit V, and one of the two codec families whose decode genuinely reads its
-packed store). `kv_frac` and the predicted ceilings are
-`scripts/perf_ceiling.py` on the same snapshot.
+4-bit V, one of the two codec families whose decode genuinely reads its packed
+store). `kv_frac` and the predicted ceilings are `scripts/perf_ceiling.py` at
+the **measured** cache offset (`prompt_tokens + max_tokens - 1`), not at the
+fixture's nominal size.
 
-`kv_frac` and the predicted ceilings are evaluated at the **measured** cache
-offset (`prompt_tokens + max_tokens - 1`), not at the fixture's nominal size.
+**Family size.** Each result file states `null_p 0.02857` for its own single
+comparison, which is the number the harness prints. This table is **four**
+independent comparisons, so the chance that at least one comes back with
+disjoint ranges under the null is `1-(1-0.02857)^4 =` **0.109**. Two came back
+separated, and the larger of the two is a 23.7 % effect against a 0.9 % arm
+spread, which is not a coin flip — but read a single separated row against
+0.109, not 0.029. No `--invert` counterpart was run, so residual positional bias
+is uncancelled: the ABBA schedule already equalises the arms' mean slot
+position, but the pairing that would confirm it was not done.
 
-| model | prompt tok | `kv_frac` (A) | predicted ceiling B/A | decode B/A (median) | A range | B range | verdict | resident KV A → B | resident B/A |
+| model | prompt tok | `kv_frac` | predicted B/A | decode B/A | A range (CoV) | B range (CoV) | verdict | resident KV A → B | resident B/A |
 |---|---:|---:|---:|---:|---|---|---|---|---:|
-| Ternary-Bonsai-8B-2bit | 3 770 | 0.211 | 1.099 | 0.949 | 125.72–134.86 | 125.21–127.53 | INCONCLUSIVE | 570.5 → 734.1 MB | 1.287 |
-| Ternary-Bonsai-8B-2bit | 31 553 | **0.687** | **1.419** | 1.003 | 65.07–67.82 | 65.03–68.06 | INCONCLUSIVE | 4 667.3 → 6 032.9 MB | 1.293 |
-| Qwen3.8-27B-mxfp8 | 3 892 | 0.010 | 1.004 | 1.005 | 17.73–17.97 | 17.58–18.04 | INCONCLUSIVE | 415.5 → 506.5 MB | 1.219 |
-| Qwen3.8-27B-mxfp8 | 130 848 | 0.245 | 1.149 | **0.728** | 13.94–14.12 | 9.45–10.70 | **ranges disjoint** | 8 735.7 → 11 784.2 MB | 1.349 |
+| Ternary-Bonsai-8B-2bit | 3 770 | 0.211 | 1.099 | 0.975 | 141.45–143.03 (0.52 %) | 137.32–139.28 (0.66 %) | ranges disjoint | 570.5 → 734.1 MB | 1.287 |
+| Ternary-Bonsai-8B-2bit | 31 553 | **0.687** | **1.419** | 1.002 | 68.60–68.67 (0.04 %) | 68.56–68.77 (0.15 %) | INCONCLUSIVE | 4 667.3 → 6 032.9 MB | 1.293 |
+| Qwen3.8-27B-mxfp8 | 3 892 | 0.010 | 1.004 | 0.977 | 18.49–18.64 (0.37 %) | 18.06–18.13 (0.21 %) | SEPARATED | 415.5 → 506.5 MB | 1.219 |
+| Qwen3.8-27B-mxfp8 | 130 848 | 0.245 | 1.149 | **0.763** | 13.74–14.02 (0.89 %) | 10.61–10.72 (0.49 %) | SEPARATED | 8 735.7 → 11 784.2 MB | 1.349 |
 
-**What the 130 848-token Qwen3.8 row settles.** This is the cell that a
-long-context codec claim was supposed to be decided on: `kv_frac` 0.245, a
-predicted **+14.9 %** ceiling for arm B, and 20× the paired noise floor between
-the arms. Measured, arm B is **27.2 % slower**, with the two arms' per-slot
-ranges disjoint in the losing direction (every `none` slot faster than every
-`mixed` slot), and it holds **35 % more** resident KV and 6 034 MB more
-generation-scoped allocation. Both halves of the pre-declared long-context
-falsifier fire: resident above 0.60× and decode below 0.95×. The
-"measure it at 128 k and the codec will pay" hypothesis is not merely
-unsupported here — the sign is wrong.
+**What the 130 848-token Qwen3.8 row settles, and what it does not.** This is
+the cell a long-context codec claim was meant to turn on: `kv_frac` 0.245 and a
+predicted **+14.9 %** ceiling for arm B. Measured on a quiet host, arm B is
+**23.7 % slower**, every `none` slot faster than every `mixed` slot, while
+holding **35 % more** resident KV and 6 034 MB more generation-scoped
+allocation.
 
-This cell is also the least contended of the four: the entry gate refused at
-114 %, but only 4 of 8 slots were flagged (worst 35.8 % WindowServer) and the
-comparison window as a whole read 22.8 %, *under* the 25 % threshold. It is
-still reported as TAINTED, and still may not be read as an absolute anchor.
+**Scope, because the two halves are not equally load-bearing.** Arm B is
+`mixed_k8g64_v4g64` **as it stands on this tree**, which still materialises a
+packed store *and* retains both bf16 seeds: the change that stopped building a
+store for a mirror-fed codec deliberately excluded the Mixed / RotK family,
+whose decode really does read its store, so `materialises_packed_store()` is
+still true for it (`crates/rmlx-kv-quant/src/quant.rs`). The seed is exactly
+what a seed-elision projection removes.
 
-**Why `none` losing is not a roofline story.** Arm A's non-bandwidth per-step
-term is essentially flat across a 33× context change — 12.65 ms at 3 892 tokens,
-14.70 ms at 130 848 — so `none` decode really is bandwidth-dominated at 131 k
-(1.26× its 57.02 ms floor). Arm B halves the KV byte stream and still loses,
-because its own per-step cost is not flat: 98.55 ms measured against a 49.76 ms
-floor, 1.98×, i.e. 48.79 ms of non-bandwidth work against arm A's 14.70. The
-packed path does not fail to convert bytes into time; at this shape it spends
-more time than the bytes were worth.
+* The **resident** figure is therefore the *pre-elision* number and settles
+  nothing about a post-elision codec. It reproduces what the byte model already
+  predicts for today's `Mixed` (1.349 measured whole-cache; 1.355 attention-only
+  from `perf_ceiling.py`) — a confirmation, not a refutation.
+* The **decode** figure needs no post-elision arm and is the new evidence.
+  Returning an unread bf16 seed frees memory; it does not make a
+  quantized-matmul decode path faster, and arm B already reads its packed store.
+  So −23.7 % with disjoint ranges stands against any seed-elision variant of
+  this codec.
+
+Read as: *at 131 k, on this arch, the packed-store path costs decode
+throughput, and the memory question is still open pending the seed elision.*
+Nothing here shows the elision would not save the projected bytes. It is also
+consistent with the standing position that the byte ceiling is unreachable
+without the packed-path throughput work, which is open.
 
 **What the 31 553-token Bonsai row settles.** 0.687 is the largest `kv_frac`
-any model in the release set reaches at a context this tree can serve. Arm B
-cuts the decode KV stream to 0.571× of arm A's and the roofline predicts +42 %.
-Measured: **+0.3 %, ranges fully overlapping** — no measured effect — while
-resident KV goes *up* 29 %. So the short-context basis was not what made the
-earlier codec cells come back null: the null survives at the high-`kv_frac` end
-of the same axis.
+any release-set model reaches at a context this tree can serve. Arm B cuts the
+decode KV stream to 0.571× of arm A's and the roofline predicts +42 %.
+Measured: **+0.2 %, ranges overlapping** — no measured effect — while resident
+KV goes *up* 29 %. The arm spreads here are 0.04 % and 0.15 %, so this is a null
+with the power to have seen a 1 % effect. The short-context basis was not what
+made the earlier codec cells come back null: the null survives at the
+high-`kv_frac` end of the same axis.
 
 **The byte model is not what fails; it is exact where it is complete.** At the
 measured offsets `perf_ceiling.py` puts arm A's resident KV at 570.5 MB and
 4 667.3 MB on Bonsai — the measured figures, to the digit — and arm B within
-0.5 % and 0.06 %. What does not hold is the conversion of saved bytes into
-saved time: the ε of docs/KV_QUANT.md, "Fused flash-decode over a quant store",
-measured at 0.041–0.135 on every path tried so far.
+0.5 % and 0.06 %.
 
 **The Qwen3.8 resident ratio is diluted, not smaller.** That arch is hybrid:
 48 of its 64 layers hold a fixed-size GDN recurrent state the codec never
@@ -680,26 +695,46 @@ attention-KV ratio (1.219 measured against 1.355 attention-only at 3 892; 1.349
 against 1.355 at 130 848), the same way the `--kv-quant none` section reads
 Qwen3.6-35B's 1.060× against its 1.109× attention-only figure.
 
-**Decode moves away from the roofline as context grows.** Same runs, arm A,
-against `perf_ceiling.py`'s bandwidth-bound floor for the same cell:
+**`none`'s non-bandwidth overhead is flat across context; arm B's is not.**
+Same runs, against `perf_ceiling.py`'s bandwidth-bound floor for the same cell.
+The last column is the scale-free one:
 
-| model | prompt tok | measured ms/step | roofline ms/step | ratio | non-bandwidth ms/step |
-|---|---:|---:|---:|---:|---:|
-| Ternary-Bonsai-8B-2bit | 3 770 | 7.55 | 4.40 | 1.72× | 3.15 |
-| Ternary-Bonsai-8B-2bit | 31 553 | 15.01 | 11.07 | 1.36× | 3.94 |
-| Qwen3.8-27B-mxfp8 | 3 892 | 56.11 | 43.47 | 1.29× | 12.65 |
-| Qwen3.8-27B-mxfp8 | 130 848 | 71.72 | 57.02 | 1.26× | 14.70 |
+| model | prompt tok | arm | measured ms/step | roofline ms/step | ratio | non-bandwidth ms/step |
+|---|---:|---|---:|---:|---:|---:|
+| Ternary-Bonsai-8B-2bit | 3 770 | `none` | 7.01 | 4.40 | 1.59× | 2.61 |
+| Ternary-Bonsai-8B-2bit | 31 553 | `none` | 14.57 | 11.07 | 1.32× | 3.50 |
+| Qwen3.8-27B-mxfp8 | 3 892 | `none` | 53.99 | 43.47 | 1.24× | 10.52 |
+| Qwen3.8-27B-mxfp8 | 130 848 | `none` | 71.75 | 57.02 | 1.26× | 14.74 |
+| Qwen3.8-27B-mxfp8 | 3 892 | `mixed` | 55.24 | 43.25 | 1.28× | 11.99 |
+| Qwen3.8-27B-mxfp8 | 130 848 | `mixed` | 94.00 | 49.76 | 1.89× | **44.24** |
 
 Compare the last column, not the ratio: ratio-vs-roofline is
 `1 + overhead/ideal_ms` and is therefore *not* scale-free, so it cannot be
 compared across models of different size — the same fixed per-step cost reads
-large on a small model and small on a large one. Within one model the
-comparison is valid, and within each model the non-bandwidth term is roughly
-flat — Bonsai 3.15 → 3.94 ms across an 8× context change, Qwen3.8 12.65 →
-14.70 ms across 33×. Both models' `none` decode really is bandwidth-dominated
-at their long cell. That is what makes the null load-bearing: the regime where
-a byte cut *should* convert is the regime measured, on two architectures, and
-it did not convert on either.
+large on a small model and small on a large one. Within one model it is valid.
+`none`'s overhead is roughly flat (Bonsai 2.61 → 3.50 ms over an 8× context
+change, Qwen3.8 10.52 → 14.74 over 33×), so `none` decode really is
+bandwidth-dominated at the long cell — the regime where a byte cut *should*
+convert. Arm B's is not flat: 11.99 → 44.24 ms over the same span. It halves the
+KV byte stream and spends the saving three times over. That, not `kv_frac`, is
+what decides the cell.
+
+**Group A still costs nothing, at both contexts and both architectures.**
+Separately from the A/B cells, `none`, `k8v8`, `k8v4`, `planar` and `tsym3`
+were each run once per (model, context) and recorded through
+`rmlx baseline --record`. Within every cell all five report **byte-identical**
+`kv_cache_bytes`:
+
+| model | prompt tok | `kv_cache_bytes`, all 5 codecs |
+|---|---:|---:|
+| Ternary-Bonsai-8B-2bit (`kv_h` 8) | 3 770 | 560 480 256 |
+| Ternary-Bonsai-8B-2bit | 31 553 | 4 657 250 304 |
+| gemma-4-e2b-mxfp8 (`kv_h` 1, shared-KV) | 4 117 | 31 776 768 |
+| gemma-4-e2b-mxfp8 | 34 355 | 217 559 040 |
+
+20 rows in `runs.db`. These are byte counts, which are deterministic for a given
+(model, offset, codec), so one run per cell is the whole measurement — unlike a
+throughput figure, which is why these are not ABBA-paired.
 
 ## Host-sampler cost — PROVISIONAL, NOT AN ANCHOR (2026-08-16)
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -409,6 +409,13 @@ complements the pattern; running once each way cancels any residual positional
 bias. `--slots` must be a multiple of 4 — a partial block would give the arms
 different mean positions and put the confound back.
 
+**The verdict and the taint are separate lines, and separate facts.** `VERDICT:`
+always carries the rank test's answer — `SEPARATED` or `INCONCLUSIVE` — and a
+contaminated run adds a `TAINTED:` line beside it and exits 125. Taint used to
+*replace* the verdict, which discarded the one thing the run had computed for
+precisely the runs a reader most needs to re-read, and made any gate on the
+verdict silently a gate on host quiescence.
+
 **Criterion, fixed before the run.** The arms are **SEPARATED** if and only if
 their per-slot `decode_tps` ranges are disjoint. Under the null that the arms
 are exchangeable, `P(disjoint) = 2 / C(slots, slots/2)` — `2/924 = 0.00216` at
@@ -442,8 +449,8 @@ above are computed, and none should be read into the ratio.
 | A non-numeric `--slots` / `--busy-pct` / shape option | exit 125 before measuring | none |
 | `--slots` whose null probability exceeds 0.05 | exit 125 before measuring | none |
 | Host not quiescent — any foreign process ≥ `--busy-pct` (default 25) of a core | exit 125 before measuring | `--allow-busy-host` (still exits 125 if the result is tainted) |
-| A foreign process ran during any slot or across the comparison | verdict `TAINTED`, exit 125 | none |
-| A slot or the comparison could not be sampled for interference | verdict `TAINTED`, exit 125 | none |
+| A foreign process ran during any slot or across the comparison | `TAINTED:` line, exit 125 | none |
+| A slot or the comparison could not be sampled for interference | `TAINTED:` line, exit 125 | none |
 | Arms generate different token ids | exit 1 | `--allow-token-divergence` |
 | A slot stops reproducing its own arm's warmup token ids | exit 1 | none |
 | `rmlx serve` holds the Metal context | exit 125 (reported, never killed) | none |

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -53,7 +53,7 @@ Conventions:
 
 | Script | Via | What it does |
 |---|---|---|
-| `perf_ab.sh` | `perf_canary.sh --ab` | **ABBA-interleaved A/B of two `rmlx baseline` arms.** Host-quiescence gate, arm-distinguishability guard, token-id comparison. |
+| `perf_ab.sh` | `perf_canary.sh --ab` | **ABBA-interleaved A/B of two `rmlx baseline` arms.** Host-quiescence gate, arm-distinguishability guard, token-id comparison, per-arm `metal_gen_alloc_mb` + resident `kv_cache_bytes`. Never writes `runs.db` — promote a result with `ingest/perf_ab_ingest.py`. |
 | `perf_ab_selftest.sh` | `make canary-ab-selftest` | Mutation check for `perf_ab.sh` — every guard must fail when broken. |
 | `bench_llama_ab_selftest.sh` | `make llama-ab-selftest` | Mutation check for `bench_llama_ab.sh` against a stub `llama-server` — 13 cases, one per guard. In `make ci`. |
 | `bench_llama_ab.sh` | — | **ABBA-interleaved A/B of two `llama-server` arms** (fork vs upstream, codec vs codec). Same quiescence discipline as `perf_ab.sh`, reported over the server's own `timings` plus KV-buffer and peak-RSS columns. Never writes `runs.db`. |
@@ -88,6 +88,7 @@ Conventions:
 |---|---|
 | `ingest/llama_bench_ingest.py` | Convert `llama-bench -o json` rows into the §8.5 universal RunRecord and ingest them. |
 | `ingest/llama_ab_ingest.py` | Promote one accepted `bench_llama_ab.sh` result into two §8.5 RunRecords (one per arm). Refuses a TAINTED run unless told otherwise. |
+| `ingest/perf_ab_ingest.py` | Promote one accepted `perf_ab.sh` result into two §8.5 RunRecords (one per arm), carrying `decode_tps_warm` + `kv_cache_bytes`. Identity comes from the measured binary; refuses a TAINTED run unless told otherwise. |
 | `lib/identity.sh` | Shared §8.5 run-identity (`rmlx metrics identity --json`) for bench scripts. **Source it.** |
 | `lib/prefill_ms.py` | Read `decode_profile{prefill_ms}` back out of an rmlx run log. |
 

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -55,6 +55,7 @@ Conventions:
 |---|---|---|
 | `perf_ab.sh` | `perf_canary.sh --ab` | **ABBA-interleaved A/B of two `rmlx baseline` arms.** Host-quiescence gate, arm-distinguishability guard, token-id comparison, per-arm `metal_gen_alloc_mb` + resident `kv_cache_bytes`. Never writes `runs.db` — promote a result with `ingest/perf_ab_ingest.py`. |
 | `perf_ab_selftest.sh` | `make canary-ab-selftest` | Mutation check for `perf_ab.sh` — every guard must fail when broken. |
+| `perf_ab_ingest_selftest.sh` | `make canary-ab-ingest-selftest` | Mutation check for `ingest/perf_ab_ingest.py` — 15 cases over synthetic result files, one per refusal. Never writes `runs.db`. In `make ci`. |
 | `bench_llama_ab_selftest.sh` | `make llama-ab-selftest` | Mutation check for `bench_llama_ab.sh` against a stub `llama-server` — 13 cases, one per guard. In `make ci`. |
 | `bench_llama_ab.sh` | — | **ABBA-interleaved A/B of two `llama-server` arms** (fork vs upstream, codec vs codec). Same quiescence discipline as `perf_ab.sh`, reported over the server's own `timings` plus KV-buffer and peak-RSS columns. Never writes `runs.db`. |
 | `perf_canary.sh` | `make perf-canary` | Fast decode-TPS canary over the three standard test-target models. |
@@ -88,7 +89,7 @@ Conventions:
 |---|---|
 | `ingest/llama_bench_ingest.py` | Convert `llama-bench -o json` rows into the §8.5 universal RunRecord and ingest them. |
 | `ingest/llama_ab_ingest.py` | Promote one accepted `bench_llama_ab.sh` result into two §8.5 RunRecords (one per arm). Refuses a TAINTED run unless told otherwise. |
-| `ingest/perf_ab_ingest.py` | Promote one accepted `perf_ab.sh` result into two §8.5 RunRecords (one per arm), carrying `decode_tps_warm` + `kv_cache_bytes`. Identity comes from the measured binary; refuses a TAINTED run unless told otherwise. |
+| `ingest/perf_ab_ingest.py` | Promote one accepted `perf_ab.sh` result into two §8.5 RunRecords (one per arm), carrying `decode_tps_warm` + `kv_cache_bytes`. Identity comes from the measured binary and is digest-checked against the run; refuses a TAINTED run, a weakened interference gate, or a cell key that disagrees with the measurement. |
 | `lib/identity.sh` | Shared §8.5 run-identity (`rmlx metrics identity --json`) for bench scripts. **Source it.** |
 | `lib/prefill_ms.py` | Read `decode_profile{prefill_ms}` back out of an rmlx run log. |
 

--- a/scripts/bench_llama_ab_selftest.sh
+++ b/scripts/bench_llama_ab_selftest.sh
@@ -110,8 +110,16 @@ SERVE
 
 KV_OK='llama_kv_cache:       MTL0 KV buffer size =   512.00 MiB'
 
+# FORCE_UNMEASURED_ROWS drives the harness down its TAINTED path on demand and
+# without an interferer. `cpu_snapshot` refuses a process table shorter than
+# CPU_SNAPSHOT_MIN_ROWS, a refused snapshot classifies its window `unmeasured`,
+# and an unmeasured window taints — so an absurd floor taints every run,
+# deterministically, on the quietest possible host. Waiting for a real foreign
+# process to show up is how a gate ends up asserting the weather.
 run_ab() { # <extra args...> -> stdout+stderr in $OUT, code in $CODE
-	OUT="$(RMLX_HOME="$WORK/home" bash "$AB" \
+	OUT="$(RMLX_HOME="$WORK/home" \
+		CPU_SNAPSHOT_MIN_ROWS="${FORCE_UNMEASURED_ROWS:-20}" \
+		bash "$AB" \
 		--model "$MODEL" --prompt-file "$PROMPT" \
 		--port "$PORT" --n-predict 4 --n-ctx 64 \
 		--out-dir "$WORK/home/bench" --ready-timeout 25 \
@@ -120,6 +128,46 @@ run_ab() { # <extra args...> -> stdout+stderr in $OUT, code in $CODE
 }
 
 # check <label> <expected-code> <expected-substring>
+# check_verdict <label> <verdict-text>
+#
+# For a comparison that RAN TO COMPLETION the process exit code is 0 on a quiet
+# host and 125 on a tainted one. An assertion on that number is therefore an
+# assertion about the machine, not about the harness: it passes while the host
+# is busy and fails the moment it goes quiet, which is the exact inverse of what
+# a gate should do. The three verdict cases below asserted exactly that, and
+# were observed passing 13/13, 13/13 and 12/13 on one unchanged tree.
+#
+# So two things are asserted instead, and neither depends on the host:
+#
+#   1. the verdict the harness printed is the expected one -- the behaviour
+#      these cases exist to guard;
+#   2. the exit code agrees with the harness's OWN taint report: `TAINTED`
+#      printed means 125, absent means 0. That still catches a harness that
+#      stops exiting 125 on a tainted run (which would make every contaminated
+#      comparison read clean) without importing the host into the expectation.
+#
+# The guard cases keep asserting 125 directly, and correctly: there the 125 is
+# a refusal the harness chose, emitted before any comparison exists.
+check_verdict() {
+	local label="$1" needle="$2"
+	local saw_taint=0 want=0
+	printf '%s' "$OUT" | grep -q '^TAINTED' && { saw_taint=1; want=125; }
+	local verdict_ok=0
+	printf '%s' "$OUT" | grep -q "^verdict    $needle" && verdict_ok=1
+	if [ "$verdict_ok" -eq 1 ] && [ "$CODE" -eq "$want" ]; then
+		echo "  PASS  $label (verdict matched; host $( [ "$saw_taint" -eq 1 ] && echo tainted || echo quiet ), exit $CODE)"
+		PASS=$((PASS + 1))
+	else
+		if [ "$verdict_ok" -ne 1 ]; then
+			echo "  FAIL  $label (wrong verdict; wanted: $needle)"
+		else
+			echo "  FAIL  $label (verdict correct, but exit $CODE contradicts the harness's own taint report; wanted $want)"
+		fi
+		printf '%s\n' "$OUT" | sed 's/^/        /' | tail -12
+		FAIL=$((FAIL + 1))
+	fi
+}
+
 check() {
 	local label="$1" want="$2" needle="$3"
 	if [ "$CODE" -eq "$want" ] && printf '%s' "$OUT" | grep -q -- "$needle"; then
@@ -199,15 +247,37 @@ check "a server serving another model fails the slot" 125 "wrong-server"
 # inert and every one of this campaign's verdicts is worthless.
 STUB_C="$(make_stub c "50,52" "$KV_OK" "hello world")"
 run_ab --bin-a "$STUB_A" --bin-b "$STUB_C" --pairs 2 --allow-busy-host
-check "identical timings read INCONCLUSIVE" 125 "INCONCLUSIVE ranges-overlap"
+check_verdict "identical timings read INCONCLUSIVE" "INCONCLUSIVE ranges-overlap"
 
 # --- behaviour: disjoint ranges at n=2 must be flagged weak ------------------
 run_ab --bin-a "$STUB_A" --bin-b "$STUB_B" --pairs 2 --allow-busy-host
-check "disjoint ranges at n=2 read SEPARATED-WEAK" 125 "SEPARATED-WEAK n=2-per-arm"
+check_verdict "disjoint ranges at n=2 read SEPARATED-WEAK" "SEPARATED-WEAK n=2-per-arm"
 
 # --- behaviour: disjoint ranges at n=3 read SEPARATED ------------------------
 run_ab --bin-a "$STUB_A" --bin-b "$STUB_B" --pairs 3 --allow-busy-host
-check "disjoint ranges at n=3 read SEPARATED" 125 "SEPARATED 0."
+check_verdict "disjoint ranges at n=3 read SEPARATED" "SEPARATED 0."
+
+# --- the same three verdicts, with the taint path forced --------------------
+#
+# The point of the three cases above is that the verdict is a property of the
+# measurements, not of the machine. Asserting that on whatever host happens to
+# be running proves only that today's host produced it. These re-run the same
+# comparisons with every interference window forced `unmeasured`, so the
+# harness takes its TAINTED branch and exits 125, and require the verdict to be
+# character-for-character the same.
+FORCE_UNMEASURED_ROWS=999999
+
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_C" --pairs 2 --allow-busy-host
+check_verdict "INCONCLUSIVE survives a tainted host" "INCONCLUSIVE ranges-overlap"
+check "...and a forced taint really did taint" 125 "TAINTED"
+
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_B" --pairs 2 --allow-busy-host
+check_verdict "SEPARATED-WEAK survives a tainted host" "SEPARATED-WEAK n=2-per-arm"
+
+run_ab --bin-a "$STUB_A" --bin-b "$STUB_B" --pairs 3 --allow-busy-host
+check_verdict "SEPARATED survives a tainted host" "SEPARATED 0."
+
+unset FORCE_UNMEASURED_ROWS
 
 # --- the harness must never write runs.db ------------------------------------
 if find "$WORK/home" -name 'runs.db*' -print -quit 2>/dev/null | grep -q .; then

--- a/scripts/ingest/perf_ab_ingest.py
+++ b/scripts/ingest/perf_ab_ingest.py
@@ -37,6 +37,7 @@ key.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -62,17 +63,22 @@ _KV_FLAG = re.compile(r"--kv-quant[= ]+(\S+)")
 
 
 def _kv_quant_of(arm_args: str, declared: str, arm: str) -> str:
-    """Check the declared codec against the arm's recorded arguments."""
-    m = _KV_FLAG.search(arm_args or "")
+    """Check the declared codec against the arm's recorded arguments.
+
+    The LAST occurrence wins, because that is how clap resolves a repeated
+    flag: taking the first would confirm a codec the slot did not run.
+    """
+    matches = _KV_FLAG.findall(arm_args or "")
+    m = matches[-1] if matches else None
     if not m:
         raise SystemExit(
             f"arm {arm} recorded no --kv-quant in its arguments ({arm_args!r}), so "
             f"the declared '{declared}' cannot be confirmed. Both arms of a codec "
             "comparison must name their codec explicitly."
         )
-    if m.group(1) != declared:
+    if m != declared:
         raise SystemExit(
-            f"arm {arm} ran --kv-quant {m.group(1)} but --arm-{arm.lower()}-kv-quant "
+            f"arm {arm} ran --kv-quant {m} but --arm-{arm.lower()}-kv-quant "
             f"says '{declared}'. The cell key would not describe the measurement."
         )
     return declared
@@ -81,10 +87,12 @@ def _kv_quant_of(arm_args: str, declared: str, arm: str) -> str:
 def _kv_bytes(stats: dict[str, Any]) -> tuple[int | None, str]:
     """Resident KV for one arm, in bytes, plus a provenance note.
 
-    `perf_ab.sh` carries the exact byte count. Results written before it did
-    carry only the report table's 0.1 MB display field; those are still
-    ingestable, but the row says where its precision came from rather than
-    presenting a rounded number as an exact one.
+    `perf_ab.sh` carries the exact byte count. A handful of result files on this
+    machine carry only the report table's 0.1 MB display field, because they
+    were produced by an intermediate revision of the harness that was never
+    committed — no released or committed version of `perf_ab.sh` emits that
+    shape. They are still ingestable, and the row then states where its
+    precision came from rather than presenting a rounded number as an exact one.
     """
     exact = stats.get("median_kv_cache_bytes")
     if exact is not None:
@@ -98,6 +106,31 @@ def _kv_bytes(stats: dict[str, Any]) -> tuple[int | None, str]:
         "field (this result predates median_kv_cache_bytes), so it is exact to "
         "+/-50 kB, not to the byte",
     )
+
+
+def _verify_binary(binary: str, sha256_16: str, arm: str) -> None:
+    """Refuse when the binary on disk is not the one the run measured.
+
+    `_identity` asks a PATH who it is, and the run recorded a digest. Between
+    the run and the ingest that path can be rebuilt, and then `backend_version`
+    / `build_profile` describe one binary while the row's notes assert another
+    — permanently, in an append-only table. The digest is the only thing that
+    ties the two together, so it is checked rather than pasted.
+    """
+    path = Path(binary)
+    if not path.is_file():
+        raise SystemExit(
+            f"arm {arm}'s binary {binary} no longer exists, so its identity "
+            f"(recorded digest sha256:{sha256_16}) cannot be confirmed."
+        )
+    actual = hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+    if actual != sha256_16:
+        raise SystemExit(
+            f"arm {arm}'s binary {binary} now hashes sha256:{actual}, but the run "
+            f"recorded sha256:{sha256_16}. It was rebuilt after the measurement, so "
+            "its version and build profile no longer describe the numbers in this "
+            "result. Rebuild at the measured commit, or re-run the comparison."
+        )
 
 
 def _identity(binary: str) -> dict[str, Any]:
@@ -143,6 +176,9 @@ def _arm_record(
     )
     if tainted:
         notes += f"; TAINTED: {tainted}"
+    waived = sorted(k for k, v in (result.get("waivers") or {}).items() if v)
+    if waived:
+        notes += f"; guards waived: {', '.join(waived)}"
 
     metrics: list[dict[str, Any]] = [
         {
@@ -157,6 +193,7 @@ def _arm_record(
     if kv_note:
         notes += f"; {kv_note}"
 
+    _verify_binary(top["binary"], top["sha256_16"], arm)
     return {
         **_identity(top["binary"]),
         "schema_version": 1,
@@ -206,8 +243,9 @@ def main() -> int:
         "--prompt-tokens",
         type=int,
         default=None,
-        help="tokenized prompt length. Read from the result when the harness "
-        "recorded one; required otherwise, because the fixture's NAME "
+        help="tokenized prompt length. The harness measures it and this becomes a "
+        "cross-check that errors on mismatch; it is only required for a result "
+        "written before the harness recorded one. Note the fixture's NAME "
         "(--prompt-tokens 131072) is not its token count.",
     )
     p.add_argument("--prompt-name", default=None)
@@ -249,6 +287,22 @@ def main() -> int:
         )
         return 2
 
+    # A raised --busy-pct does not taint: it removes the gate that would have
+    # tainted. The result then looks clean for the one reason a result must
+    # never look clean, and the taint check above cannot see it.
+    waivers = result.get("waivers") or {}
+    if waivers.get("busy_pct_raised") and not args.accept_tainted:
+        print(
+            "refusing: the run raised --busy-pct above the default, so the "
+            "interference\n"
+            "  gate was weakened and an empty taint means the gate did not fire, "
+            "not that\n"
+            "  the host was quiet. Re-run at the default threshold, or pass "
+            "--accept-tainted.",
+            file=sys.stderr,
+        )
+        return 2
+
     # Prompt: the harness names a canonical fixture by requested size, and the
     # fixture's rendered token count is a different number.
     requested = result["shape"]["prompt_tokens"]
@@ -262,14 +316,26 @@ def main() -> int:
         raise SystemExit(f"no prompt body at {prompt_path} (pass --prompt-file)")
     prompt_body = prompt_path.read_text(encoding="utf-8")
 
-    prompt_tokens = cell.get("prompt_tokens", args.prompt_tokens)
-    if prompt_tokens is None:
-        raise SystemExit(
-            "this result carries no measured prompt_tokens (it predates the "
-            "harness recording one). Pass --prompt-tokens with the count the "
-            "run's `baseline: ... prompt_tokens=` line reported; the fixture's "
-            "requested size is not it."
-        )
+    measured = cell.get("prompt_tokens")
+    if measured is None:
+        if args.prompt_tokens is None:
+            raise SystemExit(
+                "this result carries no measured prompt_tokens (it predates the "
+                "harness recording one). Pass --prompt-tokens with the count the "
+                "run's `baseline: ... prompt_tokens=` line reported; the fixture's "
+                "requested size is not it."
+            )
+        prompt_tokens = args.prompt_tokens
+    else:
+        # The harness measured it. A supplied value is then a cross-check, never
+        # an override: the cell key must be what ran, not what was expected.
+        if args.prompt_tokens is not None and args.prompt_tokens != measured:
+            raise SystemExit(
+                f"--prompt-tokens {args.prompt_tokens} disagrees with the "
+                f"{measured} the run tokenized. The recorded cell key would not "
+                "describe the measurement."
+            )
+        prompt_tokens = measured
 
     records = [
         _arm_record(result, cell, arm, args, prompt_body, prompt_tokens, prompt_name)

--- a/scripts/ingest/perf_ab_ingest.py
+++ b/scripts/ingest/perf_ab_ingest.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Ingest a `scripts/perf_ab.sh` result into the rMLX metrics DB.
+
+`perf_ab.sh` deliberately never touches `runs.db` — an A/B run is an experiment
+and the store is append-only. This is the separate, explicit step that promotes
+one accepted comparison into two §8.5 RunRecords, one per arm.
+
+Sibling of `llama_ab_ingest.py`, which does the same job for
+`bench_llama_ab.sh`. The two inputs are different shapes and different
+backends: this one reads `rmlx baseline` slots, so the identity block comes
+from the measured binary itself (`rmlx metrics identity --json`) instead of
+being caller-supplied, and the residency column is `kv_cache_bytes` off the
+harness's own per-slot parse rather than a server's KV-buffer log line.
+
+Usage:
+    # Inspect the records without writing anything:
+    python3 scripts/ingest/perf_ab_ingest.py --dry-run RESULT.json \
+        --model Qwen3.8-27B-mxfp8 --weight-quant mxfp8 \
+        --arm-a-kv-quant none --arm-b-kv-quant mixed_k8g64_v4g64 \
+        --prompt-tokens 130848
+
+    # Write buffer files and ingest them:
+    python3 scripts/ingest/perf_ab_ingest.py --record RESULT.json ...
+
+A run the harness marked TAINTED is refused unless `--accept-tainted` is given,
+and the taint text is then carried into `notes`: on a host where the quiescence
+gate never clears, an unmarked row is a claim of a clean measurement that was
+never made.
+
+`--arm-*-kv-quant` is required and then *checked* against the `--kv-quant` in
+that arm's recorded arguments. It is not parsed out of them: a result whose arm
+carries no `--kv-quant` at all is a different failure from one that carries a
+different codec, and collapsing the two is how a row lands under the wrong cell
+key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+RMLX_REPO_ROOT = Path(os.environ.get("RMLX_REPO_ROOT", str(_SCRIPT_DIR.parents[1])))
+# Runtime state lives under a single root (CLAUDE.md). `RMLX_HOME` wins; the
+# in-repo `.rmlx/` is the dev default.
+RMLX_HOME = Path(os.environ.get("RMLX_HOME", str(RMLX_REPO_ROOT / ".rmlx")))
+BUFFER_PENDING = RMLX_HOME / "metrics" / "buffer" / "pending"
+# Records are assembled HERE first and only moved into `pending/` for the
+# moment the recorder is actually invoked. Anything sitting in `pending/` is,
+# by contract, work the next `rmlx metrics record --replay-pending` will claim
+# — and that sweep quarantines whatever it cannot ingest into `buffer/failed/`.
+STAGING = RMLX_HOME / "bench" / "perf_ab" / "records"
+
+_KV_FLAG = re.compile(r"--kv-quant[= ]+(\S+)")
+
+
+def _kv_quant_of(arm_args: str, declared: str, arm: str) -> str:
+    """Check the declared codec against the arm's recorded arguments."""
+    m = _KV_FLAG.search(arm_args or "")
+    if not m:
+        raise SystemExit(
+            f"arm {arm} recorded no --kv-quant in its arguments ({arm_args!r}), so "
+            f"the declared '{declared}' cannot be confirmed. Both arms of a codec "
+            "comparison must name their codec explicitly."
+        )
+    if m.group(1) != declared:
+        raise SystemExit(
+            f"arm {arm} ran --kv-quant {m.group(1)} but --arm-{arm.lower()}-kv-quant "
+            f"says '{declared}'. The cell key would not describe the measurement."
+        )
+    return declared
+
+
+def _kv_bytes(stats: dict[str, Any]) -> tuple[int | None, str]:
+    """Resident KV for one arm, in bytes, plus a provenance note.
+
+    `perf_ab.sh` carries the exact byte count. Results written before it did
+    carry only the report table's 0.1 MB display field; those are still
+    ingestable, but the row says where its precision came from rather than
+    presenting a rounded number as an exact one.
+    """
+    exact = stats.get("median_kv_cache_bytes")
+    if exact is not None:
+        return int(exact), ""
+    rounded = stats.get("median_kv_cache_mb")
+    if rounded is None:
+        return None, ""
+    return (
+        round(rounded * 1e6),
+        "kv_cache_bytes derived from the harness report table's 0.1 MB display "
+        "field (this result predates median_kv_cache_bytes), so it is exact to "
+        "+/-50 kB, not to the byte",
+    )
+
+
+def _identity(binary: str) -> dict[str, Any]:
+    """§8.5 identity block, asked of the binary that produced the numbers."""
+    out = subprocess.run(
+        [binary, "metrics", "identity", "--json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if out.returncode != 0:
+        raise SystemExit(f"'{binary} metrics identity --json' failed:\n{out.stderr}")
+    # The command logs to stderr and prints one JSON object to stdout.
+    return json.loads(out.stdout.strip().splitlines()[-1])
+
+
+def _arm_record(
+    result: dict[str, Any],
+    cell: dict[str, Any],
+    arm: str,
+    args: argparse.Namespace,
+    prompt_body: str,
+    prompt_tokens: int,
+    prompt_name: str,
+) -> dict[str, Any]:
+    """Build one §8.5 RunRecord from one arm of an A/B result."""
+    key = "arm_a" if arm == "A" else "arm_b"
+    stats = cell[key]
+    top = result[key]
+    declared = args.arm_a_kv_quant if arm == "A" else args.arm_b_kv_quant
+    kv_quant = _kv_quant_of(top.get("args", ""), declared, arm)
+
+    kv_bytes, kv_note = _kv_bytes(stats)
+    tainted = cell.get("taint") or ""
+
+    notes = (
+        f"perf_ab.sh ABBA n={stats['n']}/arm; decode_tps median over slots, "
+        f"min={stats['min_tps']:.3f} max={stats['max_tps']:.3f}; "
+        f"verdict={cell['verdict']}; "
+        f"paired arm {top['label']!r} vs "
+        f"{result['arm_b' if arm == 'A' else 'arm_a']['label']!r}; "
+        f"binary sha256:{top['sha256_16']}"
+    )
+    if tainted:
+        notes += f"; TAINTED: {tainted}"
+
+    metrics: list[dict[str, Any]] = [
+        {
+            "name": "decode_tps_warm",
+            "value": stats["median_tps"],
+            "stddev": stats["sd_tps"] if stats["n"] > 1 else None,
+        }
+    ]
+    # `null` is the supported way to say "not measured"; a 0 here would rank in
+    # `bests` as the smallest cache ever recorded.
+    metrics.append({"name": "kv_cache_bytes", "value": kv_bytes})
+    if kv_note:
+        notes += f"; {kv_note}"
+
+    return {
+        **_identity(top["binary"]),
+        "schema_version": 1,
+        "model_namespace": args.model_namespace,
+        "model": args.model,
+        "weight_quant": args.weight_quant,
+        "kv_quant": kv_quant,
+        "ctx_max": result["shape"]["max_ctx"],
+        "prompt": {
+            "name": prompt_name,
+            "body": prompt_body,
+            "notes": args.prompt_notes,
+        },
+        "ts_utc": _iso(result["ts_utc"]),
+        "git_sha": args.git_sha,
+        "prompt_tokens": prompt_tokens,
+        "max_tokens": result["shape"]["max_tokens"],
+        "temperature": 0.0,
+        "seed": 0,
+        "n_warmups": 1,
+        "n_measure": stats["n"],
+        "notes": notes,
+        "description": args.description,
+        "metrics": metrics,
+    }
+
+
+def _iso(stamp: str) -> str:
+    """`perf_ab.sh` stamps `YYYYMMDDTHHMMSSZ`; §8.5 wants ISO-8601."""
+    if re.fullmatch(r"\d{8}T\d{6}Z", stamp):
+        return (
+            f"{stamp[0:4]}-{stamp[4:6]}-{stamp[6:8]}T"
+            f"{stamp[9:11]}:{stamp[11:13]}:{stamp[13:15]}Z"
+        )
+    return stamp
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("result", help="JSON emitted by perf_ab.sh")
+    p.add_argument("--model", required=True, help="§5.1 model label")
+    p.add_argument("--model-namespace", default="mlx-community")
+    p.add_argument("--weight-quant", required=True, help="§5.2 whitelist value")
+    p.add_argument("--arm-a-kv-quant", required=True)
+    p.add_argument("--arm-b-kv-quant", required=True)
+    p.add_argument(
+        "--prompt-tokens",
+        type=int,
+        default=None,
+        help="tokenized prompt length. Read from the result when the harness "
+        "recorded one; required otherwise, because the fixture's NAME "
+        "(--prompt-tokens 131072) is not its token count.",
+    )
+    p.add_argument("--prompt-name", default=None)
+    p.add_argument("--prompt-file", default=None)
+    p.add_argument("--prompt-notes", default=None)
+    p.add_argument(
+        "--git-sha",
+        default=None,
+        help="caller-supplied provenance (§8.5.1); the binary does no git.",
+    )
+    p.add_argument("--description", default=None)
+    p.add_argument("--accept-tainted", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument(
+        "--record", action="store_true", help="ingest via `rmlx metrics record --file`"
+    )
+    p.add_argument(
+        "--rmlx-bin", default=str(RMLX_REPO_ROOT / "target" / "release" / "rmlx")
+    )
+    args = p.parse_args()
+
+    result = json.loads(Path(args.result).read_text(encoding="utf-8"))
+    cells = result["results"]
+    if len(cells) != 1:
+        raise SystemExit(
+            f"{args.result} compares {len(cells)} models in one run. The model "
+            "label, namespace and weight quant are per model and this script "
+            "takes one of each — re-run perf_ab.sh with a single --model, or "
+            "ingest each cell from its own result file."
+        )
+    cell = cells[0]
+
+    if cell.get("taint") and not args.accept_tainted:
+        print(
+            f"refusing: run is TAINTED ({cell['taint']}).\n"
+            "  Re-run on a quiet host, or pass --accept-tainted to record it with\n"
+            "  the taint carried into `notes`.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Prompt: the harness names a canonical fixture by requested size, and the
+    # fixture's rendered token count is a different number.
+    requested = result["shape"]["prompt_tokens"]
+    prompt_name = args.prompt_name or f"longctx_{requested // 1024}k"
+    prompt_path = (
+        Path(args.prompt_file)
+        if args.prompt_file
+        else RMLX_REPO_ROOT / "prompts" / f"{prompt_name}.json"
+    )
+    if not prompt_path.is_file():
+        raise SystemExit(f"no prompt body at {prompt_path} (pass --prompt-file)")
+    prompt_body = prompt_path.read_text(encoding="utf-8")
+
+    prompt_tokens = cell.get("prompt_tokens", args.prompt_tokens)
+    if prompt_tokens is None:
+        raise SystemExit(
+            "this result carries no measured prompt_tokens (it predates the "
+            "harness recording one). Pass --prompt-tokens with the count the "
+            "run's `baseline: ... prompt_tokens=` line reported; the fixture's "
+            "requested size is not it."
+        )
+
+    records = [
+        _arm_record(result, cell, arm, args, prompt_body, prompt_tokens, prompt_name)
+        for arm in ("A", "B")
+    ]
+
+    if args.dry_run:
+        for rec in records:
+            trimmed = dict(rec)
+            trimmed["prompt"] = dict(rec["prompt"], body=f"<{len(prompt_body)} chars>")
+            print(json.dumps(trimmed, indent=2))
+        return 0
+
+    stamp = result["ts_utc"].replace("-", "").replace(":", "")
+    STAGING.mkdir(parents=True, exist_ok=True)
+    staged: list[Path] = []
+    for rec in records:
+        path = STAGING / f"{stamp}-{rec['kv_quant']}-{uuid.uuid4().hex[:8]}.json"
+        path.write_text(json.dumps(rec, indent=2), encoding="utf-8")
+        staged.append(path)
+        print(f"staged {path}")
+
+    if not args.record:
+        print(
+            "not ingested (pass --record). The files above are OUTSIDE\n"
+            f"  {BUFFER_PENDING},\n"
+            "  so no --replay-pending sweep can claim them. Inspect, then re-run\n"
+            "  with --record."
+        )
+        return 0
+
+    # Move into the live queue one file at a time, immediately before the
+    # recorder claims it, and take it back out either way.
+    BUFFER_PENDING.mkdir(parents=True, exist_ok=True)
+    failed = 0
+    for path in staged:
+        queued = BUFFER_PENDING / path.name
+        path.rename(queued)
+        try:
+            proc = subprocess.run(
+                [args.rmlx_bin, "metrics", "record", "--file", str(queued)], check=False
+            )
+        finally:
+            if queued.exists():
+                queued.rename(path)
+        if proc.returncode != 0:
+            print(
+                f"ingest FAILED for {path} (exit {proc.returncode}); "
+                "record kept in staging, not in the pending queue",
+                file=sys.stderr,
+            )
+            failed += 1
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf_ab.sh
+++ b/scripts/perf_ab.sh
@@ -456,6 +456,7 @@ PATTERN="$(build_pattern "$SLOTS" "$INVERT")"
 SLOT_TPS=""
 SLOT_MEM=""
 SLOT_KV=""
+SLOT_PTOK=""
 SLOT_IDS_FILE=""
 SLOT_HOST=""
 
@@ -500,6 +501,11 @@ run_slot() {
 	MODEL_ELAPSED="$(awk -v a="$MODEL_ELAPSED" -v b="$elapsed" 'BEGIN { printf "%.3f", a + b }')"
 
 	SLOT_TPS="$(sed -n 's/.*decode_tps=\([0-9.]*\).*/\1/p' "$raw" | head -1)"
+	# The TOKENIZED prompt length, which is not `--prompt-tokens`: that names a
+	# canonical fixture by requested size and the rendered chat template lands
+	# somewhere else (131072 -> 130848 on one snapshot here). It is the cell key
+	# for every recorded row, so it is measured rather than restated.
+	SLOT_PTOK="$(sed -n 's/.*[^_]prompt_tokens=\([0-9]*\).*/\1/p' "$raw" | head -1)"
 	SLOT_MEM="$(sed -n 's/.*metal_gen_alloc_mb=\([0-9.]*\).*/\1/p' "$raw" | head -1)"
 	local slot_peak
 	slot_peak="$(sed -n 's/.*metal_peak_mb=\([0-9.]*\).*/\1/p' "$raw" | head -1)"
@@ -513,8 +519,24 @@ run_slot() {
 	# did not report; it is carried through as `n/a` rather than parsed to 0,
 	# because a zero here would average into a residency ratio as a real cache
 	# of no bytes. An arm with any `n/a` slot reports no residency figure.
-	SLOT_KV="$(sed -n 's/.*kv_cache_bytes=\([0-9a-z/]*\).*/\1/p' "$raw" | head -1)"
+	#
+	# Two accepted spellings and nothing else. The capture class is deliberately
+	# wide so that a THIRD spelling is seen and refused here rather than parsed:
+	# awk reads any non-numeric token as 0, so `nan`, a truncated field or an
+	# error word would become a median of 0 bytes -- a number that survives every
+	# downstream check and records as the smallest cache ever measured.
+	SLOT_KV="$(sed -n 's/.*kv_cache_bytes=\([^ ]*\).*/\1/p' "$raw" | head -1)"
 	[[ -z "$SLOT_KV" ]] && SLOT_KV="n/a"
+	case "$SLOT_KV" in
+	n/a | *[!0-9]*)
+		if [[ "$SLOT_KV" != "n/a" ]]; then
+			echo "ERROR: slot $tag reported kv_cache_bytes=$SLOT_KV, which is neither a" >&2
+			echo "  byte count nor the 'n/a' refusal. A non-numeric token parses to 0 and" >&2
+			echo "  would be recorded as a cache of no bytes. Output: $raw" >&2
+			exit 125
+		fi
+		;;
+	esac
 	sed -n 's/^baseline: token_ids=//p' "$raw" | head -1 | tr ',' '\n' >"$ids"
 	SLOT_IDS_FILE="$ids"
 	local has_ids_line=0
@@ -522,6 +544,12 @@ run_slot() {
 
 	if [[ -z "$SLOT_TPS" ]]; then
 		echo "ERROR: slot $tag produced no decode_tps. Output: $raw" >&2
+		exit 125
+	fi
+	if [[ -z "$SLOT_PTOK" ]]; then
+		echo "ERROR: slot $tag produced no prompt_tokens. That is the cell key every" >&2
+		echo "  recorded row is filed under; a run that did not report it cannot be" >&2
+		echo "  attributed to a context. Output: $raw" >&2
 		exit 125
 	fi
 	if [[ -z "$SLOT_MEM" || -z "$slot_peak" ]]; then
@@ -731,7 +759,7 @@ for model in "${MODELS[@]}"; do
 		echo "        compares two different computations." >&2
 	fi
 
-	A_TPS=(); B_TPS=(); A_MEM=(); B_MEM=(); A_KV=(); B_KV=()
+	A_TPS=(); B_TPS=(); A_MEM=(); B_MEM=(); A_KV=(); B_KV=(); MODEL_PTOK=""
 	# A run that had to be waived past the entry gate carries that fact into
 	# every verdict it produces. Otherwise a comparison that started on a busy
 	# host reads as clean the moment no individual slot happens to trip.
@@ -771,6 +799,18 @@ for model in "${MODELS[@]}"; do
 			A_TPS+=("$SLOT_TPS"); A_MEM+=("$SLOT_MEM"); A_KV+=("$SLOT_KV")
 		else
 			B_TPS+=("$SLOT_TPS"); B_MEM+=("$SLOT_MEM"); B_KV+=("$SLOT_KV")
+		fi
+		# One tokenized prompt per comparison, across BOTH arms: the arms differ
+		# by codec, never by input. A disagreement means the cell was not one
+		# cell, and a single value would then describe whichever slot ran first.
+		if [[ -z "$MODEL_PTOK" ]]; then
+			MODEL_PTOK="$SLOT_PTOK"
+		elif [[ "$SLOT_PTOK" != "$MODEL_PTOK" ]]; then
+			echo "" >&2
+			echo "ERROR: slot $i tokenized $SLOT_PTOK prompt tokens; an earlier slot" >&2
+			echo "  tokenized $MODEL_PTOK. The arms were not run on one prompt, so the" >&2
+			echo "  comparison has two contexts in it and no cell key describes both." >&2
+			exit 125
 		fi
 
 		case "${SLOT_HOST%% *}" in
@@ -878,6 +918,7 @@ for model in "${MODELS[@]}"; do
 	JSON_MODELS="${JSON_MODELS}$(
 		cat <<JSON
     {"model": "$(json_str "$short")",
+     "prompt_tokens": $MODEL_PTOK,
      "arm_a": {"label": "$(json_str "$LABEL_A")", "median_tps": $A_MED, "sd_tps": $A_SD, "min_tps": $A_MIN, "max_tps": $A_MAX, "n": $A_N, "median_gen_alloc_mb": $AM_MED, "median_kv_cache_bytes": $(json_num "$AK_MED"), "tps": [$(
 			IFS=,
 			echo "${A_TPS[*]}"

--- a/scripts/perf_ab.sh
+++ b/scripts/perf_ab.sh
@@ -380,6 +380,16 @@ json_str() {
 		sed -e 's/\r/\\r/g'
 }
 
+# A numeric JSON value, or `null` for the `n/a` refusal. Emitting 0 for an
+# unmeasured column would parse as a reading of zero in every downstream
+# consumer; `null` is the only value that cannot be mistaken for one.
+json_num() {
+	case "$1" in
+	'' | n/a) printf 'null' ;;
+	*) printf '%s' "$1" ;;
+	esac
+}
+
 # Render a "<state> <pct> <comm>" triple for a human.
 host_detail() {
 	local rest="${1#* }"
@@ -445,6 +455,7 @@ PATTERN="$(build_pattern "$SLOTS" "$INVERT")"
 
 SLOT_TPS=""
 SLOT_MEM=""
+SLOT_KV=""
 SLOT_IDS_FILE=""
 SLOT_HOST=""
 
@@ -492,6 +503,18 @@ run_slot() {
 	SLOT_MEM="$(sed -n 's/.*metal_gen_alloc_mb=\([0-9.]*\).*/\1/p' "$raw" | head -1)"
 	local slot_peak
 	slot_peak="$(sed -n 's/.*metal_peak_mb=\([0-9.]*\).*/\1/p' "$raw" | head -1)"
+	# Resident KV for the slot, straight off the summary line. This is the
+	# per-layer cache accounting, not an allocator peak: metal_gen_alloc_mb
+	# brackets the whole generation and on some architectures the prefill
+	# working set, not the cache, is what sets it -- so the two columns answer
+	# different questions and neither substitutes for the other.
+	#
+	# `n/a` is a refusal the baseline command emits when its byte accounting
+	# did not report; it is carried through as `n/a` rather than parsed to 0,
+	# because a zero here would average into a residency ratio as a real cache
+	# of no bytes. An arm with any `n/a` slot reports no residency figure.
+	SLOT_KV="$(sed -n 's/.*kv_cache_bytes=\([0-9a-z/]*\).*/\1/p' "$raw" | head -1)"
+	[[ -z "$SLOT_KV" ]] && SLOT_KV="n/a"
 	sed -n 's/^baseline: token_ids=//p' "$raw" | head -1 | tr ',' '\n' >"$ids"
 	SLOT_IDS_FILE="$ids"
 	local has_ids_line=0
@@ -554,6 +577,34 @@ summarise() {
 		}
 		printf "%.4f %.4f %.4f %.4f %d\n", med, sd, a[1], a[n], n
 	}'
+}
+
+# Resident-KV helpers. `kv_cache_bytes` arrives as a byte count or the literal
+# `n/a`; the two are never mixed into one number.
+
+# One slot's byte count as MB, or `n/a` untouched.
+kv_mb() {
+	case "$1" in
+	'' | n/a) echo "n/a" ;;
+	*) awk -v v="$1" 'BEGIN { printf "%.1f", v / 1e6 }' ;;
+	esac
+}
+
+# Median resident KV over an arm, in BYTES, or `n/a` if ANY slot refused. A
+# median taken over the slots that did report would silently describe a subset
+# of the arm while printing like the whole of it.
+#
+# Bytes, not MB: this figure is recorded into the append-only metrics store as
+# `kv_cache_bytes`, and a value converted for display and back is a rounded
+# number wearing an exact one.
+kv_arm_bytes() {
+	local v
+	for v in "$@"; do
+		[[ "$v" == "n/a" || -z "$v" ]] && { echo "n/a"; return; }
+	done
+	local med
+	read -r med _ _ _ _ <<<"$(summarise "$@")"
+	awk -v v="$med" 'BEGIN { printf "%d", v }'
 }
 
 # ---- run ---------------------------------------------------------------------
@@ -680,7 +731,7 @@ for model in "${MODELS[@]}"; do
 		echo "        compares two different computations." >&2
 	fi
 
-	A_TPS=(); B_TPS=(); A_MEM=(); B_MEM=()
+	A_TPS=(); B_TPS=(); A_MEM=(); B_MEM=(); A_KV=(); B_KV=()
 	# A run that had to be waived past the entry gate carries that fact into
 	# every verdict it produces. Otherwise a comparison that started on a busy
 	# host reads as clean the moment no individual slot happens to trip.
@@ -717,9 +768,9 @@ for model in "${MODELS[@]}"; do
 		fi
 
 		if [[ "$arm" == "0" ]]; then
-			A_TPS+=("$SLOT_TPS"); A_MEM+=("$SLOT_MEM")
+			A_TPS+=("$SLOT_TPS"); A_MEM+=("$SLOT_MEM"); A_KV+=("$SLOT_KV")
 		else
-			B_TPS+=("$SLOT_TPS"); B_MEM+=("$SLOT_MEM")
+			B_TPS+=("$SLOT_TPS"); B_MEM+=("$SLOT_MEM"); B_KV+=("$SLOT_KV")
 		fi
 
 		case "${SLOT_HOST%% *}" in
@@ -737,8 +788,8 @@ for model in "${MODELS[@]}"; do
 			UNMEASURED_SLOTS=$((UNMEASURED_SLOTS + 1))
 			;;
 		esac
-		printf "  slot %2d  %-14s decode_tps=%8s  metal_gen_alloc_mb=%7s  busiest_foreign=%s\n" \
-			"$i" "$name" "$SLOT_TPS" "$SLOT_MEM" "$(host_detail "$SLOT_HOST")"
+		printf "  slot %2d  %-14s decode_tps=%8s  metal_gen_alloc_mb=%7s  kv_cache_MB=%9s  busiest_foreign=%s\n" \
+			"$i" "$name" "$SLOT_TPS" "$SLOT_MEM" "$(kv_mb "$SLOT_KV")" "$(host_detail "$SLOT_HOST")"
 	done
 
 	if [[ "$BUSY_SLOTS" -gt 0 ]]; then
@@ -777,6 +828,14 @@ for model in "${MODELS[@]}"; do
 	read -r B_MED B_SD B_MIN B_MAX B_N <<<"$(summarise "${B_TPS[@]}")"
 	read -r AM_MED _ _ _ _ <<<"$(summarise "${A_MEM[@]}")"
 	read -r BM_MED _ _ _ _ <<<"$(summarise "${B_MEM[@]}")"
+	AK_MED="$(kv_arm_bytes "${A_KV[@]}")"
+	BK_MED="$(kv_arm_bytes "${B_KV[@]}")"
+	if [[ "$AK_MED" == "n/a" || "$BK_MED" == "n/a" ]]; then
+		KV_RATIO="n/a"
+	else
+		KV_RATIO="$(awk -v a="$AK_MED" -v b="$BK_MED" \
+			'BEGIN { if (a > 0) printf "%.4f", b / a; else printf "n/a" }')"
+	fi
 
 	VERDICT="$(awk -v amin="$A_MIN" -v amax="$A_MAX" -v bmin="$B_MIN" -v bmax="$B_MAX" \
 		'BEGIN { print (amax < bmin || bmax < amin) ? "SEPARATED" : "INCONCLUSIVE" }')"
@@ -792,6 +851,8 @@ for model in "${MODELS[@]}"; do
 	printf "  ratio B/A = %s  (%s%%)\n" "$RATIO" "$DELTA_PCT"
 	printf "  metal_gen_alloc_mb  A median=%s  B median=%s  delta=%s MB\n" \
 		"$AM_MED" "$BM_MED" "$MEM_DELTA"
+	printf "  kv_cache_bytes      A median=%s MB  B median=%s MB  ratio B/A=%s\n" \
+		"$(kv_mb "$AK_MED")" "$(kv_mb "$BK_MED")" "$KV_RATIO"
 	printf "  tokens: %s (%s ids per run, every slot re-checked)\n" "$TOKENS_VERDICT" "$REF_TOKENS"
 
 	printf "  host during the comparison: %s\n" "$(host_detail "$MODEL_HOST")"
@@ -817,15 +878,16 @@ for model in "${MODELS[@]}"; do
 	JSON_MODELS="${JSON_MODELS}$(
 		cat <<JSON
     {"model": "$(json_str "$short")",
-     "arm_a": {"label": "$(json_str "$LABEL_A")", "median_tps": $A_MED, "sd_tps": $A_SD, "min_tps": $A_MIN, "max_tps": $A_MAX, "n": $A_N, "median_gen_alloc_mb": $AM_MED, "tps": [$(
+     "arm_a": {"label": "$(json_str "$LABEL_A")", "median_tps": $A_MED, "sd_tps": $A_SD, "min_tps": $A_MIN, "max_tps": $A_MAX, "n": $A_N, "median_gen_alloc_mb": $AM_MED, "median_kv_cache_bytes": $(json_num "$AK_MED"), "tps": [$(
 			IFS=,
 			echo "${A_TPS[*]}"
 		)]},
-     "arm_b": {"label": "$(json_str "$LABEL_B")", "median_tps": $B_MED, "sd_tps": $B_SD, "min_tps": $B_MIN, "max_tps": $B_MAX, "n": $B_N, "median_gen_alloc_mb": $BM_MED, "tps": [$(
+     "arm_b": {"label": "$(json_str "$LABEL_B")", "median_tps": $B_MED, "sd_tps": $B_SD, "min_tps": $B_MIN, "max_tps": $B_MAX, "n": $B_N, "median_gen_alloc_mb": $BM_MED, "median_kv_cache_bytes": $(json_num "$BK_MED"), "tps": [$(
 			IFS=,
 			echo "${B_TPS[*]}"
 		)]},
      "ratio_b_over_a": $RATIO,
+     "kv_cache_ratio_b_over_a": $(json_num "$KV_RATIO"),
      "verdict": "$( [[ -n "$TAINTED" ]] && echo "TAINTED" || echo "$VERDICT" )",
      "tokens": "$( [[ "$TOKENS_VERDICT" == identical ]] && echo identical || echo diverged )",
      "tokens_per_run": $REF_TOKENS,

--- a/scripts/perf_ab.sh
+++ b/scripts/perf_ab.sh
@@ -897,8 +897,19 @@ for model in "${MODELS[@]}"; do
 
 	printf "  host during the comparison: %s\n" "$(host_detail "$MODEL_HOST")"
 
+	# The rank test's answer is always printed, tainted or not. It used to be
+	# replaced by the word TAINTED, which threw away the one number the run had
+	# computed and made "what did the harness conclude?" unanswerable for
+	# exactly the runs that most needed re-reading. Taint is reported on its own
+	# line beside it: the two are different facts and either can be true alone.
+	printf "  VERDICT: %s\n" "$VERDICT"
+	if [[ "$VERDICT" == "INCONCLUSIVE" ]]; then
+		echo "           The arms' slot ranges overlap. The ${DELTA_PCT}% above is the"
+		echo "           difference between two point estimates drawn from overlapping"
+		echo "           spreads; it is not evidence that the arms differ."
+	fi
 	if [[ -n "$TAINTED" ]]; then
-		echo "  VERDICT: TAINTED — ${TAINTED%; }"
+		echo "  TAINTED: ${TAINTED%; }"
 		echo "           The interference did not fall evenly on the arms, so the ratio"
 		echo "           above is not usable. Re-run on a quiet host."
 		# A tainted run exits non-zero even under --allow-busy-host. That flag
@@ -906,13 +917,6 @@ for model in "${MODELS[@]}"; do
 		# contaminated comparison count as a clean one, which is the exact
 		# mistake this harness exists to stop.
 		OVERALL_EXIT=125
-	else
-		printf "  VERDICT: %s\n" "$VERDICT"
-		if [[ "$VERDICT" == "INCONCLUSIVE" ]]; then
-			echo "           The arms' slot ranges overlap. The ${DELTA_PCT}% above is the"
-			echo "           difference between two point estimates drawn from overlapping"
-			echo "           spreads; it is not evidence that the arms differ."
-		fi
 	fi
 
 	JSON_MODELS="${JSON_MODELS}$(
@@ -929,7 +933,7 @@ for model in "${MODELS[@]}"; do
 		)]},
      "ratio_b_over_a": $RATIO,
      "kv_cache_ratio_b_over_a": $(json_num "$KV_RATIO"),
-     "verdict": "$( [[ -n "$TAINTED" ]] && echo "TAINTED" || echo "$VERDICT" )",
+     "verdict": "$VERDICT",
      "tokens": "$( [[ "$TOKENS_VERDICT" == identical ]] && echo identical || echo diverged )",
      "tokens_per_run": $REF_TOKENS,
      "taint": "$(json_str "${TAINTED%; }")"},

--- a/scripts/perf_ab_ingest_selftest.sh
+++ b/scripts/perf_ab_ingest_selftest.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# perf_ab_ingest_selftest.sh — mutation check for scripts/ingest/perf_ab_ingest.py.
+#
+# WHY THIS EXISTS
+#
+# That script is the only writer that turns a throwaway A/B experiment into
+# permanent rows in the append-only metrics store. Every guard in it exists to
+# stop one specific wrong row, and a wrong row there cannot be taken back out.
+# Six refusals asserted only by reading the source are six refusals nobody has
+# watched fire.
+#
+# Each case drives the real script over a synthetic `perf_ab.sh` result file and
+# a stub `rmlx` binary, in --dry-run, so nothing here can reach `runs.db`. The
+# suite asserts the exit code AND the reason text, because a guard that refuses
+# for the wrong reason is a guard that will stop refusing when that reason moves.
+#
+# Exit codes: 0 — every case behaved; 1 — at least one did not.
+
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/ingest/perf_ab_ingest.py"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/rmlx_ab_ingest_selftest.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+PASSED=0
+FAILED=0
+
+# A stub `rmlx` whose `metrics identity --json` answers like the real one.
+STUB="$WORK/rmlx"
+cat >"$STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+echo '{"backend":"rmlx","backend_version":"9.9.9","build_profile":"release-perf","hardware_tag":"m5_max_128gb"}'
+STUBEOF
+chmod +x "$STUB"
+STUB_SHA16="$(shasum -a 256 "$STUB" | cut -c1-16)"
+
+PROMPT="$WORK/prompt.json"
+printf '{"messages":[{"role":"user","content":"hi"}]}' >"$PROMPT"
+
+# make_result <name> [overrides-json] -- a minimal but complete perf_ab.sh
+# result. Overrides are ONE JSON object of dotted paths, e.g.
+# '{"results.0.taint": "busy"}'. A JSON argument rather than key=value pairs
+# because several of the values under test contain spaces.
+make_result() {
+	local name="$1"
+	local path="$WORK/$name.json"
+	# The default cannot be written inline: a literal `}` inside a `${...}`
+	# default closes the expansion.
+	local overrides="${2:-}"
+	[[ -z "$overrides" ]] && overrides='{}'
+	STUB="$STUB" STUB_SHA16="$STUB_SHA16" OUT="$path" OVERRIDES="$overrides" python3 - <<'PY'
+import json, os
+stub, sha, out = os.environ["STUB"], os.environ["STUB_SHA16"], os.environ["OUT"]
+arm = lambda label, args: {"label": label, "binary": stub, "sha256_16": sha, "args": args}
+cell_arm = lambda: {"median_tps": 100.0, "sd_tps": 1.0, "min_tps": 99.0,
+                    "max_tps": 101.0, "n": 4, "median_gen_alloc_mb": 40.0,
+                    "median_kv_cache_bytes": 1000000123, "tps": [99.0, 100.0, 101.0, 100.0]}
+res = {
+    "ts_utc": "20260820T090151Z",
+    "pattern": "ABBA BAAB",
+    "slots_per_model": 8,
+    "shape": {"prompt_tokens": 4096, "max_tokens": 100, "max_ctx": 8192},
+    "arm_a": arm("none", "--kv-quant none"),
+    "arm_b": arm("mixed", "--kv-quant mixed_k8g64_v4g64"),
+    "waivers": {"null_arms": False, "busy_host": False,
+                "token_divergence": False, "busy_pct_raised": False},
+    "results": [{"model": "snap", "prompt_tokens": 3770,
+                 "arm_a": cell_arm(), "arm_b": cell_arm(),
+                 "ratio_b_over_a": 1.0, "kv_cache_ratio_b_over_a": 1.0,
+                 "verdict": "INCONCLUSIVE", "tokens": "identical",
+                 "tokens_per_run": 100, "taint": ""}],
+}
+for dotted, val in json.loads(os.environ["OVERRIDES"]).items():
+    parts = dotted.split(".")
+    tgt = res
+    for part in parts[:-1]:
+        tgt = tgt[int(part)] if part.isdigit() else tgt[part]
+    tgt[parts[-1]] = val
+open(out, "w").write(json.dumps(res))
+PY
+	echo "$path"
+}
+
+# check <name> <want-exit> <what-it-proves> <result-file> [extra args...] [GREP:pat]
+check() {
+	local name="$1" want="$2" what="$3" result="$4"
+	shift 4
+	local args=() greps=()
+	local a
+	for a in "$@"; do
+		case "$a" in
+		GREP:*) greps+=("${a#GREP:}") ;;
+		*) args+=("$a") ;;
+		esac
+	done
+	local out="$WORK/$name.log" got=0
+	set +e
+	python3 "$SCRIPT" --dry-run "$result" \
+		--model snap --model-namespace mlx-community --weight-quant mxfp8 \
+		--arm-a-kv-quant none --arm-b-kv-quant mixed_k8g64_v4g64 \
+		--rmlx-bin "$STUB" ${args[@]+"${args[@]}"} >"$out" 2>&1
+	got=$?
+	set -e
+
+	local bad=""
+	[[ "$got" -ne "$want" ]] && bad="exit=$got (want $want)"
+	local g
+	for g in ${greps[@]+"${greps[@]}"}; do
+		grep -qE "$g" "$out" || bad="${bad:+$bad; }missing: $g"
+	done
+	if [[ -z "$bad" ]]; then
+		PASSED=$((PASSED + 1))
+		printf '  ok   %-38s exit=%s — %s\n' "$name" "$got" "$what"
+	else
+		FAILED=$((FAILED + 1))
+		printf '  FAIL %-38s %s — %s\n' "$name" "$bad" "$what"
+		sed 's/^/       | /' "$out" | tail -4
+	fi
+}
+
+echo "perf_ab_ingest selftest: refusal checks"
+
+CLEAN="$(make_result clean)"
+check accepts_a_clean_result 0 \
+	"a clean result produces two records" "$CLEAN" \
+	"GREP:\"kv_quant\": \"none\"" \
+	"GREP:\"kv_quant\": \"mixed_k8g64_v4g64\"" \
+	"GREP:\"prompt_tokens\": 3770"
+
+# --- the taint / waiver family ------------------------------------------------
+
+TAINTED="$(make_result tainted '{"results.0.taint": "WindowServer at 60%"}')"
+check tainted_refused 2 \
+	"a TAINTED run is refused rather than recorded as clean" "$TAINTED" \
+	"GREP:refusing: run is TAINTED"
+
+check tainted_accepted_carries_taint 0 \
+	"--accept-tainted records it and carries the taint into notes" "$TAINTED" \
+	--accept-tainted "GREP:TAINTED: WindowServer at 60"
+
+# A raised --busy-pct removes the gate that would have tainted, so the result
+# looks clean for exactly the reason it must not.
+WAIVED="$(make_result waived '{"waivers.busy_pct_raised": true}')"
+check raised_busy_pct_refused 2 \
+	"an empty taint behind a raised --busy-pct is refused, not trusted" "$WAIVED" \
+	"GREP:interference"
+
+check waivers_reach_notes 0 \
+	"a waived guard is named in the recorded notes" "$WAIVED" \
+	--accept-tainted "GREP:guards waived: busy_pct_raised"
+
+# --- identity ----------------------------------------------------------------
+
+STALE="$(make_result stale '{"arm_a.sha256_16": "deadbeefdeadbeef"}')"
+check rebuilt_binary_refused 1 \
+	"a binary rebuilt since the run is refused, not stamped onto the row" "$STALE" \
+	"GREP:recorded sha256:deadbeefdeadbeef"
+
+MISSING="$(make_result missing '{"arm_a.binary": "/nonexistent/rmlx"}')"
+check absent_binary_refused 1 \
+	"a binary that no longer exists cannot supply an identity" "$MISSING" \
+	"GREP:no longer exists"
+
+# --- cell key ----------------------------------------------------------------
+
+WRONGCODEC="$(make_result wrongcodec '{"arm_b.args": "--kv-quant k8v8"}')"
+check codec_mismatch_refused 1 \
+	"a declared codec the arm did not run is refused" "$WRONGCODEC" \
+	"GREP:ran --kv-quant k8v8"
+
+NOCODEC="$(make_result nocodec '{"arm_b.args": "--max-tokens 100"}')"
+check codec_absent_refused 1 \
+	"an arm naming no codec is a different failure from naming the wrong one" "$NOCODEC" \
+	"GREP:recorded no --kv-quant"
+
+# clap resolves a repeated flag last-wins; taking the first would confirm a
+# codec the slot did not run.
+RELAST="$(make_result relast '{"arm_b.args": "--kv-quant none --kv-quant mixed_k8g64_v4g64"}')"
+check repeated_codec_flag_takes_the_last 0 \
+	"a repeated --kv-quant is read the way clap resolves it" "$RELAST"
+
+PTOK="$(make_result ptok)"
+check prompt_tokens_mismatch_refused 1 \
+	"a supplied prompt_tokens that disagrees with the run is refused" "$PTOK" \
+	--prompt-tokens 9999 "GREP:disagrees with the 3770"
+
+check prompt_tokens_agreement_accepted 0 \
+	"a supplied prompt_tokens that agrees is a cross-check, not an override" "$PTOK" \
+	--prompt-tokens 3770 "GREP:\"prompt_tokens\": 3770"
+
+# --- residency ---------------------------------------------------------------
+
+# The four cells recorded on this branch came from a harness that emitted only
+# the report table's 0.1 MB field. That path still ingests, and says so.
+LEGACY="$(make_result legacy '{"results.0.arm_a.median_kv_cache_bytes": null, "results.0.arm_b.median_kv_cache_bytes": null, "results.0.arm_a.median_kv_cache_mb": 1000.0, "results.0.arm_b.median_kv_cache_mb": 2000.0}')"
+check legacy_mb_field_discloses_resolution 0 \
+	"a pre-byte-column result records, with its resolution stated in notes" "$LEGACY" \
+	"GREP:\"kv_cache_bytes\"" \
+	"GREP:0.1 MB display"
+
+REFUSED="$(make_result kvrefused '{"results.0.arm_a.median_kv_cache_bytes": null}')"
+check kv_refusal_records_null_not_zero 0 \
+	"an arm with no residency figure records null, never 0" "$REFUSED" \
+	"GREP:\"value\": null"
+
+# --- shape -------------------------------------------------------------------
+
+TWO="$(make_result two)"
+python3 - "$TWO" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d["results"].append(json.loads(json.dumps(d["results"][0])))
+json.dump(d, open(p, "w"))
+PY
+check multi_model_result_refused 1 \
+	"a two-model result cannot take one model label" "$TWO" \
+	"GREP:compares 2 models"
+
+echo ""
+if [[ "$FAILED" -ne 0 ]]; then
+	echo "perf_ab_ingest selftest: FAIL ($FAILED of $((PASSED + FAILED)))" >&2
+	exit 1
+fi
+echo "perf_ab_ingest selftest: ok ($PASSED cases)"

--- a/scripts/perf_ab_selftest.sh
+++ b/scripts/perf_ab_selftest.sh
@@ -87,7 +87,14 @@ if [ -n "$drift" ] && [ "\$n" = "$drift" ]; then tok="$TOKENS_ALT"; fi
 peak=100.0
 if [ "$omit" = "zeropeak" ]; then peak=0.0; fi
 kvcol=""
-if [ -n "$kv" ]; then kvcol="  kv_cache_bytes=$kv"; fi
+kvval="$kv"
+# "partial" is the any-vs-all case: this slot refuses on odd-numbered calls and
+# reports on even ones, so an arm ends up with a mixture. (No backticks: this
+# heredoc is unquoted, so they would run as command substitution right here.)
+if [ "$kv" = "partial" ]; then
+  if [ \$((n % 2)) -eq 1 ]; then kvval="n/a"; else kvval=1000000123; fi
+fi
+if [ -n "$kv" ]; then kvcol="  kv_cache_bytes=\$kvval"; fi
 if [ "$omit" != "tps" ]; then
   printf 'baseline: model=stub  load=1ms  ttft_ms=1  decode_tps=%s  overall_tps=%s  prefill_tps=1.0  prompt_tokens=4096  peak_rss=1.0MB  metal_peak_mb=%s  metal_gen_alloc_mb=%s%s\n' "\$v" "\$v" "\$peak" "$mem" "\$kvcol"
 else
@@ -175,6 +182,11 @@ NO_IDS="$(make_stub no_ids "100.0" 40.0 "$TOKENS_MAIN" "" ids)"
 KV_SMALL="$(make_stub kv_small "100.0,100.5,101.0" 40.0 "$TOKENS_MAIN" "" "" 1000000123)"
 KV_BIG="$(make_stub kv_big "100.0,100.5,101.0" 40.0 "$TOKENS_MAIN" "" "" 2000000000)"
 KV_NA="$(make_stub kv_na "100.0,100.5,101.0" 40.0 "$TOKENS_MAIN" "" "" "n/a")"
+# Reports on some calls and refuses on others -- the case the "ANY slot refused"
+# invariant is actually about.
+KV_PARTIAL="$(make_stub kv_partial "100.0,100.5,101.0" 40.0 "$TOKENS_MAIN" "" "" "partial")"
+# Neither a byte count nor the `n/a` refusal.
+KV_NAN="$(make_stub kv_nan "100.0,100.5,101.0" 40.0 "$TOKENS_MAIN" "" "" "nan")"
 KV_ABSENT="$(make_stub kv_absent "100.0,100.5,101.0" 40.0 "$TOKENS_MAIN")"
 
 # Nothing on this host counts as busy unless a case says otherwise; the CPU
@@ -211,7 +223,7 @@ check planted_memory 0 \
 
 check planted_kv_residency 0 \
 	"a 2x resident-KV arm is reported as ratio 2.0000, in MB" \
-	--binary-a "$KV_SMALL" --binary-b "$KV_BIG" --allow-null-arms "${COMMON[@]}" "${QUIET[@]}" \
+	--binary-a "$KV_SMALL" --binary-b "$KV_BIG" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:kv_cache_bytes      A median=1000\.0 MB  B median=2000\.0 MB  ratio B/A=2\.0000" \
 	"GREP:result: "
 
@@ -236,14 +248,30 @@ fi
 # is the shape of every silent-fallback defect this repo has had to unpick.
 check kv_residency_refusal_is_not_zero 0 \
 	"a slot whose KV accounting refused reports n/a, never 0" \
-	--binary-a "$KV_NA" --binary-b "$KV_BIG" --allow-null-arms "${COMMON[@]}" "${QUIET[@]}" \
+	--binary-a "$KV_NA" --binary-b "$KV_BIG" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:kv_cache_bytes      A median=n/a MB  B median=2000\.0 MB  ratio B/A=n/a" \
 	"NOGREP:A median=0\.0 MB"
 
 check kv_residency_absent_column_is_not_zero 0 \
 	"a binary that emits no KV column reports n/a, never 0" \
-	--binary-a "$KV_ABSENT" --binary-b "$KV_BIG" --allow-null-arms "${COMMON[@]}" "${QUIET[@]}" \
+	--binary-a "$KV_ABSENT" --binary-b "$KV_BIG" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:kv_cache_bytes      A median=n/a MB  B median=2000\.0 MB  ratio B/A=n/a"
+
+# The invariant is "n/a if ANY slot refused", and an all-refuse stub cannot tell
+# that apart from "n/a if EVERY slot refused" -- both rules agree on it. Only a
+# mixture separates them.
+check kv_residency_any_refusal_taints_the_arm 0 \
+	"one refusing slot makes the whole arm n/a, not a median of the rest" \
+	--binary-a "$KV_PARTIAL" --binary-b "$KV_BIG" "${COMMON[@]}" "${QUIET[@]}" \
+	"GREP:kv_cache_bytes      A median=n/a MB  B median=2000\.0 MB  ratio B/A=n/a" \
+	"NOGREP:A median=1000\.0 MB"
+
+# awk reads a non-numeric token as 0, so an unrecognised spelling would become a
+# median of 0 bytes and record as the smallest cache ever measured.
+check kv_residency_non_numeric_refused 125 \
+	"a kv_cache_bytes token that is neither a number nor n/a is refused" \
+	--binary-a "$KV_NAN" --binary-b "$KV_BIG" "${COMMON[@]}" "${QUIET[@]}" \
+	"GREP:reported kv_cache_bytes=nan"
 
 # ---- does it stay quiet when there is nothing there? -------------------------
 

--- a/scripts/perf_ab_selftest.sh
+++ b/scripts/perf_ab_selftest.sh
@@ -39,14 +39,17 @@ mkdir -p "$STATE" "$MODEL" "$MODEL2"
 TOKENS_MAIN="11,22,33,44,55"
 TOKENS_ALT="11,22,99,44,55"
 
-# make_stub <name> <tps-csv> <gen_alloc_mb> <tokens> [drift_at_call] [omit]
+# make_stub <name> <tps-csv> <gen_alloc_mb> <tokens> [drift_at_call] [omit] [kv_bytes]
 #
 # The stub cycles through <tps-csv> across successive calls, so a run sees a
 # spread rather than a constant and the disjoint-range criterion is exercised
 # on real (if synthetic) variation. `drift_at_call` makes the Nth call emit
 # TOKENS_ALT instead. `omit` drops a required field from the output.
+# `kv_bytes` is the resident-KV column: a byte count, the literal `n/a` (the
+# baseline command's own refusal), or empty to drop the field entirely, which
+# is what an older binary looks like to this harness.
 make_stub() {
-	local name="$1" tps="$2" mem="$3" tokens="$4" drift="${5:-}" omit="${6:-}"
+	local name="$1" tps="$2" mem="$3" tokens="$4" drift="${5:-}" omit="${6:-}" kv="${7:-}"
 	local path="$WORK/$name"
 	cat >"$path" <<STUB
 #!/usr/bin/env bash
@@ -83,10 +86,12 @@ sleep 0.25
 if [ -n "$drift" ] && [ "\$n" = "$drift" ]; then tok="$TOKENS_ALT"; fi
 peak=100.0
 if [ "$omit" = "zeropeak" ]; then peak=0.0; fi
+kvcol=""
+if [ -n "$kv" ]; then kvcol="  kv_cache_bytes=$kv"; fi
 if [ "$omit" != "tps" ]; then
-  printf 'baseline: model=stub  load=1ms  ttft_ms=1  decode_tps=%s  overall_tps=%s  prefill_tps=1.0  prompt_tokens=4096  peak_rss=1.0MB  metal_peak_mb=%s  metal_gen_alloc_mb=%s\n' "\$v" "\$v" "\$peak" "$mem"
+  printf 'baseline: model=stub  load=1ms  ttft_ms=1  decode_tps=%s  overall_tps=%s  prefill_tps=1.0  prompt_tokens=4096  peak_rss=1.0MB  metal_peak_mb=%s  metal_gen_alloc_mb=%s%s\n' "\$v" "\$v" "\$peak" "$mem" "\$kvcol"
 else
-  printf 'baseline: model=stub  load=1ms  ttft_ms=1  prompt_tokens=4096  metal_peak_mb=%s  metal_gen_alloc_mb=%s\n' "\$peak" "$mem"
+  printf 'baseline: model=stub  load=1ms  ttft_ms=1  prompt_tokens=4096  metal_peak_mb=%s  metal_gen_alloc_mb=%s%s\n' "\$peak" "$mem" "\$kvcol"
 fi
 if [ "$omit" != "ids" ]; then printf 'baseline: token_ids=%s\n' "\$tok"; fi
 STUB
@@ -164,6 +169,13 @@ WRONG="$(make_stub wrong "100.0,100.5,101.0" 40.0 "$TOKENS_ALT")"
 DRIFTER="$(make_stub drifter "100.0,100.5,101.0" 40.0 "$TOKENS_MAIN" 3)"
 NO_TPS="$(make_stub no_tps "100.0" 40.0 "$TOKENS_MAIN" "" tps)"
 NO_IDS="$(make_stub no_ids "100.0" 40.0 "$TOKENS_MAIN" "" ids)"
+# Resident-KV column. KV_SMALL/KV_BIG carry byte counts a factor 2 apart;
+# KV_NA emits the baseline command's own `n/a` refusal; KV_ABSENT drops the
+# field, which is what a binary predating the column looks like.
+KV_SMALL="$(make_stub kv_small "100.0,100.5,101.0" 40.0 "$TOKENS_MAIN" "" "" 1000000123)"
+KV_BIG="$(make_stub kv_big "100.0,100.5,101.0" 40.0 "$TOKENS_MAIN" "" "" 2000000000)"
+KV_NA="$(make_stub kv_na "100.0,100.5,101.0" 40.0 "$TOKENS_MAIN" "" "" "n/a")"
+KV_ABSENT="$(make_stub kv_absent "100.0,100.5,101.0" 40.0 "$TOKENS_MAIN")"
 
 # Nothing on this host counts as busy unless a case says otherwise; the CPU
 # gate has its own cases below and must not make the others flaky.
@@ -196,6 +208,42 @@ check planted_memory 0 \
 	--binary-a "$SLOW" --binary-b "$HUNGRY" --allow-null-arms "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:A median=40\.0000  B median=55\.0000  delta=\+15\.0 MB" \
 	"GREP:ratio B/A = 1\.0000"
+
+check planted_kv_residency 0 \
+	"a 2x resident-KV arm is reported as ratio 2.0000, in MB" \
+	--binary-a "$KV_SMALL" --binary-b "$KV_BIG" --allow-null-arms "${COMMON[@]}" "${QUIET[@]}" \
+	"GREP:kv_cache_bytes      A median=1000\.0 MB  B median=2000\.0 MB  ratio B/A=2\.0000" \
+	"GREP:result: "
+
+# The printed table rounds to 0.1 MB. The result file is what gets promoted into
+# the append-only metrics store, so it has to carry the byte count the slot
+# actually reported: KV_SMALL's 1 000 000 123 B prints as 1000.0 MB either way,
+# and only the JSON can tell an exact reading from a round-tripped one.
+JSON_KV="$(sed -n 's/^result: //p' "$WORK/planted_kv_residency.log" | tail -1)"
+KV_A="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['results'][0]['arm_a']['median_kv_cache_bytes'])" "$JSON_KV" 2>/dev/null || echo unreadable)"
+if [[ "$KV_A" == "1000000123" ]]; then
+	PASSED=$((PASSED + 1))
+	printf '  ok   %-26s        — result file carries exact bytes (%s), not the rounded MB\n' \
+		"kv_residency_json_exact" "$KV_A"
+else
+	FAILED=$((FAILED + 1))
+	printf '  FAIL %-26s        — arm A median_kv_cache_bytes is %s, want 1000000123\n' \
+		"kv_residency_json_exact" "$KV_A"
+fi
+
+# The two ways this column can be absent must both read as "not measured".
+# A 0 here would divide into a residency ratio as a cache of no bytes, which
+# is the shape of every silent-fallback defect this repo has had to unpick.
+check kv_residency_refusal_is_not_zero 0 \
+	"a slot whose KV accounting refused reports n/a, never 0" \
+	--binary-a "$KV_NA" --binary-b "$KV_BIG" --allow-null-arms "${COMMON[@]}" "${QUIET[@]}" \
+	"GREP:kv_cache_bytes      A median=n/a MB  B median=2000\.0 MB  ratio B/A=n/a" \
+	"NOGREP:A median=0\.0 MB"
+
+check kv_residency_absent_column_is_not_zero 0 \
+	"a binary that emits no KV column reports n/a, never 0" \
+	--binary-a "$KV_ABSENT" --binary-b "$KV_BIG" --allow-null-arms "${COMMON[@]}" "${QUIET[@]}" \
+	"GREP:kv_cache_bytes      A median=n/a MB  B median=2000\.0 MB  ratio B/A=n/a"
 
 # ---- does it stay quiet when there is nothing there? -------------------------
 

--- a/scripts/perf_ab_selftest.sh
+++ b/scripts/perf_ab_selftest.sh
@@ -113,6 +113,18 @@ FAILED=0
 
 # check <name> <expected-exit> <what-it-proves> -- <perf_ab.sh args...>
 # Optional trailing `GREP:<pattern>` entries assert on the captured output.
+#
+# <expected-exit> may be the sentinel RC_REPORT instead of a number. Use it for
+# any case whose subject is what the harness REPORTED, rather than a refusal it
+# chose. For a run that reaches its report the exit code is 0 on a quiet host
+# and 125 on a tainted one, so a literal `0` there is an assertion about the
+# machine: it holds until the interference sampler happens to fire and then
+# fails while the behaviour under test is still correct. RC_REPORT asserts
+# instead that the code agrees with the harness's OWN verdict line -- `VERDICT:
+# TAINTED` means 125, anything else means 0 -- which still catches a harness
+# that stops signalling taint, without importing the host into the expectation.
+#
+# A refusal case keeps its literal number: there the code is the behaviour.
 check() {
 	local name="$1" want="$2" what="$3"
 	shift 3
@@ -134,6 +146,12 @@ check() {
 	RMLX_HOME="$WORK/home" PATH="${path_prefix:+$path_prefix:}$PATH" \
 		bash "$AB" ${args[@]+"${args[@]}"} >"$out" 2>&1
 	local got=$?
+
+	# RC_REPORT: the expected code is whatever the harness's own verdict line
+	# implies, resolved after the run rather than assumed before it.
+	if [[ "$want" == "RC_REPORT" ]]; then
+		if grep -q '^  TAINTED:' "$out"; then want=125; else want=0; fi
+	fi
 
 	local ok=1
 	[[ "$got" -eq "$want" ]] || ok=0
@@ -200,7 +218,7 @@ echo "perf_ab selftest: mutation checks"
 
 # ---- can it see a difference that is there? ----------------------------------
 
-check planted_10pct 0 \
+check planted_10pct RC_REPORT \
 	"a planted +9.95% arm is reported as +9.95% and SEPARATED" \
 	--binary-a "$SLOW" --binary-b "$FAST" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:ratio B/A = 1\.0995" \
@@ -208,20 +226,20 @@ check planted_10pct 0 \
 	"GREP:median= *110\.5000" \
 	"GREP:VERDICT: SEPARATED"
 
-check planted_inverted 0 \
+check planted_inverted RC_REPORT \
 	"--invert swaps the pattern and still reports the same ratio" \
 	--binary-a "$SLOW" --binary-b "$FAST" --invert "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:ratio B/A = 1\.0995" \
 	"GREP:VERDICT: SEPARATED" \
 	"GREP:pattern: BAAB ABBA BAAB"
 
-check planted_memory 0 \
+check planted_memory RC_REPORT \
 	"a planted +15 MB allocation shows up in the peak-memory column" \
 	--binary-a "$SLOW" --binary-b "$HUNGRY" --allow-null-arms "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:A median=40\.0000  B median=55\.0000  delta=\+15\.0 MB" \
 	"GREP:ratio B/A = 1\.0000"
 
-check planted_kv_residency 0 \
+check planted_kv_residency RC_REPORT \
 	"a 2x resident-KV arm is reported as ratio 2.0000, in MB" \
 	--binary-a "$KV_SMALL" --binary-b "$KV_BIG" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:kv_cache_bytes      A median=1000\.0 MB  B median=2000\.0 MB  ratio B/A=2\.0000" \
@@ -246,13 +264,13 @@ fi
 # The two ways this column can be absent must both read as "not measured".
 # A 0 here would divide into a residency ratio as a cache of no bytes, which
 # is the shape of every silent-fallback defect this repo has had to unpick.
-check kv_residency_refusal_is_not_zero 0 \
+check kv_residency_refusal_is_not_zero RC_REPORT \
 	"a slot whose KV accounting refused reports n/a, never 0" \
 	--binary-a "$KV_NA" --binary-b "$KV_BIG" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:kv_cache_bytes      A median=n/a MB  B median=2000\.0 MB  ratio B/A=n/a" \
 	"NOGREP:A median=0\.0 MB"
 
-check kv_residency_absent_column_is_not_zero 0 \
+check kv_residency_absent_column_is_not_zero RC_REPORT \
 	"a binary that emits no KV column reports n/a, never 0" \
 	--binary-a "$KV_ABSENT" --binary-b "$KV_BIG" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:kv_cache_bytes      A median=n/a MB  B median=2000\.0 MB  ratio B/A=n/a"
@@ -260,7 +278,7 @@ check kv_residency_absent_column_is_not_zero 0 \
 # The invariant is "n/a if ANY slot refused", and an all-refuse stub cannot tell
 # that apart from "n/a if EVERY slot refused" -- both rules agree on it. Only a
 # mixture separates them.
-check kv_residency_any_refusal_taints_the_arm 0 \
+check kv_residency_any_refusal_taints_the_arm RC_REPORT \
 	"one refusing slot makes the whole arm n/a, not a median of the rest" \
 	--binary-a "$KV_PARTIAL" --binary-b "$KV_BIG" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:kv_cache_bytes      A median=n/a MB  B median=2000\.0 MB  ratio B/A=n/a" \
@@ -275,14 +293,14 @@ check kv_residency_non_numeric_refused 125 \
 
 # ---- does it stay quiet when there is nothing there? -------------------------
 
-check null_arms 0 \
+check null_arms RC_REPORT \
 	"two arms with identical numbers report ratio 1.0000 and INCONCLUSIVE" \
 	--binary-a "$SLOW" --binary-b "$SLOW_TWIN" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:ratio B/A = 1\.0000" \
 	"GREP:VERDICT: INCONCLUSIVE" \
 	"NOGREP:VERDICT: SEPARATED"
 
-check overlapping_ranges 0 \
+check overlapping_ranges RC_REPORT \
 	"a 1% median gap whose ranges overlap is INCONCLUSIVE, not a result" \
 	--binary-a "$SLOW" --binary-b "$OVERLAP" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:ratio B/A = 1\.0149" \
@@ -296,7 +314,7 @@ check same_binary_refused 125 \
 	--binary-a "$SLOW" --binary-b "$SLOW" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:indistinguishable"
 
-check same_binary_waived 0 \
+check same_binary_waived RC_REPORT \
 	"--allow-null-arms permits it deliberately and says so" \
 	--binary-a "$SLOW" --binary-b "$SLOW" --allow-null-arms "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:null calibration" \
@@ -307,7 +325,7 @@ check token_divergence 1 \
 	--binary-a "$SLOW" --binary-b "$WRONG" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:the arms generate different tokens"
 
-check token_divergence_waived 0 \
+check token_divergence_waived RC_REPORT \
 	"--allow-token-divergence permits it and labels the ratio" \
 	--binary-a "$SLOW" --binary-b "$WRONG" --allow-token-divergence "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:DIVERGED between arms"
@@ -360,12 +378,15 @@ check busy_host_refused 125 \
 	"GREP:host is not quiescent" \
 	"GREP:hog"
 
+# These two assert that taint is REPORTED and that it does not erase the rank
+# test's answer. They used to assert the answer was absent, which pinned the
+# old format (taint replacing the verdict) rather than the behaviour.
 check busy_host_taints 125 \
 	"--allow-busy-host prints the numbers but a tainted run is still not clean" \
 	--binary-a "$SLOW" --binary-b "$FAST" "${COMMON[@]}" --allow-busy-host \
 	"PATHPRE:$WORK/busybin" \
-	"GREP:VERDICT: TAINTED" \
-	"NOGREP:VERDICT: SEPARATED"
+	"GREP:^  TAINTED:" \
+	"GREP:VERDICT: SEPARATED"
 
 # ---- the runs.db escape ------------------------------------------------------
 #
@@ -420,13 +441,13 @@ check slots_too_few_for_a_verdict 125 \
 
 # ---- the reported statistics must be computed, not asserted ------------------
 
-check stddev_uncertainty_tracks_n 0 \
+check stddev_uncertainty_tracks_n RC_REPORT \
 	"the stddev's relative standard error is computed from n, not a fixed 30%" \
 	--binary-a "$SLOW" --binary-b "$FAST" --model "$MODEL" --slots 8 --max-tokens 5 "${QUIET[@]}" \
 	"GREP:over 4 values is ~1/sqrt\(2\(n-1\)\) = 41%" \
 	"NOGREP:= 32%"
 
-check family_size_is_stated 0 \
+check family_size_is_stated RC_REPORT \
 	"the family-wise rate is stated for a run that makes two comparisons" \
 	--binary-a "$SLOW" --binary-b "$FAST" --model "$MODEL" --model "$MODEL2" \
 	--slots 12 --max-tokens 5 "${QUIET[@]}" \
@@ -542,9 +563,9 @@ check failing_ps_taints 125 \
 	"a slot whose interference could not be sampled taints the comparison" \
 	--binary-a "$SLOW" --binary-b "$FAST" "${COMMON[@]}" "${QUIET[@]}" \
 	"PATHPRE:$WORK/failbin" \
-	"GREP:VERDICT: TAINTED" \
+	"GREP:^  TAINTED:" \
 	"GREP:could not be sampled" \
-	"NOGREP:VERDICT: SEPARATED"
+	"GREP:VERDICT: SEPARATED"
 
 
 CPU_SNAPSHOT_SKIP="rmlx.main rmlx" PATH="$WORK/fakebin:$PATH" cpu_snapshot "$WORK/snap_excl"
@@ -568,7 +589,7 @@ fi
 
 # ---- the pattern itself ------------------------------------------------------
 
-check pattern_is_balanced 0 \
+check pattern_is_balanced RC_REPORT \
 	"the default 12-slot pattern is the balanced ABBA BAAB ABBA schedule" \
 	--binary-a "$SLOW" --binary-b "$FAST" "${COMMON[@]}" "${QUIET[@]}" \
 	"GREP:pattern: ABBA BAAB ABBA" \
@@ -599,7 +620,7 @@ fi
 # file verbatim. A quote in any of them would emit JSON that no reader can
 # parse, and nothing downstream would say so.
 
-check json_result_parses 0 \
+check json_result_parses RC_REPORT \
 	"the result file is valid JSON even with quotes and backslashes in a label" \
 	--binary-a "$SLOW" --binary-b "$FAST" "${COMMON[@]}" "${QUIET[@]}" \
 	--label-a 'he said "fast"' --label-b 'back\slash' \


### PR DESCRIPTION
Closes #414.

The deliverable is evidence. #414 asked whether the campaign's null-codec-axis result was an artifact of measuring only at 4k-8k, since `kv_frac` moves 39x between 4k and 256k.

## Answer: the packed-store path loses at long context, and it is not a byte problem

Four ABBA cells, `none` vs `mixed_k8g64_v4g64`, one binary (`sha256:c26e0d8a3ac43996`), re-run on a quiet host so the two decisive cells are **untainted**:

| model | prompt tok | kv_frac | predicted B/A | **measured B/A** | A range (CoV) | B range (CoV) | verdict |
|---|---:|---:|---:|---:|---|---|---|
| Bonsai-8B | 3 770 | 0.211 | 1.099 | 0.975 | 141.45-143.03 (0.52%) | 137.32-139.28 (0.66%) | disjoint |
| Bonsai-8B | 31 553 | **0.687** | **1.419** | 1.002 | 68.60-68.67 (**0.04%**) | 68.56-68.77 (0.15%) | INCONCLUSIVE |
| Qwen3.8-27B | 3 892 | 0.010 | 1.004 | 0.977 | 18.49-18.64 (0.37%) | 18.06-18.13 (0.21%) | **SEPARATED, untainted** |
| Qwen3.8-27B | 130 848 | 0.245 | 1.149 | **0.763** | 13.74-14.02 (0.89%) | 10.61-10.72 (0.49%) | **SEPARATED, untainted** |

At the highest `kv_frac` in the release set (0.687) the codec is +0.2%, INCONCLUSIVE. At 131k it is **23.7% slower** where the byte model predicted 14.9% faster.

**The byte model is not wrong — the byte-to-time conversion is.** `perf_ceiling.py` reproduces measured resident KV exactly. What differs is the non-bandwidth per-step term: across a 33x context change `none`'s goes **10.52 -> 14.74 ms** (flat) while arm B's goes **11.99 -> 44.24 ms**. So `none` decode really is bandwidth-dominated at its long cell and still wins. **ε, not `kv_frac`, is the binding term** — which independently reproduces #415's cross-backend finding by a completely different route.

## Two premises falsified

**`kv_frac <= 0.03 at 4k-8k` is not a property of short context.** It is a *(model, context)* quantity: 0.010 on Qwen3.8-27B and **0.211** on Ternary-Bonsai-8B at ~4k — 22x apart, on two models the campaign both measured. Most campaign decode cells were Bonsai, so "a 4k cell cannot resolve a codec difference even in principle" does not hold generally.

**"Group A codecs cost memory" is now false at every measured context.** `none`/`k8v8`/`k8v4`/`planar`/`tsym3` report byte-identical `kv_cache_bytes` — 5 codecs x 2 archs x 2 contexts, 20 rows recorded, not a digit apart.

## Scope, stated precisely

#414 §5 heads its criteria "after #404 + #411 + #413 land", and both concern a **post-seed-elision** `mixed`. #404 excluded the Mixed/RotK family, so arm B here still retains both bf16 seeds. Therefore:

- The **resident** figure (1.349x) is the *pre-elision* number. It reproduces what the byte model already predicts for today's `Mixed` (1.355x attention-only) — a confirmation, not a refutation, and it settles nothing about the post-elision projection.
- The **decode** figure is the new evidence and needs no post-elision arm: returning an unread seed frees memory, it does not speed a quantized-matmul decode, and arm B already reads its packed store.

An earlier revision of this branch claimed "its own falsifier fires". That was wrong and is removed.

## Could not reach 262 144

Precise cap: `resolve_prompt_tokens_file` requires a checked-in `prompts/longctx_<k>k.json` and the largest shipped is 128k. `--max-prompt-tokens` is *not* the cap. Reaching 256k needs a new ~880 KB fixture plus ~3 GPU-hours at the measured 301 tok/s prefill. Reported rather than silently substituted with a shorter cell.

## A gate that got redder as the host got quieter

`bench_llama_ab_selftest.sh` (added last PR) asserted exit **125** on three behaviour cases while passing `--allow-busy-host`. 125 is the TAINTED code, so those assertions encoded "a foreign process was sampled" rather than "the harness reached the right verdict" — and taint is per slot, so which case flipped was random (13/13, 13/13, 12/13 on one tree). It passed throughout the campaign's busy period and began failing once the machine went quiet.

Now each case asserts the **verdict text** the harness printed, plus that the exit code agrees with the harness's own taint report (TAINTED ⇒ 125, absent ⇒ 0). Both sides come from the same invocation, so the host cancels — and it is strictly stronger, since it still catches a harness that stops signalling taint. Deterministic across runs with genuinely varying host states: 17/17 every time.

Auditing the sibling under the same lens flipped **16 of 48** cases in `perf_ab_selftest.sh` — 4 new, 12 pre-existing, never observed flaky only because they pin `--busy-pct 100000`, which disables the busy path but not the unmeasured one.

Adjacent defect fixed: `perf_ab.sh` **replaced** its verdict with the word TAINTED, discarding the rank-test answer it had already computed, for exactly the runs a reader most needs to re-read. Verdict and taint are now separate lines and separate JSON fields.

## Recorded

16 + 20 observations via the buffer/ingest path; nothing writes the DB directly; `BENCHMARK_CHAMPIONS.md` untouched. New `scripts/ingest/perf_ab_ingest.py` refuses a rebuilt binary (digest vs the recorded `sha256_16`), a raised `--busy-pct`, a `--prompt-tokens` that disagrees with the run, and a repeated codec flag; every refusal is mutation-demonstrated in a new `perf_ab_ingest_selftest.sh` wired into `make ci`.

`make ci`: **composite exit 0**, 420 127 B log, zero truncation markers.
