### PR TITLE
fix(ci): report every kind of red the GPU runner found before it exits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,14 @@ jobs:
       # recall in both directions — violations caught, legitimate shapes left be.
       - name: the #[ignore] gate still catches what it is for
         run: make check-gpu-tests-ignored-fixtures
+      # The runner those tests execute under accumulates shader-validation
+      # diagnostics and crate failures independently, and both have to reach the
+      # operator in the same run — while any diagnostic stands, reporting one and
+      # exiting turns every genuine GPU failure into silence. The check drives
+      # the real runner over stub crates, so it needs neither Metal nor a Rust
+      # toolchain and belongs on this Linux job rather than the macOS one.
+      - name: the GPU runner reports every red it found
+        run: make gpu-runner-selftest
       # A Metal-kernel dispatcher that blocks on Array::eval() produces exactly
       # the right tokens, so no test can see it — it only shows up as a decode
       # rate several times below what the codec should reach. Static gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,7 @@ hand — keeps the CI gate and the local gate identical.
 | `make check-kv-codec-disposition-fixtures` | CI gate (in `make ci`): recall test for the above, 18 synthetic scan roots (one edit each), each asserting which rule fired and exit 2 vs exit 1. |
 | `make check-kv-byte-model-parity` | CI gate (in `make ci`): `scripts/perf_ceiling.py`'s KV byte model against the engine's, swept from `ALL_KV_QUANTS` across both topologies and two shapes. The engine is the oracle — this does not check either model is right, only that there is effectively one of them. |
 | `make check-kv-byte-model-parity-fixtures` | CI gate (in `make ci`): recall test for the above, synthetic scan roots asserting the reason as well as exit 2 vs exit 1. |
+| `make gpu-runner-selftest` | CI gate (in `make ci` and hosted CI): the GPU runner reports a shader-validation hit and a crate failure found in the same run, and the access mix it prints is the one the diagnostics named. Stub crates, no GPU. |
 | `make check-doc-source-citations` | CI gate (in `make ci`): every `crates/...` path cited in `docs/` resolves. Covers paths only, not identifiers — telling a test name from a variable needs a parser. |
 | `make check-eval-lock` | CI gate (in `make ci`): every MLX eval FFI call is made under the process-wide evaluation lock (25-symbol reach-set). |
 | `make check-eval-lock-fixtures` | CI gate (in `make ci`): recall test for the above, 26 synthetic scan roots, each asserting which rule fired. |

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ AUDIT_IGNORES := --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
         check-kv-codec-disposition-fixtures \
         check-kv-byte-model-parity check-kv-byte-model-parity-fixtures \
         check-no-decode-swallow check-gpu-tests-ignored \
-        check-gpu-tests-ignored-fixtures \
+        check-gpu-tests-ignored-fixtures gpu-runner-selftest \
         check-eval-lock check-eval-lock-fixtures eval-lock-stress \
         check-no-kernel-input-eval check-no-kernel-input-eval-fixtures \
         check-kernel-dtype-contract check-kernel-dtype-contract-fixtures \
@@ -410,6 +410,9 @@ check-gpu-tests-ignored: ## CI gate: fail if a GPU-touching test in ANY workspac
 check-gpu-tests-ignored-fixtures: ## CI gate: the #[ignore] gate still fires on macro-generated and helper-reached GPU tests
 	@bash scripts/check_gpu_tests_ignored_fixtures.sh
 
+gpu-runner-selftest: ## CI gate: the GPU runner reports a failing test and a shader-validation hit in the same run, and reports the access mix it saw (stubbed crates, no GPU)
+	@bash scripts/run_gpu_tests_selftest.sh
+
 check-no-kernel-input-eval: ## CI gate: fail if a Metal-kernel dispatcher blocks on Array::eval() (serialises host vs GPU once per layer per decode step)
 	@bash scripts/check_no_kernel_input_eval.sh
 
@@ -448,6 +451,7 @@ ci: fmt-check lint test test-capture deny audit ci-metrics ## full pre-merge gat
 	@bash scripts/check_eval_lock_fixtures.sh
 	@bash scripts/check_gpu_tests_ignored.sh
 	@bash scripts/check_gpu_tests_ignored_fixtures.sh
+	@bash scripts/run_gpu_tests_selftest.sh
 	@bash scripts/check_no_kernel_input_eval.sh
 	@bash scripts/check_no_kernel_input_eval_fixtures.sh
 	@bash scripts/check_kernel_dtype_contract.sh

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -755,27 +755,36 @@ Read the diagnostic's own wording before assuming that is what happened. A
 *store* is corruption; a *load* is illegal but can only affect the result if the
 lanes it fills are ones the kernel keeps, and whether they are is a property of
 the kernel, not of the diagnostic. The final banner prints the mix it actually
-saw — each hit's own `device load` / `device store` wording, counted — so it is
+saw — each hit's own `device load` / `device store` wording, counted per
+diagnostic rather than per output line, since the layer writes while libtest is
+mid-line and reports routinely share a line — so it is
 read off the run rather than assumed; the one standing hit in this tree is
 160/160 loads, see the entry below on `affine_qmm_t_splitk`. The converse does
 not hold either: a clean scan does not establish that nothing read out of
 bounds, for the buffer-versus-array reason recorded with that entry.
 
-**Both kinds of red are reported in the same run.** Shader-validation hits and
-crate failures — a failing test, a crate that executed fewer tests than were
+**Every red the run found is reported, at both levels.** Shader-validation hits
+and crate failures — a failing test, a crate that executed fewer tests than were
 classified for it, a crate that produced no validation banner — accumulate
 independently across the crate loop, and every one of them is printed before the
-runner exits. That ordering is load-bearing rather than cosmetic: while any
-standing diagnostic exists, reporting the validation aggregate and exiting would
-discard the failing test names the runner already extracted, and each crate's log
-is deleted inside the loop, so nothing would survive to re-read. The failing-test
-oracle would be real, working, and starved of execution by an earlier,
-less-specific exit — the same "gate that cannot fail" shape as a vacuous oracle
-or a golden that skips silently. `scripts/run_gpu_tests_selftest.sh`
-(`make gpu-runner-selftest`, in `make ci`) pins it against stub crates, with no
-GPU: a canned libtest log per crate carrying a validation hit, a failing test, an
-under-match and a missing banner, each case asserting the reason that reaches the
-final report rather than only the exit code.
+runner exits. Within a crate the same holds: a shortfall is recorded and falls
+through to the exit-code check rather than skipping the rest, because an aborting
+test binary produces both, and a shortfall alone reads as "a filter stopped
+matching" and sends the reader after a renamed fn instead of the test that took
+the binary down.
+
+That ordering is load-bearing rather than cosmetic: while any standing diagnostic
+exists, reporting the validation aggregate and exiting would discard the failing
+test names the runner already extracted, and each crate's log is deleted inside
+the loop, so nothing would survive to re-read. The failing-test oracle would be
+real, working, and starved of execution by an earlier, less-specific exit — the
+same "gate that cannot fail" shape as a vacuous oracle or a golden that skips
+silently. `scripts/run_gpu_tests_selftest.sh` (`make gpu-runner-selftest`, in
+`make ci` and in the hosted `source gates` job) pins it against stub crates, with
+no GPU: a canned libtest log per crate carries a validation hit, a failing test,
+an under-match, a missing banner and two diagnostics sharing one output line, and
+each case asserts the reason that reaches the final report rather than only the
+exit code.
 
 #### Where it runs: `make ci-perf`, not `make ci`
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -754,11 +754,28 @@ result no test result can be read for.
 Read the diagnostic's own wording before assuming that is what happened. A
 *store* is corruption; a *load* is illegal but can only affect the result if the
 lanes it fills are ones the kernel keeps, and whether they are is a property of
-the kernel, not of the diagnostic. The aggregate makes no distinction, and the
-one standing hit in this tree is 160/160 loads — see the entry below on
-`affine_qmm_t_splitk`. The converse does not hold either: a clean scan does not
-establish that nothing read out of bounds, for the buffer-versus-array reason
-recorded with that entry.
+the kernel, not of the diagnostic. The final banner prints the mix it actually
+saw — each hit's own `device load` / `device store` wording, counted — so it is
+read off the run rather than assumed; the one standing hit in this tree is
+160/160 loads, see the entry below on `affine_qmm_t_splitk`. The converse does
+not hold either: a clean scan does not establish that nothing read out of
+bounds, for the buffer-versus-array reason recorded with that entry.
+
+**Both kinds of red are reported in the same run.** Shader-validation hits and
+crate failures — a failing test, a crate that executed fewer tests than were
+classified for it, a crate that produced no validation banner — accumulate
+independently across the crate loop, and every one of them is printed before the
+runner exits. That ordering is load-bearing rather than cosmetic: while any
+standing diagnostic exists, reporting the validation aggregate and exiting would
+discard the failing test names the runner already extracted, and each crate's log
+is deleted inside the loop, so nothing would survive to re-read. The failing-test
+oracle would be real, working, and starved of execution by an earlier,
+less-specific exit — the same "gate that cannot fail" shape as a vacuous oracle
+or a golden that skips silently. `scripts/run_gpu_tests_selftest.sh`
+(`make gpu-runner-selftest`, in `make ci`) pins it against stub crates, with no
+GPU: a canned libtest log per crate carrying a validation hit, a failing test, an
+under-match and a missing banner, each case asserting the reason that reaches the
+final report rather than only the exit code.
 
 #### Where it runs: `make ci-perf`, not `make ci`
 
@@ -1001,8 +1018,8 @@ reads are loads only and are shown bitwise not to reach the output — including
 with the out-of-range rows held at NaN under the same kernel instantiation.
 
 Two cautions that generalise beyond this kernel. A diagnostic names a *load* or
-a *store* and the two differ in severity, but the aggregate does not
-distinguish them. And **absence of a diagnostic is not absence of an
+a *store* and the two differ in severity, so read the access mix the banner
+prints rather than the total. And **absence of a diagnostic is not absence of an
 out-of-bounds access**: the validation layer bounds against the MTLBuffer, not
 the logical array, and MLX recycles buffers from size buckets, so a read past
 an array's end that lands inside a roomier recycled allocation is silent. A

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -46,6 +46,7 @@ Conventions:
 | Script | Via | What it does |
 |---|---|---|
 | `run_gpu_tests.sh` | `make gpu-test` | Runs the `#[ignore]` Metal tests per member crate, `--test-threads=1`. |
+| `run_gpu_tests_selftest.sh` | `make gpu-runner-selftest` | Recall test for the runner's reporting: a shader-validation hit and a crate failure in the same run are both reported, and the access mix is the one observed. Stubbed crates, no GPU. |
 | `eval_lock_stress.sh` | `make eval-lock-stress` | Drives the evaluation-lock reproducer across N fresh processes. Deliberately out of `make ci`. |
 | `schema_constraint_canary.sh` | — | Real-model proof for the `json_schema` constrained-decoding path. |
 | `ssd_canary.sh` | — | End-to-end long-session SSD prompt-cache tier canary (see `docs/SSD_CANARY.md`). |

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -191,6 +191,18 @@ VALIDATION_BANNER='Metal GPU Validation Enabled'
 # is what keeps a test's own "invalid" wording from forging a hit.
 VALIDATION_DIAGNOSTIC='Invalid .{0,120}(at offset [0-9]+|executing kernel function:)'
 
+# The access kind as the layer itself worded it — `device load`, `device store`
+# and the threadgroup spellings all arrive through the pattern above, and they
+# differ in severity: a dropped write is corruption outright, a zero-filled read
+# only matters if the kernel keeps the lanes it filled. Reads diagnostics on
+# stdin, one per line, and writes one kind per line.
+access_kind() {
+    sed -E -e 's/^Invalid[[:space:]]+//' \
+           -e 's/[[:space:]]*(at offset [0-9]+|executing kernel function:).*$//' \
+           -e 's/[[:space:]]*,[[:space:]]*$//' \
+           -e 's/^$/unnamed access/'
+}
+
 # Same environment the crates run under, hoisted so the canary above can use it.
 # `${arr[@]+"${arr[@]}"}` is the portable spelling: mtl_unset is empty whenever
 # the caller exported no MTL_* names, and expanding an empty array is an
@@ -296,6 +308,7 @@ failed_crates=""
 total_passed=0
 total_failed=0
 validation_hits=""
+validation_kinds=""
 
 if [ "${SHADER_VALIDATION}" = "1" ]; then
     echo "shader validation: ON (invalid Metal memory access fails this run)"
@@ -410,12 +423,18 @@ for crate in "${crates[@]}"; do
         # allocator, so KV stores come through as `buffer: <unnamed>`.
         hits="$(grep -Eo "${VALIDATION_DIAGNOSTIC}[^\"]*\"[^\"]*\"" "${log}" \
                 | grep -Eo 'kernel function: "[^"]*"' | sort | uniq -c | sort -rn)"
-        n_hits="$(grep -Ec "${VALIDATION_DIAGNOSTIC}" "${log}")"
+        # Counted per diagnostic, not per line: the layer writes to stderr while
+        # libtest is mid-line, so two reports routinely share one output line and
+        # a line count scores them as one. The kind tally comes off the same
+        # extraction, so the mix in the final banner sums to this count.
+        diagnostics="$(grep -Eo "${VALIDATION_DIAGNOSTIC}" "${log}")"
+        n_hits="$(printf '%s' "${diagnostics}" | grep -c '.')"
         if [ "${n_hits}" -gt 0 ]; then
             validation_hits="${validation_hits}  ${crate}: ${n_hits} invalid access(es)"$'\n'
             if [ -n "${hits}" ]; then
                 validation_hits="${validation_hits}$(printf '%s\n' "${hits}" | sed 's/^/    /')"$'\n'
             fi
+            validation_kinds="${validation_kinds}$(printf '%s\n' "${diagnostics}" | access_kind)"$'\n'
         fi
     fi
     rm -f "${log}"
@@ -449,16 +468,30 @@ for crate in "${crates[@]}"; do
 done
 
 echo
+# Every kind of red this run found is printed before the single exit at the end.
+# The two accumulators fill independently across the crate loop and co-occur
+# routinely: exiting inside the first block would compute the failing test names,
+# hold them in a shell variable, and discard them, leaving an operator who is
+# triaging a standing validation diagnostic no sign that a test also went red in
+# the same run. Each crate's log is deleted inside the loop, so what is not
+# printed here is gone.
+red=0
+
 # An invalid access is a failure even though every test reported `ok` and cargo
-# exited 0 — that is the whole point: the store is dropped, the buffer freezes,
-# and the assertions downstream of it still pass.
+# exited 0 — that is the whole point: the access never reaches the buffer, and
+# the assertions downstream of it still pass.
 if [ "${SHADER_VALIDATION}" = "1" ] && [ -n "${validation_hits}" ]; then
     echo "ERROR: Metal shader validation reported invalid memory access:" >&2
     printf '%s' "${validation_hits}" >&2
     echo >&2
-    echo "An out-of-bounds device store is DROPPED, not raised: the tests above" >&2
-    echo "still passed and cargo still exited 0. Treat this as corruption." >&2
-    exit 1
+    echo "Access mix over the hits above:" >&2
+    printf '%s' "${validation_kinds}" | sort | uniq -c | sort -rn | sed 's/^ */    /' >&2
+    echo "An invalid access is DROPPED, not raised — an invalid write is discarded," >&2
+    echo "an invalid read is zero-filled — so the tests over it can still report ok" >&2
+    echo "with cargo exiting 0. A write that never landed is corruption outright; a" >&2
+    echo "read only matters if the kernel keeps the lanes it filled, so read the mix." >&2
+    echo >&2
+    red=1
 fi
 
 if [ -n "${failed_crates}" ]; then
@@ -474,6 +507,10 @@ if [ -n "${failed_crates}" ]; then
     echo "from one you inherited, and it is cheap. See docs/TESTING.md." >&2
     echo "A crate reported as 'ran uninstrumented' usually failed to BUILD: no test" >&2
     echo "binary means no Metal device and therefore no validation banner." >&2
+    red=1
+fi
+
+if [ "${red}" = "1" ]; then
     exit 1
 fi
 

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -321,7 +321,7 @@ if [ "${SHADER_VALIDATION}" = "1" ]; then
     #
     # The canary kernel stores out of bounds on purpose and lives behind its own
     # feature, so it is not built into any ordinary test run.
-    canary_log="$(mktemp -t rmlx-gpu-canary)"
+    canary_log="$(mktemp "${TMPDIR:-/tmp}/rmlx-gpu-canary.XXXXXX")"
     "${validation_prefix_canary[@]}" cargo test --no-fail-fast -p rmlx-kv-quant \
         --features shader-validation-canary --lib -- \
         --ignored --test-threads=1 "${CANARY_TEST}" >"${canary_log}" 2>&1
@@ -358,7 +358,7 @@ for crate in "${crates[@]}"; do
     done < <(printf '%s' "${selected}" | awk -F'\t' -v c="${crate}" '$1 == c {print $2}' | sort -u)
     echo "── ${crate} (${classified} GPU tests) ──────────────────────────"
 
-    log="$(mktemp -t "rmlx-gpu-test-${crate}")"
+    log="$(mktemp "${TMPDIR:-/tmp}/rmlx-gpu-test-${crate}.XXXXXX")"
     # `--tests` selects every target with `test = true` — the lib's unit tests,
     # each bin's unit tests, and the `tests/*.rs` integration binaries. That is
     # exactly the set the classifier scans, so the runner cannot be pointed at
@@ -405,10 +405,15 @@ for crate in "${crates[@]}"; do
     # Harvest the failing test names while the log still exists — a red gate
     # that only names the crate leaves an operator unable to tell their own
     # regression from the known baseline without re-running by hand.
+    # libtest prints the region twice: a captured-output block per failure, then
+    # the plain name list. `---- <name> stdout ----` opens the first, so it ends
+    # the harvest; a panic detail or a line the test itself printed is indented
+    # exactly like a name and would otherwise be reported as a failing test.
     crate_fails="$(awk '
         /^failures:$/ { f = 1; next }
+        /^---- / { f = 0 }
         /^test result:/ { f = 0 }
-        f && /^    [A-Za-z_]/ { print $1 }
+        f && /^    [A-Za-z_][A-Za-z0-9_:]*$/ { print $1 }
     ' "${log}" | sort -u)"
 
     if [ "${SHADER_VALIDATION}" = "1" ]; then
@@ -421,13 +426,18 @@ for crate in "${crates[@]}"; do
         # Report the kernel each hit names, deduped — a codec's kernel name is
         # the actionable identifier here. The buffer field is not: MLX owns the
         # allocator, so KV stores come through as `buffer: <unnamed>`.
-        hits="$(grep -Eo "${VALIDATION_DIAGNOSTIC}[^\"]*\"[^\"]*\"" "${log}" \
+        # Split first, then match. The layer writes to stderr while libtest is
+        # mid-line, so reports routinely share an output line, and the detector's
+        # bounded `.{0,120}` is greedy: with a short kernel name the second
+        # report starts inside that window and both collapse into one match,
+        # losing the second one's kernel, kind and count. Everything below is
+        # then per diagnostic rather than per line, so the mix in the final
+        # banner sums to the count printed beside it.
+        one_per_line="$(awk '{ gsub(/Invalid /, "\n&"); print }' "${log}")"
+        hits="$(printf '%s\n' "${one_per_line}" \
+                | grep -Eo "${VALIDATION_DIAGNOSTIC}[^\"]*\"[^\"]*\"" \
                 | grep -Eo 'kernel function: "[^"]*"' | sort | uniq -c | sort -rn)"
-        # Counted per diagnostic, not per line: the layer writes to stderr while
-        # libtest is mid-line, so two reports routinely share one output line and
-        # a line count scores them as one. The kind tally comes off the same
-        # extraction, so the mix in the final banner sums to this count.
-        diagnostics="$(grep -Eo "${VALIDATION_DIAGNOSTIC}" "${log}")"
+        diagnostics="$(printf '%s\n' "${one_per_line}" | grep -Eo "${VALIDATION_DIAGNOSTIC}")"
         n_hits="$(printf '%s' "${diagnostics}" | grep -c '.')"
         if [ "${n_hits}" -gt 0 ]; then
             validation_hits="${validation_hits}  ${crate}: ${n_hits} invalid access(es)"$'\n'
@@ -449,10 +459,14 @@ for crate in "${crates[@]}"; do
     # built, a test compiled out behind a feature — which is silence, not
     # success. Over-matching inflates `executed` and is harmless, so this is a
     # one-sided `-lt`.
+    #
+    # It records and falls through rather than skipping the rest of the crate: a
+    # test binary that aborts produces both a shortfall and a non-zero exit, and
+    # reporting only the shortfall sends the reader after a renamed fn instead of
+    # the test that took the binary down.
     if [ "${executed}" -lt "${classified}" ]; then
         echo "ERROR: ${crate} classified ${classified} GPU tests but executed ${executed} — a filter stopped matching." >&2
         failed_crates="${failed_crates}  ${crate}: under-matched (${executed}/${classified} executed)"$'\n'
-        continue
     fi
     if [ "${rc}" -ne 0 ]; then
         failed_crates="${failed_crates}  ${crate}:"$'\n'

--- a/scripts/run_gpu_tests_selftest.sh
+++ b/scripts/run_gpu_tests_selftest.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# run_gpu_tests_selftest.sh — recall check for how `scripts/run_gpu_tests.sh`
+# reports a red run.
+#
+# The runner accumulates two independent kinds of red across its crate loop:
+# Metal shader-validation diagnostics, and everything that makes a crate fail
+# (a failing test, a crate that under-matched its classified population, a crate
+# that produced no validation banner). Both have to reach the operator in the
+# same run. A tree carrying a standing validation diagnostic otherwise turns
+# every genuine test failure into silence — the failing test names are computed,
+# held in a shell variable, and thrown away at exit, and each crate's log is
+# deleted inside the loop, so nothing survives to re-read.
+#
+# That is a property of the reporting code, not of the GPU, so it is checked
+# here against stubs: a stub `cargo` replays a canned libtest log per crate and
+# a stub classifier names the population. No Metal device, no snapshot, no
+# compile. The runner is copied into a throwaway root per case rather than
+# reimplemented, so this file cannot drift from what the gate runs.
+#
+# Every case asserts the REASON — the strings an operator triages a red gate
+# from, taken only from the final report block, not from the interleaved `tee`
+# output the report is supposed to summarise — so a runner that exits 1 while
+# reporting the wrong half of the run still fails here.
+#
+# Exit 0 = every case reported exactly what it should.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="${ROOT}/scripts/run_gpu_tests.sh"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/rmlx_gpu_runner_selftest.XXXXXX")"
+trap 'rm -rf "${WORK}"' EXIT
+
+failures=0
+CASE=""
+CASE_ROOT=""
+OUT=""
+STATUS=0
+REPORT=""
+
+# new_case <name> — build a throwaway repo root: a copy of the runner, a stub
+# classifier reading this case's population, and a stub PATH. Sets CASE_ROOT.
+# Not a command substitution: the case name has to reach the assertions below,
+# and a subshell would drop it.
+new_case() {
+    CASE="$1"
+    CASE_ROOT="${WORK}/$1"
+    local root="${CASE_ROOT}"
+    mkdir -p "${root}/scripts" "${root}/bin" "${root}/logs" || return 1
+    cp "${RUNNER}" "${root}/scripts/run_gpu_tests.sh" || return 1
+    : >"${root}/classified"
+
+    cat >"${root}/scripts/check_gpu_tests_ignored.sh" <<STUB
+#!/usr/bin/env bash
+cat "${root}/classified"
+STUB
+
+    # The GPU-free preconditions are not what this file exercises, and one of
+    # them reads the whole host: stub the process check so a live MLX server
+    # cannot decide the outcome of a reporting test, and answer the shader
+    # validation canary so the detector's positive control passes.
+    cat >"${root}/bin/pgrep" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+
+    cat >"${root}/bin/cargo" <<STUB
+#!/usr/bin/env bash
+set -u
+crate=""
+prev=""
+for a in "\$@"; do
+    [ "\$prev" = "-p" ] && crate="\$a"
+    if [ "\$a" = "shader-validation-canary" ]; then
+        echo 'Metal GPU Validation Enabled'
+        echo 'Invalid device store at offset 4000068, executing kernel function: "custom_kernel_rmlx_canary_oob_store"'
+        echo 'test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out'
+        exit 0
+    fi
+    prev="\$a"
+done
+if [ ! -f "${root}/logs/\${crate}.log" ]; then
+    echo "stub cargo: no canned log for '\${crate}'" >&2
+    exit 99
+fi
+cat "${root}/logs/\${crate}.log"
+exit "\$(cat "${root}/logs/\${crate}.rc" 2>/dev/null || echo 0)"
+STUB
+
+    chmod +x "${root}/bin/pgrep" "${root}/bin/cargo" || return 1
+}
+
+# classify <root> <crate> <fn>... — name the GPU tests the classifier reports.
+classify() {
+    local root="$1" crate="$2" fn
+    shift 2
+    for fn in "$@"; do
+        printf '%s\t%s\n' "${crate}" "${fn}" >>"${root}/classified"
+    done
+}
+
+# crate_log <root> <crate> <cargo-exit-code> — canned libtest log on stdin.
+crate_log() {
+    local root="$1" crate="$2" rc="$3"
+    cat >"${root}/logs/${crate}.log"
+    printf '%s\n' "${rc}" >"${root}/logs/${crate}.rc"
+}
+
+# run_case <root> — run this case's runner; set OUT, STATUS and REPORT.
+#
+# REPORT is the final block only: everything from the first post-loop ERROR
+# header on. The crate logs are teed to the same stream, so asserting against
+# OUT would pass on a failing test name that only ever appeared in the 1000-line
+# scroll the operator is not reading.
+run_case() {
+    local root="$1"
+    OUT="$(PATH="${root}/bin:${PATH}" env -u RMLX_SKIP_GPU \
+        RMLX_O_MODELS_ROOT="${WORK}" bash "${root}/scripts/run_gpu_tests.sh" 2>&1)"
+    STATUS=$?
+    REPORT="$(printf '%s\n' "${OUT}" | awk '
+        /^ERROR: Metal shader validation reported invalid memory access:/ { seen = 1 }
+        /^ERROR: GPU tests failed in:/ { seen = 1 }
+        seen')"
+}
+
+fail() {
+    echo "FAIL [${CASE}] $1" >&2
+    failures=$((failures + 1))
+}
+
+expect_status() {
+    [ "${STATUS}" = "$1" ] || fail "exit ${STATUS}, expected $1"
+}
+
+expect_report() {
+    case "${REPORT}" in
+        *"$1"*) ;;
+        *) fail "final report does not mention: $1" ;;
+    esac
+}
+
+expect_no_report() {
+    case "${REPORT}" in
+        *"$1"*) fail "final report should not mention: $1" ;;
+    esac
+}
+
+expect_out() {
+    case "${OUT}" in
+        *"$1"*) ;;
+        *) fail "output does not mention: $1" ;;
+    esac
+}
+
+expect_no_out() {
+    case "${OUT}" in
+        *"$1"*) fail "output should not mention: $1" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# A validation hit and a failing test in the same run: both are reported.
+# This is the masking case — the hit alone is enough to fail the run, so a
+# runner that reports it and exits never mentions the test that also went red.
+#
+# The diagnostic lands appended to a libtest line on purpose: that is the shape
+# the validation layer actually produces, and an anchored detector misses it.
+new_case both_kinds || exit 1
+classify "${CASE_ROOT}" rmlx-kv-quant kv_gpu_alpha kv_gpu_beta
+crate_log "${CASE_ROOT}" rmlx-kv-quant 101 <<'LOG'
+Metal GPU Validation Enabled
+running 2 tests
+test kv::gpu_alpha ... ok
+test kv::gpu_beta ... FAILEDInvalid device load at offset 4000068, executing kernel function: "affine_qmm_t_splitk_bfloat16_t_gs_64_b_8_alN_false"
+
+failures:
+
+    kv::gpu_beta
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 1
+expect_report "ERROR: Metal shader validation reported invalid memory access:"
+expect_report "1 device load"
+expect_report "ERROR: GPU tests failed in:"
+expect_report "kv::gpu_beta"
+
+# ---------------------------------------------------------------------------
+# A failing test with no validation hit still reports as itself.
+new_case failure_only || exit 1
+classify "${CASE_ROOT}" rmlx-kv-quant kv_gpu_alpha kv_gpu_beta
+crate_log "${CASE_ROOT}" rmlx-kv-quant 101 <<'LOG'
+Metal GPU Validation Enabled
+running 2 tests
+test kv::gpu_alpha ... ok
+test kv::gpu_beta ... FAILED
+
+failures:
+
+    kv::gpu_beta
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 1
+expect_report "ERROR: GPU tests failed in:"
+expect_report "kv::gpu_beta"
+expect_no_report "Metal shader validation reported"
+
+# ---------------------------------------------------------------------------
+# Hits only, all of them loads: the banner reports the mix it saw. A hardcoded
+# claim of "store" over a run of pure loads sends the reader after the wrong
+# kernel, and severity differs between the two. Two of the four diagnostics
+# share one output line, which is routine — the layer writes while libtest is
+# mid-line — so this also pins that hits are counted per diagnostic and not per
+# line, without which the mix would not sum to the count printed beside it.
+new_case loads_only || exit 1
+classify "${CASE_ROOT}" rmlx-kv-quant kv_gpu_alpha
+crate_log "${CASE_ROOT}" rmlx-kv-quant 0 <<'LOG'
+Metal GPU Validation Enabled
+running 1 test
+Invalid device load at offset 4000068, executing kernel function: "affine_qmm_t_splitk"
+Invalid device load at offset 4000132, executing kernel function: "affine_qmm_t_splitk"
+test kv::gpu_alpha ... okInvalid device load at offset 4000196, executing kernel function: "affine_qmm_t_splitk_bfloat16_t_gs_64_b_8_alN_false"Invalid device load at offset 4000260, executing kernel function: "affine_qmm_t_splitk_bfloat16_t_gs_64_b_8_alN_false"
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 1
+expect_report "rmlx-kv-quant: 4 invalid access(es)"
+expect_report "4 device load"
+expect_no_report "device store"
+expect_no_report "ERROR: GPU tests failed in:"
+
+# ---------------------------------------------------------------------------
+# The converse: a pure-store run must not be described as loads.
+new_case stores_only || exit 1
+classify "${CASE_ROOT}" rmlx-kv-quant kv_gpu_alpha
+crate_log "${CASE_ROOT}" rmlx-kv-quant 0 <<'LOG'
+Metal GPU Validation Enabled
+running 1 test
+Invalid device store at offset 4000068, executing kernel function: "custom_kernel_rmlx_q8_quantize"
+Invalid device store at offset 4000132, executing kernel function: "custom_kernel_rmlx_q8_quantize"
+test kv::gpu_alpha ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 1
+expect_report "2 device store"
+expect_no_report "device load"
+
+# ---------------------------------------------------------------------------
+# Both kinds of access across two crates: every kind is counted, not the first.
+new_case mixed_kinds || exit 1
+classify "${CASE_ROOT}" rmlx-kv-quant kv_gpu_alpha
+classify "${CASE_ROOT}" rmlx-models models_gpu_alpha
+crate_log "${CASE_ROOT}" rmlx-kv-quant 0 <<'LOG'
+Metal GPU Validation Enabled
+running 1 test
+Invalid device load at offset 4000068, executing kernel function: "affine_qmm_t_splitk"
+Invalid device load at offset 4000132, executing kernel function: "affine_qmm_t_splitk"
+test kv::gpu_alpha ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+crate_log "${CASE_ROOT}" rmlx-models 0 <<'LOG'
+Metal GPU Validation Enabled
+running 1 test
+Invalid device store at offset 512, executing kernel function: "custom_kernel_rmlx_q8_quantize"
+Invalid device load at offset 640, executing kernel function: "custom_kernel_rmlx_q8_quantize"
+test models::gpu_alpha ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 1
+expect_report "3 device load"
+expect_report "1 device store"
+
+# ---------------------------------------------------------------------------
+# A crate that under-matched its classified population is a second kind of
+# crate failure, and it must survive a co-occurring validation hit too — the
+# ordering has to hold for every failure kind the runner can report, not for
+# the failing-test one alone.
+new_case undermatch_with_hit || exit 1
+classify "${CASE_ROOT}" rmlx-kv-quant kv_gpu_alpha kv_gpu_beta kv_gpu_gamma
+crate_log "${CASE_ROOT}" rmlx-kv-quant 0 <<'LOG'
+Metal GPU Validation Enabled
+running 1 test
+test kv::gpu_alpha ... okInvalid device load at offset 4000068, executing kernel function: "affine_qmm_t_splitk"
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 1
+expect_report "Metal shader validation reported"
+expect_report "under-matched (1/3 executed)"
+
+# ---------------------------------------------------------------------------
+# So must the third kind: a crate that produced no validation banner ran
+# uninstrumented (usually it failed to build), while another crate reported hits.
+new_case uninstrumented_with_hit || exit 1
+classify "${CASE_ROOT}" rmlx-kv-quant kv_gpu_alpha
+classify "${CASE_ROOT}" rmlx-models models_gpu_alpha
+crate_log "${CASE_ROOT}" rmlx-kv-quant 0 <<'LOG'
+Metal GPU Validation Enabled
+running 1 test
+test kv::gpu_alpha ... okInvalid device load at offset 4000068, executing kernel function: "affine_qmm_t_splitk"
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+crate_log "${CASE_ROOT}" rmlx-models 0 <<'LOG'
+running 1 test
+test models::gpu_alpha ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 1
+expect_report "Metal shader validation reported"
+expect_report "ran uninstrumented (no validation banner)"
+
+# ---------------------------------------------------------------------------
+# The harness's own positive control: with nothing wrong, the same stubs produce
+# a green run. Without this, every case above could be passing because the stub
+# crates never ran at all.
+new_case clean || exit 1
+classify "${CASE_ROOT}" rmlx-kv-quant kv_gpu_alpha kv_gpu_beta
+crate_log "${CASE_ROOT}" rmlx-kv-quant 0 <<'LOG'
+Metal GPU Validation Enabled
+running 2 tests
+test kv::gpu_alpha ... ok
+test kv::gpu_beta ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 0
+expect_out "OK: 2 GPU tests passed"
+expect_out "shader validation clean"
+expect_no_out "INCOMPLETE"
+expect_no_out "ERROR:"
+
+if [ "${failures}" -ne 0 ]; then
+    echo >&2
+    echo "run_gpu_tests_selftest: ${failures} assertion(s) failed." >&2
+    exit 1
+fi
+
+echo "run_gpu_tests_selftest: OK — every kind of red is reported, and the access mix is the one observed."

--- a/scripts/run_gpu_tests_selftest.sh
+++ b/scripts/run_gpu_tests_selftest.sh
@@ -38,6 +38,7 @@ CASE_ROOT=""
 OUT=""
 STATUS=0
 REPORT=""
+MIX=""
 
 # new_case <name> — build a throwaway repo root: a copy of the runner, a stub
 # classifier reading this case's population, and a stub PATH. Sets CASE_ROOT.
@@ -107,12 +108,17 @@ crate_log() {
     printf '%s\n' "${rc}" >"${root}/logs/${crate}.rc"
 }
 
-# run_case <root> — run this case's runner; set OUT, STATUS and REPORT.
+# run_case <root> — run this case's runner; set OUT, STATUS, REPORT and MIX.
 #
 # REPORT is the final block only: everything from the first post-loop ERROR
 # header on. The crate logs are teed to the same stream, so asserting against
 # OUT would pass on a failing test name that only ever appeared in the 1000-line
 # scroll the operator is not reading.
+#
+# MIX is narrower still — the counted access-kind lines alone. The prose around
+# them is static and mentions neither kind, but asserting a kind's ABSENCE over
+# the whole report would be a statement about that prose as much as about the
+# tally, and would start passing for the wrong reason the day the wording moves.
 run_case() {
     local root="$1"
     OUT="$(PATH="${root}/bin:${PATH}" env -u RMLX_SKIP_GPU \
@@ -122,6 +128,10 @@ run_case() {
         /^ERROR: Metal shader validation reported invalid memory access:/ { seen = 1 }
         /^ERROR: GPU tests failed in:/ { seen = 1 }
         seen')"
+    MIX="$(printf '%s\n' "${REPORT}" | awk '
+        /^Access mix over the hits above:$/ { in_mix = 1; next }
+        in_mix && /^[[:space:]]+[0-9]+[[:space:]]/ { print; next }
+        in_mix { in_mix = 0 }')"
 }
 
 fail() {
@@ -143,6 +153,19 @@ expect_report() {
 expect_no_report() {
     case "${REPORT}" in
         *"$1"*) fail "final report should not mention: $1" ;;
+    esac
+}
+
+expect_mix() {
+    case "${MIX}" in
+        *"$1"*) ;;
+        *) fail "access mix does not count: $1" ;;
+    esac
+}
+
+expect_no_mix() {
+    case "${MIX}" in
+        *"$1"*) fail "access mix should not count: $1" ;;
     esac
 }
 
@@ -176,6 +199,13 @@ test kv::gpu_beta ... FAILEDInvalid device load at offset 4000068, executing ker
 
 failures:
 
+---- kv::gpu_beta stdout ----
+    Divergence
+thread 'kv::gpu_beta' panicked at crates/rmlx-kv-quant/src/codec_tests.rs:165:5:
+sorted vs broadcast diverge beyond atol+rtol*|b| by 0.059472658
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+failures:
     kv::gpu_beta
 
 test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
@@ -183,9 +213,13 @@ LOG
 run_case "${CASE_ROOT}"
 expect_status 1
 expect_report "ERROR: Metal shader validation reported invalid memory access:"
-expect_report "1 device load"
+expect_mix "1 device load"
 expect_report "ERROR: GPU tests failed in:"
 expect_report "kv::gpu_beta"
+# The captured-stdout block sits between the same two markers the failing names
+# are harvested from, and a panic detail can be indented exactly like a name. A
+# harvester that scrapes it reports lines that are not tests as if they were.
+expect_no_report "Divergence"
 
 # ---------------------------------------------------------------------------
 # A failing test with no validation hit still reports as itself.
@@ -199,6 +233,13 @@ test kv::gpu_beta ... FAILED
 
 failures:
 
+---- kv::gpu_beta stdout ----
+    Divergence
+thread 'kv::gpu_beta' panicked at crates/rmlx-kv-quant/src/codec_tests.rs:165:5:
+sorted vs broadcast diverge beyond atol+rtol*|b| by 0.059472658
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+failures:
     kv::gpu_beta
 
 test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
@@ -207,6 +248,7 @@ run_case "${CASE_ROOT}"
 expect_status 1
 expect_report "ERROR: GPU tests failed in:"
 expect_report "kv::gpu_beta"
+expect_no_report "Divergence"
 expect_no_report "Metal shader validation reported"
 
 # ---------------------------------------------------------------------------
@@ -229,8 +271,8 @@ LOG
 run_case "${CASE_ROOT}"
 expect_status 1
 expect_report "rmlx-kv-quant: 4 invalid access(es)"
-expect_report "4 device load"
-expect_no_report "device store"
+expect_mix "4 device load"
+expect_no_mix "device store"
 expect_no_report "ERROR: GPU tests failed in:"
 
 # ---------------------------------------------------------------------------
@@ -247,11 +289,13 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 LOG
 run_case "${CASE_ROOT}"
 expect_status 1
-expect_report "2 device store"
-expect_no_report "device load"
+expect_mix "2 device store"
+expect_no_mix "device load"
 
 # ---------------------------------------------------------------------------
-# Both kinds of access across two crates: every kind is counted, not the first.
+# Every kind of access across two crates is counted, not just the first — and
+# `device` is not the only spelling the layer emits, so a threadgroup access
+# rides along to keep the tally from being read off a hardcoded pair.
 new_case mixed_kinds || exit 1
 classify "${CASE_ROOT}" rmlx-kv-quant kv_gpu_alpha
 classify "${CASE_ROOT}" rmlx-models models_gpu_alpha
@@ -268,13 +312,67 @@ Metal GPU Validation Enabled
 running 1 test
 Invalid device store at offset 512, executing kernel function: "custom_kernel_rmlx_q8_quantize"
 Invalid device load at offset 640, executing kernel function: "custom_kernel_rmlx_q8_quantize"
+Invalid threadgroup load at offset 96, executing kernel function: "custom_kernel_rmlx_q8_quantize"
 test models::gpu_alpha ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
 LOG
 run_case "${CASE_ROOT}"
 expect_status 1
-expect_report "3 device load"
-expect_report "1 device store"
+expect_mix "3 device load"
+expect_mix "1 device store"
+expect_mix "1 threadgroup load"
+
+# ---------------------------------------------------------------------------
+# Two diagnostics adjacent on one output line, under a kernel name short enough
+# that the second one starts within the detector's bounded window. The pattern
+# is greedy, so a single match spans both and the second access — a store, the
+# severe kind — disappears from the count and the mix. Kernel names in this tree
+# run from about 20 to 50 characters, so which of the two shapes a run produces
+# is not something the reader controls.
+new_case adjacent_hits_short_kernel_name || exit 1
+classify "${CASE_ROOT}" rmlx-kv-quant kv_gpu_alpha
+crate_log "${CASE_ROOT}" rmlx-kv-quant 0 <<'LOG'
+Metal GPU Validation Enabled
+running 1 test
+test kv::gpu_alpha ... okInvalid device load at offset 4096, executing kernel function: "custom_kernel_rmlx_q8_quantize"Invalid device store at offset 8192, executing kernel function: "custom_kernel_rmlx_q8_quantize"
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 1
+expect_report "rmlx-kv-quant: 2 invalid access(es)"
+expect_mix "1 device load"
+expect_mix "1 device store"
+
+# ---------------------------------------------------------------------------
+# A crate that both under-matched and failed tests: an aborting test binary
+# produces exactly that pair, since the tests after the abort never run. Both
+# lines have to reach the report — the under-match alone says a filter stopped
+# matching, which sends the reader looking for a renamed fn rather than at the
+# test that took the binary down.
+new_case undermatch_plus_failing_test || exit 1
+classify "${CASE_ROOT}" rmlx-kv-quant kv_gpu_alpha kv_gpu_beta kv_gpu_gamma
+crate_log "${CASE_ROOT}" rmlx-kv-quant 101 <<'LOG'
+Metal GPU Validation Enabled
+running 3 tests
+test kv::gpu_alpha ... ok
+test kv::gpu_beta ... FAILED
+
+failures:
+
+---- kv::gpu_beta stdout ----
+thread 'kv::gpu_beta' panicked at crates/rmlx-kv-quant/src/codec_tests.rs:165:5:
+sorted vs broadcast diverge beyond atol+rtol*|b| by 0.059472658
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+failures:
+    kv::gpu_beta
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 1
+expect_report "under-matched (2/3 executed)"
+expect_report "kv::gpu_beta"
 
 # ---------------------------------------------------------------------------
 # A crate that under-matched its classified population is a second kind of


### PR DESCRIPTION
Closes #447.

## What was wrong

`scripts/run_gpu_tests.sh` accumulates two independent kinds of red across its
crate loop and then checks them in sequence, exiting inside the first block:

* `scripts/run_gpu_tests.sh:455-462` (pre-fix) — the shader-validation block
  prints `validation_hits` and `exit 1`s.
* `scripts/run_gpu_tests.sh:464-478` (pre-fix) — the crate-failure block, only
  reached when the block above did not exit.

A run with both non-empty reported only the validation aggregate. The failing
test names the loop had already extracted (`crate_fails`) were held in a shell
variable and discarded at process exit, and each crate's log is `rm -f`'d inside
the loop, so the only surviving trace was whatever scrolled past in a ~21-minute
interleaved `tee`. While any standing diagnostic exists, that makes the
failing-test oracle real, working, and starved of execution by an earlier,
less-specific exit — and `make ci-perf` cannot opt out of shader validation.

Second, smaller defect: `scripts/run_gpu_tests.sh:459-460` claimed "an
out-of-bounds device store" unconditionally, without inspecting what the
detector matched. `VALIDATION_DIAGNOSTIC` matches loads and stores alike, and
the diagnostics this tree currently carries are 160/160 **loads** — so the
banner named the wrong access type, and the two differ in severity.

## What changed

* Both post-loop blocks now print and set a flag; a single `exit 1` follows
  them. Nothing special-cases the failing-test kind: the flag is set by the
  crate-failure block, which already covers a failing test, an under-matched
  crate and a crate that produced no validation banner.
* Each hit's own access wording (`device load` / `device store`, and any other
  spelling the layer emits) is read off the diagnostic and printed as a counted
  mix, replacing the hardcoded claim.
* Hits are counted per diagnostic instead of per line, so the mix sums to the
  count printed beside it. The validation layer writes to stderr while libtest
  is mid-line, so two reports routinely share one output line.
* Docs: `docs/TESTING.md` no longer says the aggregate makes no load/store
  distinction, and records the reporting order and its gate; `scripts/INDEX.md`
  gains the new script.

## How it is proven

`scripts/run_gpu_tests_selftest.sh` — `make gpu-runner-selftest`, wired into
`make ci`, no GPU and no compile. A stub `cargo` replays a canned libtest log
per crate through a **copy of the real runner**, so the check cannot drift from
the gate. Eight cases assert the reason that reaches the *final report block*
(not the interleaved `tee` output the report is meant to summarise): a hit plus
a failing test in one run, a failure alone, loads only, stores only, mixed
kinds, an under-match plus a hit, an uninstrumented crate plus a hit, and a
clean run as the harness's own positive control.

Red-first, against the runner as it stands on `main`: **11 assertions across 6
cases fail**, including `both_kinds: final report does not mention: ERROR: GPU
tests failed in:` and `kv::gpu_beta`. All green after the fix.

Mutation-checked — each of these reds the suite again:

| mutation | caught |
|---|---|
| validation block `exit 1`s again | 4 assertions, incl. both `undermatch` and `uninstrumented` cases |
| access kind hardcoded to `device store` | 5 |
| access kind hardcoded to `device load` | 4 |
| crate-failure block no longer sets the flag | `failure_only` exits 0 |
| hits counted per line again | the count/mix mismatch |
| hits accumulated unconditionally | the clean case goes red |

`make ci`: green (exit 0). No GPU run was needed — the defect and its fix are
in the runner's reporting, and the selftest drives that path end to end with
stubs.

## Note on the issue text

Every claim in the issue checks out against source, including all
`run_gpu_tests.sh` line references and the `rm -f` of each crate log inside the
loop. Two Makefile line references are off by a line or two (`ci-perf`'s GPU
half is `Makefile:251`, not `:249` which is its `--preflight` line; the
`gpu-test` recipe is `Makefile:275`, not `:273`), which does not affect the
conclusion.
