### PR TITLE
fix(release): drop the stale Homebrew bottle block instead of refreshing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Homebrew formula no longer advertises a bottle it does not have.** A
+  `bottle do` block names a `root_url` pinned to one release, but Homebrew
+  derives the bottle *filename* from the formula's current version — so a block
+  left in place across a version bump sends `brew install` after a bottle that
+  was never built, under the previous release's URL. The block shipped pinned to
+  `v0.3.0` through both 0.3.0 and 0.4.0 while the only bottle asset in existence
+  was `rmlx-0.3.0.arm64_tahoe.bottle.tar.gz`, and `brew info` reported
+  `(bottled)` the whole time. Nothing in the release flow regenerated it and
+  nothing failed when it went stale.
+
+  The block is removed rather than refreshed, so `brew install rmlx` builds from
+  source — which is what `depends_on "rust" => :build` always described.
+  Reinstating a bottle needs the ABI coupling solved first, not a fresh sha: a
+  bottle is linked against the builder's `mlx-c`, that dependency is
+  deliberately unversioned, and `mlx-pin.txt` records that a mismatched
+  mlx / mlx-c pair aborts at load with a dyld `Symbol not found`. A source build
+  links the user's own pair and cannot hit that. `docs/RELEASING.md` step 8
+  records the decision; `scripts/release/build_bottle.sh` and `make bottle` are
+  kept but are no longer part of the flow.
+
 ## [0.4.1] - 2026-09-02
 
 A patch release carrying one decode-path fix, one correction to what the

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,8 +17,8 @@ crates are `publish = false`). There is no separate `VERSION` file.
   the binary links.
 - A published tap repo `Pushkinist/homebrew-rmlx` for `brew tap`.
 
-> **What the shipped artifacts resolve MLX to.** Both the bottle and the
-> release tarball link `libmlx.dylib` / `libmlxc.dylib` through the moving
+> **What the shipped artifacts resolve MLX to.** The release tarball links
+> `libmlx.dylib` / `libmlxc.dylib` through the moving
 > `/opt/homebrew/opt/...` symlinks, so **neither carries the MLX it was built
 > against** — each runs against whatever the installing user has, which
 > `depends_on "mlx-c"` resolves to the current release. Two consequences worth
@@ -28,7 +28,8 @@ crates are `publish = false`). There is no separate `VERSION` file.
 >     machine actually loaded (`crates/rmlx-mlx/src/nax.rs`), so a row from a
 >     distributed binary is the *user's* answer, not the builder's. Nothing
 >     about the nax capability is baked into the artifact.
-> - Run `make mlx-preflight` on the release machine before step 8's keg build.
+> - Run `make mlx-preflight` on the release machine before building the
+>   release binary.
 >   It does not change what users get, but it keeps the release machine's own
 >   published prefill numbers honest.
 >
@@ -77,107 +78,39 @@ crates are `publish = false`). There is no separate `VERSION` file.
    your authenticated identity + the public Rekor log — real provenance for
    the prebuilt binary. Consumer-side verification is in "Verify both install
    paths".
-8. **Build + publish the Homebrew bottle** (binary install channel — no Rust
-   toolchain required for users):
+8. **No Homebrew bottle is published.** `brew install rmlx` builds from source,
+   which is what `depends_on "rust" => :build` in the formula has always
+   described. The formula carries **no `bottle do` block**, and adding one back
+   needs the two problems below solved first — not just a fresh sha.
 
-   a. **Build the keg from source** on the release machine (the same
-      Apple-Silicon Mac used for the binary artifact above).
-
-      > **Do step 9 (formula `url` + `sha256`) FIRST.** The bottle is a build of
-      > the *formula's* source `url`, so the formula must already point at the
-      > new `v<version>` tag tarball before you build the keg — otherwise you
-      > bottle the previous release. (The 0.2.x releases shipped the formula-url
-      > bump and the bottle as two separate PRs for this reason.)
-
-      > **Homebrew ≥6 refuses a loose `.rb` path** (`Error: Homebrew requires
-      > formulae to be in a tap`). The documented `brew install --build-bottle
-      > packaging/homebrew/rmlx.rb` no longer works — build from the tap formula
-      > instead. Mirror the url+sha-bumped formula into the tap checkout, then
-      > install from the tap reference:
-      ```sh
-      cp packaging/homebrew/rmlx.rb \
-        "$(brew --repository)/Library/Taps/pushkinist/homebrew-rmlx/Formula/rmlx.rb"
-      HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-bottle pushkinist/rmlx/rmlx
-      ```
-      This is a full source build (a few minutes). `--build-bottle` forces a
-      source build (a plain `brew install` may reuse a cached bottle). The
-      temporary tap-checkout copy is overwritten by `make tap-sync` (step 10).
-      If the tap is not yet tapped locally:
-      `brew tap pushkinist/rmlx && brew trust pushkinist/rmlx`. Note your `cp`
-      may be aliased to `cp -i` — use `/bin/cp -f` if it prompts.
-
-   b. **Build the bottle and upload it:**
-      ```sh
-      make bottle          # runs scripts/release/build_bottle.sh
-      ```
-      The script:
-      - Runs `brew bottle --json --root-url=https://github.com/Pushkinist/rMLX/releases/download/v<ver>`.
-      - Renames the local `rmlx--<ver>.<tag>.bottle.tar.gz` to the remote
-        single-dash name `rmlx-<ver>.<tag>.bottle.tar.gz` (Homebrew's
-        intentional local/remote naming split — the remote asset must use
-        single-dash or `brew install` gets a 404).
-      - Prints the `bottle do … end` block to paste into the formula.
-      - Prints the exact `gh release upload` command.
-
-      Run the printed upload command:
-      ```sh
-      gh release upload v<version> dist/rmlx-<ver>.<tag>.bottle.tar.gz
-      ```
-
-   c. **Paste the `bottle do` block into `packaging/homebrew/rmlx.rb`.**
-      The script prints the block with the correct `root_url`, `cellar`, OS
-      tag, and sha256.  Insert it immediately after the `head` line, before
-      the `depends_on` lines:
-      ```ruby
-      bottle do
-        root_url "https://github.com/Pushkinist/rMLX/releases/download/v<ver>"
-        sha256 cellar: :any_skip_relocation, arm64_tahoe: "<sha256>"
-      end
-      ```
-      The `depends_on "rust" => :build` and `depends_on "mlx-c"` lines remain
-      unchanged.  When a `bottle do` block is present, `brew install` fetches
-      the binary directly; if the bottle is unavailable for the user's macOS
-      version Homebrew falls back to the source build automatically.
-
-   d. **Commit the formula update** via a PR (main is ruleset-protected). By now
-      the formula carries the new `url` + source `sha256` (step 9 — done first,
-      see the ordering note in 8a) **and** the `bottle do` block (8c). Commit
-      them together as one formula PR:
-      ```sh
-      git add packaging/homebrew/rmlx.rb
-      git commit -m "chore(release): bump Homebrew formula to v<version>"
-      ```
-      Open the PR, let CI pass, merge it, then run `make tap-sync` (step 10).
-
-   > **Clean-machine verification (optional but recommended):**
-   > On a machine without a local rmlx keg:
-   > - `brew tap Pushkinist/rmlx && brew trust Pushkinist/rmlx && brew install rmlx` —
-   >   should download the prebuilt bottle, not compile from source (confirm with
-   >   `brew install --verbose rmlx` — the word "Bottled" appears in output).
-   > - `brew uninstall mlx-c && brew install rmlx` — should fail cleanly with a
-   >   dependency error before attempting any download or compile.
+   > **Why the block was removed (0.4.1).** A `bottle do` block names a
+   > `root_url` pinned to one release, but Homebrew derives the bottle
+   > *filename* from the formula's current version. So a block left behind after
+   > a version bump sends `brew install` looking for a bottle that was never
+   > built, under the previous release's URL, and it 404s. The block shipped
+   > pinned to `v0.3.0` through both `v0.3.0` and `v0.4.0` while the only bottle
+   > asset in existence was `rmlx-0.3.0.arm64_tahoe.bottle.tar.gz` — `brew info`
+   > reported `(bottled)` the whole time. Nothing in the release flow regenerated
+   > it, and nothing failed when it went stale.
    >
-   > **Verifying the pour ON the release machine is misleading.** The release
-   > machine's keg was built with `--build-bottle` (source), and `brew reinstall
-   > rmlx` *repeats the install options* — so it rebuilds from source even when
-   > the bottle is valid. To confirm the bottle pours here, either
-   > `brew uninstall rmlx && brew install rmlx` (a fresh install pours) or
-   > `brew reinstall --force-bottle rmlx` (pours or fails loudly with the real
-   > reason). Check `INSTALL_RECEIPT.json` → `poured_from_bottle: true`, or
-   > `brew info rmlx` → `(bottled)`.
+   > **The deeper reason not to reinstate it casually.** A bottle is a binary
+   > linked against the `mlx-c` present on the build machine, but `mlx-c` is
+   > deliberately an unversioned dependency (see the rationale in
+   > `packaging/homebrew/rmlx.rb`), and `crates/rmlx-mlx/mlx-pin.txt` records
+   > that a mismatched mlx / mlx-c pair aborts at load with a dyld
+   > `Symbol not found`. A bottle poured onto a user whose mlx-c revision differs
+   > from the builder's can therefore fail at load, where a source build against
+   > that user's own mlx-c cannot. Building one on this machine also requires
+   > `brew unpin mlx mlx-c`, which upgrades the pinned pair the project's own
+   > measurements depend on.
    >
-   > **The uploaded bottle asset has the same CDN-transient sha as the source
-   > archive** (see step 9): right after `gh release upload`, GitHub may serve
-   > stale bytes for ~1 min, so a verify run in that window sha-mismatches the
-   > bottle and silently falls back to source. Re-fetch the bottle URL
-   > (`curl -fsSL .../v<ver>/rmlx-<ver>.<tag>.bottle.tar.gz | shasum -a 256`)
-   > until it equals the formula's bottle `sha256` before trusting a non-pour.
-   > Do **not** re-upload with `--clobber` to "fix" it — that just restarts the
-   > propagation window.
+   > `scripts/release/build_bottle.sh` and `make bottle` are kept for a future
+   > bottle channel that solves the ABI coupling — an mlx-c version constraint,
+   > or a static link. They are **not** part of the release flow. Do not run them
+   > and paste the output into the formula without also arranging for the next
+   > release to rebuild or remove the block.
 
-9. **Formula url + sha256** — do this **before** building the bottle (step 8):
-   the bottle is a build of the formula's source `url`, so the formula must
-   point at the new tag first. Note `make release-sha` only **prints** the
+9. **Formula url + sha256.** Note `make release-sha` only **prints** the
    sha of the `v<version>` GitHub source tarball; to patch the `url` +
    `sha256` in `packaging/homebrew/rmlx.rb` in place, run the script with
    `--write`:
@@ -189,8 +122,10 @@ crates are `publish = false`). There is no separate `VERSION` file.
    > `source_sha256.sh`-written value is usually the correct stable one — but
    > re-fetch the archive 2-3× (`curl -fsSL .../archive/refs/tags/v<version>.tar.gz
    > | shasum -a 256`) and confirm the digest is stable before trusting it.
-   The url+sha change is committed **together with the bottle block** as one
-   formula PR (see 8d); `main` is ruleset-protected.
+   Commit the url+sha change as its own formula PR; `main` is
+   ruleset-protected. Verify **both** lines read the new version before opening
+   it — `--write` patches `url` and `sha256` together, but a mismatch between
+   them makes `brew install` fail the checksum.
 10. **Publish the tap:** `make tap-sync` (copies the formula into
     `Pushkinist/homebrew-rmlx` as `Formula/rmlx.rb` and pushes).
 
@@ -218,22 +153,6 @@ merge. Do **not** `git branch -D` the local branch before the remote has the
 fix (the migration commit is otherwise only reachable via reflog).
 
 ## Verify both install paths
-
-**Homebrew bottle (binary — no compile):**
-```sh
-brew tap Pushkinist/rmlx
-brew trust Pushkinist/rmlx
-brew install rmlx               # fetches bottle, does NOT invoke cargo
-brew test rmlx
-rmlx --version
-```
-Confirm no source build occurred: `brew install --verbose rmlx` shows "Bottled"
-in the output. To confirm the clean mlx-c dependency failure:
-```sh
-brew uninstall mlx-c
-brew install rmlx               # fails with dependency error, not a dyld crash
-brew install mlx-c              # reinstate
-```
 
 **Prebuilt binary (from the Release):**
 ```sh
@@ -280,7 +199,7 @@ brew audit --strict --new rmlx
 | `CHANGELOG.md` | Durable release notes (Keep a Changelog); body source |
 | `packaging/homebrew/rmlx.rb` | Canonical formula (source of truth) |
 | `scripts/release/package_binary.sh` | Build + bundle the binary tarball |
-| `scripts/release/build_bottle.sh` | Build the Homebrew bottle from an installed keg, rename, and print upload + formula instructions |
+| `scripts/release/build_bottle.sh` | Retired from the flow (step 8). Kept for a future bottle channel; not run at release time |
 | `scripts/release/source_sha256.sh` | Compute / patch the formula source sha256 |
 | `scripts/release/sync_tap.sh` | Push the formula to the tap repo |
 | `scripts/release/changelog_section.sh` | Print one version's CHANGELOG section |

--- a/packaging/homebrew/rmlx.rb
+++ b/packaging/homebrew/rmlx.rb
@@ -44,11 +44,6 @@ class Rmlx < Formula
   license any_of: ["MIT", "Apache-2.0"]
   head "https://github.com/Pushkinist/rMLX.git", branch: "main"
 
-  bottle do
-    root_url "https://github.com/Pushkinist/rMLX/releases/download/v0.3.0"
-    sha256 cellar: :any, arm64_tahoe: "4bd5ad4f87cdac86646e2da43015b1fd9b376ada0516ed6bca79d47dd7ac3aa7"
-  end
-
   depends_on "rust" => :build
   depends_on arch: :arm64
   depends_on :macos


### PR DESCRIPTION
`brew install rmlx` has been advertising a bottle that does not exist since 0.3.0. This removes the block rather than refreshing it, and records why in the release doc so the next release does not put it back.

## The defect

A `bottle do` block pins a `root_url` to one release, but Homebrew derives the bottle *filename* from the formula's current version. So a block left in place across a version bump sends `brew install` looking for `rmlx-<newver>.<tag>.bottle.tar.gz` under the **previous** release's URL, and 404s.

The block shipped pinned to `v0.3.0` through both v0.3.0 and v0.4.0. The only bottle asset that exists in any release is `rmlx-0.3.0.arm64_tahoe.bottle.tar.gz`:

```
v0.3.0: rmlx-0.3.0.arm64_tahoe.bottle.tar.gz, tarball, sha256, cosign.bundle
v0.4.0: tarball, sha256, cosign.bundle
v0.4.1: tarball, sha256, cosign.bundle
```

`brew info rmlx` reported `0.3.0 → stable 0.4.1 (bottled)` the whole time. Nothing in the release flow regenerated the block, and nothing failed when it went stale — `docs/RELEASING.md` step 8 built the bottle by hand, so the step is easy to drop and its omission is silent.

## Why removed rather than refreshed

A refresh comes back stale at 0.4.2. Two things need solving before a bottle channel earns its place:

* **ABI coupling.** A bottle is a binary linked against the build machine's `mlx-c`. That dependency is deliberately unversioned (the rationale is in the formula header — pinning would force an MLX downgrade on M1–M4 for a benefit that hardware cannot use), and `crates/rmlx-mlx/mlx-pin.txt` records that a mismatched mlx / mlx-c pair aborts at load with a dyld `Symbol not found`. A bottle poured onto a user whose revision differs from the builder's can fail at load; a source build links that user's own pair and cannot.
* **It cannot be built here without breaking the pin.** `brew install --build-bottle` refuses: `You must brew unpin mlx mlx-c as installing pushkinist/rmlx/rmlx requires the latest version of pinned dependencies.` Unpinning upgrades to mlx 0.32.0, whose bottle ships no NAX GEMM kernels — the regression the pin exists to prevent, and the pair every published prefill number depends on.

So the formula now does what its own header always said: `depends_on "rust" => :build`, source build. `scripts/release/build_bottle.sh` and `make bottle` are kept for a future channel that solves the coupling, and step 8 states they are not part of the flow.

## Changes

* `packaging/homebrew/rmlx.rb` — `bottle do` block removed. Nothing else touched; the two pre-existing `brew style` offences in `install` (`Formula[...].opt_prefix`) are left alone.
* `docs/RELEASING.md` — step 8 replaced with the decision and both reasons; step 9 no longer ordered around a bottle build; the "Verify both install paths" bottle path removed (the source-build path below it already covers `brew install`); the preamble's MLX-resolution note and the files table corrected.
* `CHANGELOG.md` — entry under `[Unreleased]`.

## Verification

* `make ci` green (exit 0).
* `ruby -c packaging/homebrew/rmlx.rb` → `Syntax OK`; `brew style pushkinist/rmlx/rmlx` reports only the two pre-existing offences.
* **Not verified: `brew install rmlx` end to end on this machine.** It requires `brew unpin mlx mlx-c` for the reason above, which is exactly what this PR declines to do. The source-build path is the formula's documented default and its `depends_on` lines are unchanged, but a clean-machine install is untested here.
