### PR TITLE
docs(kv,perf): lifting epsilon is answered negative (#340, #405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -414,6 +414,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Lifting ε is answered negative, and the residual it was blamed on was the
+  wrong residual.** Two standing proposals — re-index the flash-decode P1 grid
+  by KV head, and lift the `mixed_*` packed-store path to ≥ 400 GB/s — are
+  recorded as answered-negative in `docs/KV_QUANT.md` § "Lifting ε does not pay"
+  and `docs/PERF_BASELINE.md`. The grid mechanism is true and re-verified at
+  source (`turbo_flash_p1.metal:17,20,27`; `:29-32` in each iso/rotor P1), but
+  its consequence is not: removing the *entire* query-head class moves the ON
+  arm only 0.231× → 0.311× of the generic path, because the kernel is
+  issue-bound (Integer and Conditional 50.45%) rather than memory-bound (LLC
+  10.66%), the redesign adds ~54–126 f32 per lane against 22.24% occupancy with
+  no spill headroom, the one store dense enough to clear a lifted ceiling
+  (`tsym3`) is byte- and token-identical to `none`, and the best real codec on
+  that kernel (`iso4_sym` @32k) decodes at 0.170× of `none` while holding more
+  bytes than bf16. The ≥ 400 GB/s and ≤ 4× pass criteria both presume a bound
+  the counters contradict. `docs/KV_QUANT.md` had attributed the residual to
+  "the f32 `partial_o` P1→P2 round trip plus the thread-0-serial softmax
+  between threadgroup barriers" — `turbo_flash_p1` has zero
+  `threadgroup_barrier`, no thread-0 section and no `partial_o` at all, and the
+  P2 that does have them is 3.66% of GPU time; the iso/rotor P1s do carry both
+  and have never been profiled. `docs/models/bonsai/27B/rMLX.md` restated the
+  same attribution as "chiefly because". Both corrected, and the one unmeasured
+  cell (`iso_flash_decode_symv_p1`) is recorded with a pre-registered decision
+  rule.
+
+- **Metal System Trace granularity is per encoder, and the driver-coalescing
+  claim was unsupported.** `scripts/mst_capture.sh`, `docs/PROFILING.md` and the
+  XML unescaper in `rmlx-mlx` all said the driver merges consecutive compute
+  encoders into one GPU kick so a row can cover several. Re-derived from the two
+  bundles under `<RMLX_HOME>/traces/mst`: 14 140 rmlx `metal-gpu-intervals` rows
+  carry 13 996 distinct `encoder-id`s, and the same run's
+  `metal-application-command-buffer-submissions` sums 13 997 encoders over
+  14 512 command buffers, of which 13 592 hold exactly one. No row is a
+  coalesced kick, and no `gpu-channel-name` in either export is anything but
+  `Compute` / `Fragment` / `Vertex` — the `&` the unescaper exists for comes
+  from the compositor's IOSurface labels. Also corrected: "no pipeline or
+  function names in the export" is true of `metal-gpu-intervals` only. The
+  bundle names 52 rmlx pipelines in `metal-shader-profiler-shader-list`; what is
+  missing is a join key, because the stock template records `Shader Timeline:
+  Disabled` and `metal-shader-profiler-intervals` exports zero rows —
+  configuration, not a device ceiling. Counters genuinely are dead headlessly:
+  the bundle holds exactly one, `RT Unit Active`.
+
 - **The gemma4 SWA comment claimed quantized codecs take a full-size path.**
   They do not, and never did on this tree: `KvCache::with_quant_max_seq_window`
   selects the rotating ring on `window > 0` alone, `update` / `enter_prefill` /

--- a/crates/rmlx-mlx/src/xctrace.rs
+++ b/crates/rmlx-mlx/src/xctrace.rs
@@ -541,9 +541,9 @@ fn attr(attrs: &str, want: &str) -> Option<String> {
     None
 }
 
-/// The five predefined XML entities. Encoder labels really do contain `&` —
-/// the driver coalesces encoders and names the row `EncA & EncB` — so leaving
-/// `&amp;` in place would corrupt the one field used to identify a submission.
+/// The five predefined XML entities. Row labels really do contain `&` — the
+/// compositor's IOSurface access labels read `Read Surface: 86(6016x3384:83b&)`
+/// — so leaving `&amp;` in place would corrupt a field used to identify a row.
 fn unescape(s: &str) -> String {
     if !s.contains('&') {
         return s.to_owned();

--- a/crates/rmlx-mlx/src/xctrace_tests.rs
+++ b/crates/rmlx-mlx/src/xctrace_tests.rs
@@ -575,17 +575,18 @@ fn the_csv_is_nanoseconds_and_one_row_per_channel() {
     reason = "fixture is a literal in this file; a parse failure here is the test failing"
 )]
 fn ampersands_in_a_label_survive_unescaping() {
-    // The driver coalesces consecutive compute encoders and names the row
-    // "EncA & EncB", which the export escapes. Leaving it escaped corrupts the
-    // one field that identifies a submission.
+    // Row labels really do carry `&` — the compositor's IOSurface access labels
+    // read "Read Surface: 86(6016x3384:83b&)" — and the export escapes it.
+    // Leaving it escaped corrupts a field used to identify a row. The label
+    // goes in the channel-name cell because that is this fixture schema's only
+    // string column.
+    let label = "Read Surface: 86(6016x3384:83b&)";
     let rows = "<row><start-time fmt=\"a\">1</start-time><duration fmt=\"b\">2</duration>\
-                <sentinel/><gpu-channel-name fmt=\"EncA &amp; EncB\">EncA &amp; EncB</gpu-channel-name>\
+                <sentinel/>\
+                <gpu-channel-name fmt=\"l\">Read Surface: 86(6016x3384:83b&amp;)</gpu-channel-name>\
                 <process fmt=\"rmlx (1)\"></process></row>";
     let rows = collect(&doc(rows)).unwrap();
-    assert_eq!(
-        rows.first().unwrap().get(3).unwrap().text(),
-        Some("EncA & EncB")
-    );
+    assert_eq!(rows.first().unwrap().get(3).unwrap().text(), Some(label));
 }
 
 #[test]

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -3344,14 +3344,35 @@ threadgroups each stream the identical KV bytes. That caps the shell at
 | gemma-4-e2b | 8 | 0.125 | 0.052 (42% of ceiling) |
 
 Measured ε differs between the two archs by 2.6×; `heads_per_kv` alone predicts
-2.0×. The geometry is the dominant term. The residual ≈2× is the f32
-`partial_o` P1→P2 DRAM round trip plus the thread-0-serial online-softmax
-section, where all but one lane idle twice per KV token.
+2.0×. The residual ≈2× is **unattributed**, and the two constructs it is easiest
+to blame are not available to blame in general:
+
+* `turbo_flash_p1.metal` contains **zero** `threadgroup_barrier` and no thread-0
+  serial section — its online softmax is per-lane with a `simd_sum` at `:106`,
+  and its only `lane == 0` is the epilogue store at `:153`. It has no
+  `partial_o` either; its P1→P2 buffers are `partial_out` / `partial_ms`. Both
+  constructs live in `turbo_flash_p2.metal` (barrier `:37`, `tid == 0u` `:20`),
+  which measures **3.66%** of GPU time, so eliminating it entirely recovers at
+  most that.
+* The iso and rotor P1 kernels do carry both constructs inside the per-KV-token
+  loop (`iso_flash_decode_symv_p1.metal:84` between barriers at `:81` / `:107`;
+  same shape in `iso_flash_decode_p1`, `rotor_flash_decode_p1`,
+  `rotor_flash_decode_symv_p1`). Their **magnitude has never been measured** —
+  every counter and timing measurement to date is of `turbo_flash_p1`.
+
+Where the residual went on the one kernel that was profiled: `turbo_flash_p1`
+is **issue-bound, not memory-bound** — Integer and Conditional Limiter 50.45%,
+Instruction Throughput 45.66%, Control Flow 28.92%, against LLC 10.66% and L1
+3.31%, at 22.24% occupancy with 94 allocated registers and 0 spilled bytes. The
+bf16 `sdpa_vector` encoders in the same capture are the opposite: LLC 42.16%,
+occupancy 52.93%, 56 registers. See "Lifting ε does not pay" below.
 
 **Corollary for `kv_h == 1` architectures.** e2b's geometric ceiling (0.125) is
 *below* the densest store in the tree (`tsym3`, ρ = 0.158). On such an arch no
 fused decode over any store that exists or has been proposed can beat bf16 **even
-with a perfect kernel body**, until the grid stops re-reading KV per query head.
+with a perfect kernel body**, while the grid re-reads KV per query head. That is
+a necessary condition, not a sufficient one — lifting it is measured below and
+does not produce a win either.
 
 ### What ρ would have to be
 
@@ -3372,8 +3393,136 @@ Against what exists or has been specced:
 
 **The binding constraint is ε, not ρ.** Repacking a store is necessary for some
 of these codecs to stop costing memory, but it is not sufficient to make a fused
-decode win, and on `kv_h == 1` it is not even close. Order kernel-shell work
-first; judge a store repack on its memory merits, not on an expected decode win.
+decode win, and on `kv_h == 1` it is not even close. Judge a store repack on its
+memory merits, not on an expected decode win — and read the next section before
+funding kernel-shell work on the expectation that lifting ε collects the
+difference.
+
+### Lifting ε does not pay — answered negative
+
+Two proposals rested on the arithmetic above. Both are answered **no** from
+evidence already in the tree, with no new measurement. Neither is a throughput
+lever; do not sequence a codec change behind either.
+
+**What was asked.**
+
+* *Re-index the P1 grid by KV head* — carry `heads_per_kv` query vectors and
+  their online-softmax state in registers so each KV byte is read once per
+  threadgroup instead of `heads_per_kv` times. Predicted ceiling lift 4× at
+  `heads_per_kv = 4`, 8× at 8; success criterion ε on `iso3_sym` at Bonsai-8B
+  rising from 0.135 toward 0.25.
+* *Close the mirror→packed bandwidth cliff in `mixed_*`* — the `Mixed` decode
+  path streams its packed KV at 227.8 GB/s where the bf16 path moves the same
+  layers' KV at 533.9 GB/s on the same host, shape and context segment. Pass
+  criterion: those layers reach ≥ 400 GB/s, 65% of the 614 GB/s host ceiling.
+
+**The re-index's mechanism is true; its consequence is not.** The grid really is
+indexed by query head — `turbo_flash_p1.metal:17,20,27` (`bh_idx` flat over
+`B * n_q_heads`, `kv_head = q_head / n_repeats`) and `:29-32` in each of
+`iso_flash_decode_p1`, `iso_flash_decode_symv_p1`, `rotor_flash_decode_p1`,
+`rotor_flash_decode_symv_p1` (`kv_h_idx = hq / heads_per_kv`) — so
+`heads_per_kv` threadgroups do stream identical bytes, and `ε ≤ 1/heads_per_kv`
+is a correct analytic cap. What fails is the step from that cap to a win. A
+`1/heads_per_kv` cap binds only if the kernel is waiting on memory, and it is
+not.
+
+1. **The headroom ladder.** `.rmlx/analysis/kv-campaign/P12/03_headroom_calc.txt`
+   (Bonsai-8B `k8v4` @32k, `--turbo-flash off|on`, ABBA, 12 slots): removing the
+   **entire** query-head class — an upper bound on the re-index, since that class
+   also holds irreducible per-query-head arithmetic — moves the ON arm from
+   0.231× of the generic path to **0.311×**. End-to-end that is a 1.348×
+   speedup on a kernel 4.33× behind, i.e. perfect execution still lands 3.21×
+   slower than not running the codec at all. Reaching parity needs the *bytes*
+   class to run ~3× better as well (0.701×), and only full per-byte parity with
+   MLX `sdpa_vector` clears 1.0 (1.283×).
+2. **The kernel is issue-bound, so a bandwidth fix has little to recover.**
+   Xcode Metal Debugger counter export, Bonsai-8B `k8v4` @8192, Serial
+   execution mode / Maximum performance state: `turbo_flash_p1` reads Integer
+   and Conditional Limiter **50.45%**, Instruction Throughput 45.66%, Control
+   Flow 28.92%, against LLC **10.66%** and L1 3.31%. The bf16 `sdpa_vector`
+   encoders in the same capture invert it — LLC 42.16%, Integer and Conditional
+   9.50%. Every memory limiter on the fused kernel is small; the byte savings
+   are real and have nothing to convert into. *Serial execution mode makes
+   absolute wall-clock and absolute bandwidth non-production numbers; limiters,
+   occupancy, register counts and the P1:P2 ratio are the precise half, and are
+   what is quoted here.*
+3. **The redesign worsens the real co-limiter.** Occupancy is 22.24% at 94
+   allocated registers with **0** spilled bytes, so resident threadgroups are
+   already register-limited without spilling. *Derivation* from the declared
+   per-lane arrays in `turbo_flash_p1.metal` — `q_vals[8]` (`:38`), `o_state[8]`
+   (`:47`), `m_state` / `l_state` (`:45,:46`) are per query context and would
+   replicate `heads_per_kv` times; `v_decoded[8]` (`:116`) is shared. 18 f32 per
+   query context: today 18 + 8 = 26, after the re-index 18·`heads_per_kv` + 8 —
+   **80 at `heads_per_kv` 4 (+54, 94 → ~148)** and **152 at 8 (+126, 94 → ~220)**.
+   This is a source-level count of declared f32s, not a compiler allocation, but
+   the direction is not in doubt: the architecture where the re-index predicts
+   the largest lift (8×, `kv_h == 1`) is the one with the least room to hold the
+   registers it needs.
+4. **The one store whose ρ clears a lifted ceiling is inert.** `tsym3` (ρ =
+   0.158) is the only spelling that would clear 0.25. It encodes nothing today:
+   in `.rmlx/analysis/kv-disposition-416/inertness_base.csv` it is
+   **byte-identical and token-identical to `none`** at 4 096 and 32 768 tokens on
+   both gemma-4-e2b and Ternary-Bonsai-8B (e.g. Bonsai @32 768: 4 667 277 312 B
+   and ids `eafa8d9dd4d4a507` on both). ρ = 0.158 is a specification, not a
+   store, and it has no symv-family kernel either.
+5. **No codec that does exist turns a lifted ε into a win.** `iso4_sym` at 32 768
+   tokens on Bonsai-8B decodes at **0.170×** of `none` (10.703 vs 62.936 TPS)
+   while holding **1.3% more** resident KV than bf16
+   (`.rmlx/analysis/kv-disposition-416/inertness_fix.csv`). A 4× ceiling lift
+   applied to the whole gap does not reach 1.0 from there, and there is no
+   bandwidth prize to collect at ρ > 1.
+
+**Cross-backend control.** `llama-cpp-turboquant`'s independently written fused
+decode dispatches over the same query-head grid (`ne02` is the query-head count,
+see "Cross-backend calibration" above) and loses 0.653–0.733× against its own
+f16 baseline, worsening with context. The geometry is shared by both
+implementations, so it is not what separates a winning fused decode from a
+losing one.
+
+**The packed-store proposal's motivation survives; its fix targets do not.**
+The byte→time conversion really is where the loss lives — that is the same
+finding, from the other side. But:
+
+* *Fix target 1* was to determine whether the GQA `expand_dims(-3)` broadcast in
+  `crates/rmlx-kv-quant/src/mixed_quant/sdpa.rs` materialises or is re-read per
+  repeat group. It does neither, and there is nothing in rMLX to change: MLX's
+  quantized-matmul batch addressing accumulates `pos_in_dim * stride` per axis
+  (`elem_to_loc_broadcast`, `mlx/backend/metal/kernels/steel/utils.h:7-22`, via
+  `adjust_matrix_offsets` in `quantized.h`), so a stride-0 axis contributes zero
+  and every repeat group resolves to the same base pointer. *This is a reading
+  of the installed MLX kernel headers; MLX's C++ `eval_gpu` is not on this
+  machine to confirm no copy precedes dispatch.* The measurement agrees
+  independently: a "K re-read r times" model needs r = 3.06 to explain `k8v4`
+  and r = 4.15 to explain `k4v4`, i.e. it does not fit.
+* *Fix target 2* is inside MLX's `affine_qmv_*` / `affine_qvm_split_k_*`
+  kernels, not in rMLX code.
+* The **≥ 400 GB/s pass criterion presumes a bandwidth bound the counters
+  contradict**, and would fail work that did everything right — the same defect
+  as the ≤ 4× criterion on the re-index, which is unreachable because the whole
+  query-head class measures 29.9% ± 4.1% of the loss.
+* There are also no users to collect for: the auto default is bf16 on every arch
+  (`DEFAULT_KV_QUANT = KvQuant::None`,
+  `crates/rmlx-models/src/kv_cache/mod.rs:461`), the codec holds 21.9–34.9% more
+  resident KV than `none` across the four cells measured, and the long cell went
+  the other way — Qwen3.8-27B at 130 848 tokens, ABBA n=4, is **23.7% slower**
+  with disjoint ranges where the byte model predicted +14.9% faster
+  (`docs/PERF_BASELINE.md`, "Codec cells across context").
+
+**The one genuinely open cell.** Every counter measurement in this argument is
+of `turbo_flash_p1` (ε = 0.041). The best kernel in the tree,
+`iso_flash_decode_symv_p1` (ε = 0.135, 3.3× better), **has never been
+profiled** — and it is also the one whose P1 does hold the barrier pair and the
+thread-0 softmax section, so its limiter split may differ. The decision rule is
+pre-registered here so the answer cannot be chosen after the fact. Capture it as
+`docs/PROFILING.md` describes (Bonsai-8B, `--kv-quant iso3_sym`, `--skip 32
+--steps 8`, Serial execution / Maximum performance) and read
+`iso_flash_decode_symv_p1`'s Counters tab:
+
+| reading | conclusion |
+|---|---|
+| Last Level Cache Limiter **> 35%** | memory-bound; the grid re-index becomes a live proposal for this kernel family and the question reopens |
+| LLC **< 20%** with Integer and Conditional **> 40%** | same disease as `turbo_flash_p1`; the negative result covers both families and the question is closed on evidence |
+| anything between | inconclusive; state it as such and do not fund on it |
 
 ### Codec disposition — what every codec in the tree is for
 

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -810,6 +810,33 @@ were each run once per (model, context) and recorded through
 (model, offset, codec), so one run per cell is the whole measurement — unlike a
 throughput figure, which is why these are not ABBA-paired.
 
+### Disposition: the packed-store throughput gap is not a funded lever (2026-08-22)
+
+The table above is the measured basis for a proposal to lift the `mixed_*`
+decode path from 227.8 GB/s to ≥ 400 GB/s on its own layers, alongside a
+proposal to re-index the fused flash-decode grid by KV head. **Both are
+answered negative and neither should be scheduled as a throughput lever.** The
+argument, its artifacts and the one cell that stays open are in
+`docs/KV_QUANT.md` § "Lifting ε does not pay — answered negative". In summary,
+against this section's numbers:
+
+* The ≥ 400 GB/s pass criterion presumes a bandwidth bound. GPU counters on the
+  fused path measure the opposite — Integer and Conditional Limiter 50.45%
+  against Last Level Cache 10.66% — so the byte savings have nothing to convert
+  into and the criterion would fail work that did everything right.
+* The 130 848-token row above is the long cell the claim was meant to turn on,
+  and it went the other way: **23.7% slower**, ranges disjoint, where the byte
+  model predicted +14.9% faster.
+* The `mixed_*` GQA broadcast is already consumed as a stride-0 view by MLX's
+  quantized-matmul batch addressing, so the first named fix target has nothing
+  to change; the second is inside MLX's kernels, not rMLX code.
+* The auto default is bf16 on every arch
+  (`DEFAULT_KV_QUANT = KvQuant::None`), so no user reaches this path unless
+  they ask for it by name.
+
+The `none` rows in this section keep their standing as anchors. What is retired
+is the expectation that the packed-store arms in them have collectable headroom.
+
 ## Host-sampler cost — PROVISIONAL, NOT AN ANCHOR (2026-08-16)
 
 First measurement of the sampling / penalty / mask / logprob path, which every

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -407,10 +407,24 @@ using it:
   `make traces-gc` does not cover this directory: it owns `.gputrace` bundles
   only, and its reported total is scoped to those.
 
-Pipeline and function names do **not** survive the export (only encoder,
-command-buffer, buffer and queue labels), and the driver coalesces consecutive
-compute encoders into one GPU kick — so one row can cover several encoders. Pair
-it with the identity list from a capture when you need to know *which* kernel.
+**One row is one encoder.** In the Bonsai-8B bundle above, 14 140 rmlx rows
+carry 13 996 distinct `encoder-id`s, and the same run's
+`metal-application-command-buffer-submissions` table sums **13 997** encoders
+across 14 512 command buffers — 13 592 of which hold exactly one encoder, 826
+hold none, and 94 hold between 2 and 9. So the row is the encoder, the
+`cmdbuffer-id` column groups rows into submissions, and no row is a coalesced
+multi-encoder kick. Every `gpu-channel-name` in both bundles is exactly
+`Compute`, `Fragment` or `Vertex`.
+
+**Names are in the bundle; the join key is not.** The `metal-gpu-intervals`
+export carries no pipeline or function names, but
+`metal-shader-profiler-shader-list` names every pipeline the run compiled — 52
+for `rmlx` in the Bonsai bundle, MLX kernels and any rMLX `.metal` body the run
+dispatched alike. There is no key from one of those names to a timed row,
+because the stock template
+records `Shader Timeline: Disabled` and `metal-shader-profiler-intervals`
+therefore exports zero rows. Until that changes, pair the timeline with the
+identity list from a `.gputrace` capture when you need to know *which* kernel.
 
 #### Reading the timeline
 

--- a/docs/models/bonsai/27B/rMLX.md
+++ b/docs/models/bonsai/27B/rMLX.md
@@ -394,10 +394,14 @@ Ranked by impact:
      rotor, against bf16's 16.0), so there was never a bandwidth prize to
      collect — see "Memory truth" in `docs/KV_QUANT.md`.
    * The kernel shell itself achieves only 4–14 % of MLX `sdpa_vector`'s
-     per-byte throughput, chiefly because its P1 grid is indexed by *query* head
-     and so re-reads the whole KV stream `heads_per_kv` times. Even the densest
-     store in the tree is too fat to clear that bar. The `ρ < ε` arithmetic,
-     the two-architecture measurement and the corollary for `kv_h == 1` are in
+     per-byte throughput. Its P1 grid is indexed by *query* head and so re-reads
+     the whole KV stream `heads_per_kv` times, which caps the shell at
+     `1/heads_per_kv` — but that cap is **not** where the loss is: the fused
+     kernel is issue-bound, not memory-bound, and removing the entire
+     query-head class leaves it 3.2× slower than the generic path. Even the
+     densest store in the tree is too fat to clear the bar either way. The
+     `ρ < ε` arithmetic, the two-architecture measurement, the corollary for
+     `kv_h == 1` and the negative result on lifting ε are in
      `docs/KV_QUANT.md` § "Fused flash-decode over a quant store — the break-even
      condition".
 

--- a/scripts/mst_capture.sh
+++ b/scripts/mst_capture.sh
@@ -31,12 +31,26 @@
 #      table. --time-limit bounds the recording and the newest --keep bundles
 #      are retained; the rest are removed after a successful run.
 #
-# WHAT IT CANNOT GIVE — do not plan around these; they are device ceilings.
-#   No per-dispatch kernel timing (supportsCounterSampling(atDispatchBoundary)
-#   is false), no occupancy / limiter / bandwidth counters (one counter set,
-#   GPUTimestamp), and no pipeline or function names in the export. The driver
-#   also coalesces consecutive compute encoders into one GPU kick, so one row
-#   can cover several encoders.
+# WHAT IT CANNOT GIVE
+#   Device ceiling: no per-dispatch kernel timing
+#   (supportsCounterSampling(atDispatchBoundary) is false) and no occupancy /
+#   limiter / bandwidth counters — a recorded bundle carries exactly one GPU
+#   counter, "RT Unit Active". Those come from the Xcode GPU counter replay
+#   (docs/PROFILING.md), which needs a human.
+#
+#   Configuration, not ceiling: the exported metal-gpu-intervals table has no
+#   pipeline or function names, but the BUNDLE does — metal-shader-profiler-
+#   shader-list names every pipeline the run compiled (52 for rmlx in the
+#   bundles under <RMLX_HOME>/traces/mst). What is missing is a join key from a
+#   name to a timed row: the stock template ships Shader Timeline: Disabled, so
+#   metal-shader-profiler-intervals exports zero rows. Pair with
+#   scripts/gputrace_kernels.sh for identity until that changes.
+#
+#   GRANULARITY IS PER ENCODER, one row each. Measured on the bundles above:
+#   14 140 rmlx rows carry 13 996 distinct encoder-ids, and the same run's
+#   metal-application-command-buffer-submissions table sums 13 997 encoders over
+#   14 512 command buffers — of which 13 592 hold exactly one encoder and only
+#   94 hold more than one. Do not read a row as a coalesced multi-encoder kick.
 #
 # USAGE
 #   bash scripts/mst_capture.sh --model /path/to/snapshot


### PR DESCRIPTION
Refs #340. Refs #405.

**Documentation only.** No kernel change, no bench, no GPU claim. Both proposals are recorded as answered-negative on evidence already in the tree, and the claims that conclusion falsified are corrected in place.

Whether to close the two issues is a call for the maintainer; this PR is what makes that decision reviewable.

## #340 — the mechanism is true, the consequence is not

**True, verified at source:** every P1 kernel indexes `n_bh = b · n_q_heads` and addresses KV as `kv_h_idx = hq / heads_per_kv` (`turbo_flash_p1.metal:17,20,27`; the same shape at `:29-32` in all four iso/rotor P1s). The grid does re-read the KV stream once per query head.

**The 1/heads_per_kv cap does not bind**, for five independent reasons, four already measured:

1. **Perfect execution is still a loss.** The campaign's own headroom ladder (`.rmlx/analysis/kv-campaign/P12/03_headroom_calc.txt`) puts the ON arm at 0.231x of OFF as measured; removing the **entire** query-head class reaches 0.311x — **3.21x slower than the generic path it replaces**. #340 alone is 1.348x on a kernel that is 4.33x behind.
2. **The mechanism is not the limiter.** The counter export in #409 (2026-08-19, this host) has `turbo_flash_p1` integer-issue-bound: Integer & Conditional 50.45%, Instruction Throughput 45.66%, against **LLC 10.66% / L1 3.31%**. Eliminating all memory traffic recovers at most ~14%.
3. **The redesign worsens the real co-limiter.** Carrying `heads_per_kv` query vectors and softmax states per threadgroup is ~+54 f32 at `heads_per_kv` 4 (94 -> ~148 registers) and ~+220 at `head_dim` 256 / `heads_per_kv` 8, against 22.24% occupancy and 0 spilled bytes. The architecture where #340 predicts the largest win is the one that cannot hold the registers. *(derivation from source f32 counts, not a compiler allocation — labelled as such)*
4. **The codec whose rho clears a lifted ceiling does not exist.** `tsym3` (rho 0.158) is **inert** — byte- and token-identical to `none` at 4k and 32k on both architectures (`.rmlx/analysis/kv-disposition-416/inertness_fix.csv`). rho 0.158 is a spec, not a store.
5. **The codecs that do exist cannot be rescued by any epsilon.** `iso4_sym` on Bonsai-8B @32k is 10.703 TPS against `none`'s 62.936 — **0.170x, at 1.34% more resident KV**. It dispatches `iso_flash_decode_symv_sdpa::<4>`, the exact kernel in question.

**Cross-backend control:** llama.cpp's independent fused decode uses the same query-head grid geometry and loses 0.653-0.733x, worsening with context, with the fork-vs-upstream confound measured and null. The geometry is not what separates a winning implementation from a losing one.

## #405 — the motivation is real, the fix targets are not

- **Fix target 1 is already correct.** The GQA broadcast reaches MLX as a stride-0 view: `elem_to_loc_broadcast` (`steel/utils.h:7-22`) accumulates `pos_in_dim * strides[i]`, so a stride-0 axis contributes 0 and every repeat group resolves to one base pointer. *One half is not readable here* — whether `QuantizedMatmul::eval_gpu` copies a non-contiguous input before dispatch cannot be checked from a headers-only Homebrew install. Stated inline as a gap.
- **Fix target 2 is upstream MLX**, not rMLX code. The only in-tree alternative is a fused MSL kernel for `Mixed` — the class this campaign measured as losing.
- **The pass criterion is likely the wrong axis.** ">= 400 GB/s, 65% of ceiling" presumes a bandwidth bound the analogous counter export contradicts.
- **The codec has no default users** (`DEFAULT_KV_QUANT = KvQuant::None`) and costs **21.9-34.9%** more memory across the four measured cells.
- **The long cell went the other way**: Qwen3.8-27B @130 848 tokens, ABBA n=4 — **-27.2% with disjoint ranges**, where the byte model predicted +14.9%.

## Four claim classes corrected, in place

- **The epsilon residual attribution.** `docs/KV_QUANT.md` credited "the f32 `partial_o` P1->P2 round trip plus the thread-0-serial softmax between threadgroup barriers". False for turbo_flash: its P1 has **zero** `threadgroup_barrier` and no thread-0 section (softmax is a per-lane `simd_sum`), and P2 is 3.66% of GPU time. The sweep also showed the doc named a buffer that kernel does not have — it has `partial_out`/`partial_ms`. The claim *is* structurally plausible for the iso/rotor P1s, which do carry both inside the per-token loop — and those are unprofiled, so it is now stated as unproven rather than asserted.
- **The encoder-coalescing claim**, at four sites (`scripts/mst_capture.sh`, `docs/PROFILING.md`, and two in `crates/rmlx-mlx/src/xctrace*`). Unsupported: `num-encoders` across 14 512 rmlx command buffers is 0->826 / 1->13 592 / 2-9->94, summing to 13 997 against 13 996 distinct encoder-ids. One row is one encoder.
- **"No pipeline or function names in the export"** — narrowed. The bundle names 52 rmlx pipelines in `metal-shader-profiler-shader-list`; what is missing is a **join key** to any timed row, because the stock template ships `Shader Timeline: Disabled` so `metal-shader-profiler-intervals` has 0 rows.
- **A restatement in `docs/models/bonsai/27B/rMLX.md`**, found by grepping the cited symbol `heads_per_kv` rather than the wording — the rule that directory has defeated twice in this campaign.

## The one genuinely open cell

Every counter measurement to date is of `turbo_flash_p1` (epsilon 0.041). **The best kernel, `iso_flash_decode_symv_p1` (epsilon 0.135, 3.3x better), has never been profiled** — and unlike turbo_flash it does carry per-token barriers and a thread-0 section.

Recorded with a pre-registered decision rule so the next person does not re-litigate it: **LLC limiter > 35%** => memory-bound, #340 reopens for that kernel; **LLC < 20% with Integer & Conditional > 40%** => same disease as turbo_flash, closed on evidence; between => inconclusive, fund nothing. Not run — and the verdict does not depend on it, since the headroom ladder is an upper bound that already fails.

Full argument, with per-claim evidence classes and a falsified-claims table, at `.rmlx/kv-fused-decode-eps-scoping.md` (gitignored).

`make ci` composite **0**; `cargo +1.98.0 clippy --workspace --all-targets --all-features -- -D warnings` **0**.
