### PR TITLE
docs: the gate table names the three checks added with the KV campaign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,7 +311,10 @@ hand — keeps the CI gate and the local gate identical.
 | `make ci-perf` | `test-perf` under `release-perf` + the serialized GPU/Metal suite. Requires an idle GPU. Run before merging perf-sensitive or codec-layer changes (~21 min). |
 | `make check-kv-layer-quants` | CI gate (in `make ci`): the per-layer KV codec vector has one producer (`kv_layer_quants`) — no second `kv_quant_for_layer` loop, and every per-layer cache stack either uses it or declares itself uniform. |
 | `make check-kv-codec-disposition` | CI gate (in `make ci`): the `--kv-quant` / `--kv-bits` help and the `docs/KV_QUANT.md` INERT banners agree with each codec's runtime disposition, derived from `ALL_KV_QUANTS` + `decode_reads_packed_store` / `feeds_bf16_{k,v}_at_decode`. |
-| `make check-kv-codec-disposition-fixtures` | CI gate (in `make ci`): recall test for the above, 10 synthetic scan roots (one edit each), each asserting which rule fired and exit 2 vs exit 1. |
+| `make check-kv-codec-disposition-fixtures` | CI gate (in `make ci`): recall test for the above, 18 synthetic scan roots (one edit each), each asserting which rule fired and exit 2 vs exit 1. |
+| `make check-kv-byte-model-parity` | CI gate (in `make ci`): `scripts/perf_ceiling.py`'s KV byte model against the engine's, swept from `ALL_KV_QUANTS` across both topologies and two shapes. The engine is the oracle — this does not check either model is right, only that there is effectively one of them. |
+| `make check-kv-byte-model-parity-fixtures` | CI gate (in `make ci`): recall test for the above, synthetic scan roots asserting the reason as well as exit 2 vs exit 1. |
+| `make check-doc-source-citations` | CI gate (in `make ci`): every `crates/...` path cited in `docs/` resolves. Covers paths only, not identifiers — telling a test name from a variable needs a parser. |
 | `make check-eval-lock` | CI gate (in `make ci`): every MLX eval FFI call is made under the process-wide evaluation lock (25-symbol reach-set). |
 | `make check-eval-lock-fixtures` | CI gate (in `make ci`): recall test for the above, 26 synthetic scan roots, each asserting which rule fired. |
 | `make eval-lock-stress` | Drive the evaluation-lock reproducer across `RUNS` fresh processes (default 60). Not in `make ci` — probabilistic (~8%/run) and costs ~412 threads. |


### PR DESCRIPTION
`CLAUDE.md`'s gate table did not list three checks that run in `make ci`:

- `check-kv-byte-model-parity` — binds `scripts/perf_ceiling.py`'s KV byte model to the engine's, swept from `ALL_KV_QUANTS`. Landed in #461 after that script was found overstating `mixed_k8g64_v4g64` by 3.46x while being cited as authoritative from three docs.
- `check-kv-byte-model-parity-fixtures` — its recall test, asserting the reason and not only the exit code.
- `check-doc-source-citations` — landed in #471; fails when a doc cites a `crates/...` path that no longer resolves. Found 9 stale citations on its first run.

Also corrects the disposition fixture count, 10 → 18, after rules 7, 8 and 9 landed.

The table is what a reader consults to know what the pre-merge gate actually covers, so understating it is the same class of drift the campaign spent itself fixing.
