### PR TITLE
fix(kv): stride over the whole bf16 V mirror instead of slicing it, in all three flash-decode dispatchers

### DIFF
--- a/crates/rmlx-kv-quant/src/flash_decode_common.rs
+++ b/crates/rmlx-kv-quant/src/flash_decode_common.rs
@@ -86,12 +86,40 @@
 use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{pad, Array, Device, Dtype};
 
-/// Flatten a bf16 / f16 / f32 V mirror for a flash-decode kernel, and report
-/// the stride the kernel must index its sequence axis with.
+/// A bf16 / f16 / f32 V accumulator, paired with the number of sequence
+/// positions in it that hold real data.
 ///
-/// `v` is `[b, kv_h, v_seq, head_dim]` with `v_seq >= kv_seq`: the caller hands
-/// over the **whole** mirror allocation, not a `..kv_seq` slice of it, and
-/// `kv_seq` stays the attended length. Only the stride changes.
+/// The two travel together because the buffer alone cannot carry the second
+/// half. A flash-decode kernel indexes the mirror at its **allocation** stride
+/// while attending only its valid prefix, so a caller that hands over the
+/// buffer without saying how much of it is live has silently asked the kernel
+/// to read whatever the tail happens to hold — zeros, or a previous, longer
+/// sequence's V. Carrying `valid` makes that a checked error instead
+/// ([`flatten_v_mirror`]).
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct VMirror<'a> {
+    /// The whole `[b, kv_h, v_seq, head_dim]` allocation.
+    pub buf: &'a Array,
+    /// Sequence positions of `buf` that hold appended data, `<= v_seq`.
+    pub valid: i32,
+}
+
+impl<'a> VMirror<'a> {
+    /// Pair a mirror allocation with the number of positions in it that hold
+    /// appended data.
+    #[must_use]
+    pub const fn new(buf: &'a Array, valid: i32) -> Self {
+        Self { buf, valid }
+    }
+}
+
+/// Flatten a V mirror for a flash-decode kernel, and report the stride the
+/// kernel must index its sequence axis with.
+///
+/// `v.buf` is `[b, kv_h, v_seq, head_dim]`: the caller hands over the **whole**
+/// allocation, not a `..kv_seq` slice of it, and `kv_seq` stays the attended
+/// length. Only the stride changes.
 ///
 /// That distinction is the point of this helper. The mirror is head-major, so
 /// cutting a `..kv_seq` prefix out of it leaves a gap between heads: the view is
@@ -100,15 +128,29 @@ use rmlx_mlx::{pad, Array, Device, Dtype};
 /// `contiguous()` call at the site to make it visible. Flattening the
 /// allocation itself copies nothing at any `kv_h`.
 ///
+/// # The `valid == kv_seq` check is load-bearing
+///
+/// It is not a redundant assertion. Attending a `..kv_seq` cut used to enforce
+/// this implicitly: the flatten was to `b * kv_h * kv_seq * head_dim` elements
+/// and MLX's `reshape` rejects an element-count mismatch, so a V shorter than
+/// the attended length could not reach the kernel. Striding over the allocation
+/// removes that coupling — the element count now matches whatever was passed —
+/// so the check has to be made explicitly, and in every profile: the two
+/// lengths come from independent producers (the packed K store's accumulated
+/// sequence against the mirror's own append accounting), and they have gone out
+/// of step before. A `debug_assert` would not do, being compiled out of
+/// `release-perf`; the failure mode it would miss is plausible-but-wrong output
+/// with no error.
+///
 /// # Errors
 ///
-/// [`Error::Quant`] when `v` is not rank 4, when its `b` / `kv_h` / `head_dim`
-/// axes disagree with the passed shape metadata, when its sequence axis is
-/// shorter than `kv_seq` (the kernel would read past the buffer), when the flat
-/// element count overflows `i32`, or for a non-float dtype. Forwards `reshape`
-/// errors otherwise.
+/// [`Error::Quant`] when `v.buf` is not rank 4, when its `b` / `kv_h` /
+/// `head_dim` axes disagree with the passed shape metadata, when `v.valid`
+/// differs from `kv_seq` or exceeds the allocation, when the flat element count
+/// overflows `i32`, or for a non-float dtype. Forwards `reshape` errors
+/// otherwise.
 pub(crate) fn flatten_v_mirror(
-    v: &Array,
+    v: VMirror<'_>,
     kernel: &str,
     b: i32,
     kv_h: i32,
@@ -116,7 +158,7 @@ pub(crate) fn flatten_v_mirror(
     head_dim: i32,
     device: Device,
 ) -> Result<(Array, i32)> {
-    let shape = v.shape();
+    let shape = v.buf.shape();
     let [v_b, v_kv_h, v_seq, v_head_dim] = shape[..] else {
         return Err(Error::Quant(format!(
             "{kernel}: V rank != 4, got {shape:?}"
@@ -127,12 +169,21 @@ pub(crate) fn flatten_v_mirror(
             "{kernel}: V shape {shape:?} disagrees with b={b}, kv_h={kv_h}, head_dim={head_dim}"
         )));
     }
-    if v_seq < kv_seq {
+    if v.valid != kv_seq {
         return Err(Error::Quant(format!(
-            "{kernel}: V sequence extent {v_seq} is shorter than the attended kv_seq={kv_seq}"
+            "{kernel}: the V mirror holds {} valid positions but {kv_seq} are being attended — \
+             the store and the mirror are out of step, and the kernel would read the mirror's \
+             tail as if it were V",
+            v.valid
         )));
     }
-    match v.dtype() {
+    if v.valid > v_seq {
+        return Err(Error::Quant(format!(
+            "{kernel}: the V mirror claims {} valid positions in an allocation of {v_seq}",
+            v.valid
+        )));
+    }
+    match v.buf.dtype() {
         Dtype::F32 | Dtype::Bf16 | Dtype::F16 => {}
         other @ (Dtype::U8 | Dtype::U32 | Dtype::I32) => {
             return Err(Error::Quant(format!(
@@ -146,7 +197,7 @@ pub(crate) fn flatten_v_mirror(
             "{kernel}: V element count {total} overflows i32 at v_seq={v_seq}"
         ))
     })?;
-    Ok((v.reshape(&[total], device)?, v_seq))
+    Ok((v.buf.reshape(&[total], device)?, v_seq))
 }
 
 /// Minimum per-token `norms` element count (`b * kv_h * kv_seq`) a symmetric

--- a/crates/rmlx-kv-quant/src/flash_decode_common.rs
+++ b/crates/rmlx-kv-quant/src/flash_decode_common.rs
@@ -1,5 +1,9 @@
-//! Shared scaffold for the symmetric (quant-K + quant-V) flash-decode MSL
-//! dispatchers — [`crate::iso_flash_decode_symv_msl`] and
+//! Shared scaffold for the flash-decode MSL dispatchers.
+//!
+//! # The `norms` device-address-space floor
+//!
+//! Scoped to the symmetric (quant-K + quant-V) dispatchers —
+//! [`crate::iso_flash_decode_symv_msl`] and
 //! [`crate::rotor_flash_decode_symv_msl`].
 //!
 //! Both bind a per-token `norms` array as a kernel input. On the MLX build this
@@ -80,7 +84,70 @@
 //! `// eval-ok: <reason>` marker.
 
 use rmlx_core::error::{Error, Result};
-use rmlx_mlx::{pad, Array, Device};
+use rmlx_mlx::{pad, Array, Device, Dtype};
+
+/// Flatten a bf16 / f16 / f32 V mirror for a flash-decode kernel, and report
+/// the stride the kernel must index its sequence axis with.
+///
+/// `v` is `[b, kv_h, v_seq, head_dim]` with `v_seq >= kv_seq`: the caller hands
+/// over the **whole** mirror allocation, not a `..kv_seq` slice of it, and
+/// `kv_seq` stays the attended length. Only the stride changes.
+///
+/// That distinction is the point of this helper. The mirror is head-major, so
+/// cutting a `..kv_seq` prefix out of it leaves a gap between heads: the view is
+/// row-contiguous only when `b * kv_h == 1`, and flattening it anywhere else
+/// materialises the whole prefix — once per layer per decode step, with no
+/// `contiguous()` call at the site to make it visible. Flattening the
+/// allocation itself copies nothing at any `kv_h`.
+///
+/// # Errors
+///
+/// [`Error::Quant`] when `v` is not rank 4, when its `b` / `kv_h` / `head_dim`
+/// axes disagree with the passed shape metadata, when its sequence axis is
+/// shorter than `kv_seq` (the kernel would read past the buffer), when the flat
+/// element count overflows `i32`, or for a non-float dtype. Forwards `reshape`
+/// errors otherwise.
+pub(crate) fn flatten_v_mirror(
+    v: &Array,
+    kernel: &str,
+    b: i32,
+    kv_h: i32,
+    kv_seq: i32,
+    head_dim: i32,
+    device: Device,
+) -> Result<(Array, i32)> {
+    let shape = v.shape();
+    let [v_b, v_kv_h, v_seq, v_head_dim] = shape[..] else {
+        return Err(Error::Quant(format!(
+            "{kernel}: V rank != 4, got {shape:?}"
+        )));
+    };
+    if v_b != b || v_kv_h != kv_h || v_head_dim != head_dim {
+        return Err(Error::Quant(format!(
+            "{kernel}: V shape {shape:?} disagrees with b={b}, kv_h={kv_h}, head_dim={head_dim}"
+        )));
+    }
+    if v_seq < kv_seq {
+        return Err(Error::Quant(format!(
+            "{kernel}: V sequence extent {v_seq} is shorter than the attended kv_seq={kv_seq}"
+        )));
+    }
+    match v.dtype() {
+        Dtype::F32 | Dtype::Bf16 | Dtype::F16 => {}
+        other @ (Dtype::U8 | Dtype::U32 | Dtype::I32) => {
+            return Err(Error::Quant(format!(
+                "{kernel}: V dtype must be F32 / Bf16 / F16, got {other:?}"
+            )))
+        }
+    }
+    let total: i64 = i64::from(b) * i64::from(kv_h) * i64::from(v_seq) * i64::from(head_dim);
+    let total = i32::try_from(total).map_err(|_| {
+        Error::Quant(format!(
+            "{kernel}: V element count {total} overflows i32 at v_seq={v_seq}"
+        ))
+    })?;
+    Ok((v.reshape(&[total], device)?, v_seq))
+}
 
 /// Minimum per-token `norms` element count (`b * kv_h * kv_seq`) a symmetric
 /// flash-decode kernel (iso or rotor) is dispatched with. See the module doc

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
@@ -121,7 +121,7 @@ use rmlx_core::error::{Error, Result};
 use rmlx_mlx::metal_kernel::{MetalKernel, MetalKernelInvoke};
 use rmlx_mlx::{Array, Device, Dtype};
 
-use crate::flash_decode_common::flatten_v_mirror;
+use crate::flash_decode_common::{flatten_v_mirror, VMirror};
 use crate::isoquant::FIXED_QUAT;
 use crate::storage::{iso_n_groups_for, ISO_QUAT_BLOCK_SIZE};
 use crate::turboquant::lloyd_gaussian_codebook;
@@ -472,11 +472,11 @@ fn p2_kernel() -> Result<&'static MetalKernel> {
 ///   reinterpreted.
 /// * `k_norms`   — per-token L2 norms, flat `[B * kv_seq * kv_h]`, same dtype
 ///   handling as `k_scales`.
-/// * `v`         — bf16 / f16 / f32 V, shape `[B, kv_h, v_seq, head_dim]` with
-///   `v_seq >= kv_seq`: pass the whole mirror allocation rather than a
-///   `..kv_seq` slice of it, and the kernel strides over it (see
-///   [`flatten_v_mirror`]). Read in its native dtype; the dispatcher does NOT
-///   astype-upcast.
+/// * `v`         — the bf16 / f16 / f32 V mirror, `[B, kv_h, v_seq, head_dim]`,
+///   passed whole rather than as a `..kv_seq` slice, with the number of valid
+///   positions in it. The kernel strides over the allocation and
+///   [`flatten_v_mirror`] checks `valid == kv_seq`. Read in its native dtype;
+///   the dispatcher does NOT astype-upcast.
 /// * `additive_mask` — optional `f32 [B, n_q_heads, 1, kv_seq]`.
 /// * `b`, `kv_h`, `kv_seq`, `head_dim`, `heads_per_kv` — shape metadata.
 /// * `scale`     — softmax pre-scale (typically `1/sqrt(head_dim)`).
@@ -499,7 +499,7 @@ pub fn iso_flash_decode_sdpa<const BITS: u8>(
     k_codes: &Array,
     k_scales: &Array,
     k_norms: &Array,
-    v: &Array,
+    v: VMirror<'_>,
     additive_mask: Option<&Array>,
     b: i32,
     kv_h: i32,

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl.rs
@@ -121,6 +121,7 @@ use rmlx_core::error::{Error, Result};
 use rmlx_mlx::metal_kernel::{MetalKernel, MetalKernelInvoke};
 use rmlx_mlx::{Array, Device, Dtype};
 
+use crate::flash_decode_common::flatten_v_mirror;
 use crate::isoquant::FIXED_QUAT;
 use crate::storage::{iso_n_groups_for, ISO_QUAT_BLOCK_SIZE};
 use crate::turboquant::lloyd_gaussian_codebook;
@@ -372,11 +373,12 @@ pub fn assert_fixed_quat_blocks(quaternions: &[f32], what: &str) -> Result<()> {
 // 1. codes     : u32  [B * kv_seq * kv_h * n_groups]
 // 2. scales    : f32  [B * kv_seq * kv_h * n_groups]
 // 3. norms     : f32  [B * kv_seq * kv_h]
-// 4. v_flat    : bf16 / f16 / f32 [B * kv_h * kv_seq * head_dim] (native dtype)
+// 4. v_flat    : bf16 / f16 / f32 [B * kv_h * v_seq_stride * head_dim]
+//               (native dtype; `v_seq_stride >= kv_seq`)
 // 5. mask_flat : f32  [B * n_q_heads * kv_seq] or [1] dummy when no mask
 // 6. scale_arr : f32  [1]
-// 7. dims      : u32  [8] — {head_dim, kv_seq, n_bh, kv_h, heads_per_kv,
-//                            n_tiles, has_mask, n_groups}
+// 7. dims      : u32  [9] — {head_dim, kv_seq, n_bh, kv_h, heads_per_kv,
+//                            n_tiles, has_mask, n_groups, v_seq_stride}
 //
 // P1 outputs:
 // 0. partial_o     : f32 [n_tiles * n_bh * head_dim]
@@ -470,8 +472,11 @@ fn p2_kernel() -> Result<&'static MetalKernel> {
 ///   reinterpreted.
 /// * `k_norms`   — per-token L2 norms, flat `[B * kv_seq * kv_h]`, same dtype
 ///   handling as `k_scales`.
-/// * `v`         — bf16 / f16 / f32 V, shape `[B, kv_h, kv_seq, head_dim]`.
-///   Read in its native dtype; the dispatcher does NOT astype-upcast.
+/// * `v`         — bf16 / f16 / f32 V, shape `[B, kv_h, v_seq, head_dim]` with
+///   `v_seq >= kv_seq`: pass the whole mirror allocation rather than a
+///   `..kv_seq` slice of it, and the kernel strides over it (see
+///   [`flatten_v_mirror`]). Read in its native dtype; the dispatcher does NOT
+///   astype-upcast.
 /// * `additive_mask` — optional `f32 [B, n_q_heads, 1, kv_seq]`.
 /// * `b`, `kv_h`, `kv_seq`, `head_dim`, `heads_per_kv` — shape metadata.
 /// * `scale`     — softmax pre-scale (typically `1/sqrt(head_dim)`).
@@ -573,16 +578,8 @@ pub fn iso_flash_decode_sdpa<const BITS: u8>(
     let norms_flat = to_sideband_dtype(&k_norms.reshape(&[tok_count as i32], device)?, device)?;
 
     // ── V flat — keep native dtype (bf16 / f16 / f32) ─────────────────────
-    let v_total: i64 = tok_count * i64::from(head_dim);
-    let v_flat = match v.dtype() {
-        Dtype::F32 | Dtype::Bf16 | Dtype::F16 => v.reshape(&[v_total as i32], device)?,
-        Dtype::U8 | Dtype::U32 | Dtype::I32 => {
-            let dt = v.dtype();
-            return Err(Error::Quant(format!(
-                "iso_flash_decode: V dtype must be F32 / Bf16 / F16, got {dt:?}"
-            )));
-        }
-    };
+    let (v_flat, v_seq_stride) =
+        flatten_v_mirror(v, "iso_flash_decode", b, kv_h, kv_seq, head_dim, device)?;
 
     // ── Mask ──────────────────────────────────────────────────────────────
     let (mask_flat, has_mask) = if let Some(m) = additive_mask {
@@ -607,11 +604,11 @@ pub fn iso_flash_decode_sdpa<const BITS: u8>(
         Array::from_bytes(&bytes, &[1], Dtype::F32)?
     };
 
-    // ── dims (8 u32) ──────────────────────────────────────────────────────
+    // ── dims (9 u32) ──────────────────────────────────────────────────────
     // `bits` is not carried — the dispatcher selects the per-BITS kernel and
     // its header supplies IF_BITS / IF_MASK.
     let dims_arr = {
-        let dims: [u32; 8] = [
+        let dims: [u32; 9] = [
             head_dim as u32,
             kv_seq as u32,
             n_bh as u32,
@@ -620,15 +617,16 @@ pub fn iso_flash_decode_sdpa<const BITS: u8>(
             n_tiles as u32,
             has_mask,
             n_groups as u32,
+            v_seq_stride as u32,
         ];
         // SAFETY:
-        // * `dims` is a stack-local `[u32; 8]` fully initialised above.
+        // * `dims` is a stack-local `[u32; 9]` fully initialised above.
         // * `u32` has stricter alignment than `u8`, so the cast is sound.
-        // * The byte length `8 * 4` equals `size_of::<[u32; 8]>()`.
+        // * The byte length `9 * 4` equals `size_of::<[u32; 9]>()`.
         // * The borrow is bounded by the enclosing block; `Array::from_bytes`
         //   copies into mlx storage before this scope ends.
-        let bytes: &[u8] = unsafe { std::slice::from_raw_parts(dims.as_ptr().cast::<u8>(), 8 * 4) };
-        Array::from_bytes(bytes, &[8], Dtype::U32)
+        let bytes: &[u8] = unsafe { std::slice::from_raw_parts(dims.as_ptr().cast::<u8>(), 9 * 4) };
+        Array::from_bytes(bytes, &[9], Dtype::U32)
             .map_err(|e| Error::Mlx(format!("iso_flash_decode dims: {e}")))?
     };
 

--- a/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/iso_flash_decode_msl_tests.rs
@@ -7,6 +7,7 @@
 //! replaces — not merely that it is self-consistent.
 
 use super::*;
+use crate::flash_decode_common::VMirror;
 use crate::isoquant::{iso_decode_fast, iso_encode_fast};
 use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
 use rmlx_mlx::{Array, Device, Dtype};
@@ -205,7 +206,7 @@ fn run_oracle_masked(
             &codes,
             &scales,
             &norms,
-            &v_arr,
+            VMirror::new(&v_arr, kv_seq as i32),
             mask_arr.as_ref(),
             b as i32,
             kv_h as i32,
@@ -220,7 +221,7 @@ fn run_oracle_masked(
             &codes,
             &scales,
             &norms,
-            &v_arr,
+            VMirror::new(&v_arr, kv_seq as i32),
             mask_arr.as_ref(),
             b as i32,
             kv_h as i32,
@@ -304,7 +305,7 @@ fn bench_iso(
                 &codes,
                 &scales,
                 &norms,
-                &v_arr,
+                VMirror::new(&v_arr, kv_seq as i32),
                 None,
                 b as i32,
                 kv_h as i32,
@@ -319,7 +320,7 @@ fn bench_iso(
                 &codes,
                 &scales,
                 &norms,
-                &v_arr,
+                VMirror::new(&v_arr, kv_seq as i32),
                 None,
                 b as i32,
                 kv_h as i32,
@@ -554,7 +555,7 @@ fn iso_decode_with_transposed_mask(bits: u8, mask_bf16: bool, prep: MaskPrep) ->
             &codes,
             &scales,
             &norms,
-            &v_arr,
+            VMirror::new(&v_arr, kv_seq as i32),
             Some(&mask),
             b as i32,
             kv_h as i32,
@@ -569,7 +570,7 @@ fn iso_decode_with_transposed_mask(bits: u8, mask_bf16: bool, prep: MaskPrep) ->
             &codes,
             &scales,
             &norms,
-            &v_arr,
+            VMirror::new(&v_arr, kv_seq as i32),
             Some(&mask),
             b as i32,
             kv_h as i32,
@@ -694,7 +695,7 @@ fn iso_flash_decode_rejects_non_pow2_head_dim() {
         &codes,
         &dummy,
         &dummy,
-        &dummy,
+        VMirror::new(&dummy, 8),
         None,
         1,
         1,
@@ -719,7 +720,7 @@ fn iso_flash_decode_rejects_head_dim_above_max() {
         &codes,
         &dummy,
         &dummy,
-        &dummy,
+        VMirror::new(&dummy, 8),
         None,
         1,
         1,
@@ -746,7 +747,7 @@ fn iso_flash_decode_rejects_unsupported_bits() {
         &codes,
         &dummy,
         &dummy,
-        &dummy,
+        VMirror::new(&dummy, 8),
         None,
         1,
         1,

--- a/crates/rmlx-kv-quant/src/kvcache/helpers.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/helpers.rs
@@ -1,7 +1,7 @@
 //! Free helper functions, test-only probes, and unit tests for `KvCache`.
 #![allow(clippy::too_many_lines)]
 
-use rmlx_core::error::Result;
+use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{Array, Device, Dtype};
 
 use super::KvCache;
@@ -209,6 +209,32 @@ pub(super) fn array_to_f32_vec(a: &Array, device: Device) -> Result<Vec<f32>> {
             .map(|c| f32::from_le_bytes(c.try_into().unwrap())),
     );
     Ok(out)
+}
+
+/// Cut the first `seq_len` sequence positions out of a rank-4 bf16 V mirror
+/// `[b, kv_h, v_seq, head_dim]`.
+///
+/// For consumers that need an exactly-sized tensor. The flash-decode kernels do
+/// not: the mirror is head-major, so this view is row-contiguous only when
+/// `b * kv_h == 1` and flattening it anywhere else copies the whole prefix.
+/// Those dispatchers take the mirror whole and stride over it instead — see
+/// `crate::flash_decode_common::flatten_v_mirror`.
+pub(super) fn slice_v_prefix(v: &Array, seq_len: i32, device: Device) -> Result<Array> {
+    let shape = v.shape();
+    let [b, kv_h, v_seq, head_dim] = shape[..] else {
+        return Err(Error::Mlx(format!("V mirror rank != 4, got {shape:?}")));
+    };
+    if seq_len < 0 || seq_len > v_seq {
+        return Err(Error::Mlx(format!(
+            "V mirror prefix {seq_len} out of range for sequence extent {v_seq}"
+        )));
+    }
+    v.slice(
+        &[0_i32; 4],
+        &[b, kv_h, seq_len, head_dim],
+        &[1_i32; 4],
+        device,
+    )
 }
 
 pub(super) fn f32_vec_to_array(data: &[f32], shape: &[i32]) -> Result<Array> {

--- a/crates/rmlx-kv-quant/src/kvcache/helpers.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/helpers.rs
@@ -219,13 +219,18 @@ pub(super) fn array_to_f32_vec(a: &Array, device: Device) -> Result<Vec<f32>> {
 /// `b * kv_h == 1` and flattening it anywhere else copies the whole prefix.
 /// Those dispatchers take the mirror whole and stride over it instead — see
 /// `crate::flash_decode_common::flatten_v_mirror`.
+///
+/// # Errors
+///
+/// [`Error::Quant`] for a non-rank-4 `v` or an out-of-range `seq_len` — the
+/// same shape-contract kind `flatten_v_mirror` raises for the same faults.
 pub(super) fn slice_v_prefix(v: &Array, seq_len: i32, device: Device) -> Result<Array> {
     let shape = v.shape();
     let [b, kv_h, v_seq, head_dim] = shape[..] else {
-        return Err(Error::Mlx(format!("V mirror rank != 4, got {shape:?}")));
+        return Err(Error::Quant(format!("V mirror rank != 4, got {shape:?}")));
     };
     if seq_len < 0 || seq_len > v_seq {
-        return Err(Error::Mlx(format!(
+        return Err(Error::Quant(format!(
             "V mirror prefix {seq_len} out of range for sequence extent {v_seq}"
         )));
     }

--- a/crates/rmlx-kv-quant/src/kvcache/mod.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/mod.rs
@@ -115,6 +115,12 @@ mod rotor_flash_dispatch_tests;
 #[path = "iso_flash_dispatch_tests.rs"]
 mod iso_flash_dispatch_tests;
 
+// A flash-decode step strides over the bf16 V mirror instead of copying its
+// `..kv_seq` prefix.
+#[cfg(test)]
+#[path = "v_mirror_alloc_tests.rs"]
+mod v_mirror_alloc_tests;
+
 // The rotor K-only `update()` decode path gates its GPU encode on the store's
 // sticky QJL flag, not the process-global env.
 #[cfg(test)]

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -22,7 +22,7 @@ use crate::rotor_flash_decode_symv_msl::{
 };
 use crate::storage::{KvStorage, ISO_QUAT_BLOCK_SIZE};
 
-use super::helpers::{f32_vec_to_array, storage_variant_name};
+use super::helpers::{f32_vec_to_array, slice_v_prefix, storage_variant_name};
 use super::shared_kv::SharedKv;
 use super::KvCache;
 
@@ -962,10 +962,10 @@ impl KvCache {
             KvStorage::RotorKOnly3 { .. } | KvStorage::RotorKOnly4 { .. } => {
                 let kv_seq = rotor_k_accumulated_seq(&self.storage)?;
                 Self::check_shared_kv_len(kv_len, kv_seq)?;
-                let v_full = self.slice_decode_fp16_v(kv_seq, device)?;
+                let v_mirror = self.decode_fp16_v_mirror(kv_seq)?;
                 self.rotor_k_flash_over_store(
                     queries,
-                    &v_full,
+                    v_mirror,
                     scale,
                     additive_mask,
                     kv_seq,
@@ -975,8 +975,8 @@ impl KvCache {
             KvStorage::IsoKOnly3 { .. } | KvStorage::IsoKOnly4 { .. } => {
                 let kv_seq = iso_k_accumulated_seq(&self.storage)?;
                 Self::check_shared_kv_len(kv_len, kv_seq)?;
-                let v_full = self.slice_decode_fp16_v(kv_seq, device)?;
-                self.iso_k_flash_over_store(queries, &v_full, scale, additive_mask, kv_seq, device)
+                let v_mirror = self.decode_fp16_v_mirror(kv_seq)?;
+                self.iso_k_flash_over_store(queries, v_mirror, scale, additive_mask, kv_seq, device)
             }
             // Both axes come from the quant store — no `slice_decode_fp16_v`,
             // because this codec keeps no bf16 V to slice.
@@ -993,10 +993,10 @@ impl KvCache {
             KvStorage::PlanarK { .. } => {
                 let kv_seq = planar_k_accumulated_seq(&self.storage)?;
                 Self::check_shared_kv_len(kv_len, kv_seq)?;
-                let v_full = self.slice_decode_fp16_v(kv_seq, device)?;
+                let v_mirror = self.decode_fp16_v_mirror(kv_seq)?;
                 self.planar_k_flash_over_store(
                     queries,
-                    &v_full,
+                    v_mirror,
                     scale,
                     additive_mask,
                     kv_seq,
@@ -1190,15 +1190,17 @@ impl KvCache {
         }
     }
 
-    /// Read-only slice of the bf16 V accumulator to `kv_seq` positions.
+    /// The whole bf16 V accumulator, checked to cover `kv_seq` positions.
     ///
-    /// Matches what `update_decode_fp16_v_only` returns to the producer on the
-    /// same step, so producer and consumer attend the identical V window.
+    /// The read-only consumer counterpart of
+    /// `update_decode_fp16_v_slab`: the flash-decode kernels stride over the
+    /// mirror rather than take a `..kv_seq` cut of it, so producer and consumer
+    /// hand them the identical buffer and attend the identical window.
     #[allow(
         clippy::indexing_slicing,
         reason = "bounds established by the rank-4 check immediately above"
     )]
-    fn slice_decode_fp16_v(&self, kv_seq: i32, device: Device) -> Result<Array> {
+    fn decode_fp16_v_mirror(&self, kv_seq: i32) -> Result<&Array> {
         let v_buf = self.decode_fp16_v.as_ref().ok_or_else(|| {
             Error::Mlx(
                 "decode_fp16_v missing on a store-backed share — the fused arms maintain it on \
@@ -1218,12 +1220,13 @@ impl KvCache {
                 v_shape[2]
             )));
         }
-        v_buf.slice(
-            &[0_i32; 4],
-            &[v_shape[0], v_shape[1], kv_seq, v_shape[3]],
-            &[1_i32; 4],
-            device,
-        )
+        Ok(v_buf)
+    }
+
+    /// Read-only slice of the bf16 V accumulator to `kv_seq` positions, for
+    /// consumers that need an exactly-sized tensor.
+    fn slice_decode_fp16_v(&self, kv_seq: i32, device: Device) -> Result<Array> {
+        slice_v_prefix(self.decode_fp16_v_mirror(kv_seq)?, kv_seq, device)
     }
 
     /// Slice the bf16 K/V mirror to the current `self.offset` so a
@@ -1417,15 +1420,26 @@ impl KvCache {
         // shadow, and allocating it via the full `update_decode_fp16` would
         // waste an O(seq) bf16 K buffer every decode step.  Mirrors the
         // pattern from `update_iso_k_only_3`/`_4`.
-        let v_full = self.update_decode_fp16_v_only(new_v, max_seq, device)?;
+        let (v_mirror, v_valid) = self.update_decode_fp16_v_slab(new_v, max_seq, device)?;
+        debug_assert_eq!(
+            kv_seq, v_valid,
+            "planar_k_fused: store seq {kv_seq} != the bf16 V mirror's valid length {v_valid} — \
+             the store append and the attended V window disagree"
+        );
 
         // Past this point the cache is already mutated (store appended, offset
         // advanced, bf16 V accumulated), so `Ok(None)` is no longer available —
         // it would send the caller into the legacy `update()` path, which
         // appends a second time. Every not-eligible condition is screened
         // above.
-        let out =
-            self.planar_k_flash_over_store(queries, &v_full, scale, additive_mask, kv_seq, device)?;
+        let out = self.planar_k_flash_over_store(
+            queries,
+            &v_mirror,
+            scale,
+            additive_mask,
+            kv_seq,
+            device,
+        )?;
         Ok(Some(out))
     }
 
@@ -1437,9 +1451,9 @@ impl KvCache {
     /// same kernels the producer used, instead of the producer having to
     /// materialise bf16 K/V for it.
     ///
-    /// `kv_seq` is the accumulated store length and `v_full` the matching bf16
-    /// V prefix; both come from the caller so producer and consumer read the
-    /// identical window.
+    /// `kv_seq` is the accumulated store length and `v_mirror` the whole bf16 V
+    /// accumulator (sequence extent `>= kv_seq`); both come from the caller so
+    /// producer and consumer read the identical window.
     #[allow(clippy::too_many_arguments)]
     #[allow(
         clippy::indexing_slicing,
@@ -1448,7 +1462,7 @@ impl KvCache {
     fn planar_k_flash_over_store(
         &self,
         queries: &Array,
-        v_full: &Array,
+        v_mirror: &Array,
         scale: f32,
         additive_mask: Option<&Array>,
         kv_seq: i32,
@@ -1527,7 +1541,7 @@ impl KvCache {
                 &codes_arr,
                 &scales_arr,
                 &rot32_arr,
-                v_full,
+                v_mirror,
                 additive_mask,
                 b,
                 kv_h,
@@ -1569,9 +1583,12 @@ impl KvCache {
         // SV path: probs `[B, n_q_heads, 1, kv_seq]` × V `[B, kv_h, kv_seq, head_dim]`.
         // GQA broadcast: reshape probs to `[B, kv_h, heads_per_kv, 1, kv_seq]`
         // and V to `[B, kv_h, 1, kv_seq, head_dim]`, then matmul along the
-        // last two dims (the kv_seq contraction), then reshape back.
+        // last two dims (the kv_seq contraction), then reshape back. Unlike the
+        // flash kernel above, this arm cannot stride over the mirror, so it
+        // takes the `..kv_seq` cut and pays for making it contiguous.
         let probs_g = probs.reshape(&[b, kv_h, heads_per_kv, 1, kv_seq], device)?;
-        let v_g = v_full.reshape(&[b, kv_h, 1, kv_seq, head_dim], device)?;
+        let v_att = slice_v_prefix(v_mirror, kv_seq, device)?;
+        let v_g = v_att.reshape(&[b, kv_h, 1, kv_seq, head_dim], device)?;
         let out_g = matmul(&probs_g, &v_g, device)?;
         let out = out_g.reshape(&[b, n_q_heads, 1, head_dim], device)?;
         // Match the legacy SDPA output dtype (bf16/f16 callers); softmax may
@@ -1658,7 +1675,7 @@ impl KvCache {
         // appending. Same ordering as `update_and_sdpa_planar_k_fused`.
         self.offset = prev_seq + new_seq;
         let max_seq = rotor_k_max_seq(&self.storage)?;
-        let v_full = self.update_decode_fp16_v_only(new_v, max_seq, device)?;
+        let (v_mirror, v_valid) = self.update_decode_fp16_v_slab(new_v, max_seq, device)?;
 
         // Take `kv_seq` from the store the ring was written from, not from
         // `self.offset` — one source of truth. They must agree; a divergence
@@ -1666,10 +1683,9 @@ impl KvCache {
         // Same precedent as `update_and_sdpa_planar_k_fused` (`k_shape[2]`).
         let kv_seq = rotor_k_accumulated_seq(&self.storage)?;
         debug_assert_eq!(
-            kv_seq, self.offset,
-            "rotor_k_fused: store seq {kv_seq} != cache offset {} — the ring write \
-             and the attention length disagree",
-            self.offset
+            kv_seq, v_valid,
+            "rotor_k_fused: store seq {kv_seq} != the bf16 V mirror's valid length {v_valid} — \
+             the ring write and the attention length disagree"
         );
         // Past this point the cache is already mutated (store appended, offset
         // advanced, bf16 V accumulated), so `Ok(None)` is NOT available: it
@@ -1678,8 +1694,14 @@ impl KvCache {
         // condition is screened at the call-site gate and by
         // `rotor_flash_shape_ok` BEFORE any mutation; reaching here without a
         // ring means an internal invariant broke, so fail loudly.
-        let out =
-            self.rotor_k_flash_over_store(queries, &v_full, scale, additive_mask, kv_seq, device)?;
+        let out = self.rotor_k_flash_over_store(
+            queries,
+            &v_mirror,
+            scale,
+            additive_mask,
+            kv_seq,
+            device,
+        )?;
         Ok(Some(out))
     }
 
@@ -1691,9 +1713,9 @@ impl KvCache {
     /// same kernel the producer used, instead of the producer having to
     /// materialise bf16 K/V for it.
     ///
-    /// `kv_seq` is the accumulated store length and `v_full` the matching bf16
-    /// V prefix; both come from the caller so producer and consumer read the
-    /// identical window.
+    /// `kv_seq` is the accumulated store length and `v_mirror` the whole bf16 V
+    /// accumulator (sequence extent `>= kv_seq`); both come from the caller so
+    /// producer and consumer read the identical window.
     #[allow(clippy::too_many_arguments)]
     #[allow(
         clippy::indexing_slicing,
@@ -1702,7 +1724,7 @@ impl KvCache {
     fn rotor_k_flash_over_store(
         &self,
         queries: &Array,
-        v_full: &Array,
+        v_mirror: &Array,
         scale: f32,
         additive_mask: Option<&Array>,
         kv_seq: i32,
@@ -1728,7 +1750,7 @@ impl KvCache {
             )));
         };
 
-        let v_shape = v_full.shape();
+        let v_shape = v_mirror.shape();
         if v_shape.len() != 4 {
             return Err(Error::Mlx(format!(
                 "rotor_k_fused: V rank != 4, got {v_shape:?}"
@@ -1771,7 +1793,7 @@ impl KvCache {
                 &scales,
                 &norms,
                 &rotors,
-                v_full,
+                v_mirror,
                 additive_mask,
                 b,
                 kv_h,
@@ -1787,7 +1809,7 @@ impl KvCache {
                 &scales,
                 &norms,
                 &rotors,
-                v_full,
+                v_mirror,
                 additive_mask,
                 b,
                 kv_h,
@@ -2225,16 +2247,15 @@ impl KvCache {
         // appending. Same ordering as `update_and_sdpa_rotor_k_fused`.
         self.offset = prev_seq + new_seq;
         let max_seq = iso_k_max_seq(&self.storage)?;
-        let v_full = self.update_decode_fp16_v_only(new_v, max_seq, device)?;
+        let (v_mirror, v_valid) = self.update_decode_fp16_v_slab(new_v, max_seq, device)?;
 
         // Take `kv_seq` from the store the ring was written from, not from
         // `self.offset` — one source of truth.
         let kv_seq = iso_k_accumulated_seq(&self.storage)?;
         debug_assert_eq!(
-            kv_seq, self.offset,
-            "iso_k_fused: store seq {kv_seq} != cache offset {} — the ring write \
-             and the attention length disagree",
-            self.offset
+            kv_seq, v_valid,
+            "iso_k_fused: store seq {kv_seq} != the bf16 V mirror's valid length {v_valid} — \
+             the ring write and the attention length disagree"
         );
         // Past this point the cache is already mutated, so `Ok(None)` is NOT
         // available: it would send the caller into the legacy `update()` path,
@@ -2242,7 +2263,7 @@ impl KvCache {
         // not-eligible condition is screened at the call-site gate and by
         // `iso_flash_shape_ok` BEFORE any mutation.
         let out =
-            self.iso_k_flash_over_store(queries, &v_full, scale, additive_mask, kv_seq, device)?;
+            self.iso_k_flash_over_store(queries, &v_mirror, scale, additive_mask, kv_seq, device)?;
         Ok(Some(out))
     }
 
@@ -2261,7 +2282,7 @@ impl KvCache {
     fn iso_k_flash_over_store(
         &self,
         queries: &Array,
-        v_full: &Array,
+        v_mirror: &Array,
         scale: f32,
         additive_mask: Option<&Array>,
         kv_seq: i32,
@@ -2286,7 +2307,7 @@ impl KvCache {
             )));
         };
 
-        let v_shape = v_full.shape();
+        let v_shape = v_mirror.shape();
         if v_shape.len() != 4 {
             return Err(Error::Mlx(format!(
                 "iso_k_fused: V rank != 4, got {v_shape:?}"
@@ -2328,7 +2349,7 @@ impl KvCache {
                 &codes,
                 &scales,
                 &norms,
-                v_full,
+                v_mirror,
                 additive_mask,
                 b,
                 kv_h,
@@ -2343,7 +2364,7 @@ impl KvCache {
                 &codes,
                 &scales,
                 &norms,
-                v_full,
+                v_mirror,
                 additive_mask,
                 b,
                 kv_h,

--- a/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/sdpa.rs
@@ -10,6 +10,7 @@
 use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{add, matmul, scaled_dot_product_attention, softmax_precise, Array, Device, Dtype};
 
+use crate::flash_decode_common::VMirror;
 use crate::iso_flash_decode_msl::{iso_flash_decode_sdpa, ISO_FLASH_HEAD_DIM_MAX};
 use crate::iso_flash_decode_symv_msl::{iso_flash_decode_symv_sdpa, IsoFlashShape, IsoPackedAxis};
 use crate::mixed_quant::mixed_quantized_sdpa;
@@ -962,7 +963,7 @@ impl KvCache {
             KvStorage::RotorKOnly3 { .. } | KvStorage::RotorKOnly4 { .. } => {
                 let kv_seq = rotor_k_accumulated_seq(&self.storage)?;
                 Self::check_shared_kv_len(kv_len, kv_seq)?;
-                let v_mirror = self.decode_fp16_v_mirror(kv_seq)?;
+                let v_mirror = self.decode_fp16_v_mirror()?;
                 self.rotor_k_flash_over_store(
                     queries,
                     v_mirror,
@@ -975,7 +976,7 @@ impl KvCache {
             KvStorage::IsoKOnly3 { .. } | KvStorage::IsoKOnly4 { .. } => {
                 let kv_seq = iso_k_accumulated_seq(&self.storage)?;
                 Self::check_shared_kv_len(kv_len, kv_seq)?;
-                let v_mirror = self.decode_fp16_v_mirror(kv_seq)?;
+                let v_mirror = self.decode_fp16_v_mirror()?;
                 self.iso_k_flash_over_store(queries, v_mirror, scale, additive_mask, kv_seq, device)
             }
             // Both axes come from the quant store — no `slice_decode_fp16_v`,
@@ -993,7 +994,7 @@ impl KvCache {
             KvStorage::PlanarK { .. } => {
                 let kv_seq = planar_k_accumulated_seq(&self.storage)?;
                 Self::check_shared_kv_len(kv_len, kv_seq)?;
-                let v_mirror = self.decode_fp16_v_mirror(kv_seq)?;
+                let v_mirror = self.decode_fp16_v_mirror()?;
                 self.planar_k_flash_over_store(
                     queries,
                     v_mirror,
@@ -1190,43 +1191,38 @@ impl KvCache {
         }
     }
 
-    /// The whole bf16 V accumulator, checked to cover `kv_seq` positions.
+    /// The whole bf16 V accumulator, paired with how much of it is valid.
     ///
-    /// The read-only consumer counterpart of
-    /// `update_decode_fp16_v_slab`: the flash-decode kernels stride over the
-    /// mirror rather than take a `..kv_seq` cut of it, so producer and consumer
-    /// hand them the identical buffer and attend the identical window.
-    #[allow(
-        clippy::indexing_slicing,
-        reason = "bounds established by the rank-4 check immediately above"
-    )]
-    fn decode_fp16_v_mirror(&self, kv_seq: i32) -> Result<&Array> {
-        let v_buf = self.decode_fp16_v.as_ref().ok_or_else(|| {
+    /// The read-only consumer counterpart of `update_decode_fp16_v_slab`: the
+    /// flash-decode kernels stride over the mirror rather than take a `..kv_seq`
+    /// cut of it, so producer and consumer hand them the identical buffer and
+    /// attend the identical window.
+    ///
+    /// The valid length is the cache's own `offset`, reported rather than
+    /// assumed: the dispatcher checks it against the length the K store says is
+    /// being attended, and a producer/consumer desync fails there instead of
+    /// attending the mirror's tail.
+    fn decode_fp16_v_mirror(&self) -> Result<VMirror<'_>> {
+        let buf = self.decode_fp16_v.as_ref().ok_or_else(|| {
             Error::Mlx(
                 "decode_fp16_v missing on a store-backed share — the fused arms maintain it on \
                  every append, so this is an internal invariant violation"
                     .to_owned(),
             )
         })?;
-        let v_shape = v_buf.shape();
+        let v_shape = buf.shape();
         if v_shape.len() != 4 {
             return Err(Error::Mlx(format!(
                 "decode_fp16_v rank != 4, got {v_shape:?}"
             )));
         }
-        if kv_seq > v_shape[2] {
-            return Err(Error::Mlx(format!(
-                "shared-KV length {kv_seq} exceeds the bf16 V mirror (v_seq={})",
-                v_shape[2]
-            )));
-        }
-        Ok(v_buf)
+        Ok(VMirror::new(buf, self.offset))
     }
 
     /// Read-only slice of the bf16 V accumulator to `kv_seq` positions, for
     /// consumers that need an exactly-sized tensor.
     fn slice_decode_fp16_v(&self, kv_seq: i32, device: Device) -> Result<Array> {
-        slice_v_prefix(self.decode_fp16_v_mirror(kv_seq)?, kv_seq, device)
+        slice_v_prefix(self.decode_fp16_v_mirror()?.buf, kv_seq, device)
     }
 
     /// Slice the bf16 K/V mirror to the current `self.offset` so a
@@ -1420,12 +1416,7 @@ impl KvCache {
         // shadow, and allocating it via the full `update_decode_fp16` would
         // waste an O(seq) bf16 K buffer every decode step.  Mirrors the
         // pattern from `update_iso_k_only_3`/`_4`.
-        let (v_mirror, v_valid) = self.update_decode_fp16_v_slab(new_v, max_seq, device)?;
-        debug_assert_eq!(
-            kv_seq, v_valid,
-            "planar_k_fused: store seq {kv_seq} != the bf16 V mirror's valid length {v_valid} — \
-             the store append and the attended V window disagree"
-        );
+        let (v_slab, v_valid) = self.update_decode_fp16_v_slab(new_v, max_seq, device)?;
 
         // Past this point the cache is already mutated (store appended, offset
         // advanced, bf16 V accumulated), so `Ok(None)` is no longer available —
@@ -1434,7 +1425,7 @@ impl KvCache {
         // above.
         let out = self.planar_k_flash_over_store(
             queries,
-            &v_mirror,
+            VMirror::new(&v_slab, v_valid),
             scale,
             additive_mask,
             kv_seq,
@@ -1452,8 +1443,9 @@ impl KvCache {
     /// materialise bf16 K/V for it.
     ///
     /// `kv_seq` is the accumulated store length and `v_mirror` the whole bf16 V
-    /// accumulator (sequence extent `>= kv_seq`); both come from the caller so
-    /// producer and consumer read the identical window.
+    /// accumulator with its valid length; both come from the caller so producer
+    /// and consumer read the identical window, and the dispatcher rejects the
+    /// pair if they disagree.
     #[allow(clippy::too_many_arguments)]
     #[allow(
         clippy::indexing_slicing,
@@ -1462,7 +1454,7 @@ impl KvCache {
     fn planar_k_flash_over_store(
         &self,
         queries: &Array,
-        v_mirror: &Array,
+        v_mirror: VMirror<'_>,
         scale: f32,
         additive_mask: Option<&Array>,
         kv_seq: i32,
@@ -1587,7 +1579,7 @@ impl KvCache {
         // flash kernel above, this arm cannot stride over the mirror, so it
         // takes the `..kv_seq` cut and pays for making it contiguous.
         let probs_g = probs.reshape(&[b, kv_h, heads_per_kv, 1, kv_seq], device)?;
-        let v_att = slice_v_prefix(v_mirror, kv_seq, device)?;
+        let v_att = slice_v_prefix(v_mirror.buf, kv_seq, device)?;
         let v_g = v_att.reshape(&[b, kv_h, 1, kv_seq, head_dim], device)?;
         let out_g = matmul(&probs_g, &v_g, device)?;
         let out = out_g.reshape(&[b, n_q_heads, 1, head_dim], device)?;
@@ -1675,18 +1667,13 @@ impl KvCache {
         // appending. Same ordering as `update_and_sdpa_planar_k_fused`.
         self.offset = prev_seq + new_seq;
         let max_seq = rotor_k_max_seq(&self.storage)?;
-        let (v_mirror, v_valid) = self.update_decode_fp16_v_slab(new_v, max_seq, device)?;
+        let (v_slab, v_valid) = self.update_decode_fp16_v_slab(new_v, max_seq, device)?;
 
         // Take `kv_seq` from the store the ring was written from, not from
-        // `self.offset` — one source of truth. They must agree; a divergence
-        // would silently attend over the wrong prefix length rather than error.
-        // Same precedent as `update_and_sdpa_planar_k_fused` (`k_shape[2]`).
+        // `self.offset` — one source of truth. The dispatcher checks it against
+        // the mirror's valid length, so a divergence errors rather than
+        // silently attending over the wrong prefix.
         let kv_seq = rotor_k_accumulated_seq(&self.storage)?;
-        debug_assert_eq!(
-            kv_seq, v_valid,
-            "rotor_k_fused: store seq {kv_seq} != the bf16 V mirror's valid length {v_valid} — \
-             the ring write and the attention length disagree"
-        );
         // Past this point the cache is already mutated (store appended, offset
         // advanced, bf16 V accumulated), so `Ok(None)` is NOT available: it
         // would send the caller into the legacy `update()` path, which appends
@@ -1696,7 +1683,7 @@ impl KvCache {
         // ring means an internal invariant broke, so fail loudly.
         let out = self.rotor_k_flash_over_store(
             queries,
-            &v_mirror,
+            VMirror::new(&v_slab, v_valid),
             scale,
             additive_mask,
             kv_seq,
@@ -1714,8 +1701,9 @@ impl KvCache {
     /// materialise bf16 K/V for it.
     ///
     /// `kv_seq` is the accumulated store length and `v_mirror` the whole bf16 V
-    /// accumulator (sequence extent `>= kv_seq`); both come from the caller so
-    /// producer and consumer read the identical window.
+    /// accumulator with its valid length; both come from the caller so producer
+    /// and consumer read the identical window, and the dispatcher rejects the
+    /// pair if they disagree.
     #[allow(clippy::too_many_arguments)]
     #[allow(
         clippy::indexing_slicing,
@@ -1724,7 +1712,7 @@ impl KvCache {
     fn rotor_k_flash_over_store(
         &self,
         queries: &Array,
-        v_mirror: &Array,
+        v_mirror: VMirror<'_>,
         scale: f32,
         additive_mask: Option<&Array>,
         kv_seq: i32,
@@ -1750,15 +1738,15 @@ impl KvCache {
             )));
         };
 
-        let v_shape = v_mirror.shape();
-        if v_shape.len() != 4 {
+        // From the K store, not from V: the dispatcher cross-checks V's own
+        // axes against these, and a metadata triple read off V would compare V
+        // with itself.
+        let k_shape = rotor_k_store_shape(&self.storage)?;
+        let [b, kv_h, _, head_dim] = k_shape[..] else {
             return Err(Error::Mlx(format!(
-                "rotor_k_fused: V rank != 4, got {v_shape:?}"
+                "rotor_k_fused: K store shape rank != 4, got {k_shape:?}"
             )));
-        }
-        let b = v_shape[0];
-        let kv_h = v_shape[1];
-        let head_dim = v_shape[3];
+        };
 
         let q_shape = queries.shape();
         if q_shape.len() != 4 {
@@ -2247,23 +2235,26 @@ impl KvCache {
         // appending. Same ordering as `update_and_sdpa_rotor_k_fused`.
         self.offset = prev_seq + new_seq;
         let max_seq = iso_k_max_seq(&self.storage)?;
-        let (v_mirror, v_valid) = self.update_decode_fp16_v_slab(new_v, max_seq, device)?;
+        let (v_slab, v_valid) = self.update_decode_fp16_v_slab(new_v, max_seq, device)?;
 
         // Take `kv_seq` from the store the ring was written from, not from
-        // `self.offset` — one source of truth.
+        // `self.offset` — one source of truth. The dispatcher checks it against
+        // the mirror's valid length, so a divergence errors rather than
+        // silently attending over the wrong prefix.
         let kv_seq = iso_k_accumulated_seq(&self.storage)?;
-        debug_assert_eq!(
-            kv_seq, v_valid,
-            "iso_k_fused: store seq {kv_seq} != the bf16 V mirror's valid length {v_valid} — \
-             the ring write and the attention length disagree"
-        );
         // Past this point the cache is already mutated, so `Ok(None)` is NOT
         // available: it would send the caller into the legacy `update()` path,
         // which appends K/V a second time and advances `offset` again. Every
         // not-eligible condition is screened at the call-site gate and by
         // `iso_flash_shape_ok` BEFORE any mutation.
-        let out =
-            self.iso_k_flash_over_store(queries, &v_mirror, scale, additive_mask, kv_seq, device)?;
+        let out = self.iso_k_flash_over_store(
+            queries,
+            VMirror::new(&v_slab, v_valid),
+            scale,
+            additive_mask,
+            kv_seq,
+            device,
+        )?;
         Ok(Some(out))
     }
 
@@ -2282,7 +2273,7 @@ impl KvCache {
     fn iso_k_flash_over_store(
         &self,
         queries: &Array,
-        v_mirror: &Array,
+        v_mirror: VMirror<'_>,
         scale: f32,
         additive_mask: Option<&Array>,
         kv_seq: i32,
@@ -2307,15 +2298,15 @@ impl KvCache {
             )));
         };
 
-        let v_shape = v_mirror.shape();
-        if v_shape.len() != 4 {
+        // From the K store, not from V: the dispatcher cross-checks V's own
+        // axes against these, and a metadata triple read off V would compare V
+        // with itself.
+        let k_shape = iso_k_store_shape(&self.storage)?;
+        let [b, kv_h, _, head_dim] = k_shape[..] else {
             return Err(Error::Mlx(format!(
-                "iso_k_fused: V rank != 4, got {v_shape:?}"
+                "iso_k_fused: K store shape rank != 4, got {k_shape:?}"
             )));
-        }
-        let b = v_shape[0];
-        let kv_h = v_shape[1];
-        let head_dim = v_shape[3];
+        };
 
         let q_shape = queries.shape();
         if q_shape.len() != 4 {
@@ -2787,21 +2778,27 @@ fn rotor_sym_accumulated_seq(storage: &KvStorage) -> Result<i32> {
     Ok(k_seq)
 }
 
+/// The K store's accumulated `[B, kv_h, S, D]` shape for the active rotor
+/// K-only variant.
+fn rotor_k_store_shape(storage: &KvStorage) -> Result<&[i32]> {
+    if let KvStorage::RotorKOnly3 { k: Some(ks), .. } = storage {
+        Ok(&ks.shape)
+    } else if let KvStorage::RotorKOnly4 { k: Some(ks), .. } = storage {
+        Ok(&ks.shape)
+    } else {
+        Err(Error::KvStorageMismatch {
+            expected: "RotorKOnly3 | RotorKOnly4 with a live K buffer",
+            got: storage_variant_name(storage),
+        })
+    }
+}
+
 /// Accumulated sequence length held by the active rotor K-only store.
 ///
 /// The store's own `shape[2]` — the length the GPU ring was written against —
 /// so callers do not have to trust that `KvCache::offset` still agrees.
 fn rotor_k_accumulated_seq(storage: &KvStorage) -> Result<i32> {
-    let shape = if let KvStorage::RotorKOnly3 { k: Some(ks), .. } = storage {
-        &ks.shape
-    } else if let KvStorage::RotorKOnly4 { k: Some(ks), .. } = storage {
-        &ks.shape
-    } else {
-        return Err(Error::KvStorageMismatch {
-            expected: "RotorKOnly3 | RotorKOnly4 with a live K buffer",
-            got: storage_variant_name(storage),
-        });
-    };
+    let shape = rotor_k_store_shape(storage)?;
     shape.get(2).copied().ok_or_else(|| {
         Error::Mlx(format!(
             "rotor_k_fused: rotor K store shape {shape:?} has no seq axis"
@@ -2837,21 +2834,27 @@ fn planar_k_accumulated_seq(storage: &KvStorage) -> Result<i32> {
 /// is what the kernel attends and what a shared-KV consumer sizes its mask
 /// from.
 fn iso_k_accumulated_seq(storage: &KvStorage) -> Result<i32> {
-    let shape = if let KvStorage::IsoKOnly3 { k: Some(ks), .. } = storage {
-        &ks.shape
-    } else if let KvStorage::IsoKOnly4 { k: Some(ks), .. } = storage {
-        &ks.shape
-    } else {
-        return Err(Error::KvStorageMismatch {
-            expected: "IsoKOnly3 | IsoKOnly4 with a live K buffer",
-            got: storage_variant_name(storage),
-        });
-    };
+    let shape = iso_k_store_shape(storage)?;
     shape.get(2).copied().ok_or_else(|| {
         Error::Mlx(format!(
             "iso_k_fused: iso K store shape {shape:?} has no seq axis"
         ))
     })
+}
+
+/// The K store's accumulated `[B, kv_h, S, D]` shape for the active iso K-only
+/// variant.
+fn iso_k_store_shape(storage: &KvStorage) -> Result<&[i32]> {
+    if let KvStorage::IsoKOnly3 { k: Some(ks), .. } = storage {
+        Ok(&ks.shape)
+    } else if let KvStorage::IsoKOnly4 { k: Some(ks), .. } = storage {
+        Ok(&ks.shape)
+    } else {
+        Err(Error::KvStorageMismatch {
+            expected: "IsoKOnly3 | IsoKOnly4 with a live K buffer",
+            got: storage_variant_name(storage),
+        })
+    }
 }
 
 /// The K store's accumulated `[B, kv_h, S, D]` shape for the active iso

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -20,7 +20,9 @@ use crate::storage::{
 use crate::turbo_flash_msl::{turbo_flash_sdpa, turbo_flash_should_run};
 use crate::KvQuant;
 
-use super::helpers::{array_to_f32_vec, arrays_to_f32, f32_vec_to_array, storage_variant_name};
+use super::helpers::{
+    array_to_f32_vec, arrays_to_f32, f32_vec_to_array, slice_v_prefix, storage_variant_name,
+};
 use super::KvCache;
 
 /// Narrow `layer_idx` (`usize`) to `u32` for rotor-seed APIs.
@@ -4492,7 +4494,8 @@ impl KvCache {
         Ok((k_full, v_full))
     }
 
-    /// V-only bf16 update helper for IsoKOnly variants.
+    /// V-only bf16 update helper for IsoKOnly variants, returning the whole
+    /// mirror allocation and the number of valid positions in it.
     ///
     /// Mirrors [`Self::update_decode_fp16`] but **only** manages the V side
     /// (`decode_fp16_v`). It deliberately does NOT touch `self.decode_fp16_k`.
@@ -4504,6 +4507,14 @@ impl KvCache {
     /// `decode_fp16_k.is_some()` early-return guard in `update_iso3_sym` /
     /// `update_iso4_sym` to short-circuit the codec on the *next* decode step
     /// (silent bf16-K regression guarded by regression test).
+    ///
+    /// The mirror is `[b, kv_h, max_seq, head_dim]` and the returned length is
+    /// its valid prefix on axis 2. Callers that dispatch a flash-decode kernel
+    /// pass the allocation on whole, because cutting the prefix out of a
+    /// head-major mirror yields a view that is row-contiguous only when
+    /// `b * kv_h == 1` — flattening it anywhere else copies the prefix, once
+    /// per layer per decode step. Callers that need an exactly-sized tensor use
+    /// [`Self::update_decode_fp16_v_only`].
     #[allow(
         clippy::indexing_slicing,
         reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
@@ -4512,12 +4523,12 @@ impl KvCache {
         clippy::unwrap_used,
         reason = "decode_fp16_v is Some by construction: the needs_expand branch above always sets it, and this path is only reached after that guard"
     )]
-    pub(super) fn update_decode_fp16_v_only(
+    pub(super) fn update_decode_fp16_v_slab(
         &mut self,
         new_v: &Array,
         max_seq: i32,
         device: Device,
-    ) -> Result<Array> {
+    ) -> Result<(Array, i32)> {
         let shape = new_v.shape();
         let b = shape[0];
         let kv_h = shape[1];
@@ -4570,12 +4581,19 @@ impl KvCache {
         *v_buf = v_updated;
         let _ = v_buf.async_eval();
 
-        let slice_start = vec![0i32; ndim];
-        let slice_stop: Vec<i32> = [b, kv_h, new_offset, head_dim].into();
-        let slice_strides = vec![1i32; ndim];
-        let v_full = v_buf.slice(&slice_start, &slice_stop, &slice_strides, device)?;
+        Ok((v_buf.try_clone()?, new_offset))
+    }
 
-        Ok(v_full)
+    /// [`Self::update_decode_fp16_v_slab`] cut to its valid prefix, for callers
+    /// that need an exactly-sized `[b, kv_h, offset, head_dim]` V tensor.
+    pub(super) fn update_decode_fp16_v_only(
+        &mut self,
+        new_v: &Array,
+        max_seq: i32,
+        device: Device,
+    ) -> Result<Array> {
+        let (v_slab, v_seq) = self.update_decode_fp16_v_slab(new_v, max_seq, device)?;
+        slice_v_prefix(&v_slab, v_seq, device)
     }
 
     #[allow(

--- a/crates/rmlx-kv-quant/src/kvcache/v_mirror_alloc_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/v_mirror_alloc_tests.rs
@@ -1,0 +1,459 @@
+//! A flash-decode step must stride over the bf16 V mirror, not copy its prefix.
+//!
+//! The mirror is head-major `[b, kv_h, max_seq, head_dim]`. Cutting its valid
+//! `..kv_seq` prefix out gives a view that is row-contiguous only when
+//! `b * kv_h == 1`; flattening that view for a kernel materialises the whole
+//! prefix, once per layer per decode step, with no `contiguous()` call at the
+//! site to make it visible. So the dispatchers take the mirror whole and carry
+//! its sequence stride in `dims` instead.
+//!
+//! # Why the oracle is bytes and not tokens per second
+//!
+//! A regression here is silent: it costs throughput and changes no output bit.
+//! Decode rate is the wrong instrument — this host's rate drifts by more than
+//! the effect — but the copy's size is exact arithmetic,
+//! `kv_h * kv_seq * head_dim * sizeof(bf16)` bytes, and the Metal allocator
+//! reports it. [`PeakBracket`] scopes that reading to one region.
+//!
+//! # Two things every test here holds
+//!
+//! * **`kv_h > 1`.** At `kv_h == 1` the prefix slice is contiguous and the copy
+//!   does not exist, so a fixture at that shape would pass against the defect.
+//! * **The kernel actually ran.** Each allocation bound is paired with a
+//!   dispatch-count delta or an output comparison, so a bound cannot pass by
+//!   measuring a path that never reached the kernel.
+//!
+//! [`the_slice_the_dispatchers_no_longer_take_costs_a_measurable_prefix_copy`]
+//! is what gives the bounds their power: it pays the copy on purpose, in the
+//! same process at the same shape, so the oracle is shown to see one rather
+//! than assumed to.
+
+use super::KvCache;
+use crate::clifford::make_rotor_table;
+use crate::iso_flash_decode_msl::{iso_flash_decode_dispatch_count, iso_flash_decode_sdpa};
+use crate::isoquant::iso_encode_fast;
+use crate::kvcache::helpers::slice_v_prefix;
+use crate::planar_flash_decode_msl::planar_flash_decode_sdpa;
+use crate::planarquant_msl::planar_quantize_v4_gpu;
+use crate::quant::KvQuant;
+use crate::rotor_flash_decode_msl::{rotor_flash_decode_dispatch_count, rotor_flash_decode_sdpa};
+use crate::rotorquant::{n_groups_for, rotor3_encode};
+use crate::storage::{KvStorage, QuantRotorK3, ISO_QUAT_BLOCK_SIZE};
+use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
+use rmlx_core::DispatchPolicy;
+use rmlx_mlx::{mlx_active_memory_bytes, Array, Device, Dtype, PeakBracket};
+
+/// `b * kv_h > 1` — the shape the copy exists at.
+const KV_H: i32 = 8;
+const HEAD_DIM: i32 = 128;
+const HEADS_PER_KV: i32 = 4;
+const N_Q_HEADS: i32 = KV_H * HEADS_PER_KV;
+const B: i32 = 1;
+
+/// Attended length in the direct-dispatch tests, and the mirror's own extent.
+/// They differ so the `..kv_seq` cut is a strict, non-contiguous sub-view.
+const KV_SEQ: i32 = 1024;
+const MIRROR_SEQ: i32 = 2048;
+
+/// Bytes one `..kv_seq` prefix copy of a `[1, KV_H, _, HEAD_DIM]` bf16 mirror
+/// costs — the size of the defect, straight from the shape.
+const fn prefix_copy_bytes(kv_seq: i32) -> u64 {
+    (KV_H as u64) * (kv_seq as u64) * (HEAD_DIM as u64) * 2
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn f32_array(data: &[f32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::F32).expect("f32_array")
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn u32_array(data: &[u32], shape: &[i32]) -> Array {
+    let bytes: Vec<u8> = data.iter().flat_map(|w| w.to_le_bytes()).collect();
+    Array::from_bytes(&bytes, shape, Dtype::U32).expect("u32_array")
+}
+
+/// The bf16 V mirror and the `..KV_SEQ` cut of it the dispatchers used to take.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn v_mirror_and_cut() -> (Array, Array) {
+    let n = (B * KV_H * MIRROR_SEQ * HEAD_DIM) as usize;
+    let mirror = f32_array(&lcg_data(n, 0x5EED), &[B, KV_H, MIRROR_SEQ, HEAD_DIM])
+        .astype(Dtype::Bf16, Device::Gpu)
+        .expect("V mirror astype bf16");
+    mirror.eval().expect("V mirror eval");
+    let cut = slice_v_prefix(&mirror, KV_SEQ, Device::Gpu).expect("V mirror prefix");
+    (mirror, cut)
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn decode_query(seed: u64) -> Array {
+    f32_array(
+        &lcg_data((B * N_Q_HEADS * HEAD_DIM) as usize, seed),
+        &[B, N_Q_HEADS, 1, HEAD_DIM],
+    )
+}
+
+/// Sequence-major K for the direct-dispatch tests: token `(s, h)` at row
+/// `s * kv_h + h`, which is the layout every packed K store writes.
+fn k_seq_major() -> Vec<f32> {
+    lcg_data((KV_SEQ * KV_H * HEAD_DIM) as usize, 0xB0B)
+}
+
+// ── Per-codec direct dispatch, parameterised only by the V argument ───────────
+//
+// Each codec's packed K is built once, up front, and evaluated: an allocation
+// bracket around a dispatch must not also contain the fixture's own buffers.
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn evaluated(a: Array) -> Array {
+    a.eval().expect("fixture eval");
+    a
+}
+
+/// iso3-packed K: `(codes, scales, norms)`.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn iso3_packed() -> (Array, Array, Array) {
+    let (codes, scales, _quat, norms) =
+        iso_encode_fast(&k_seq_major(), HEAD_DIM as usize, ISO_QUAT_BLOCK_SIZE, 3)
+            .expect("iso_encode_fast");
+    (
+        evaluated(u32_array(&codes, &[codes.len() as i32])),
+        evaluated(f32_array(&scales, &[scales.len() as i32])),
+        evaluated(f32_array(&norms, &[norms.len() as i32])),
+    )
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn iso3_dispatch(packed: &(Array, Array, Array), v: &Array) -> Vec<u8> {
+    let (codes, scales, norms) = packed;
+    let out = iso_flash_decode_sdpa::<3>(
+        &decode_query(0xA1),
+        codes,
+        scales,
+        norms,
+        v,
+        None,
+        B,
+        KV_H,
+        KV_SEQ,
+        HEAD_DIM,
+        HEADS_PER_KV,
+        1.0 / (HEAD_DIM as f32).sqrt(),
+        Device::Gpu,
+    )
+    .expect("iso_flash_decode_sdpa");
+    out.eval().expect("iso out eval");
+    out.to_bytes().expect("iso out bytes")
+}
+
+/// rotor3-packed K: `(codes, scales, norms, rotors)`.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn rotor3_packed() -> (Array, Array, Array, Array) {
+    let rotors = make_rotor_table(0, 0, n_groups_for(HEAD_DIM as usize));
+    let (codes, scales, norms) =
+        rotor3_encode(&k_seq_major(), &rotors, HEAD_DIM as usize).expect("rotor3_encode");
+    (
+        evaluated(u32_array(&codes, &[codes.len() as i32])),
+        evaluated(f32_array(&scales, &[scales.len() as i32])),
+        evaluated(f32_array(&norms, &[norms.len() as i32])),
+        evaluated(f32_array(&rotors, &[rotors.len() as i32])),
+    )
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn rotor3_dispatch(packed: &(Array, Array, Array, Array), v: &Array) -> Vec<u8> {
+    let (codes, scales, norms, rotors) = packed;
+    let out = rotor_flash_decode_sdpa::<3>(
+        &decode_query(0xA2),
+        codes,
+        scales,
+        norms,
+        rotors,
+        v,
+        None,
+        B,
+        KV_H,
+        KV_SEQ,
+        HEAD_DIM,
+        HEADS_PER_KV,
+        1.0 / (HEAD_DIM as f32).sqrt(),
+        Device::Gpu,
+    )
+    .expect("rotor_flash_decode_sdpa");
+    out.eval().expect("rotor out eval");
+    out.to_bytes().expect("rotor out bytes")
+}
+
+/// planar4-packed K: `(codes, scales, rot32)`.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn planar4_packed() -> (Array, Array, Array) {
+    let k = f32_array(&k_seq_major(), &[B, KV_SEQ, KV_H, HEAD_DIM]);
+    let (codes, scales, rot32) =
+        planar_quantize_v4_gpu(&k, Device::Gpu).expect("planar_quantize_v4_gpu");
+    (evaluated(codes), evaluated(scales), evaluated(rot32))
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn planar4_dispatch(packed: &(Array, Array, Array), v: &Array) -> Vec<u8> {
+    let (codes, scales, rot32) = packed;
+    let out = planar_flash_decode_sdpa(
+        &decode_query(0xA3),
+        codes,
+        scales,
+        rot32,
+        v,
+        None,
+        B,
+        KV_H,
+        KV_SEQ,
+        HEAD_DIM,
+        HEADS_PER_KV,
+        4,
+        1.0 / (HEAD_DIM as f32).sqrt(),
+        Device::Gpu,
+    )
+    .expect("planar_flash_decode_sdpa");
+    out.eval().expect("planar out eval");
+    out.to_bytes().expect("planar out bytes")
+}
+
+// ── The stride reaches every dispatcher's kernel, and changes no bit ──────────
+
+/// Each dispatcher must return the same bytes whether it is handed the whole
+/// mirror or the `..kv_seq` cut of it.
+///
+/// The two arms differ only in V's sequence extent, so the stride the kernel
+/// indexes V with differs between them. A dispatcher that dropped the stride,
+/// or a kernel body that read it from the wrong `dims` slot, would read V at
+/// the wrong offset in the whole-mirror arm and the bytes would diverge —
+/// which is the per-codec wiring this covers and the allocation bounds below
+/// do not.
+#[test]
+#[ignore = "GPU Metal context — run explicitly"]
+fn every_flash_decode_dispatcher_strides_over_the_whole_v_mirror() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let (mirror, cut) = v_mirror_and_cut();
+    assert_ne!(
+        mirror.shape()[2],
+        cut.shape()[2],
+        "the two arms must differ in V's sequence extent, or the comparison is trivial"
+    );
+    let iso = iso3_packed();
+    let rotor = rotor3_packed();
+    let planar = planar4_packed();
+    #[allow(
+        clippy::type_complexity,
+        reason = "one local table of per-codec dispatch closures; naming the type buys nothing"
+    )]
+    let codecs: [(&str, Box<dyn Fn(&Array) -> Vec<u8>>); 3] = [
+        ("iso3", Box::new(|v| iso3_dispatch(&iso, v))),
+        ("rotor3", Box::new(|v| rotor3_dispatch(&rotor, v))),
+        ("planar4", Box::new(|v| planar4_dispatch(&planar, v))),
+    ];
+    for (codec, dispatch) in codecs {
+        assert_eq!(
+            dispatch(&mirror),
+            dispatch(&cut),
+            "{codec}: striding over the whole V mirror must be bit-identical to \
+             attending its cut prefix"
+        );
+    }
+}
+
+// ── The copy is real, is visible, and the dispatchers no longer pay it ────────
+
+/// Measure the resident bytes an iso dispatch holds when V arrives whole
+/// against when it arrives as the `..kv_seq` cut, and hold both halves of the
+/// claim: the cut costs one full prefix copy, and the whole mirror costs none
+/// of it.
+///
+/// The first half is the gate's power measurement. Without it, the second half
+/// could pass against a fixture that never allocated a copy in either arm.
+///
+/// Resident bytes rather than a peak bracket, because Metal releases a
+/// completed dispatch's buffers on the next dispatch: at steady state the copy
+/// is already live when a bracket opens and is replaced in place, so the peak
+/// never rises above the open reading and every delta derived from it is zero.
+/// What the copy does move is the settled live count, exactly and repeatably.
+#[test]
+#[ignore = "GPU Metal context — run explicitly"]
+#[allow(
+    clippy::expect_used,
+    reason = "test: every expect is on a fixture built immediately above"
+)]
+fn the_slice_the_dispatchers_no_longer_take_costs_a_measurable_prefix_copy() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let (mirror, cut) = v_mirror_and_cut();
+    let iso = iso3_packed();
+
+    // Repeat until the allocator settles: the first dispatch of a kernel
+    // compiles it, and each dispatch's buffers are released on the next one.
+    let settled_live = |v: &Array| -> u64 {
+        for _ in 0..4 {
+            let _ = iso3_dispatch(&iso, v);
+        }
+        let live = mlx_active_memory_bytes()
+            .expect("no Metal allocator reading — the measurement below is vacuous");
+        assert!(live > 0, "the allocator reports nothing resident at all");
+        live
+    };
+
+    let whole_before = settled_live(&mirror);
+    let sliced = settled_live(&cut);
+    let whole_after = settled_live(&mirror);
+    assert_eq!(
+        whole_before, whole_after,
+        "the whole-mirror arm must settle to the same resident bytes either side \
+         of the cut arm, or this is measuring drift rather than the copy"
+    );
+
+    let copy = prefix_copy_bytes(KV_SEQ);
+    let extra = sliced.saturating_sub(whole_before);
+    assert!(
+        extra >= copy,
+        "the cut arm must hold one prefix copy ({copy} B) more than the strided \
+         arm; measured {extra} B (whole={whole_before}, sliced={sliced}). A smaller \
+         delta means this fixture no longer reproduces the copy, and the bounds \
+         below are blind."
+    );
+}
+
+// ── The production decode step does not pay it either ─────────────────────────
+
+const MAX_SEQ: i32 = 1024;
+const PREFILL: i32 = 1016;
+const WARMUP_STEPS: u64 = 2;
+
+/// What one bracketed decode step observed.
+#[derive(Debug)]
+struct StepProbe {
+    headroom: u64,
+    kv_seq: i32,
+}
+
+/// Prefill a cache, warm it, then bracket exactly one steady-state decode step.
+///
+/// `dispatch_count` is the codec's own kernel counter; a step that did not
+/// advance it never reached the kernel, and its allocation reading would
+/// describe a CPU-dequant fallback instead.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn bracket_one_decode_step(
+    codec: &str,
+    mut cache: KvCache,
+    dispatch_count: fn() -> u64,
+) -> StepProbe {
+    let device = Device::Gpu;
+    let scale = 1.0_f32 / (HEAD_DIM as f32).sqrt();
+
+    let pf = (PREFILL * KV_H * HEAD_DIM) as usize;
+    let k = f32_array(&lcg_data(pf, 1), &[B, KV_H, PREFILL, HEAD_DIM]);
+    let v = f32_array(&lcg_data(pf, 2), &[B, KV_H, PREFILL, HEAD_DIM]);
+    let q = f32_array(
+        &lcg_data((PREFILL * N_Q_HEADS * HEAD_DIM) as usize, 3),
+        &[B, N_Q_HEADS, PREFILL, HEAD_DIM],
+    );
+    cache
+        .update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
+        .expect("prefill update_and_sdpa");
+    cache.exit_prefill(device).expect("exit_prefill");
+
+    let step = |cache: &mut KvCache, seed: u64| {
+        let one = (KV_H * HEAD_DIM) as usize;
+        let k1 = f32_array(&lcg_data(one, 10 + seed), &[B, KV_H, 1, HEAD_DIM]);
+        let v1 = f32_array(&lcg_data(one, 20 + seed), &[B, KV_H, 1, HEAD_DIM]);
+        let q1 = f32_array(
+            &lcg_data((N_Q_HEADS * HEAD_DIM) as usize, 30 + seed),
+            &[B, N_Q_HEADS, 1, HEAD_DIM],
+        );
+        let out = cache
+            .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
+            .expect("decode update_and_sdpa");
+        out.eval().expect("decode out eval");
+    };
+    for s in 0..WARMUP_STEPS {
+        step(&mut cache, s);
+    }
+
+    let before = dispatch_count();
+    let bracket = PeakBracket::open();
+    step(&mut cache, 99);
+    let reading = bracket.close();
+
+    assert!(
+        dispatch_count() > before,
+        "{codec}: the bracketed step never reached the flash-decode kernel — the \
+         reading describes a CPU-dequant fallback, not the dispatch this gate is about"
+    );
+    assert!(
+        reading.measurable(),
+        "{codec}: peak mark could not be zeroed — the reading is not scoped to the step"
+    );
+    assert!(
+        reading.observed_allocation(),
+        "{codec}: the bracketed decode step allocated nothing: {reading:?}"
+    );
+    StepProbe {
+        headroom: reading.headroom_bytes(),
+        kv_seq: cache.offset(),
+    }
+}
+
+/// One decode step must allocate far less than one V-mirror prefix copy.
+fn assert_step_pays_no_prefix_copy(codec: &str, probe: &StepProbe) {
+    let copy = prefix_copy_bytes(probe.kv_seq);
+    assert!(
+        probe.headroom < copy / 2,
+        "{codec}: one decode step allocated {} B, on the order of the {copy} B it \
+         costs to flatten a non-contiguous `..kv_seq` cut of the bf16 V mirror at \
+         kv_h={KV_H} — the mirror is being copied per layer per step again ({probe:?})",
+        probe.headroom
+    );
+}
+
+#[test]
+#[ignore = "GPU Metal context — run explicitly"]
+fn iso_decode_step_does_not_copy_the_v_mirror() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    let cache = KvCache::with_quant_max_seq(KvQuant::IsoKOnly3, MAX_SEQ);
+    let probe = bracket_one_decode_step("iso3", cache, iso_flash_decode_dispatch_count);
+    assert_step_pays_no_prefix_copy("iso3", &probe);
+}
+
+#[test]
+#[ignore = "GPU Metal context — run explicitly"]
+fn rotor_decode_step_does_not_copy_the_v_mirror() {
+    if skip_if_no_gpu_env() {
+        return;
+    }
+    // Seeding the rotor table pins the store's QJL decision off without touching
+    // the process-global toggle: both append paths only set `qjl_s_matrix` in
+    // their `rotors.is_empty()` lazy-init branch. A QJL-carrying store keeps the
+    // CPU dequant path and would never reach the kernel.
+    let rotors = make_rotor_table(0, 0, n_groups_for(HEAD_DIM as usize));
+    let storage = KvStorage::RotorKOnly3 {
+        k: Some(QuantRotorK3::from_cpu_blocks(
+            rotors,
+            None,
+            Vec::new(),
+            vec![B, KV_H, 0, HEAD_DIM],
+            0,
+        )),
+        max_seq: MAX_SEQ,
+    };
+    let cache = KvCache::from_storage(
+        storage,
+        KvQuant::RotorKOnly3,
+        0,
+        0,
+        DispatchPolicy::default(),
+        false,
+    );
+    let probe = bracket_one_decode_step("rotor3", cache, rotor_flash_decode_dispatch_count);
+    assert_step_pays_no_prefix_copy("rotor3", &probe);
+}

--- a/crates/rmlx-kv-quant/src/kvcache/v_mirror_alloc_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/v_mirror_alloc_tests.rs
@@ -13,23 +13,40 @@
 //! Decode rate is the wrong instrument — this host's rate drifts by more than
 //! the effect — but the copy's size is exact arithmetic,
 //! `kv_h * kv_seq * head_dim * sizeof(bf16)` bytes, and the Metal allocator
-//! reports it. [`PeakBracket`] scopes that reading to one region.
+//! reports it.
 //!
-//! # Two things every test here holds
+//! # What each test covers, and what it does not
 //!
-//! * **`kv_h > 1`.** At `kv_h == 1` the prefix slice is contiguous and the copy
-//!   does not exist, so a fixture at that shape would pass against the defect.
-//! * **The kernel actually ran.** Each allocation bound is paired with a
-//!   dispatch-count delta or an output comparison, so a bound cannot pass by
-//!   measuring a path that never reached the kernel.
+//! * [`every_flash_decode_dispatcher_strides_over_the_whole_v_mirror`] — all
+//!   three codecs, at `kv_h > 1` and at `kv_h == 1`. Bytes, not allocation: it
+//!   is what pins each kernel's `dims` slot, and it fails if any one of them
+//!   reads the stride from the wrong place.
+//! * [`the_slice_the_dispatchers_no_longer_take_costs_a_measurable_prefix_copy`]
+//!   — the allocation oracle's power measurement. It pays a prefix copy on
+//!   purpose so the growth bounds below are shown to be able to see one.
+//! * [`iso_decode_does_not_copy_the_v_mirror`] and its rotor sibling — the
+//!   production seam, through `update_and_sdpa`.
 //!
-//! [`the_slice_the_dispatchers_no_longer_take_costs_a_measurable_prefix_copy`]
-//! is what gives the bounds their power: it pays the copy on purpose, in the
-//! same process at the same shape, so the oracle is shown to see one rather
-//! than assumed to.
+//! **Planar has no production-seam probe.** Its fused arm is warm-TTFT
+//! quiescent: after `exit_prefill` the bf16 K seed is live and the dispatcher
+//! bypasses it by design (`warm_ttft_tests`), and its flash arm is additionally
+//! off by default (`DispatchPolicy::planar_flash_decode`). A probe would have
+//! to construct a configuration production does not reach. Its kernel indexing
+//! is covered by the equivalence test above; what is untested is whether the
+//! saving is realised in a served request, and on the default policy it is not.
+//!
+//! # Two shapes, for opposite reasons
+//!
+//! `kv_h > 1` is the only shape the copy exists at, so the allocation bounds
+//! run there. `kv_h == 1` is the shape where the `(b * kv_h + kv_h_idx)` term
+//! vanishes and the stride cancels out of the address arithmetic entirely — a
+//! stride bug and a correct stride are indistinguishable there, which is why it
+//! is an equivalence arm proving the change is inert and not an allocation arm.
+//! It is also the production shape of Gemma4's global layers.
 
 use super::KvCache;
 use crate::clifford::make_rotor_table;
+use crate::flash_decode_common::VMirror;
 use crate::iso_flash_decode_msl::{iso_flash_decode_dispatch_count, iso_flash_decode_sdpa};
 use crate::isoquant::iso_encode_fast;
 use crate::kvcache::helpers::slice_v_prefix;
@@ -38,27 +55,49 @@ use crate::planarquant_msl::planar_quantize_v4_gpu;
 use crate::quant::KvQuant;
 use crate::rotor_flash_decode_msl::{rotor_flash_decode_dispatch_count, rotor_flash_decode_sdpa};
 use crate::rotorquant::{n_groups_for, rotor3_encode};
-use crate::storage::{KvStorage, QuantRotorK3, ISO_QUAT_BLOCK_SIZE};
+use crate::storage::{iso_n_groups_for, KvStorage, QuantRotorK3, ISO_QUAT_BLOCK_SIZE};
 use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
 use rmlx_core::DispatchPolicy;
 use rmlx_mlx::{mlx_active_memory_bytes, Array, Device, Dtype};
 
-/// `b * kv_h > 1` — the shape the copy exists at.
-const KV_H: i32 = 8;
-const HEAD_DIM: i32 = 128;
-const HEADS_PER_KV: i32 = 4;
-const N_Q_HEADS: i32 = KV_H * HEADS_PER_KV;
+/// One direct-dispatch fixture shape.
+#[derive(Debug, Clone, Copy)]
+struct Shape {
+    kv_h: i32,
+    heads_per_kv: i32,
+    /// Attended length.
+    kv_seq: i32,
+    /// The mirror allocation's own sequence extent, `> kv_seq` so the
+    /// `..kv_seq` cut is a strict, non-contiguous sub-view.
+    mirror_seq: i32,
+}
+
 const B: i32 = 1;
+const HEAD_DIM: i32 = 128;
 
-/// Attended length in the direct-dispatch tests, and the mirror's own extent.
-/// They differ so the `..kv_seq` cut is a strict, non-contiguous sub-view.
-const KV_SEQ: i32 = 1024;
-const MIRROR_SEQ: i32 = 2048;
+/// The shape the copy exists at (`b * kv_h > 1`), and the one it does not.
+const MULTI_HEAD: Shape = Shape {
+    kv_h: 8,
+    heads_per_kv: 4,
+    kv_seq: 1024,
+    mirror_seq: 2048,
+};
+const SINGLE_HEAD: Shape = Shape {
+    kv_h: 1,
+    heads_per_kv: 4,
+    kv_seq: 1024,
+    mirror_seq: 2048,
+};
 
-/// Bytes one `..kv_seq` prefix copy of a `[1, KV_H, _, HEAD_DIM]` bf16 mirror
-/// costs — the size of the defect, straight from the shape.
-const fn prefix_copy_bytes(kv_seq: i32) -> u64 {
-    (KV_H as u64) * (kv_seq as u64) * (HEAD_DIM as u64) * 2
+impl Shape {
+    const fn n_q_heads(self) -> i32 {
+        self.kv_h * self.heads_per_kv
+    }
+
+    /// Bytes one `..kv_seq` prefix copy of this shape's bf16 mirror costs.
+    const fn prefix_copy_bytes(self, tokens: i32) -> u64 {
+        (self.kv_h as u64) * (tokens as u64) * (HEAD_DIM as u64) * 2
+    }
 }
 
 #[allow(clippy::expect_used, reason = "test helper: invariants documented")]
@@ -73,49 +112,57 @@ fn u32_array(data: &[u32], shape: &[i32]) -> Array {
     Array::from_bytes(&bytes, shape, Dtype::U32).expect("u32_array")
 }
 
-/// The bf16 V mirror and the `..KV_SEQ` cut of it the dispatchers used to take.
-#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
-fn v_mirror_and_cut() -> (Array, Array) {
-    let n = (B * KV_H * MIRROR_SEQ * HEAD_DIM) as usize;
-    let mirror = f32_array(&lcg_data(n, 0x5EED), &[B, KV_H, MIRROR_SEQ, HEAD_DIM])
-        .astype(Dtype::Bf16, Device::Gpu)
-        .expect("V mirror astype bf16");
-    mirror.eval().expect("V mirror eval");
-    let cut = slice_v_prefix(&mirror, KV_SEQ, Device::Gpu).expect("V mirror prefix");
-    (mirror, cut)
-}
-
-#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
-fn decode_query(seed: u64) -> Array {
-    f32_array(
-        &lcg_data((B * N_Q_HEADS * HEAD_DIM) as usize, seed),
-        &[B, N_Q_HEADS, 1, HEAD_DIM],
-    )
-}
-
-/// Sequence-major K for the direct-dispatch tests: token `(s, h)` at row
-/// `s * kv_h + h`, which is the layout every packed K store writes.
-fn k_seq_major() -> Vec<f32> {
-    lcg_data((KV_SEQ * KV_H * HEAD_DIM) as usize, 0xB0B)
-}
-
-// ── Per-codec direct dispatch, parameterised only by the V argument ───────────
-//
-// Each codec's packed K is built once, up front, and evaluated: an allocation
-// bracket around a dispatch must not also contain the fixture's own buffers.
-
 #[allow(clippy::expect_used, reason = "test helper: invariants documented")]
 fn evaluated(a: Array) -> Array {
     a.eval().expect("fixture eval");
     a
 }
 
+/// The bf16 V mirror and the `..kv_seq` cut of it the dispatchers used to take.
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn v_mirror_and_cut(shape: Shape) -> (Array, Array) {
+    let n = (B * shape.kv_h * shape.mirror_seq * HEAD_DIM) as usize;
+    let mirror = f32_array(
+        &lcg_data(n, 0x5EED),
+        &[B, shape.kv_h, shape.mirror_seq, HEAD_DIM],
+    )
+    .astype(Dtype::Bf16, Device::Gpu)
+    .expect("V mirror astype bf16");
+    let mirror = evaluated(mirror);
+    let cut =
+        evaluated(slice_v_prefix(&mirror, shape.kv_seq, Device::Gpu).expect("V mirror prefix"));
+    (mirror, cut)
+}
+
+#[allow(clippy::expect_used, reason = "test helper: invariants documented")]
+fn decode_query(shape: Shape, seed: u64) -> Array {
+    f32_array(
+        &lcg_data((B * shape.n_q_heads() * HEAD_DIM) as usize, seed),
+        &[B, shape.n_q_heads(), 1, HEAD_DIM],
+    )
+}
+
+/// Sequence-major K: token `(s, h)` at row `s * kv_h + h`, the layout every
+/// packed K store writes.
+fn k_seq_major(shape: Shape) -> Vec<f32> {
+    lcg_data((shape.kv_seq * shape.kv_h * HEAD_DIM) as usize, 0xB0B)
+}
+
+// ── Per-codec direct dispatch, parameterised only by the V argument ───────────
+//
+// Each codec's packed K is built once, up front, and evaluated: an allocation
+// measurement around a dispatch must not also contain the fixture's own buffers.
+
 /// iso3-packed K: `(codes, scales, norms)`.
 #[allow(clippy::expect_used, reason = "test helper: invariants documented")]
-fn iso3_packed() -> (Array, Array, Array) {
-    let (codes, scales, _quat, norms) =
-        iso_encode_fast(&k_seq_major(), HEAD_DIM as usize, ISO_QUAT_BLOCK_SIZE, 3)
-            .expect("iso_encode_fast");
+fn iso3_packed(shape: Shape) -> (Array, Array, Array) {
+    let (codes, scales, _quat, norms) = iso_encode_fast(
+        &k_seq_major(shape),
+        HEAD_DIM as usize,
+        ISO_QUAT_BLOCK_SIZE,
+        3,
+    )
+    .expect("iso_encode_fast");
     (
         evaluated(u32_array(&codes, &[codes.len() as i32])),
         evaluated(f32_array(&scales, &[scales.len() as i32])),
@@ -124,20 +171,20 @@ fn iso3_packed() -> (Array, Array, Array) {
 }
 
 #[allow(clippy::expect_used, reason = "test helper: invariants documented")]
-fn iso3_dispatch(packed: &(Array, Array, Array), v: &Array) -> Vec<u8> {
+fn iso3_dispatch(shape: Shape, packed: &(Array, Array, Array), v: &Array) -> Vec<u8> {
     let (codes, scales, norms) = packed;
     let out = iso_flash_decode_sdpa::<3>(
-        &decode_query(0xA1),
+        &decode_query(shape, 0xA1),
         codes,
         scales,
         norms,
-        v,
+        VMirror::new(v, shape.kv_seq),
         None,
         B,
-        KV_H,
-        KV_SEQ,
+        shape.kv_h,
+        shape.kv_seq,
         HEAD_DIM,
-        HEADS_PER_KV,
+        shape.heads_per_kv,
         1.0 / (HEAD_DIM as f32).sqrt(),
         Device::Gpu,
     )
@@ -148,10 +195,10 @@ fn iso3_dispatch(packed: &(Array, Array, Array), v: &Array) -> Vec<u8> {
 
 /// rotor3-packed K: `(codes, scales, norms, rotors)`.
 #[allow(clippy::expect_used, reason = "test helper: invariants documented")]
-fn rotor3_packed() -> (Array, Array, Array, Array) {
+fn rotor3_packed(shape: Shape) -> (Array, Array, Array, Array) {
     let rotors = make_rotor_table(0, 0, n_groups_for(HEAD_DIM as usize));
     let (codes, scales, norms) =
-        rotor3_encode(&k_seq_major(), &rotors, HEAD_DIM as usize).expect("rotor3_encode");
+        rotor3_encode(&k_seq_major(shape), &rotors, HEAD_DIM as usize).expect("rotor3_encode");
     (
         evaluated(u32_array(&codes, &[codes.len() as i32])),
         evaluated(f32_array(&scales, &[scales.len() as i32])),
@@ -161,21 +208,21 @@ fn rotor3_packed() -> (Array, Array, Array, Array) {
 }
 
 #[allow(clippy::expect_used, reason = "test helper: invariants documented")]
-fn rotor3_dispatch(packed: &(Array, Array, Array, Array), v: &Array) -> Vec<u8> {
+fn rotor3_dispatch(shape: Shape, packed: &(Array, Array, Array, Array), v: &Array) -> Vec<u8> {
     let (codes, scales, norms, rotors) = packed;
     let out = rotor_flash_decode_sdpa::<3>(
-        &decode_query(0xA2),
+        &decode_query(shape, 0xA2),
         codes,
         scales,
         norms,
         rotors,
-        v,
+        VMirror::new(v, shape.kv_seq),
         None,
         B,
-        KV_H,
-        KV_SEQ,
+        shape.kv_h,
+        shape.kv_seq,
         HEAD_DIM,
-        HEADS_PER_KV,
+        shape.heads_per_kv,
         1.0 / (HEAD_DIM as f32).sqrt(),
         Device::Gpu,
     )
@@ -186,28 +233,31 @@ fn rotor3_dispatch(packed: &(Array, Array, Array, Array), v: &Array) -> Vec<u8> 
 
 /// planar4-packed K: `(codes, scales, rot32)`.
 #[allow(clippy::expect_used, reason = "test helper: invariants documented")]
-fn planar4_packed() -> (Array, Array, Array) {
-    let k = f32_array(&k_seq_major(), &[B, KV_SEQ, KV_H, HEAD_DIM]);
+fn planar4_packed(shape: Shape) -> (Array, Array, Array) {
+    let k = f32_array(
+        &k_seq_major(shape),
+        &[B, shape.kv_seq, shape.kv_h, HEAD_DIM],
+    );
     let (codes, scales, rot32) =
         planar_quantize_v4_gpu(&k, Device::Gpu).expect("planar_quantize_v4_gpu");
     (evaluated(codes), evaluated(scales), evaluated(rot32))
 }
 
 #[allow(clippy::expect_used, reason = "test helper: invariants documented")]
-fn planar4_dispatch(packed: &(Array, Array, Array), v: &Array) -> Vec<u8> {
+fn planar4_dispatch(shape: Shape, packed: &(Array, Array, Array), v: &Array) -> Vec<u8> {
     let (codes, scales, rot32) = packed;
     let out = planar_flash_decode_sdpa(
-        &decode_query(0xA3),
+        &decode_query(shape, 0xA3),
         codes,
         scales,
         rot32,
-        v,
+        VMirror::new(v, shape.kv_seq),
         None,
         B,
-        KV_H,
-        KV_SEQ,
+        shape.kv_h,
+        shape.kv_seq,
         HEAD_DIM,
-        HEADS_PER_KV,
+        shape.heads_per_kv,
         4,
         1.0 / (HEAD_DIM as f32).sqrt(),
         Device::Gpu,
@@ -220,45 +270,48 @@ fn planar4_dispatch(packed: &(Array, Array, Array), v: &Array) -> Vec<u8> {
 // ── The stride reaches every dispatcher's kernel, and changes no bit ──────────
 
 /// Each dispatcher must return the same bytes whether it is handed the whole
-/// mirror or the `..kv_seq` cut of it.
+/// mirror or the `..kv_seq` cut of it, at both a multi-head and a single-head
+/// shape.
 ///
 /// The two arms differ only in V's sequence extent, so the stride the kernel
 /// indexes V with differs between them. A dispatcher that dropped the stride,
-/// or a kernel body that read it from the wrong `dims` slot, would read V at
-/// the wrong offset in the whole-mirror arm and the bytes would diverge —
-/// which is the per-codec wiring this covers and the allocation bounds below
-/// do not.
+/// or a kernel body that read it from the wrong `dims` slot, reads V at the
+/// wrong offset in the whole-mirror arm and the bytes diverge — which is the
+/// per-codec wiring this covers and the allocation bounds below do not.
 #[test]
 #[ignore = "GPU Metal context — run explicitly"]
 fn every_flash_decode_dispatcher_strides_over_the_whole_v_mirror() {
     if skip_if_no_gpu_env() {
         return;
     }
-    let (mirror, cut) = v_mirror_and_cut();
-    assert_ne!(
-        mirror.shape()[2],
-        cut.shape()[2],
-        "the two arms must differ in V's sequence extent, or the comparison is trivial"
-    );
-    let iso = iso3_packed();
-    let rotor = rotor3_packed();
-    let planar = planar4_packed();
-    #[allow(
-        clippy::type_complexity,
-        reason = "one local table of per-codec dispatch closures; naming the type buys nothing"
-    )]
-    let codecs: [(&str, Box<dyn Fn(&Array) -> Vec<u8>>); 3] = [
-        ("iso3", Box::new(|v| iso3_dispatch(&iso, v))),
-        ("rotor3", Box::new(|v| rotor3_dispatch(&rotor, v))),
-        ("planar4", Box::new(|v| planar4_dispatch(&planar, v))),
-    ];
-    for (codec, dispatch) in codecs {
-        assert_eq!(
-            dispatch(&mirror),
-            dispatch(&cut),
-            "{codec}: striding over the whole V mirror must be bit-identical to \
-             attending its cut prefix"
+    for shape in [MULTI_HEAD, SINGLE_HEAD] {
+        let (mirror, cut) = v_mirror_and_cut(shape);
+        assert_ne!(
+            mirror.shape()[2],
+            cut.shape()[2],
+            "the two arms must differ in V's sequence extent, or the comparison is trivial"
         );
+        let iso = iso3_packed(shape);
+        let rotor = rotor3_packed(shape);
+        let planar = planar4_packed(shape);
+        #[allow(
+            clippy::type_complexity,
+            reason = "one local table of per-codec dispatch closures; naming the type buys nothing"
+        )]
+        let codecs: [(&str, Box<dyn Fn(&Array) -> Vec<u8>>); 3] = [
+            ("iso3", Box::new(|v| iso3_dispatch(shape, &iso, v))),
+            ("rotor3", Box::new(|v| rotor3_dispatch(shape, &rotor, v))),
+            ("planar4", Box::new(|v| planar4_dispatch(shape, &planar, v))),
+        ];
+        for (codec, dispatch) in codecs {
+            assert_eq!(
+                dispatch(&mirror),
+                dispatch(&cut),
+                "{codec} at kv_h={}: striding over the whole V mirror must be bit-identical \
+                 to attending its cut prefix",
+                shape.kv_h
+            );
+        }
     }
 }
 
@@ -287,14 +340,15 @@ fn the_slice_the_dispatchers_no_longer_take_costs_a_measurable_prefix_copy() {
     if skip_if_no_gpu_env() {
         return;
     }
-    let (mirror, cut) = v_mirror_and_cut();
-    let iso = iso3_packed();
+    let shape = MULTI_HEAD;
+    let (mirror, cut) = v_mirror_and_cut(shape);
+    let iso = iso3_packed(shape);
 
     // Repeat until the allocator settles: the first dispatch of a kernel
     // compiles it, and each dispatch's buffers are released on the next one.
     let settled_live = |v: &Array| -> u64 {
         for _ in 0..4 {
-            let _ = iso3_dispatch(&iso, v);
+            let _ = iso3_dispatch(shape, &iso, v);
         }
         let live = mlx_active_memory_bytes()
             .expect("no Metal allocator reading — the measurement below is vacuous");
@@ -311,7 +365,7 @@ fn the_slice_the_dispatchers_no_longer_take_costs_a_measurable_prefix_copy() {
          of the cut arm, or this is measuring drift rather than the copy"
     );
 
-    let copy = prefix_copy_bytes(KV_SEQ);
+    let copy = shape.prefix_copy_bytes(shape.kv_seq);
     let extra = sliced.saturating_sub(whole_before);
     assert!(
         extra >= copy,
@@ -354,14 +408,15 @@ fn resident_growth_over_decode(
     dispatch_count: fn() -> u64,
 ) -> GrowthProbe {
     let device = Device::Gpu;
+    let shape = MULTI_HEAD;
     let scale = 1.0_f32 / (HEAD_DIM as f32).sqrt();
 
-    let pf = (PREFILL * KV_H * HEAD_DIM) as usize;
-    let k = f32_array(&lcg_data(pf, 1), &[B, KV_H, PREFILL, HEAD_DIM]);
-    let v = f32_array(&lcg_data(pf, 2), &[B, KV_H, PREFILL, HEAD_DIM]);
+    let pf = (PREFILL * shape.kv_h * HEAD_DIM) as usize;
+    let k = f32_array(&lcg_data(pf, 1), &[B, shape.kv_h, PREFILL, HEAD_DIM]);
+    let v = f32_array(&lcg_data(pf, 2), &[B, shape.kv_h, PREFILL, HEAD_DIM]);
     let q = f32_array(
-        &lcg_data((PREFILL * N_Q_HEADS * HEAD_DIM) as usize, 3),
-        &[B, N_Q_HEADS, PREFILL, HEAD_DIM],
+        &lcg_data((PREFILL * shape.n_q_heads() * HEAD_DIM) as usize, 3),
+        &[B, shape.n_q_heads(), PREFILL, HEAD_DIM],
     );
     cache
         .update_and_sdpa(&q, &k, &v, scale, "causal", None, device)
@@ -369,12 +424,12 @@ fn resident_growth_over_decode(
     cache.exit_prefill(device).expect("exit_prefill");
 
     let step = |cache: &mut KvCache, seed: u64| {
-        let one = (KV_H * HEAD_DIM) as usize;
-        let k1 = f32_array(&lcg_data(one, 10 + seed), &[B, KV_H, 1, HEAD_DIM]);
-        let v1 = f32_array(&lcg_data(one, 20 + seed), &[B, KV_H, 1, HEAD_DIM]);
+        let one = (shape.kv_h * HEAD_DIM) as usize;
+        let k1 = f32_array(&lcg_data(one, 10 + seed), &[B, shape.kv_h, 1, HEAD_DIM]);
+        let v1 = f32_array(&lcg_data(one, 20 + seed), &[B, shape.kv_h, 1, HEAD_DIM]);
         let q1 = f32_array(
-            &lcg_data((N_Q_HEADS * HEAD_DIM) as usize, 30 + seed),
-            &[B, N_Q_HEADS, 1, HEAD_DIM],
+            &lcg_data((shape.n_q_heads() * HEAD_DIM) as usize, 30 + seed),
+            &[B, shape.n_q_heads(), 1, HEAD_DIM],
         );
         let out = cache
             .update_and_sdpa(&q1, &k1, &v1, scale, "", None, device)
@@ -386,7 +441,7 @@ fn resident_growth_over_decode(
         step(&mut cache, s);
     }
     let live_before = mlx_active_memory_bytes()
-        .expect("no Metal allocator reading — the bound below would be vacuous");
+        .expect("no Metal allocator reading — the bounds below would be vacuous");
     let offset_before = cache.offset();
     let dispatches_before = dispatch_count();
 
@@ -408,7 +463,7 @@ fn resident_growth_over_decode(
     assert!(
         live_after > live_before,
         "{codec}: resident memory did not grow at all over {MEASURED_STEPS} steps \
-         ({live_before} -> {live_after}); the bound below would pass by measuring nothing"
+         ({live_before} -> {live_after}); the bounds below would pass by measuring nothing"
     );
     GrowthProbe {
         grown_bytes: live_after - live_before,
@@ -416,25 +471,46 @@ fn resident_growth_over_decode(
     }
 }
 
-/// A decode loop must not grow resident memory by a V prefix per step.
+/// A decode loop must not grow resident memory by a V prefix per step, and its
+/// clean floor must stay where it was measured.
 ///
-/// Budget: one and a half V-prefix copies over the measured run. The packed K
-/// view has its own prefix-sized materialisation, measured at ~0.9 copies at
-/// this shape, so the budget clears it; a re-materialised V prefix takes the
-/// total to ~2.9 (the live copy plus the previous step's, released one dispatch
-/// late). Both terms scale with `kv_h * head_dim`, so the ratio, and this
-/// budget, hold at any shape.
-fn assert_growth_holds_no_v_prefix(codec: &str, probe: &GrowthProbe) {
-    let copy = prefix_copy_bytes(probe.tokens);
-    let budget = copy * 3 / 2;
+/// Two bounds, deliberately.
+///
+/// The first is the defect bound: a re-materialised V prefix puts growth near
+/// 2900 per mille of one copy (the live one plus the previous step's, released
+/// a dispatch late — measured 2884 for iso3 and 3142 for rotor3), so 1500
+/// separates it from either clean floor with margin both ways.
+///
+/// The second pins that clean floor, which is not zero and is not a shared
+/// constant. What this loop grows by is the packed **K** view's own
+/// prefix-sized materialisation, and that term scales with the K codec's bit
+/// width and its sideband planes where the V term scales with `sizeof(bf16)` —
+/// so it differs per codec, measured at 886 per mille for iso3 against 1144 for
+/// rotor3. `floor_band` is that measurement, per caller. Pinning it makes
+/// K-side drift a named failure here rather than silent margin eaten out of the
+/// bound above.
+fn assert_growth_holds_no_v_prefix(
+    codec: &str,
+    probe: &GrowthProbe,
+    floor_band: std::ops::RangeInclusive<u64>,
+) {
+    let copy = MULTI_HEAD.prefix_copy_bytes(probe.tokens);
+    let per_mille = probe.grown_bytes * 1000 / copy;
     assert!(
-        probe.grown_bytes <= budget,
-        "{codec}: {} B stayed resident over {} decoded tokens, above the {budget} B \
-         budget — a V prefix of {copy} B is being re-materialised per step, which \
-         is what flattening a non-contiguous `..kv_seq` cut of the head-major bf16 \
-         mirror at kv_h={KV_H} costs ({probe:?})",
+        probe.grown_bytes < copy * 3 / 2,
+        "{codec}: {} B stayed resident over {} decoded tokens — {per_mille} per mille of the \
+         {copy} B V-mirror prefix, where flattening a non-contiguous `..kv_seq` cut of the \
+         head-major mirror at kv_h={} would put it near 2900 ({probe:?})",
         probe.grown_bytes,
-        probe.tokens
+        probe.tokens,
+        MULTI_HEAD.kv_h
+    );
+    assert!(
+        floor_band.contains(&per_mille),
+        "{codec}: the clean floor moved — {per_mille} per mille of a V prefix copy, outside \
+         the measured band {floor_band:?}. Nothing about V changed (the bound above still \
+         holds), so the packed-K view's own per-token growth drifted; re-measure and re-pin, \
+         or the V bound above loses the margin it depends on ({probe:?})"
     );
 }
 
@@ -446,7 +522,8 @@ fn iso_decode_does_not_copy_the_v_mirror() {
     }
     let cache = KvCache::with_quant_max_seq(KvQuant::IsoKOnly3, MAX_SEQ);
     let probe = resident_growth_over_decode("iso3", cache, iso_flash_decode_dispatch_count);
-    assert_growth_holds_no_v_prefix("iso3", &probe);
+    // Measured 886 per mille of one V prefix copy.
+    assert_growth_holds_no_v_prefix("iso3", &probe, 750..=1000);
 }
 
 #[test]
@@ -465,7 +542,7 @@ fn rotor_decode_does_not_copy_the_v_mirror() {
             rotors,
             None,
             Vec::new(),
-            vec![B, KV_H, 0, HEAD_DIM],
+            vec![B, MULTI_HEAD.kv_h, 0, HEAD_DIM],
             0,
         )),
         max_seq: MAX_SEQ,
@@ -479,5 +556,121 @@ fn rotor_decode_does_not_copy_the_v_mirror() {
         false,
     );
     let probe = resident_growth_over_decode("rotor3", cache, rotor_flash_decode_dispatch_count);
-    assert_growth_holds_no_v_prefix("rotor3", &probe);
+    // Measured 1144 per mille — rotor3's packed view carries more per token
+    // than iso3's, which is why the band is per codec and not shared.
+    assert_growth_holds_no_v_prefix("rotor3", &probe, 1000..=1300);
+}
+
+// ── The mirror's valid length is checked in every profile ─────────────────────
+
+/// A mirror whose valid length disagrees with the attended `kv_seq` must be a
+/// hard error, in every build profile.
+///
+/// This is the invariant the pre-stride code enforced implicitly: it flattened
+/// V to `b * kv_h * kv_seq * head_dim` elements and MLX's `reshape` rejects an
+/// element-count mismatch. Striding over the allocation decouples the two, so
+/// the check is now explicit — and it has to be an `Err`, not a `debug_assert`,
+/// because the profile the engine ships under compiles assertions out and
+/// executes no GPU test. The failure it prevents is a decode step attending the
+/// mirror's tail (zeros, or a previous longer sequence's V) and returning
+/// plausible-but-wrong output with no error at all.
+///
+/// `Device::Cpu` on purpose: the check runs before any Metal dispatch, so this
+/// is not a GPU test and must not be `#[ignore]`d — `#[ignore]` is what would
+/// keep it out of the profile it exists to cover.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: every expect is on a fixture built immediately above"
+)]
+fn a_v_mirror_shorter_than_the_attended_prefix_is_rejected() {
+    let shape = MULTI_HEAD;
+    let kv_seq = 8_i32;
+    let n_groups = iso_n_groups_for(HEAD_DIM as usize) as i32;
+
+    // Correctly sized K planes: the V check sits behind the K flattens, so
+    // undersized dummies would fail earlier and this would pass for the wrong
+    // reason.
+    let tok = B * kv_seq * shape.kv_h;
+    let codes = u32_array(&vec![0_u32; (tok * n_groups) as usize], &[tok * n_groups]);
+    let scales = f32_array(&vec![0.0_f32; (tok * n_groups) as usize], &[tok * n_groups]);
+    let norms = f32_array(&vec![0.0_f32; tok as usize], &[tok]);
+    let q = decode_query(shape, 0xD1);
+    let mirror = f32_array(
+        &vec![0.0_f32; (B * shape.kv_h * 16 * HEAD_DIM) as usize],
+        &[B, shape.kv_h, 16, HEAD_DIM],
+    );
+
+    let err = iso_flash_decode_sdpa::<3>(
+        &q,
+        &codes,
+        &scales,
+        &norms,
+        VMirror::new(&mirror, kv_seq - 1),
+        None,
+        B,
+        shape.kv_h,
+        kv_seq,
+        HEAD_DIM,
+        shape.heads_per_kv,
+        1.0,
+        Device::Cpu,
+    )
+    .expect_err("a mirror shorter than the attended prefix must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("out of step"),
+        "expected the store/mirror desync error, got: {msg}"
+    );
+}
+
+/// `slice_v_prefix` must cut the right rows at a head-major shape whose
+/// `head_dim` is not a power of two.
+///
+/// The flash dispatchers reject non-power-of-two `head_dim` outright (their
+/// tree reduction needs one), so that shape cannot be an arm of the equivalence
+/// test above. It does reach `slice_v_prefix`: planar's non-flash fused-QK
+/// fallback calls it, and that arm is exactly where a non-power-of-two
+/// `head_dim` lands.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: every expect is on a fixture built immediately above"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test: chunks_exact(4) guarantees the 4-byte length"
+)]
+fn slice_v_prefix_cuts_the_valid_rows_at_a_non_pow2_head_dim() {
+    let (kv_h, head_dim, mirror_seq, valid) = (3_i32, 96_i32, 8_i32, 5_i32);
+    let n = (B * kv_h * mirror_seq * head_dim) as usize;
+    let data: Vec<f32> = (0..n).map(|i| i as f32).collect();
+    let mirror = f32_array(&data, &[B, kv_h, mirror_seq, head_dim]);
+
+    let cut = slice_v_prefix(&mirror, valid, Device::Cpu).expect("slice_v_prefix");
+    assert_eq!(cut.shape(), vec![B, kv_h, valid, head_dim]);
+    // Materialise before reading: `to_bytes` hands back the backing buffer, so
+    // a strided view read straight out of it reports the allocation's leading
+    // elements rather than the view's.
+    let cut = cut.contiguous(Device::Cpu).expect("cut contiguous");
+    cut.eval().expect("cut eval");
+    let got: Vec<f32> = cut
+        .to_bytes()
+        .expect("cut bytes")
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
+        .collect();
+
+    // Head-major: head h's valid rows start at h * mirror_seq * head_dim, which
+    // is what makes the cut non-contiguous once kv_h > 1.
+    let want: Vec<f32> = (0..kv_h)
+        .flat_map(|h| {
+            let base = (h * mirror_seq * head_dim) as usize;
+            (0..(valid * head_dim) as usize).map(move |i| (base + i) as f32)
+        })
+        .collect();
+    assert_eq!(
+        got, want,
+        "the cut must hold each head's first {valid} rows"
+    );
 }

--- a/crates/rmlx-kv-quant/src/kvcache/v_mirror_alloc_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/v_mirror_alloc_tests.rs
@@ -41,7 +41,7 @@ use crate::rotorquant::{n_groups_for, rotor3_encode};
 use crate::storage::{KvStorage, QuantRotorK3, ISO_QUAT_BLOCK_SIZE};
 use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
 use rmlx_core::DispatchPolicy;
-use rmlx_mlx::{mlx_active_memory_bytes, Array, Device, Dtype, PeakBracket};
+use rmlx_mlx::{mlx_active_memory_bytes, Array, Device, Dtype};
 
 /// `b * kv_h > 1` — the shape the copy exists at.
 const KV_H: i32 = 8;
@@ -322,30 +322,37 @@ fn the_slice_the_dispatchers_no_longer_take_costs_a_measurable_prefix_copy() {
     );
 }
 
-// ── The production decode step does not pay it either ─────────────────────────
+// ── The production decode loop does not pay it either ────────────────────────
 
-const MAX_SEQ: i32 = 1024;
-const PREFILL: i32 = 1016;
-const WARMUP_STEPS: u64 = 2;
+const MAX_SEQ: i32 = 4096;
+const PREFILL: i32 = 512;
+const SETTLE_STEPS: u64 = 256;
+const MEASURED_STEPS: u64 = 1024;
 
-/// What one bracketed decode step observed.
+/// How much resident memory a decode loop grew over a run of steps.
 #[derive(Debug)]
-struct StepProbe {
-    headroom: u64,
-    kv_seq: i32,
+struct GrowthProbe {
+    grown_bytes: u64,
+    tokens: i32,
 }
 
-/// Prefill a cache, warm it, then bracket exactly one steady-state decode step.
+/// Drive `update_and_sdpa` on `cache` and report how many bytes stay resident
+/// per token decoded.
 ///
-/// `dispatch_count` is the codec's own kernel counter; a step that did not
-/// advance it never reached the kernel, and its allocation reading would
+/// A slope, not a level: every buffer sized at `max_seq` — the mirror, the
+/// packed ring — is allocated before the measurement starts and cancels out.
+/// What is left grows with the attended prefix, and a re-materialised V prefix
+/// is `kv_h * kv_seq * head_dim * 2` bytes of exactly that.
+///
+/// `dispatch_count` is the codec's own kernel counter: a run that did not
+/// advance it once per step never reached the kernel, and its slope would
 /// describe a CPU-dequant fallback instead.
 #[allow(clippy::expect_used, reason = "test helper: invariants documented")]
-fn bracket_one_decode_step(
+fn resident_growth_over_decode(
     codec: &str,
     mut cache: KvCache,
     dispatch_count: fn() -> u64,
-) -> StepProbe {
+) -> GrowthProbe {
     let device = Device::Gpu;
     let scale = 1.0_f32 / (HEAD_DIM as f32).sqrt();
 
@@ -374,60 +381,77 @@ fn bracket_one_decode_step(
             .expect("decode update_and_sdpa");
         out.eval().expect("decode out eval");
     };
-    for s in 0..WARMUP_STEPS {
+
+    for s in 0..SETTLE_STEPS {
         step(&mut cache, s);
     }
+    let live_before = mlx_active_memory_bytes()
+        .expect("no Metal allocator reading — the bound below would be vacuous");
+    let offset_before = cache.offset();
+    let dispatches_before = dispatch_count();
 
-    let before = dispatch_count();
-    let bracket = PeakBracket::open();
-    step(&mut cache, 99);
-    let reading = bracket.close();
+    for s in SETTLE_STEPS..SETTLE_STEPS + MEASURED_STEPS {
+        step(&mut cache, s);
+    }
+    let live_after = mlx_active_memory_bytes().expect("no Metal allocator reading");
+    let tokens = cache.offset() - offset_before;
 
-    assert!(
-        dispatch_count() > before,
-        "{codec}: the bracketed step never reached the flash-decode kernel — the \
-         reading describes a CPU-dequant fallback, not the dispatch this gate is about"
+    assert_eq!(
+        tokens, MEASURED_STEPS as i32,
+        "{codec}: the cache advanced {tokens} positions over {MEASURED_STEPS} decode steps"
     );
     assert!(
-        reading.measurable(),
-        "{codec}: peak mark could not be zeroed — the reading is not scoped to the step"
+        dispatch_count() - dispatches_before >= MEASURED_STEPS,
+        "{codec}: the measured steps did not each reach the flash-decode kernel — \
+         the slope describes a CPU-dequant fallback, not the dispatch this gate is about"
     );
     assert!(
-        reading.observed_allocation(),
-        "{codec}: the bracketed decode step allocated nothing: {reading:?}"
+        live_after > live_before,
+        "{codec}: resident memory did not grow at all over {MEASURED_STEPS} steps \
+         ({live_before} -> {live_after}); the bound below would pass by measuring nothing"
     );
-    StepProbe {
-        headroom: reading.headroom_bytes(),
-        kv_seq: cache.offset(),
+    GrowthProbe {
+        grown_bytes: live_after - live_before,
+        tokens,
     }
 }
 
-/// One decode step must allocate far less than one V-mirror prefix copy.
-fn assert_step_pays_no_prefix_copy(codec: &str, probe: &StepProbe) {
-    let copy = prefix_copy_bytes(probe.kv_seq);
+/// A decode loop must not grow resident memory by a V prefix per step.
+///
+/// Budget: one and a half V-prefix copies over the measured run. The packed K
+/// view has its own prefix-sized materialisation, measured at ~0.9 copies at
+/// this shape, so the budget clears it; a re-materialised V prefix takes the
+/// total to ~2.9 (the live copy plus the previous step's, released one dispatch
+/// late). Both terms scale with `kv_h * head_dim`, so the ratio, and this
+/// budget, hold at any shape.
+fn assert_growth_holds_no_v_prefix(codec: &str, probe: &GrowthProbe) {
+    let copy = prefix_copy_bytes(probe.tokens);
+    let budget = copy * 3 / 2;
     assert!(
-        probe.headroom < copy / 2,
-        "{codec}: one decode step allocated {} B, on the order of the {copy} B it \
-         costs to flatten a non-contiguous `..kv_seq` cut of the bf16 V mirror at \
-         kv_h={KV_H} — the mirror is being copied per layer per step again ({probe:?})",
-        probe.headroom
+        probe.grown_bytes <= budget,
+        "{codec}: {} B stayed resident over {} decoded tokens, above the {budget} B \
+         budget — a V prefix of {copy} B is being re-materialised per step, which \
+         is what flattening a non-contiguous `..kv_seq` cut of the head-major bf16 \
+         mirror at kv_h={KV_H} costs ({probe:?})",
+        probe.grown_bytes,
+        probe.tokens
     );
 }
 
 #[test]
 #[ignore = "GPU Metal context — run explicitly"]
-fn iso_decode_step_does_not_copy_the_v_mirror() {
+fn iso_decode_does_not_copy_the_v_mirror() {
     if skip_if_no_gpu_env() {
         return;
     }
     let cache = KvCache::with_quant_max_seq(KvQuant::IsoKOnly3, MAX_SEQ);
-    let probe = bracket_one_decode_step("iso3", cache, iso_flash_decode_dispatch_count);
-    assert_step_pays_no_prefix_copy("iso3", &probe);
+    let probe = resident_growth_over_decode("iso3", cache, iso_flash_decode_dispatch_count);
+    assert_growth_holds_no_v_prefix("iso3", &probe);
 }
 
 #[test]
 #[ignore = "GPU Metal context — run explicitly"]
-fn rotor_decode_step_does_not_copy_the_v_mirror() {
+fn rotor_decode_does_not_copy_the_v_mirror() {
     if skip_if_no_gpu_env() {
         return;
     }
@@ -454,6 +478,6 @@ fn rotor_decode_step_does_not_copy_the_v_mirror() {
         DispatchPolicy::default(),
         false,
     );
-    let probe = bracket_one_decode_step("rotor3", cache, rotor_flash_decode_dispatch_count);
-    assert_step_pays_no_prefix_copy("rotor3", &probe);
+    let probe = resident_growth_over_decode("rotor3", cache, rotor_flash_decode_dispatch_count);
+    assert_growth_holds_no_v_prefix("rotor3", &probe);
 }

--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -113,6 +113,9 @@ pub mod turbo_k4_fused_qk_msl;
 pub mod turboquant;
 pub mod turboquant_msl;
 
+// The V-mirror pair the three flash-decode dispatchers take. Re-exported rather
+// than opening the whole module: the rest of `flash_decode_common` is internal.
+pub use flash_decode_common::VMirror;
 pub use kvcache::{KvCache, SharedKv};
 pub use linear_attn::LinearAttnCache;
 pub use quant::{

--- a/crates/rmlx-kv-quant/src/metal/iso_flash_decode_p1.metal
+++ b/crates/rmlx-kv-quant/src/metal/iso_flash_decode_p1.metal
@@ -8,6 +8,10 @@ uint heads_per_kv = dims[4];
 uint n_tiles      = dims[5];
 uint has_mask     = dims[6];
 uint n_groups     = dims[7];
+// V's own sequence extent, which may exceed `kv_seq`: the caller hands over the
+// whole bf16 mirror allocation rather than a `..kv_seq` slice of it, so that no
+// partial-slice view has to be made row-contiguous before dispatch.
+uint v_seq_stride = dims[8];
 
 uint tile_idx = threadgroup_position_in_grid.x;
 uint bh       = threadgroup_position_in_grid.y;
@@ -105,14 +109,14 @@ for (uint t = tile_start; t < tile_end; t++) {
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     // ── V read + softmax-weighted accumulation ──────────────────────
-    // V layout: [B, kv_h, kv_seq, head_dim], flat. Read in V's native dtype
+    // V layout: [B, kv_h, v_seq_stride, head_dim], flat. Read in V's native dtype
     // (bf16 / f16 / f32) — the pointer is auto-typed by mlx-c from the array
     // dtype and MSL promotes to float at the read site, halving V bandwidth
     // vs. an f32 astype upcast.
     float corr = s_corr[0];
     float es   = s_expsc[0];
 
-    uint v_off  = ((b * kv_h + kv_h_idx) * kv_seq + t) * head_dim + tid;
+    uint v_off  = ((b * kv_h + kv_h_idx) * v_seq_stride + t) * head_dim + tid;
     float v_val = v_flat[v_off];
 
     acc_v = acc_v * corr + es * v_val;

--- a/crates/rmlx-kv-quant/src/metal/planar_flash_decode_p1.metal
+++ b/crates/rmlx-kv-quant/src/metal/planar_flash_decode_p1.metal
@@ -7,6 +7,10 @@ uint kv_h         = dims[3];
 uint heads_per_kv = dims[4];
 uint n_tiles      = dims[5];
 uint has_mask     = dims[6];
+// V's own sequence extent, which may exceed `kv_seq`: the caller hands over the
+// whole bf16 mirror allocation rather than a `..kv_seq` slice of it, so that no
+// partial-slice view has to be made row-contiguous before dispatch.
+uint v_seq_stride = dims[7];
 
 uint tile_idx = threadgroup_position_in_grid.x;
 uint bh       = threadgroup_position_in_grid.y;
@@ -146,11 +150,11 @@ for (uint t = tile_start; t < tile_end; t++) {
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     // ── V read + softmax-weighted accumulation ──────────────────────
-    // V layout: [B, kv_h, kv_seq, head_dim], flat.
+    // V layout: [B, kv_h, v_seq_stride, head_dim], flat.
     float corr = s_corr[0];
     float es   = s_expsc[0];
 
-    uint v_off  = ((b * kv_h + kv_h_idx) * kv_seq + t) * head_dim + tid;
+    uint v_off  = ((b * kv_h + kv_h_idx) * v_seq_stride + t) * head_dim + tid;
     float v_val = v_flat[v_off];
 
     acc_v = acc_v * corr + es * v_val;

--- a/crates/rmlx-kv-quant/src/metal/rotor_flash_decode_p1.metal
+++ b/crates/rmlx-kv-quant/src/metal/rotor_flash_decode_p1.metal
@@ -8,6 +8,10 @@ uint heads_per_kv = dims[4];
 uint n_tiles      = dims[5];
 uint has_mask     = dims[6];
 uint n_groups     = dims[7];
+// V's own sequence extent, which may exceed `kv_seq`: the caller hands over the
+// whole bf16 mirror allocation rather than a `..kv_seq` slice of it, so that no
+// partial-slice view has to be made row-contiguous before dispatch.
+uint v_seq_stride = dims[8];
 
 uint tile_idx = threadgroup_position_in_grid.x;
 uint bh       = threadgroup_position_in_grid.y;
@@ -122,14 +126,14 @@ for (uint t = tile_start; t < tile_end; t++) {
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     // ── V read + softmax-weighted accumulation ──────────────────────
-    // V layout: [B, kv_h, kv_seq, head_dim], flat. Read in V's native dtype
+    // V layout: [B, kv_h, v_seq_stride, head_dim], flat. Read in V's native dtype
     // (bf16 / f16 / f32) — the pointer is auto-typed by mlx-c from the array
     // dtype and MSL promotes to float at the read site, halving V bandwidth
     // vs. an f32 astype upcast.
     float corr = s_corr[0];
     float es   = s_expsc[0];
 
-    uint v_off  = ((b * kv_h + kv_h_idx) * kv_seq + t) * head_dim + tid;
+    uint v_off  = ((b * kv_h + kv_h_idx) * v_seq_stride + t) * head_dim + tid;
     float v_val = v_flat[v_off];
 
     acc_v = acc_v * corr + es * v_val;

--- a/crates/rmlx-kv-quant/src/planar_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/planar_flash_decode_msl.rs
@@ -56,6 +56,7 @@ use std::fmt::Write as _;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 
+use crate::flash_decode_common::flatten_v_mirror;
 use crate::planarquant::{planar_rotation_codebook, N_ROTATIONS};
 use crate::turboquant::{lloyd_gaussian_codebook, GROUP_SIZE};
 use rmlx_core::error::{Error, Result};
@@ -173,10 +174,11 @@ fn build_flash_header(bits: u8) -> Result<String> {
 // 1. k_codes   : u32  [B * kv_seq * kv_h * (head_dim / 32) * 4]
 // 2. k_scales  : f32  [B * kv_seq * kv_h * (head_dim / 2)]
 // 3. k_rot32   : u32  [B * kv_seq * kv_h * (head_dim / 16)]
-// 4. v_flat    : bf16 / f16 / f32 [B * kv_h * kv_seq * head_dim] (native dtype)
+// 4. v_flat    : bf16 / f16 / f32 [B * kv_h * v_seq_stride * head_dim]
+//               (native dtype; `v_seq_stride >= kv_seq`)
 // 5. mask_flat : f32  [B * n_q_heads * kv_seq] or [1] dummy when no mask
 // 6. scale_arr : f32  [1]
-// 7. dims      : u32  [7] — see below
+// 7. dims      : u32  [8] — see below
 //
 // `dims` layout:
 //   dims[0] = head_dim                (D, also threadgroup size)
@@ -186,6 +188,7 @@ fn build_flash_header(bits: u8) -> Result<String> {
 //   dims[4] = heads_per_kv            (n_q_heads / kv_h)
 //   dims[5] = n_tiles                 (ceil_div(kv_seq, TILE_SIZE))
 //   dims[6] = has_mask                (0 or 1)
+//   dims[7] = v_seq_stride            (V's own seq extent, >= kv_seq)
 //
 // Outputs (P1):
 // 0. partial_o     : f32 [n_tiles * n_bh * head_dim]
@@ -288,9 +291,12 @@ fn p2_kernel() -> Result<&'static MetalKernel> {
 ///   `B * kv_h * kv_seq * head_dim/2`).
 /// * `k_rot32`   — 4-bit rotation indices (`u32`, flat
 ///   `B * kv_h * kv_seq * head_dim/16`).
-/// * `v`         — bf16 / f16 / f32 V, shape `[B, kv_h, kv_seq, head_dim]`.
-///   Read in its native dtype via implicit promotion to `float` inside MSL;
-///   the dispatcher does NOT astype-upcast.  Other dtypes are rejected.
+/// * `v`         — bf16 / f16 / f32 V, shape `[B, kv_h, v_seq, head_dim]` with
+///   `v_seq >= kv_seq`: pass the whole mirror allocation rather than a
+///   `..kv_seq` slice of it, and the kernel strides over it (see
+///   [`flatten_v_mirror`]). Read in its native dtype via implicit promotion to
+///   `float` inside MSL; the dispatcher does NOT astype-upcast.  Other dtypes
+///   are rejected.
 /// * `additive_mask` — optional `f32 [B, n_q_heads, 1, kv_seq]`.
 /// * `b`, `kv_h`, `kv_seq`, `head_dim`, `heads_per_kv` — shape metadata.
 /// * `bits`      — K code bit-width.  Must be `4` (only PlanarK 4-bit storage
@@ -390,17 +396,9 @@ pub fn planar_flash_decode_sdpa(
     // The kernel param is auto-typed by mlx-c from the array dtype and the
     // MSL body uses `float v_val = v_flat[v_off];` to rely on implicit
     // promotion to float.  This halves V bandwidth vs. an f32 astype upcast
-    // on the bf16/f16 hot paths (halves V bandwidth vs. an f32 astype upcast).
-    let v_total: i64 = tok_count * i64::from(head_dim);
-    let v_flat = match v.dtype() {
-        Dtype::F32 | Dtype::Bf16 | Dtype::F16 => v.reshape(&[v_total as i32], device)?,
-        Dtype::U8 | Dtype::U32 | Dtype::I32 => {
-            let dt = v.dtype();
-            return Err(Error::Quant(format!(
-                "planar_flash_decode: V dtype must be F32 / Bf16 / F16, got {dt:?}"
-            )));
-        }
-    };
+    // on the bf16/f16 hot paths.
+    let (v_flat, v_seq_stride) =
+        flatten_v_mirror(v, "planar_flash_decode", b, kv_h, kv_seq, head_dim, device)?;
 
     // ── Mask ──────────────────────────────────────────────────────────────
     let (mask_flat, has_mask) = if let Some(m) = additive_mask {
@@ -425,12 +423,12 @@ pub fn planar_flash_decode_sdpa(
         Array::from_bytes(&bytes, &[1], Dtype::F32)?
     };
 
-    // ── dims (7 u32) ──────────────────────────────────────────────────────
+    // ── dims (8 u32) ──────────────────────────────────────────────────────
     // Layout mirrors the kernel buffer-layout comment above.  `bits` is no
     // longer carried — the dispatcher validates `bits == 4` up-front and the
     // kernel statics only have a 4-bit variant.
     let dims_arr = {
-        let dims: [u32; 7] = [
+        let dims: [u32; 8] = [
             head_dim as u32,
             kv_seq as u32,
             n_bh as u32,
@@ -438,15 +436,16 @@ pub fn planar_flash_decode_sdpa(
             heads_per_kv as u32,
             n_tiles as u32,
             has_mask,
+            v_seq_stride as u32,
         ];
         // SAFETY:
-        // * `dims` is a stack-local `[u32; 7]` fully initialised above.
+        // * `dims` is a stack-local `[u32; 8]` fully initialised above.
         // * `u32` has stricter alignment than `u8`, so the cast is sound.
-        // * The byte length `7 * 4` equals `size_of::<[u32; 7]>()`.
+        // * The byte length `8 * 4` equals `size_of::<[u32; 8]>()`.
         // * The borrow is bounded by the enclosing block; `Array::from_bytes`
         //   copies into mlx storage before this scope ends.
-        let bytes: &[u8] = unsafe { std::slice::from_raw_parts(dims.as_ptr().cast::<u8>(), 7 * 4) };
-        Array::from_bytes(bytes, &[7], Dtype::U32)
+        let bytes: &[u8] = unsafe { std::slice::from_raw_parts(dims.as_ptr().cast::<u8>(), 8 * 4) };
+        Array::from_bytes(bytes, &[8], Dtype::U32)
             .map_err(|e| Error::Mlx(format!("planar_flash_decode dims: {e}")))?
     };
 

--- a/crates/rmlx-kv-quant/src/planar_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/planar_flash_decode_msl.rs
@@ -56,7 +56,7 @@ use std::fmt::Write as _;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 
-use crate::flash_decode_common::flatten_v_mirror;
+use crate::flash_decode_common::{flatten_v_mirror, VMirror};
 use crate::planarquant::{planar_rotation_codebook, N_ROTATIONS};
 use crate::turboquant::{lloyd_gaussian_codebook, GROUP_SIZE};
 use rmlx_core::error::{Error, Result};
@@ -291,12 +291,12 @@ fn p2_kernel() -> Result<&'static MetalKernel> {
 ///   `B * kv_h * kv_seq * head_dim/2`).
 /// * `k_rot32`   — 4-bit rotation indices (`u32`, flat
 ///   `B * kv_h * kv_seq * head_dim/16`).
-/// * `v`         — bf16 / f16 / f32 V, shape `[B, kv_h, v_seq, head_dim]` with
-///   `v_seq >= kv_seq`: pass the whole mirror allocation rather than a
-///   `..kv_seq` slice of it, and the kernel strides over it (see
-///   [`flatten_v_mirror`]). Read in its native dtype via implicit promotion to
-///   `float` inside MSL; the dispatcher does NOT astype-upcast.  Other dtypes
-///   are rejected.
+/// * `v`         — the bf16 / f16 / f32 V mirror, `[B, kv_h, v_seq, head_dim]`,
+///   passed whole rather than as a `..kv_seq` slice, with the number of valid
+///   positions in it. The kernel strides over the allocation and
+///   [`flatten_v_mirror`] checks `valid == kv_seq`. Read in its native dtype
+///   via implicit promotion to `float` inside MSL; the dispatcher does NOT
+///   astype-upcast.  Other dtypes are rejected.
 /// * `additive_mask` — optional `f32 [B, n_q_heads, 1, kv_seq]`.
 /// * `b`, `kv_h`, `kv_seq`, `head_dim`, `heads_per_kv` — shape metadata.
 /// * `bits`      — K code bit-width.  Must be `4` (only PlanarK 4-bit storage
@@ -320,7 +320,7 @@ pub fn planar_flash_decode_sdpa(
     k_codes: &Array,
     k_scales: &Array,
     k_rot32: &Array,
-    v: &Array,
+    v: VMirror<'_>,
     additive_mask: Option<&Array>,
     b: i32,
     kv_h: i32,

--- a/crates/rmlx-kv-quant/src/planar_flash_decode_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/planar_flash_decode_msl_tests.rs
@@ -10,6 +10,7 @@
 //! `cargo test planar_flash_decode -- --include-ignored --test-threads=1`.
 
 use super::*;
+use crate::flash_decode_common::VMirror;
 use crate::planar_fused_qk_msl::planar_fused_qk;
 use crate::planarquant_msl::planar_quantize_v4_gpu;
 use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
@@ -193,7 +194,7 @@ fn run_parity_with_v_dtype(
         &codes,
         &scales,
         &rot32,
-        &v_arr,
+        VMirror::new(&v_arr, kv_seq),
         None,
         b,
         kv_h,
@@ -358,7 +359,7 @@ fn planar_flash_decode_rejects_non_pow2_head_dim() {
         &dummy_codes,
         &dummy_scales,
         &dummy_rot,
-        &dummy_v,
+        VMirror::new(&dummy_v, 1),
         None,
         1,
         1,
@@ -513,7 +514,7 @@ fn flash_vs_split_chain(
         &codes,
         &scales,
         &rot32,
-        &v_arr,
+        VMirror::new(&v_arr, kv_seq),
         None,
         b,
         kv_h,
@@ -753,7 +754,7 @@ fn planar_flash_decode_returns_query_dtype() {
         &codes,
         &scales,
         &rot32,
-        &v_arr,
+        VMirror::new(&v_arr, kv_seq),
         None,
         b,
         kv_h,

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_msl.rs
@@ -108,6 +108,7 @@ use rmlx_mlx::metal_kernel::{MetalKernel, MetalKernelInvoke};
 use rmlx_mlx::{Array, Device, Dtype};
 
 use crate::clifford::MV_DIM;
+use crate::flash_decode_common::flatten_v_mirror;
 use crate::rotorquant::{n_groups_for, ROTOR3_GROUP_SIZE};
 use crate::turboquant::lloyd_gaussian_codebook;
 
@@ -437,11 +438,12 @@ pub(crate) fn build_rotor_flash_header(bits: u8) -> Result<String> {
 // 2. scales    : f32  [B * kv_seq * kv_h * n_groups]
 // 3. norms     : f32  [B * kv_seq * kv_h]
 // 4. rotors    : f32  [n_groups * 4]
-// 5. v_flat    : bf16 / f16 / f32 [B * kv_h * kv_seq * head_dim] (native dtype)
+// 5. v_flat    : bf16 / f16 / f32 [B * kv_h * v_seq_stride * head_dim]
+//               (native dtype; `v_seq_stride >= kv_seq`)
 // 6. mask_flat : f32  [B * n_q_heads * kv_seq] or [1] dummy when no mask
 // 7. scale_arr : f32  [1]
-// 8. dims      : u32  [8] — {head_dim, kv_seq, n_bh, kv_h, heads_per_kv,
-//                            n_tiles, has_mask, n_groups}
+// 8. dims      : u32  [9] — {head_dim, kv_seq, n_bh, kv_h, heads_per_kv,
+//                            n_tiles, has_mask, n_groups, v_seq_stride}
 //
 // P1 outputs:
 // 0. partial_o     : f32 [n_tiles * n_bh * head_dim]
@@ -542,8 +544,11 @@ fn p2_kernel() -> Result<&'static MetalKernel> {
 ///   handling as `k_scales`.
 /// * `k_rotors`  — static per-(layer, head) rotor table, flat `[n_groups * 4]`
 ///   f32 in `[s, b12, b13, b23]` order.
-/// * `v`         — bf16 / f16 / f32 V, shape `[B, kv_h, kv_seq, head_dim]`.
-///   Read in its native dtype; the dispatcher does NOT astype-upcast.
+/// * `v`         — bf16 / f16 / f32 V, shape `[B, kv_h, v_seq, head_dim]` with
+///   `v_seq >= kv_seq`: pass the whole mirror allocation rather than a
+///   `..kv_seq` slice of it, and the kernel strides over it (see
+///   [`flatten_v_mirror`]). Read in its native dtype; the dispatcher does NOT
+///   astype-upcast.
 /// * `additive_mask` — optional `f32 [B, n_q_heads, 1, kv_seq]`.
 /// * `b`, `kv_h`, `kv_seq`, `head_dim`, `heads_per_kv` — shape metadata.
 /// * `scale`     — softmax pre-scale (typically `1/sqrt(head_dim)`).
@@ -640,16 +645,8 @@ pub fn rotor_flash_decode_sdpa<const BITS: u8>(
     let rotors_flat = k_rotors.reshape(&[rotors_total as i32], device)?;
 
     // ── V flat — keep native dtype (bf16 / f16 / f32) ─────────────────────
-    let v_total: i64 = tok_count * i64::from(head_dim);
-    let v_flat = match v.dtype() {
-        Dtype::F32 | Dtype::Bf16 | Dtype::F16 => v.reshape(&[v_total as i32], device)?,
-        Dtype::U8 | Dtype::U32 | Dtype::I32 => {
-            let dt = v.dtype();
-            return Err(Error::Quant(format!(
-                "rotor_flash_decode: V dtype must be F32 / Bf16 / F16, got {dt:?}"
-            )));
-        }
-    };
+    let (v_flat, v_seq_stride) =
+        flatten_v_mirror(v, "rotor_flash_decode", b, kv_h, kv_seq, head_dim, device)?;
 
     // ── Mask ──────────────────────────────────────────────────────────────
     let (mask_flat, has_mask) = if let Some(m) = additive_mask {
@@ -674,11 +671,11 @@ pub fn rotor_flash_decode_sdpa<const BITS: u8>(
         Array::from_bytes(&bytes, &[1], Dtype::F32)?
     };
 
-    // ── dims (8 u32) ──────────────────────────────────────────────────────
+    // ── dims (9 u32) ──────────────────────────────────────────────────────
     // `bits` is not carried — the dispatcher selects the per-BITS kernel and
     // its header supplies RF_BITS / RF_MASK.
     let dims_arr = {
-        let dims: [u32; 8] = [
+        let dims: [u32; 9] = [
             head_dim as u32,
             kv_seq as u32,
             n_bh as u32,
@@ -687,15 +684,16 @@ pub fn rotor_flash_decode_sdpa<const BITS: u8>(
             n_tiles as u32,
             has_mask,
             n_groups as u32,
+            v_seq_stride as u32,
         ];
         // SAFETY:
-        // * `dims` is a stack-local `[u32; 8]` fully initialised above.
+        // * `dims` is a stack-local `[u32; 9]` fully initialised above.
         // * `u32` has stricter alignment than `u8`, so the cast is sound.
-        // * The byte length `8 * 4` equals `size_of::<[u32; 8]>()`.
+        // * The byte length `9 * 4` equals `size_of::<[u32; 9]>()`.
         // * The borrow is bounded by the enclosing block; `Array::from_bytes`
         //   copies into mlx storage before this scope ends.
-        let bytes: &[u8] = unsafe { std::slice::from_raw_parts(dims.as_ptr().cast::<u8>(), 8 * 4) };
-        Array::from_bytes(bytes, &[8], Dtype::U32)
+        let bytes: &[u8] = unsafe { std::slice::from_raw_parts(dims.as_ptr().cast::<u8>(), 9 * 4) };
+        Array::from_bytes(bytes, &[9], Dtype::U32)
             .map_err(|e| Error::Mlx(format!("rotor_flash_decode dims: {e}")))?
     };
 

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_msl.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_msl.rs
@@ -108,7 +108,7 @@ use rmlx_mlx::metal_kernel::{MetalKernel, MetalKernelInvoke};
 use rmlx_mlx::{Array, Device, Dtype};
 
 use crate::clifford::MV_DIM;
-use crate::flash_decode_common::flatten_v_mirror;
+use crate::flash_decode_common::{flatten_v_mirror, VMirror};
 use crate::rotorquant::{n_groups_for, ROTOR3_GROUP_SIZE};
 use crate::turboquant::lloyd_gaussian_codebook;
 
@@ -544,11 +544,11 @@ fn p2_kernel() -> Result<&'static MetalKernel> {
 ///   handling as `k_scales`.
 /// * `k_rotors`  — static per-(layer, head) rotor table, flat `[n_groups * 4]`
 ///   f32 in `[s, b12, b13, b23]` order.
-/// * `v`         — bf16 / f16 / f32 V, shape `[B, kv_h, v_seq, head_dim]` with
-///   `v_seq >= kv_seq`: pass the whole mirror allocation rather than a
-///   `..kv_seq` slice of it, and the kernel strides over it (see
-///   [`flatten_v_mirror`]). Read in its native dtype; the dispatcher does NOT
-///   astype-upcast.
+/// * `v`         — the bf16 / f16 / f32 V mirror, `[B, kv_h, v_seq, head_dim]`,
+///   passed whole rather than as a `..kv_seq` slice, with the number of valid
+///   positions in it. The kernel strides over the allocation and
+///   [`flatten_v_mirror`] checks `valid == kv_seq`. Read in its native dtype;
+///   the dispatcher does NOT astype-upcast.
 /// * `additive_mask` — optional `f32 [B, n_q_heads, 1, kv_seq]`.
 /// * `b`, `kv_h`, `kv_seq`, `head_dim`, `heads_per_kv` — shape metadata.
 /// * `scale`     — softmax pre-scale (typically `1/sqrt(head_dim)`).
@@ -571,7 +571,7 @@ pub fn rotor_flash_decode_sdpa<const BITS: u8>(
     k_scales: &Array,
     k_norms: &Array,
     k_rotors: &Array,
-    v: &Array,
+    v: VMirror<'_>,
     additive_mask: Option<&Array>,
     b: i32,
     kv_h: i32,

--- a/crates/rmlx-kv-quant/src/rotor_flash_decode_msl_tests.rs
+++ b/crates/rmlx-kv-quant/src/rotor_flash_decode_msl_tests.rs
@@ -8,6 +8,7 @@
 
 use super::*;
 use crate::clifford::make_rotor_table;
+use crate::flash_decode_common::VMirror;
 use crate::rotorquant::{rotor3_decode, rotor3_encode, rotor4_decode, rotor4_encode};
 use crate::test_utils::{lcg_data, skip_if_no_gpu_env};
 use rmlx_mlx::{Array, Device, Dtype};
@@ -206,7 +207,7 @@ fn run_oracle_masked(
             &scales,
             &norms,
             &rotors,
-            &v_arr,
+            VMirror::new(&v_arr, kv_seq as i32),
             mask_arr.as_ref(),
             b as i32,
             kv_h as i32,
@@ -222,7 +223,7 @@ fn run_oracle_masked(
             &scales,
             &norms,
             &rotors,
-            &v_arr,
+            VMirror::new(&v_arr, kv_seq as i32),
             mask_arr.as_ref(),
             b as i32,
             kv_h as i32,
@@ -303,7 +304,7 @@ fn bench_rotor(
                 &scales,
                 &norms,
                 &rotors,
-                &v_arr,
+                VMirror::new(&v_arr, kv_seq as i32),
                 None,
                 b as i32,
                 kv_h as i32,
@@ -319,7 +320,7 @@ fn bench_rotor(
                 &scales,
                 &norms,
                 &rotors,
-                &v_arr,
+                VMirror::new(&v_arr, kv_seq as i32),
                 None,
                 b as i32,
                 kv_h as i32,
@@ -462,7 +463,7 @@ fn rotor_flash_decode_rejects_non_pow2_head_dim() {
         &dummy,
         &dummy,
         &dummy,
-        &dummy,
+        VMirror::new(&dummy, 8),
         None,
         1,
         1,
@@ -489,7 +490,7 @@ fn rotor_flash_decode_rejects_head_dim_above_max() {
         &dummy,
         &dummy,
         &dummy,
-        &dummy,
+        VMirror::new(&dummy, 8),
         None,
         1,
         1,
@@ -517,7 +518,7 @@ fn rotor_flash_decode_rejects_unsupported_bits() {
         &dummy,
         &dummy,
         &dummy,
-        &dummy,
+        VMirror::new(&dummy, 8),
         None,
         1,
         1,

--- a/crates/rmlx-kv-quant/src/sparse_attn/sparse_attn_tests.rs
+++ b/crates/rmlx-kv-quant/src/sparse_attn/sparse_attn_tests.rs
@@ -24,6 +24,7 @@ use super::phase1_score_msl::{phase1_score, phase1_score_dispatch_count, TOP_PER
 use super::phase2_sparse_attend_msl::{
     phase2_lse_merge, phase2_sparse_attend, phase2_sparse_attend_dispatch_count,
 };
+use crate::flash_decode_common::VMirror;
 use crate::planar_flash_decode_msl::planar_flash_decode_sdpa;
 use crate::planarquant_msl::planar_quantize_v4_gpu;
 use crate::test_utils::{cosine_similarity_per_row, lcg_data, skip_if_no_gpu_env};
@@ -186,7 +187,7 @@ fn run_parity(
         &k_codes,
         &k_scales,
         &k_rot32,
-        &v_arr,
+        VMirror::new(&v_arr, kv_seq),
         None,
         b,
         kv_h,

--- a/crates/rmlx-models/tests/sparse_attn_dispatch.rs
+++ b/crates/rmlx-models/tests/sparse_attn_dispatch.rs
@@ -29,6 +29,7 @@ use rmlx_kv_quant::planar_flash_decode_msl::planar_flash_decode_sdpa;
 use rmlx_kv_quant::planar_fused_qk_msl::planar_fused_qk_dispatch_count;
 use rmlx_kv_quant::planarquant_msl::planar_quantize_v4_gpu;
 use rmlx_kv_quant::sparse_attn::sparse_attn_total_dispatch_count;
+use rmlx_kv_quant::VMirror;
 use rmlx_kv_quant::{KvCache, KvQuant};
 use rmlx_loader::HeadBudgets;
 use rmlx_mlx::{Array, Device, Dtype};
@@ -312,7 +313,7 @@ fn sparse_attn_dispatches_on_seedless_planar_k() {
         &k_codes,
         &k_scales,
         &k_rot32,
-        &v_arr,
+        VMirror::new(&v_arr, kv_seq),
         None,
         b,
         kv_h,
@@ -462,7 +463,7 @@ fn sparse_attn_seedless_planar_k_v2_budgets_wire_through() {
         &k_codes,
         &k_scales,
         &k_rot32,
-        &v_arr,
+        VMirror::new(&v_arr, kv_seq),
         None,
         b,
         kv_h,
@@ -652,7 +653,7 @@ fn sparse_attn_seedless_planar_k_competing_keys_v2_vs_v1() {
         &k_codes,
         &k_scales,
         &k_rot32,
-        &v_arr,
+        VMirror::new(&v_arr, kv_seq),
         None,
         b,
         kv_h,

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -2948,3 +2948,52 @@ so the per-cache K-seed delta is below RSS noise there; the deterministic
 `resident_bytes` accounting is the authoritative measure and is regression-locked
 by the warm-TTFT K-only tests, which assert the seed is absent and that the
 reported total is the K store plus the surviving V seed and nothing else.)
+
+## V-mirror stride: allocation anchors and output identity (2026-09-02)
+
+The three bf16-V flash-decode dispatchers (iso, rotor, planar) used to be
+handed a `..kv_seq` cut of the head-major `[b, kv_h, max_seq, head_dim]` bf16 V
+mirror. That view is row-contiguous only at `b * kv_h == 1`, so flattening it
+for the kernel materialised the whole attended prefix once per layer per decode
+step. They now take the allocation whole and index it at its own sequence
+stride.
+
+The saving is an allocation, not a rate: it is `kv_h * kv_seq * head_dim * 2`
+bytes per layer per step, exact from the shape. `metal_gen_alloc_mb` is the
+anchor; decode TPS at the cell below moved inside its own run-to-run spread and
+**no rate claim is recorded here**.
+
+Command per cell (one process per arm, two snapshotted binaries, verified
+distinct by symbol before use):
+
+```bash
+rmlx baseline --model <snapshot> --kv-quant <codec> \
+  --prompt-tokens 4096 --max-ctx 8192 --max-tokens 16 --emit-token-ids
+```
+
+| Model | arch | `kv_h` | codec | `metal_gen_alloc_mb` before → after | token ids |
+|---|---|---|---|---|---|
+| Ternary-Bonsai-8B-mlx-2bit | `Qwen3ForCausalLM` | 8 | `k_iso3` | 2176.2 → **1886.5** (−289.7) | identical |
+| Ternary-Bonsai-8B-mlx-2bit | `Qwen3ForCausalLM` | 8 | `k_rotor3` | 2307.1 → **2003.8** (−303.3) | identical |
+| gemma-4-e2b-it-mxfp8 | `Gemma4ForConditionalGeneration` | 1 | `k_iso3` | 1077.6 → 1077.6 | identical |
+
+Prompt 3770 tokens, 16 generated, greedy. The iso row matches its prediction
+from shape: 36 layers × 8 kv-heads × 3786 positions × 128 head_dim × 2 B =
+279.2 MB against 289.7 MB measured. The `kv_h == 1` row is the control and is
+expected to be unchanged in both columns — at one KV head the cut is already
+contiguous, so there was no copy to remove. Both architectures are the pair
+CLAUDE.md's regression-bench discipline names for a KV-indexing change.
+
+Generated ids, for a later re-check without re-running the old binary:
+
+* Bonsai-8B `k_iso3` — `654,3029,7208,25,30811,11682,9705,323,5333,4344,11,18860,16376,2390,6891,13`
+* Bonsai-8B `k_rotor3` — `654,3029,7208,25,30811,11682,9705,323,5333,4344,11,18860,16376,2213,13,2303`
+* gemma-4-e2b `k_iso3` — `212922,236761,12362,236787,8099,598,122170,3004,236761,107,2182,236746,13422,236743,236770,236761`
+
+A longer-context run of the same cell (10867-token prompt, 32 generated,
+`--max-ctx 16384`) reads 4698.9 on both arms: there the prefill working set,
+not the decode-step transients, sets the generation peak, so the saving is real
+but not visible in this metric. `ornith-1.0-9b-mxfp8`
+(`Qwen3_5ForConditionalGeneration`, `kv_h == 4`) likewise reads 1795.1 on both
+arms with identical ids — the arch is mostly linear-attention layers, so few
+full-attention layers hold a bf16 V mirror at all.


### PR DESCRIPTION
Closes #467. The only decode-path item funded by the R4 ceiling ladder.

## The defect

`update_decode_fp16_v_only` returned a slice over a `[b, kv_h, max_seq, head_dim]` allocation, cut on axis 2. That leaves a stride gap between heads, so the result is row-contiguous **only when `b * kv_h == 1`** — non-contiguous exactly when `kv_h > 1`. Three dispatchers then reshaped it to 1-D with no `.contiguous()`, so MLX materialised the whole valid V prefix, once per layer per decode step. An O(kv_seq) byte copy with no `.contiguous()` call anywhere to make it visible.

The site is split across two files, which is why two earlier investigations each got it half right and it stayed unfixed: the slice is at `kvcache/update.rs:4576`, the reshape is in the dispatcher at `iso_flash_decode_msl.rs:576-578`.

## The fix, once

V's contract becomes `[b, kv_h, v_seq, head_dim]` with `v_seq >= kv_seq`, carried as a `VMirror { buf, valid }` so the buffer and its valid length cannot drift apart or be transposed at a call site — they sit among five same-typed `i32` parameters, and they are the concept this change introduces. The stride goes into `dims` as a new trailing slot (iso 8→9, rotor 8→9, planar 7→8) and each `.metal` body reads it for the V offset only; `kv_seq` still bounds the tile loop, the seq-major K index and the mask index.

One mechanism covers all three dispatchers, plus the shared-KV consumer arms that fed the same cut through `slice_decode_fp16_v`. `turbo_flash_msl.rs` and the two symv dispatchers are correctly untouched — verified directly, none takes a bf16 V input.

## Measured

Bonsai-8B, 4k/16-tok, `--emit-token-ids`, binaries snapshotted and verified distinct by sha256 **and** by a symbol present in only one:

| model | `kv_h` | codec | `metal_gen_alloc_mb` | token ids |
|---|---|---|---|---|
| Ternary-Bonsai-8B | 8 | `k_iso3` | 2176.2 → **1886.5** | identical |
| Ternary-Bonsai-8B | 8 | `k_rotor3` | 2307.1 → **2003.8** | identical |
| gemma-4-e2b | 1 | `k_iso3` | 1077.6 → 1077.6 | identical |

−289.7 MB against a shape-derived prediction of `36 x 8 x 3786 x 128 x 2 B = 279.2 MB`. The `kv_h == 1` row is the negative control: unchanged in both output and bytes, because that slice was already contiguous.

R4 measured this rung at **1.0749x, SEPARATED** at 32k. This branch makes **no throughput claim** — at the 4k gate shape the ABBA ranges overlap at n=6/arm, and the deterministic allocation delta is the evidence. Recorded in `docs/PERF_BASELINE.md` with the command, the prediction, the literal generated id sequences (so a later check needs no old binary), and the two no-delta cells with why they read zero.

## A silent-output regression, caught in review

The first implementation replaced a check that fired in **every** profile with one that fires in **none of the shipping ones**.

The old reshape targeted `b * kv_h * kv_seq * head_dim`, so `mlx_reshape`'s element-count check turned any `v_valid != kv_seq` divergence into a loud `Err` unconditionally. The first draft reshaped to V's own element count and validated only `v_seq >= kv_seq` — where `v_seq` is the `max_seq` allocation, so the predicate holds trivially — leaving the real invariant to a `debug_assert_eq!` that is compiled out under `release-perf`.

That is not hypothetical here: `kv_seq` comes off the packed K store and `v_valid` off the mirror's own accounting, and the comment block above the planar call site records that this coupling has already been broken once ("the V accumulator ends up permanently one-step lagged… the original fused-QK landing missed this step"). The SWA-hydration branch is a second producer.

And no gate could have caught it: `make ci` runs `dev` with no `--ignored`, so no GPU path executes; `make gpu-test` runs `dev` with the assert live but is not in `make ci`; `test-perf` runs `release-perf` with the assert dead and executes no `Device::Gpu` test by Hard rule 9. **The assertion was never evaluated in the profile where it was disarmed.**

`flatten_v_mirror` now rejects the desync with a real error, and `decode_fp16_v_mirror` reports `self.offset` rather than comparing against the allocation extent, so the shared-KV arms are covered by the same check. Its regression test is `Device::Cpu` and deliberately **not** `#[ignore]`d — the check precedes any Metal dispatch, and ignoring it is exactly what would keep it out of the profile it exists to cover. Mutation-checked in both profiles.

## The gate

Throughput is the wrong oracle — TPS drifts 11% across runs on this host. The gate measures **resident growth per decoded token**, where every `max_seq`-sized buffer is allocated before the window and cancels, leaving only prefix-scaled terms.

Its first design was **vacuous and only mutation-checking caught it**: a peak-memory bracket went green against a deliberately reintroduced copy, because Metal releases a dispatch's buffers on the *next* dispatch, so at steady state the copy is already live when the bracket opens and is replaced in place. It passed its own non-vacuity assertions while measuring nothing.

The replacement's baseline is measured, not asserted, and is **not** shared between codecs: iso3's clean floor is 886 per mille of one V prefix, rotor3's is 1144 — a 29% spread, because the K term tracks the codec's rate and sideband planes rather than `sizeof(bf16)`. Each codec carries its own band, checked after the defect bound so a real defect still gets the message naming V while K-side drift gets its own named failure instead of eating margin.

Non-vacuity is structural: `KV_H = 8` (a `kv_h == 1` fixture cannot exhibit the defect), a per-codec dispatch-count delta asserted `>= MEASURED_STEPS` so a CPU fallback fails rather than reads clean, and a companion test that pays the copy on purpose and measures it.

Four mutations, all red: the producer handing back the cut; the dispatcher dropping the stride; one kernel reading the wrong `dims` slot (fails on that codec alone, pinning per-codec wiring no allocation bound can see); and the desync check deleted. Restores from file snapshots with sha256 verified — `git checkout --` restores from the index and silently reverts uncommitted work.

## Coverage boundary, stated rather than implied

Planar's **kernel** change is covered and mutation-killed by the equivalence test. Its **production seam** has no probe: that arm is warm-TTFT quiescent *and* `DispatchPolicy::planar_flash_decode` is off by default, so a probe would have to build a configuration production does not reach. The consequence is recorded — on the default policy, planar's share of this saving is not realised.

The equivalence test runs `kv_h == 1` as an inertness arm as well as `kv_h == 8`. Non-power-of-two `head_dim` is not an arm because all three dispatchers reject it before any V handling, with existing tests pinning that; the reachable half is covered by a CPU test at `kv_h = 3, head_dim = 96`.

## Verification

`make ci` green. `make gpu-test CRATE=rmlx-kv-quant` 252 passed, shader validation clean. `cargo test -p rmlx-kv-quant --lib` 540 passed under both `dev` and `release-perf`. `make check-metal-compiles` OK, 58 kernels at metal3.1 and metal4.0.

## Followups, filed not fixed

`Array::to_bytes()` on a strided view returns the backing buffer's leading elements, not the view's — `array_to_f32_vec` has that shape with no contiguity guard, so a caller passing a slice or transpose gets silently wrong values. Found while writing the non-pow2 test. Also: the packed-K view has its own prefix-sized materialisation, now the entirety of what a clean decode loop grows by per token, same class and unexamined. And `phase2_sparse_attend` was checked rather than assumed — its only production entry has no non-test caller, so it is not a live seam.
