### PR TITLE
docs(kv): land the KV campaign's confirmed mechanisms, and stop publishing figures a program can derive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         smoke-codec-matrix \
         e2e \
         file-size-report check-no-inline-tests check-no-scalar-f32-leak \
+        check-doc-source-citations \
         check-kv-layer-quants check-kv-codec-disposition \
         check-kv-codec-disposition-fixtures \
         check-kv-byte-model-parity check-kv-byte-model-parity-fixtures \
@@ -388,6 +389,9 @@ check-kv-byte-model-parity: ## CI gate: fail if scripts/perf_ceiling.py's KV byt
 check-kv-byte-model-parity-fixtures: ## CI gate: recall test for the above — 8 synthetic manifests, each asserting which check fired
 	@bash scripts/check_kv_byte_model_parity_fixtures.sh
 
+check-doc-source-citations: ## CI gate: fail if a `crates/...` source path cited in docs/ does not exist
+	@bash scripts/check_doc_source_citations.sh
+
 check-no-decode-swallow: ## CI gate: fail if a decode-step failure breaks instead of propagating (would report as finish_reason="length")
 	@bash scripts/check_no_decode_swallow.sh
 
@@ -438,6 +442,7 @@ ci: fmt-check lint test test-capture deny audit ci-metrics ## full pre-merge gat
 	@bash scripts/check_kv_codec_disposition_fixtures.sh
 	@bash scripts/check_kv_byte_model_parity.sh
 	@bash scripts/check_kv_byte_model_parity_fixtures.sh
+	@bash scripts/check_doc_source_citations.sh
 	@bash scripts/check_no_decode_swallow.sh
 	@bash scripts/check_eval_lock.sh
 	@bash scripts/check_eval_lock_fixtures.sh

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -388,7 +388,7 @@ dynamic range, lowering affine-K quant PPL.
 plain MLX `matmul` against a precomputed `[D,D]` `R` — correct + coherent,
 but O(D²) arithmetic and materialises an intermediate `K_rot` tensor.
 
-**Fused FWHT kernel:** `crates/rmlx-models/src/kv_cache/rot_k_msl.rs`
+**Fused FWHT kernel:** `crates/rmlx-kv-quant/src/rot_k_msl.rs`
 implements a fused Metal kernel using the Fast Walsh-Hadamard Transform (FWHT),
 which is O(D log₂D) instead of O(D²). For D=128 (Bonsai): 896 ops vs 16 384 —
 ~18× fewer arithmetic ops plus elimination of the intermediate `K_rot` DRAM
@@ -404,7 +404,7 @@ Default-OFF. Enable via `--rot-k-fused on` (or `RMLX_ROT_K_FUSED=1`).
 Supported D: {32, 64, 128, 256, 512}.
 Falls back to v1 matmul on unsupported D or kernel error.
 
-Reference math: `crates/rmlx-models/src/kv_cache/rot_k.rs`; rotorquant README
+Reference math: `crates/rmlx-kv-quant/src/rot_k.rs`; rotorquant README
 (`../rotorquant/`).
 
 Example: `--ctk rot_k --ctv q4_g64` on Bonsai → coherent.
@@ -749,7 +749,7 @@ probe and is **not recommended for production use**.
 
 **Decision**: GPU dispatch wiring **reverted** at `update_k8vturbo3` (V-side
 stays on CPU as in the first pass).  The Metal kernel source is kept under
-`crates/rmlx-models/src/kv_cache/k8vturbo3_append_msl.rs` as a
+`crates/rmlx-kv-quant/src/k8vturbo3_append_msl.rs` as a
 future-reference hook with full bit-equivalence unit-test coverage (CPU
 vs GPU max abs diff < 1e-3 on a fixed-seed input).  Re-wiring it later is
 a one-line dispatch-site change once Gemma4-arch PPL coverage exists.

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -181,11 +181,18 @@ On a dense architecture those two now report a net *saving* and the warn does
 not fire; the estimate takes the same `shares_kv` the allocation does, so the
 two cannot disagree.
 
-Historical note: before that change, measured on Gemma4 e2b (7 global + 28
-windowed layers, head_dim 256, 1 KV head) at a 4096-token prompt, `k8v4` ≈
-125.0 MB vs `none` ≈ 113.2 MB (`kv_cache_bytes`) — `k8v4` was +11.7 MB on the
-global layers, zero delta on the windowed layers. Those two numbers are equal
-now.
+Historical note: before that change, measured on Gemma4 e2b at a 4096-token
+prompt, `k8v4` reported a larger `kv_cache_bytes` than `none` — all of the
+excess on the global layers, zero delta on the windowed ones. Those two
+numbers are equal now.
+
+Size a Gemma4 layer from the **class** it is in. Windowed layers are
+`head_dim` × `num_key_value_heads`; global layers are `global_head_dim` ×
+`num_global_key_value_heads`, which is a different and wider shape (see
+docs/MODELS.md, "Attention geometry splits by layer class"). Both figures come
+off the snapshot's `text_config`, and `gemma4/generate/mod.rs` builds the
+per-layer `KvLayerShape` vector from exactly that pair — read it there rather
+than assuming one width for the stack.
 
 rMLX emits one structured `warn!` at request build time when the resolved codec
 is estimated to increase resident KV vs bf16 on the active layer mix:
@@ -202,8 +209,10 @@ they are never dropped. Consider --kv-quant none if memory is the goal.
   kv_quant=mixed_k8g64_v8g64 eff_seq=8192 n_global=7 n_windowed=28 est_extra_bytes=31195136
 ```
 
-(Gemma4 e2b: 7 global layers at `head_dim` 256, 1 KV head, 8192 tokens — each
-holds 12 845 056 B under the codec against 8 388 608 B of bf16.)
+`n_global` and `n_windowed` are the two layer classes; `est_extra_bytes` is
+`estimated_resident_bytes_per_layer` summed over the mix, so the per-class
+per-layer figures behind it are recomputed rather than recorded here. To see
+them for a codec, run `rmlx info --list-cache-types`.
 
 Only the **sign** of that number is exact; size nothing from its magnitude.
 
@@ -1553,7 +1562,7 @@ tail/head candidate set; the fallback to `K8V8` is the correct safety net.
 
 ---
 
-### `KvStorage::TurboSym3` — symmetric WHT-3 K + turbo3 V
+### `KvStorage::TurboSym3` — symmetric turbo-3 K + turbo-3 V
 
 > **INERT on this build** — `tsym3` decodes from the bf16 mirror on both
 > axes, so `exit_prefill` never builds the packed store described below and the
@@ -1575,6 +1584,12 @@ regressed −2% TPS; see K8VTurbo3 finding).
 
 Both K and V use the **same codebook** — the symmetric designation is
 literal: the codec treats K and V identically.
+
+**No rotation is applied on either axis**, despite the family's name and the
+`_wht_` substring in the layout tag below; that substring is an SSD geometry
+identifier, not a description of the encoder. See §"The turbo family's missing
+rotation — what it is worth, and where" for what the absent transform would buy
+and on which axis.
 
 The K buffer is `QuantKTurbo3` (independent type from `QuantK` and
 `QuantKTurbo4`), decoupled from V to keep append paths separate.
@@ -2183,7 +2198,7 @@ across a policy change.
 | `planar` | `KvQuant::Planar` |
 | `k8vturbo3` | `KvQuant::K8VTurbo3` |
 | `k8vturbo3tcq` | `KvQuant::K8VTurbo3Tcq` (Viterbi trellis 3-bit V; reuses turbo3 codebook) |
-| `tsym4` | `KvQuant::TurboSym4` (symmetric WHT-4 K + tq4 V; rejected on Qwen MoE) |
+| `tsym4` | `KvQuant::TurboSym4` (symmetric 4-bit K + tq4 V, no rotation; rejected on Qwen MoE) |
 | `k8vturbo2` | `KvQuant::K8VTurbo2` |
 | `mixed_k<kb>g<kg>_v<vb>g<vg>` | `KvQuant::Mixed { .. }` |
 
@@ -2205,8 +2220,8 @@ is a clap hard error (caught before the subcommand body runs).
 |---|---|---|
 | `fp16` | `KvQuant::None` | bf16 unquantized both sides (`KvQuant` variant named `None`, not `Option::None`) |
 | `q8` | `KvQuant::K8V8` | symmetric 8-bit K+V |
-| `speed` | `KvQuant::TurboSym3` | symmetric WHT-3 K+V, matches mtq `speed`; rejected on Qwen MoE |
-| `quality` | `KvQuant::TurboSym4` | symmetric WHT-4 K + tq4 V, matches mtq `quality` byte-for-byte; rejected on Qwen MoE arch guard |
+| `speed` | `KvQuant::TurboSym3` | symmetric 3-bit K+V, no rotation; matches mtq `speed`; rejected on Qwen MoE |
+| `quality` | `KvQuant::TurboSym4` | symmetric 4-bit K + tq4 V, no rotation; matches mtq `quality` byte-for-byte; rejected on Qwen MoE arch guard |
 | `planar` | `KvQuant::Planar` | PlanarQuant V-side |
 | `planar3` | `KvQuant::Planar3` | PlanarQuant 3-bit V-side |
 | `k_only_planar` | `KvQuant::PlanarK` | PlanarQuant K-side, V bf16; rejected on Qwen MoE |
@@ -2223,14 +2238,18 @@ reads its own packed store; before that it is another spelling of `fp16`.
 
 #### Preset semantics — divergence from mtq
 
-rMLX `speed` maps to `TurboSym3` — symmetric WHT-3 K+V, matching mtq `speed`
-preset definition exactly. Both K and V use the Lloyd-Max N(0,1) 8-centroid
+rMLX `speed` maps to `TurboSym3` — symmetric 3-bit K+V, matching mtq `speed`
+preset definition. Both K and V use the Lloyd-Max N(0,1) 8-centroid
 3-bit codebook; K-side uses the GPU turbo3 MSL kernel. Arch guard: rejected on
 Qwen MoE (K-side 3-bit is the PPL-disaster zone).
 
-rMLX `quality` maps to `TurboSym4` (symmetric WHT-4 K + tq4 V),
+rMLX `quality` maps to `TurboSym4` (symmetric 4-bit K + tq4 V),
 matching mtq `quality` byte-for-byte. Both retain their historical CLI aliases —
 no flag changes.
+
+Neither preset applies a rotation — rMLX's turbo encoder has none on either
+axis. Where the upstream name implies one, §"The turbo family's missing
+rotation — what it is worth, and where" records what it would be worth.
 
 Examples:
 
@@ -3967,6 +3986,64 @@ The LLC-limiter decision rule that stood here is therefore retired unfired: the
 per-kernel limiter split it asked for is not what the Counters export provides,
 and the disposition no longer depends on it.
 
+### The decode ceiling — deleting the codec's arithmetic does not reach bf16
+
+The section above answers "is lifting ε worth funding?" from evidence gathered
+for other purposes. The question was then put directly, with an **ablation
+ladder**: one serving cell, one packed-store codec, four binaries that
+progressively *delete* decode work rather than optimise it, each rung
+ABBA-interleaved against the same baseline arm.
+
+| rung | what it deletes | output |
+|---|---|---|
+| (a) | nothing — the shipped codec | correct |
+| (b) | **all** per-step decode math and all K-store traffic | deliberately wrong |
+| (c) | the rotation only | deliberately wrong |
+| (d) | the V-slab copy only | bit-identical to (a) |
+
+Rungs (b) and (c) compute the wrong answer on purpose. They are cost probes: no
+number taken from them describes a working configuration. Rung (b) is the
+load-bearing one, because it is an **upper bound on every decode-math item
+combined** — a rotation hoist, a narrower K store, a better codebook, vector
+loads on the code plane, and anything not yet proposed. Whatever the codec could
+compute more cheaply, (b) has already deleted.
+
+**Rung (b) does not reach `none`, and it is not close.** With 100% of the decode
+math and the whole K-store read gone, the codec is still far short of bf16, and
+the majority of the per-step gap survives into the rung that computes nothing.
+That surviving majority is the **kernel shell** — dispatch, grid geometry,
+barriers, the fixed per-layer cost of running a custom kernel at all — not codec
+arithmetic.
+
+Three consequences, and they are what this result is for:
+
+1. **Every decode-math proposal shares one ceiling, and the ceiling is below
+   parity.** They cannot be justified individually against a parity target,
+   because their *sum* does not reach it. "The codec is slow because of what it
+   computes" is retired as a fundable theory.
+2. **The next measurement is a shell variant** — tokens per iteration, barrier
+   count, dispatches per layer — not another decode-math one. The ladder shows
+   where the cost is; it does **not** show that a shell rewrite would collect
+   it, and nothing here licenses that assumption.
+3. **Rung (d) is the exception, and it shipped.** A bounded fix, output
+   bit-identical to the baseline, no stored-format change, covering the three
+   dispatchers that shared the defect (`iso_flash_decode_msl.rs`,
+   `rotor_flash_decode_msl.rs`, `planar_flash_decode_msl.rs`). Its anchors,
+   command line and control cell are in docs/PERF_BASELINE.md, "V-mirror
+   stride".
+
+**No figure from the ladder is transcribed here.** Three of its four arms are
+instrumented throwaway binaries not reproducible from any committed ref, so
+nothing was ingested into `runs.db` and a ratio written into this page would
+have no producer to check it against. The raw transcripts, the per-slot result
+JSONs and the three variant patches are in `.rmlx/analysis/r4-ceiling-ladder/`
+(gitignored scratch); the *ordering* of the rungs, which is the durable result,
+is what this section carries.
+
+This supersedes argument 1's headroom ladder in scope rather than contradicting
+it: that one deletes the query-head class, this one deletes the whole
+decode-math class, and the two agree in direction.
+
 ### Codec disposition — what every codec in the tree is for
 
 The KV enum spells **28 codecs**. This section gives each one an explicit
@@ -4185,22 +4262,64 @@ byte-for-byte across runs — so these are exact, not medians.
 | `k_rotor3` / `k_rotor4` — now | 1.022× | 1.004× | 1.009× | 1.008× |
 | `rotor3_sym` / `rotor4_sym` — was | 1.326× | 1.337× | 1.270× | 1.265× |
 | `rotor3_sym` / `rotor4_sym` — now | 1.043× | 1.009× | 1.019× | 1.015× |
-| `mixed_k8g64_v4g64` | 1.339× | 1.396× | withdrawn† | withdrawn† |
-| `rot_k_v8g64` | 1.541× | 1.533× | withdrawn† | withdrawn† |
+| `mixed_k8g64_v4g64` | 1.339× | 1.396× | in `runs.db`† | in `runs.db`† |
+| `rot_k_v8g64` | 1.541× | 1.533× | in `runs.db`† | in `runs.db`† |
 
-† The two Bonsai cells for `mixed` / `rot_k` were measured on a binary that
-built the bf16 K/V mirror on **every** architecture. `exit_prefill` now builds
-each mirror only where a decode path reads it, and `feeds_bf16_{k,v}_at_decode`
-answers the cache's own `shares_kv` for exactly these two variants — so on a
-stack whose layers do not share K/V nothing reads the mirror and it is not
-allocated. Bonsai is such a stack; gemma-4-e2b is not, which is why its two
-columns stand unchanged and are the *reason* the mirror is kept at all. The
-cells are withdrawn rather than re-typed: what these codecs now hold is
-computed per topology by `rmlx info --list-cache-types`, and the whole-stack
-figure by `mixed_layer_stack_delivered_bits_per_value`
-(`crates/rmlx-models/src/kv_cache/tests.rs`), which derives it from
-`LAYER_ADAPTIVE_HEAD_N` / `LAYER_ADAPTIVE_TAIL_N` rather than restating it. A
-re-measurement on this arch belongs in this table when one is taken.
+† The two Bonsai cells for `mixed` / `rot_k` were first measured on a binary
+that built the bf16 K/V mirror on **every** architecture. `exit_prefill` now
+builds each mirror only where a decode path reads it, and
+`feeds_bf16_{k,v}_at_decode` answers the cache's own `shares_kv` for exactly
+these two variants — so on a stack whose layers do not share K/V nothing reads
+the mirror and it is not allocated. Bonsai is such a stack; gemma-4-e2b is not,
+which is why its two columns stand and are the *reason* the mirror is kept at
+all.
+
+Those cells have since been re-measured on a dense stack. They are **not**
+re-typed here — both arms are rows in `runs.db`, which is where to read them:
+
+```bash
+rmlx metrics query "SELECT model, prompt_tokens, kv_quant, value \
+  FROM observations WHERE id BETWEEN 122793 AND 122804 \
+    AND metric = 'kv_cache_bytes' \
+  ORDER BY model, prompt_tokens, kv_quant"
+```
+
+Both architectures, both contexts, `--max-tokens 200`. `kv_cache_bytes` is
+`KvCache::resident_bytes` — a sum over live allocations, not the estimator — and
+residency is deterministic for a given (model, offset, codec), so one row per
+cell is the whole measurement. The result is the **sign flip**: on the dense
+stack these two now hold materially *less* than `none`; on the shared-KV stack
+they still hold more. One codec, two answers, exactly as
+`global_layer_store_plus_mirror_codec_sign_follows_shared_kv` predicts. For a
+codec outside that query, `rmlx info --list-cache-types` computes the
+per-topology figure and `mixed_layer_stack_delivered_bits_per_value`
+(`crates/rmlx-models/src/kv_cache/tests.rs`) pins the whole-stack rate from
+`LAYER_ADAPTIVE_HEAD_N` / `LAYER_ADAPTIVE_TAIL_N` rather than restating it.
+
+**The mirror elision is not the whole cause; the earlier attribution was
+wrong.** Walking one dense cell across the two commits shows the elision moves
+part of the distance and the later **in-family boundary floor** moves the rest.
+Read "the mirror elision inverted `mixed` on dense stacks" as an overstatement
+of a two-step change. Across the elision alone the token ids are bit-identical
+and `store_skipped` is unchanged — it moved bytes and nothing else — and its
+decode-neutrality, asserted when it landed, has since been measured
+INCONCLUSIVE against a pre-elision arm, i.e. no difference resolvable at that
+design's power.
+
+**The elision is not over-broad**, and this is measured rather than read off the
+`shares_kv` condition: gemma-4-e2b is byte-identical *and*
+greedy-digest-identical across the commit's parent, the commit, and main — all
+three codecs, both contexts, both generation lengths. The e2b columns above also
+reproduced on the post-elision binary, which is the instrument check on the arm
+that did not move.
+
+**Do not certify a codec inert from a short generation.** At `--max-tokens 32`
+these cells give `mixed` and `rot_k` the same greedy digest on Bonsai at 4k, and
+`rot_k` reproduces `none`'s digest exactly at 32k; at 200 tokens all three
+separate. A digest match at 32 tokens is not evidence of an inert codec, and
+`scripts/bench/codec_inertness_probe.sh` is wrong on main where it says `mixed_*`
+sets `store_skipped` on Bonsai — the in-family floor promotes it to a
+store-reading variant.
 
 The iso / rotor rows are the ring-layout result restated on real serving. Both
 families spend one whole `u32` code word per group; iso's group is 4 head-dim
@@ -4287,8 +4406,14 @@ misled by is worth more than one name fewer.
 * **Whether any codec should eventually be deleted.** That turns on whether the
   re-enable path can be made to pay. It is decided by a fused decode kernel over
   a packed store that beats bf16 at a context this tree can serve — not by
-  another residency measurement, which is now saturated at "no codec is
-  smaller".
+  another residency measurement. The residency axis is **settled, not
+  saturated**: iso is under bf16 on every topology, `mixed` / `rot_k` are under
+  it on a dense stack and over it on a shared-KV one, and rotor is over it
+  everywhere. An earlier revision of this bullet read "saturated at *no codec is
+  smaller*", which the table above already contradicted.
+  What that kernel has to beat is now bounded from the other side too — see
+  "The decode ceiling", which measures the shell rather than the codec
+  arithmetic as the majority of the gap.
 * **Whether a better ring layout clears 16 bits/value for iso/rotor.** Nothing
   measured here touches it; the layout, not the algorithm, is what fails.
 * **Which member of a byte-identical 3-bit/4-bit pair survives a fold.** The
@@ -4312,15 +4437,25 @@ no model launched — unlike the measured cells below it:
 | Qwen3.8-27B-mxfp8 (26.4 GB/step of weights) | 0.010 | 0.020 | 0.075 | 0.245 |
 | Qwen3.6-35B-A3B-8bit (MoE, 3.1 GB/step) | 0.026 | 0.051 | 0.177 | 0.462 |
 | gemma-4-e2b-mxfp8 (SWA on most layers) | 0.030 | 0.053 | 0.170 | 0.445 |
-| Ternary-Bonsai-8B-2bit (2.1 GB/step) | **0.221** | **0.362** | **0.694** | 0.901 |
+| Ternary-Bonsai-8B-2bit (2.1 GB/step) | **0.221** | **0.362** | **0.694** | 0.901 ‡ |
+
+‡ Arithmetic only. Bonsai-8B's `max_position_embeddings` is below 131 072 and
+the engine refuses a prompt past it with no override, so no cell at that column
+can be run on this model — the projection is not a target anyone can measure.
+Check the ceiling in the snapshot's `config.json` before designing a
+long-context cell around a model; a second, independent cap
+(`--max-prompt-tokens`) hard-errors on the GPU path and is easy to hit first.
 
 So "measured at 4k" and "measured where the codec axis is near-zero" are not
 the same qualifier, and a claim scoped by the first is not scoped by the
 second. A 2-bit 8B model at a 4k prompt already puts 22% of its decode bytes on
 the codec axis; a dense 27B at 131k puts 25%.
 
-**A large `kv_frac` is necessary, not sufficient.** Measured on this tree,
-`none` vs `mixed_k8g64_v4g64` ABBA-paired (`scripts/perf_ab.sh`, n=4/arm; the
+**A large `kv_frac` is necessary, not sufficient — at 8-bit K.** Every cell in
+this table is `mixed_k8g64_v4g64`, so every conclusion drawn from it is scoped
+to a **K side of 8 bits**. That scope turned out to be load-bearing; see "The
+null was a bit-width result" below before generalising any of it. Measured on
+this tree, `none` vs `mixed_k8g64_v4g64` ABBA-paired (`scripts/perf_ab.sh`, n=4/arm; the
 two Qwen3.8 cells untainted at 7.0–7.3 % foreign CPU, the two Bonsai cells
 tainted only by a monitoring process at their entry gate — see
 docs/PERF_BASELINE.md for per-cell conditions and spreads):
@@ -4334,26 +4469,28 @@ docs/PERF_BASELINE.md for per-cell conditions and spreads):
 
 † All four are dense stacks, and arm B's resident figures were measured before
 the `Mixed` / `RotK` mirror became conditional on `shares_kv`. Every one of them
-is a measurement of two bf16 buffers this arch no longer allocates. The `kv_frac`
-and `predicted ceiling B/A` columns are arm A (`none`) and arm B respectively,
-from `scripts/perf_ceiling.py` at the measured cache offset
-(`prompt_tokens + max_tokens - 1`); arm A is unaffected, arm B's prediction was
-produced by the same pre-elision model and reads **low** — it is being
-re-derived with the corrected model, and the decode columns, which are the
-argument this table carries, are untouched by any of it.
+was a measurement of two bf16 buffers a dense arch no longer allocates, so they
+are withdrawn rather than corrected in place. The Bonsai cells have since been
+re-measured post-elision — read them from `runs.db` via the query in
+§"Class 3", not from prose. The Qwen3.8 cells have not been re-measured and no
+substitute figure is offered for them. The `kv_frac` and `predicted ceiling B/A`
+columns are arm A (`none`) and arm B respectively, from
+`scripts/perf_ceiling.py` at the measured cache offset (`prompt_tokens +
+max_tokens - 1`); arm A is unaffected, arm B's prediction came from the same
+pre-elision byte model and reads **low** — `make check-kv-byte-model-parity`
+now binds that model to the engine's, so the re-derivation is a re-run of the
+script rather than a re-typing. The decode columns, which are the argument this
+table carries, are untouched by any of it.
 
 Two rows carry the argument. The Bonsai **31 553** row is the high-`kv_frac`
 end: at 0.687 — the largest any release-set model reaches *at a context this
-tree can serve*; the static table above projects 0.901 for the same model at
-131 072, which no measured cell reaches — a codec that cuts the decode KV
-stream to 0.571× and is predicted +42% moves decode by +0.3%, inside the noise,
-while costing +29% resident KV — a null with the power to have seen a 1%
-effect, since the arm spreads there are 0.04% and 0.15%. The Qwen3.8
-**130 848** row is the long-context
-end: `kv_frac` 0.245, predicted +14.9%, measured **−23.7% with the arms'
-per-slot ranges disjoint in the losing direction**, and +35% resident
-whole-cache — which on that hybrid arch understates the attention-KV ratio,
-1.355 excluding its codec-independent GDN state.
+tree can serve* — a codec that cuts the decode KV stream to 0.571× and is
+predicted +42% moves decode by +0.3%, inside the noise: a null with the power
+to have seen a 1% effect, since the arm spreads there are 0.04% and 0.15%. The
+Qwen3.8 **130 848** row is the long-context end: `kv_frac` 0.245, predicted
++14.9%, measured **−23.7% with the arms' per-slot ranges disjoint in the losing
+direction**. Both rows' resident columns are withdrawn per † and neither
+conclusion rests on one.
 
 **Scope on arm B.** It is `mixed_k8g64_v4g64` measured while it retained both
 bf16 seeds on every architecture. It still materialises a packed store — that
@@ -4376,9 +4513,56 @@ packed path does not merely fail to convert: its non-bandwidth per-step cost
 grows 12.0 → 44.2 ms between 3 892 and 130 848 tokens while `none`'s stays flat
 at 10.5 → 14.7, so halving the byte stream still loses.
 
+#### The null was a bit-width result, not a context result
+
+Every cell above holds K at 8 bits. The same harness, the same model and the
+same ABBA design were later run with **K at 4 bits** (`mixed_k4g64_v4g64`), and
+the sign changes: on the dense 8B target the 4-bit-K arm beats `none` with the
+arms' per-slot ranges disjoint, at a 32k prompt and again at a 63k one — where
+the 8-bit-K arm at the identical shapes returns INCONCLUSIVE.
+
+The earlier null is **sound, and was not a measurement error.** One of the new
+cells independently reproduces this table's Bonsai 31 553 row — same model,
+same context, same shape, a different session — and lands on the same verdict.
+It was measured at the wrong K width. No 4-bit-K cell existed anywhere in this
+tree until then.
+
+Read the consequence narrowly, because it is narrower than "quantized KV wins":
+
+* **"Quantized KV always loses at decode" is retired.** That was a statement
+  about 8-bit K which had been reading as a statement about codecs.
+* **The win is on the `Mixed` path, through MLX's `quantized_matmul`** — not on
+  a fused flash-decode kernel over a packed store. It does not transfer to the
+  iso / rotor / planar ring, and it is neither evidence for nor against §"The
+  decode ceiling".
+* **It is not a long-context effect.** It holds at 32k as well as 63k. On a
+  low-`kv_frac` substrate the 8→4 bit change moves decode by a rounding error
+  while cutting the store substantially, so the gain is not bandwidth being
+  converted. On that same substrate the `Mixed` path *loses*, and loses harder
+  at longer context — which localises a per-step cost that grows with `kv_seq`
+  and does **not** shrink when the store shrinks. That cost is inferred from the
+  pairing, not localised in code; localising it is the open item, not
+  re-encoding the codec.
+
+Cells, arms, per-slot values and byte counts:
+
+```bash
+rmlx metrics query "SELECT id, model, prompt_tokens, kv_quant, metric, value \
+  FROM observations WHERE id BETWEEN 122807 AND 122836 \
+  ORDER BY model, prompt_tokens, kv_quant, metric, id"
+```
+
+One binary for both arms of every comparison, `--kv-quant` and `--max-ctx`
+explicit per slot, arm A `none`, six measured slots per arm after one untimed
+warmup. Two of the comparisons deliberately returned INCONCLUSIVE on a clean
+host, which is the negative control: the harness is not merely emitting
+SEPARATED.
+
 Read together with the ε table: **`kv_frac` bounds the prize, ε decides how much
-of it is collectable, and ε is the binding term.** State `kv_frac` next to a
-codec cell so a reader can see the bound; do not infer an effect from it.
+of it is collectable, and ε is the binding term on the fused-kernel path.**
+State `kv_frac` next to a codec cell so a reader can see the bound; do not infer
+an effect from it — and state the **K bit width** too, since a cell that omits
+it cannot be compared with one that chose differently.
 
 ---
 
@@ -5846,11 +6030,55 @@ The startup resolvers (`rmlx-cli` `resolve_kv_quant`, the server's
 the model is loaded, so it is the only value available. They stay as the
 fast-feedback path (`exit 78` at launch); they are no longer the only check.
 
-Empirical positive test: `validate_resolved_qwen_moe_low_k_bits_rejected_post_decompose`
+Empirical positive test: `qwen_moe_low_k_bits_rejected_post_decompose`
 in `crates/rmlx-models/src/kv_cache/cache_type_tests.rs` verifies the
 runtime rejection path. The declared-vs-resolved bypass is covered by
 `crates/rmlx-models/tests/resolved_arch_class.rs`, which builds a snapshot
 that declares dense while shipping MoE tensors and asserts the guard fires.
+
+#### The guard's stated premise does not reproduce on 8:1 GQA
+
+The K-side bit floor is justified upstream by a claim that GQA *amplifies*
+K-side quantization error — one K head serving many query heads, so its error
+is said to compound with the ratio. That prediction was tested directly, as a
+needle-in-a-haystack retrieval screen across the rotation-based K codecs at two
+architectures (an 8:1 shared-KV Gemma4 and a 4:1 dense Qwen3), two contexts and
+five needle depths, against a criterion declared before any cell ran.
+
+**It does not fire.** Retrieval is perfect in every treatment cell, on both
+ratios, and the precondition arm (`none`) passed, so the run is valid rather
+than void. The 8:1 arm was in fact *less* perturbed than the 4:1 arm by greedy
+digest — the opposite of the amplification prediction, and the direction the
+rotation predicts, since these codecs decorrelate before quantizing. That is
+reported as direction only: the two arms are not coverage-matched and their
+head widths differ, so it is not a ratio.
+
+Codec liveness was confirmed on device rather than inferred from the enum —
+`decode_reads_packed_store` true for the K-only iso variant, no bf16 K seed
+allocated, and per-cell dispatch counters equal to decode steps × the arch's
+quantized-layer count exactly, against zero for `none` and `k8v8`.
+
+**No guard was added and none is warranted**: a geometry-keyed screen built on
+this would gate a variable with no measured effect. The upstream perplexity
+figure behind the bit floor remains an unbacked external claim, and byte-exact
+needle retrieval at 8:1 is incompatible with catastrophic degradation. The
+floor itself stays — this measurement removes a *rationale*, not a rejection
+rule, and re-litigating the rule needs a perplexity cell, which NIAH is not.
+
+One limit, stated because it bounds the claim: NIAH excludes catastrophic
+degradation outright but cannot resolve *subtle* degradation on the shared-KV
+arch, where the greedy digest separated in too few cells to carry a null.
+The verdict rests on retrieval rate and the dispatch counter, never on digest
+divergence — the digest was not leaned on where it was measured blind.
+
+**Two premises this section used to imply are false.** Sliding layers
+short-circuit to bf16 before any K-codec arm, so **only full-attention layers
+carry the codec** on a Gemma4 stack, and boundary promotion protects none of
+the long-range ones — it lands on cacheless consumers and sliding layers. The
+treatment on those layers is therefore total, not diluted; an argument that
+reasons from a whole-stack layer count will get the dilution backwards. And
+digest identity does not imply a void cell: see §"Class 3" for the same trap
+measured from the other side.
 
 ---
 
@@ -5930,6 +6158,59 @@ buy at most `0.5·log2(b)` bits. That is what makes the 1.5-bit gate a
 separation rather than a fitted number — it demands an effective block of 8 or
 more. Substitutes measure 0.91 bits (the same Hadamard truncated to blocks of
 4) and 0.47 (the iso quaternion), both rejected.
+
+### The turbo family's missing rotation — what it is worth, and where
+
+TurboQuant is named for a rotation this tree does not apply. The shipped codec
+quantizes raw KV against a Lloyd-Max codebook with no decorrelating transform,
+at any width, on either axis: `crates/rmlx-kv-quant/src/turboquant.rs` contains
+no Hadamard or Walsh-Hadamard code at all. The `_wht_` substring inside
+`TURBOSYM3_LAYOUT_TAG` / `TURBOSYM4_LAYOUT_TAG` is an on-disk geometry
+identifier for the SSD reader, **not** a claim about the encoder; do not read it
+as one.
+
+Whether adding the transform is worth its implementation cost was measured
+*before* any transform code was written, by
+`crates/rmlx-kv-quant/src/turbo_rotation_fidelity_tests.rs`. It holds the turbo
+codec, the width and the group size fixed and moves only a full-`head_dim`
+normalized FWHT in and out around the shipped CPU encoder. A test-side reference
+rotation is a controlled ablation and needs no codec change — which is why the
+gate could precede the implementation, and why "there cannot be an ablation
+until the rotation exists" was wrong.
+
+**The result inverts the family's cost structure.** Run the gate for the
+figures; the ordering is what matters here:
+
+| data shape | rotation is worth | implementing it costs |
+|---|---|---|
+| K-shaped (outlier channels) | order of a bit to two bits | reuses `maybe_pre_rotate_q_gpu` — close to wiring |
+| V-shaped (i.i.d. Gaussian) | order of a hundredth of a bit | an explicit inverse transform after SV accumulation: the P2 kernel, four dequant kernels, both fused-QK kernels |
+
+Turbo is primarily a **V** codec. So the measured payoff lands on the smaller
+half of the family, and the expensive half is the half where the measurement
+says there is nothing to recover. The payoff also shrinks monotonically as the
+codebook widens, which puts what value there is at the *narrow* spellings, not
+the wide ones. Anyone scoping the transform should read that as: K axis, narrow
+widths, and a separate justification demanded for the V-side kernel work.
+
+This also settles a confound the older per-codec cosine comparison could not:
+holding group size fixed, the absent rotation — not the difference in scale
+cadence — is the dominant term in turbo's reconstruction-error deficit against
+a rotated sibling at the same width.
+
+Scope it honestly: this is measured on a **model** of K-cache structure, not on
+a K/V tensor captured from a forward pass. Read it as an estimate for a real
+checkpoint; the honest check is a serving cell and has not been run. The
+threshold is imported from `ROT_K_MIN_OUTLIER_GAIN_BITS` rather than retyped,
+and the gate carries its own mutation check.
+
+**Read the gate's verdict, not only its magnitudes.** It records a FAIL of the
+magnitude criterion together with a PASS of the ordering, and both halves are
+the result: the rotation helps on exactly the data it was predicted to help on,
+and by less than the imported threshold at the widest codebook. An earlier draft
+reported PASS from these same numbers by moving the verdict into a friendlier
+bucket with the threshold untouched. Committing the criterion first protects the
+numbers; it does not protect the conclusion.
 
 ### Rate-distortion — is the bit width delivering
 

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -1688,7 +1688,7 @@ startup; the decode hot path holds no cross-namespace lock. Per sweep, one
 `--prefix-index {linear|radix}` (default `linear`) selects how the in-RAM
 prompt cache resolves the longest-prefix block-hash match. Both paths
 implement the `PrefixIndex` trait in
-`crates/rmlx-models/src/prefix_index.rs`:
+`crates/rmlx-models/src/prefix_index/mod.rs`:
 
 - `linear` — O(slots × n_blocks) scan over `Vec<Slot>`. Bisect-safe fallback.
 - `radix` — NVIDIA Dynamo positional radix tree port (single-payload

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -722,11 +722,11 @@ audio fields under `audio_config`.
 
 | Field | Type | Notes |
 |---|---|---|
-| `num_hidden_layers` | int | 42 for e4b/e2b, larger for 26B/31B |
+| `num_hidden_layers` | int | differs per size, including between e2b and e4b — read the snapshot's `text_config`, do not carry one size's depth to another |
 | `hidden_size` | int | 2560 for e4b |
 | `num_attention_heads` | int | 8 for e4b |
 | `num_key_value_heads` | int | SWA-layer KV heads |
-| `num_global_key_value_heads` | int | full-attention KV heads (26B/31B) |
+| `num_global_key_value_heads` | int | full-attention KV heads. Absent on e2b/e4b, where `gemma4/config.rs` falls back to `num_key_value_heads` — the split by layer class exists on every size, the override only on some |
 | `head_dim` | int | 256 for SWA layers |
 | `global_head_dim` | int | 512 for full-attention layers (every size: e2b, e4b, 26B, 31B) |
 | `intermediate_size` | int | dense MLP width |
@@ -800,10 +800,13 @@ behaviour rather than the bare-prompt artifact.
 
 ### Key structural properties
 
-**SWA + FullAttention alternation.** Per-layer `layer_types` array determines
-the attention type. The default pattern is 5 sliding + 1 full, repeated. SWA
-layers use a rotating ring-buffer KV cache; full-attention layers use the full
-buffer.
+**SWA + FullAttention alternation.** The per-layer `layer_types` array
+determines the attention type and is the only authority for it. **The
+alternation period is not a constant across sizes** — e2b and e4b differ — so
+a period read off one size mis-places every full-attention layer on the other.
+Derive the full-attention indices from the array, never from a repeat count.
+SWA layers use a rotating ring-buffer KV cache; full-attention layers use the
+full buffer.
 
 **Cross-layer KV sharing.** `num_kv_shared_layers` sets the number of trailing
 SWA layers whose K/V is produced by the model but immediately overwritten with
@@ -814,16 +817,29 @@ footprint for those layers.
 
 **K=V sharing for full-attention layers (26B/31B).** When `attention_k_eq_v=true`,
 the snapshot stores only `k_proj` for full-attention layers; `v_proj` is
-absent and the loader reuses `k_proj` weights as `v_proj`. The KV head count
-for full-attention layers is taken from `num_global_key_value_heads` in this
-case.
+absent and the loader reuses `k_proj` weights as `v_proj`.
 
-**Dual head dimensions.** SWA layers use `head_dim` (256); full-attention
-layers use `global_head_dim` (512 on every size, e2b through 31B — see
-`gemma4/loader.rs`). Partial rotary factor applies to `global_head_dim` for
-the full-attention RoPE. No gemma-4 layer is 128 wide, which is why none of
-them reaches MLX's fused attention kernel — see `docs/FFI.md`
-§`scaled_dot_product_attention`.
+**Attention geometry splits by layer class — both axes.** A Gemma4 layer's KV
+shape depends on which class it is in, and *both* the head width and the KV
+head count switch:
+
+| axis | SWA layers | full-attention layers |
+|---|---|---|
+| head width | `head_dim` | `global_head_dim` |
+| KV heads | `num_key_value_heads` | `num_global_key_value_heads` |
+
+`gemma4/loader.rs` selects the width (`LayerType::FullAttention =>
+cfg.global_head_dim`) and `gemma4/generate/mod.rs` builds the per-layer
+`KvLayerShape` vector from the same pair. The KV-head split is **not** a
+26B/31B special case: it applies on every size, and on e2b/e4b — which do not
+ship `num_global_key_value_heads` — the full-attention count falls back to
+`num_key_value_heads`, so the two happen to coincide there. Sizing a global
+layer from `head_dim` / `num_key_value_heads` is the recurring mistake; it
+reads the SWA geometry.
+
+Partial rotary factor applies to `global_head_dim` for the full-attention
+RoPE. No gemma-4 layer is 128 wide, which is why none of them reaches MLX's
+fused attention kernel — see `docs/FFI.md` §`scaled_dot_product_attention`.
 
 **AltUp residual.** `hidden_size_per_layer_input` enables an AltUp-style
 residual gate when non-zero.

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -66,7 +66,7 @@ across all three test-target arches.
   `model.forward_arr(&y, 1, Some(&mut kv_caches), Some(&mut lin_caches), …)`
   (line 197 / 595); prefill via `forward_seq_with_cache` (line 413).
 
-- **Gemma4** (`crates/rmlx-models/src/gemma4/generate.rs`): decode loop
+- **Gemma4** (`crates/rmlx-models/src/gemma4/generate/mod.rs`): decode loop
   `for step_idx in 1..n_tokens` (line 375 / 970) calls
   `model.forward_arr(&y, 1, Some(&mut caches), device)` (line 379 / 973);
   prefill via `forward_seq_with_cache` (line 755).
@@ -673,7 +673,17 @@ and Qwen3.6 (separate arch files) are unchanged. On the `none` path the gain
 widens with context as KV bandwidth dominates: Bonsai `none` decode_tps
 ~101→~135 at 4 k, ~48→~83 at 16 k, ~19→~38 at 64 k.
 
-## Codec cells across context — `none` vs `mixed_k8g64_v4g64` (2026-08-21)
+## Codec cells across context — `none` vs `mixed_k8g64_v4g64`, **8-bit K** (2026-08-21)
+
+> **Scope, added after the fact and load-bearing.** Every cell here holds K at
+> **8 bits**. A later campaign ran the same harness, the same model and the same
+> ABBA design at `mixed_k4g64_v4g64` and got the opposite sign, on this file's
+> own Bonsai shapes. The null below is sound — one of those later cells
+> reproduces this section's 31 553 row independently — but it is a result about
+> **8-bit K**, not about quantized KV. Do not carry any conclusion from this
+> section to a different K width. See docs/KV_QUANT.md, "The null was a
+> bit-width result, not a context result", and read the cells out of `runs.db`
+> rather than out of prose.
 
 Why this section exists: every earlier codec cell in this file and in
 `docs/KV_QUANT.md` was taken at 4 096–32 768 tokens, and the standing objection
@@ -713,19 +723,39 @@ spread, which is not a coin flip — but read a single separated row against
 is uncancelled: the ABBA schedule already equalises the arms' mean slot
 position, but the pairing that would confirm it was not done.
 
-| model | prompt tok | `kv_frac` | predicted B/A | decode B/A | A range (CoV) | B range (CoV) | verdict | resident KV A → B | resident B/A |
-|---|---:|---:|---:|---:|---|---|---|---|---:|
-| Ternary-Bonsai-8B-2bit | 3 770 | 0.211 | 1.099 | 0.975 | 141.45–143.03 (0.52 %) | 137.32–139.28 (0.66 %) | ranges disjoint | 570.5 → 734.1 MB | 1.287 |
-| Ternary-Bonsai-8B-2bit | 31 553 | **0.687** | **1.419** | 1.002 | 68.60–68.67 (0.04 %) | 68.56–68.77 (0.15 %) | INCONCLUSIVE | 4 667.3 → 6 032.9 MB | 1.293 |
-| Qwen3.8-27B-mxfp8 | 3 892 | 0.010 | 1.004 | 0.977 | 18.49–18.64 (0.37 %) | 18.06–18.13 (0.21 %) | SEPARATED | 415.5 → 506.5 MB | 1.219 |
-| Qwen3.8-27B-mxfp8 | 130 848 | 0.245 | 1.149 | **0.763** | 13.74–14.02 (0.89 %) | 10.61–10.72 (0.49 %) | SEPARATED | 8 735.7 → 11 784.2 MB | 1.349 |
+| model | prompt tok | `kv_frac` | predicted B/A | decode B/A | A range (CoV) | B range (CoV) | verdict | resident KV A → B |
+|---|---:|---:|---:|---:|---|---|---|---|
+| Ternary-Bonsai-8B-2bit | 3 770 | 0.211 | 1.099 | 0.975 | 141.45–143.03 (0.52 %) | 137.32–139.28 (0.66 %) | ranges disjoint | withdrawn† |
+| Ternary-Bonsai-8B-2bit | 31 553 | **0.687** | **1.419** | 1.002 | 68.60–68.67 (0.04 %) | 68.56–68.77 (0.15 %) | INCONCLUSIVE | withdrawn† |
+| Qwen3.8-27B-mxfp8 | 3 892 | 0.010 | 1.004 | 0.977 | 18.49–18.64 (0.37 %) | 18.06–18.13 (0.21 %) | SEPARATED | withdrawn† |
+| Qwen3.8-27B-mxfp8 | 130 848 | 0.245 | 1.149 | **0.763** | 13.74–14.02 (0.89 %) | 10.61–10.72 (0.49 %) | SEPARATED | withdrawn† |
+
+† Arm B's resident figures were taken on a binary that built the bf16 K/V mirror
+on **every** architecture. All four cells are dense stacks, where that mirror is
+no longer allocated, so each figure measured two buffers these arches no longer
+hold. They are withdrawn rather than corrected in place — the same withdrawal
+docs/KV_QUANT.md §"Class 3" records, so the two pages agree.
+
+The Bonsai cells have since been re-measured post-elision. Read them from
+`runs.db`, not from prose:
+
+```bash
+rmlx metrics query "SELECT model, prompt_tokens, kv_quant, value \
+  FROM observations WHERE id BETWEEN 122793 AND 122804 \
+    AND metric = 'kv_cache_bytes' \
+  ORDER BY model, prompt_tokens, kv_quant"
+```
+
+The Qwen3.8 cells have **not** been re-measured and no substitute figure is
+offered for them. The **decode** columns are unaffected by any of this: an
+unread bf16 seed costs memory, not decode time, and arm B already read its
+packed store. They are the argument this table carries.
 
 **What the 130 848-token Qwen3.8 row settles, and what it does not.** This is
 the cell a long-context codec claim was meant to turn on: `kv_frac` 0.245 and a
 predicted **+14.9 %** ceiling for arm B. Measured on a quiet host, arm B is
-**23.7 % slower**, every `none` slot faster than every `mixed` slot, while
-holding **35 % more** resident KV and 6 034 MB more generation-scoped
-allocation.
+**23.7 % slower**, every `none` slot faster than every `mixed` slot. Its
+resident figure is withdrawn per † and this row does not rest on one.
 
 **Scope, because the two halves are not equally load-bearing.** Arm B is
 `mixed_k8g64_v4g64` **as it stands on this tree**, which still materialises a
@@ -735,10 +765,11 @@ whose decode really does read its store, so `materialises_packed_store()` is
 still true for it (`crates/rmlx-kv-quant/src/quant.rs`). The seed is exactly
 what a seed-elision projection removes.
 
-* The **resident** figure is therefore the *pre-elision* number and settles
-  nothing about a post-elision codec. It reproduces what the byte model already
-  predicts for today's `Mixed` (1.349 measured whole-cache; 1.355 attention-only
-  from `perf_ceiling.py`) — a confirmation, not a refutation.
+* The **resident** figure was therefore a *pre-elision* number and settled
+  nothing about a post-elision codec. It is withdrawn per †; the arch has not
+  been re-measured, and `perf_ceiling.py` — now bound to the engine's byte model
+  by `make check-kv-byte-model-parity` — is where a prediction for it comes
+  from.
 * The **decode** figure needs no post-elision arm and is the new evidence.
   Returning an unread bf16 seed frees memory; it does not make a
   quantized-matmul decode path faster, and arm B already reads its packed store.
@@ -754,16 +785,19 @@ without the packed-path throughput work, which is open.
 **What the 31 553-token Bonsai row settles.** 0.687 is the largest `kv_frac`
 any release-set model reaches at a context this tree can serve. Arm B cuts the
 decode KV stream to 0.571× of arm A's and the roofline predicts +42 %.
-Measured: **+0.2 %, ranges overlapping** — no measured effect — while resident
-KV goes *up* 29 %. The arm spreads here are 0.04 % and 0.15 %, so this is a null
-with the power to have seen a 1 % effect. The short-context basis was not what
-made the earlier codec cells come back null: the null survives at the
-high-`kv_frac` end of the same axis.
+Measured: **+0.2 %, ranges overlapping** — no measured effect. The arm spreads
+here are 0.04 % and 0.15 %, so this is a null with the power to have seen a 1 %
+effect. The short-context basis was not what made the earlier codec cells come
+back null: the null survives at the high-`kv_frac` end of the same axis. What it
+*was* is the K bit width — see the scope banner at the head of this section.
 
 **The byte model is not what fails; it is exact where it is complete.** At the
 measured offsets `perf_ceiling.py` puts arm A's resident KV at 570.5 MB and
-4 667.3 MB on Bonsai — the measured figures, to the digit — and arm B within
-0.5 % and 0.06 %.
+4 667.3 MB on Bonsai — the measured figures, to the digit. Arm A is unaffected
+by the mirror elision. Its arm-B agreement is not quoted here: the model that
+produced it has since been corrected on three axes and is now diffed against the
+engine's by `make check-kv-byte-model-parity`, so re-run the script rather than
+trusting a transcribed agreement.
 
 **The Qwen3.8 resident ratio is diluted, not smaller.** That arch is hybrid:
 48 of its 64 layers hold a fixed-size GDN recurrent state the codec never
@@ -774,14 +808,16 @@ it, and the gap between its prediction and the measurement is that state — the
 | prompt tok | arm | predicted (attention KV) | measured | gap |
 |---:|---|---:|---:|---:|
 | 3 892 | `none` | 261.6 MB | 415.5 MB | +153.9 |
-| 3 892 | `mixed` | 354.5 MB | 506.5 MB | +152.0 |
+| 3 892 | `mixed` (pre-elision) | 354.5 MB | 506.5 MB | +152.0 |
 | 130 848 | `none` | 8 581.7 MB | 8 735.7 MB | +154.0 |
-| 130 848 | `mixed` | 11 632.3 MB | 11 784.2 MB | +151.9 |
+| 130 848 | `mixed` (pre-elision) | 11 632.3 MB | 11 784.2 MB | +151.9 |
 
-Read the whole-cache ratio on a hybrid arch as a lower bound on the
-attention-KV ratio (1.219 measured against 1.355 attention-only at 3 892; 1.349
-against 1.355 at 130 848), the same way the `--kv-quant none` section reads
-Qwen3.6-35B's 1.060× against its 1.109× attention-only figure.
+The two `mixed` rows are pre-elision and are shown only to demonstrate that the
+GDN gap is the *same constant* on both arms — which is the point of the table,
+and is unaffected by the withdrawal. Read a whole-cache ratio on a hybrid arch as
+a lower bound on the attention-KV ratio, the same way the `--kv-quant none`
+section reads Qwen3.6-35B's 1.060× against its 1.109× attention-only figure; the
+codec ratios themselves are withdrawn per †.
 
 **`none`'s non-bandwidth overhead is flat across context; arm B's is not.**
 Same runs, against `perf_ceiling.py`'s bandwidth-bound floor for the same cell.
@@ -848,8 +884,25 @@ against this section's numbers:
   (`DEFAULT_KV_QUANT = KvQuant::None`), so no user reaches this path unless
   they ask for it by name.
 
+Two later results bear on this disposition and neither overturns it:
+
+* **The fused-kernel side is bounded harder than this argued.** An ablation
+  ladder that deletes 100% of a fused codec's decode math still leaves it far
+  short of `none`, which puts every decode-math item — the ε work included —
+  under one ceiling below parity, and identifies the kernel *shell* as the
+  majority of the gap. See docs/KV_QUANT.md, "The decode ceiling". This
+  strengthens the negative verdict and redirects the next measurement to a
+  shell variant.
+* **The `Mixed` side's verdict is scoped to 8-bit K.** At 4-bit K the same
+  harness measures the same model *winning* against `none` with disjoint
+  ranges — on the `quantized_matmul` path, not a fused kernel, so it does not
+  transfer to the bullets above. It does mean this section's rows must not be
+  cited as "quantized KV loses at decode". See docs/KV_QUANT.md, "The null was
+  a bit-width result, not a context result".
+
 The `none` rows in this section keep their standing as anchors. What is retired
-is the expectation that the packed-store arms in them have collectable headroom.
+is the expectation that the **8-bit-K** packed-store arms in them have
+collectable headroom.
 
 ## Host-sampler cost — PROVISIONAL, NOT AN ANCHOR (2026-08-16)
 
@@ -1115,10 +1168,10 @@ Equivalent diagnostic emitted for `iso4_sym`, `k_iso3`, `k_iso4`. The codec smok
 - K-only variants (`k_iso3` / `k_iso4`) are bottlenecked by the CPU-only K-side iso decode path (no GPU q8_0 affine fast path on K). Bonsai `k_iso4` shows wide cross-run variance (32–58 TPS); first reading should not be treated as a regression floor without a paired re-bench on identical binary/build/host.
 - All four variants are opt-in only — never an auto baseline.
 
-## TurboSym3 (WHT-3 K + WHT-3 V) decode-TPS anchor (2026-05-31)
+## TurboSym3 (turbo-3 K + turbo-3 V) decode-TPS anchor (2026-05-31)
 
 **Binary**: `target/release/rmlx` (debug-assertions on — ship-quality builds use release-perf, these numbers are the ceiling, not the floor).
-**Codec**: TurboSym3 (WHT 3-bit K + WHT 3-bit V, symmetric). Both K and V sides use the same WHT + Lloyd-Max 3-bit codebook path.
+**Codec**: TurboSym3 (3-bit K + 3-bit V, symmetric). Both K and V sides use the same Lloyd-Max 3-bit codebook path. **No rotation is applied on either axis** — the family's name and the `_wht_` substring in its layout tag imply one that the encoder does not have; see docs/KV_QUANT.md, "The turbo family's missing rotation".
 **Shape**: 2-token prompt ("Hello world") + `--max-tokens 100`. Single-MLX preflight between each run. Hardware: M5 Max.
 **Protocol**: 3 measured runs per model. Mean decode TPS reported. No warmup run (short prompt; all runs included).
 
@@ -1140,7 +1193,7 @@ k8vturbo3' (K=8-bit, V=turbo3).
 - Reference `k8vturbo3` anchors (4k-prompt shape, mean n=3): Bonsai 98.95 TPS, Gemma4 73.16 TPS. The short-prompt shape here inflates TPS vs the 4k-prompt shape for both codecs; this table is directly comparable to the iso3_sym / iso4_sym and rotor3_sym / rotor4_sym anchors which also used the 2-token short-prompt shape.
 - tsym3 Bonsai (143.20) is close to `iso3_sym` (142.64) and `rotor3_sym` (145.49) — all three symmetric 3-bit variants cluster in the 140-146 TPS band on this shape and arch.
 - tsym3 Gemma4 (79.93) aligns with `iso3_sym` (80.12) and `rotor3_sym` (81.53) — consistent with the ~80 TPS band for symmetric 3-bit codecs on Gemma4-e4b at this shape.
-- TurboSym3 is **CPU-only** on the hot path (same precedent as iso3_sym, rotor3_sym). Both K and V sides dispatch through the WHT + Lloyd-Max CPU encode/dequant path; no MSL kernel at this revision.
+- TurboSym3 is **CPU-only** on the hot path (same precedent as iso3_sym, rotor3_sym). Both K and V sides dispatch through the Lloyd-Max CPU encode/dequant path; no MSL kernel at this revision.
 - All variants are opt-in only — `tsym3` is never an auto baseline.
 
 ## Symmetric / K-only rotor K-side variants (2026-05-31)
@@ -1847,7 +1900,7 @@ at the same preset.
 
 Head-to-head bench of `LinearScan` vs `RadixTree` (NVIDIA Dynamo positional
 radix tree port) at the longest-prefix match path. Both implement the
-`PrefixIndex` trait in `crates/rmlx-models/src/prefix_index.rs`; the CLI
+`PrefixIndex` trait in `crates/rmlx-models/src/prefix_index/mod.rs`; the CLI
 flag `--prefix-index {linear|radix}` selects which one each freshly built
 `PromptCache<E>` uses.
 

--- a/docs/WEIGHT_QUANTS.md
+++ b/docs/WEIGHT_QUANTS.md
@@ -299,15 +299,36 @@ in `rows × cols` and is dominated by the cache-coherent scan of
 per field per group), then amortized across `group_size` elements.
 
 Source: `crates/rmlx-quant/src/affine.rs`
-MSL kernel (q8_g128): `crates/rmlx-models/src/q8_msl.rs`
+MSL kernel (q8_g128): `crates/rmlx-kv-quant/src/q8_msl.rs`
 
 ---
 
-## 5. TurboQuant — rotation-based Lloyd-Max codebook
+## 5. TurboQuant — Lloyd-Max codebook, **no rotation**
 
 TurboQuant is used in rMLX primarily for the V side of the KV cache
 (4-bit) and for weight quantization experiments. It uses a fixed-codebook
 scalar quantizer with a per-block scale rather than affine scale + bias.
+
+**The name promises a rotation this implementation does not have.** Upstream
+TurboQuant decorrelates before quantizing — that is the point of the family, and
+it is what IsoQuant, PlanarQuant and RotorQuant all do. rMLX's turbo encoder
+applies no transform on either axis at any width: §5.2 and §5.3 below are the
+whole codec, and the source contains no Hadamard or Walsh-Hadamard code. The
+`_wht_` substring in the `tsym3` / `tsym4` SSD layout tags is a geometry
+identifier for the block reader, not a description of the encoder.
+
+What the missing transform would be worth has been measured, by a controlled
+test-side ablation around the shipped encoder
+(`crates/rmlx-kv-quant/src/turbo_rotation_fidelity_tests.rs`). The short form:
+it is worth roughly a bit to two bits on **K**-shaped data with channel
+outliers, roughly a hundredth of a bit on **V**-shaped i.i.d. data, and the
+payoff shrinks as the codebook widens. Since rMLX uses turbo primarily on the V
+axis, and the V-side implementation is the expensive one — it needs an explicit
+inverse transform after the SV accumulation, across the P2 kernel, four dequant
+kernels and both fused-QK kernels — the value and the cost are inverted with
+respect to each other. Full account, including the scope limits:
+docs/KV_QUANT.md, "The turbo family's missing rotation — what it is worth, and
+where".
 
 ### 5.1 Codebook
 
@@ -356,9 +377,9 @@ path) for 8-bit K-cache or weight quantization.
 All — TurboQuant is arch-agnostic. Primary production use: V-cache at 4-bit
 in the K8V4 asymmetric config; see [KV_CACHE.md](KV_CACHE.md).
 
-Source: `crates/rmlx-quant/src/turboquant.rs`
-MSL kernel: `crates/rmlx-models/src/turboquant_msl.rs`
-TurboFlash kernel (K8+V4, split-K FlashAttention): `crates/rmlx-models/src/turbo_flash_msl.rs`
+Source: `crates/rmlx-kv-quant/src/turboquant.rs`
+MSL kernel: `crates/rmlx-kv-quant/src/turboquant_msl.rs`
+TurboFlash kernel (K8+V4, split-K FlashAttention): `crates/rmlx-kv-quant/src/turbo_flash_msl.rs`
 
 ---
 
@@ -432,8 +453,8 @@ reconstruction error is guaranteed to be ≤ TurboQuant on any input.
 All — PlanarQuant is arch-agnostic. Primarily used for the V side of the
 KV cache; see [KV_CACHE.md](KV_CACHE.md).
 
-Source: `crates/rmlx-quant/src/planarquant.rs`
-MSL kernel: `crates/rmlx-models/src/planarquant_msl.rs`
+Source: `crates/rmlx-kv-quant/src/planarquant.rs`
+MSL kernel: `crates/rmlx-kv-quant/src/planarquant_msl.rs`
 
 ---
 

--- a/docs/models/gemma4/rMLX.md
+++ b/docs/models/gemma4/rMLX.md
@@ -36,11 +36,19 @@ serve), so rMLX cells compare directly. Bar (§0.1): WIN / TIE-on-CI-overlap / L
   to −4…+1 % (🟢 WIN @16k) and halved its KV.** Only **31b dense still trails
   −2…−12 %** (dense-bandwidth physics, near the ceiling). Headline: **#44 + #51 made
   e2b/e4b/26b competitive with mlx-lm decode; only 31b dense trails.**
-- **KV codec is a decode no-op on every model** (all mainstream codecs ≈ `none`)
-  **AND memory-inflating** (1.2–4× resident KV) — **EXCEPT 31b dense**, the lone
-  model where KV quant pays a small decode win (k8vturbo2/tsym +3–4 % @32k–64k,
-  bandwidth-bound; n=2, soft). The quant block keeps its bf16 warm-decode seed
-  *alongside* the packed blocks, so every codec is larger than `none`.
+- **KV codec is a decode no-op on every Gemma4 model** (all mainstream codecs ≈
+  `none`) — **EXCEPT 31b dense**, the lone model here where KV quant pays a small
+  decode win (k8vturbo2/tsym +3–4 % @32k–64k, bandwidth-bound; n=2, soft).
+  Scope this to Gemma4 and to the K widths swept: on a *dense* arch at **4-bit
+  K** the `Mixed` path has since been measured beating `none` with disjoint
+  ranges (docs/KV_QUANT.md, "The null was a bit-width result").
+  **The memory half of this claim was wrong and is withdrawn.** It read "every
+  codec is larger than `none`", reasoning from a bf16 warm-decode seed that is
+  now built only where a decode path reads it. Gemma4 is a shared-KV arch, so
+  `mixed` / `rot_k` do keep their mirror here — but the iso family is under
+  `none` on this arch too. Per-codec, per-topology figures come from `rmlx info
+  --list-cache-types` and the Class 3 table in docs/KV_QUANT.md; do not carry a
+  ratio out of this bullet.
 - **TTFT exposes per-codec prefill cost invisible in decode.** `rotor*_sym`
   catastrophic (e4b 102 s, 31b 528 s @64k cold — QJL prefill); turbo*tcq elevated;
   K-only `k_iso* / k_rotor*` crawl (host CPU dequant, capped early).

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -31,6 +31,7 @@ Conventions:
 | `check_kv_byte_model_parity_fixtures.sh` | Recall test for the above — 9 synthetic manifests, each asserting which check fired and exit 2 vs exit 1, including head- and tail-layer edits that a sampled codec vector could not see. |
 | `check_metal_compiles.sh` | Every `.metal` kernel compiles natively at `-std=metal3.1` and `-std=metal4.0`, and is named by its `probes/kernels.manifest`. |
 | `check_metal_format.sh` | Every `.metal` file is formatted. |
+| `check_doc_source_citations.sh` | Every `crates/...` source path cited in a tracked `docs/*.md` file resolves. The subsystem docs replace figures with citations; the trade only holds while the citations do. |
 | `check_no_decode_swallow.sh` | A failed decode step or failed sampler call cannot be swallowed into a silent success. |
 | `check_no_inline_tests.sh` | No inline `#[cfg(test)] mod tests` outside `*_tests.rs` / `tests.rs`. |
 | `check_no_kernel_input_eval.sh` | No blocking `Array::eval()` on a kernel input inside a dispatcher. |

--- a/scripts/check_doc_source_citations.sh
+++ b/scripts/check_doc_source_citations.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# scripts/check_doc_source_citations.sh — CI gate: every `crates/...` source
+# path cited in a tracked docs/*.md file must exist in the tree.
+#
+# Why this exists: the subsystem docs replace figures with citations — "pinned
+# by X (`crates/.../y_tests.rs`)", "the predicate lives in `crates/.../z.rs`".
+# That trade is only honest while the citations resolve. A crate rename or a
+# `foo.rs` -> `foo/mod.rs` split leaves the prose reading correctly and pointing
+# at nothing, which is indistinguishable from a stale figure and harder to spot.
+#
+# Scope: backticked paths beginning `crates/` and ending in a source extension,
+# in files `git ls-files docs` reports. Fenced code blocks are included on
+# purpose — a shell snippet naming a moved file is as wrong as prose naming it.
+#
+# Not in scope: identifiers (a test or function name), which need a language
+# parser to tell from a variable, and non-crate paths.
+#
+# Exit 0 = every cited path resolves. Exit 1 = at least one does not.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# shellcheck disable=SC2016
+pattern='`(crates/[A-Za-z0-9_][A-Za-z0-9_./-]*\.(rs|metal|sql|toml|txt))`'
+
+violations=0
+cited=0
+
+while IFS= read -r doc; do
+    [ -f "$doc" ] || continue
+    while IFS=: read -r lineno path; do
+        cited=$((cited + 1))
+        if [ ! -e "$path" ]; then
+            if [ "$violations" -eq 0 ]; then
+                echo "ERROR: docs cite source paths that do not exist:" >&2
+            fi
+            echo "  ${doc}:${lineno}: ${path}" >&2
+            violations=$((violations + 1))
+        fi
+    done < <(grep -nEo "$pattern" "$doc" | sed 's/`//g')
+done < <(git ls-files 'docs/*.md' 'docs/**/*.md')
+
+if [ "$violations" -gt 0 ]; then
+    echo >&2
+    echo "Repoint each citation at the file that holds the item today, or drop it." >&2
+    echo "A citation that resolves to nothing is the same defect as a stale figure." >&2
+    exit 1
+fi
+
+echo "OK: ${cited} cited source paths in docs/ all resolve."


### PR DESCRIPTION
Lands the durable conclusions of a ten-item KV research campaign into tracked docs. Results live in issue comments on #453, #454, #455, #457, #459 and #470; merged code in #461, #462, #464, #465, #469.

**Docs only.** No engine behaviour changed, no `.rs` files touched.

## The rule this follows

A number a program can derive is never written into prose here. Stale hand-written figures were the disease in five of this campaign's seven issues, so replacing them with fresh hand-written figures would recreate it. Every load-bearing number points at its producer instead:

| what | points at |
|---|---|
| `mixed_*` / `rot_k` residency | `rmlx metrics query` over `runs.db` ids 122793-122804 (rows verified present) |
| 4-bit decode ratios | `rmlx metrics query` over ids 122807-122836 |
| rotation's worth | `turbo_rotation_fidelity_tests.rs`, whose threshold is imported from `ROT_K_MIN_OUTLIER_GAIN_BITS`, not retyped |
| per-layer KV bytes | `rmlx info --list-cache-types` / `estimated_resident_bytes_per_layer` |
| byte-model agreement | re-run `perf_ceiling.py` under `make check-kv-byte-model-parity` |

**R4's ladder ratios are deliberately carried in no form at all.** Three of its four arms are throwaway instrumented binaries reproducible from no committed ref and absent from `runs.db`, so the docs state the rung *ordering* and the qualitative result, point at `.rmlx/analysis/r4-ceiling-ladder/`, and say why no ratio is quoted.

## Mechanisms landed

- **The decode ceiling.** Deleting 100% of the decode math still leaves that codec far short of `none` — most of the gap is kernel shell, not codec arithmetic. This inverts what future kernel work is worth funding, and both `KV_QUANT.md` and `PERF_BASELINE.md` implied the opposite.
- **The null was a bit-width result, not a context result.** 4-bit K wins where 8-bit K is a wash, on the model and harness that recorded the earlier null. The earlier null is *sound* — it was measured at the wrong K width. `PERF_BASELINE.md:676`'s section is now scoped to 8-bit K rather than reading as a general law.
- **Residency, with corrected attribution.** The mirror elision alone did not produce the whole change; a later boundary-floor change did the rest.
- **The GQA guard's stated premise does not reproduce on 8:1**, and the dilution arithmetic behind it was backwards in a way that matters for anyone reasoning about Gemma4 layer classes.
- **The turbo family's rotation is worth roughly a bit or two on K-shaped data and about a hundredth of a bit on V-shaped** — inverted relative to implementation cost, since the V side is the expensive one. Recorded as orders of magnitude, pointing at the test.

## Contradictions found and resolved

Five, three of them cases where two pages gave different answers to the same question:

1. `PERF_BASELINE.md` still published the four pre-elision resident ratios that `KV_QUANT.md` had deliberately withdrawn — same numbers, two pages, two answers.
2. `KV_QUANT.md` said residency was "saturated at *no codec is smaller*" about 130 lines below its own table showing iso under bf16 everywhere.
3. `docs/models/gemma4/rMLX.md` asserted "every codec is larger than `none`" — false on gemma4 too, where the iso family is under it.
4. `KV_QUANT.md` attributed the SWA geometry (`head_dim` 256, 1 KV head) to e2b's *global* layers in two places; the loader selects `global_head_dim` for that class.
5. Six places claimed a Walsh-Hadamard transform that `turboquant.rs` does not implement.

## Architecture facts corrected

`MODELS.md` no longer claims 42 layers for gemma-4-e2b, declares the alternation period non-constant, and gains a table for attention geometry splitting by layer class — reading only `num_key_value_heads` scores several models wrong. Bonsai-8B's context cap is recorded where the campaign assumed otherwise.

## A gate for citations

The phantom-gate instruction was treated as a class rather than one string: a second phantom test citation and **9 stale source paths** were found and repointed. `scripts/check_doc_source_citations.sh` (new, in `make ci`) fails when a doc cites a source path that does not exist.

Mutation-checked both directions — a crate rename and a `mod.rs` split each go red naming the offending doc line, and restore green:

```
OK: 184 cited source paths in docs/ all resolve.            EXIT=0
ERROR: docs cite source paths that do not exist:
  docs/WEIGHT_QUANTS.md:380: crates/rmlx-quant/src/turboquant.rs        EXIT=1
```

It lands green because all 9 pre-existing violations were fixed first, rather than shipping as a red gate nobody can satisfy. It deliberately does **not** cover cited *identifiers* — telling a test name from a variable needs a parser, and 14 such citations currently resolve to nothing (mostly Metal kernel names from gputrace captures, legitimately absent).

## Verification

`make ci` green. `check_kv_codec_disposition.sh` OK (28 codecs, CLI help and docs agree), `check_kv_byte_model_parity.sh` OK (168 rows), both fixture suites PASS, `check_doc_source_citations.sh` 184/184. `runs.db` id ranges confirmed present by read-only query before being cited. Architecture claims verified against the checkpoints' `config.json` and the loader, not against the issue text.

## Not done

`CLAUDE.md`'s gate table does not list the new target — that file was left alone deliberately; it wants a one-line addition. `scripts/bench/codec_inertness_probe.sh`'s stale `store_skipped` claim is documented in `KV_QUANT.md` but the script is untouched (#466 owns it). R10's inventory is scoping with no measurement, so nothing from it belongs in subsystem docs yet — but its blocker is real and undocumented: `stats.hits` increments before the policy gate, which makes `rmlx bench` unusable for TTFT work (#470).
