### PR TITLE
fix(mlx): to_bytes returns the array's own elements, not the parent buffer's

### DIFF
--- a/crates/rmlx-kv-quant/src/kvcache/shared_source_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/shared_source_tests.rs
@@ -316,15 +316,7 @@ fn shared_source_refuses_a_declared_producer_rebuilt_from_the_store_alone() {
             );
         }
         Ok((_, SharedKv::Bf16(k_full, _))) => {
-            // `Array::to_bytes` reads by raw linear offset, and the surfaced
-            // mirror is a strided slice over the full `max_seq` buffer, so
-            // flatten the view first — otherwise the count describes the
-            // parent allocation rather than the share.
-            let flat = k_full
-                .contiguous(device)
-                .expect("flatten the surfaced mirror");
-            flat.eval().expect("materialise the surfaced mirror");
-            let bytes = flat.to_bytes().expect("surfaced mirror bytes");
+            let bytes = k_full.to_bytes().expect("surfaced mirror bytes");
             let nonzero = bytes.iter().filter(|&&b| b != 0).count();
             let total = bytes.len();
             panic!(
@@ -332,7 +324,7 @@ fn shared_source_refuses_a_declared_producer_rebuilt_from_the_store_alone() {
                  {:?} mirror of {total} bytes of which only {nonzero} are non-zero — \
                  every one of the {prefix} prefix tokens is the zero-fill this path \
                  must never answer with",
-                flat.shape(),
+                k_full.shape(),
             );
         }
         Ok((_, SharedKv::Store { kv_len })) => {

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -2672,13 +2672,12 @@ impl KvCache {
         // strided view over the parent allocation — `eval` does not flatten it.
         // Two things follow that the seed's own contract denies. It is not
         // compact: the whole `max_seq` parent stays resident behind it until the
-        // first decode step expands the mirror. And anything that reads the
-        // buffer by raw linear offset rather than by stride — `Array::to_bytes`,
-        // which is how the SSD tier serialises it — sees the parent's leading
-        // bytes under the slice's shape, i.e. head 0's whole row window in place
-        // of every head. Materialising row-major here, on the inference thread
-        // that owns the Metal stream, is what makes the seed mean what its shape
-        // says for every later reader.
+        // first decode step expands the mirror. And a raw-linear MSL kernel —
+        // which is what the flash-decode paths feed this seed to — reads the
+        // parent's leading bytes under the slice's shape, i.e. head 0's whole
+        // row window in place of every head. Materialising row-major here, on
+        // the inference thread that owns the Metal stream, is what makes the
+        // seed mean what its shape says for every later reader.
         let is_bf16_storage = matches!(self.storage, KvStorage::None { .. });
         let need_k_seed = is_bf16_storage || self.quant.feeds_bf16_k_at_decode(self.shares_kv);
         let need_v_seed = is_bf16_storage || self.quant.feeds_bf16_v_at_decode(self.shares_kv);

--- a/crates/rmlx-kv-quant/src/kvcache/v_mirror_alloc_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/v_mirror_alloc_tests.rs
@@ -649,11 +649,6 @@ fn slice_v_prefix_cuts_the_valid_rows_at_a_non_pow2_head_dim() {
 
     let cut = slice_v_prefix(&mirror, valid, Device::Cpu).expect("slice_v_prefix");
     assert_eq!(cut.shape(), vec![B, kv_h, valid, head_dim]);
-    // Materialise before reading: `to_bytes` hands back the backing buffer, so
-    // a strided view read straight out of it reports the allocation's leading
-    // elements rather than the view's.
-    let cut = cut.contiguous(Device::Cpu).expect("cut contiguous");
-    cut.eval().expect("cut eval");
     let got: Vec<f32> = cut
         .to_bytes()
         .expect("cut bytes")

--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -998,36 +998,41 @@ impl Array {
     pub fn to_bytes(&self) -> Result<Vec<u8>> {
         install_error_handler();
         self.eval()?;
+        let nbytes = unsafe { sys::mlx_array_nbytes(self.inner) };
+        if nbytes == 0 {
+            return Ok(Vec::new());
+        }
         if self.is_row_contiguous()? {
-            return self.copy_row_major_bytes();
+            return self.copy_row_major_bytes(nbytes);
         }
         // The bytes are bound for host memory and the caller is already
         // blocking on them, so relaying out on the CPU stream keeps the read
         // path free of a GPU dispatch to wait on. Reading an evaluated array's
         // buffer from the host is what this method does either way.
+        tracing::debug!(
+            shape = ?self.shape(),
+            nbytes,
+            "to_bytes: relaying out a non-row-contiguous array"
+        );
         let dense = self.contiguous(Device::Cpu)?;
         dense.eval()?;
-        dense.copy_row_major_bytes()
+        dense.copy_row_major_bytes(nbytes)
     }
 
     /// Copy `nbytes` straight off the data pointer.
     ///
     /// Callers must have evaluated the array and established that it is
-    /// row-contiguous; otherwise the read follows the parent allocation's
-    /// layout instead of this array's, and for a broadcast it runs past the
-    /// end of that allocation.
-    fn copy_row_major_bytes(&self) -> Result<Vec<u8>> {
-        let nbytes = unsafe { sys::mlx_array_nbytes(self.inner) };
-        if nbytes == 0 {
-            return Ok(Vec::new());
-        }
-
+    /// row-contiguous, and must pass this array's own `mlx_array_nbytes`;
+    /// otherwise the read follows the parent allocation's layout instead of
+    /// this array's, and for a broadcast it runs past the end of that
+    /// allocation.
+    fn copy_row_major_bytes(&self, nbytes: usize) -> Result<Vec<u8>> {
         // SAFETY: mlx_array_data_uint8 returns a raw pointer valid while the
         // array is alive and evaluated. We copy out immediately.
         let ptr = unsafe { sys::mlx_array_data_uint8(self.inner) };
         if ptr.is_null() {
             return Err(Error::Mlx(
-                "Array::to_bytes: data pointer is null — was eval() called?".into(),
+                "Array::to_bytes: data pointer is null after eval".into(),
             ));
         }
         // SAFETY: ptr is non-null and points to `nbytes` contiguous bytes
@@ -1049,6 +1054,11 @@ impl Array {
     /// **Evaluate first.** The flag describes a materialised buffer, and MLX
     /// only sets it when one is attached; on an unevaluated array it reports
     /// the layout of nothing and answers `true` for a view that is not dense.
+    ///
+    /// `mlx/c/array.h` declares `_mlx_array_is_row_contiguous` an internal
+    /// function with no stability promise, so every host readback now rests on
+    /// an mlx-c internal. The behaviour pin is the layout-flag test in
+    /// `lib_tests.rs`; re-run it whenever the pinned mlx / mlx-c pair moves.
     fn is_row_contiguous(&self) -> Result<bool> {
         install_error_handler();
         let mut res = false;
@@ -1131,9 +1141,12 @@ impl Array {
     /// linear index, so they see the un-permuted physical order and silently
     /// produce scrambled results. Call this before feeding a transposed (or
     /// otherwise non-contiguous) array to such a kernel so the physical layout
-    /// matches the logical shape. `mlx_reshape` to the same element count does
-    /// not guarantee this — a flattened strided view can still report as
-    /// "contiguous" while its bytes follow the original strides.
+    /// matches the logical shape. The case that needs it is a transpose or a
+    /// strided slice fed straight to the kernel: a `reshape` that changes the
+    /// shape already relayouts, because MLX copies a non-row-contiguous
+    /// reshape input dense instead of sharing its buffer. A reshape to the
+    /// shape the array already has returns the array itself and relayouts
+    /// nothing.
     pub fn contiguous(&self, device: Device) -> Result<Array> {
         install_error_handler();
         let mut res = unsafe { sys::mlx_array_new() };

--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -975,7 +975,7 @@ impl Array {
         unsafe { check_status(status, "Array::async_eval") }
     }
 
-    /// Copy array contents into a fresh `Vec<u8>`.
+    /// Copy the array's logical elements, row-major, into a fresh `Vec<u8>`.
     ///
     /// Forces evaluation first so the read is always of materialized data.
     /// MLX is lazy and `async_eval` only *schedules* compute; the data pointer
@@ -985,9 +985,38 @@ impl Array {
     /// it, reading the pointer can race the asynchronous evaluation and return
     /// stale/recycled buffer bytes (another array's data) rather than this
     /// array's value.
+    ///
+    /// Evaluation is not enough on its own: a transpose, a strided slice and a
+    /// broadcast all evaluate to the *parent's* allocation with adjusted
+    /// strides, and a linear read of one returns the parent's leading elements
+    /// under the view's shape — right length, right dtype, wrong values. Such
+    /// an input is relaid out row-major before the read, so the returned bytes
+    /// always mean what the array's shape says. The relayout costs a copy, and
+    /// only on inputs whose linear read would otherwise be wrong; a dense array
+    /// — every reduction, elementwise, matmul and kernel output — pays one
+    /// layout-flag read on top of what it paid before.
     pub fn to_bytes(&self) -> Result<Vec<u8>> {
         install_error_handler();
         self.eval()?;
+        if self.is_row_contiguous()? {
+            return self.copy_row_major_bytes();
+        }
+        // The bytes are bound for host memory and the caller is already
+        // blocking on them, so relaying out on the CPU stream keeps the read
+        // path free of a GPU dispatch to wait on. Reading an evaluated array's
+        // buffer from the host is what this method does either way.
+        let dense = self.contiguous(Device::Cpu)?;
+        dense.eval()?;
+        dense.copy_row_major_bytes()
+    }
+
+    /// Copy `nbytes` straight off the data pointer.
+    ///
+    /// Callers must have evaluated the array and established that it is
+    /// row-contiguous; otherwise the read follows the parent allocation's
+    /// layout instead of this array's, and for a broadcast it runs past the
+    /// end of that allocation.
+    fn copy_row_major_bytes(&self) -> Result<Vec<u8>> {
         let nbytes = unsafe { sys::mlx_array_nbytes(self.inner) };
         if nbytes == 0 {
             return Ok(Vec::new());
@@ -1005,6 +1034,31 @@ impl Array {
         // owned by the mlx array. Copied into Vec before returning.
         let bytes = unsafe { std::slice::from_raw_parts(ptr, nbytes) }.to_vec();
         Ok(bytes)
+    }
+
+    /// Whether the elements are laid out row-major and dense from the data
+    /// pointer — i.e. whether reading `nbytes` linearly off that pointer yields
+    /// the logical elements in logical order.
+    ///
+    /// False for a transpose, a strided slice, and a broadcast: MLX gives each
+    /// of those the parent's allocation with adjusted strides rather than a
+    /// copy, and `eval` materialises the graph without relaying anything out.
+    /// A broadcast is the sharpest case — its logical size exceeds the elements
+    /// the parent owns, so a linear read of `nbytes` runs off the buffer.
+    ///
+    /// **Evaluate first.** The flag describes a materialised buffer, and MLX
+    /// only sets it when one is attached; on an unevaluated array it reports
+    /// the layout of nothing and answers `true` for a view that is not dense.
+    fn is_row_contiguous(&self) -> Result<bool> {
+        install_error_handler();
+        let mut res = false;
+        // SAFETY: inner is a valid mlx_array. The call reads the array's layout
+        // flags and never touches the data buffer, so it cannot fault on an
+        // unevaluated array — it just answers about a buffer that is not there.
+        let status = unsafe { sys::_mlx_array_is_row_contiguous(&raw mut res, self.inner) };
+        // SAFETY: called immediately after the C function on the same thread.
+        unsafe { check_status(status, "Array::is_row_contiguous") }?;
+        Ok(res)
     }
 
     /// Create a logical copy of this array using `mlx_array_set`.

--- a/crates/rmlx-mlx/src/lib_tests.rs
+++ b/crates/rmlx-mlx/src/lib_tests.rs
@@ -222,6 +222,140 @@ fn slice_1d() {
     assert_eq!(out, vec![20.0, 30.0, 40.0]);
 }
 
+// ── to_bytes over non-contiguous views ────────────────────────────────────
+//
+// Every array below shares its parent's allocation and differs from it only in
+// strides, so a reader that walks the data pointer linearly returns the
+// parent's leading elements under the view's shape — right length, right
+// dtype, wrong values, no error. `slice_1d` above cannot cover this: a rank-1
+// stride-1 slice is dense by construction because its offset lands in the data
+// pointer.
+
+#[test]
+fn to_bytes_of_a_strided_slice_reads_the_slice() {
+    let data: Vec<f32> = (0..16).map(|i| i as f32).collect();
+    let a = Array::from_bytes(f32_as_bytes(&data), &[1, 2, 4, 2], Dtype::F32).unwrap();
+    // Take the first two of four sequence positions in both heads.
+    let view = a
+        .slice(&[0, 0, 0, 0], &[1, 2, 2, 2], &[1, 1, 1, 1], Device::Cpu)
+        .unwrap();
+    let out = bytes_to_f32(&view.to_bytes().unwrap());
+    assert_eq!(
+        out,
+        vec![0.0, 1.0, 2.0, 3.0, 8.0, 9.0, 10.0, 11.0],
+        "head 1 must start at element 8; [4..8] is the parent's tail of head 0"
+    );
+}
+
+#[test]
+fn to_bytes_of_a_rank2_slice_reads_the_window() {
+    let data: Vec<f32> = (0..9).map(|i| i as f32).collect();
+    let a = Array::from_bytes(f32_as_bytes(&data), &[3, 3], Dtype::F32).unwrap();
+    // Two leading columns of every row.
+    let view = a.slice(&[0, 0], &[3, 2], &[1, 1], Device::Cpu).unwrap();
+    let out = bytes_to_f32(&view.to_bytes().unwrap());
+    assert_eq!(out, vec![0.0, 1.0, 3.0, 4.0, 6.0, 7.0]);
+}
+
+#[test]
+fn to_bytes_of_a_transpose_reads_the_permuted_order() {
+    let data: [f32; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let a = Array::from_bytes(f32_as_bytes(&data), &[2, 3], Dtype::F32).unwrap();
+    let view = a.transpose(&[1, 0], Device::Cpu).unwrap();
+    assert_eq!(view.shape(), vec![3, 2]);
+    let out = bytes_to_f32(&view.to_bytes().unwrap());
+    assert_eq!(out, vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+}
+
+#[test]
+fn to_bytes_of_an_attention_v_transpose_reads_head_major_order() {
+    // The shape every attention block hands to the KV cache: `[b, seq, kv_h,
+    // head_dim]` permuted to `[b, kv_h, seq, head_dim]`. Dense at seq == 1 —
+    // the permuted axis has extent 1 — and strided for every longer step.
+    let data: Vec<f32> = (0..12).map(|i| i as f32).collect();
+    let a = Array::from_bytes(f32_as_bytes(&data), &[1, 3, 2, 2], Dtype::F32).unwrap();
+    let view = a.transpose(&[0, 2, 1, 3], Device::Cpu).unwrap();
+    assert_eq!(view.shape(), vec![1, 2, 3, 2]);
+    let out = bytes_to_f32(&view.to_bytes().unwrap());
+    assert_eq!(
+        out,
+        vec![0.0, 1.0, 4.0, 5.0, 8.0, 9.0, 2.0, 3.0, 6.0, 7.0, 10.0, 11.0]
+    );
+}
+
+#[test]
+fn to_bytes_of_a_broadcast_reads_the_expanded_shape() {
+    // A broadcast view is the one case where the linear read is not merely
+    // wrong: its logical size exceeds the elements the parent actually owns.
+    let data: [f32; 3] = [1.0, 2.0, 3.0];
+    let a = Array::from_bytes(f32_as_bytes(&data), &[1, 3], Dtype::F32).unwrap();
+    let view = broadcast_to(&a, &[2, 3], Device::Cpu).unwrap();
+    let out = bytes_to_f32(&view.to_bytes().unwrap());
+    assert_eq!(out, vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn reshape_of_a_transposed_view_is_relaid_out_and_says_so() {
+    // `to_bytes` skips the relayout on the strength of the layout flag, so the
+    // flag has to be right about the one op that quietly materialises a copy:
+    // MLX reshapes a non-row-contiguous input by copying it dense.
+    let data: [f32; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let a = Array::from_bytes(f32_as_bytes(&data), &[2, 3], Dtype::F32).unwrap();
+    let flat = a
+        .transpose(&[1, 0], Device::Cpu)
+        .unwrap()
+        .reshape(&[6], Device::Cpu)
+        .unwrap();
+    flat.eval().unwrap();
+    assert!(flat.is_row_contiguous().unwrap());
+    assert_eq!(
+        bytes_to_f32(&flat.to_bytes().unwrap()),
+        vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
+    );
+}
+
+/// GPU variant — the relayout runs on the CPU stream while the view it reads
+/// was evaluated on the Metal one, which is the one thing the CPU cases above
+/// cannot show.
+#[test]
+#[ignore = "requires Metal GPU; run with `-- --ignored` in a GPU-capable environment"]
+fn to_bytes_of_a_gpu_transpose_reads_the_permuted_order() {
+    let data: [f32; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let a = Array::from_bytes(f32_as_bytes(&data), &[2, 3], Dtype::F32).unwrap();
+    let view = a.transpose(&[1, 0], Device::Gpu).unwrap();
+    view.eval().unwrap();
+    let out = bytes_to_f32(&view.to_bytes().unwrap());
+    assert_eq!(out, vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+}
+
+#[test]
+fn to_bytes_of_an_empty_array_is_empty() {
+    // The load-path warmup evaluates a `[0]` array through this method.
+    let a = Array::from_bytes(&[], &[0], Dtype::F32).unwrap();
+    assert!(a.to_bytes().unwrap().is_empty());
+}
+
+#[test]
+fn layout_flag_classifies_views_once_they_are_evaluated() {
+    // The flag describes a materialised buffer, so it is only meaningful after
+    // `eval` — which is the order `to_bytes` reads it in.
+    let data: [f32; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let a = Array::from_bytes(f32_as_bytes(&data), &[2, 3], Dtype::F32).unwrap();
+    a.eval().unwrap();
+    assert!(a.is_row_contiguous().unwrap());
+
+    let view = a.transpose(&[1, 0], Device::Cpu).unwrap();
+    view.eval().unwrap();
+    assert!(!view.is_row_contiguous().unwrap());
+
+    let dense = view.contiguous(Device::Cpu).unwrap();
+    dense.eval().unwrap();
+    assert!(
+        dense.is_row_contiguous().unwrap(),
+        "the relayout to_bytes falls back to must itself be readable linearly"
+    );
+}
+
 // ── slice_update ──────────────────────────────────────────────────────────
 
 #[test]

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -829,6 +829,35 @@ returns `Err` if the pointer is null.
 let bytes = unsafe { std::slice::from_raw_parts(ptr, nbytes) }.to_vec();
 ```
 
+**The contract is the array's logical elements in row-major order, for any
+input.** Evaluating is not enough to earn that: a transpose, a strided slice
+and a broadcast all evaluate to the *parent's* allocation with adjusted strides
+— the same "`eval` materialises but does not relayout" fact the MSL-kernel
+rules above turn on — while `mlx_array_nbytes` reports the *logical*
+`size * itemsize`. Reading that many bytes linearly off such a
+view returns the parent's leading elements under the view's shape — right
+length, right dtype, wrong values, and for a broadcast a read past the end of
+the allocation, since the logical size exceeds the elements the parent owns.
+
+So `to_bytes` reads `_mlx_array_is_row_contiguous` after evaluating and, when
+it is false, relays the array out through `contiguous()` on the CPU stream and
+reads the copy. The flag is only meaningful once the array is evaluated, which
+is why the order is eval → classify → read. Cost: a dense array — every
+reduction, elementwise, matmul and kernel output — pays one extra layout-flag
+read; the copy falls only on inputs whose linear read would otherwise be wrong.
+The CPU stream is the right one because the bytes are bound for host memory and
+the caller is already blocking on them, so no GPU dispatch is added to a read
+path that already dereferences the buffer from the host.
+
+Callers therefore never need a defensive `.contiguous()` purely to make a
+readback correct. Sites that call it before `to_bytes` for a *different* reason
+— compacting a slice so the parent allocation can be dropped, or handing the
+same array to a raw-linear MSL kernel — keep it. Pinned by the non-contiguous
+readback cases in `crates/rmlx-mlx/src/lib_tests.rs` (strided slice, rank-2
+window, transpose, the `[b, seq, kv_h, head_dim]` attention permutation, and
+broadcast), plus `reshape_of_a_transposed_view_is_relaid_out_and_says_so`,
+which pins the flag's honesty about the one op that quietly copies.
+
 ---
 
 ## Core Ops

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -849,6 +849,19 @@ The CPU stream is the right one because the bytes are bound for host memory and
 the caller is already blocking on them, so no GPU dispatch is added to a read
 path that already dereferences the buffer from the host.
 
+`_mlx_array_is_row_contiguous` is declared in `mlx/c/array.h` as an **internal
+function** — "use at your own risk", no stability promise — so every host
+readback in the workspace now depends on one. That is a deliberate trade: the
+alternative is recomputing the predicate from `mlx_array_strides` and
+`mlx_array_shape`, which duplicates MLX's own definition of the flag and drifts
+from it silently. `layout_flag_classifies_views_once_they_are_evaluated`
+(`crates/rmlx-mlx/src/lib_tests.rs`) is the behaviour pin: it asserts the flag's
+answer for a dense array, a transpose, and a `contiguous()` result, and must be
+re-run whenever the pinned mlx / mlx-c pair moves (`crates/rmlx-mlx/src/pin.rs`). Note what
+it pins and why the order in `to_bytes` is eval → classify → read: before
+evaluation the flag describes a buffer that is not attached yet and answers
+`true` for a transpose.
+
 Callers therefore never need a defensive `.contiguous()` purely to make a
 readback correct. Sites that call it before `to_bytes` for a *different* reason
 — compacting a slice so the parent allocation can be dropped, or handing the

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -761,15 +761,15 @@ prompt-cache hit and the RAM-served one produce the same tokens. bf16
 round-trips bit-for-bit.
 
 The row-major step is load-bearing, not hygiene: a live mirror is normally a
-**slice view** over the larger prefill/decode buffer, and the serialiser reads
-the raw allocation by linear offset (`Array::to_bytes` ignores strides).
-Persisting the view directly writes the parent buffer's leading bytes under the
-slice's shape, which for `kv_h > 1` is head 0's whole row window in place of
-every head — it reads back as one head of real KV and zeros for the rest, with
-no error anywhere. Pinned by
+**slice view** over the larger prefill/decode buffer, and the same seed is fed
+to raw-linear MSL kernels, which read the parent buffer's leading bytes under
+the slice's shape — for `kv_h > 1` that is head 0's whole row window in place of
+every head. Serialisation is no longer part of that argument: `Array::to_bytes`
+relays a non-row-contiguous array out before reading it (`docs/FFI.md`
+§"Data readback"), so a view reaching the spill writer costs a copy on the drain
+thread rather than corrupting the block. Pinned by
 `block_io_tests::roundtrip_mirror_codec_spills_and_hydrates_as_bf16`, which
-drives the mirror through a real prefill (a fixture that installs an
-already-compact array cannot see this failure), and by
+drives the mirror through a real prefill, and by
 `decode_expanded_mirror_is_refused_rather_than_spilled_with_its_tail` and
 `expanded_mirror_in_one_layer_fails_the_whole_block` for the refusal.
 

--- a/docs/SSD_TIER.md
+++ b/docs/SSD_TIER.md
@@ -769,7 +769,8 @@ relays a non-row-contiguous array out before reading it (`docs/FFI.md`
 §"Data readback"), so a view reaching the spill writer costs a copy on the drain
 thread rather than corrupting the block. Pinned by
 `block_io_tests::roundtrip_mirror_codec_spills_and_hydrates_as_bf16`, which
-drives the mirror through a real prefill, and by
+drives the mirror through a real prefill (a fixture that installs an
+already-compact array cannot see this failure), and by
 `decode_expanded_mirror_is_refused_rather_than_spilled_with_its_tail` and
 `expanded_mirror_in_one_layer_fails_the_whole_block` for the refusal.
 


### PR DESCRIPTION
## What

`Array::to_bytes` returned the **parent allocation's** leading elements for any non-contiguous input — a transpose, a strided slice, a broadcast. It now returns the array's logical elements in row-major order for every input.

Closes #473.

## Why it was wrong

`mlx_array_nbytes` is the *logical* `size * itemsize`. The data pointer absorbs a view's byte offset but not its strides, and `eval` materialises the compute graph without relaying anything out — MLX's slice, transpose and broadcast primitives all share the parent buffer and adjust strides. So the linear read gave the right length, the right dtype, and the wrong values, with no error, no length mismatch, and no downstream check that could fire. A broadcast is worse than wrong: its logical size exceeds the elements the parent owns, so the read runs past the end of the allocation.

Measured on this tree, `Device::Cpu`, before the fix:

| view | `to_bytes` returned | correct |
|---|---|---|
| `[1,2,4,2]` f32, slice → `[1,2,2,2]` | `[0,1,2,3,4,5,6,7]` | `[0,1,2,3,8,9,10,11]` |
| `[3,3]` f32, slice → `[3,2]` | `[0,1,2,3,4,5]` | `[0,1,3,4,6,7]` |
| `[2,3]` f32, `.transpose([1,0])` | `[1,2,3,4,5,6]` | `[1,4,2,5,3,6]` |
| `[1,3,2,2]` f32, `.transpose([0,2,1,3])` (the attention V permutation at `seq=3`) | `[0..12)` verbatim | `[0,1,4,5,8,9,2,3,6,7,10,11]` |
| `[1,3]` f32, broadcast → `[2,3]` | `[1,2,3,0,0,0]` — 12 bytes past the buffer | `[1,2,3,1,2,3]` |

## The contract, and why this one

The issue put three real options on the table: relay out internally, return an error, or patch `array_to_f32_vec`'s F32 branch. This lands the first, at the API boundary.

- **The method's job is to hand back the array's contents.** A strided view has perfectly well-defined contents; erroring on one asks every caller to solve a problem the callee is better placed to solve, and to guess a `Device` to solve it with. `to_bytes` takes no `Device` — resolved by relaying out on the **CPU stream**, which is right rather than merely available: the bytes are bound for host memory and the caller is already blocking on them, so no GPU dispatch is added to a path that already dereferences the buffer from the host.
- **Erroring would trade silent corruption for a production failure, where this trades it for a correct answer.** The census's all-safe verdict rests on properties that can drift — three of its classes are safe *by rank*, *by `astype` copying*, or *by `reshape` relayouting. Under the error contract, any of those drifting turns a working request into a 500. Under this one it turns into a copy.
- **The live hazardous shapes are values, not mistakes.** `update_decode_fp16_v_only` hands a non-contiguous rank-4 array across a crate boundary on every decode step, and every arch's attention block produces the V transpose. Those are legitimate arrays to read; the readback should just work on them.
- **Cost.** The check is an O(1) layout-flag read. A dense array — every reduction, elementwise, matmul and kernel output, i.e. essentially every caller today — pays that and nothing else. The copy falls only where the linear read would have been wrong, and every such copy replaces a wrong answer. This is never slower than the error contract plus a correct caller, and strictly faster than the error contract plus a caller that defensively copies everything.

Fixing the boundary subsumes option 3: the `Dtype::F32` branch of `array_to_f32_vec` forwarded the array unrelaid and is reached 66 times from the KV decode arms — all 66 are covered, with no change at that site.

## How it is proven

**Red first.** Six `Device::Cpu` tests, un-ignored, in `crates/rmlx-mlx/src/lib_tests.rs`. All six fail on the pre-fix code with exactly the values in the table above.

**Mutation-checked**, each restoring from a sha256-verified snapshot:

| mutation | result |
|---|---|
| contiguity branch forced to the linear read | 5 value tests red |
| `eval()` dropped after the relayout | SIGSEGV — the eval is load-bearing, the copy is not readable until it has run |
| contiguity branch forced to the linear read | `slice_v_prefix_cuts_the_valid_rows_at_a_non_pow2_head_dim` red (`kv_h = 3`, `head_dim = 96`) |

Two further tests pin the premises the fast path rests on rather than the fix itself: `layout_flag_classifies_views_once_they_are_evaluated` (the flag is only meaningful post-`eval`, which is why the order is eval → classify → read — pre-`eval` it answers `true` for a transpose), and `reshape_of_a_transposed_view_is_relaid_out_and_says_so` (MLX copies a non-row-contiguous reshape dense, and the flag is honest about it — if it were ever not, skipping the relayout would be unsound).

**Gates.** `make ci` green. `cargo test -p rmlx-mlx -p rmlx-kv-quant --lib --profile release-perf` green — 638 passed; the guard is a runtime check, not a `debug_assert`, so it survives the profile that ships. `scripts/check_gpu_tests_ignored.sh` OK.

**GPU.** One `#[ignore]`d test, `to_bytes_of_a_gpu_transpose_reads_the_permuted_order`, covers the one thing the CPU cases cannot: a view evaluated on the Metal stream, relaid out on the CPU stream. Executed via `make gpu-test CRATE=rmlx-mlx FILTER=to_bytes_of_a_gpu_transpose`, with Metal GPU Validation on:

```
test lib_tests::to_bytes_of_a_gpu_transpose_reads_the_permuted_order ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 108 filtered out; finished in 1.67s
OK: 1 GPU tests passed across 1 workspace member(s), shader validation clean.
```

No production caller reaches the relayout branch today, on either device.

## Stale code removed

Two `contiguous()` + `eval()` pairs that existed only to work around this readback are gone, and the tests that carried them now gate the fix instead of hiding it:

- `v_mirror_alloc_tests::slice_v_prefix_cuts_the_valid_rows_at_a_non_pow2_head_dim`
- `shared_source_tests::shared_source_refuses_a_declared_producer_rebuilt_from_the_store_alone`

The `exit_prefill` comment in `update.rs` no longer cites `to_bytes` as its consumer — the residency argument and the raw-linear MSL kernels are what still justify the `contiguous()` there, and the call stays. `docs/FFI.md` §"Data readback" states the new contract; `docs/SSD_TIER.md` drops "`Array::to_bytes` ignores strides".

## Review follow-ups

The second commit lands the review findings. `Array::contiguous`'s doc no longer claims a flattened strided view can report as contiguous — it cannot, and `to_bytes`'s fast path is sound only if it cannot, so the file had been asserting both; it now names the case that does need the call. The relayout branch emits a `debug!` with shape and byte count before copying, so a future caller that starts routing a strided array through a per-decode-step readback is visible in the log rather than merely slow. `docs/FFI.md` records that `_mlx_array_is_row_contiguous` is an mlx-c internal with no stability promise, names the layout-flag test as the pin to re-run when the pinned pair moves, and says why recomputing the predicate from `mlx_array_strides` would be worse. The zero-byte early-out moved ahead of the layout check so an empty array does not build a `Contiguous` graph to return nothing, and `docs/SSD_TIER.md` keeps the note on why its spill roundtrip must drive a real prefill. `docs/FFI.md` did not repeat the reshape claim, so nothing there needed that edit.

## Issue claims checked against source

Everything load-bearing in the issue holds. `helpers.rs:196` `array_to_f32_vec`, 44 `array_to_f32_vec` + 22 `arrays_to_f32` sites in `update.rs`, `block_io.rs:352` `none_bf16_payloads`, `block_io.rs:2458` doc comment, `nax.rs:324` `CStr::to_bytes`, and the "two gates that cannot fail" reading of `transpose_2d` and `slice_1d` are all accurate. The reproduction table reproduces value for value. One drift: the count is **98** non-test `.to_bytes()` occurrences today, not 97 — commits landed since filing. The classification is unaffected.
