### PR TITLE
docs(kv,perf,profiling): five documentation-truth corrections (#407, #402, #403, #406, #410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,9 +412,113 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate carries the observed value. This is what identified the Gemma4 result
   below in one run instead of by reading the dispatcher.
 
+### Documentation
+
+- **The gemma4 SWA comment claimed quantized codecs take a full-size path.**
+  They do not, and never did on this tree: `KvCache::with_quant_max_seq_window`
+  selects the rotating ring on `window > 0` alone, `update` / `enter_prefill` /
+  `exit_prefill` all return before any codec dispatch when it is set, and
+  `KvStorage` is allocated lazily, so a windowed layer under `k8v8` holds
+  exactly what it holds under `none`. There was no "pending follow-up" branch
+  behind the comment. Corrected at the gemma4 site and at the five places that
+  restated it — `gemma3/generate.rs`, `speculative/mod.rs` (which additionally
+  claimed the window is *ignored* for quantized modes, and named a per-arch
+  default table that no longer exists), the `rotating` module doc, the
+  `KvCache::rotating` field doc, and `docs/KV_CACHE.md`'s windowed-ring scope
+  note.
+
+- **`CLAUDE.md` filed ParoQuant as a rotation-based KV family and both
+  ParoQuant and IsoQuant as "rotation-KV references".** ParoQuant is a
+  weight-only INT4 method — the token `kv` does not occur in its upstream repo
+  and its calibration path drops `use_cache` — and rMLX has no `KvQuant::Paro*`
+  variant, no ParoQuant `KvStorage` and no `--kv-quant` name for it. IsoQuant
+  upstream is five files, two stage-1 CUDA kernels, no cache and no decode
+  path, so rMLX's `iso*` codecs have no upstream KV counterpart to port. The
+  capability line now names the four families that are KV codecs
+  (TurboQuant, IsoQuant, PlanarQuant, RotorQuant) and says where ParoQuant
+  actually lives; the reference entries state each repo's real scope. The same
+  parenthetical in `README.md` carried the same error twice and is corrected
+  with it. No code changes — `docs/WEIGHT_QUANTS.md` §7 already filed ParoQuant
+  correctly.
+
+- **`docs/PERF_BASELINE.md` H2's "active bytes/step" was nameplate arithmetic.**
+  The four figures (`~2 / ~4 / ~3.5 / ~3.5 GB`) were active-parameter counts
+  times the weight-quant bit width. They dropped the quantization sidebands,
+  the tied `lm_head` (all four models set `tie_word_embeddings`), the per-arch
+  auxiliaries — and KV traffic entirely, while being divided into a decode rate
+  measured at a 4 096-token prompt. Replaced with a tensor census from
+  `scripts/perf_ceiling.py` (`config.json` + safetensors headers, KV term from
+  the engine's own accounting), with the invocation recorded so the row is
+  re-checkable without a device. The correction is not a constant bias: three
+  ceilings fall and Qwen3.6-35B's rises 9%, because 30 of its 40 layers are GDN
+  and hold no attention projections. The band tightens from 1.84x–2.66x to
+  1.69x–2.15x, dissolving the reading that Bonsai is a factor-of-1.4 outlier
+  with arch-specific overhead worth hunting — most of its excess was the
+  missing KV term, 13.9% of its stream at that shape. `measured decode_tps` is
+  untouched; only the denominator moved. Carried through every dependent claim
+  in the file — the decode-only re-baseline table, the H2 addendum's per-step
+  overhead comparison against llama.cpp (still INCONCLUSIVE, ranges still
+  overlap), H9b, H10 and the net narrative — and through
+  `docs/KV_CACHE.md`'s restatement of the band, which also repeated an
+  unmeasured literature envelope that `PERF_BASELINE.md` had already retracted.
+  H9b and H10 additionally ranked Qwen3.6 "the best of the four models" by
+  ratio-vs-ceiling; that is a comparison across models of different size, which
+  the same document forbids, so both now read the scale-free quantity
+  (per-step overhead, 5.30 ms against a 4.65–6.93 ms range) and reach the same
+  conclusion.
+
+- **The iso / rotor stored bit rate is now stated symbolically and at the point
+  of selection.** `docs/KV_QUANT.md` said the 16.25 bits/value result is
+  "head_dim independent" and then gave two different values for two head dims.
+  The rate is `16 + 32/head_dim` for iso and `(64·⌈D/3⌉ + 32)/D` for rotor,
+  floors 16.0 (approached from above, never reached) and 21.33 — so it is the
+  *sign*, not the rate, that holds at every finite head dim, and both are
+  strictly above bf16's 16.0. Both formulas are derivations from
+  `QuantKGpuRing::alloc`, marked as such. The "Memory and bit-rate summary"
+  table omitted the ring families entirely while listing seven codecs below
+  bf16; the four ring rows are added, flagged as the only rows whose decode
+  reads the store they describe. `rmlx info --list-cache-types` — where these
+  tags are actually chosen — now says the bit width in an `iso_*`/`rotor_*`
+  name is its codebook rather than its stored rate.
+
+- **Three stale claims found beside the above and corrected.** `--rotor-qjl`
+  has defaulted to `off` since the rotor Metal path landed, but four places in
+  `docs/KV_QUANT.md` still called `on` the default — including the decode-cost
+  caveat, which therefore described the CPU path as what an operator gets.
+  `docs/KV_QUANT.md` also said the V-only `iso3`/`iso4` codecs "measure ≈2.1×
+  `none`", which its own codec-disposition section measures as byte-identical
+  (they build no store); the 48.25 bits/value figure is the rate they would
+  cost once a kernel reads one, and now says so. And `KvQuant::K8VTurbo3`'s doc
+  comment still described itself as the auto default for Gemma4 small, which
+  the retired per-arch table used to make true.
+
+- **Metal System Trace does instrument `rmlx` on this host.**
+  `docs/PROFILING.md` claimed the headless path "exports zero rows for `rmlx`".
+  Reproduced twice at xctrace 16.0 / Xcode 26.6 on M5 Max — 6 931 rmlx rows
+  (gemma-4-e2b `none` @4096, `target/release/rmlx`) and 14 140 (Bonsai-8B
+  `k8v4` @8192, `target/release-perf/rmlx`), `Compute` channel,
+  `start-latency` populated, no `sudo` and no entitlement. The recordings that
+  produced the claim held 24 rows for the *whole machine* over 25 s, against
+  36 441 here over 20 s, so what failed was the recording. The false sentence
+  is removed and the real boundary stated: MST carries no kernel names and no
+  counters, which is what the Xcode GUI replay is for.
+
 ### Changed
 
+- **`xctrace`'s "no rows" refusal splits into the two states it was
+  conflating.** A table with no rows at all (the recording captured nothing)
+  and a table holding other processes' rows and none of this one's (the
+  recording ran; this process was not in it) have opposite remedies, and both
+  were reported as `parsed but contains no rows` — which `scripts/mst_capture.sh`
+  then annotated with "the run itself failed", sending the reader to re-run a
+  workload that is fine. `XctraceError::NoRowsForProcess` is the second case
+  and carries the row count and the process census the recording *did* see, on
+  both the plain and the `--skip-ms` entry branch. This is the diagnostic that
+  would have identified the four zero-row recordings above as failed
+  recordings.
+
 - **`--kv-preset auto` resolves to `DEFAULT_KV_QUANT`, the same constant
+  `--kv-quant auto` resolves to.** It previously ran its own resolver — a
   `--kv-quant auto` resolves to.** It previously ran its own resolver — a
   decision tree over `sysctl hw.memsize` and a `config.json` parameter estimate
   that returned a "compressing" preset when the model plus its bf16 KV would not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -447,9 +447,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the tied `lm_head` (all four models set `tie_word_embeddings`), the per-arch
   auxiliaries — and KV traffic entirely, while being divided into a decode rate
   measured at a 4 096-token prompt. Replaced with a tensor census from
-  `scripts/perf_ceiling.py` (`config.json` + safetensors headers, KV term from
-  the engine's own accounting), with the invocation recorded so the row is
-  re-checkable without a device. The correction is not a constant bias: three
+  `scripts/perf_ceiling.py` (`config.json` + safetensors headers), with the
+  invocation recorded so the row is re-checkable without a device. The KV term
+  is a **second producer** — the script transcribes
+  `decode_reads_packed_store`, `feeds_bf16_{k,v}_at_decode` and
+  `kv_quant_for_layer` into Python by hand and nothing gates the two copies
+  against each other, which the doc now states rather than calling the term
+  "the engine's own accounting". The correction is not a constant bias: three
   ceilings fall and Qwen3.6-35B's rises 9%, because 30 of its 40 layers are GDN
   and hold no attention projections. The band tightens from 1.84x–2.66x to
   1.69x–2.15x, dissolving the reading that Bonsai is a factor-of-1.4 outlier
@@ -513,12 +517,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   then annotated with "the run itself failed", sending the reader to re-run a
   workload that is fine. `XctraceError::NoRowsForProcess` is the second case
   and carries the row count and the process census the recording *did* see, on
-  both the plain and the `--skip-ms` entry branch. This is the diagnostic that
-  would have identified the four zero-row recordings above as failed
-  recordings.
+  both the plain and the `--skip-ms` entry branch. A third state,
+  `SkipRemovedEveryRow`, covers the case those two cannot describe honestly: the
+  process IS in the recording and `--skip-ms` cut past its work.
+  `SkipExceedsSpan` does not subsume it — that guard fires on
+  `origin >= max(start + duration)`, so one long submission straddling the
+  origin keeps it silent while every row's `start` is below the floor, and the
+  refusal would otherwise claim the process was absent while printing its own
+  row count in the census. This is the diagnostic that would have identified the
+  four zero-row recordings above as failed recordings.
 
 - **`--kv-preset auto` resolves to `DEFAULT_KV_QUANT`, the same constant
-  `--kv-quant auto` resolves to.** It previously ran its own resolver — a
   `--kv-quant auto` resolves to.** It previously ran its own resolver — a
   decision tree over `sysctl hw.memsize` and a `config.json` parameter estimate
   that returned a "compressing" preset when the model plus its bf16 KV would not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,9 @@ One `cargo build --release` binary that:
    input for models that support those modalities.
 3. Supports the **widest weight × KV quantization matrix** MLX can express,
    including rotation-based KV families no other MLX server ships
-   (TurboQuant, IsoQuant, PlanarQuant, ParoQuant).
+   (TurboQuant, IsoQuant, PlanarQuant, RotorQuant). ParoQuant is supported
+   too, on the **weight** side — it is not a KV method (see
+   `docs/WEIGHT_QUANTS.md` §7).
 4. **Converts** models between quant formats / layouts (re-quantize, KV-quant
    repack) — MLX in, MLX out.
 5. Multi-model lifecycle (load on demand, unload on idle), but enforces a
@@ -104,7 +106,12 @@ coverage grows.
 - `oxideai/mlx-rs` — community Rust binding over `mlx-c`.
 - `ml-explore/mlx-c` — Apple's stable C ABI.
 - `huggingface/safetensors` — Rust safetensors crate.
-- `z-lab/paroquant`, `ParaMind2025/isoquant` — rotation-KV references.
+- `z-lab/paroquant` — weight-side pairwise-rotation INT4 reference. Not a KV
+  method: the token `kv` does not occur in the repo, and its calibration path
+  drops `use_cache`. See `docs/WEIGHT_QUANTS.md` §7.
+- `ParaMind2025/isoquant` — SO(4) isoclinic rotation reference. Stage-1
+  quantize/dequantize only (5 tracked files, two CUDA kernels); no cache and no
+  decode path upstream, so rMLX's `iso*` KV codecs have no counterpart to port.
 
 ## Hard rules
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ OpenAI- and Anthropic-compatible alternative to `mlx_lm.server`, and a
 Metal-native counterpart to `llama.cpp` that runs MLX-format models directly.
 One `cargo build --release` artifact — no Python runtime, no GGUF translation layer — and the widest
 weight × KV-quantization matrix any MLX server ships, including rotation-based
-KV families (TurboQuant, IsoQuant, PlanarQuant, RotorQuant, ParoQuant) that no
-other MLX server offers. Works as a local backend for any OpenAI/Anthropic-compatible
+KV families (TurboQuant, IsoQuant, PlanarQuant, RotorQuant) that no
+other MLX server offers, plus ParoQuant on the weight side. Works as a local backend for any OpenAI/Anthropic-compatible
 coding agent (Claude Code, Cursor, Aider, OpenCode).
 
 > Status: **feature-complete native MLX backend** — OpenAI- and
@@ -105,9 +105,10 @@ quantization surface in a single process.
 
 <sub>¹ `mlx-lm` itself is text; vision lives in the separate `mlx-vlm` package.
 ² `llama.cpp` audio is in the `mtmd` CLI, not the HTTP server.
-³ affine 2–8 bit, fp8, mxfp/nvfp4, **plus** five rotation-KV families
-(TurboQuant, IsoQuant, PlanarQuant, RotorQuant, ParoQuant) no other MLX server
-ships. Widest *matrix*, not a memory win: measured on two architectures at two
+³ affine 2–8 bit, fp8, mxfp/nvfp4, **plus** four rotation-KV families
+(TurboQuant, IsoQuant, PlanarQuant, RotorQuant) no other MLX server
+ships. ParoQuant is a weight quantizer, not a KV codec, and is counted in the
+weight column. Widest *matrix*, not a memory win: measured on two architectures at two
 contexts, no KV codec in the tree currently holds fewer resident bytes than
 plain bf16 — 17 of the 28 build no packed store at all and decode identically to
 it, bf16 itself is the 18th, and the other 10 are larger. The honest per-codec disposition, and why the

--- a/crates/rmlx-cli/src/startup.rs
+++ b/crates/rmlx-cli/src/startup.rs
@@ -293,16 +293,23 @@ pub(crate) fn print_cache_type_table() {
     // the store spends. The iso and rotor tags decode from a shared GPU ring
     // that costs one whole u32 code word plus one f32 scale per group whatever
     // the codebook width, so a 3-bit and a 4-bit member of the same family
-    // occupy byte-identical space and both land above bf16. Said here because
-    // this listing is where the tags are chosen.
+    // occupy byte-identical space; planar spends an f32 per PAIR and is wider
+    // still. None of the three is a compression format at this layout. Said
+    // here because this listing is where the tags are chosen.
     println!();
-    println!("note: the bit width in an iso_*/rotor_* name is its codebook, not what");
-    println!("      it stores. Their shared ring spends one u32 code word and one f32");
-    println!("      scale per group whatever that width, so a store built from it holds");
-    println!("      16 + 32/head_dim bits per value (iso) or (64*ceil(head_dim/3)+32)");
-    println!("      /head_dim (rotor) — 16.25 and 21.75 at head_dim 128, against bf16's");
-    println!("      16.00, and the 3-bit and 4-bit members are byte-identical. These are");
-    println!("      the widest cells on this menu, not the narrowest. Derived from the");
-    println!("      ring allocation; for which pairings actually build that store see");
-    println!("      docs/KV_QUANT.md \"Codec disposition\".");
+    println!("note: the bit width in an iso_*/rotor_*/planar* name is its codebook, not");
+    println!("      what it stores. None of the three is a compression format at the");
+    println!("      layout it ships: each spends a whole u32 code word and an f32 scale");
+    println!("      per group (planar, per PAIR), so all land ABOVE bf16's 16.00 bits");
+    println!("      per value. At head_dim 128:");
+    println!("        iso_k_3/4, iso_v_3/4         16.25   (16 + 32/head_dim)");
+    println!("        rotor_k_3/4, rotor_v_3/4     21.75   ((64*ceil(D/3)+32)/D)");
+    println!("        planar3, planar4, planar_k4  22.00   (at every head_dim)");
+    println!("      so planar is the widest cell on this menu, not iso or rotor. Each");
+    println!("      pair is byte-identical across its 3-bit and 4-bit member. The");
+    println!("      iso/rotor rates are derived from the ring allocation; the rotor and");
+    println!("      planar figures are also measured by the crate rate gate");
+    println!("      (kv_rate_tests), which measures iso in its wider CPU-block form.");
+    println!("      For which pairings actually build such a store see docs/KV_QUANT.md");
+    println!("      \"Codec disposition\".");
 }

--- a/crates/rmlx-cli/src/startup.rs
+++ b/crates/rmlx-cli/src/startup.rs
@@ -235,8 +235,8 @@ pub(crate) fn print_cache_type_table() {
             CacheType::Turbo2Tcq => "TurboQuant + Viterbi trellis (2-bit)",
             CacheType::IsoK3 => "IsoQuant K-rotation (3-bit)",
             CacheType::IsoK4 => "IsoQuant K-rotation (4-bit)",
-            CacheType::RotorK3 => "Clifford rotor K-side (3-bit, +QJL)",
-            CacheType::RotorK4 => "Clifford rotor K-side (4-bit, +QJL)",
+            CacheType::RotorK3 => "Clifford rotor K-side (3-bit)",
+            CacheType::RotorK4 => "Clifford rotor K-side (4-bit)",
             // Symmetric WHT-3 K+V.
             CacheType::TurboSym3 => "TurboQuant sym K+V (3-bit)",
         };
@@ -289,4 +289,20 @@ pub(crate) fn print_cache_type_table() {
             sides,
         );
     }
+    // The nominal width in a rotation codec's name is its codebook, not what
+    // the store spends. The iso and rotor tags decode from a shared GPU ring
+    // that costs one whole u32 code word plus one f32 scale per group whatever
+    // the codebook width, so a 3-bit and a 4-bit member of the same family
+    // occupy byte-identical space and both land above bf16. Said here because
+    // this listing is where the tags are chosen.
+    println!();
+    println!("note: the bit width in an iso_*/rotor_* name is its codebook, not what");
+    println!("      it stores. Their shared ring spends one u32 code word and one f32");
+    println!("      scale per group whatever that width, so a store built from it holds");
+    println!("      16 + 32/head_dim bits per value (iso) or (64*ceil(head_dim/3)+32)");
+    println!("      /head_dim (rotor) — 16.25 and 21.75 at head_dim 128, against bf16's");
+    println!("      16.00, and the 3-bit and 4-bit members are byte-identical. These are");
+    println!("      the widest cells on this menu, not the narrowest. Derived from the");
+    println!("      ring allocation; for which pairings actually build that store see");
+    println!("      docs/KV_QUANT.md \"Codec disposition\".");
 }

--- a/crates/rmlx-kv-quant/src/kvcache/core.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/core.rs
@@ -73,8 +73,8 @@ pub struct KvCache {
     /// model actually pushed is recorded instead of guessed.
     pub(super) stream_dtype: Option<Dtype>,
     /// If `Some`, this cache uses the SWA ring-buffer code path
-    /// (RotatingKvCache port). Activated by SWA layers in
-    /// `KvQuant::None` mode only.
+    /// (RotatingKvCache port). Activated by any layer constructed with a
+    /// positive `sliding_window`, under every `KvQuant`.
     pub(super) rotating: Option<RotatingState>,
     // ── Head-major persistent K8V4 storage ──
     //

--- a/crates/rmlx-kv-quant/src/kvcache/windowed_ring_sizing_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/windowed_ring_sizing_tests.rs
@@ -362,3 +362,131 @@ fn windowed_ring_retains_full_swa_window() {
         assert_window_retained(&read_rows(&kk), head + 1);
     }
 }
+
+// ── The codec-independence of the rotating path ─────────────────────────────
+//
+// "A windowed layer runs the bf16 ring whatever codec it is handed" is asserted
+// in the `rotating` module doc, on the `KvCache::rotating` field, in
+// `with_quant_max_seq_window`'s own doc, in three per-arch cache-construction
+// comments and in two `docs/` files. Until this test it was pinned by nothing
+// that varied the codec — which is exactly how the gemma4 comment came to claim
+// the opposite for long enough to be filed as a defect. One table, every codec a
+// caller can hand a windowed layer.
+
+/// Codecs a windowed layer can be constructed with, spanning the classes that
+/// behave differently on a GLOBAL layer: bf16 (`None`), mirror-fed with no
+/// store (`K8V8`, `K8V4`, `Planar`) and store-reading (`Mixed`). If the window
+/// were conditional on the codec, these would not agree.
+fn windowed_codec_table() -> Vec<(&'static str, KvQuant)> {
+    vec![
+        ("none", KvQuant::None),
+        ("k8v8", KvQuant::K8V8),
+        ("k8v4", KvQuant::K8V4),
+        ("planar", KvQuant::Planar),
+        (
+            "mixed_k8g64_v4g64",
+            KvQuant::Mixed {
+                k_bits: 8,
+                v_bits: 4,
+                k_group_size: 64,
+                v_group_size: 64,
+            },
+        ),
+    ]
+}
+
+/// Prefill `ctx` tokens into a cache built at `quant`, chunked, and return it.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test — panics are the intended failure mode"
+)]
+fn prefilled(quant: KvQuant, window: Option<i32>, ctx: i32) -> KvCache {
+    let device = Device::Cpu;
+    let mut cache = KvCache::with_quant_max_seq_window(quant, ctx.max(4096), window);
+    cache.enter_prefill();
+    let mut pos = 0;
+    while pos < ctx {
+        let s = PREFILL_CHUNK.min(ctx - pos);
+        let n = (B * KV_H * s * D) as usize;
+        let bytes = vec![0u8; n * 2];
+        let k = Array::from_bytes(&bytes, &[B, KV_H, s, D], Dtype::Bf16).unwrap();
+        let v = Array::from_bytes(&bytes, &[B, KV_H, s, D], Dtype::Bf16).unwrap();
+        cache.update(&k, &v, device).unwrap();
+        pos += s;
+    }
+    cache.exit_prefill(device).unwrap();
+    cache
+}
+
+/// A windowed layer takes the bf16 ring under **every** codec, allocates no
+/// packed store and keeps no decode seed, and holds byte-identical KV to
+/// `none`. This is the claim six comments make; here it is measured.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test — panics are the intended failure mode"
+)]
+fn a_windowed_layer_is_the_bf16_ring_under_every_codec() {
+    // Longer than the window, so the ring has wrapped and any codec that was
+    // going to encode something has had a full prefill to do it in.
+    let ctx = WINDOW * 3;
+    let mut baseline: Option<u64> = None;
+    for (name, quant) in windowed_codec_table() {
+        let cache = prefilled(quant, Some(WINDOW), ctx);
+        assert!(
+            cache.is_rotating(),
+            "{name}: a layer given a window must take the rotating path"
+        );
+        assert_eq!(
+            cache.storage().resident_bytes(),
+            0,
+            "{name}: the rotating path must allocate no packed store"
+        );
+        assert!(
+            cache.decode_fp16_kv().is_none(),
+            "{name}: the rotating path must materialise no decode seed"
+        );
+        let bytes = cache.resident_bytes();
+        match baseline {
+            None => baseline = Some(bytes),
+            Some(want) => assert_eq!(
+                bytes, want,
+                "{name}: windowed KV must be byte-identical to `none` ({bytes} vs {want})"
+            ),
+        }
+    }
+    assert!(
+        baseline.is_some_and(|b| b > 0),
+        "the harness stored nothing"
+    );
+}
+
+/// The null control, and the reason the test above is not vacuous: the same
+/// codecs on a layer with **no** window do not take the ring, and the
+/// store-reading one really does build a store. Without this a change that made
+/// every cache rotating would pass the table above.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test — panics are the intended failure mode"
+)]
+fn the_same_codecs_without_a_window_do_not_take_the_ring() {
+    let ctx = 128;
+    for (name, quant) in windowed_codec_table() {
+        let cache = prefilled(quant, None, ctx);
+        assert!(
+            !cache.is_rotating(),
+            "{name}: a layer with no window must not take the rotating path"
+        );
+        // `Mixed` is the one codec here whose decode reads its own packed
+        // store, so it is the one that must have built one. The rest are
+        // mirror-fed by design and legitimately hold none.
+        if matches!(quant, KvQuant::Mixed { .. }) {
+            assert!(
+                cache.storage().resident_bytes() > 0,
+                "{name}: a global store-reading layer must allocate its store — \
+                 without this the windowed assertion above cannot fail"
+            );
+        }
+    }
+}

--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -101,7 +101,9 @@ pub enum KvQuant {
     /// K = affine q8_0 (group_size=128),
     /// V = TurboQuant **3-bit** Lloyd-Max N(0,1) codebook (group=32).
     ///
-    /// Auto default for Gemma4 small (non-MoE, hidden_size ≤ 2560, non-paroquant).
+    /// Opt-in on every arch — `auto` resolves to bf16 and never selects it. It
+    /// was the auto default for Gemma4 small (non-MoE, `hidden_size` ≤ 2560,
+    /// non-paroquant) until the per-arch table was retired.
     /// Validated on Gemma4-e4b: −0.40% vs K8V4 at canary shape (within the
     /// <1% promote gate). Cosine gate ≥ 0.9807 passes.
     ///

--- a/crates/rmlx-kv-quant/src/quant.rs
+++ b/crates/rmlx-kv-quant/src/quant.rs
@@ -1053,7 +1053,8 @@ impl KvQuant {
     /// at 24 B per 4-value group against the 8 B it actually holds. The sign of
     /// the net-benefit decision is unaffected — 8 B per 4 values already exceeds
     /// bf16's 8 B before the per-token norm — but the magnitude reported in the
-    /// advisory's `est_extra_bytes` is high for `k_iso*` / `iso*_sym`.
+    /// advisory's byte field is high for `k_iso*` / `iso*_sym`, which is why
+    /// that field is named `est_extra_bytes_upper_bound`.
     /// `estimator_matches_actual_iso_rotor_encode_bytes` anchors the estimate to
     /// the CPU-encode bytes deliberately.
     ///

--- a/crates/rmlx-kv-quant/src/rotating.rs
+++ b/crates/rmlx-kv-quant/src/rotating.rs
@@ -9,9 +9,11 @@
 //! attention reads at most `max_size` tokens — no per-step trimming, no per-step
 //! window mask.
 //!
-//! Used by SWA layers (e.g. Gemma3/Gemma4) in **bf16-KV mode only**.
-//! Quantized SWA layers stay on the existing full-size [`KvStorage`] codec
-//! paths; mlx-lm's reference also keeps RotatingKVCache as bf16
+//! Used by SWA layers (e.g. Gemma3/Gemma4) under **every** `KvQuant`. The
+//! rotating branch is selected on `window > 0` alone
+//! ([`crate::KvCache::with_quant_max_seq_window`]), so a quantized codec on an
+//! SWA layer runs this bf16 ring and its [`crate::KvStorage`] is never
+//! allocated; mlx-lm's reference also keeps RotatingKVCache as bf16
 //! (`to_quantized` raises `NotImplementedError`).
 //!
 //! Algorithm (mirrors mlx-lm exactly):

--- a/crates/rmlx-mlx/src/xctrace.rs
+++ b/crates/rmlx-mlx/src/xctrace.rs
@@ -161,13 +161,46 @@ pub enum XctraceError {
         actual: String,
     },
 
-    /// A well-formed export with no rows. Never silently reported as an empty
-    /// result: it means the recording captured nothing, which is a failed run,
-    /// not a run with zero GPU work.
+    /// A well-formed export with **no rows at all**. Never silently reported as
+    /// an empty result: the recording captured nothing, from any process.
+    ///
+    /// This is deliberately narrower than "the summary is empty". A table that
+    /// holds rows for other processes and none for the one asked about is a
+    /// different state with a different remedy, and it is
+    /// [`Self::NoRowsForProcess`].
     #[error("schema '{schema}' parsed but contains no rows")]
     NoRows {
         /// Name of the parsed schema.
         schema: String,
+    },
+
+    /// The table is populated, but no row is attributed to a process matching
+    /// the filter.
+    ///
+    /// Separated from [`Self::NoRows`] because the two point at opposite
+    /// things: an empty table means the recording failed, while a populated
+    /// one means it ran and this process was not in it — because it never
+    /// launched, exited before submitting GPU work, or was not instrumented.
+    /// Reporting the second as the first sends the reader to re-run a workload
+    /// that is fine. The processes the recording *did* see are the evidence
+    /// that distinguishes them, so they are carried here rather than left for
+    /// a second pass the caller has to know to make.
+    #[error(
+        "'{schema}' holds {rows_total} rows but none for a process matching \
+         {filter:?}{after_skip} — the recording ran; this process was not in it. \
+         Processes seen: {processes}"
+    )]
+    NoRowsForProcess {
+        /// Name of the parsed schema.
+        schema: String,
+        /// Rows in the table before the process filter.
+        rows_total: u64,
+        /// The substring the caller filtered on.
+        filter: String,
+        /// Process display names seen, with row counts, busiest first.
+        processes: String,
+        /// `" after the requested skip"` when a skip was in force, else empty.
+        after_skip: String,
     },
 
     /// The requested skip covers everything the matched process did.

--- a/crates/rmlx-mlx/src/xctrace.rs
+++ b/crates/rmlx-mlx/src/xctrace.rs
@@ -187,7 +187,7 @@ pub enum XctraceError {
     /// a second pass the caller has to know to make.
     #[error(
         "'{schema}' holds {rows_total} rows but none for a process matching \
-         {filter:?}{after_skip} — the recording ran; this process was not in it. \
+         {filter:?} — the recording ran; this process was not in it. \
          Processes seen: {processes}"
     )]
     NoRowsForProcess {
@@ -199,8 +199,37 @@ pub enum XctraceError {
         filter: String,
         /// Process display names seen, with row counts, busiest first.
         processes: String,
-        /// `" after the requested skip"` when a skip was in force, else empty.
-        after_skip: String,
+    },
+
+    /// Rows for the requested scope exist, and the `skip_ms` floor removed all
+    /// of them.
+    ///
+    /// A third state, not a decoration on the other two. Reporting it as
+    /// [`Self::NoRowsForProcess`] is self-contradictory — the message would
+    /// claim the process is absent while printing that process's own row count
+    /// in the census — and reporting it as [`Self::NoRows`] loses the skip
+    /// entirely.
+    ///
+    /// [`Self::SkipExceedsSpan`] does **not** subsume it. That guard fires on
+    /// `origin_ns >= latest` where `latest` is `max(start + duration)`, so a
+    /// single long submission straddling the origin keeps it silent while every
+    /// row's `start` is below the floor.
+    #[error(
+        "the {skip_ms} ms skip removed every one of the {matched} rows recorded \
+         for {scope} in '{schema}' ({rows_total} rows total) — that work all \
+         starts before the skip origin; lower the skip or record for longer"
+    )]
+    SkipRemovedEveryRow {
+        /// Name of the parsed schema.
+        schema: String,
+        /// Rows in the table before any filter.
+        rows_total: u64,
+        /// Rows the scope matched before the skip floor was applied.
+        matched: u64,
+        /// The skip that was asked for, milliseconds.
+        skip_ms: u64,
+        /// What the rows were scoped to — a process filter, or the whole table.
+        scope: String,
     },
 
     /// The requested skip covers everything the matched process did.

--- a/crates/rmlx-mlx/src/xctrace_gpu_intervals.rs
+++ b/crates/rmlx-mlx/src/xctrace_gpu_intervals.rs
@@ -128,17 +128,36 @@ pub struct SummaryFilter<'a> {
 /// branches say the same thing.
 ///
 /// Only reachable on a table that *has* rows: `for_each_row` refuses an empty
-/// export itself, before either caller gets here. So a filter being present is
-/// the whole decision — when one is, the rows exist and belong to somebody
-/// else, and naming who is what separates "the recording failed" from "this
-/// process was not in it".
+/// export itself, before either caller gets here. Three outcomes, and they are
+/// separate states rather than one message with adjectives:
+///
+/// * `skip_emptied` — the scope's rows exist and the `skip_ms` floor removed
+///   all of them. Checked first, because it is the only case where the census
+///   would otherwise print the very process the message claims is absent.
+/// * a filter is set and matched nothing — the recording ran without this
+///   process in it, and the census is the evidence.
+/// * no filter — the whole table is empty, which `for_each_row` already
+///   refuses, so this arm exists for completeness.
 fn no_rows_error(
     schema: String,
     rows_total: u64,
     process_filter: Option<&str>,
     processes: &[(String, u64)],
-    after_skip: bool,
+    skip_emptied: Option<(u64, u64)>,
 ) -> XctraceError {
+    let scope = process_filter.map_or_else(
+        || "the whole table".to_owned(),
+        |f| format!("a process matching {f:?}"),
+    );
+    if let Some((matched, skip_ms)) = skip_emptied {
+        return XctraceError::SkipRemovedEveryRow {
+            schema,
+            rows_total,
+            matched,
+            skip_ms,
+            scope,
+        };
+    }
     let Some(want) = process_filter else {
         return XctraceError::NoRows { schema };
     };
@@ -158,11 +177,6 @@ fn no_rows_error(
         } else {
             seen
         },
-        after_skip: if after_skip {
-            " after the requested skip".to_owned()
-        } else {
-            String::new()
-        },
     }
 }
 
@@ -175,7 +189,8 @@ fn no_rows_error(
 /// nothing, and reporting zeros for it is how a profiling harness lies. Which
 /// refusal says which: [`XctraceError::NoRows`] when the table itself is empty,
 /// [`XctraceError::NoRowsForProcess`] when it holds other processes' work and
-/// none of this one's.
+/// none of this one's, and [`XctraceError::SkipRemovedEveryRow`] when this
+/// scope's rows exist and `skip_ms` removed all of them.
 pub fn summarise_gpu_intervals(xml: &str, filter: SummaryFilter<'_>) -> Result<GpuIntervalSummary> {
     // Checked up front, from the header alone, so the wrong table refuses
     // identically whatever the options say. Left inside the row walk it would
@@ -190,7 +205,7 @@ pub fn summarise_gpu_intervals(xml: &str, filter: SummaryFilter<'_>) -> Result<G
         });
     }
     if filter.skip_ms == 0 {
-        return summarise_from(xml, filter.process, 0);
+        return summarise_from(xml, filter.process, 0, 0);
     }
     // The origin is not known until the table has been read once. Rows are
     // cheap to revisit; buffering them all is the memory this parser streams to
@@ -199,19 +214,23 @@ pub fn summarise_gpu_intervals(xml: &str, filter: SummaryFilter<'_>) -> Result<G
     let mut latest = 0u64;
     // Counted on the way past so the refusal below can name what the recording
     // did hold; a second pass purely to answer that would be a second reader of
-    // the same table.
+    // the same table. Only built when a filter is set: without one the census
+    // is guaranteed unused (the refusal is `NoRows`, which carries no census),
+    // and reading the `process` column would newly make an unfiltered summary
+    // fail on a column this branch never used to touch — on exports of 36k-120k
+    // rows.
     let mut rows_total = 0u64;
     let mut processes: HashMap<String, u64> = HashMap::new();
     for_each_row(xml, |row| {
         rows_total += 1;
-        let seen = row.fmt("process")?.unwrap_or("<unattributed>");
-        match processes.get_mut(seen) {
-            Some(n) => *n += 1,
-            None => {
-                processes.insert(seen.to_owned(), 1);
-            }
-        }
         if let Some(want) = filter.process {
+            let seen = row.fmt("process")?.unwrap_or("<unattributed>");
+            match processes.get_mut(seen) {
+                Some(n) => *n += 1,
+                None => {
+                    processes.insert(seen.to_owned(), 1);
+                }
+            }
             if !seen.contains(want) {
                 return Ok(());
             }
@@ -226,12 +245,16 @@ pub fn summarise_gpu_intervals(xml: &str, filter: SummaryFilter<'_>) -> Result<G
         Ok(())
     })?;
     if earliest == u64::MAX {
+        // The floor is not applied in this pass, so reaching here means the
+        // *filter* matched nothing — the skip cannot be the cause and `None` is
+        // correct by construction, not by assumption. A skip that empties a
+        // non-empty match is caught inside `summarise_from`.
         return Err(no_rows_error(
             GPU_INTERVALS_SCHEMA.to_owned(),
             rows_total,
             filter.process,
             &sorted_processes(processes),
-            false,
+            None,
         ));
     }
     let origin_ns = earliest.saturating_add(filter.skip_ms.saturating_mul(1_000_000));
@@ -243,18 +266,23 @@ pub fn summarise_gpu_intervals(xml: &str, filter: SummaryFilter<'_>) -> Result<G
             span_ms: latest.saturating_sub(earliest) / 1_000_000,
         });
     }
-    summarise_from(xml, filter.process, origin_ns)
+    summarise_from(xml, filter.process, origin_ns, filter.skip_ms)
 }
 
 fn summarise_from(
     xml: &str,
     process_filter: Option<&str>,
     start_floor_ns: u64,
+    skip_ms: u64,
 ) -> Result<GpuIntervalSummary> {
     let mut summary = GpuIntervalSummary::default();
     let mut channels: HashMap<String, ChannelStats> = HashMap::new();
     let mut processes: HashMap<String, u64> = HashMap::new();
     let mut first_start = u64::MAX;
+    // Rows the scope matched *before* the skip floor. This is what tells "the
+    // process is not in this recording" apart from "it is, and the skip removed
+    // its window" — the two states the one refusal used to fuse.
+    let mut matched_before_floor = 0u64;
 
     let schema = for_each_row(xml, |row| {
         summary.rows_total += 1;
@@ -272,6 +300,7 @@ fn summarise_from(
         if !keep {
             return Ok(());
         }
+        matched_before_floor += 1;
         // See the note in summarise_gpu_intervals: a NULL here is an absence,
         // and read as 0 it would set first_start to 0 and inflate span_ns.
         let start = row.u64_required("start")?;
@@ -302,12 +331,21 @@ fn summarise_from(
     })?;
 
     if summary.rows_matched == 0 {
+        // A floor in force here always means the scope HAD rows: the only
+        // caller that passes a non-zero floor is the skip branch, which
+        // refuses first when the filter matches nothing. `matched_before_floor`
+        // is therefore the count to report, not a second condition to test —
+        // adding it as one would be a conjunct no input can falsify. The
+        // caller ordering that makes this true is pinned by
+        // `the_skip_branch_reports_the_same_distinction`, which goes red if a
+        // filter that matches nothing ever reaches here with a floor set.
+        let skip_emptied = (start_floor_ns > 0).then_some((matched_before_floor, skip_ms));
         return Err(no_rows_error(
             schema.name,
             summary.rows_total,
             process_filter,
             &sorted_processes(processes),
-            start_floor_ns > 0,
+            skip_emptied,
         ));
     }
 

--- a/crates/rmlx-mlx/src/xctrace_gpu_intervals.rs
+++ b/crates/rmlx-mlx/src/xctrace_gpu_intervals.rs
@@ -124,13 +124,58 @@ pub struct SummaryFilter<'a> {
     pub skip_ms: u64,
 }
 
+/// The refusal for "the filter matched nothing", built once so both entry
+/// branches say the same thing.
+///
+/// Only reachable on a table that *has* rows: `for_each_row` refuses an empty
+/// export itself, before either caller gets here. So a filter being present is
+/// the whole decision — when one is, the rows exist and belong to somebody
+/// else, and naming who is what separates "the recording failed" from "this
+/// process was not in it".
+fn no_rows_error(
+    schema: String,
+    rows_total: u64,
+    process_filter: Option<&str>,
+    processes: &[(String, u64)],
+    after_skip: bool,
+) -> XctraceError {
+    let Some(want) = process_filter else {
+        return XctraceError::NoRows { schema };
+    };
+    // Bounded: a recording holds a handful of processes, and the census is
+    // read only on this error path.
+    let seen = processes
+        .iter()
+        .map(|(name, n)| format!("{name} ({n} rows)"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    XctraceError::NoRowsForProcess {
+        schema,
+        rows_total,
+        filter: want.to_owned(),
+        processes: if seen.is_empty() {
+            "<none>".to_owned()
+        } else {
+            seen
+        },
+        after_skip: if after_skip {
+            " after the requested skip".to_owned()
+        } else {
+            String::new()
+        },
+    }
+}
+
 /// Parses a `metal-gpu-intervals` export and summarises it.
 ///
 /// # Errors
 /// [`XctraceError::WrongSchema`] when the export is a different table, plus any
-/// parse error. A filter that matches no row is [`XctraceError::NoRows`]: an
-/// empty summary is indistinguishable from a run that recorded nothing, and
-/// reporting zeros for it is how a profiling harness lies.
+/// parse error. A filter that matches no row is refused rather than summarised
+/// as zeros — an empty summary is indistinguishable from a run that recorded
+/// nothing, and reporting zeros for it is how a profiling harness lies. Which
+/// refusal says which: [`XctraceError::NoRows`] when the table itself is empty,
+/// [`XctraceError::NoRowsForProcess`] when it holds other processes' work and
+/// none of this one's.
 pub fn summarise_gpu_intervals(xml: &str, filter: SummaryFilter<'_>) -> Result<GpuIntervalSummary> {
     // Checked up front, from the header alone, so the wrong table refuses
     // identically whatever the options say. Left inside the row walk it would
@@ -152,9 +197,22 @@ pub fn summarise_gpu_intervals(xml: &str, filter: SummaryFilter<'_>) -> Result<G
     // avoid.
     let mut earliest = u64::MAX;
     let mut latest = 0u64;
+    // Counted on the way past so the refusal below can name what the recording
+    // did hold; a second pass purely to answer that would be a second reader of
+    // the same table.
+    let mut rows_total = 0u64;
+    let mut processes: HashMap<String, u64> = HashMap::new();
     for_each_row(xml, |row| {
+        rows_total += 1;
+        let seen = row.fmt("process")?.unwrap_or("<unattributed>");
+        match processes.get_mut(seen) {
+            Some(n) => *n += 1,
+            None => {
+                processes.insert(seen.to_owned(), 1);
+            }
+        }
         if let Some(want) = filter.process {
-            if !row.fmt("process")?.unwrap_or_default().contains(want) {
+            if !seen.contains(want) {
                 return Ok(());
             }
         }
@@ -168,12 +226,13 @@ pub fn summarise_gpu_intervals(xml: &str, filter: SummaryFilter<'_>) -> Result<G
         Ok(())
     })?;
     if earliest == u64::MAX {
-        return Err(XctraceError::NoRows {
-            schema: filter.process.map_or_else(
-                || GPU_INTERVALS_SCHEMA.to_owned(),
-                |f| format!("{GPU_INTERVALS_SCHEMA} filtered to process containing {f:?}"),
-            ),
-        });
+        return Err(no_rows_error(
+            GPU_INTERVALS_SCHEMA.to_owned(),
+            rows_total,
+            filter.process,
+            &sorted_processes(processes),
+            false,
+        ));
     }
     let origin_ns = earliest.saturating_add(filter.skip_ms.saturating_mul(1_000_000));
     if origin_ns >= latest {
@@ -243,14 +302,13 @@ fn summarise_from(
     })?;
 
     if summary.rows_matched == 0 {
-        let mut what = schema.name;
-        if let Some(f) = process_filter {
-            what = format!("{what} filtered to process containing {f:?}");
-        }
-        if start_floor_ns > 0 {
-            what = format!("{what} after the requested skip");
-        }
-        return Err(XctraceError::NoRows { schema: what });
+        return Err(no_rows_error(
+            schema.name,
+            summary.rows_total,
+            process_filter,
+            &sorted_processes(processes),
+            start_floor_ns > 0,
+        ));
     }
 
     summary.first_start_ns = if first_start == u64::MAX {
@@ -268,11 +326,16 @@ fn summarise_from(
             .cmp(&a.busy_ns)
             .then_with(|| a.channel.cmp(&b.channel))
     });
-    summary.processes = processes.into_iter().collect();
-    summary
-        .processes
-        .sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    summary.processes = sorted_processes(processes);
     Ok(summary)
+}
+
+/// Process census as a busiest-first list, ties broken by name so the order is
+/// stable across runs (the refusal message quotes it).
+fn sorted_processes(processes: HashMap<String, u64>) -> Vec<(String, u64)> {
+    let mut out: Vec<(String, u64)> = processes.into_iter().collect();
+    out.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    out
 }
 
 /// Renders a summary as CSV — the form a regression script asserts on.

--- a/crates/rmlx-mlx/src/xctrace_tests.rs
+++ b/crates/rmlx-mlx/src/xctrace_tests.rs
@@ -396,6 +396,65 @@ fn a_channel_with_no_latency_sample_reports_empty_not_zero() {
 fn a_process_filter_matching_nothing_is_an_error_not_an_empty_summary() {
     let err = summarise_gpu_intervals(&doc(ROWS_HAPPY), only("no-such-process"))
         .expect_err("a filter that selects nothing must be refused");
+    assert!(
+        matches!(err, XctraceError::NoRowsForProcess { .. }),
+        "got {err}"
+    );
+}
+
+/// A recording that captured nothing and a recording that captured other
+/// processes are different states with different remedies, and reporting both
+/// as "no rows" sends the reader to re-run a command that works. The table
+/// knows which one it is: `rows_total` and the process census are both in
+/// hand at the point of refusal.
+#[test]
+fn a_table_with_rows_for_other_processes_says_so_and_names_them() {
+    let err = summarise_gpu_intervals(&doc(ROWS_HAPPY), only("no-such-process"))
+        .expect_err("a filter that selects nothing must be refused");
+    let text = err.to_string();
+    assert!(
+        text.contains("rmlx (99)"),
+        "the refusal must name the processes the recording did see; got {text}"
+    );
+    assert!(
+        text.contains('2'),
+        "the refusal must say how many rows the table held; got {text}"
+    );
+    // The empty-table wording would send the reader to re-run the workload.
+    assert!(
+        !text.contains("contains no rows"),
+        "a populated table must not be reported as an empty one; got {text}"
+    );
+}
+
+/// The `skip_ms > 0` entry takes its own pre-pass over the table, so the
+/// distinction has to hold on both branches or a `--skip-ms` run reports the
+/// wrong one.
+#[test]
+fn the_skip_branch_reports_the_same_distinction() {
+    let err = summarise_gpu_intervals(
+        &doc(ROWS_HAPPY),
+        SummaryFilter {
+            process: Some("no-such-process"),
+            skip_ms: 1,
+        },
+    )
+    .expect_err("a filter that selects nothing must be refused on the skip branch too");
+    assert!(
+        matches!(err, XctraceError::NoRowsForProcess { .. }),
+        "got {err}"
+    );
+    assert!(err.to_string().contains("rmlx (99)"), "got {err}");
+}
+
+/// An empty table keeps the empty-table wording: there the recording really
+/// did capture nothing. Refused by the row walk itself, before the summary's
+/// own filter check — which is why that check needs no emptiness test of its
+/// own.
+#[test]
+fn an_empty_table_is_still_reported_as_an_empty_table() {
+    let err = summarise_gpu_intervals(&doc(""), only("rmlx"))
+        .expect_err("an export with no rows must be refused");
     assert!(matches!(err, XctraceError::NoRows { .. }), "got {err}");
 }
 

--- a/crates/rmlx-mlx/src/xctrace_tests.rs
+++ b/crates/rmlx-mlx/src/xctrace_tests.rs
@@ -393,31 +393,23 @@ fn a_channel_with_no_latency_sample_reports_empty_not_zero() {
 }
 
 #[test]
-fn a_process_filter_matching_nothing_is_an_error_not_an_empty_summary() {
+fn a_table_with_rows_for_other_processes_says_so_and_names_them() {
     let err = summarise_gpu_intervals(&doc(ROWS_HAPPY), only("no-such-process"))
         .expect_err("a filter that selects nothing must be refused");
     assert!(
         matches!(err, XctraceError::NoRowsForProcess { .. }),
         "got {err}"
     );
-}
-
-/// A recording that captured nothing and a recording that captured other
-/// processes are different states with different remedies, and reporting both
-/// as "no rows" sends the reader to re-run a command that works. The table
-/// knows which one it is: `rows_total` and the process census are both in
-/// hand at the point of refusal.
-#[test]
-fn a_table_with_rows_for_other_processes_says_so_and_names_them() {
-    let err = summarise_gpu_intervals(&doc(ROWS_HAPPY), only("no-such-process"))
-        .expect_err("a filter that selects nothing must be refused");
     let text = err.to_string();
     assert!(
         text.contains("rmlx (99)"),
         "the refusal must name the processes the recording did see; got {text}"
     );
+    // `contains('2')` would pass on the census suffix "rmlx (99) (2 rows)"
+    // whatever `rows_total` is — the count has to be asserted where it is
+    // printed, not anywhere in the string.
     assert!(
-        text.contains('2'),
+        text.contains("holds 2 rows"),
         "the refusal must say how many rows the table held; got {text}"
     );
     // The empty-table wording would send the reader to re-run the workload.
@@ -427,9 +419,12 @@ fn a_table_with_rows_for_other_processes_says_so_and_names_them() {
     );
 }
 
-/// The `skip_ms > 0` entry takes its own pre-pass over the table, so the
-/// distinction has to hold on both branches or a `--skip-ms` run reports the
-/// wrong one.
+/// The `skip_ms > 0` entry takes its own pre-pass over the table, so an absent
+/// process has to be named as absent there too. This also pins the *ordering*
+/// the third state depends on: the pre-pass refuses a filter that matches
+/// nothing before any floor is applied, which is why `summarise_from` may read
+/// a non-zero floor as "the scope had rows". Let the pre-pass stop refusing and
+/// this test goes red with `SkipRemovedEveryRow`.
 #[test]
 fn the_skip_branch_reports_the_same_distinction() {
     let err = summarise_gpu_intervals(
@@ -445,6 +440,76 @@ fn the_skip_branch_reports_the_same_distinction() {
         "got {err}"
     );
     assert!(err.to_string().contains("rmlx (99)"), "got {err}");
+}
+
+/// One long submission straddling the skip origin keeps `SkipExceedsSpan`
+/// silent — it fires on `origin_ns >= latest`, and `latest` is
+/// `max(start + duration)` — while every row's `start` is below the origin, so
+/// the summary matches nothing. The process IS in the recording; only the skip
+/// removed its rows. Refusing that with "this process was not in it" while
+/// printing its own name in the census is a message that contradicts itself.
+const ROWS_LONG_STRADDLING_SUBMISSION: &str = "\
+<row>\
+<start-time id=\"1\" fmt=\"00:00.000\">0</start-time>\
+<duration id=\"2\" fmt=\"50.00 ms\">50000000</duration>\
+<duration id=\"3\" fmt=\"5.00 µs\">5000</duration>\
+<gpu-channel-name id=\"4\" fmt=\"Compute\">Compute</gpu-channel-name>\
+<process id=\"5\" fmt=\"rmlx (99)\"><pid id=\"6\" fmt=\"99\">99</pid></process>\
+</row>\
+<row>\
+<start-time id=\"7\" fmt=\"00:00.001\">1000000</start-time>\
+<duration id=\"8\" fmt=\"10.00 µs\">10000</duration>\
+<duration ref=\"3\"/>\
+<gpu-channel-name ref=\"4\"/>\
+<process ref=\"5\"/>\
+</row>";
+
+#[test]
+fn a_skip_that_removes_every_row_is_not_reported_as_an_absent_process() {
+    // origin = earliest(0) + 10 ms; both starts (0 and 1 ms) are below it, and
+    // latest = 0 + 50 ms > origin, so SkipExceedsSpan does not fire.
+    let err = summarise_gpu_intervals(
+        &doc(ROWS_LONG_STRADDLING_SUBMISSION),
+        SummaryFilter {
+            process: Some("rmlx"),
+            skip_ms: 10,
+        },
+    )
+    .expect_err("a skip that removes every matched row must be refused");
+    assert!(
+        matches!(err, XctraceError::SkipRemovedEveryRow { .. }),
+        "the process is present; only the skip emptied the window — got {err}"
+    );
+    let text = err.to_string();
+    assert!(
+        !text.contains("was not in it"),
+        "must not claim the process is absent while its rows exist; got {text}"
+    );
+    assert!(
+        text.contains("10 ms"),
+        "must name the skip it applied; got {text}"
+    );
+}
+
+/// The `process_filter == None` shape must still say a skip was in force. The
+/// pre-split code appended "after the requested skip" to the schema name and
+/// the first refactor dropped it, which is a regression in message truth that
+/// no assertion covered.
+#[test]
+fn an_unfiltered_summary_emptied_by_the_skip_still_names_the_skip() {
+    let err = summarise_gpu_intervals(
+        &doc(ROWS_LONG_STRADDLING_SUBMISSION),
+        SummaryFilter {
+            process: None,
+            skip_ms: 10,
+        },
+    )
+    .expect_err("a skip that removes every row must be refused with no filter too");
+    assert!(
+        matches!(err, XctraceError::SkipRemovedEveryRow { .. }),
+        "got {err}"
+    );
+    assert!(err.to_string().contains("10 ms"), "got {err}");
 }
 
 /// An empty table keeps the empty-table wording: there the recording really

--- a/crates/rmlx-models/src/gemma3/generate.rs
+++ b/crates/rmlx-models/src/gemma3/generate.rs
@@ -233,8 +233,11 @@ pub fn generate_greedy<'a>(
 
     // Allocate one KvCache per decoder layer using the selected quant mode.
     //
-    // SWA layers in bf16-KV mode (`KvQuant::None`) use the byte-for-byte
-    // RotatingKvCache port. medgemma has the SWA pattern (5 sliding + 1 full).
+    // SWA layers always use the byte-for-byte RotatingKvCache port and stay
+    // bf16 at `sliding_window` tokens whatever codec they are handed — the
+    // rotating branch is chosen on `window > 0` alone
+    // (`KvCache::with_quant_max_seq_window`). medgemma has the SWA pattern
+    // (5 sliding + 1 full), so only the full-attention layer is quantized.
     use super::config::LayerType;
     let sliding_window_i32 = model.cfg.sliding_window as i32;
     let n_layers = model.cfg.num_hidden_layers;

--- a/crates/rmlx-models/src/gemma4/generate/mod.rs
+++ b/crates/rmlx-models/src/gemma4/generate/mod.rs
@@ -386,12 +386,16 @@ pub fn generate_greedy<'a>(
             // Allocate one KvCache per decoder layer using the selected
             // quant mode.
             //
-            // SWA layers in bf16-KV mode (`KvQuant::None`) use the
-            // byte-for-byte RotatingKvCache port (mirrors mlx-lm
-            // `gemma4_text.py::Model.make_cache` line 686:
+            // SWA layers always use the byte-for-byte RotatingKvCache port
+            // (mirrors mlx-lm `gemma4_text.py::Model.make_cache`:
             // `RotatingKVCache(max_size=sliding_window)` for sliding layers,
-            // `KVCache()` for full-attention). Quantized KV codecs stay on
-            // the existing full-size path (pending follow-up).
+            // `KVCache()` for full-attention) and stay bf16 at
+            // `sliding_window` tokens **regardless of the requested KV
+            // codec** — mlx-lm's `RotatingKVCache.to_quantized` raises
+            // `NotImplementedError` and we mirror that. The codec flag is
+            // recorded on the cache but unused by the rotating update path;
+            // only full-attention layers are quantized. See
+            // `KvCache::with_quant_max_seq_window`.
             //
             // Force K8V8 for boundary layers (first head_n + last tail_n) to
             // protect output quality when base_quant uses aggressive V

--- a/crates/rmlx-models/src/kv_cache/mod.rs
+++ b/crates/rmlx-models/src/kv_cache/mod.rs
@@ -278,6 +278,15 @@ pub struct KvLayerShape {
 /// `eff_seq` is the effective prompt+generate length the global layers will
 /// hold (the resolved `--max-ctx` ceiling or the prompt length — either is a
 /// fine estimate for the sign of the saving).
+///
+/// The emitted byte count is named `est_extra_bytes_upper_bound` and not
+/// `est_extra_bytes` on purpose. `KvQuant::estimated_resident_bytes_per_layer`
+/// sizes an iso group from the CPU-block layout — codes, scale, a 4xf32
+/// quaternion and a norm — while the ring the `k_iso*` / `iso*_sym` codecs
+/// decode from carries no quaternion, so the figure runs ~3x high for exactly
+/// the codecs this warning most often fires on. Only the sign is exact, and the
+/// sign is what the warning is for; a reader must not size a buffer from the
+/// number.
 pub fn warn_if_kv_codec_net_negative(quant: KvQuant, layers: &[KvLayerShape], eff_seq: u64) {
     let (total_saving, n_global, n_windowed) = kv_codec_net_saving_total(quant, layers, eff_seq);
     if total_saving < 0 {
@@ -286,8 +295,8 @@ pub fn warn_if_kv_codec_net_negative(quant: KvQuant, layers: &[KvLayerShape], ef
             eff_seq,
             n_global,
             n_windowed,
-            est_extra_bytes = -total_saving,
-            "KV codec increases resident KV vs bf16 on this layer mix — the per-global-layer warm-TTFT bf16 seed plus codec scales exceed the bytes saved at this context; windowed layers already run bf16 and are unaffected. Consider --kv-quant none if memory is the goal."
+            est_extra_bytes_upper_bound = -total_saving,
+            "KV codec increases resident KV vs bf16 on this layer mix — the per-global-layer warm-TTFT bf16 seed plus codec scales exceed the bytes saved at this context; windowed layers already run bf16 and are unaffected. The byte figure is an UPPER BOUND, not an estimate: the iso arm of the estimator sizes a group from the CPU-block layout, which carries a per-group quaternion the GPU ring the iso codecs actually decode from does not, so for those codecs it overstates by roughly 3x. The sign is exact either way. Consider --kv-quant none if memory is the goal."
         );
     }
 }

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -630,13 +630,13 @@ impl SpeculativeDispatcher {
         );
 
         // --- Allocate per-layer caches for verifier and draft. ---------
-        // SWA layers in bf16-KV mode use the RotatingKvCache port.
-        // For quantized modes (planar/k8v8/k8v4) the per-layer window is
-        // ignored — `with_quant_max_seq_window` falls back to the standard
-        // full-size cache, preserving the existing spec-decode `truncate_to`
-        // semantics. Spec is only validated with the default per-arch quant
-        // (which for 31b is `Planar`, for e2b draft is `K8V8`); the bf16
-        // path is not exercised by the spec smoke.
+        // A layer that reports a sliding window gets the RotatingKvCache port
+        // whatever codec it is handed — the branch is `window > 0` alone
+        // (`KvCache::with_quant_max_seq_window`), so an SWA layer here is bf16
+        // at `sliding_window` tokens under every `kv_quant`, and only the
+        // full-attention layers quantize. Rollback below calls `truncate_to`
+        // on every layer without consulting `is_trimmable()`, which a rotating
+        // layer only satisfies until it wraps.
         let mut verifier_caches: Vec<KvCache> = (0..self.verifier.num_hidden_layers())
             .map(|i| {
                 let window = self.verifier.layer_sliding_window(i);

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -1462,7 +1462,11 @@ prompt registry, `bests` view, query API).
 
 - llama.cpp 4-bit KV cache discussion: <https://github.com/ggml-org/llama.cpp/pull/5932>
 - MLX `mx.quantize` API reference: <https://ml-explore.github.io/mlx/build/html/python/_autosummary/mlx.core.quantize.html>
-- ParoQuant (z-lab): <https://github.com/z-lab/paroquant>
-- IsoQuant (ParaMind2025): <https://github.com/ParaMind2025/isoquant>
+- ParoQuant (z-lab): <https://github.com/z-lab/paroquant> — a **weight**
+  quantizer (pairwise-rotation INT4). Listed here for the rotation math, not as
+  a KV reference: its upstream repo has no KV-cache surface at all.
+- IsoQuant (ParaMind2025): <https://github.com/ParaMind2025/isoquant> — SO(4)
+  isoclinic rotation, stage-1 quantize/dequantize only. No cache and no decode
+  path upstream, so rMLX's `iso*` KV codecs have no counterpart to port.
 - Metrics database operating rules: `docs/METRICS_DB.md`
 - Profiling runbook (samply, Instruments, dhat): `docs/PROFILING.md`

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -284,10 +284,12 @@ retained set always contains the full most-recent `window` — no still-attended
 key is ever evicted).
 
 Scope note: the rotating ring is the bf16 SWA path used by Gemma3/Gemma4 (the
-only archs with interleaved windowed + global attention). Quantized SWA codecs
-are not currently routed through the ring (mlx-lm's reference keeps SWA bf16
-too — `RotatingKVCache.to_quantized` raises), but the SWA layers are bf16 by
-default (§5.7), so the bound applies on every shipping SWA configuration.
+only archs with interleaved windowed + global attention), and it is taken under
+**every** `KvQuant` — `KvCache::with_quant_max_seq_window` branches on
+`window > 0` alone, so a quantized codec on an SWA layer runs this ring and
+never allocates its `KvStorage` (mlx-lm's reference keeps SWA bf16 too —
+`RotatingKVCache.to_quantized` raises). The bound therefore applies at every
+codec, not only at the default.
 
 ### `resident_bytes` counts the live-inference KV (filled prefix, not ceiling)
 
@@ -1349,16 +1351,22 @@ TPS) are dominated by prefill latency, **not** decode speed.
 The corrected **decode-only** numbers and their derivation are in
 [`docs/PERF_BASELINE.md`](PERF_BASELINE.md). Short summary: once prefill is
 excluded, all four models
-run at **1.8–2.7× the 614 GB/s bandwidth ceiling**, which is the normal
-batch-1 band that llama.cpp and mlx-lm hit on dense models — there is no
-inference defect. The "headline" decode-only figures are:
+run at **1.7–2.2× the 614 GB/s bandwidth ceiling** — there is no inference
+defect. (An earlier revision called that "the normal batch-1 band that
+llama.cpp and mlx-lm hit on dense models". That envelope came from the
+literature, and the local measurement neither confirms nor contradicts it:
+ratio-vs-ceiling is not comparable across models of different size, and on the
+scale-free quantity the two runtimes overlap. See `PERF_BASELINE.md` H2
+addendum.) The "headline" decode-only figures, and the ceilings they are read
+against, are a tensor census of what a step streams at
+`--ctx 4096 --max-ctx 8192`:
 
-| Model | §10 cell (combined) | decode-only (PERF_BASELINE.md) | ratio vs ceiling |
-|---|---:|---:|---|
-| Bonsai 8B 2bit | 15.88 TPS | ~110 TPS | ~2.7x |
-| Gemma4-e4b mxfp8 | 27.50 TPS | ~74 TPS | ~2.1x |
-| Gemma4-26b MoE | 3.47 TPS | ~72 TPS | ~2.4x |
-| Qwen3.6-35B MoE | 4.46 TPS | ~96 TPS | ~1.8x |
+| Model | §10 cell (combined) | decode-only (PERF_BASELINE.md) | ceiling @614 GB/s | ratio vs ceiling |
+|---|---:|---:|---:|---|
+| Bonsai 8B 2bit | 15.88 TPS | 115.21 TPS | 248.2 | 2.15x |
+| Gemma4-e4b mxfp8 | 27.50 TPS | 72.92 TPS | 123.5 | 1.69x |
+| Gemma4-26b MoE | 3.47 TPS | 72.19 TPS | 144.4 | 2.00x |
+| Qwen3.6-35B MoE | 4.46 TPS | 94.96 TPS | 191.1 | 2.01x |
 
 For steady-state decode reasoning — picking a KV quant, estimating
 throughput, comparing combos — use the **decode-only** TPS from

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -156,10 +156,18 @@ is estimated to increase resident KV vs bf16 on the active layer mix:
 ```
 WARN KV codec increases resident KV vs bf16 on this layer mix — the
 per-global-layer warm-TTFT bf16 seed plus codec scales exceed the bytes saved
-at this context; windowed layers already run bf16 and are unaffected. Consider
---kv-quant none if memory is the goal.
-  kv_quant=mixed_k8g64_v8g64 eff_seq=8192 n_global=7 n_windowed=28 est_extra_bytes=51380224
+at this context; windowed layers already run bf16 and are unaffected. The byte
+figure is an UPPER BOUND, not an estimate: the iso arm of the estimator sizes a
+group from the CPU-block layout, which carries a per-group quaternion the GPU
+ring the iso codecs actually decode from does not, so for those codecs it
+overstates by roughly 3x. The sign is exact either way. Consider --kv-quant none
+if memory is the goal.
+  kv_quant=mixed_k8g64_v8g64 eff_seq=8192 n_global=7 n_windowed=28 est_extra_bytes_upper_bound=51380224
 ```
+
+The field is named for what it is. Only the **sign** of that number is exact;
+size nothing from its magnitude, and for `k_iso*` / `iso*_sym` expect it to run
+about 3x high (`KvQuant::approx_code_bits`, iso arm).
 
 The estimate is model-agnostic — keyed only on layer geometry (`head_dim`,
 `kv_heads`, `window`) and codec attributes (`KvQuant::approx_code_bits`, the
@@ -540,8 +548,10 @@ short-context parity benches only.
 
 **CLI**: `--kv-quant none` (aliases: `bf16`, `f16`).
 
-**Arch defaults**: `Qwen3VLMoeForConditionalGeneration` defaults to `None`
-because quantized KV produces incoherent output on that checkpoint.
+**Arch defaults**: none. `auto` is bf16 on every arch, so this is what
+`Qwen3VLMoeForConditionalGeneration` gets — which matters there beyond
+uniformity, because quantized KV produces incoherent output on that
+checkpoint.
 
 **Smoke-probe status**: validated across all primary test-target families.
 
@@ -887,8 +897,10 @@ K below 8-bit on a 7:1 GQA model amplifies quantization error through
 softmax and produces catastrophic PPL degradation (218 → 8641 observed).
 The K-side codec is the safeguard — not the variant name.
 
-**Arch defaults**: `Qwen3_5ForConditionalGeneration` (PARO checkpoints);
-`Gemma4ForConditionalGeneration` (small + PARO); auto-by-ctx at ≤8192 tokens.
+**Arch defaults**: none. `auto` is bf16 on every arch and at every context;
+K8V4 is opt-in. It was the default for `Qwen3_5ForConditionalGeneration` (PARO
+checkpoints) and `Gemma4ForConditionalGeneration` (small + PARO), and the
+per-context policy picked it at ≤8192 tokens, until both were retired.
 
 **CLI**: `--kv-quant k8v4`; or `--ctk q8_g128 --ctv tq4`.
 
@@ -956,9 +968,10 @@ the rate. Measured, not modelled — `kv_rate_tests.rs` reads the bytes
   prefill bracket), and the resident bytes of any future decode path that reads
   the store.
 
-**Arch defaults**: `Gemma3ForConditionalGeneration`;
-`Gemma4ForConditionalGeneration` (dense, hidden_size ≥ 5376); auto-by-ctx at
->32K tokens.
+**Arch defaults**: none. `auto` is bf16 on every arch and at every context;
+Planar is opt-in. It was the default for `Gemma3ForConditionalGeneration` and
+dense `Gemma4ForConditionalGeneration` (`hidden_size` ≥ 5376), and the
+per-context policy picked it above 32K tokens, until both were retired.
 
 **CLI**: `--kv-quant planar`; or `--ctk q8_g128 --ctv planar4`.
 
@@ -1054,7 +1067,9 @@ On GQA-light MoE archs (25% FA layers) Mixed K8V4 regresses by 11–28% vs
 K8V8 — the `quantize` + `quantized_matmul` overhead amortises poorly when
 most layers are not full-attention.
 
-**Arch defaults**: `Qwen3ForCausalLM` at `weight_bits=2` (Bonsai ternary).
+**Arch defaults**: none. `auto` is bf16 on every arch; Mixed is opt-in. It
+was the default for `Qwen3ForCausalLM` at `weight_bits=2` (Bonsai ternary)
+until the per-arch table was retired.
 
 **CLI**: `--kv-quant mixed_k<kb>g<kg>_v<vb>g<vg>` (e.g.
 `mixed_k8g64_v4g64`). The `RotK` variant is reached via `--ctk rot_k` (see
@@ -2030,7 +2045,7 @@ the allocation — `(D/4)·4 B` codes + `(D/4)·4 B` scales + `4 B` norm — giv
 iso stored bits/value = 16 + 32/head_dim
 ```
 
-so 16.25 at D=128, 16.125 at D=256, 16.03 at D=512, approaching 16.0 **from
+so 16.25 at D=128, 16.125 at D=256, 16.0625 at D=512, approaching 16.0 **from
 above** and never reaching it. Two planes at 8 B per 4 values are already
 exactly bf16's density, and the per-token norm is what keeps the sum strictly
 greater at every finite head dim. This is a derivation from
@@ -2220,7 +2235,7 @@ differences are the codebook (16 centroids vs 8) and the pack density
 |---|---|---|
 | Code bits / element | 3 | 4 |
 | Delivered bits / element, ring-resident (`k_iso*`, `*_sym`) | **16.25** (260 B/token at head\_dim=128 — see Memory truth in iso3 section) | **16.25** — byte-identical to iso3; the codebook width never reaches the store |
-| Delivered bits / element, CPU-blocks-resident (`iso3` / `iso4`) | ≈48.25 (≈772 B/token at head\_dim=128, incl. the constant quaternion sideband) | ≈48.25 — same sideband, same code word |
+| Delivered bits / element, CPU-blocks form (`iso3` / `iso4`) — **hypothetical, not resident** | ≈48.25 (≈772 B/token at head\_dim=128, incl. the constant quaternion sideband). These two codecs decode from the bf16 mirror, so `exit_prefill` builds them no store and they measure byte-identical to `none` (§"Codec disposition", Class 2); this is the rate they would cost once a kernel reads one | ≈48.25 — same sideband, same code word, same hypothetical |
 | Codebook | `lloyd_gaussian_codebook(3)` (8 centroids) | `lloyd_gaussian_codebook(4)` (16 centroids) |
 | Pack density (per u32) | 10 vals (30 bits used, 2 wasted) | 8 vals (32 bits used, 0 wasted) |
 | Rotation | Golden-ratio fixed quaternion (`FIXED_QUAT`) | Same |
@@ -2861,7 +2876,7 @@ table.
 | `None` (bf16) | 2·D | 2·D | 4·D |
 | `K8V8` | 1·D + D/128·4 | 1·D + D/128·4 | ~2.06·D |
 | `K8V4` | 1·D + D/128·4 | 0.5·D + D/32·4 | ~1.65·D |
-| `Planar` | 1·D + D/128·4 | 0.5·D + 0.5·D + D/16·4 | ~2.13·D |
+| `Planar` | 1·D + D/128·4 | 2.75·D (measured) | ~3.78·D |
 | `Mixed{k8g64,v4g64}` | 1·D + 2·D/64·4 | 0.5·D + 2·D/64·4 | ~1.75·D |
 | `K8VTurbo3` | 1·D + D/128·4 | 0.375·D + D/32·4 | ~1.51·D |
 | `K8VTurbo2` | 1·D + D/128·4 | 0.25·D + D/32·4 | ~1.38·D |
@@ -2870,17 +2885,26 @@ table.
 | `k_rotor3` / `k_rotor4` | 8·⌈D/3⌉ + 4 | 2·D (bf16) | ~4.67·D + 4 |
 | `rotor3_sym` / `rotor4_sym` | 8·⌈D/3⌉ + 4 | 8·⌈D/3⌉ + 4 | ~5.33·D + 8 |
 
-PlanarQuant V carries extra rotation state (two u32 per group of 32), which
-raises its byte cost above K8V4 despite the same 4-bit code width. The
-quality improvement compensates on dense full-attention archs.
+PlanarQuant's V row is **measured**, not a layout formula, and it is the one
+row an earlier revision of this table got wrong (`~2.13·D`, from a per-group
+sideband cadence the codec does not use). Its scale is per **pair** — one `f32`
+per 2 elements — which is 16 bits per value before a single code bit, so the
+store is **22.00 bits per value at every head_dim and at both bit widths**
+(`planar3` and `planar4` are byte-identical). That is the widest rate in the
+crate's rate gate, above rotor's 21.75, and it is why `planar3` / `planar4` /
+`planar_k4` carry a written exemption in
+`crates/rmlx-kv-quant/src/kv_rate_tests.rs` rather than a fix: a scale-cadence
+change is a format change. The quality improvement is what it buys on dense
+full-attention archs.
 
 Two groups of rows here have a decode that reads the store they describe, so
 their rates are live rather than hypothetical: the `Mixed{k8g64,v4g64}` row and
 the four ring rows (§"Codec disposition", Class 3). Every other row is a rate
 its codec would cost the day a kernel reads its store. Of all of them, only the
-four ring rows are **above** the `None` row *on rate* — `Mixed` is below it
-here and still measures larger resident, because it keeps both bf16 seeds
-beside its store, which is a residency fact this table does not carry.
+four ring rows are **above** the `None` row *on rate*; `Planar` is the closest
+of the rest at 3.78·D against 4·D, i.e. a 5% saving for a 4-bit name. `Mixed` is
+below the `None` row here and still measures larger resident, because it keeps
+both bf16 seeds beside its store — a residency fact this table does not carry.
 
 Each ring side spends one `u32` code word and one `f32` scale per group
 whatever the codebook width, so the nominal
@@ -5159,12 +5183,14 @@ is what makes the dB interpretable. i.i.d. Gaussian fixture, 256 x 128:
 
 No shipped cell is short of its anchor by more than 0.35 bits.
 
-† **The iso rate is path-specific.** 48.25 is the CPU `IsoBlocks` figure, which
-carries a per-group quaternion sideband; it is the right number for the V-only
-`iso3` / `iso4` stores. `k_iso3/4` and `iso3_sym/4_sym` decode from a GPU ring
-that does not carry the quaternion — it is the constant `FIXED_QUAT` replicated
-per group, not data — and sit at **16.25** bits/value. See § iso3 "Memory
-truth". Read against rotor's 21.75 without that distinction the table inverts
+† **The iso rate is path-specific, and neither path is resident today.** 48.25
+is the CPU `IsoBlocks` figure, which carries a per-group quaternion sideband. It
+is the rate the V-only `iso3` / `iso4` stores *would* cost — those codecs decode
+from the bf16 mirror, so `exit_prefill` builds them no store at all and they
+measure byte-identical to `none` (§"Codec disposition", Class 2). `k_iso3/4` and
+`iso3_sym/4_sym` do build a store: a GPU ring that does not carry the quaternion
+— it is the constant `FIXED_QUAT` replicated per group, not data — and they sit
+at **16.25** bits/value. See § iso3 "Memory truth". Read against rotor's 21.75 without that distinction the table inverts
 the comparison: on the ring path iso is the cheaper of the two. Distortion is
 identical on both paths, so only the rate column is affected.
 

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -2021,20 +2021,35 @@ where `*` is the **Hamilton product** and `v ∈ ℝ⁴` is treated as a quatern
 The nominal codebook width never reaches the store: iso3 uses 12 of its 32
 code bits and iso4 uses 16, so **iso3 and iso4 occupy byte-identical
 storage**. At head_dim=128 that is 260 B per token per kv_head against bf16's
-256 B: **16.25 bits per value, 1.02× bf16**. The result is head_dim
-independent — at head_dim=512 it is 1028 B against 1024 B.
+256 B: **16.25 bits per value, 1.02× bf16**.
 
-Stores that keep the CPU `IsoBlocks` (the V-only `iso3` / `iso4` codecs) add a
-4×f32 quaternion per group on top, taking the same token to ≈772 B (≈48.25
-bits per value, 3.0× bf16). That sideband is the constant `FIXED_QUAT`
-replicated per group, not data — the GPU ring the K-only and symmetric codecs
-decode from does not carry it, which is why `k_iso3/4` and `iso3_sym/4_sym`
-measure ≈1.00–1.02× `none` while `iso3` / `iso4` measure ≈2.1×. Those are
-whole-cache ratios against the `none` *control*, which on the architectures
-with promoted global layers was itself a bf16/K8V8 mixture when they were
-recorded — see §"`--kv-quant none` is a bf16 control" for the per-arch
-restatement factor. The per-group figures above are the store density and are
-unaffected.
+The rate itself does move with head dim; the *sign* does not. Reading it off
+the allocation — `(D/4)·4 B` codes + `(D/4)·4 B` scales + `4 B` norm — gives
+
+```
+iso stored bits/value = 16 + 32/head_dim
+```
+
+so 16.25 at D=128, 16.125 at D=256, 16.03 at D=512, approaching 16.0 **from
+above** and never reaching it. Two planes at 8 B per 4 values are already
+exactly bf16's density, and the per-token norm is what keeps the sum strictly
+greater at every finite head dim. This is a derivation from
+`QuantKGpuRing::alloc` (`Dtype::U32` codes, `Dtype::F32` scales and norms, one
+element each per group per token per KV head), not a measurement.
+
+The CPU `IsoBlocks` form adds a 4×f32 quaternion per group on top, taking the
+same token to ≈772 B (≈48.25 bits per value, 3.0× bf16). That sideband is the
+constant `FIXED_QUAT` replicated per group, not data, and the GPU ring the
+K-only and symmetric codecs decode from does not carry it. **That figure is
+hypothetical on a served request**: the V-only `iso3` / `iso4` codecs decode
+from the bf16 mirror, so `exit_prefill` builds them no store and they measure
+byte-identical to `none` (§"Codec disposition", Class 2). It is the rate they
+would cost the day a decode kernel reads their store. The store-reading members
+are `k_iso3/4` and `iso3_sym/4_sym`, and those measure 1.003–1.054× `none` on
+the ring layout above (§"Codec disposition", Class 3 — whole-cache ratios
+against a `none` that is a true bf16 control since the head/tail promotion
+stopped applying to it). The per-group figures above are the store density and
+are unaffected by that.
 
 **No iso codec is a memory win, at any head_dim.** 8 B per 4 values is exactly
 bf16's density before the per-token norm is added, so the packed side is
@@ -2289,7 +2304,7 @@ amortises across every token in the layer.
 
 | Property | rotor3 |
 |---|---|
-| Delivered bits / element | **21.75** at head\_dim=128 (348 B/token/kv\_head vs bf16's 256 B, **1.36× bf16**), split **10.75 codes + 10.75 scales + 0.25 norm**. 43 groups cover a 128-element row, and each spends one whole `u32` code word **and** one `f32` scale for 3 real grade-1 elements. rotor3 and rotor4 therefore occupy byte-identical storage. The 3.25 bpe target reported by the Python `rotorquant` reference is gated on the grade-aware codebook follow-up (deferred — see below). **No rotor codec is a memory win at any head\_dim** — see the iso3 "Memory truth" note, `iso_and_rotor_k_codecs_are_never_a_memory_win`, and the crate-wide rate ceiling in `kv_rate_tests.rs`. |
+| Delivered bits / element | **21.75** at head\_dim=128 (348 B/token/kv\_head vs bf16's 256 B, **1.36× bf16**), split **10.75 codes + 10.75 scales + 0.25 norm**. 43 groups cover a 128-element row, and each spends one whole `u32` code word **and** one `f32` scale for 3 real grade-1 elements. rotor3 and rotor4 therefore occupy byte-identical storage. Read off the same allocation, `rotor stored bits/value = (64·⌈D/3⌉ + 32) / D` — 21.75 at D=128, 21.625 at D=256, with a floor of 64/3 = **21.33** as D grows. A derivation from `QuantKGpuRing::alloc`, not a measurement. The 3.25 bpe target reported by the Python `rotorquant` reference is gated on the grade-aware codebook follow-up (deferred — see below). **No rotor codec is a memory win at any head\_dim** — see the iso3 "Memory truth" note, `iso_and_rotor_k_codecs_are_never_a_memory_win`, and the crate-wide rate ceiling in `kv_rate_tests.rs`. |
 | Dead code budget | **5 of the 8 codes per group carry no information.** A rotor sandwich is grade-preserving, so embedding 3 values as the grade-1 part leaves the scalar, three bivector and pseudoscalar slots algebraically zero on encode; on decode the inverse sandwich keeps every non-grade-1 part out of the reconstructed vector, so quantising those slots injects no error either. 15 of the 24 code bits per group are pure waste. Pinned by `clifford_tests::sandwich_of_grade1_in_3d_stays_grade1` (encode side) and `clifford_tests::inverse_sandwich_of_non_grade1_leaks_nothing_into_grade1` (decode side). Removing them is a format + MSL-kernel change and is not scheduled; the 10.75 bits/value of `f32` scale would still dominate afterwards. |
 | Codebook | `lloyd_gaussian_codebook(3)` (8 centroids), shared across all 8 mv components (single-codebook simplification) |
 | Pack density (per u32) | 10 vals (planar3 / iso3 convention; 8 codes ≤ 30 bits per group, 1 u32 per group) |
@@ -2534,9 +2549,11 @@ and K dequant matches within 1e-3.
 
 Four variants mirror the V-side rotor3 / rotor4 codecs to the K axis. They
 add an **optional 1-bit QJL residual sideband** (Johnson–
-Lindenstrauss sketch of the post-rotor MSE residual) when
-`--rotor-qjl on` (the default). The storage format is controlled by a global
-toggle ([`rotor_qjl_enabled()`] in `rmlx-kv-quant::rotor_qjl`).
+Lindenstrauss sketch of the post-rotor MSE residual) under
+`--rotor-qjl on`, which is **not** the default — QJL has no MSL kernel, so
+enabling it moves the rotor K encode + dequant onto the CPU. The storage format
+is controlled by a global toggle ([`rotor_qjl_enabled()`] in
+`rmlx-kv-quant::rotor_qjl`), whose default is `false`.
 
 | `KvQuant` | K codec | V codec | CacheType pair (`(K, V)`) | SSD tag (QJL off / on) |
 |---|---|---|---|---|
@@ -2580,14 +2597,16 @@ siblings (K-side ≤4-bit on Qwen MoE is the PPL-disaster path). The error's
 path); the affine V codec dequants to bf16 (existing `K8V4` V path); then
 `scaled_dot_product_attention` runs.
 
-**Decode-cost caveat.** Like the iso K-side codecs, the rotor K-side codecs
-have no GPU-resident code mirror: with the default `--rotor-qjl on`, each
-decode step re-decodes the full K prefix on the CPU (and re-encodes the newly
-appended token), applies an O(head_dim²)-per-cached-token QJL score
-correction, then re-uploads the K prefix — an O(kv_seq) per-step cost that the
-short-prompt anchors mask but long-prompt decode exposes. The fused-QK fast path (which would avoid the
-per-step marshaling) is reachable only with `--rotor-qjl off` and is
-default-OFF; see the Fused-QK status below.
+**Decode-cost caveat — opt-in only.** With `--rotor-qjl on` the rotor K-side
+codecs have no GPU-resident code mirror: each decode step re-decodes the full K
+prefix on the CPU (and re-encodes the newly appended token), applies an
+O(head_dim²)-per-cached-token QJL score correction, then re-uploads the K
+prefix — an O(kv_seq) per-step cost that the short-prompt anchors mask but
+long-prompt decode exposes. That is why QJL is **off** by default: the default
+path runs the rotor K encode and `rotor_flash_decode` on Metal. The fused-QK
+fast path (which would avoid the per-step marshaling) also needs
+`--rotor-qjl off` and is separately default-OFF; see the Fused-QK status
+below.
 
 **Fused-QK status:** the 6 rotor variants (`Rotor3Sym`, `Rotor4Sym`,
 `RotorKOnly3`, `RotorKOnly4`, `RotorK3Asym`, `RotorK4Asym`) are wired into
@@ -2612,8 +2631,8 @@ generated once per layer/head on first append and persisted to the SSD block
 (`l{idx}.k.qjl_s`). The layout tag (`*_qjl`) distinguishes QJL-ON blocks
 from QJL-OFF blocks so the reader can hydrate the projection matrix.
 
-**QJL toggle.** CLI: `--rotor-qjl on|off` (default `on`). Env fallback:
-`RMLX_ROTOR_QJL=0` disables. The toggle is read per-construction (not cached)
+**QJL toggle.** CLI: `--rotor-qjl on|off` (default `off`). Env fallback:
+`RMLX_ROTOR_QJL=1` enables. The toggle is read per-construction (not cached)
 so env changes between tests still propagate.
 
 **Score-time QJL correction.** The QJL correction is
@@ -2834,8 +2853,8 @@ Approximate bytes per KV pair (`B=1, 1 layer, 1 head, D elements`). These are
 **packed-store** rates — what a codec's codes and scales occupy. They are not
 resident KV for the bf16-mirror family, which builds no store: those codecs sit
 at the `None` row, 4·D, measured byte-identical (§"Per-layer net-benefit
-decision"). The rates below are what a codec would cost once decode reads its
-store.
+decision"). Which rows are live and which are hypothetical is stated under the
+table.
 
 | Mode | K bytes/tok | V bytes/tok | Total bytes/tok |
 |---|---|---|---|
@@ -2846,10 +2865,31 @@ store.
 | `Mixed{k8g64,v4g64}` | 1·D + 2·D/64·4 | 0.5·D + 2·D/64·4 | ~1.75·D |
 | `K8VTurbo3` | 1·D + D/128·4 | 0.375·D + D/32·4 | ~1.51·D |
 | `K8VTurbo2` | 1·D + D/128·4 | 0.25·D + D/32·4 | ~1.38·D |
+| `k_iso3` / `k_iso4` | 2·D + 4 | 2·D (bf16) | ~4·D + 4 |
+| `iso3_sym` / `iso4_sym` | 2·D + 4 | 2·D + 4 | ~4·D + 8 |
+| `k_rotor3` / `k_rotor4` | 8·⌈D/3⌉ + 4 | 2·D (bf16) | ~4.67·D + 4 |
+| `rotor3_sym` / `rotor4_sym` | 8·⌈D/3⌉ + 4 | 8·⌈D/3⌉ + 4 | ~5.33·D + 8 |
 
 PlanarQuant V carries extra rotation state (two u32 per group of 32), which
 raises its byte cost above K8V4 despite the same 4-bit code width. The
 quality improvement compensates on dense full-attention archs.
+
+Two groups of rows here have a decode that reads the store they describe, so
+their rates are live rather than hypothetical: the `Mixed{k8g64,v4g64}` row and
+the four ring rows (§"Codec disposition", Class 3). Every other row is a rate
+its codec would cost the day a kernel reads its store. Of all of them, only the
+four ring rows are **above** the `None` row *on rate* — `Mixed` is below it
+here and still measures larger resident, because it keeps both bf16 seeds
+beside its store, which is a residency fact this table does not carry.
+
+Each ring side spends one `u32` code word and one `f32` scale per group
+whatever the codebook width, so the nominal
+3-/4-bit label never reaches the store: iso is `16 + 32/head_dim` bits per
+value and rotor floors at `64/3` = 21.33, both strictly above bf16's 16.0 at
+every finite head dim (§ iso3 "Memory truth", § rotor3). The rate is a property
+of the ring layout, not of the algorithms; a layout that packs its scale plane
+separately is unbuilt and is the open question § "What this disposition does not
+decide" names.
 
 ---
 
@@ -3642,7 +3682,7 @@ carry QJL, `q_seq == 1`, `b == 1`, `head_dim` is a power of two and
 `<= ROTOR_FLASH_HEAD_DIM_MAX` (512). Any miss falls through to the legacy CPU
 dequant path.
 
-**QJL.** The optional 1-bit QJL residual (`--rotor-qjl on`, the default) is a
+**QJL.** The optional 1-bit QJL residual (`--rotor-qjl on`, opt-in) is a
 per-token back-projection through a dense `[head_dim, head_dim]` matrix.
 Reproducing it in the flash inner loop would mean reading that whole matrix per
 token per threadgroup — far more bandwidth than the kernel saves — so a
@@ -4083,8 +4123,9 @@ reaches it.
 | medgemma-4B (Gemma3, D=256) | `k_rotor3` | 7.37 | **51.8** | 7.0× |
 | medgemma-4B | `k_rotor4` | 7.34 | **52.1** | 7.1× |
 
-Against the *default* (`--rotor-qjl on`) baseline the same cells move
-0.66 → 17.0 (Bonsai, 26×) and 2.35 → 51.8 (medgemma, 22×).
+Against the `--rotor-qjl on` baseline — which was the default when these cells
+were taken and is now opt-in — the same cells move 0.66 → 17.0 (Bonsai, 26×)
+and 2.35 → 51.8 (medgemma, 22×).
 
 Bonsai is a noisy measurement target at this prompt size (k_rotor4 spans
 14.0–17.1 across 5 runs); medgemma is stable to ~±3%. Treat a single Bonsai run

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -143,7 +143,8 @@ affine).
 
 ### KV quantization
 
-All `KvQuant` variants supported. Default: `K8V8`.
+All `KvQuant` variants supported. `auto` resolves to `DEFAULT_KV_QUANT`
+(unquantised bf16) here as on every arch; `K8V8` is opt-in.
 
 The Qwen2 KV cache is a standard full-attention layout (no SWA). All KV quant
 modes (`K8V4`, `K8V8`, `Planar`, `Mixed`, `RotK`) are accepted via
@@ -536,9 +537,11 @@ Full coverage. Known snapshot: `mlx-community/Qwen3-VL-30B-A3B-Instruct-4bit`
 
 ### KV quantization
 
-Default: `bf16` (unquantized). K8V8 measurably degrades decode quality on this
-architecture at 4-bit weight quant — incoherent text and image output. Bf16 KV
-reproduces the mlx-vlm reference exactly.
+`auto` resolves to `DEFAULT_KV_QUANT` (unquantised bf16), which on this
+architecture is load-bearing rather than merely uniform: K8V8 measurably
+degrades decode quality at 4-bit weight quant — incoherent text and image
+output — while bf16 KV reproduces the mlx-vlm reference exactly. Do not
+override it here.
 
 All other `KvQuant` modes are mechanically available via CLI override, but are
 not validated as producing correct output.
@@ -668,10 +671,11 @@ vision + text).
 
 ### KV quantization
 
-Default: `Planar` (q8_g128 K + PlanarQuant 4-bit V with per-pair Hadamard
-rotation). The rotating SWA ring-buffer is active for sliding-attention layers;
-quantized modes fall back to the standard full-size cache for those layers
-(`with_quant_max_seq_window` semantics).
+`auto` resolves to `DEFAULT_KV_QUANT` (unquantised bf16) here as on every
+arch. The rotating SWA ring-buffer is active for sliding-attention layers
+**under every codec** — `with_quant_max_seq_window` branches on `window > 0`
+alone — so a quantized mode does not put those layers on a full-size path; only
+the full-attention layers are quantized.
 
 All `KvQuant` variants accepted.
 
@@ -1108,7 +1112,8 @@ tensor overrides are parsed from the inline `quantization` dict.
 
 ### KV quantization
 
-Default: `K8V8`. All `KvQuant` modes accepted.
+`auto` resolves to `DEFAULT_KV_QUANT` (unquantised bf16) here as on every
+arch; `K8V8` is opt-in. All `KvQuant` modes accepted.
 
 Note: per CLAUDE.md, Laguna is **out of scope for benchmarks and optimization
 work**. It is present for correctness coverage.
@@ -1201,7 +1206,8 @@ See [WEIGHT_QUANTS.md § Ternary / BitLinear](WEIGHT_QUANTS.md#ternary--bitlinea
 
 ### KV cache
 
-Default: `K8V8`. Effective max context: 4 096 tokens (from `max_position_embeddings`
+`auto` resolves to `DEFAULT_KV_QUANT` (unquantised bf16) here as on every
+arch; `K8V8` is opt-in. Effective max context: 4 096 tokens (from `max_position_embeddings`
 in config; capped at 4 096 by the loader).
 
 ### Limitations
@@ -1223,7 +1229,11 @@ Green. Validated against `mlx-community__bitnet-b1.58-2B-4T` (2026-05-28):
 - `/v1/completions` (legacy text-completion endpoint): not implemented server-side.
   Use `/v1/chat/completions` with an appropriate system prompt.
 
-**Performance note**: decode TPS is ~0.25× of the 127 TPS bandwidth ceiling. The
+**Performance note**: decode TPS is ~0.25× of the 127 TPS bandwidth ceiling — a
+nameplate figure, not a tensor census; `scripts/perf_ceiling.py` cannot produce
+one for this arch because the loader dequantizes ternary weights to BF16 while
+the safetensors headers it reads are packed `u8` (see `docs/PERF_BASELINE.md`).
+The
 gap is not bandwidth on LM-head/projections — it is Metal kernel dispatch overhead
 (~211 kernel launches per decode step). A Metal GEMV kernel would not close this
 gap; kernel fusion across per-layer projections would be required but is out of

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -1107,7 +1107,7 @@ k8vturbo3' (K=8-bit, V=turbo3).
 **Binary**: `target/release/rmlx` (debug-assertions on; ship-quality builds use release-perf — these numbers are the ceiling, not the floor).
 **Shape**: 2-token prompt ("Hello world") + `--max-tokens 100`. Single-MLX preflight between each run. Hardware: M5 Max.
 **Protocol**: 3 measured runs per (variant, model). Mean decode TPS reported. No warmup run (short prompt; first run included).
-**QJL flag**: default `on` (env not overridden). The K-only rotor variants (`k_rotor3`, `k_rotor4`) pay a per-token CPU encode + QJL sign computation cost; the symmetric variants (`rotor3_sym`, `rotor4_sym`) also pay for V-side rotor3/4 CPU dequant.
+**QJL flag**: `on` — the default at the time of this run, opt-in since (env not overridden). The K-only rotor variants (`k_rotor3`, `k_rotor4`) pay a per-token CPU encode + QJL sign computation cost; the symmetric variants (`rotor3_sym`, `rotor4_sym`) also pay for V-side rotor3/4 CPU dequant.
 
 Smoke gate: all four variants on Bonsai + Gemma4 ran end-to-end and produced coherent output (n_steps=63 for 64-token limit). Qwen3.6 errored with the A.y guard as expected (positive guard test) — quoted diagnostic:
 
@@ -1133,7 +1133,7 @@ Identical diagnostic for all four variants with variant name substituted. The co
 **Notes**:
 - Symmetric variants (`rotor3_sym` / `rotor4_sym`) match the corresponding V-only rotor anchors closely (~80–82 Gemma4, ~143–145 Bonsai), confirming the additional K-side rotor encode cost is amortised by the CPU decode path bottleneck.
 - K-only variants (`k_rotor3` / `k_rotor4`) are bottlenecked by the CPU-only rotor K-side decode + optional QJL projection. Bonsai shows wide cross-run variance (run 1 ~40 TPS, run 3 ~49 TPS) due to Metal graph JIT warm-up; Gemma4 is stable (~63–65 TPS). First run should not be treated as a regression floor.
-- **`k_rotor3/4` decode is now a fused MSL flash-decode** over the packed rotor store when `--rotor-qjl off` (`rotor_flash_decode`, see `docs/KV_QUANT.md`); the per-step full-prefix CPU dequant is gone. The anchors above are **not** superseded — they are 2-token short-prompt runs (§ below), where the prefix is empty and the dequant that this kernel removes costs nothing, so they measure a different thing. The kernel's effect scales with prefix length. Measured at a 4k prompt, `--rotor-qjl off`, medians of 3+ runs, before → after: Bonsai-8B `k_rotor3` 1.34 → **17.0**, `k_rotor4` 1.36 → **15.9**; medgemma-4B `k_rotor3` 7.37 → **51.8**, `k_rotor4` 7.34 → **52.1**. The default `--rotor-qjl on` path is unchanged (kernel dormant), as is Gemma4 (`update_and_sdpa_shared_source` never reaches the kernel).
+- **`k_rotor3/4` decode is now a fused MSL flash-decode** over the packed rotor store when `--rotor-qjl off` (`rotor_flash_decode`, see `docs/KV_QUANT.md`); the per-step full-prefix CPU dequant is gone. The anchors above are **not** superseded — they are 2-token short-prompt runs (§ below), where the prefix is empty and the dequant that this kernel removes costs nothing, so they measure a different thing. The kernel's effect scales with prefix length. Measured at a 4k prompt, `--rotor-qjl off`, medians of 3+ runs, before → after: Bonsai-8B `k_rotor3` 1.34 → **17.0**, `k_rotor4` 1.36 → **15.9**; medgemma-4B `k_rotor3` 7.37 → **51.8**, `k_rotor4` 7.34 → **52.1**. The `--rotor-qjl on` path is unchanged (kernel dormant) — it was the default when this was recorded and is opt-in now (§ line 206) — as is Gemma4 (`update_and_sdpa_shared_source` never reaches the kernel).
 - QJL toggle effect on Gemma4 `k_rotor3`: QJL ON = 66.5 TPS, QJL OFF = 73.2 TPS (encode cost). The QJL sideband is correctly stored / round-tripped; cosine lift on reconstructed K is deferred to a follow-up that applies QJL correction at score-time on the SDPA path.
 - All four variants are opt-in only — never an auto baseline.
 - Bonsai long-prompt (10867 tokens) fails with all quant variants (pre-existing SWA-layer zero-chunk bug). Use short prompt for this smoke.
@@ -1284,6 +1284,19 @@ section below).
 ### Profiling decision — Metal GEMV kernel
 
 BitNet at 31.6 TPS is at **0.25×** of its bandwidth ceiling (127 TPS at 614 GB/s).
+
+> **Ceiling provenance — nameplate, and the census cannot replace it here.**
+> The 127 TPS is the same nameplate arithmetic H2 replaced (≈2B params × bf16 ÷
+> 614 GB/s). `scripts/perf_ceiling.py` is **not applicable to this cell**: it
+> sizes weights from the safetensors headers, which for this checkpoint are
+> packed ternary `u8`, while `bitnet/loader.rs` dequantizes every weight to BF16
+> once at load (`dequant_trit_u8` → `Dtype::Bf16`). Run anyway it reports 1.179
+> GB/step and a 516 TPS ceiling — an ~8× undercount of what decode streams, in
+> the direction that would flatter the runtime. The nameplate figure is the
+> closer of the two *because* this model's runtime dtype is bf16 regardless of
+> its storage dtype. Neither number is a census; the decision below rests on the
+> dispatch count, not on the ratio.
+
 Root-cause analysis:
 
 - 211 Metal kernel launches per decode step (30 layers × 7 matmuls/layer + 1 LM head).
@@ -1440,9 +1453,8 @@ while the quotient was taken against a measurement made at a 4096-token prompt.
 
 The column above is a census instead: `config.json` plus the safetensors
 headers (dtype + shape per tensor, no tensor data read, no model launched, no
-GPU), with the KV term taken from the engine's own accounting rather than
-re-derived. It is produced by `scripts/perf_ceiling.py`, one invocation per
-row, and is re-checkable without a device:
+GPU). It is produced by `scripts/perf_ceiling.py`, one invocation per row, and
+is re-checkable without a device:
 
 ```sh
 scripts/perf_ceiling.py --model "$RMLX_O_MODELS_ROOT/<snapshot>" \
@@ -1468,14 +1480,27 @@ factor-of-1.4 outlier with arch-specific decode overhead worth hunting: most of
 its apparent excess was the missing KV term, 13.9% of its stream at this shape
 against under 7% for the other three.
 
-Three caveats the number carries. It counts bytes a decode step **must**
-stream, not bytes moved — cache residency, dequant scratch, MoE gather
-inefficiency and the gap between realized and peak bandwidth are all in the
-residual, which is what the ratio is for. 614 GB/s is this document's own host
-constant, carried over unverified. And the KV term inherits any error in
-`KvQuant::estimated_resident_bytes_per_layer` / `decode_read_bytes_per_layer`;
-it is a consistency win over an omitted term, not an independent measurement.
-`measured decode_tps` is unchanged — this revision moved only the denominator.
+**The KV term is a second producer, and nothing gates it against the first.**
+It is *not* read from the engine — `scripts/perf_ceiling.py` transcribes the
+Rust predicates into Python by hand:
+`KvQuant::decode_reads_packed_store`, `KvQuant::feeds_bf16_{k,v}_at_decode` and
+the per-layer promotion in `kv_quant_for_layer`, mirrored as
+`_DECODE_READS_PACKED_STORE`, `_NO_BF16_{K,V}` and `kv_quant_for_layer` in the
+script. The script says so itself and names the failure mode: when a codec is
+added or reclassified, both copies move together or this column is off "by a
+full store per layer, silently, in a direction that flatters the codec". That
+is the same shape as the cache-seed formula that drifted once a consumer crate
+could not depend on it. Diff the two whenever either moves; a divergence is
+invisible here and changes the ceiling, not just a caveat on it.
+
+Three further caveats. It counts bytes a decode step **must** stream, not bytes
+moved — cache residency, dequant scratch, MoE gather inefficiency and the gap
+between realized and peak bandwidth are all in the residual, which is what the
+ratio is for. 614 GB/s is this document's own host constant, carried over
+unverified. And even with the transcription correct, the column inherits any
+error in the Rust it mirrors; it is a consistency win over an omitted term, not
+an independent measurement. `measured decode_tps` is unchanged — this revision
+moved only the denominator.
 
 #### H2 addendum — the comparison envelope, measured locally (TAINTED host)
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -108,10 +108,17 @@ harder, so they were even lower.
 
 | model | git_sha | kv_quant_resolved | decode_tps | combined_tps_old | ratio_vs_ceiling | date |
 |---|---|---|---:|---:|---:|---|
-| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 877da73 | mixed_k8g64_v4g64 | 115.21 | 38.20 | 2.66x (vs ~307) | 2026-05-21 |
-| mlx-community__gemma-4-e4b-it-mxfp8 | 877da73 | k8v8 | 72.92 | 47.31 | 2.11x (vs ~154) | 2026-05-21 |
-| mlx-community__gemma-4-26b-a4b-it-mxfp8 | 877da73 | k8v8 | 72.19 | 9.57 | 2.42x (vs ~175) | 2026-05-21 |
-| mlx-community__Qwen3.6-35B-A3B-8bit | 877da73 | k8v8 | 94.96 | 12.59 | 1.84x (vs ~175) | 2026-05-21 |
+| prism-ml__Ternary-Bonsai-8B-mlx-2bit | 877da73 | mixed_k8g64_v4g64 | 115.21 | 38.20 | 2.15x (vs 248.2) | 2026-05-21 |
+| mlx-community__gemma-4-e4b-it-mxfp8 | 877da73 | k8v8 | 72.92 | 47.31 | 1.69x (vs 123.5) | 2026-05-21 |
+| mlx-community__gemma-4-26b-a4b-it-mxfp8 | 877da73 | k8v8 | 72.19 | 9.57 | 2.00x (vs 144.4) | 2026-05-21 |
+| mlx-community__Qwen3.6-35B-A3B-8bit | 877da73 | k8v8 | 94.96 | 12.59 | 2.01x (vs 191.1) | 2026-05-21 |
+
+The ceilings are a **tensor census**, not nameplate arithmetic — see H2 for the
+method, the per-model breakdown and the exact `scripts/perf_ceiling.py`
+invocations. A ceiling is a property of `(model, context, KV codec)`, so each
+one here is evaluated at this table's own shape (`--ctx 4096 --max-ctx 8192`)
+and at the `kv_quant_resolved` in column 3; a ceiling quoted without those is
+not comparable to one quoted with different ones.
 
 ### Finding: the "16-48x gap" was almost entirely prefill contamination
 
@@ -122,12 +129,12 @@ is excluded:
 
 - **Gemma4-26b MoE**: 3.47 → **72.19** decode_tps. The combined number at
   max-tokens 100 was 9.57; decode-only is ~7.5x higher than that combined
-  value. Ratio vs ceiling collapses from ~50x to **2.42x**.
-- **Qwen3.6 35B MoE**: 4.46 → **94.96** decode_tps. Ratio ~40x → **1.84x**.
-- **Bonsai 8B 2bit**: 15.88 → **115.21**. Ratio ~19x → **2.66x**.
-- **Gemma4-e4b dense**: 27.50 → **72.92**. Ratio ~5.6x → **2.11x**.
+  value. Ratio vs ceiling collapses from ~50x to **2.00x**.
+- **Qwen3.6 35B MoE**: 4.46 → **94.96** decode_tps. Ratio ~40x → **2.01x**.
+- **Bonsai 8B 2bit**: 15.88 → **115.21**. Ratio ~19x → **2.15x**.
+- **Gemma4-e4b dense**: 27.50 → **72.92**. Ratio ~5.6x → **1.69x**.
 
-All four now sit in the **1.8x–2.7x** band. The dramatic "MoE is 40-50x slow"
+All four now sit in the **1.7x–2.2x** band. The dramatic "MoE is 40-50x slow"
 signal was a **bench-harness measurement artifact** (prefill in the TPS
 denominator), not an inference-path defect.
 
@@ -1348,7 +1355,7 @@ Raw data: `.rmlx/bench/tracing_overhead.csv` (gitignored).
 > **Reframe (2026-05-21).** The "16-50x decode catastrophe" premise was
 > falsified: it was a bench-harness prefill-contamination artifact (`baseline`
 > divided tokens by prefill+decode). With decode-only TPS measured correctly,
-> all four models sit at **1.8-2.7x the 614 GB/s bandwidth ceiling** —
+> all four models sit at **1.7-2.2x the 614 GB/s bandwidth ceiling** —
 > normal-to-good for batch-1 MLX decode. The `>=50% single-cause / >=80% summed`
 > thresholds are MOOT and not applied. The section below (a) records H1/H2/H5
 > outcomes, (b) answers the 4k-vs-8k question (H7), (c) confirms the
@@ -1403,26 +1410,76 @@ decode TPS. (The `kv_bytes` demotion to `trace!` level was good hygiene, not a f
 
 ### H2 — decode is bandwidth-bound — ACCEPT
 
-Active-param bytes/step vs the 614 GB/s ceiling, compared to decode-only TPS
-(decode-only re-baseline, `release`, n=3 median):
+Bytes a decode step must stream vs the 614 GB/s ceiling, compared to
+decode-only TPS (decode-only re-baseline, `release`, n=3 median):
 
-| Model | active bytes/step | ceiling @614 GB/s | measured decode_tps | ratio vs ceiling |
-|---|---:|---:|---:|---:|
-| Bonsai 8B 2bit | ~2 GB | ~307 TPS | 115.21 | **2.66x** |
-| Gemma4-e4b mxfp8 (dense) | ~4 GB | ~154 TPS | 72.92 | **2.11x** |
-| Gemma4-26b MoE | ~3.5 GB active | ~175 TPS | 72.19 | **2.42x** |
-| Qwen3.6-35B-A3B MoE | ~3.5 GB active | ~175 TPS | 94.96 | **1.84x** |
+| Model (KV codec) | weights GB/step | KV GB/step | total GB/step | ceiling @614 GB/s | measured decode_tps | ratio vs ceiling | KV share |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Bonsai 8B 2bit (`mixed_k8g64_v4g64`) | 2.129 | 0.345 | **2.474** | **248.2** | 115.21 | **2.15x** | 13.9% |
+| Gemma4-e4b mxfp8 dense (`k8v8`) | 4.817 | 0.154 | **4.971** | **123.5** | 72.92 | **1.69x** | 3.1% |
+| Gemma4-26b MoE (`k8v8`) | 3.960 | 0.294 | **4.253** | **144.4** | 72.19 | **2.00x** | 6.9% |
+| Qwen3.6-35B-A3B MoE (`k8v8`) | 3.130 | 0.084 | **3.214** | **191.1** | 94.96 | **2.01x** | 2.6% |
 
-All four sit in a **1.8x–2.7x** band. **ACCEPT** — decode is bandwidth-bound.
+All four sit in a **1.7x–2.2x** band. **ACCEPT** — decode is bandwidth-bound.
 This is the headline answer to the question "why is decode so low?": it was
 *not* low in the sense first suspected — the matrix numbers were
 prefill-contaminated (see the decode-only re-baseline section). The residual
 ~2x is MLX batch-1 overhead (dispatch + dequant + the gap between realized and
 peak bandwidth).
 
+#### Where the denominator comes from
+
+An earlier revision of this table quoted an `active bytes/step` column of
+`~2 / ~4 / ~3.5 / ~3.5 GB`. Those were nameplate active-parameter counts times
+the weight-quant bit width, and they dropped four things a decode step really
+streams: the `scales` (and, for affine, `biases`) sidebands each quantized
+tensor ships; the tied `lm_head` (`tie_word_embeddings=true` on all four
+models, so `embed_tokens` is the streamed output projection); the per-arch
+auxiliaries the headline does not model; and **KV traffic, omitted entirely**
+while the quotient was taken against a measurement made at a 4096-token prompt.
+
+The column above is a census instead: `config.json` plus the safetensors
+headers (dtype + shape per tensor, no tensor data read, no model launched, no
+GPU), with the KV term taken from the engine's own accounting rather than
+re-derived. It is produced by `scripts/perf_ceiling.py`, one invocation per
+row, and is re-checkable without a device:
+
+```sh
+scripts/perf_ceiling.py --model "$RMLX_O_MODELS_ROOT/<snapshot>" \
+    --kv-quant <codec> --ctx 4096 --max-ctx 8192 --no-db --json
+```
+
+`--no-db` keeps the row independent of `runs.db` — it only suppresses the
+prefill anchor, which this table does not use.
+
+The KV column is what a step **streams**, not what the cache holds, and for
+`mixed_k8g64_v4g64` those differ: that codec decodes over its packed store
+while still keeping both bf16 seeds resident, so its 0.345 GB/step sits well
+below the `kv_cache_bytes` the same run reports. A bandwidth ceiling wants the
+streamed figure; a memory question wants the resident one. Do not read one as
+the other.
+
+The correction is not a constant bias, so it does not cancel out of the ratio:
+three ceilings fall and Qwen3.6-35B's **rises** 9%, because 30 of its 40 layers
+are GDN and hold no attention projections, so its active weight footprint was
+overstated at `~3.5 GB` (census: 3.130 GB). The band tightens from
+1.84x–2.66x to 1.69x–2.15x, and with it the reading that Bonsai is a
+factor-of-1.4 outlier with arch-specific decode overhead worth hunting: most of
+its apparent excess was the missing KV term, 13.9% of its stream at this shape
+against under 7% for the other three.
+
+Three caveats the number carries. It counts bytes a decode step **must**
+stream, not bytes moved — cache residency, dequant scratch, MoE gather
+inefficiency and the gap between realized and peak bandwidth are all in the
+residual, which is what the ratio is for. 614 GB/s is this document's own host
+constant, carried over unverified. And the KV term inherits any error in
+`KvQuant::estimated_resident_bytes_per_layer` / `decode_read_bytes_per_layer`;
+it is a consistency win over an omitted term, not an independent measurement.
+`measured decode_tps` is unchanged — this revision moved only the denominator.
+
 #### H2 addendum — the comparison envelope, measured locally (TAINTED host)
 
-This section used to close by calling the 1.8x–2.7x band *"at/near the healthy
+This section used to close by calling the H2 band *"at/near the healthy
 1.5-2x ceiling-vs-realized envelope llama.cpp / mlx-lm hit on dense batch-1
 decode"*. **That envelope was taken from the literature, not measured here.** The
 first local measurement is below. It does not vindicate the sentence, and it
@@ -1454,7 +1511,7 @@ The reproducible band is **1.26x–1.30x**.
 
 ##### Ratio-vs-ceiling is not comparable across models of different size
 
-It is tempting to set 1.26x–1.30x against rMLX's 1.8x–2.7x and conclude
+It is tempting to set 1.26x–1.30x against rMLX's 1.7x–2.2x and conclude
 llama.cpp is the more efficient runtime. **That inference is invalid**, and the
 reason generalises well beyond this page.
 
@@ -1466,8 +1523,8 @@ ratio = measured_ms / ideal_ms = 1 + fixed_overhead_ms / ideal_ms
 
 so *the same* fixed per-step cost produces a large ratio on a small model and a
 small ratio on a large one. The two tables are not close in scale: llama.cpp's
-cells move **9.3–13.4 GB/step**, rMLX's H2 rows **2.0–4.0 GB/step** — 2.3x to
-6.7x apart. That difference alone moves the ratio in exactly the observed
+cells move **9.3–13.4 GB/step**, rMLX's H2 rows **2.5–5.0 GB/step** — 1.9x to
+5.4x apart. That difference alone moves the ratio in exactly the observed
 direction, before any question of runtime quality.
 
 The scale-free quantity is the **absolute per-step overhead**,
@@ -1478,25 +1535,28 @@ The scale-free quantity is the **absolute per-step overhead**,
 | llama.cpp | Qwen3-8B-Q8_0 @3 753 | 9.26 GB | 15.09 | 19.21 | **4.12** | 1.27x |
 | llama.cpp | Qwen3-8B-Q8_0 @7 722 | 9.85 GB | 16.04 | 18.22 / 20.30 | **2.18 / 4.26** | 1.14x / 1.26x |
 | llama.cpp | Qwen3-8B-Q8_0 @31 536 | 13.36 GB | 21.76 | 28.37 | **6.61** | 1.30x |
-| rMLX | Qwen3.6-35B-A3B MoE | 3.5 GB | 5.70 | 10.53 | **4.83** | 1.85x |
-| rMLX | Bonsai 8B 2bit | 2.0 GB | 3.26 | 8.68 | **5.42** | 2.66x |
-| rMLX | Gemma4-e4b mxfp8 | 4.0 GB | 6.51 | 13.71 | **7.20** | 2.11x |
-| rMLX | Gemma4-26b MoE | 3.5 GB | 5.70 | 13.85 | **8.15** | 2.43x |
+| rMLX | Bonsai 8B 2bit | 2.474 GB | 4.03 | 8.68 | **4.65** | 2.15x |
+| rMLX | Qwen3.6-35B-A3B MoE | 3.214 GB | 5.23 | 10.53 | **5.30** | 2.01x |
+| rMLX | Gemma4-e4b mxfp8 | 4.971 GB | 8.10 | 13.71 | **5.62** | 1.69x |
+| rMLX | Gemma4-26b MoE | 4.253 GB | 6.93 | 13.85 | **6.93** | 2.00x |
 
-llama.cpp 2.18–6.61 ms against rMLX 4.83–8.15 ms. **The ranges overlap**, so by
+The rMLX `bytes/step` column is the H2 census, so the overhead figures moved
+when the denominator did; llama.cpp's are unchanged.
+
+llama.cpp 2.18–6.61 ms against rMLX 4.65–6.93 ms. **The ranges overlap**, so by
 the same rule this repo applies to its own A/B arms the comparison is
-**INCONCLUSIVE**: the medians differ (~4.3 ms vs ~6.3 ms) but no separation is
+**INCONCLUSIVE**: the medians differ (~4.2 ms vs ~5.5 ms) but no separation is
 demonstrated at n=3 vs n=4, across two frameworks, two weight formats and two
 measurement sessions on a tainted host.
 
 What the data *does* establish:
 
 * The **band difference is dominated by bytes/step, not by runtime efficiency.**
-  A 1.26x-vs-2.4x gap in ratios coexists with overlapping absolute overheads.
+  A 1.26x-vs-2.0x gap in ratios coexists with overlapping absolute overheads.
 * E2's original sentence is still unsupported — it cited an envelope nobody had
   measured — but it is **not falsified**, and an earlier revision of this
   addendum that claimed rMLX was "roughly 1.5x looser" was **wrong**: it compared
-  the non-scale-free quantity across a 2.3–6.7x span in model size.
+  the non-scale-free quantity across a 1.9–5.4x span in model size.
 * Settling it needs a like-for-like cell — llama.cpp on a model with
   rMLX-comparable bytes/step, or rMLX on an ~9 GB/step model — on a quiescent
   host. That has not been run.
@@ -1504,10 +1564,11 @@ What the data *does* establish:
 **Equivalence caveat, and it is load-bearing.** No file both runtimes can load
 exists: rMLX reads MLX safetensors, llama.cpp reads GGUF. The tables set a
 `q8_0` (block 32, one fp16 scale) model against rMLX's `mxfp8`/affine rows —
-near-equivalent, not identical. The rMLX bytes/step figures are themselves the
-rounded estimates this section already published (and `#403` tightens that
-census), so the overhead column inherits their uncertainty. Treat a cross-family
-gap under ~10% as unresolved by this method.
+near-equivalent, not identical. The rMLX bytes/step figures are the H2 tensor
+census, so the overhead column inherits its caveats — bytes a step must stream,
+not bytes moved — while llama.cpp's come from a separate hand-built arithmetic
+over the GGUF. Treat a cross-family gap under ~10% as unresolved by this
+method.
 
 **Cross-run absolute TPS on this host is not comparable.** The 7 722 cell above
 is the demonstration: 54.89 and 49.27, an 11% drift driven by foreground desktop
@@ -1538,10 +1599,13 @@ dispatching to `rmlx_mlx::gather_qmm` for `Linear::Quantized` experts
 (`qwen3_5_moe/layers.rs:187`) — the batched-expert fast path, equivalent to
 mlx-lm's `SwitchGLU`, not a dense-masked loop. Confirmed the `sorted_indices`
 argument is the **hardcoded `false`** positional at `layers.rs:197` (there is no
-named `sorted_indices` param; mlx-lm threads one through). With Qwen3.6's
-1.84x-of-ceiling decode being the *best* of the four models, the expert gather
-is not a bottleneck worth chasing — it is doing the right (gather_qmm) thing and
-the model is the closest to the bandwidth wall. `sorted_indices=true` for the
+named `sorted_indices` param; mlx-lm threads one through). Qwen3.6's
+absolute per-step overhead is 5.30 ms against 4.65–6.93 ms across the four
+models (H2 addendum), i.e. mid-pack and no outlier, so the expert gather is not
+a bottleneck worth chasing — it is doing the right (gather_qmm) thing. The
+scale-free quantity is the one to read here: a ratio-vs-ceiling ranking across
+models of different size is a statement about model size, not about the gather
+(same addendum). `sorted_indices=true` for the
 decode gather is a possible micro-tweak but unjustified by this data (no
 catastrophe to recover). **Characterized — fast gather_qmm path confirmed; not
 dominant.**
@@ -1645,7 +1709,7 @@ nothing) — it is used, if at all, only inside isolated layer ops / prefill, no
 the decode loop. So every decode step re-builds the Rust→mlx-c graph.
 
 Is compiling it worth doing? The bucket breakdown says the forced per-token sync
-is <0.6%, and the model is already 1.8-2.7x of the bandwidth ceiling. The
+is <0.6%, and the model is already 1.7-2.2x of the bandwidth ceiling. The
 per-step forward (8.96 ms Bonsai / 10.97 ms Qwen3.6) is dominated by the
 overlapped GPU kernel + memory traffic, not by host-side graph re-trace stalling
 the GPU (if it were, sync/idle would show up large, and the ratio-vs-ceiling
@@ -1663,16 +1727,18 @@ attention layers, each dispatching a per-step MSL kernel `gated_delta_step_gpu`
 (`qwen3_5_moe/gated_delta_net.rs:267`) plus per-step `conv1d`, several
 `rms_norm`, slices and `astype`. The GDN forward is **not** separately
 instrumented (no span), so it folds into the `forward_total` bucket. Despite the
-long per-layer GDN op chain, Qwen3.6 is the *best* of the four models at 1.84x of
-ceiling — so the GDN chain is not pathological at 4k. It is a plausible
+long per-layer GDN op chain, Qwen3.6's per-step overhead (5.30 ms) sits inside
+the four-model range 4.65–6.93 ms — so the GDN chain is not pathological at 4k.
+Compared on overhead rather than on ratio-vs-ceiling, which is not comparable
+across models of different size (H2 addendum). It is a plausible
 follow-up-branch candidate for per-step kernel fusion if longer-context decode is
 later found wanting, but MSL-kernel work is explicitly out of scope here.
 **Documented as a follow-up-branch candidate only; no action this branch.**
 
 ### Net narrative
 
-Decode is **healthy** — all four models run at ~1.8-2.7x the 614 GB/s bandwidth
-ceiling, the normal-to-good band for batch-1 MLX decode. The "16-50x
+Decode is **healthy** — all four models run at 1.7-2.2x the 614 GB/s bandwidth
+ceiling on a tensor census of what a step streams (H2). The "16-50x
 catastrophe" was a prefill-contaminated bench metric, not an inference defect.
 The modest ~2x residual is ordinary MLX batch-1 overhead (dispatch + dequant +
 sub-peak bandwidth); the forced per-token sync is <0.6% of decode time, and

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -350,6 +350,19 @@ It records the live process, exports the `metal-gpu-intervals` table, parses it
 and prints a per-channel table plus a CSV a script can assert on. See
 [Reading the timeline](#reading-the-timeline) for what the numbers mean.
 
+**This works on this host**, and the claim is worth pinning because a report
+once concluded the opposite. Two runs, xctrace 16.0 / Xcode 26.6, M5 Max:
+gemma-4-e2b `none` @4096 on `target/release/rmlx` gave 6 931 rmlx rows
+(6 927 `Compute`, `start-latency` p50 3.98 ms), and Ternary-Bonsai-8B `k8v4`
+@8192 on `target/release-perf/rmlx` — the exact cell that report used — gave
+14 140. Neither needed `sudo` or an entitlement. The earlier zero-row
+recordings held **24 rows for the whole machine** across a 25 s window, against
+36 441 here across 20 s, so what failed was the recording, not the instrument's
+coverage of the compute channel. That is the state the summariser's two
+refusals now distinguish: `contains no rows` is an empty table, `holds N rows
+but none for a process matching …` is a populated one, and the second lists the
+processes it did see.
+
 The table gives per-GPU-submission `start` and `duration` in nanoseconds,
 `gpu-channel-name`, `start-latency` (the CPU→GPU gap), and `cmdbuffer-id` /
 `encoder-id`, per process; `metal-application-encoders-list` and
@@ -695,9 +708,15 @@ its editor. An agent can capture the bundle, open it, and read the exported CSV 
 a person has to click Profile. **Ask the user; do not report the counters as
 unavailable.**
 
-Headless Metal System Trace is *not* a substitute: it exports zero rows for
-`rmlx` on this host, and per-dispatch counter sampling is unsupported on M5 Max.
-This GUI path is what remains.
+Headless Metal System Trace is *not* a substitute, but not because it fails:
+it does instrument `rmlx`'s compute work here (§5 — reproduced on this host at
+xctrace 16.0 / Xcode 26.6, 6 931 and 14 140 rmlx `Compute` rows with
+`start-latency` populated). What it does not carry is *which kernel* and *any
+counter*: the `metal-gpu-intervals` export has no pipeline or function names,
+and per-dispatch counter sampling is unsupported on M5 Max. So MST answers
+"how long did each submission take and how long did it wait", and this GUI path
+answers "which kernel, and at what occupancy / limiter". Different questions —
+use both.
 
 ### Capture
 

--- a/docs/models/bonsai/27B/rMLX.md
+++ b/docs/models/bonsai/27B/rMLX.md
@@ -106,8 +106,9 @@ directly. KV-MB from serve events `op='kv_cache_bytes'` high-water (the `baselin
     > CPU dequant that produced these numbers is gone. Re-measured at 4k: Bonsai-8B
     > 1.34 → 17.0 TPS, medgemma-4B 7.37 → 51.8 TPS. The numbers in this table are a
     > pre-kernel snapshot and were **not** re-run on the 27B. Two caveats stand:
-    > the default `--rotor-qjl on` still takes the CPU path (the kernel cannot
-    > reproduce the QJL residual), and `k_iso3/4` is untouched — it keeps its own
+    > `--rotor-qjl on` still takes the CPU path (the kernel cannot reproduce the
+    > QJL residual) — it was the default when this was recorded and is opt-in
+    > now, so the shipped path is the kernel — and `k_iso3/4` is untouched: it keeps its own
     > per-step host restaging.
 - **No long-ctx collapse (unlike the 8B).** On the 8B, `iso*`/`*_sym` cratered to
   ~6–13 TPS at 64k; on the 27B they hold **30–36 TPS at 64k**. GDN's shallow KV

--- a/scripts/mst_capture.sh
+++ b/scripts/mst_capture.sh
@@ -311,7 +311,7 @@ fi
 # its exit code is load-bearing here.
 if [ $rc -ne 0 ]; then
 	echo "ERROR: summarising $xml failed (exit $rc)" >&2
-	echo "  Read WHICH refusal it printed — they mean opposite things:" >&2
+	echo "  Read WHICH refusal it printed — they mean different things:" >&2
 	echo "  * 'contains no rows'  -> the recording captured nothing from any" >&2
 	echo "    process. The recording failed; the workload is not implicated." >&2
 	echo "  * 'holds N rows but none for a process matching ...' -> the" >&2
@@ -319,6 +319,10 @@ if [ $rc -ne 0 ]; then
 	echo "    processes it did see. Re-run the workload directly to check it" >&2
 	echo "    reaches the GPU at all:" >&2
 	echo "      ${run_cmd[*]}" >&2
+	echo "  * 'the N ms skip removed every one of the M rows ...' -> the" >&2
+	echo "    process IS in the recording and --skip-ms cut past its work." >&2
+	echo "    Lower --skip-ms or raise --time-limit; do not re-run to debug" >&2
+	echo "    the workload." >&2
 	exit $rc
 fi
 

--- a/scripts/mst_capture.sh
+++ b/scripts/mst_capture.sh
@@ -234,7 +234,9 @@ rc=$?
 # the child's termination as a non-zero exit on the ordinary, successful path.
 # The exit code therefore cannot be the gate; the bundle and the exported table
 # are. A run that genuinely failed leaves no rows for this process, and the
-# summariser refuses that rather than printing zeros.
+# summariser refuses that rather than printing zeros — naming, when the table
+# does hold rows, which processes they belong to, so "the recording failed" and
+# "this process was not in it" stay apart.
 if [ $rc -ne 0 ]; then
 	echo "note: xctrace record exited $rc — expected when --time-limit ends a" >&2
 	echo "  still-running process. The export below is what decides." >&2
@@ -309,9 +311,14 @@ fi
 # its exit code is load-bearing here.
 if [ $rc -ne 0 ]; then
 	echo "ERROR: summarising $xml failed (exit $rc)" >&2
-	echo "  If it reports no rows for this process, the run itself failed and" >&2
-	echo "  xctrace swallowed its output. Re-run it directly to see why:" >&2
-	echo "    ${run_cmd[*]}" >&2
+	echo "  Read WHICH refusal it printed — they mean opposite things:" >&2
+	echo "  * 'contains no rows'  -> the recording captured nothing from any" >&2
+	echo "    process. The recording failed; the workload is not implicated." >&2
+	echo "  * 'holds N rows but none for a process matching ...' -> the" >&2
+	echo "    recording ran and this process was not in it. It lists the" >&2
+	echo "    processes it did see. Re-run the workload directly to check it" >&2
+	echo "    reaches the GPU at all:" >&2
+	echo "      ${run_cmd[*]}" >&2
 	exit $rc
 fi
 


### PR DESCRIPTION
Closes #407. Closes #402. Closes #406. Closes #403. Closes #410.

Five issues, grouped because they are documentation-truth work over the same subsystem and because recent measurements settle several of them. Corrective, not additive: false sentences are deleted, not annotated.

## #410 — the headline is falsified

The issue reports Metal System Trace yields no compute-channel rows for `rmlx` on this host. **It does.** Reproduced twice, xctrace 16.0 / Xcode 26.6, no `sudo`, no entitlement:

- gemma-4-e2b `none` @4096 -> **6 931** rmlx rows (6 927 `Compute`, `start-latency` p50 3.984 ms)
- Ternary-Bonsai-8B `k8v4` @8192 — **the issue's own runs-1-2 cell** -> **14 140** rmlx rows

The tell was in the original report and was read backwards: its trace held **24 rows for the entire machine** across 25 s, where these hold 36 441 and 60 502 across 20 s. "The table is not empty (24 rows, all `cmux`)" was taken as proof the instrument worked. The row count *was* the anomaly — the recording failed, not the compute-channel coverage.

So the issue asked for two claims to be recorded and one probe to be run; instead this deletes the claim `docs/PROFILING.md` already carried and states the real boundary: **MST gives timing but no kernel names and no per-dispatch counters** — every `metal-object-label` in both exports is empty. That boundary is what the Xcode GUI replay is for.

**The headless GPU-timing path is available.** Worth re-scoping anything that assumed otherwise.

## The one code change

`XctraceError` split so a refusal names the state it is in. Three states, previously two:

- the export has no rows at all,
- it has rows but none for this process,
- it has rows for this process and the `--skip-ms` floor removed all of them.

The third was reachable and produced a self-contradictory message — `Processes seen: rmlx (2 rows)` while asserting the process was absent — because `SkipExceedsSpan` fires on `origin >= max(start+duration)`, so one long submission straddling the origin keeps it silent. In the no-filter shape the refactor had also started **discarding** the skip qualifier entirely, a regression against the old text.

Red-first, both shapes, on a 2-row fixture (50 ms submission at t=0, 10 µs at t=1 ms, `skip_ms=10`):

```
holds 2 rows but none for a process matching "rmlx" after the requested skip —
the recording ran; this process was not in it. Processes seen: rmlx (99) (2 rows)

(no filter) schema 'metal-gpu-intervals' parsed but contains no rows   <- on a 2-row table
```

Three mutation checks. One of them found a **second mutation-null of the same shape as the first**: a `matched_before_floor > 0` conjunct that can never be false, because the only caller passing a non-zero floor refuses first. Deleted, with the non-local caller ordering pinned instead.

## #403 — the issue's replacement numbers did not reproduce

Its Bonsai row (0.604 GB) is the `none` **resident** figure — exactly `2·2·4096·128·8·36` — where a bandwidth roofline needs what `mixed_k8g64_v4g64` actually **streams**: 0.345 GB. The other three rows reproduce to three significant figures.

So the band is **1.69x-2.15x**, not the proposed 1.7-2.0x. Consumers re-derived, because a denominator correction is not finished until they are: the decode-only re-baseline, `docs/KV_CACHE.md`'s copy, the per-step overhead table (rMLX 4.65/5.30/5.62/6.93 ms — still INCONCLUSIVE, still overlapping llama.cpp's 2.18-6.61), and H9b/H10, which **both concluded from "Qwen3.6 is best at 1.84x of ceiling"** — numerically wrong post-census (2.01x; e4b is lowest at 1.69x) *and* a ratio-vs-ceiling comparison across differently-sized models, which the addendum three sections below forbids in as many words. Restated on per-step overhead; the original conclusions survive.

## #402, #406, #407

**#402** — one comment in the issue, **six** restatements in the tree; the SWA ring is taken under every codec (`with_quant_max_seq_window` branches on `window > 0` alone, and `update`/`enter_prefill`/`exit_prefill` each return before codec dispatch). Now pinned by a table test over `[none, k8v8, k8v4, planar, mixed]` asserting `is_rotating()`, zero storage bytes, and residency byte-identical to `none`, with a null control that requires `Mixed` to build a store — so the zero is a real discriminator. Mutating the ring to gate on `KvQuant::None` — the comment written as code — reddens it.

**#406** — ParoQuant is weight-side (`git -C ../paroquant grep -i -w kv` -> exit 1, 0 lines); IsoQuant ships no cache and no decode path upstream (5 files). CLAUDE.md's capability line now names the four real rotation-KV families, RotorQuant included — it was shipped and missing. The identical parenthetical in `README.md` (twice) is fixed; "five" -> "four".

**#407** — largely shipped by #416 already. What remained: one self-contradicting sentence ("head_dim independent — at head_dim=512 it is 1028 B against 1024 B", which gives two rates for two head dims), and the point of selection. `rmlx info --list-cache-types` now states that the width in an `iso_*`/`rotor_*` name is its codebook, not its stored rate. Its criteria 2 and 3 are moot: `kv_quant_for_ctx`, `resolve_default` and `preferred_auto_kv` no longer exist.

## Two false claims this branch added, and removed

Both caught in review, both the exact defect the branch exists to remove:

- The new `--list-cache-types` note claimed iso/rotor "are the widest cells on this menu". `planar3`/`planar4` store **22.00 bits/value at every head_dim** and are on the same menu. Now a three-row table with **per-row** provenance — which surfaced that the crate gate measures iso in its wider CPU-block form (48.25), so attributing 16.25 to it would have installed a second false provenance claim inside the fix for the first.
- "with the KV term taken from the engine's own accounting rather than re-derived" — it **is** re-derived. `perf_ceiling.py` transcribes three Rust predicates into Python and its own docstring warns that nothing gates them, and that drift moves the column "by a full store per layer, silently, in a direction that flatters the codec". Now a promoted paragraph naming all three pairs and tying it to the recorded cache-seed drift class.

## Five stale-claim sweeps, whole tree

SWA-conditional-on-codec, QJL-default, retired per-arch/per-context defaults, ParoQuant-as-KV, iso-48.25-as-resident. All clean afterwards. Notables: `--rotor-qjl on` was called the default in four places while it has been `off` since the rotor Metal path landed — including in the decode-cost caveat, so the file described the CPU path as what an operator gets; three further restatements survived the first pass. `docs/MODELS.md` still asserted the SWA claim **while citing the function that disproves it**, which is why the sweep rule is now "grep the cited symbol, not only the wording".

`docs/PERF_BASELINE.md:1286` is annotated rather than re-censused, and that is itself the finding: `perf_ceiling.py` is **inapplicable** to BitNet — it sizes weights from packed-ternary `u8` headers while the loader dequantizes to BF16. Run anyway it reports a 516 TPS ceiling against the nameplate 127, an ~8x undercount in the flattering direction.

`make ci` composite **0**; `cargo +1.98.0 clippy --workspace --all-targets --all-features -- -D warnings` **0**. `cargo audit` printed a transient crates.io 503 on its yanked-status check; the advisory scan itself completed (1225 advisories, 356 deps) and the gate stayed 0.
