### PR TITLE
fix(spec): a speculative arm reproduces plain greedy, and the ring gives its rejected tail back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ areas before touching code:
 | [`docs/SSD_CANARY.md`](docs/SSD_CANARY.md) | SSD KV cross-restart smoke probe |
 | [`docs/PROMPT_CACHE.md`](docs/PROMPT_CACHE.md) | Prompt cache + automatic prefix caching (block hashing, ReusePolicy, prefix index) |
 | [`docs/SPECULATIVE.md`](docs/SPECULATIVE.md) | Speculative decoding (MTP, DFlash, Eagle3 drafters; round-loop; accept-rate gates) |
+| [`docs/SPEC_ANSWER_EQUIVALENCE.md`](docs/SPEC_ANSWER_EQUIVALENCE.md) | Answer equivalence for speculative decoding: the divergence-confidence oracle, why agreement cannot be thresholded |
 | [`docs/SAMPLING.md`](docs/SAMPLING.md) | Per-token sampling (temperature, top-k/p, penalties, thinking budget, constrained decoding) |
 | [`docs/FFI.md`](docs/FFI.md) | rmlx-mlx ↔ mlx-c FFI bridge; MSL kernel surface; unsafe policy |
 | [`docs/METRICS_DB.md`](docs/METRICS_DB.md) | Metrics DB: observations / events / bests; ingest, query, export, deltas |

--- a/crates/rmlx-kv-quant/src/kvcache/core.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/core.rs
@@ -457,24 +457,27 @@ impl KvCache {
         self.rotating.is_some()
     }
 
-    /// True if this cache can be losslessly rolled back via [`truncate_to`].
+    /// True if [`KvCache::truncate_to`] can reach `n` without losing a
+    /// position this cache would still have to serve.
     ///
-    /// Byte-for-byte port of mlx-lm `can_trim_prompt_cache`'s per-cache
-    /// predicate (`cache.py`): plain `KVCache` / `QuantizedKVCache` are
-    /// always trimmable (`is_trimmable() -> True`); a `RotatingKVCache` is
-    /// trimmable only while it has NOT wrapped (`offset < max_size`,
-    /// `cache.py:542-543`). Once an SWA ring buffer wraps, the pre-wrap K/V
-    /// have been overwritten and `truncate_to` silently no-ops on it
-    /// (`rotating::trim_lossless` returns 0) — truncating the other layers
-    /// while this one stays full would desync the caches and corrupt the
-    /// re-prefilled tail. C1's gemma4 partial-prefix path uses this to gate
-    /// the block-truncate fast path: it only fires when EVERY layer cache
-    /// reports `is_trimmable()` (mlx-lm `all(c.is_trimmable())`).
-    pub fn is_trimmable(&self) -> bool {
-        match &self.rotating {
-            Some(rot) => rot.offset < rot.max_size,
-            None => true,
-        }
+    /// Plain and quantized stores carry the whole sequence, so any `n` at or
+    /// under the offset is reachable. A sliding-window ring is reachable while
+    /// it has not wrapped — mlx-lm's `is_trimmable` (`cache.py:542-543`) — and,
+    /// past the wrap, while it is still in the temporal order a block write
+    /// leaves it in and holds enough positions to spare `n` of them. That
+    /// second regime is what makes a speculative round's rejected tail
+    /// rollable; see `rotating::RotatingState::can_trim`.
+    ///
+    /// `truncate_to` fails on exactly the cases this refuses. A caller that can
+    /// re-prefill instead — the gemma4 partial-prefix path — asks first and
+    /// takes the slower route; a caller with no second route lets the failure
+    /// surface.
+    pub fn can_truncate_to(&self, n: i32) -> bool {
+        n <= self.offset
+            && self
+                .rotating
+                .as_ref()
+                .is_none_or(|rot| rot.can_trim(self.offset - n))
     }
 
     /// Current fill offset in tokens (number of tokens appended so far).

--- a/crates/rmlx-kv-quant/src/kvcache/mod.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/mod.rs
@@ -127,6 +127,11 @@ mod v_mirror_alloc_tests;
 #[path = "rotor_qjl_store_gate_tests.rs"]
 mod rotor_qjl_store_gate_tests;
 
+// `truncate_to` reaches exactly the targets `can_truncate_to` promises.
+#[cfg(test)]
+#[path = "rollback_tests.rs"]
+mod rollback_tests;
+
 pub use core::KvCache;
 pub use fused_qk_dispatch::fused_qk_total_dispatch_count;
 pub use shared_kv::SharedKv;

--- a/crates/rmlx-kv-quant/src/kvcache/rollback_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/rollback_tests.rs
@@ -1,0 +1,109 @@
+//! `KvCache::truncate_to` fails exactly where `can_truncate_to` refuses.
+//!
+//! A rollback that cannot reach its target is the shape of defect this pair
+//! exists to stop: the SWA ring used to keep its offset and its rejected keys
+//! while every full-attention layer dropped theirs, and nothing said so.
+
+use crate::{KvCache, KvQuant};
+use rmlx_mlx::{Array, Device, Dtype};
+
+/// Deterministic `[1, 1, s, 2]` f32 K/V pair.
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn kv(s: i32, base: f32) -> Array {
+    let mut data: Vec<f32> = Vec::with_capacity((s * 2) as usize);
+    for p in 0..s {
+        data.push(base + p as f32);
+        data.push(base + p as f32 + 0.5);
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), data.len() * 4) };
+    Array::from_bytes(bytes, &[1, 1, s, 2], Dtype::F32).unwrap()
+}
+
+/// A windowed layer that a block write left in temporal order rolls its
+/// rejected tail back, and reports the rolled-back offset.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn a_windowed_layer_rolls_back_a_verify_block_tail() {
+    let device = Device::Cpu;
+    let mut cache = KvCache::with_quant_max_seq_window(KvQuant::None, 512, Some(4));
+    cache.update(&kv(6, 0.0), &kv(6, 100.0), device).unwrap();
+    cache.update(&kv(4, 6.0), &kv(4, 106.0), device).unwrap();
+    assert_eq!(cache.offset(), 10);
+
+    let target = 7;
+    assert!(
+        cache.can_truncate_to(target),
+        "a wrapped ring in temporal order must be able to give a block tail back"
+    );
+    cache
+        .truncate_to(target)
+        .expect("and truncate_to must do what can_truncate_to promised");
+    assert_eq!(cache.offset(), target);
+}
+
+/// The same layer, left in rotated order by single-token decode writes, refuses
+/// — and says which layer and how far it was asked to go back, because the
+/// message is what a caller with no second route has to act on.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn a_rotated_windowed_layer_refuses_rather_than_keeping_the_rejected_keys() {
+    let device = Device::Cpu;
+    let mut cache =
+        KvCache::with_quant_max_seq_window(KvQuant::None, 512, Some(4)).with_layer_idx(7);
+    cache.update(&kv(6, 0.0), &kv(6, 100.0), device).unwrap();
+    for step in 0..3 {
+        let p = (6 + step) as f32;
+        cache.update(&kv(1, p), &kv(1, 100.0 + p), device).unwrap();
+    }
+    let before = cache.offset();
+    assert_eq!(before, 9);
+
+    assert!(
+        !cache.can_truncate_to(8),
+        "a rotated ring cannot give a key back"
+    );
+    let err = cache
+        .truncate_to(8)
+        .expect_err("and truncate_to must refuse rather than no-op at the old offset");
+    let text = err.to_string();
+    assert!(text.contains("layer 7"), "{text}");
+    assert!(text.contains("sliding-window ring"), "{text}");
+    assert_eq!(
+        cache.offset(),
+        before,
+        "a refused rollback leaves the cache where it was"
+    );
+}
+
+/// A full-attention layer carries the whole sequence, so every prefix is
+/// reachable — the predicate must not refuse one and strand the round.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn a_full_attention_layer_reaches_every_prefix() {
+    let device = Device::Cpu;
+    let mut cache = KvCache::with_quant_max_seq_window(KvQuant::None, 512, None);
+    cache.update(&kv(10, 0.0), &kv(10, 100.0), device).unwrap();
+    for target in 0..=10 {
+        let mut c = KvCache::with_quant_max_seq_window(KvQuant::None, 512, None);
+        c.update(&kv(10, 0.0), &kv(10, 100.0), device).unwrap();
+        assert!(c.can_truncate_to(target), "target={target}");
+        c.truncate_to(target).expect("full attention rolls back");
+        assert_eq!(c.offset(), target);
+    }
+    assert!(
+        !cache.can_truncate_to(11),
+        "a target past the offset is not a prefix of anything"
+    );
+}

--- a/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/rotor_flash_dispatch_tests.rs
@@ -616,7 +616,9 @@ fn ring_only_tail_truncate_then_decode(quant: KvQuant) {
 
     // Roll back to prefill + keep (partial-accept), then decode one more token.
     let m = prefill + keep;
-    cache.truncate_to(m);
+    cache
+        .truncate_to(m)
+        .expect("a full-attention store rolls back to any prefix");
     assert_eq!(
         cache.offset(),
         m,

--- a/crates/rmlx-kv-quant/src/kvcache/shared_source_tests.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/shared_source_tests.rs
@@ -474,7 +474,9 @@ fn mixed_truncate_to_keeps_the_prefix_it_was_told_to_keep() {
     let keep = 27_i32;
 
     let mut truncated = mixed_cache_prefilled(prefix, device);
-    truncated.truncate_to(keep);
+    truncated
+        .truncate_to(keep)
+        .expect("a full-attention store rolls back to any prefix");
     assert_eq!(
         truncated.offset(),
         keep,

--- a/crates/rmlx-kv-quant/src/kvcache/update.rs
+++ b/crates/rmlx-kv-quant/src/kvcache/update.rs
@@ -4002,7 +4002,12 @@ impl KvCache {
     /// For quantised paths (K8V4/K8V8/Planar) the decode_fp16 buffers
     /// are the warm-TTFT seed; the quantised storage's
     /// `shape[2]` is also lowered to `n` via `storage.truncate_to`.
-    pub fn truncate_to(&mut self, n: i32) {
+    ///
+    /// Fails when the cache cannot reach `n` without losing a position it
+    /// would still have to serve — an SWA ring left in rotated order past its
+    /// wrap. [`Self::can_truncate_to`] is the predicate, and a caller that has
+    /// another way to reach the state (re-prefill) should ask it first.
+    pub fn truncate_to(&mut self, n: i32) -> Result<()> {
         debug_assert!(
             n <= self.offset,
             "KvCache::truncate_to: n={n} > offset={}",
@@ -4024,19 +4029,18 @@ impl KvCache {
             );
             shadow.truncate_to(n);
         }
-        // Port mlx-lm `RotatingKVCache.trim` semantics (cache.py:542-549).
-        // mlx-lm's `trim_prompt_cache(cache, num)` decrements offset/idx
-        // losslessly when `is_trimmable` (offset < max_size); otherwise
-        // silently returns 0 (cache.py:109-111). Speculative decoding
-        // tolerates this — the Gemma 31b spec test in mlx-lm relies on it.
         if let Some(ref mut rot) = self.rotating {
             let delta = self.offset - n;
-            let _trimmed = rot.trim_lossless(delta);
-            // Mirror rot's offset back onto KvCache.offset. If `trimmed == 0`
-            // (post-rotation), `rot.offset` is unchanged and KvCache.offset
-            // must stay where it was — matches mlx-lm's no-op behaviour.
+            if !rot.roll_back(delta)? {
+                return Err(Error::Mlx(format!(
+                    "KvCache::truncate_to: layer {} is a sliding-window ring that has \
+                     wrapped and is not in temporal order, so rolling it back {delta} \
+                     positions from {} would drop keys it still has to serve",
+                    self.layer_idx, self.offset,
+                )));
+            }
             self.offset = rot.offset;
-            return;
+            return Ok(());
         }
         self.storage.truncate_to(n);
         self.offset = n;
@@ -4047,6 +4051,7 @@ impl KvCache {
         if self.flash_filled > n {
             self.flash_filled = n;
         }
+        Ok(())
     }
 
     /// Force evaluation of any pending MLX lazy operations in the KV buffers.

--- a/crates/rmlx-kv-quant/src/rotating.rs
+++ b/crates/rmlx-kv-quant/src/rotating.rs
@@ -74,7 +74,7 @@ pub(super) struct RotatingState {
 /// The first `keep` positions of a `[B, kv_h, S, D]` ring buffer.
 #[allow(
     clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+    reason = "the ndim check above establishes four axes, so shape[0..4] are in bounds"
 )]
 fn slice_leading(v: &Array, keep: i32, device: Device) -> Result<Array> {
     let shape = v.shape();
@@ -153,14 +153,17 @@ impl RotatingState {
     ///   so dropping the last `n` of them is lossless exactly while what is left
     ///   still covers the window the rolled-back offset needs. A block-verify
     ///   write of `s` positions can therefore always be rolled back over its own
-    ///   rejected tail, which is at most `s - 1` long.
+    ///   rejected tail, which is at most `s - 1` long. Rolling the whole block
+    ///   back is one position too far and is refused — a caller that needs it
+    ///   (a recurrent round loop replaying from its pre-round offset) has no
+    ///   route through here.
     ///
     /// A ring left in rotated order by a single-token write
     /// (`update_in_place` past the wrap) is **not** rollable: the newest slots
     /// hold the positions they overwrote, and those are gone.
     #[allow(
         clippy::indexing_slicing,
-        reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+        reason = "the ring's K/V are always [B, kv_h, S, D], so the sequence axis is shape[2]"
     )]
     pub(super) fn can_trim(&self, n: i32) -> bool {
         if n <= 0 {
@@ -199,9 +202,16 @@ impl RotatingState {
             return Ok(true);
         }
         if self.offset >= self.max_size {
-            let Some(device) = self.stream else {
-                return Ok(false);
-            };
+            // `can_trim` admits this branch only with a stream recorded, so a
+            // missing one is a broken invariant and says so — reporting it as a
+            // refusal would blame the ring's order for a bookkeeping fault.
+            let device = self.stream.ok_or_else(|| {
+                Error::Mlx(
+                    "RotatingKvCache::roll_back: a post-wrap rollback was admitted with no \
+                     recorded stream to slice the ring on"
+                        .to_owned(),
+                )
+            })?;
             // Temporal order: the newest `n` positions are the last `n` slots.
             let keep = self.idx - n;
             self.keys = match &self.keys {

--- a/crates/rmlx-kv-quant/src/rotating.rs
+++ b/crates/rmlx-kv-quant/src/rotating.rs
@@ -52,6 +52,7 @@ pub(super) struct RotatingSnapshot {
     pub(super) max_size: i32,
     pub(super) keep: i32,
     pub(super) idx: i32,
+    pub(super) stream: Option<Device>,
 }
 
 /// Internal state for a rotating bf16 KV cache.
@@ -63,6 +64,32 @@ pub(super) struct RotatingState {
     pub(super) max_size: i32,
     pub(super) keep: i32,
     pub(super) idx: i32,
+    /// The stream the buffers above were last written on. A rollback slices
+    /// them and runs on the same one, which is why the ring records it instead
+    /// of every `truncate_to` caller carrying a device it otherwise never uses.
+    /// `None` until the first write, when there is nothing to slice.
+    pub(super) stream: Option<Device>,
+}
+
+/// The first `keep` positions of a `[B, kv_h, S, D]` ring buffer.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+)]
+fn slice_leading(v: &Array, keep: i32, device: Device) -> Result<Array> {
+    let shape = v.shape();
+    if shape.len() != 4 {
+        return Err(Error::Mlx(format!(
+            "RotatingKvCache::slice_leading expected 4-D tensor, got ndim={}",
+            shape.len()
+        )));
+    }
+    v.slice(
+        &[0, 0, 0, 0],
+        &[shape[0], shape[1], keep, shape[3]],
+        &[1i32; 4],
+        device,
+    )
 }
 
 impl RotatingState {
@@ -85,6 +112,7 @@ impl RotatingState {
             max_size: _,
             keep: _,
             idx: _,
+            stream: _,
         } = self;
         crate::bytes::opt_filled_seq_bytes(keys.as_ref(), filled)
             + crate::bytes::opt_filled_seq_bytes(values.as_ref(), filled)
@@ -98,6 +126,7 @@ impl RotatingState {
             max_size,
             keep: 0,
             idx: 0,
+            stream: None,
         }
     }
 
@@ -106,27 +135,89 @@ impl RotatingState {
         self.values = None;
         self.offset = 0;
         self.idx = 0;
+        self.stream = None;
     }
 
-    /// Lossless rollback by `n` positions, mirroring mlx-lm
-    /// `RotatingKVCache.is_trimmable` + `trim` (`cache.py:542-549`).
+    /// Whether [`Self::trim`] can roll this ring back by `n` positions without
+    /// losing a position the window would still need.
     ///
-    /// Returns the number of positions actually rolled back. mlx-lm's
-    /// `is_trimmable` is `self.offset < self.max_size` — the ring buffer is
-    /// rollable iff it has not yet wrapped. After a wrap, the original
-    /// pre-wrap K/V have been overwritten; mlx-lm's `trim_prompt_cache`
-    /// silently returns 0 in that case (`cache.py:109-111`). This port
-    /// matches that exact behaviour: returns 0 (no-op) when not trimmable.
-    pub(super) fn trim_lossless(&mut self, n: i32) -> i32 {
-        if self.offset >= self.max_size {
-            // Not trimmable — see mlx-lm `is_trimmable`. Caller treats this
-            // as `trim_prompt_cache returned 0`.
-            return 0;
+    /// Two regimes are rollable, and they are the two the ring can be left in:
+    ///
+    /// - **Before the first wrap** (`offset < max_size`), every position ever
+    ///   written is still in the buffer at its own slot, so any rollback is a
+    ///   move of the write pointer. This is mlx-lm's `is_trimmable`
+    ///   (`cache.py:542-543`).
+    /// - **After a wrap, while the buffer is in temporal order** — which is the
+    ///   state [`Self::update_concat`] leaves it in, holding `max_size + s - 1`
+    ///   positions for a write of `s`. Those are the newest positions in order,
+    ///   so dropping the last `n` of them is lossless exactly while what is left
+    ///   still covers the window the rolled-back offset needs. A block-verify
+    ///   write of `s` positions can therefore always be rolled back over its own
+    ///   rejected tail, which is at most `s - 1` long.
+    ///
+    /// A ring left in rotated order by a single-token write
+    /// (`update_in_place` past the wrap) is **not** rollable: the newest slots
+    /// hold the positions they overwrote, and those are gone.
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
+    )]
+    pub(super) fn can_trim(&self, n: i32) -> bool {
+        if n <= 0 {
+            return true;
         }
-        let n = n.min(self.offset);
+        if n > self.offset {
+            return false;
+        }
+        if self.offset < self.max_size {
+            return true;
+        }
+        let (Some(keys), Some(_)) = (self.keys.as_ref(), self.stream) else {
+            return false;
+        };
+        let len = keys.shape()[2];
+        self.idx == len && len - n >= (self.offset - n).min(self.max_size)
+    }
+
+    /// Roll the ring back by `n` positions. Returns `false` and leaves the ring
+    /// untouched when that cannot be done losslessly — see [`Self::can_trim`].
+    ///
+    /// Not to be confused with [`Self::trim`], the mlx-lm `_trim` port that
+    /// drops the ring's *oldest* positions to make room for a write.
+    ///
+    /// mlx-lm's `trim_prompt_cache` silently returns 0 for the case this
+    /// refuses (`cache.py:109-111`). A silent no-op is safe for its caller,
+    /// which re-prefills what it could not roll back; it is not safe for a
+    /// speculative round loop, where the other layers do roll back and the ring
+    /// is left holding the rejected drafts at an offset the rest of the stack
+    /// has left behind.
+    pub(super) fn roll_back(&mut self, n: i32) -> Result<bool> {
+        if !self.can_trim(n) {
+            return Ok(false);
+        }
+        if n <= 0 {
+            return Ok(true);
+        }
+        if self.offset >= self.max_size {
+            let Some(device) = self.stream else {
+                return Ok(false);
+            };
+            // Temporal order: the newest `n` positions are the last `n` slots.
+            let keep = self.idx - n;
+            self.keys = match &self.keys {
+                Some(k) => Some(slice_leading(k, keep, device)?),
+                None => None,
+            };
+            self.values = match &self.values {
+                Some(v) => Some(slice_leading(v, keep, device)?),
+                None => None,
+            };
+            self.idx = keep;
+        } else {
+            self.idx -= n;
+        }
         self.offset -= n;
-        self.idx -= n;
-        n
+        Ok(true)
     }
 
     /// Deep (refcount) clone of the ring.
@@ -171,6 +262,7 @@ impl RotatingState {
             max_size: self.max_size,
             keep: self.keep,
             idx: self.idx,
+            stream: self.stream,
         })
     }
 
@@ -194,6 +286,7 @@ impl RotatingState {
         self.max_size = snap.max_size;
         self.keep = snap.keep;
         self.idx = snap.idx;
+        self.stream = snap.stream;
         Ok(())
     }
 
@@ -208,6 +301,7 @@ impl RotatingState {
         new_v: &Array,
         device: Device,
     ) -> Result<(Array, Array)> {
+        self.stream = Some(device);
         let s = new_k.shape()[2];
         if s == 1 {
             self.update_in_place(new_k, new_v, device)

--- a/crates/rmlx-kv-quant/src/rotating_tests.rs
+++ b/crates/rmlx-kv-quant/src/rotating_tests.rs
@@ -167,9 +167,13 @@ fn snapshot_restore_multitoken_tail_wrapped() {
 /// without dropping the rejected keys reads the same offset and the wrong keys.
 ///
 /// The last case is the boundary: a rollback of the *whole* block would leave
-/// the ring one position short of its window, and is refused. A round loop never
-/// asks for it — the bonus token is always kept — so the guarantee it needs is
-/// exactly "any tail up to `block - 1`".
+/// the ring one position short of its window, and is refused. The assistant
+/// round loop never asks for it — the bonus token is always kept — so the
+/// guarantee it needs is exactly "any tail up to `block - 1`". A **recurrent**
+/// round loop does ask for the whole block, because it replays from the
+/// pre-round offset its state snapshot was taken at, and would be refused here;
+/// no architecture wired today pairs recurrent state with a windowed KV layer,
+/// and `rollback_round_caches` is where the first one that does will say so.
 #[test]
 #[allow(
     clippy::unwrap_used,
@@ -212,6 +216,62 @@ fn a_wrapped_ring_rolls_a_rejected_block_tail_back_off() {
         assert_eq!(
             tail, want,
             "kept={kept}: the rolled-back ring must hold the window ending at its offset"
+        );
+
+        // And the ring is still writable, on both paths that write it. A
+        // post-wrap rollback leaves a sliced view behind; a decode step reaches
+        // that view through `slice_update`, which no-ops silently when its
+        // bounds are wrong, and the next block write reaches it through
+        // `temporal_order` / `trim`. Reading the buffer straight after the
+        // rollback exercises neither.
+        let before_decode = st.offset;
+        let (k1, _v1) = st
+            .update_and_fetch(
+                &kv(1, before_decode as f32),
+                &kv(1, 100.0 + before_decode as f32),
+                device,
+            )
+            .unwrap();
+        assert_eq!(
+            st.offset,
+            before_decode + 1,
+            "kept={kept}: offset after a decode step"
+        );
+        // Past the wrap a decode step writes in place, so the window is present
+        // but not in order — which positions the ring holds is the assertion.
+        let mut held: Vec<f32> = host(&k1).chunks_exact(2).map(|c| c[0]).collect();
+        held.sort_by(f32::total_cmp);
+        let live = max_size.min(st.offset);
+        let want_held: Vec<f32> = ((st.offset - live)..st.offset).map(|p| p as f32).collect();
+        assert_eq!(
+            held, want_held,
+            "kept={kept}: a decode step into a rolled-back ring must leave it holding \
+             the window ending at the new offset"
+        );
+
+        let before_block = st.offset;
+        let (k2, _v2) = st
+            .update_and_fetch(
+                &kv(2, before_block as f32),
+                &kv(2, 100.0 + before_block as f32),
+                device,
+            )
+            .unwrap();
+        assert_eq!(
+            st.offset,
+            before_block + 2,
+            "kept={kept}: offset after a block write"
+        );
+        let after = host(&k2);
+        let live = max_size.min(st.offset);
+        let want_after: Vec<f32> = ((st.offset - live)..st.offset)
+            .flat_map(|p| [p as f32, p as f32 + 0.5])
+            .collect();
+        assert_eq!(
+            &after[after.len() - (live as usize) * 2..],
+            want_after.as_slice(),
+            "kept={kept}: a block write into a rolled-back ring must continue the window \
+             it kept"
         );
     }
 
@@ -297,15 +357,26 @@ fn an_unwrapped_ring_rolls_back_to_any_prefix() {
     );
 }
 
-/// `can_trim` is the predicate `roll_back` implements, at every rollback depth a
-/// ring in either regime can be asked for. A predicate that drifted from the
-/// operation is worse than none: the callers gate on it.
+/// What `can_trim` promises is what `roll_back` leaves, at every rollback depth
+/// a ring in either regime can be asked for. The callers gate on the predicate,
+/// so a predicate that drifted from the operation is worse than none.
+///
+/// Asserting only that the two *agree* would be a tautology — `roll_back`'s
+/// first statement consults `can_trim`, so no mutation short of deleting that
+/// line could fail it. Each depth therefore asserts the ring's resulting state:
+/// a rollback that happened holds the window ending at its new offset, one that
+/// was refused left the ring byte-identical, and a rollback of nothing is a
+/// no-op whichever regime the ring is in.
 #[test]
 #[allow(
     clippy::unwrap_used,
     reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
 )]
-fn can_trim_and_roll_back_agree_at_every_depth() {
+#[allow(
+    clippy::indexing_slicing,
+    reason = "the window slice is bounded by the buffer length it is taken from"
+)]
+fn what_can_trim_promises_is_what_roll_back_leaves() {
     let device = Device::Cpu;
     for rotated in [false, true] {
         for depth in 0..10i32 {
@@ -319,12 +390,37 @@ fn can_trim_and_roll_back_agree_at_every_depth() {
                 st.update_and_fetch(&kv(4, 6.0), &kv(4, 106.0), device)
                     .unwrap();
             }
+            let before = (st.offset, st.idx, host(st.keys.as_ref().unwrap()));
             let predicted = st.can_trim(depth);
             let done = st.roll_back(depth).unwrap();
             assert_eq!(
                 predicted, done,
                 "rotated={rotated} depth={depth}: can_trim promised {predicted} and \
                  roll_back did {done}"
+            );
+            let now = (st.offset, st.idx, host(st.keys.as_ref().unwrap()));
+            if !done || depth == 0 {
+                assert_eq!(
+                    now, before,
+                    "rotated={rotated} depth={depth}: a refused or empty rollback must \
+                     leave the ring exactly as it was"
+                );
+                continue;
+            }
+            assert_eq!(
+                st.offset,
+                before.0 - depth,
+                "rotated={rotated} depth={depth}: rolled-back offset"
+            );
+            let window = st.max_size.min(st.offset) as usize;
+            let want: Vec<f32> = (st.offset - window as i32..st.offset)
+                .flat_map(|p| [p as f32, p as f32 + 0.5])
+                .collect();
+            assert_eq!(
+                &now.2[now.2.len() - window * 2..],
+                want.as_slice(),
+                "rotated={rotated} depth={depth}: the ring must hold the window ending \
+                 at the offset it rolled back to"
             );
         }
     }

--- a/crates/rmlx-kv-quant/src/rotating_tests.rs
+++ b/crates/rmlx-kv-quant/src/rotating_tests.rs
@@ -157,3 +157,175 @@ fn snapshot_restore_multitoken_tail_wrapped() {
     assert_eq!(b.offset, a.offset);
     assert_eq!(b.idx, a.idx);
 }
+
+/// A block write leaves the ring holding its window plus the block, and rolling
+/// the rejected tail back off it leaves the window the shorter block would have
+/// left — which is what a speculative round's partial acceptance needs.
+///
+/// The keys carry their own absolute position (`kv` writes `p, p+0.5`), so this
+/// fails on content as well as on bookkeeping: a rollback that moved `offset`
+/// without dropping the rejected keys reads the same offset and the wrong keys.
+///
+/// The last case is the boundary: a rollback of the *whole* block would leave
+/// the ring one position short of its window, and is refused. A round loop never
+/// asks for it — the bonus token is always kept — so the guarantee it needs is
+/// exactly "any tail up to `block - 1`".
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn a_wrapped_ring_rolls_a_rejected_block_tail_back_off() {
+    let device = Device::Cpu;
+    let max_size = 4;
+    let block = 4i32;
+    let prompt = 6i32;
+
+    for kept in 1..=block {
+        let mut st = RotatingState::new(max_size);
+        st.update_and_fetch(&kv(prompt, 0.0), &kv(prompt, 100.0), device)
+            .unwrap();
+        st.update_and_fetch(
+            &kv(block, prompt as f32),
+            &kv(block, 100.0 + prompt as f32),
+            device,
+        )
+        .unwrap();
+        assert!(
+            st.offset >= st.max_size,
+            "the ring must be wrapped or this proves nothing"
+        );
+        assert!(
+            st.roll_back(block - kept).unwrap(),
+            "kept={kept}: a ring a block write left in temporal order must roll back"
+        );
+        assert_eq!(st.offset, prompt + kept, "kept={kept}: rolled-back offset");
+
+        // The window the rolled-back offset needs, read off the tail of the
+        // buffer, is the run of absolute positions ending at that offset.
+        let keys = host(st.keys.as_ref().unwrap());
+        let window = max_size.min(st.offset) as usize;
+        let tail = &keys[keys.len() - window * 2..];
+        let want: Vec<f32> = (st.offset - window as i32..st.offset)
+            .flat_map(|p| [p as f32, p as f32 + 0.5])
+            .collect();
+        assert_eq!(
+            tail, want,
+            "kept={kept}: the rolled-back ring must hold the window ending at its offset"
+        );
+    }
+
+    let mut whole = RotatingState::new(max_size);
+    whole
+        .update_and_fetch(&kv(prompt, 0.0), &kv(prompt, 100.0), device)
+        .unwrap();
+    whole
+        .update_and_fetch(
+            &kv(block, prompt as f32),
+            &kv(block, 100.0 + prompt as f32),
+            device,
+        )
+        .unwrap();
+    assert!(
+        !whole.can_trim(block),
+        "rolling the whole block back would leave the ring inside its own window"
+    );
+}
+
+/// The refusal side. A ring past its wrap that a single-token write left in
+/// rotated order cannot give a position back: the newest slots hold what they
+/// overwrote. `can_trim` says so and `roll_back` leaves the ring untouched.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn a_rotated_ring_refuses_a_rollback_instead_of_losing_keys() {
+    let device = Device::Cpu;
+    let mut st = RotatingState::new(4);
+    st.update_and_fetch(&kv(6, 0.0), &kv(6, 100.0), device)
+        .unwrap();
+    for step in 0..3 {
+        let p = (6 + step) as f32;
+        st.update_and_fetch(&kv(1, p), &kv(1, 100.0 + p), device)
+            .unwrap();
+    }
+    assert!(st.offset >= st.max_size, "the ring must be wrapped");
+    assert!(st.idx < st.keys.as_ref().unwrap().shape()[2], "and rotated");
+
+    let before = (st.offset, st.idx, host(st.keys.as_ref().unwrap()));
+    assert!(
+        !st.can_trim(1),
+        "a rotated ring cannot give a position back"
+    );
+    assert!(
+        !st.roll_back(1).unwrap(),
+        "and roll_back must say so rather than moving the offset"
+    );
+    assert_eq!(
+        (st.offset, st.idx, host(st.keys.as_ref().unwrap())),
+        before,
+        "a refused rollback leaves the ring exactly as it was"
+    );
+}
+
+/// Before the first wrap every position is still at its own slot, so any
+/// rollback is a move of the write pointer — and the ring reads back as the
+/// shorter prefix.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn an_unwrapped_ring_rolls_back_to_any_prefix() {
+    let device = Device::Cpu;
+    let mut st = RotatingState::new(64);
+    st.update_and_fetch(&kv(6, 0.0), &kv(6, 100.0), device)
+        .unwrap();
+    assert!(st.can_trim(4));
+    assert!(st.roll_back(4).unwrap());
+    assert_eq!(st.offset, 2);
+    assert_eq!(st.idx, 2);
+
+    let (k, _v) = st
+        .update_and_fetch(&kv(1, 2.0), &kv(1, 102.0), device)
+        .unwrap();
+    assert_eq!(
+        host(&k),
+        vec![0.0, 0.5, 1.0, 1.5, 2.0, 2.5],
+        "the rolled-back ring continues from the prefix it kept"
+    );
+}
+
+/// `can_trim` is the predicate `roll_back` implements, at every rollback depth a
+/// ring in either regime can be asked for. A predicate that drifted from the
+/// operation is worse than none: the callers gate on it.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn can_trim_and_roll_back_agree_at_every_depth() {
+    let device = Device::Cpu;
+    for rotated in [false, true] {
+        for depth in 0..10i32 {
+            let mut st = RotatingState::new(4);
+            st.update_and_fetch(&kv(6, 0.0), &kv(6, 100.0), device)
+                .unwrap();
+            if rotated {
+                st.update_and_fetch(&kv(1, 6.0), &kv(1, 106.0), device)
+                    .unwrap();
+            } else {
+                st.update_and_fetch(&kv(4, 6.0), &kv(4, 106.0), device)
+                    .unwrap();
+            }
+            let predicted = st.can_trim(depth);
+            let done = st.roll_back(depth).unwrap();
+            assert_eq!(
+                predicted, done,
+                "rotated={rotated} depth={depth}: can_trim promised {predicted} and \
+                 roll_back did {done}"
+            );
+        }
+    }
+}

--- a/crates/rmlx-kv-ssd/src/block_io_tests.rs
+++ b/crates/rmlx-kv-ssd/src/block_io_tests.rs
@@ -4309,7 +4309,8 @@ fn iso_sym_truncate_keeps_ring_tail() {
 
     // Truncate into the ring-only tail and confirm dequant still rebuilds it.
     let keep = prefill + steps - 3;
-    c.truncate_to(keep);
+    c.truncate_to(keep)
+        .expect("a full-attention store rolls back to any prefix");
     let (_k2, v_after, seq_after, _, _) = iso_sym3_probe(&c);
     assert_eq!(seq_after, keep, "shape[2] lowered to the truncation point");
     assert_eq!(
@@ -4397,7 +4398,8 @@ fn rotor_sym_truncate_keeps_ring_tail() {
     // Truncate into the ring-only tail (below the last CPU block, inside the
     // ring-held region) and confirm dequant still rebuilds the kept prefix.
     let keep = prefill + steps - 3;
-    c.truncate_to(keep);
+    c.truncate_to(keep)
+        .expect("a full-attention store rolls back to any prefix");
     let (_k2, v_after, seq_after, _, _) = rotor_sym3_probe(&c);
     assert_eq!(seq_after, keep, "shape[2] lowered to the truncation point");
     assert_eq!(

--- a/crates/rmlx-kv-ssd/src/hydrate_truncate_tests.rs
+++ b/crates/rmlx-kv-ssd/src/hydrate_truncate_tests.rs
@@ -61,6 +61,10 @@ fn build_kvcache_quant(quant: KvQuant, kv_h: i32, seq: i32, seed: u64) -> KvCach
     clippy::unwrap_used,
     reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
 )]
+#[allow(
+    clippy::expect_used,
+    reason = "test assertion: an unreachable rollback failure is the defect the test reports"
+)]
 fn a_prefilled_cache_has_no_block_list_to_cut() {
     let device = Device::Cpu;
     let shape = [1i32, 2, 64, 128];
@@ -84,7 +88,8 @@ fn a_prefilled_cache_has_no_block_list_to_cut() {
              cut this file exercises has nothing to act on"
         );
 
-        c.truncate_to(16);
+        c.truncate_to(16)
+            .expect("a full-attention store rolls back to any prefix");
         assert_eq!(c.offset(), 16, "{quant:?}: truncate moves the cache offset");
         assert_eq!(
             c.storage().resident_bytes(),
@@ -202,7 +207,9 @@ fn hydrated_truncate_keeps_prefix_and_correction(quant: KvQuant, kv_h: i32) {
         "{label}: full V decode length"
     );
 
-    cache.truncate_to(keep);
+    cache
+        .truncate_to(keep)
+        .expect("a full-attention store rolls back to any prefix");
 
     // The correction: distinct raw f32 from its own LCG stream.
     let corr_shape = [1_i32, kv_h, corr, head_dim];

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -524,11 +524,17 @@ impl Architecture {
         }
     }
 
-    /// Re-derive logits from a pre-final-norm hidden state.
+    /// Re-derive logits from a **pre-final-norm** hidden state: `final_norm`
+    /// then the LM head.
     ///
     /// Inverse of the tail dropped by [`Architecture::forward_hidden_states`].
-    /// Routes to `Gemma4Text::logits_from_hidden`; other architectures return
-    /// `Error::Model`. `hidden`: `[1, n, hidden]` -> `[1, n, vocab]`.
+    /// Every architecture that implements it applies the norm — a caller
+    /// holding an already-normed hidden wants
+    /// [`Architecture::logits_from_final_hidden`] instead. The two contracts
+    /// used to share this one name, and the arch that did not norm quietly
+    /// reweighted the vocabulary by the norm's own weight vector for every
+    /// caller that handed it a raw capture.
+    /// `hidden`: `[1, n, hidden]` -> `[1, n, vocab]`.
     #[allow(
         clippy::unreachable,
         reason = "Architecture::Gemma4 and Qwen3_5Moe arms are handled by the outer match; \
@@ -554,7 +560,46 @@ impl Architecture {
                     Architecture::BitNet(_) => "BitNet",
                 };
                 Err(Error::Model(format!(
-                    "logits_from_hidden not yet wired for {arch} (Gemma4 only)"
+                    "logits_from_hidden not yet wired for {arch} (Gemma4 and \
+                     Qwen3.5-MoE only)"
+                )))
+            }
+        }
+    }
+
+    /// Logits from a hidden state the caller has **already final-normed**.
+    ///
+    /// The counterpart of [`Architecture::logits_from_hidden`]: LM head (and
+    /// the architecture's logit softcap) with no norm. A verify pass that
+    /// captured after the final norm — or a drafter with a final norm of its
+    /// own — holds this shape.
+    #[allow(
+        clippy::unreachable,
+        reason = "Architecture::Gemma4 and Qwen3_5Moe arms are handled by the outer match; \
+                  the inner arms are structurally unreachable -- required to exhaust the enum \
+                  for the arch-name string table"
+    )]
+    #[allow(
+        clippy::wildcard_enum_match_arm,
+        reason = "wildcard arm is the correct fallthrough for unsupported arch/quant variants; exhaustive expansion would require updating on every new variant"
+    )]
+    pub fn logits_from_final_hidden(&self, hidden: &Array, device: Device) -> Result<Array> {
+        match self {
+            Architecture::Gemma4(m) => m.logits_from_final_hidden(hidden, device),
+            Architecture::Qwen3_5Moe(m) => m.logits_from_final_hidden(hidden, device),
+            other => {
+                let arch = match other {
+                    Architecture::Gemma4(_) | Architecture::Qwen3_5Moe(_) => unreachable!(),
+                    Architecture::Gemma3(_) => "Gemma3",
+                    Architecture::Qwen2(_) => "Qwen2",
+                    Architecture::Qwen3(_) => "Qwen3",
+                    Architecture::Laguna(_) => "Laguna",
+                    Architecture::Qwen3VlMoe(_) => "Qwen3VlMoe",
+                    Architecture::BitNet(_) => "BitNet",
+                };
+                Err(Error::Model(format!(
+                    "logits_from_final_hidden not yet wired for {arch} (Gemma4 and \
+                     Qwen3.5-MoE only)"
                 )))
             }
         }

--- a/crates/rmlx-models/src/arch/mod.rs
+++ b/crates/rmlx-models/src/arch/mod.rs
@@ -509,8 +509,14 @@ impl Architecture {
         }
     }
 
-    /// Apply the verifier's final RMSNorm to a pre-final-norm hidden (MTP
-    /// drafter conditioning -- `speculative_draft_hidden`). Gemma4 only.
+    /// Apply the architecture's final RMSNorm to a pre-final-norm hidden (MTP
+    /// drafter conditioning -- `speculative_draft_hidden`).
+    ///
+    /// This is the only place the norm is applied on this path:
+    /// [`Architecture::logits_from_hidden`] composes it with the head, so an
+    /// architecture supplies the norm and the head and never its own spelling of
+    /// the pair. One that supplies the head alone fails here rather than scoring
+    /// an un-normed hidden through it.
     #[allow(
         clippy::wildcard_enum_match_arm,
         reason = "wildcard arm is the correct fallthrough for unsupported arch/quant variants; exhaustive expansion would require updating on every new variant"
@@ -518,9 +524,11 @@ impl Architecture {
     pub fn apply_final_norm(&self, hidden: &Array, device: Device) -> Result<Array> {
         match self {
             Architecture::Gemma4(m) => m.apply_final_norm(hidden, device),
-            _ => Err(Error::Model(
-                "apply_final_norm: Gemma4 only (assistant MTP)".into(),
-            )),
+            Architecture::Qwen3_5Moe(m) => m.apply_final_norm(hidden, device),
+            other => Err(Error::Model(format!(
+                "apply_final_norm not yet wired for {}",
+                other.arch_class()
+            ))),
         }
     }
 
@@ -528,43 +536,18 @@ impl Architecture {
     /// then the LM head.
     ///
     /// Inverse of the tail dropped by [`Architecture::forward_hidden_states`].
-    /// Every architecture that implements it applies the norm — a caller
-    /// holding an already-normed hidden wants
+    /// A caller holding an already-normed hidden wants
     /// [`Architecture::logits_from_final_hidden`] instead. The two contracts
-    /// used to share this one name, and the arch that did not norm quietly
-    /// reweighted the vocabulary by the norm's own weight vector for every
-    /// caller that handed it a raw capture.
+    /// used to share this one name, and the architecture that supplied the head
+    /// alone quietly reweighted the vocabulary by the norm's own weight vector
+    /// for every caller that handed it a raw capture.
+    ///
+    /// Composed here rather than per architecture, so there is one place the
+    /// norm and the head meet and no second implementation to agree with.
     /// `hidden`: `[1, n, hidden]` -> `[1, n, vocab]`.
-    #[allow(
-        clippy::unreachable,
-        reason = "Architecture::Gemma4 and Qwen3_5Moe arms are handled by the outer match; \
-                  the inner arms are structurally unreachable -- required to exhaust the enum \
-                  for the arch-name string table"
-    )]
-    #[allow(
-        clippy::wildcard_enum_match_arm,
-        reason = "wildcard arm is the correct fallthrough for unsupported arch/quant variants; exhaustive expansion would require updating on every new variant"
-    )]
     pub fn logits_from_hidden(&self, hidden: &Array, device: Device) -> Result<Array> {
-        match self {
-            Architecture::Gemma4(m) => m.logits_from_hidden(hidden, device),
-            Architecture::Qwen3_5Moe(m) => m.logits_from_hidden(hidden, device),
-            other => {
-                let arch = match other {
-                    Architecture::Gemma4(_) | Architecture::Qwen3_5Moe(_) => unreachable!(),
-                    Architecture::Gemma3(_) => "Gemma3",
-                    Architecture::Qwen2(_) => "Qwen2",
-                    Architecture::Qwen3(_) => "Qwen3",
-                    Architecture::Laguna(_) => "Laguna",
-                    Architecture::Qwen3VlMoe(_) => "Qwen3VlMoe",
-                    Architecture::BitNet(_) => "BitNet",
-                };
-                Err(Error::Model(format!(
-                    "logits_from_hidden not yet wired for {arch} (Gemma4 and \
-                     Qwen3.5-MoE only)"
-                )))
-            }
-        }
+        let normed = self.apply_final_norm(hidden, device)?;
+        self.logits_from_final_hidden(&normed, device)
     }
 
     /// Logits from a hidden state the caller has **already final-normed**.
@@ -574,12 +557,6 @@ impl Architecture {
     /// captured after the final norm — or a drafter with a final norm of its
     /// own — holds this shape.
     #[allow(
-        clippy::unreachable,
-        reason = "Architecture::Gemma4 and Qwen3_5Moe arms are handled by the outer match; \
-                  the inner arms are structurally unreachable -- required to exhaust the enum \
-                  for the arch-name string table"
-    )]
-    #[allow(
         clippy::wildcard_enum_match_arm,
         reason = "wildcard arm is the correct fallthrough for unsupported arch/quant variants; exhaustive expansion would require updating on every new variant"
     )]
@@ -587,21 +564,10 @@ impl Architecture {
         match self {
             Architecture::Gemma4(m) => m.logits_from_final_hidden(hidden, device),
             Architecture::Qwen3_5Moe(m) => m.logits_from_final_hidden(hidden, device),
-            other => {
-                let arch = match other {
-                    Architecture::Gemma4(_) | Architecture::Qwen3_5Moe(_) => unreachable!(),
-                    Architecture::Gemma3(_) => "Gemma3",
-                    Architecture::Qwen2(_) => "Qwen2",
-                    Architecture::Qwen3(_) => "Qwen3",
-                    Architecture::Laguna(_) => "Laguna",
-                    Architecture::Qwen3VlMoe(_) => "Qwen3VlMoe",
-                    Architecture::BitNet(_) => "BitNet",
-                };
-                Err(Error::Model(format!(
-                    "logits_from_final_hidden not yet wired for {arch} (Gemma4 and \
-                     Qwen3.5-MoE only)"
-                )))
-            }
+            other => Err(Error::Model(format!(
+                "logits_from_final_hidden not yet wired for {}",
+                other.arch_class()
+            ))),
         }
     }
 

--- a/crates/rmlx-models/src/gemma4/model.rs
+++ b/crates/rmlx-models/src/gemma4/model.rs
@@ -990,7 +990,17 @@ impl Gemma4Text {
     /// returns `[1, n, vocab]`.
     pub fn logits_from_hidden(&self, hidden: &Array, device: Device) -> Result<Array> {
         let h = self.final_norm.forward(hidden, device)?;
-        let logits = self.embed_tokens.as_linear(&h, device)?;
+        self.logits_from_final_hidden(&h, device)
+    }
+
+    /// The same, from a hidden state the caller has already final-normed.
+    ///
+    /// The two entry points exist because a speculative loop holds one or the
+    /// other depending on where in the verify pass it captured: naming which is
+    /// which is what keeps a missing — or doubled — `final_norm` from becoming a
+    /// silent reweighting of the vocabulary.
+    pub fn logits_from_final_hidden(&self, hidden: &Array, device: Device) -> Result<Array> {
+        let logits = self.embed_tokens.as_linear(hidden, device)?;
         apply_softcap(&logits, self.cfg.final_logit_softcapping, device)
     }
 

--- a/crates/rmlx-models/src/gemma4/model.rs
+++ b/crates/rmlx-models/src/gemma4/model.rs
@@ -980,25 +980,18 @@ impl Gemma4Text {
         multiply(&e, &scale, device)
     }
 
-    /// Re-derive logits from a pre-final-norm hidden state.
+    /// Re-derive logits from a hidden state the caller has already
+    /// final-normed: tied LM head (`embed_tokens.as_linear`) → final-logit
+    /// softcap. `hidden`: `[1, n, hidden]`, returns `[1, n, vocab]`.
     ///
-    /// Inverse of the tail dropped by [`forward_hidden_states`]: applies
-    /// `final_norm` → tied LM head (`embed_tokens.as_linear`) → final-logit
-    /// softcap. Mirrors mlx-vlm `speculative_logits_from_hidden`, used by the
-    /// MTP deferred-greedy acceptance walk to score draft positions against the
-    /// verifier without re-running the trunk. `hidden`: `[1, n, hidden]`,
-    /// returns `[1, n, vocab]`.
-    pub fn logits_from_hidden(&self, hidden: &Array, device: Device) -> Result<Array> {
-        let h = self.final_norm.forward(hidden, device)?;
-        self.logits_from_final_hidden(&h, device)
-    }
-
-    /// The same, from a hidden state the caller has already final-normed.
-    ///
-    /// The two entry points exist because a speculative loop holds one or the
-    /// other depending on where in the verify pass it captured: naming which is
-    /// which is what keeps a missing — or doubled — `final_norm` from becoming a
-    /// silent reweighting of the vocabulary.
+    /// The norm is not applied here and must not be. With
+    /// [`Gemma4Text::apply_final_norm`] it composes into
+    /// [`Architecture::logits_from_hidden`], the mlx-vlm
+    /// `speculative_logits_from_hidden` the MTP deferred-greedy acceptance walk
+    /// uses to score draft positions against the verifier without re-running the
+    /// trunk. Naming which entry point holds which shape keeps a missing — or
+    /// doubled — `final_norm` from becoming a silent reweighting of the
+    /// vocabulary.
     pub fn logits_from_final_hidden(&self, hidden: &Array, device: Device) -> Result<Array> {
         let logits = self.embed_tokens.as_linear(hidden, device)?;
         apply_softcap(&logits, self.cfg.final_logit_softcapping, device)

--- a/crates/rmlx-models/src/gemma4/prompt_cache.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache.rs
@@ -74,19 +74,21 @@ impl Gemma4Entry {
     /// lossless on EVERY layer cache (mlx-lm `can_trim_prompt_cache`:
     /// `all(c.is_trimmable())`, `cache.py:88-92`).
     ///
-    /// Gemma4 has SWA layers backed by a `RotatingKvCache`. Once that ring
-    /// buffer wraps (cached prompt longer than `sliding_window`) it is no
-    /// longer trimmable — `truncate_kv_to_block` would silently no-op on the
-    /// SWA layers while truncating the full-attention layers, desyncing the
-    /// caches and corrupting the re-prefilled tail (this was the original
-    /// broken gemma4 Prefix path: longctx 22 -> 0 tokens). When this returns
-    /// `false` the caller MUST fall back to a full re-prefill (Miss).
+    /// Gemma4 has SWA layers backed by a `RotatingKvCache`. A ring that has
+    /// wrapped can only be rolled back while it still holds the window the
+    /// shorter prefix attends over, and a cached prompt long enough to wrap it
+    /// never does over a whole block. `truncate_kv_to_block` would then fail on
+    /// the SWA layers after truncating the full-attention ones, desyncing the
+    /// caches (this was the original broken gemma4 Prefix path: longctx
+    /// 22 -> 0 tokens). When this returns `false` the caller MUST fall back to
+    /// a full re-prefill (Miss).
     pub(crate) fn can_truncate_to_block(&self, block_count: usize) -> bool {
         debug_assert!(
             block_count >= 1,
             "block_count must be >= 1 for a prefix hit"
         );
-        self.kv_caches.iter().all(KvCache::is_trimmable)
+        let target = (block_count * BLOCK_TOKENS) as i32;
+        self.kv_caches.iter().all(|c| c.can_truncate_to(target))
     }
 
     /// True iff this entry's full token sequence is a STRICT prefix of
@@ -124,8 +126,8 @@ impl Gemma4Entry {
     /// records them geometry-only, see `block_io::write_layer`). Reusing such a
     /// hydrated entry via a prefix arm would re-prefill only the tail on top of
     /// an empty SWA prefix, giving the SWA layers the wrong attention context
-    /// and corrupting the output. `KvCache::is_trimmable()` returns `true` for a
-    /// `None` layer, so it is the wrong predicate to detect this.
+    /// and corrupting the output. `KvCache::can_truncate_to()` returns `true`
+    /// for a `None` layer, so it is the wrong predicate to detect this.
     ///
     /// A layer is payload-less when its storage is `None` AND it carries no
     /// off-storage bf16 seed. This distinguishes a dropped SWA ring (no seed →
@@ -266,7 +268,7 @@ impl PromptCacheEntry for Gemma4Entry {
                 // (`offset() == 0`) are skipped by `truncate_kv_to`, so they are
                 // excluded from the check.
                 let mut cloned = self.deep_clone()?;
-                cloned.truncate_kv_to_block(effective_blocks);
+                cloned.truncate_kv_to_block(effective_blocks)?;
                 debug_assert!(
                     {
                         let expected = (effective_blocks * BLOCK_TOKENS) as i32;

--- a/crates/rmlx-models/src/gemma4/prompt_cache.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache.rs
@@ -88,7 +88,13 @@ impl Gemma4Entry {
             "block_count must be >= 1 for a prefix hit"
         );
         let target = (block_count * BLOCK_TOKENS) as i32;
-        self.kv_caches.iter().all(|c| c.can_truncate_to(target))
+        // Same population `truncate_kv_to` acts on: a never-filled layer — the
+        // KV-shared tail, whose offset stays 0 — is skipped by the truncation
+        // and must not veto it either.
+        self.kv_caches
+            .iter()
+            .filter(|c| c.offset() > 0)
+            .all(|c| c.can_truncate_to(target))
     }
 
     /// True iff this entry's full token sequence is a STRICT prefix of

--- a/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
@@ -46,7 +46,10 @@ fn can_truncate_when_no_swa_wrap() {
         KvCache::with_quant_max_seq_window(KvQuant::K8V4, 8192, Some(1024)), // SWA
     ];
     for c in &kv {
-        assert!(c.is_trimmable(), "fresh cache (offset 0) must be trimmable");
+        assert!(
+            c.can_truncate_to(0),
+            "fresh cache (offset 0) must be rollable"
+        );
     }
     let e = entry_with(kv, (0..512u32).collect());
     assert!(

--- a/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/gemma4/prompt_cache_tests.rs
@@ -70,6 +70,56 @@ fn flat_only_snapshot_always_trimmable() {
     assert!(e.can_truncate_to_block(1));
 }
 
+/// The gate on **filled** caches, in both directions.
+///
+/// The tests above only reach the `offset == 0` arm, where the truncation has
+/// nothing to do and the gate has nothing to refuse. This is the case the gate
+/// exists for, in the shape production reaches it: an entry is cached after
+/// decode, so its sliding-window ring has taken single-token writes. Past the
+/// wrap those leave it in rotated order and it cannot give a position back; short
+/// of the wrap every position is still at its own slot and it can.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "fixture arrays are constructed just above and the CPU update path is infallible on them"
+)]
+fn a_wrapped_swa_ring_refuses_the_block_truncate_path_and_an_unwrapped_one_does_not() {
+    use rmlx_mlx::{Array, Device};
+
+    let device = Device::Cpu;
+    let kv = |n: i32| -> Array {
+        let data: Vec<f32> = (0..n * 2).map(|i| i as f32).collect();
+        Array::from_f32_slice(&data, &[1, 1, n, 2]).unwrap()
+    };
+    // Prefill `fill` positions, then decode two: the shape a cached entry has.
+    let stack = |window: i32, fill: i32| -> Vec<KvCache> {
+        let mut stack = vec![
+            KvCache::with_quant_max_seq_window(KvQuant::None, 8192, None),
+            KvCache::with_quant_max_seq_window(KvQuant::None, 8192, Some(window)),
+        ];
+        for c in &mut stack {
+            c.update(&kv(fill), &kv(fill), device).unwrap();
+            for _ in 0..2 {
+                c.update(&kv(1), &kv(1), device).unwrap();
+            }
+        }
+        stack
+    };
+
+    let unwrapped = entry_with(stack(512, 300), (0..302u32).collect());
+    assert!(
+        unwrapped.can_truncate_to_block(1),
+        "a ring short of its window must allow the block-truncate path"
+    );
+
+    let wrapped = entry_with(stack(128, 512), (0..514u32).collect());
+    assert!(
+        !wrapped.can_truncate_to_block(1),
+        "a ring a decode step left rotated past its wrap cannot give a block \
+         back, and the caller must re-prefill instead"
+    );
+}
+
 /// MISMATCH path: stored `Some(K8V8)`, runtime `K8V4` → evict + miss.
 #[test]
 #[allow(

--- a/crates/rmlx-models/src/gemma4/tests.rs
+++ b/crates/rmlx-models/src/gemma4/tests.rs
@@ -504,10 +504,16 @@ fn forward_hidden_states_matches_reference_extraction() {
         .any(|c| f32::from_le_bytes(c.try_into().unwrap()).is_nan());
     assert!(!any_nan, "hidden contains NaN");
 
-    // Reference equivalence: logits_from_hidden(hidden) == forward_seq_last_k.
+    // Reference equivalence: norm then head over the captured hidden ==
+    // forward_seq_last_k. The two halves are composed here the way
+    // `Architecture::logits_from_hidden` composes them, so a norm dropped from
+    // either one fails this.
+    let normed = model
+        .apply_final_norm(&h, device)
+        .expect("apply_final_norm");
     let logits_via_hidden = model
-        .logits_from_hidden(&h, device)
-        .expect("logits_from_hidden");
+        .logits_from_final_hidden(&normed, device)
+        .expect("logits_from_final_hidden");
     logits_via_hidden.eval().expect("eval lvh");
     let logits_direct = model
         .forward_seq_last_k(ids, k, device)
@@ -537,7 +543,7 @@ fn forward_hidden_states_matches_reference_extraction() {
     eprintln!("[forward_hidden_states_test] max_abs_logit_diff={max_abs_diff}");
     assert!(
         max_abs_diff < 1e-3,
-        "logits_from_hidden must reproduce forward_seq_last_k; max diff {max_abs_diff}"
+        "the final norm and the head must reproduce forward_seq_last_k; max diff {max_abs_diff}"
     );
 }
 

--- a/crates/rmlx-models/src/gemma4/tests.rs
+++ b/crates/rmlx-models/src/gemma4/tests.rs
@@ -455,10 +455,12 @@ fn forward_seq_multi_token_gives_different_argmax() {
 }
 
 /// `forward_hidden_states` returns the pre-final-norm trunk hidden, and
-/// `logits_from_hidden` re-derives the exact logits the standard last-K path
-/// produces. This is the reference penultimate-state extraction check: the MTP
-/// conditioning signal must compose with the LM-head tail to reproduce the
-/// verifier logits. Also asserts shape `[1, k, hidden]` + no NaN.
+/// `apply_final_norm` then `logits_from_final_hidden` re-derive the exact logits
+/// the standard last-K path produces. This is the reference penultimate-state
+/// extraction check: the MTP conditioning signal must compose with the LM-head
+/// tail to reproduce the verifier logits, and the two halves are composed here
+/// the way `Architecture::logits_from_hidden` composes them. Also asserts shape
+/// `[1, k, hidden]` + no NaN.
 #[test]
 #[ignore]
 #[allow(

--- a/crates/rmlx-models/src/kv_cache/tests.rs
+++ b/crates/rmlx-models/src/kv_cache/tests.rs
@@ -394,7 +394,9 @@ mod tests {
         cache.update(&k, &v, device).expect("update must not fail");
         assert_eq!(cache.offset(), 8);
 
-        cache.truncate_to(3);
+        cache
+            .truncate_to(3)
+            .expect("a full-attention store rolls back to any prefix");
         assert_eq!(cache.offset(), 3, "offset must equal truncation target");
         match &cache.storage {
             KvStorage::K8V8 { k, v, .. } => {
@@ -457,7 +459,9 @@ mod tests {
         assert_eq!(cache.offset(), total_tokens);
 
         let keep = 3;
-        cache.truncate_to(keep);
+        cache
+            .truncate_to(keep)
+            .expect("a full-attention store rolls back to any prefix");
         assert_eq!(cache.offset(), keep, "offset must equal truncation target");
         match &cache.storage {
             KvStorage::IsoV3 { v, .. } => {

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -23,7 +23,8 @@
 //! `PromptCacheEntry` exposes:
 //! - `prompt_token_ids() -> &[u32]` — key for prefix matching.
 //! - `deep_clone() -> Result<Self>` — cheap refcount clone of MLX arrays.
-//! - `truncate_kv_to(prefix_len: usize)` — trim KV caches to prefix length.
+//! - `truncate_kv_to(prefix_len: usize) -> Result<()>` — trim KV caches to
+//!   prefix length.
 //! - `kv_bytes() -> u64` — RAM estimate for eviction budget.
 //!
 //! ## Stats
@@ -340,21 +341,25 @@ pub(crate) trait PromptCacheEntry: Sized {
     ///
     /// Called on a cloned entry before re-prefilling the tail. The default
     /// body trims only the KV caches (`offset() > 0` guard skips never-filled
-    /// layers). The recurrent GDN [`lin_caches`] are deliberately NOT reachable
+    /// layers). It fails when a layer cannot reach `prefix_len` without losing
+    /// state it still has to serve — a wrapped SWA ring. Callers gate on
+    /// `KvCache::can_truncate_to` and degrade to a re-prefill, so the failure
+    /// path here is the gate having gone out of step with the caches. The recurrent GDN [`lin_caches`] are deliberately NOT reachable
     /// from this default — that "never truncate linear state" invariant is now
     /// structural: linear state is re-run on the tail, never sliced. Override
     /// only for a mock or a genuinely different per-arch policy.
     ///
     /// [`lin_caches`]: PromptCacheEntry::lin_caches
-    fn truncate_kv_to(&mut self, prefix_len: usize) {
+    fn truncate_kv_to(&mut self, prefix_len: usize) -> Result<()> {
         for kv in self.kv_caches_mut() {
             if kv.offset() > 0 {
-                kv.truncate_to(prefix_len as i32);
+                kv.truncate_to(prefix_len as i32)?;
             }
         }
         // lin caches deliberately untouched: recurrent GDN state is re-run on
         // the tail, never truncated. Structural now — the default body cannot
         // reach them.
+        Ok(())
     }
 
     /// Block-aligned truncation: trim KV caches to `block_count` full blocks.
@@ -365,8 +370,8 @@ pub(crate) trait PromptCacheEntry: Sized {
     /// (every layer cache trimmable — no wrapped-SWA desync). Qwen3.5-MoE never
     /// calls it: its recurrent GDN `lin_caches` cannot be reconstructed from a
     /// block-truncated KV, so MoE is gated to full-token-equality (Exact) reuse.
-    fn truncate_kv_to_block(&mut self, block_count: usize) {
-        self.truncate_kv_to(block_count * BLOCK_TOKENS);
+    fn truncate_kv_to_block(&mut self, block_count: usize) -> Result<()> {
+        self.truncate_kv_to(block_count * BLOCK_TOKENS)
     }
 
     /// Approximate RAM held by this entry's KV/recurrent state, in bytes.

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -344,7 +344,9 @@ pub(crate) trait PromptCacheEntry: Sized {
     /// layers). It fails when a layer cannot reach `prefix_len` without losing
     /// state it still has to serve — a wrapped SWA ring. Callers gate on
     /// `KvCache::can_truncate_to` and degrade to a re-prefill, so the failure
-    /// path here is the gate having gone out of step with the caches. The recurrent GDN [`lin_caches`] are deliberately NOT reachable
+    /// path here is the gate having gone out of step with the caches.
+    ///
+    /// The recurrent GDN [`lin_caches`] are deliberately NOT reachable
     /// from this default — that "never truncate linear state" invariant is now
     /// structural: linear state is re-run on the tail, never sliced. Override
     /// only for a mock or a genuinely different per-arch policy.

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -197,12 +197,14 @@ impl PromptCacheEntry for TestEntry {
         &[]
     }
 
-    fn truncate_kv_to(&mut self, prefix_len: usize) {
+    fn truncate_kv_to(&mut self, prefix_len: usize) -> Result<()> {
         self.truncated_to.set(Some(prefix_len));
+        Ok(())
     }
 
-    fn truncate_kv_to_block(&mut self, block_count: usize) {
+    fn truncate_kv_to_block(&mut self, block_count: usize) -> Result<()> {
         self.truncated_to.set(Some(block_count * BLOCK_TOKENS));
+        Ok(())
     }
 
     fn kv_bytes(&self) -> u64 {
@@ -416,6 +418,10 @@ impl PromptCacheEntry for RealEntry {
     clippy::unwrap_used,
     reason = "test-only: fixture caches are constructed just above; deep_clone/eval are infallible on this CPU K8V8 fixture"
 )]
+#[allow(
+    clippy::expect_used,
+    reason = "test assertion: an unreachable rollback failure is the defect the test reports"
+)]
 fn default_truncate_and_kv_bytes_over_real_caches() {
     // 4 full blocks of tokens, caches each holding 4*BLOCK_TOKENS positions.
     let seq = (4 * BLOCK_TOKENS) as i32;
@@ -426,7 +432,8 @@ fn default_truncate_and_kv_bytes_over_real_caches() {
     assert!(before > 0, "filled real caches must report non-zero bytes");
 
     // Truncate to 1 block (256 positions) via the DEFAULT body.
-    e.truncate_kv_to(BLOCK_TOKENS);
+    e.truncate_kv_to(BLOCK_TOKENS)
+        .expect("a full-attention entry rolls back to any prefix");
     for kv in e.kv_caches() {
         assert_eq!(
             kv.offset(),
@@ -444,7 +451,9 @@ fn default_truncate_and_kv_bytes_over_real_caches() {
     // no panic, bytes are zero.
     let mut empty = RealEntry::new(make_ids(4 * BLOCK_TOKENS), 0, 2, 0);
     assert_eq!(empty.kv_bytes(), 0, "never-filled caches hold no bytes");
-    empty.truncate_kv_to(BLOCK_TOKENS); // must not panic (offset == 0 guard)
+    empty
+        .truncate_kv_to(BLOCK_TOKENS)
+        .expect("the offset == 0 guard skips a never-filled cache");
     for kv in empty.kv_caches() {
         assert_eq!(kv.offset(), 0, "guard skipped the never-filled cache");
     }
@@ -862,6 +871,10 @@ fn over_cap_refusal_preserves_existing_slots() {
     clippy::unwrap_used,
     reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
 )]
+#[allow(
+    clippy::expect_used,
+    reason = "test assertion: an unreachable rollback failure is the defect the test reports"
+)]
 fn long_prompt_block_aligned_partial_hit() {
     let prompt_a: Vec<u32> = make_ids(16 * BLOCK_TOKENS); // 4096 tokens
     let mut cache: PromptCache<TestEntry> = PromptCache::new(4);
@@ -879,7 +892,9 @@ fn long_prompt_block_aligned_partial_hit() {
 
     // Block-aligned truncation lands at 3840 tokens.
     let mut cloned = cache.slots[slot_idx].entry.deep_clone().unwrap();
-    cloned.truncate_kv_to_block(block_count);
+    cloned
+        .truncate_kv_to_block(block_count)
+        .expect("a full-attention entry rolls back to a block boundary");
     assert_eq!(
         cloned.truncated_to.get(),
         Some(15 * BLOCK_TOKENS),
@@ -1372,7 +1387,9 @@ fn partial_hit_truncates_to_matched_block_boundary() {
     assert_eq!(blocks, 3, "exactly 3 leading blocks match");
 
     let mut cloned = cache.slots[idx].entry.deep_clone().unwrap();
-    cloned.truncate_kv_to_block(blocks);
+    cloned
+        .truncate_kv_to_block(blocks)
+        .expect("a full-attention entry rolls back to a block boundary");
     assert_eq!(
         cloned.truncated_to.get(),
         Some(3 * BLOCK_TOKENS),

--- a/crates/rmlx-models/src/qwen3_5_moe/model.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/model.rs
@@ -577,7 +577,7 @@ impl Qwen3_5MoeText {
         let h_normed = self.final_norm.forward(&h, device)?;
         let h_last = h_normed.slice(&[0, seq - k, 0], &[1, seq, hidden], &[1, 1, 1], device)?;
         let h_last = h_last.reshape(&[1, k, hidden], device)?;
-        let logits = self.logits_from_hidden(&h_last, device)?;
+        let logits = self.logits_from_final_hidden(&h_last, device)?;
 
         // Concat captures in requested order.
         let mut ordered: Vec<&Array> = Vec::with_capacity(capture_layer_ids.len());
@@ -796,7 +796,7 @@ impl Qwen3_5MoeText {
         let h_last_norm =
             h_normed.slice(&[0, seq_i - 1, 0], &[1, seq_i, hidden], &[1, 1, 1], device)?;
         let h_last_norm = h_last_norm.reshape(&[1, 1, hidden], device)?;
-        let last_logits = self.logits_from_hidden(&h_last_norm, device)?;
+        let last_logits = self.logits_from_final_hidden(&h_last_norm, device)?;
 
         // Re-order aux captures and slice to [1, seq, H] each.
         let mut ordered: Vec<Array> = Vec::with_capacity(capture_layer_ids.len());
@@ -951,6 +951,17 @@ impl Qwen3_5MoeText {
     /// `hidden`: `[1, n, hidden]` → `[1, n, vocab]`. Uses the tied
     /// `embed_tokens.as_linear` when `lm_head` is absent (mirrors `forward_arr`).
     pub fn logits_from_hidden(&self, hidden: &Array, device: Device) -> Result<Array> {
+        let h = self.final_norm.forward(hidden, device)?;
+        self.logits_from_final_hidden(&h, device)
+    }
+
+    /// The same, from a hidden state the caller has already final-normed.
+    ///
+    /// The two entry points exist because a speculative loop holds one or the
+    /// other depending on where in the verify pass it captured: naming which is
+    /// which is what keeps a missing — or doubled — `final_norm` from becoming a
+    /// silent reweighting of the vocabulary.
+    pub fn logits_from_final_hidden(&self, hidden: &Array, device: Device) -> Result<Array> {
         match &self.lm_head {
             Some(lm) => lm.forward(hidden, device),
             None => self.embed_tokens.as_linear(hidden, device),

--- a/crates/rmlx-models/src/qwen3_5_moe/model.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/model.rs
@@ -946,21 +946,23 @@ impl Qwen3_5MoeText {
         h.reshape(&[1, n as i32, self.cfg.hidden_size as i32], device)
     }
 
-    /// Re-derive logits from a hidden state via the LM head.
+    /// Apply the final RMSNorm to a pre-final-norm hidden. `[1, n, hidden]`
+    /// in/out.
+    pub fn apply_final_norm(&self, hidden: &Array, device: Device) -> Result<Array> {
+        self.final_norm.forward(hidden, device)
+    }
+
+    /// Re-derive logits from a hidden state the caller has already
+    /// final-normed, via the LM head.
     ///
     /// `hidden`: `[1, n, hidden]` → `[1, n, vocab]`. Uses the tied
     /// `embed_tokens.as_linear` when `lm_head` is absent (mirrors `forward_arr`).
-    pub fn logits_from_hidden(&self, hidden: &Array, device: Device) -> Result<Array> {
-        let h = self.final_norm.forward(hidden, device)?;
-        self.logits_from_final_hidden(&h, device)
-    }
-
-    /// The same, from a hidden state the caller has already final-normed.
     ///
-    /// The two entry points exist because a speculative loop holds one or the
-    /// other depending on where in the verify pass it captured: naming which is
-    /// which is what keeps a missing — or doubled — `final_norm` from becoming a
-    /// silent reweighting of the vocabulary.
+    /// The norm is not applied here and must not be: a speculative loop holds a
+    /// normed or a raw hidden depending on where in the verify pass it captured,
+    /// and [`Architecture::logits_from_hidden`] is the one that takes the raw
+    /// one. Naming which is which keeps a missing — or doubled — `final_norm`
+    /// from becoming a silent reweighting of the vocabulary.
     pub fn logits_from_final_hidden(&self, hidden: &Array, device: Device) -> Result<Array> {
         match &self.lm_head {
             Some(lm) => lm.forward(hidden, device),

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -523,7 +523,8 @@ impl DFlashDrafter {
                 &[1, 1, 1],
                 device,
             )?;
-            let mut logits = verifier.logits_from_hidden(&row, device)?;
+            // `forward_block` ends with the drafter's own final norm.
+            let mut logits = verifier.logits_from_final_hidden(&row, device)?;
             if let Some(cap) = self.cfg.final_logit_softcapping {
                 let cap_arr = scalar_f32(cap).astype(logits.dtype(), device)?;
                 let scaled = divide(&logits, &cap_arr, device)?;

--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -640,7 +640,7 @@ impl Eagle3Drafter {
         device: Device,
     ) -> Result<(Array, u32)> {
         // (1) Roll drafter KV cache back to pre-round state.
-        self.truncate_cache(pre_round_offset);
+        self.truncate_cache(pre_round_offset)?;
 
         // (2) Build token sequence: accepted draft prefix + correction.
         let n = accepted + 1;
@@ -768,10 +768,11 @@ impl Eagle3Drafter {
     }
 
     /// Truncate the drafter cache to `n` positions (partial-accept rollback).
-    pub fn truncate_cache(&mut self, n: i32) {
+    pub fn truncate_cache(&mut self, n: i32) -> Result<()> {
         if self.cache.offset() >= n {
-            self.cache.truncate_to(n);
+            self.cache.truncate_to(n)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -1071,7 +1071,8 @@ pub fn eagle3_generate_greedy(
                 &[1, 1, 1],
                 device,
             )?;
-            let corr_logits = verifier.logits_from_hidden(&h_corr, device)?;
+            // `v_final_hidden` is final-normed by `forward_verify_capture_hot`.
+            let corr_logits = verifier.logits_from_final_hidden(&h_corr, device)?;
             let corr_am = argmax(&corr_logits, -1, device)?;
             corr_am.eval()?;
             let corr_bytes = corr_am.to_bytes()?;

--- a/crates/rmlx-models/src/speculative/gemma4_assistant.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant.rs
@@ -736,6 +736,19 @@ pub fn mtp_assistant_generate_greedy(
             "mtp_assistant_generate_greedy: block_size must be >= 2".into(),
         ));
     }
+    // Which round loop runs is decided by the drafter snapshot's `model_type`
+    // alone, so a `gemma4_assistant` drafter can be handed any verifier. This
+    // loop conditions the drafter on the verifier's own final-normed hidden and
+    // reads its K/V directly, neither of which means anything across
+    // architectures — so the pair is refused here, at the entry, rather than
+    // deeper in a shape mismatch.
+    if !matches!(verifier, Architecture::Gemma4(_)) {
+        return Err(Error::Model(format!(
+            "mtp_assistant_generate_greedy: the Gemma4 assistant round loop needs a Gemma4 \
+             verifier and this one is {}",
+            verifier.arch_class()
+        )));
+    }
     let mut emitted: Vec<ProbeStep> = Vec::with_capacity(n_tokens);
 
     // Same constant the verifier resolves — a spec pair must not run two

--- a/crates/rmlx-models/src/speculative/gemma4_assistant.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant.rs
@@ -856,6 +856,11 @@ pub fn mtp_assistant_generate_greedy(
         verify_input.extend_from_slice(&draft_tokens);
         let v_k = verify_input.len();
 
+        // Read before the forward: it is the position the rollback returns to,
+        // and reading it afterwards makes it a function of how far each layer
+        // happened to advance.
+        let pre_round_offset = caches.iter().map(KvCache::offset).max().unwrap_or(0);
+
         let t0 = Instant::now();
         let (v_hidden, new_sliding, new_full, _off) =
             verifier.forward_hidden_states_shared_kv(&verify_input, v_k, &mut caches, device)?;
@@ -903,15 +908,19 @@ pub fn mtp_assistant_generate_greedy(
         // -- Phase D: rollback + next-round setup. ---------------------------
         // The verifier consumed v_k positions; valid prefix = prev + accept + 1
         // (the correction v_tokens[accept] is a prediction, not yet processed).
-        let v_offset_before = caches[0].offset();
-        let v_target = v_offset_before - (draft_tokens.len() as i32 - accept as i32);
-        for c in &mut caches {
-            // KV-shared layers read another layer's K/V and never advance their
-            // own cache (offset stays 0); truncating them would assert n>offset.
-            // Only roll back caches that actually accumulated this round's keys.
-            if c.offset() >= v_target {
-                c.truncate_to(v_target);
-            }
+        let v_target = pre_round_offset + accept as i32 + 1;
+        let rejected = v_k as i32 - (accept as i32 + 1);
+        if rejected > 0 {
+            super::rollback_round_caches(
+                verifier,
+                &mut caches,
+                None,
+                None,
+                &verify_input,
+                pre_round_offset,
+                v_target,
+                device,
+            )?;
         }
 
         // Next hidden = verifier penultimate at the accepted position, then
@@ -927,16 +936,14 @@ pub fn mtp_assistant_generate_greedy(
         hidden = verifier.apply_final_norm(&hidden_slice, device)?;
         b = v_tokens[accept];
 
-        // Shared K/V for the next round: re-read from the just-advanced cache.
-        // On full accept the verify-call K/V is valid as-is; on partial accept
-        // we truncated, so the verify-call K/V tail is stale — re-derive cheaply
-        // by re-running a zero-length probe is overkill; instead the shared K/V
-        // is the verifier's last-layer accumulated K/V which the truncate_to
-        // already trimmed in the cache. The verify call returned the *pre-trim*
-        // K/V; slice it to v_target length to match.
-        let kv_keep = v_target; // absolute length of valid keys after trim
-        sliding_kv = slice_kv_len(&new_sliding, kv_keep, device)?;
-        full_kv = slice_kv_len(&new_full, kv_keep, device)?;
+        // Shared K/V for the next round. The verify call returned the
+        // *pre-rollback* K/V, so the rejected drafts are still on its tail;
+        // drop exactly those. Counting from the tail rather than slicing to an
+        // absolute length is what makes this right for both layer types: a
+        // full-attention layer's K/V is the whole sequence, a sliding layer's
+        // is a window that does not start at position 0.
+        sliding_kv = drop_kv_tail(&new_sliding, rejected, device)?;
+        full_kv = drop_kv_tail(&new_full, rejected, device)?;
         kv_offset = v_target;
 
         tracing::debug!(
@@ -944,7 +951,7 @@ pub fn mtp_assistant_generate_greedy(
             accept,
             num_draft = draft_tokens.len(),
             emitted_total = emitted.len(),
-            v_offset_before,
+            pre_round_offset,
             v_target,
             "mtp assistant round"
         );
@@ -980,16 +987,17 @@ pub fn mtp_assistant_generate_greedy(
     Ok(emitted)
 }
 
-/// Slice a shared `(K, V)` pair to the first `keep` key positions (axis 2).
-/// `[1, n_kv, kv, hd] -> [1, n_kv, keep, hd]`. No-op when already <= keep.
+/// Drop the last `drop` key positions (axis 2) from a shared `(K, V)` pair.
+/// `[1, n_kv, kv, hd] -> [1, n_kv, kv - drop, hd]`. No-op when `drop <= 0`.
 #[allow(
     clippy::indexing_slicing,
     reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
 )]
-fn slice_kv_len(kv: &(Array, Array), keep: i32, device: Device) -> Result<(Array, Array)> {
+fn drop_kv_tail(kv: &(Array, Array), drop: i32, device: Device) -> Result<(Array, Array)> {
     let do_slice = |a: &Array| -> Result<Array> {
         let s = a.shape();
-        if s[2] <= keep {
+        let keep = s[2] - drop.max(0);
+        if keep >= s[2] {
             return a.try_clone();
         }
         a.slice(

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -1541,7 +1541,23 @@ fn rollback_round_caches(
         )));
     }
 
-    truncate_kv_to(kv, pre_round_offset)?;
+    // The whole verify block, not the rejected tail: the recurrent state has no
+    // sequence axis to truncate, so it is restored from the pre-round snapshot
+    // and the accepted prefix replayed into KV caches that must start where the
+    // snapshot does. A sliding-window ring cannot serve that past its wrap — it
+    // can give back a rejected tail but not the block that established its
+    // window — so this branch and a sliding layer are mutually exclusive. No
+    // architecture wired today pairs the two (`Architecture::layer_sliding_window`
+    // names only the Gemma families, and neither carries recurrent state); the
+    // first one that does lands here rather than anywhere subtler.
+    truncate_kv_to(kv, pre_round_offset).map_err(|e| {
+        Error::Model(format!(
+            "rollback_round_caches: a recurrent verifier rolls the whole verify block off \
+             and replays the accepted prefix, which a sliding-window layer cannot do past \
+             its wrap — this architecture pairs recurrent state with a windowed KV layer \
+             and the round loop has no rollback for that combination: {e}"
+        ))
+    })?;
     for (c, snap) in lin.iter_mut().zip(snapshot) {
         c.restore_snapshot(snap);
     }
@@ -1559,11 +1575,26 @@ fn rollback_round_caches(
 /// A GDN layer's KvCache never advances past 0, so an unguarded truncate would
 /// set it to a positive offset over an empty store.
 ///
-/// A layer that cannot reach `n` stops the round rather than being left behind
-/// the rest of the stack: an SWA ring that silently kept the rejected drafts
-/// while the full-attention layers dropped them is how a speculative arm stops
-/// reproducing plain greedy at long context.
+/// **All or nothing.** Every layer is asked whether it can reach `n` before any
+/// is moved, because a stack left half rolled back is the defect this function
+/// exists to prevent, not a milder version of it: an SWA ring that kept the
+/// rejected drafts while the full-attention layers dropped them is how a
+/// speculative arm stops reproducing plain greedy at long context, and a
+/// failure part-way through the loop produces exactly that state with no way
+/// back. `KvCache::can_truncate_to` is the same predicate `truncate_to` fails
+/// on, so the gate and the operation cannot disagree.
 fn truncate_kv_to(kv: &mut [KvCache], n: i32) -> Result<()> {
+    if let Some((idx, c)) = kv
+        .iter()
+        .enumerate()
+        .find(|(_, c)| c.offset() >= n && !c.can_truncate_to(n))
+    {
+        return Err(Error::Model(format!(
+            "truncate_kv_to: layer {idx} holds {} positions and cannot be rolled back to \
+             {n}, so no layer was, and the stack is still where the round left it",
+            c.offset(),
+        )));
+    }
     for c in kv.iter_mut() {
         if c.offset() >= n {
             c.truncate_to(n)?;

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -486,9 +486,9 @@ impl SpeculativeDispatcher {
         // whatever codec it is handed — the branch is `window > 0` alone
         // (`KvCache::with_quant_max_seq_window`), so an SWA layer here is bf16
         // at `sliding_window` tokens under every `kv_quant`, and only the
-        // full-attention layers quantize. Rollback below calls `truncate_to`
-        // on every layer without consulting `is_trimmable()`, which a rotating
-        // layer only satisfies until it wraps.
+        // full-attention layers quantize. A block-verify write leaves that ring
+        // holding its window plus the block, which is what lets the rollback
+        // below drop the rejected tail out of it losslessly.
         let mut verifier_caches: Vec<KvCache> = (0..self.verifier.num_hidden_layers())
             .map(|i| {
                 let window = self.verifier.layer_sliding_window(i);
@@ -1527,8 +1527,7 @@ fn rollback_round_caches(
     device: Device,
 ) -> Result<()> {
     let Some((lin, snapshot)) = lin.zip(snapshot).filter(|(l, _)| !l.is_empty()) else {
-        truncate_kv_to(kv, target_offset);
-        return Ok(());
+        return truncate_kv_to(kv, target_offset);
     };
 
     let kept = (target_offset - pre_round_offset).max(0) as usize;
@@ -1542,7 +1541,7 @@ fn rollback_round_caches(
         )));
     }
 
-    truncate_kv_to(kv, pre_round_offset);
+    truncate_kv_to(kv, pre_round_offset)?;
     for (c, snap) in lin.iter_mut().zip(snapshot) {
         c.restore_snapshot(snap);
     }
@@ -1559,12 +1558,18 @@ fn rollback_round_caches(
 ///
 /// A GDN layer's KvCache never advances past 0, so an unguarded truncate would
 /// set it to a positive offset over an empty store.
-fn truncate_kv_to(kv: &mut [KvCache], n: i32) {
+///
+/// A layer that cannot reach `n` stops the round rather than being left behind
+/// the rest of the stack: an SWA ring that silently kept the rejected drafts
+/// while the full-attention layers dropped them is how a speculative arm stops
+/// reproducing plain greedy at long context.
+fn truncate_kv_to(kv: &mut [KvCache], n: i32) -> Result<()> {
     for c in kv.iter_mut() {
         if c.offset() >= n {
-            c.truncate_to(n);
+            c.truncate_to(n)?;
         }
     }
+    Ok(())
 }
 
 /// Run `n` greedy decode steps through `model` with persistent `caches`.

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -1581,8 +1581,14 @@ fn rollback_round_caches(
 /// rejected drafts while the full-attention layers dropped them is how a
 /// speculative arm stops reproducing plain greedy at long context, and a
 /// failure part-way through the loop produces exactly that state with no way
-/// back. `KvCache::can_truncate_to` is the same predicate `truncate_to` fails
-/// on, so the gate and the operation cannot disagree.
+/// back. `KvCache::can_truncate_to` decides reachability on exactly the ground
+/// `truncate_to` refuses on — a sliding-window ring's order past its wrap — so
+/// on that question the gate and the operation cannot disagree.
+///
+/// It does not model a fault in the write itself: a ring admitted with no
+/// recorded stream, or a buffer that is not 4-D. Both are structural invariants
+/// rather than states a caller can reach, and either would still return
+/// mid-stack.
 fn truncate_kv_to(kv: &mut [KvCache], n: i32) -> Result<()> {
     if let Some((idx, c)) = kv
         .iter()

--- a/crates/rmlx-models/src/speculative/mtp.rs
+++ b/crates/rmlx-models/src/speculative/mtp.rs
@@ -157,10 +157,10 @@ impl MtpDrafter {
     /// grown — but that is a fill the caller's accounting did not predict, and
     /// silently skipping it lets a slot-vs-position gap open one step at a time
     /// and show up only as a quietly decaying accept rate. Say so.
-    pub fn truncate_to(&mut self, target: i32) {
+    pub fn truncate_to(&mut self, target: i32) -> Result<()> {
         for c in &mut self.caches {
             if c.offset() >= target {
-                c.truncate_to(target);
+                c.truncate_to(target)?;
             } else {
                 tracing::warn!(
                     target_positions = target,
@@ -170,6 +170,7 @@ impl MtpDrafter {
                 );
             }
         }
+        Ok(())
     }
 
     /// Project one `(token_embed, hidden)` pair through the `fc` + pre-fc norms.
@@ -889,7 +890,7 @@ pub fn mtp_generate_greedy(
         // above). Keeping only `accept` would drop the last accepted draft's KV
         // every round, silently degrading draft accept-rate.
         let d_target = draft_start + accept as i32 + 1;
-        drafter.truncate_to(d_target);
+        drafter.truncate_to(d_target)?;
 
         // Next-round conditioning: the verifier hidden at the newly accepted
         // bonus slot (= position `accept` of the captured penultimate hidden).

--- a/crates/rmlx-models/src/speculative/mtp.rs
+++ b/crates/rmlx-models/src/speculative/mtp.rs
@@ -241,7 +241,9 @@ impl MtpDrafter {
             // Project + run the head decoder layer(s) -> next hidden [1,1,H].
             let h_next = self.forward_token(&tok_embed, &h_prev, offset)?;
             // Re-use the verifier LM head to pick the next draft token (greedy).
-            let logits = verifier.logits_from_hidden(&h_next, self.device)?;
+            // `forward_token` ends with the sidecar's own final norm, so the
+            // verifier's norm must not be applied a second time.
+            let logits = verifier.logits_from_final_hidden(&h_next, self.device)?;
             let next = argmax(&logits, -1, self.device)?;
             next.eval()?;
             let id = u32::from_le_bytes(next.to_bytes()?[..4].try_into().unwrap());
@@ -570,9 +572,12 @@ fn load_mtp_head(draft_dir: &Path, hidden_size: usize) -> Result<(MtpHeadWeights
 /// `_speculative_walk_deferred_greedy`).
 ///
 /// `target_hidden` is the verifier's penultimate hidden at positions
-/// `[carry, d0, d1, ...]` — shape `[1, n_draft+1, H]`. For each position the
-/// verifier logits are re-derived from the hidden (deferred — only until the
-/// first reject) and compared greedily against the draft. Returns
+/// `[carry, d0, d1, ...]` — shape `[1, n_draft+1, H]`, captured **before** the
+/// final norm, which is why the logits go through
+/// [`Architecture::logits_from_hidden`] and not its already-normed counterpart.
+/// For each position the verifier logits are re-derived from the hidden
+/// (deferred — only until the first reject) and compared greedily against the
+/// draft. Returns
 /// `(accepted, new_tokens)` where `new_tokens` are the verifier-confirmed token
 /// ids to emit (accepted prefix + one correction/bonus), capped at `budget`.
 #[allow(

--- a/crates/rmlx-models/src/speculative/tests.rs
+++ b/crates/rmlx-models/src/speculative/tests.rs
@@ -400,3 +400,89 @@ fn verifier_prefill_cuts_the_prompt_at_the_architectures_chunk() {
         );
     }
 }
+
+/// Deterministic `[1, 1, s, 2]` f32 K/V pair for the rollback tests below.
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn rollback_kv(s: i32, base: f32) -> Array {
+    let mut data: Vec<f32> = Vec::with_capacity((s * 2) as usize);
+    for p in 0..s {
+        data.push(base + p as f32);
+        data.push(base + p as f32 + 0.5);
+    }
+    Array::from_f32_slice(&data, &[1, 1, s, 2]).unwrap()
+}
+
+/// A prompt then three decode steps, which leaves a windowed layer rotated and
+/// a plain one able to roll back to anywhere.
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn filled_layer(window: Option<i32>, device: Device) -> KvCache {
+    let mut cache = KvCache::with_quant_max_seq_window(KvQuant::None, 512, window);
+    cache
+        .update(&rollback_kv(6, 0.0), &rollback_kv(6, 100.0), device)
+        .unwrap();
+    for step in 0..3 {
+        let p = (6 + step) as f32;
+        cache
+            .update(&rollback_kv(1, p), &rollback_kv(1, 100.0 + p), device)
+            .unwrap();
+    }
+    cache
+}
+
+/// `truncate_kv_to` moves every layer or none.
+///
+/// A stack left half rolled back is the same desync the ring fix exists to
+/// stop, reached through the failure path instead of through a silent no-op:
+/// the layers that did move sit behind an offset the refusing one still holds,
+/// and no caller can put them back. So the refusal is decided before any layer
+/// is touched, and it names the layer that decided it.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "the stack is built with two layers immediately above"
+)]
+#[allow(
+    clippy::panic,
+    reason = "the else-branch of a let-else that only a broken gate can reach"
+)]
+fn a_stack_with_one_layer_that_cannot_roll_back_moves_no_layer() {
+    let device = Device::Cpu;
+    // Layer 0 could reach the target on its own. Layer 1 is a window that
+    // decode writes left rotated, and cannot.
+    let mut stack = vec![filled_layer(None, device), filled_layer(Some(4), device)];
+    assert_eq!((stack[0].offset(), stack[1].offset()), (9, 9));
+    assert!(stack[0].can_truncate_to(8));
+    assert!(!stack[1].can_truncate_to(8));
+
+    let Err(err) = truncate_kv_to(&mut stack, 8) else {
+        panic!("a stack holding a layer that cannot reach 8 must not report success")
+    };
+    assert_eq!(
+        (stack[0].offset(), stack[1].offset()),
+        (9, 9),
+        "the layer that could roll back must not have"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("layer 1"),
+        "the refusal must name the layer: {msg}"
+    );
+    assert!(
+        msg.contains("cannot be rolled back to 8"),
+        "and the target it could not reach: {msg}"
+    );
+
+    // And a target every layer can reach is not refused.
+    assert!(truncate_kv_to(&mut stack, 9).is_ok());
+    assert_eq!((stack[0].offset(), stack[1].offset()), (9, 9));
+}

--- a/crates/rmlx-models/src/speculative/tests.rs
+++ b/crates/rmlx-models/src/speculative/tests.rs
@@ -482,7 +482,15 @@ fn a_stack_with_one_layer_that_cannot_roll_back_moves_no_layer() {
         "and the target it could not reach: {msg}"
     );
 
-    // And a target every layer can reach is not refused.
-    assert!(truncate_kv_to(&mut stack, 9).is_ok());
-    assert_eq!((stack[0].offset(), stack[1].offset()), (9, 9));
+    // And the gate does not stand in the way of a rollback the whole stack can
+    // make. A target both layers are already at would prove nothing — it is
+    // `roll_back(0)` on one and a no-op on the other, and a loop that skipped
+    // the truncation outright would still pass it. So this one moves.
+    let mut reachable = vec![filled_layer(None, device), filled_layer(None, device)];
+    assert!(truncate_kv_to(&mut reachable, 7).is_ok());
+    assert_eq!(
+        (reachable[0].offset(), reachable[1].offset()),
+        (7, 7),
+        "a target every layer can reach must move every layer"
+    );
 }

--- a/crates/rmlx-models/tests/gemma4_kv_cache_equivalence.rs
+++ b/crates/rmlx-models/tests/gemma4_kv_cache_equivalence.rs
@@ -413,13 +413,14 @@ fn gemma4_partial_prefix_reuse_cold_equal() {
         let first_shared = n_layers - model.cfg.num_kv_shared_layers;
         for c in &cloned[..first_shared] {
             assert!(
-                c.is_trimmable(),
-                "own-KV SWA cache not trimmable — test prompt exceeded sliding_window"
+                c.can_truncate_to(prefix_len as i32),
+                "own-KV SWA cache not rollable — test prompt exceeded sliding_window"
             );
         }
         for (i, c) in cloned.iter_mut().enumerate() {
             if c.offset() > 0 {
-                c.truncate_to(prefix_len as i32);
+                c.truncate_to(prefix_len as i32)
+                    .expect("every layer reported the prefix reachable above");
             }
             if i < first_shared {
                 assert_eq!(

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -24,23 +24,24 @@
 //! same context up to that position, so this judges the **pair**, and it needs
 //! no per-prompt calibration: it is a rank, not a number of nats.
 //!
-//! Over the six prompts in [`PROMPTS`], measured by
-//! `the_agreement_a_correct_pair_reaches`:
+//! Over the six prompts in [`PROMPTS`], for each pair, run against the shipped
+//! engine and against two deliberately broken ones:
 //!
 //! | engine | first divergence | percentile of the reference arm's own margins |
 //! |---|---|---|
-//! | assistant pair, as shipped | 4 to 193 | 0.0000 to 0.0352 |
-//! | MTP pair, as shipped | 35 to 256 (three prompts bit-identical) | 0.0000 to 0.0234 |
-//! | assistant pair, SWA ring keeping its rejected block tail | 3 to 7 | 0.0000 to 0.9531 |
-//! | MTP pair, acceptance walk without the final norm | 4 to 28 | 0.1680 to 0.4453 |
+//! | assistant pair, as shipped | 16 to 256 (one prompt bit-identical) | 0.0000 to 0.0820 |
+//! | recurrent pair, as shipped | 65 to 256 (three prompts bit-identical) | 0.0000 to 0.0234 |
+//! | assistant pair, SWA ring keeping its rejected block tail | 6 to 9 | 0.4219 to 0.9258 |
+//! | recurrent pair, acceptance walk without the final norm | 1 to 24 | 0.0000 to 0.5000 |
 //!
 //! **There is deliberately no subsequence floor.** How much of one answer two
 //! correct arms share is decided by where their first near-tie lands and by
-//! nothing else: the assistant pair reads 0.9180 when it falls at token 91 and
-//! 0.3281 when it falls at token 4 — an exact tie, both answers well-formed
-//! prose — while the two broken engines above read 0.2070 to 0.6953. The
-//! populations overlap. `report` prints the figure on every run and the gate does
-//! not assert it.
+//! nothing else: the assistant pair reads 0.9375 on the 4k document and 0.4766
+//! on a short prose prompt whose arms flip an **exact** tie (top-two margin
+//! 0.0000) at token 37, after which both write well-formed, correct, different
+//! prose. The two broken engines read 0.2188 to 0.4615 on the same measure. The
+//! populations overlap. [`report`] prints the figure on every run and the gate
+//! does not assert it.
 //!
 //! **The repetition control** is the second oracle, and it exists because the
 //! first has nothing to read when both arms are degenerate: two arms in the same
@@ -68,15 +69,13 @@
 //! arm trips the control the input is outside the gate's domain and the gate
 //! says so, rather than accusing plain greedy of a repetition loop.
 //!
-//! # Recall, and what escapes
+//! # Recall
 //!
-//! Over the twelve (pair, prompt) cells the two broken engines above produce,
-//! the gate refuses eleven. The twelfth is the assistant pair's broken ring on
-//! the one prompt where a *correct* pair also flips an exact tie at token 4:
-//! there the divergence carries no information either way, and the subsequence
-//! ratio that would separate them — 0.2070 broken against 0.3281 correct — is
-//! inside the correct population's own spread. It is recorded rather than
-//! designed around.
+//! Over the twelve (pair, prompt) cells each broken engine above produces, the
+//! gate refuses six of six on the assistant pair and four of six on the
+//! recurrent one. The two it does not refuse read 0.0000 and 0.0977 — inside the
+//! ceiling — and are why the gate runs **every** prompt rather than one: recall
+//! is a property of the set. Both broken engines turn both gates red.
 //!
 //! # Pairs
 //!
@@ -1010,13 +1009,13 @@ fn the_ratio_is_over_the_shorter_arm_and_the_length_guard_covers_it() {
         .is_none());
 }
 
-/// The length floor is pinned in both directions, and it is under what a correct
-/// engine produces on the shortest prompt the gate runs.
+/// The length floor is pinned in both directions, and it is under every answer a
+/// correct pair produced.
 ///
-/// A floor a real answer cannot reach refuses a *fixed* engine and the
-/// reproducer could never flip to green; a floor nothing can fail is free.
+/// A floor a real answer cannot reach refuses a *fixed* engine and no reproducer
+/// could ever flip to green; a floor nothing can fail is free.
 #[test]
-fn the_length_floor_admits_the_shortest_answer_the_prompts_produce() {
+fn the_length_floor_admits_every_answer_the_prompts_produce() {
     let at_floor = Rng(0x00F1_7EDD).prose(MIN_ANSWER_TOKENS);
     assert!(
         judge(&at_floor, &at_floor, &[]).refusal().is_none(),
@@ -1028,15 +1027,18 @@ fn the_length_floor_admits_the_shortest_answer_the_prompts_produce() {
         "two arms one token under the floor must not be returned as agreement"
     );
 
-    // The shortest arm any prompt in the sweep produced. Driven through `judge`
-    // rather than compared as constants, so it pins the gate and not a pair of
-    // numbers.
-    let measured = Rng(0x2181_2181).prose(SHORTEST_MEASURED_ARM);
+    // Every arm the gate judged ran to the budget, so the floor is under all of
+    // them. Driven through `judge` rather than compared as constants.
+    let budget = Rng(0x2181_2181).prose(N_TOKENS);
     assert!(
-        judge(&measured, &measured, &[]).refusal().is_none(),
-        "a correct engine answers the shortest prompt in {SHORTEST_MEASURED_ARM} tokens \
-         and must clear the floor"
+        judge(&budget, &budget, &[]).refusal().is_none(),
+        "a pair that answers in full must clear the floor"
     );
+    const {
+        // A floor at or above the budget would pass only if neither arm ever
+        // emitted a stop id, which is a different assertion from this one.
+        assert!(MIN_ANSWER_TOKENS < N_TOKENS);
+    }
 
     // And the floor leaves the last tail window able to read the period the
     // documented collapse repeats at.
@@ -1047,10 +1049,6 @@ fn the_length_floor_admits_the_shortest_answer_the_prompts_produce() {
          evidence a period-8 cycle, which is the collapse this gate was built on"
     );
 }
-
-/// The shortest arm any prompt in [`PROMPTS`] produced on the calibrating pair,
-/// printed by `the_agreement_a_correct_pair_reaches`.
-const SHORTEST_MEASURED_ARM: usize = 216;
 
 /// A run that stopped short is refused rather than passed on its short prefix.
 #[test]
@@ -1105,38 +1103,35 @@ fn a_late_onset_divergence_is_judged_where_it_begins() {
 /// The two measured regimes put through `judge` itself, so the test fails when
 /// the oracle's composition changes and not only when a constant moves.
 ///
-/// Both come from the prompt sweep. Correct: the assistant pair's worst reading,
-/// a first divergence at the 3.5th percentile of the reference arm's own
-/// margins. Broken: the MTP sidecar before its acceptance walk was given the
-/// final norm, whose lowest reading over six prompts was the 16.8th percentile.
+/// Correct: the worst reading a shipped pair produced, a first divergence at the
+/// 8.2nd percentile of the reference arm's own margins. Broken: the lowest
+/// reading a broken engine produced that the gate still has to refuse, the 16.8th.
 #[test]
 fn the_gate_admits_the_worst_correct_regime_and_refuses_the_lowest_broken_one() {
     let plain: Vec<u32> = (0..N_TOKENS as u32).map(|t| t % 97).collect();
     let mut spec = plain.clone();
     spec[64] = 60_000;
 
-    // A margin distribution in which position 64 sits at the 3.5th percentile.
-    let correct: Vec<f32> = (0..N_TOKENS)
-        .map(|i| if i < N_TOKENS * 35 / 1000 { 0.01 } else { 5.0 })
-        .map(|m: f32| m)
-        .collect();
-    let mut correct = correct;
-    correct[64] = 0.02;
+    let margins_with_percentile = |pct: usize| -> Vec<f32> {
+        let mut m: Vec<f32> = (0..N_TOKENS)
+            .map(|i| if i < N_TOKENS * pct / 1000 { 0.01 } else { 5.0 })
+            .collect();
+        m[64] = 0.02;
+        m
+    };
+
+    let correct = margins_with_percentile(82);
     let (_, worst_correct) = divergence_confidence(&spec, &plain, &correct).expect("a divergence");
     assert!(
-        (worst_correct - 0.035).abs() < 0.005,
-        "the reconstructed correct regime reads {worst_correct:.4}, not the measured 0.0352"
+        (worst_correct - 0.082).abs() < 0.005,
+        "the reconstructed correct regime reads {worst_correct:.4}, not the measured 0.0820"
     );
     assert!(
         judge(&spec, &plain, &correct).refusal().is_none(),
-        "it must pass"
+        "the worst correct regime must pass"
     );
 
-    // The same divergence at the 16.8th percentile.
-    let mut broken: Vec<f32> = (0..N_TOKENS)
-        .map(|i| if i < N_TOKENS * 168 / 1000 { 0.01 } else { 5.0 })
-        .collect();
-    broken[64] = 0.02;
+    let broken = margins_with_percentile(168);
     let (_, lowest_broken) = divergence_confidence(&spec, &plain, &broken).expect("a divergence");
     assert!(
         (lowest_broken - 0.168).abs() < 0.005,
@@ -1144,7 +1139,7 @@ fn the_gate_admits_the_worst_correct_regime_and_refuses_the_lowest_broken_one() 
     );
     let failure = judge(&spec, &plain, &broken)
         .refusal()
-        .expect("broken must fail");
+        .expect("the lowest broken regime must be refused");
     assert!(failure.contains("nearly tied"), "{failure}");
 }
 

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -36,7 +36,8 @@
 //!
 //! **There is deliberately no subsequence floor.** How much of one answer two
 //! correct arms share is decided by where their first near-tie lands and by
-//! nothing else: the assistant pair reads 0.9375 on the 4k document and 0.4766
+//! nothing else: on `lcs_ratio` — not the tail — the assistant pair reads 0.9375
+//! on the 4k document and 0.4766
 //! on a short prose prompt whose arms flip an **exact** tie (top-two margin
 //! 0.0000) at token 37, after which both write well-formed, correct, different
 //! prose. The two broken engines read 0.2188 to 0.4615 on the same measure —
@@ -183,14 +184,21 @@ const MAX_CTX: i32 = 8192;
 /// at least four of its six.
 const MAX_DIVERGENCE_CONFIDENCE: f64 = 0.12;
 
-/// The worst tail agreement a **correct** pair reached over the prompts the gate
-/// judged, on either pair. Not a threshold the gate applies — see below — but
-/// the reference `two_arms_in_the_same_ragged_loop_are_not_returned_as_agreement`
+/// The worst [`weakest_tail`] reading a **correct** pair reached over the prompts
+/// the gate judged, on either pair. Not a threshold the gate applies — see below
+/// — but the reference `two_arms_in_the_same_ragged_loop_are_not_returned_as_agreement`
 /// uses to decide whether a synthetic pair still looks like agreement at all.
+/// `the_worst_correct_tail_is_the_worst_of_the_tails_measured` holds it to that
+/// population.
+///
+/// The paragraph below is about a **different measure** and its figures are not
+/// comparable to the one above: [`lcs_ratio`] over the whole arm, where the same
+/// runs read higher.
 ///
 /// There is deliberately **no subsequence floor**. How much of one answer two
 /// correct arms share is decided by where their first near-tie lands and by
-/// nothing else: the assistant pair reads 0.9375 on the 4k document and 0.4766
+/// nothing else: on `lcs_ratio` the assistant pair reads 0.9375 on the 4k
+/// document and 0.4766
 /// on a short prose prompt whose arms flip an exact tie at token 37, and the two
 /// broken engines measured here read 0.2188 to 0.4615 — three per cent under
 /// that, with nothing bounding the correct minimum from below. `report` prints
@@ -889,8 +897,10 @@ fn two_arms_in_the_same_ragged_loop_are_not_returned_as_agreement() {
 /// it to the population it names fails in both directions.
 #[test]
 fn the_worst_correct_tail_is_the_worst_of_the_tails_measured() {
-    /// Every tail agreement a correct pair reached, over both pairs and the
-    /// prompts each of them judged.
+    /// Every [`weakest_tail`] reading a correct pair reached, over both pairs and
+    /// the prompts each of them judged. These are tails, not [`lcs_ratio`] over
+    /// the whole arm — the same runs read 0.4766 to 1.0000 on that measure, and
+    /// the two figures the "no subsequence floor" paragraphs quote come from it.
     const MEASURED: &[f64] = &[
         // Assistant pair, six prompts.
         0.3125, 0.3750, 0.3906, 0.2344, 1.0000, 0.9062,
@@ -1065,28 +1075,26 @@ fn the_length_floor_admits_every_answer_the_prompts_produce() {
         judge(&budget, &budget, &[]).refusal().is_none(),
         "a pair that answers in full must clear the floor"
     );
+    // Both sides of the floor, at compile time, and each is the tightest form
+    // its evidence supports. The band they leave is [160, 165] and the shipped
+    // floor sits on its lower limit.
     const {
         // The upper side, and it is not merely the budget. A correct pair can
-        // answer and stop well before the budget — run at 512 tokens these same
-        // prompts stop the reference arm at 330 — so a floor that only cleared
-        // `N_TOKENS` would still class a pair that answered and stopped as a
-        // prompt that produced nothing, driving `judged` to zero and failing
-        // `run_gate`'s own guard for the wrong reason. Two thirds is the
-        // fraction that measurement leaves.
-        assert!(MIN_ANSWER_TOKENS * 3 <= N_TOKENS * 2);
-        // And the lower side: below this the last tail window cannot evidence a
-        // cycle at all.
-        assert!(MIN_ANSWER_TOKENS > TAIL_WINDOWS * MIN_CYCLE_SAMPLES);
+        // answer and stop well before the budget: the assistant pair run at a
+        // 512-token budget over these prompts stops the reference arm on the 4k
+        // document at 330, a fraction of 330/512. A floor that only cleared
+        // `N_TOKENS` would class a pair that answered and stopped as a prompt
+        // that produced nothing, driving `judged` to zero and failing
+        // `run_gate`'s own guard for the wrong reason. The measured fraction is
+        // asserted rather than a rounder one above it.
+        assert!(MIN_ANSWER_TOKENS * 512 <= N_TOKENS * 330);
+        // The lower side: the last tail window is `MIN_ANSWER_TOKENS /
+        // TAIL_WINDOWS`, and it has to leave `MIN_CYCLE_SAMPLES` comparisons
+        // over and above the period-8 cycle the documented collapse repeats at.
+        // The looser `MIN_ANSWER_TOKENS > TAIL_WINDOWS * MIN_CYCLE_SAMPLES`
+        // admits 129 and rejects nothing this does not.
+        assert!(MIN_ANSWER_TOKENS / TAIL_WINDOWS >= MIN_CYCLE_SAMPLES + 8);
     }
-
-    // And the floor leaves the last tail window able to read the period the
-    // documented collapse repeats at.
-    let last_window = MIN_ANSWER_TOKENS / TAIL_WINDOWS;
-    assert!(
-        last_window.saturating_sub(MIN_CYCLE_SAMPLES) >= 8,
-        "at this floor the last tail window is {last_window} tokens and cannot \
-         evidence a period-8 cycle, which is the collapse this gate was built on"
-    );
 }
 
 /// A run that stopped short is refused rather than passed on its short prefix.

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -1,0 +1,1342 @@
+//! Speculative decoding must not change what the model says.
+//!
+//! Greedy speculative decoding emits the verifier's own argmax at every
+//! position, so at temperature 0 a speculative run and a plain run of the same
+//! verifier are two ways of computing one answer. Every change to a drafter, a
+//! block policy or an acceptance walk can trade that away for throughput, and
+//! nothing about the throughput number says it happened.
+//!
+//! **It is not bit-identity, and measurement says so.** The verify pass scores a
+//! whole block in one forward where plain decode steps one token at a time, and
+//! that is a different reduction order. On the Gemma4-e2b assistant pair — a
+//! full-attention verifier whose rollback is an exact KV truncation, the most
+//! favourable case there is — the two arms share 91 leading tokens and then
+//! differ by a word, after which both continue the same explanation. A gate
+//! demanding identity would fail on that.
+//!
+//! **The oracle is therefore length-scaled, not positional**, and it is read
+//! twice: over the whole answer, and over each tail window, because those
+//! separate two failures the whole-stream ratio blends. One benign flip early
+//! and a divergence that begins late and never comes back can both land near
+//! 0.8 overall; only the second collapses a window. Measured on that pair at
+//! [`N_TOKENS`] tokens:
+//!
+//! | rollback | whole-stream LCS | weakest tail window | first divergence |
+//! |---|---|---|---|
+//! | as shipped | 0.9180 | 0.6875 at token 192 | 91 |
+//! | one rejected draft key left in the cache | 0.4062 | 0.2031 at token 192 | 8 |
+//!
+//! [`MIN_LCS_RATIO`] and [`MIN_TAIL_LCS_RATIO`] sit in those gaps. The shared
+//! prefix is reported and never asserted on: it collapses the moment a near-tie
+//! flips early, which is a property of the prompt and the arithmetic rather
+//! than of the round loop.
+//!
+//! **Each case declares its own horizon.** The short prompt answers past 512
+//! tokens and asks for [`MIN_ANSWER_TOKENS`]; the long-context one answers in
+//! about 200 and asks for [`MIN_LONG_CONTEXT_ANSWER_TOKENS`], because a floor
+//! its own prompt cannot meet would refuse a *fixed* engine and the reproducer
+//! could never flip to green.
+//!
+//! **Length is bounded from both sides.** Two configurations that differ can
+//! agree for the first few dozen tokens of an easy answer, so a short run is a
+//! gate that cannot fail. A long one is a different trap: greedy decoding
+//! compounds, so one benign flip makes the two arms write different paragraphs a
+//! few hundred tokens later — the same pair reads 0.9180 at 256 tokens, 0.8438
+//! at 512 and 0.6846 at its natural stop near 800, the last below any floor that
+//! still refuses a broken rollback. [`N_TOKENS`] is the horizon where the two
+//! regimes are separable; it is not a length past which nothing goes wrong.
+//!
+//! **The control.** Two arms that collapse into the *same* loop agree on
+//! garbage, and the subsequence oracle cannot refuse that by itself — it
+//! measures a subsequence over the same periodic base, so independent
+//! raggedness costs it far less than it costs a cycle reading. Two arms sharing
+//! a healthy prefix and then locked in the same period-8 loop read LCS 0.70 to
+//! 0.93 across the whole 12–40% ragged range. So every run also checks that
+//! neither arm repeats at a short period across more than
+//! [`MAX_CYCLE_FRACTION`] of its tokens — over the whole stream and over each of
+//! the same tail cuts the oracle uses, at every period up to
+//! [`MAX_CYCLE_PERIOD`] that leaves [`MIN_CYCLE_SAMPLES`] comparisons.
+//!
+//! Windowing and the period sweep are both load-bearing; three real degeneracies
+//! score under any ceiling without them:
+//!
+//! | shape | whole stream, period ≤ 8 | whole stream, period ≤ 64 | windowed |
+//! |---|---|---|---|
+//! | collapse from token 0 | 1.0000 | 1.0000 | 1.0000 |
+//! | collapse over the last two fifths | 0.3992 | 0.3992 | 1.0000 |
+//! | a twelve-token phrase over four fifths | 0.0000 | 0.7960 | 1.0000 |
+//!
+//! **There is no general threshold, which is why the prompts are what they
+//! are.** Healthy output spans 0.03 for prose to 0.88 for a markdown table with
+//! a yes/no column; degenerate output spans 0.37 for a ragged loop to 1.00 for
+//! an exact one. Those populations overlap over most of their range and no
+//! ceiling separates them — an earlier revision of this file put one at 0.85 and
+//! thereby admitted every pair in the ragged range while refusing a healthy
+//! low-entropy table.
+//!
+//! Prose is the regime where they do separate, and this gate owns its prompts.
+//! [`PROSE_INSTRUCTION`] is what makes the ceiling meaningful: measured on the
+//! real pair the two arms read 0.0893 and 0.1000, and 1000 synthetic healthy
+//! streams at each of six lengths trip it 0 times with a peak of 0.1351
+//! (`the_false_positive_rate_on_healthy_output` prints that). At 0.50 the whole
+//! ragged range is refused, and at 50% raggedness [`MIN_LCS_RATIO`] takes over —
+//! no gap between them.
+//!
+//! The limit that remains is a false *positive*: structured output trips this
+//! control. That is an input the gate controls rather than a class it lets
+//! through, and it is recorded by
+//! `structured_output_trips_the_control_which_is_why_the_prompts_forbid_it`.
+//!
+//! **Known gap: this gate runs at a short context and there is a defect past
+//! it.** `speculative_greedy_reproduces_plain_greedy_at_long_context` is the
+//! same gate over the 4k document in `prompts/longctx_4k.json` and it **fails
+//! today**: the speculative arm collapses into a period-8 repetition loop
+//! (`x86 is:66 is x86 is:66 is …`) while plain greedy writes a clean summary and
+//! stops at 218 while the speculative arm runs to the budget writing a
+//! different, degraded summary — whole-stream LCS 0.2798, first divergence at
+//! token 6. Asked for the structured summary an earlier revision of this file
+//! used, the same defect showed as an outright period-8 repetition loop reading
+//! 1.0000. It reproduces identically on `main` (8ccc0593), so it is not this
+//! branch's. It
+//! is filed, with the Qwen MTP sidecar's 0.520 as a second case, and it is a
+//! reproducer rather than a paragraph so that fixing it is what moves this gate
+//! onto the long prompt.
+//!
+//! Server-free. Both snapshots resolve by slug from `RMLX_O_MODELS_ROOT`, so
+//! `make gpu-test` runs this on a machine holding them and
+//! `scripts/run_gpu_tests.sh` reports a machine without them as INCOMPLETE.
+//! `RMLX_KV_TEST_MODEL` and `RMLX_DRAFT_TEST_MODEL` override either half:
+//!
+//! cargo test -p rmlx-models --test spec_greedy_equivalence -- --ignored --nocapture
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::ignore_without_reason
+)]
+
+use std::path::{Path, PathBuf};
+
+mod common;
+
+use rmlx_mlx::Device;
+use rmlx_models::arch;
+use rmlx_models::speculative::gemma4_assistant::{
+    mtp_assistant_generate_greedy, Gemma4AssistantDrafter,
+};
+
+/// Token budget per arm. A ceiling, not a target: both arms stop on the
+/// verifier's own stop ids and this answer is shorter than the budget.
+///
+/// The budget is what makes the horizon long enough to matter — hundreds of
+/// rounds and a kilotoken of context, against the 48 tokens the sibling
+/// alignment suites compare. Running *past* the answer is the opposite problem:
+/// with no stop ids both arms emit end-of-turn forever, and a comparison over
+/// that filler measures nothing about the round loop.
+const N_TOKENS: usize = 256;
+
+/// The shorter arm must be at least this long on the short prompt, or there is
+/// not enough answer to compare. A digest over 32 generated tokens has already
+/// given two configurations of this engine the same value where 200 separated
+/// them.
+const MIN_ANSWER_TOKENS: usize = 256;
+
+/// Which prompt an arm came from, and so how much answer the gate may demand.
+///
+/// A closed type rather than a `usize` parameter: `judge(a, b, 0)` disables the
+/// length guard entirely and nothing would refuse it. The two constants below
+/// stay the only producers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Horizon {
+    /// The short prose prompt, which answers past the budget.
+    ShortPrompt,
+    /// The 4k document, whose summary is shorter.
+    LongContext,
+}
+
+impl Horizon {
+    const fn min_answer(self) -> usize {
+        match self {
+            Self::ShortPrompt => MIN_ANSWER_TOKENS,
+            Self::LongContext => MIN_LONG_CONTEXT_ANSWER_TOKENS,
+        }
+    }
+}
+
+/// The same floor for the long-context case, whose prompt answers shorter.
+///
+/// **Measured**, not chosen: plain greedy writes its summary of that document in
+/// 218 tokens and stops, so the floor is set just under the length a correct
+/// engine produces. A floor of 256 would fail a *fixed* engine — both arms would
+/// agree at ~218 tokens and the gate would still report "an arm stopped early",
+/// so the reproducer could never flip to green. A much lower one would admit
+/// arms whose last tail window is too short to read the period the collapse
+/// repeats at: at 200 tokens that window is 50 and periods to 18 are readable,
+/// which covers the documented period-8 loop; at 150 it is 38 and they are not.
+const MIN_LONG_CONTEXT_ANSWER_TOKENS: usize = 200;
+
+/// What plain greedy actually answers that prompt in, measured on the pair.
+/// The floor above is set under it; `a_fixed_engine_would_pass_the_long_context_reproducer`
+/// drives a stream of this length through `judge` so the relation is pinned.
+const MEASURED_LONG_CONTEXT_PLAIN_ARM: usize = 218;
+
+/// The shorter arm over the longer. `lcs_ratio` divides by the shorter stream,
+/// so an arm that stopped at a third of the other's length and matched its
+/// prefix would otherwise score 1.0.
+const MIN_LENGTH_RATIO: f64 = 0.60;
+
+/// Draft block. Small enough that a rollback runs every few tokens, which is
+/// the code path the oracle protects.
+const BLOCK_SIZE: usize = 4;
+
+/// Context both arms run under. Above the 4k prompt plus the budget, and the
+/// same on both sides — a different cap on either would make this a measurement
+/// of the cap.
+const MAX_CTX: i32 = 8192;
+
+/// How much of one answer both arms must have produced.
+///
+/// Between the two measured regimes in the module docs: 1.3x below the shipped
+/// rollback's reading and 2.7x above a rollback that leaves one rejected key in
+/// the cache.
+const MIN_LCS_RATIO: f64 = 0.70;
+
+/// How much of an arm — or of any tail cut of it — may repeat at a short period
+/// before it counts as collapsed.
+///
+/// Set against **the output this gate's own prompts produce**, which is prose:
+/// the real arms read 0.0893 and 0.1000, and 1800 synthetic healthy streams
+/// across six lengths peaked at 0.1212. Every pair of arms locked in the same
+/// period-8 loop up to 40% raggedness is refused above it, and at 50% the
+/// subsequence floor takes over — so the whole degenerate range is covered with
+/// no gap.
+///
+/// It is **not** a general degeneracy threshold and there is none: healthy
+/// markdown tables read 0.68 to 0.88 on this measure and ragged loops read 0.37
+/// to 0.85, two populations overlapping over most of their range. Structured
+/// output therefore trips this control, which is why [`PROSE_INSTRUCTION`]
+/// exists and why the value here is only meaningful for arms these prompts
+/// produced.
+const MAX_CYCLE_FRACTION: f64 = 0.50;
+
+/// Longest cycle the control looks for.
+///
+/// A degeneracy in real output is usually a repeated phrase or sentence, not a
+/// repeated token: a 12-token phrase filling four fifths of a stream scores
+/// 0.0000 at any period under 12 and 0.7960 at 12. The defect this file
+/// documents repeats at period 8, one step under the ceiling this replaced.
+///
+/// Bounded again by what leaves [`MIN_CYCLE_SAMPLES`] comparisons in whatever
+/// window is being read, which is the only bound that turned out to be needed.
+const MAX_CYCLE_PERIOD: usize = 64;
+
+/// Fewest comparisons a cycle reading may be computed from.
+///
+/// `strongest_cycle` divides by `len - period`. In the last quarter of a
+/// 256-token arm that is a 64-token window, and at period 63 the denominator is
+/// **one comparison** — a single coincidental token match read 1.0000 and the
+/// gate reported a repetition loop on healthy output. Every false positive
+/// observed came from a denominator of one or two, at any ceiling, so this floor
+/// is the whole fix; `the_false_positive_rate_on_healthy_output` prints the
+/// measured rate per length rather than recording a number nothing can
+/// regenerate.
+///
+/// A bound on the *period relative to the window* was tried alongside it and
+/// removed: it changed no false-positive rate and it blinded the sweep to real
+/// collapses — a period-40 loop over the last quarter of a 512-token arm read
+/// 0.4074 under it and 1.0000 without it, which is the shape the windowed sweep
+/// exists for.
+const MIN_CYCLE_SAMPLES: usize = 32;
+
+/// The stream is cut at each `1/TAIL_WINDOWS` boundary and the suffixes
+/// compared, so a divergence that begins late has a window it dominates.
+const TAIL_WINDOWS: usize = 4;
+
+/// How much of one answer both arms must share over every tail window.
+///
+/// Lower than the whole-stream floor: a suffix starts wherever the cut falls,
+/// so it can open mid-divergence where the whole stream does not. Between the
+/// two measured regimes in the module docs — 1.6x below the shipped rollback's
+/// weakest window and 1.9x above the broken one's.
+const MIN_TAIL_LCS_RATIO: f64 = 0.40;
+
+// ── Oracle ───────────────────────────────────────────────────────────────────
+
+/// How many leading tokens two streams share. Reported, never asserted on — see
+/// the module docs.
+fn common_prefix_len(a: &[u32], b: &[u32]) -> usize {
+    a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
+}
+
+/// Longest common subsequence of two token streams, over the shorter of them.
+fn lcs_ratio(a: &[u32], b: &[u32]) -> f64 {
+    let (n, m) = (a.len(), b.len());
+    if n == 0 || m == 0 {
+        return 0.0;
+    }
+    let mut prev = vec![0usize; m + 1];
+    let mut cur = vec![0usize; m + 1];
+    for i in 1..=n {
+        for j in 1..=m {
+            cur[j] = if a[i - 1] == b[j - 1] {
+                prev[j - 1] + 1
+            } else {
+                cur[j - 1].max(prev[j])
+            };
+        }
+        std::mem::swap(&mut prev, &mut cur);
+        cur.fill(0);
+    }
+    prev[m] as f64 / n.min(m) as f64
+}
+
+/// The strongest short cycle in `tokens`: its period, and the fraction of
+/// positions that repeat at that period.
+///
+/// The control. A stream stuck in a loop matches itself at the loop's period,
+/// and two arms in the same loop agree perfectly — so the equivalence oracle
+/// says nothing exactly when this is high. It covers every period up to
+/// [`MAX_CYCLE_PERIOD`], because a collapse that starts at token 20 and a
+/// two-token `A B A B` cycle are both degeneracies a leading-run measure scores
+/// at zero.
+fn strongest_cycle(tokens: &[u32]) -> (usize, f64) {
+    let mut worst = (1usize, 0.0f64);
+    for period in 1..=MAX_CYCLE_PERIOD.min(tokens.len().saturating_sub(MIN_CYCLE_SAMPLES)) {
+        let samples = tokens.len() - period;
+        let matches = tokens[period..]
+            .iter()
+            .zip(tokens)
+            .filter(|(a, b)| a == b)
+            .count();
+        let fraction = matches as f64 / samples as f64;
+        if fraction > worst.1 {
+            worst = (period, fraction);
+        }
+    }
+    worst
+}
+
+/// The strongest short cycle in `tokens` or in any tail cut of it: where it
+/// starts, its period, and the fraction of that window repeating at it.
+///
+/// Over the whole stream a collapse confined to the last two fifths reads
+/// 0.3992 — under the ceiling, because the healthy majority dilutes it. The
+/// same cuts `weakest_tail` uses give it a window it fills.
+fn strongest_windowed_cycle(tokens: &[u32]) -> (usize, usize, f64) {
+    let starts =
+        std::iter::once(0).chain((1..TAIL_WINDOWS).map(|n| tokens.len() * n / TAIL_WINDOWS));
+    let mut worst = (0usize, 1usize, 0.0f64);
+    for start in starts {
+        let (period, fraction) = strongest_cycle(&tokens[start..]);
+        if fraction > worst.2 {
+            worst = (start, period, fraction);
+        }
+    }
+    worst
+}
+
+/// The weakest agreement over the tail windows, and where it was found.
+///
+/// The whole-stream ratio blends a run that diverged once at token 60 and
+/// re-converged with a run that diverged at token 700 and never came back: both
+/// can land near 0.8. A regression that begins past a cache-size threshold is
+/// the second shape, and the repository has shipped that class. Suffix windows
+/// separate them — the late one collapses the last window while the early one
+/// leaves every window high.
+fn weakest_tail(spec: &[u32], plain: &[u32]) -> (usize, f64) {
+    let shorter = spec.len().min(plain.len());
+    let mut worst = (0usize, 1.0f64);
+    for numerator in 1..TAIL_WINDOWS {
+        let start = shorter * numerator / TAIL_WINDOWS;
+        let ratio = lcs_ratio(&spec[start..], &plain[start..]);
+        if ratio < worst.1 {
+            worst = (start, ratio);
+        }
+    }
+    worst
+}
+
+/// Judge one pair of streams. Returns the failure text, or `None` when the
+/// oracle and both controls held.
+fn judge(spec: &[u32], plain: &[u32], horizon: Horizon) -> Option<String> {
+    let shorter = spec.len().min(plain.len());
+    let longer = spec.len().max(plain.len());
+
+    // The controls first. A degenerate arm is a more specific verdict than a
+    // short one, and a collapse can be what cut the run short.
+    for (name, arm) in [("plain", plain), ("speculative", spec)] {
+        let (start, period, fraction) = strongest_windowed_cycle(arm);
+        if fraction > MAX_CYCLE_FRACTION {
+            return Some(format!(
+                "the {name} arm repeats at period {period} across {fraction:.4} of its \
+                 tokens from {start} on (ceiling {MAX_CYCLE_FRACTION}) — it has collapsed \
+                 into a repetition loop, so agreement between the arms would say nothing"
+            ));
+        }
+    }
+
+    let min_answer = horizon.min_answer();
+    if shorter < min_answer {
+        return Some(format!(
+            "an arm stopped early — spec={} plain={}, under {min_answer}; a short \
+             run is a comparison with no power, not a pass",
+            spec.len(),
+            plain.len()
+        ));
+    }
+    let length_ratio = shorter as f64 / longer as f64;
+    if length_ratio < MIN_LENGTH_RATIO {
+        return Some(format!(
+            "the arms answered at {} and {} tokens, a ratio of {length_ratio:.4} (floor \
+             {MIN_LENGTH_RATIO}) — one stopped well before the other, and the subsequence \
+             ratio is taken over the shorter, where a truncated arm reads high on the \
+             other's prefix",
+            spec.len(),
+            plain.len()
+        ));
+    }
+
+    let ratio = lcs_ratio(spec, plain);
+    if ratio < MIN_LCS_RATIO {
+        return Some(format!(
+            "the arms share {ratio:.4} of one answer (floor {MIN_LCS_RATIO}), sharing \
+             {} leading tokens — the round loop did not reproduce what the verifier \
+             decodes on its own",
+            common_prefix_len(spec, plain)
+        ));
+    }
+
+    let (start, tail) = weakest_tail(spec, plain);
+    if tail < MIN_TAIL_LCS_RATIO {
+        return Some(format!(
+            "the arms share {ratio:.4} of the whole answer but only {tail:.4} of it from \
+             token {start} on (floor {MIN_TAIL_LCS_RATIO}), first differing at token {} — \
+             a divergence that begins late and does not come back, which the whole-stream \
+             ratio blends with one benign flip",
+            common_prefix_len(spec, plain)
+        ));
+    }
+    None
+}
+
+// ── Oracle tests (no model, no GPU) ──────────────────────────────────────────
+
+/// One near-tie flip that both arms write around is the shipped behaviour and
+/// must pass; a stream that goes its own way must not.
+#[test]
+fn a_single_flip_passes_and_a_divergent_stream_does_not() {
+    let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
+
+    let mut one_flip = plain.clone();
+    one_flip[66] = 9999;
+    assert!(
+        judge(&one_flip, &plain, Horizon::ShortPrompt).is_none(),
+        "one flip must pass"
+    );
+
+    let diverged: Vec<u32> = plain
+        .iter()
+        .enumerate()
+        .map(|(i, t)| if i > 8 { 50_000 + i as u32 } else { *t })
+        .collect();
+    let failure =
+        judge(&diverged, &plain, Horizon::ShortPrompt).expect("a divergent stream must fail");
+    assert!(failure.contains("did not reproduce"), "{failure}");
+}
+
+/// Two arms stuck in the same repetition loop agree perfectly and mean nothing.
+/// The control is what separates that from a real match — for a loop that
+/// starts at the first token, one that starts part-way through, and one whose
+/// cycle is longer than a single token. A leading-run measure scores the second
+/// and third at zero and lets both through.
+#[test]
+fn every_shape_of_repetition_loop_is_refused() {
+    let healthy: Vec<u32> = (0..N_TOKENS as u32).collect();
+    for (shape, stream) in [
+        ("from the first token", vec![7u32; N_TOKENS]),
+        (
+            "beginning at token 20",
+            healthy[..20]
+                .iter()
+                .copied()
+                .chain(std::iter::repeat_n(7u32, N_TOKENS - 20))
+                .collect(),
+        ),
+        (
+            "a two-token cycle",
+            (0..N_TOKENS)
+                .map(|i| if i % 2 == 0 { 7 } else { 9 })
+                .collect(),
+        ),
+        (
+            "a three-token cycle beginning at token 40",
+            healthy[..40]
+                .iter()
+                .copied()
+                .chain((0..N_TOKENS - 40).map(|i| [7u32, 9, 11][i % 3]))
+                .collect(),
+        ),
+        // Over the whole stream this reads 0.3992 at period 1 — under the
+        // ceiling, because the healthy three fifths dilute it. Its own tail
+        // window is where it is visible.
+        (
+            "a collapse confined to the last two fifths",
+            healthy[..N_TOKENS * 3 / 5]
+                .iter()
+                .copied()
+                .chain(std::iter::repeat_n(7u32, N_TOKENS - N_TOKENS * 3 / 5))
+                .collect(),
+        ),
+        // A repeated sentence is the commonest real degeneracy and reads
+        // 0.0000 at every period under its own length.
+        (
+            "a twelve-token phrase over four fifths",
+            healthy[..N_TOKENS / 5]
+                .iter()
+                .copied()
+                .chain((0..N_TOKENS - N_TOKENS / 5).map(|i| 1000 + (i % 12) as u32))
+                .collect(),
+        ),
+    ] {
+        let failure = judge(&stream, &stream, Horizon::ShortPrompt)
+            .unwrap_or_else(|| panic!("{shape} was not refused"));
+        assert!(failure.contains("repetition loop"), "{shape}: {failure}");
+    }
+}
+
+/// A speculative arm that degenerated while the plain one did not is caught by
+/// the control that reads the speculative arm, not only the plain one.
+#[test]
+fn a_degenerate_speculative_arm_is_caught() {
+    let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
+    let looping = vec![7u32; N_TOKENS];
+    let failure = judge(&looping, &plain, Horizon::ShortPrompt).expect("must refuse");
+    assert!(failure.contains("speculative arm"), "{failure}");
+}
+
+/// A deterministic stand-in for token streams, seeded per case.
+///
+/// A plain `t % 97` stream was the previous control: 97 is prime and above the
+/// period ceiling, so it reads exactly 0.0000 at every period the sweep looks at
+/// and could not detect a control that fires on real output. These shapes can.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        // xorshift64*, so the fixtures are reproducible without a dependency.
+        self.0 ^= self.0 >> 12;
+        self.0 ^= self.0 << 25;
+        self.0 ^= self.0 >> 27;
+        self.0.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    fn below(&mut self, n: u32) -> u32 {
+        (self.next() % u64::from(n)) as u32
+    }
+
+    /// Word ids drawn from a Zipf-ish distribution, as prose is.
+    fn prose(&mut self, len: usize) -> Vec<u32> {
+        (0..len)
+            .map(|_| {
+                let r = self.below(1000);
+                r % (1 + r / 8)
+            })
+            .collect()
+    }
+}
+
+/// Structured output trips this control, and that is why the prompts forbid it.
+///
+/// A markdown table repeats its delimiters every row and a numbered list its
+/// `N. **` prefix every item. On this measure they read far above prose and
+/// above any ceiling that still refuses a ragged loop — so the control is not a
+/// general degeneracy classifier and this test records that rather than
+/// asserting it away. [`PROSE_INSTRUCTION`] is what keeps these shapes out of
+/// the arms the gate actually judges; if an answer ever comes back structured,
+/// the gate refuses it and the reason will say "repetition loop", which is this
+/// limit and not a defect in the engine.
+#[test]
+fn structured_output_trips_the_control_which_is_why_the_prompts_forbid_it() {
+    let mut rng = Rng(0x5EED_5EED);
+    let mut table = Vec::new();
+    while table.len() < N_TOKENS {
+        // `| ` name `| ` value `|` newline — two of six tokens vary.
+        table.extend_from_slice(&[900, 901, rng.below(50), 902, rng.below(50), 903]);
+    }
+    let mut boolean_table = Vec::new();
+    while boolean_table.len() < N_TOKENS {
+        // The same shape with a yes/no column: lower entropy, higher reading.
+        boolean_table.extend_from_slice(&[900, 901, rng.below(2), 902, rng.below(2), 903]);
+    }
+    let mut numbered = Vec::new();
+    while numbered.len() < N_TOKENS {
+        numbered.extend_from_slice(&[910, 911, 912]);
+        numbered.extend((0..3).map(|_| rng.below(80)));
+        numbered.extend_from_slice(&[913, 914]);
+    }
+    for (shape, stream) in [
+        ("a markdown table", table[..N_TOKENS].to_vec()),
+        (
+            "a table with a yes/no column",
+            boolean_table[..N_TOKENS].to_vec(),
+        ),
+        ("a numbered list", numbered[..N_TOKENS].to_vec()),
+    ] {
+        let (_, _, fraction) = strongest_windowed_cycle(&stream);
+        assert!(
+            fraction > MAX_CYCLE_FRACTION,
+            "{shape} reads {fraction:.4}, at or under the ceiling — if structured \
+             output has stopped tripping this control the module docs are wrong \
+             about why the prompts are what they are"
+        );
+    }
+}
+
+/// Prose does not, at any length the gate can hand it, and that is the
+/// population the ceiling is set against.
+#[test]
+fn prose_clears_the_control_at_every_length_the_gate_can_hand_it() {
+    let mut worst = 0.0f64;
+    for len in [40usize, 120, 200, 218, 256] {
+        for seed in 0..64u64 {
+            let stream = Rng(0x1234_0000 + seed).prose(len);
+            let (start, period, fraction) = strongest_windowed_cycle(&stream);
+            assert!(
+                fraction <= MAX_CYCLE_FRACTION,
+                "healthy prose of {len} tokens (seed {seed}) read {fraction:.4} at \
+                 period {period} from {start}"
+            );
+            worst = worst.max(fraction);
+        }
+    }
+    assert!(
+        worst < MAX_CYCLE_FRACTION * 0.5,
+        "the margin over healthy prose has fallen to {worst:.4} against a ceiling \
+         of {MAX_CYCLE_FRACTION}; the real arms measure about 0.09"
+    );
+}
+
+/// The one bound that makes a reading mean something.
+///
+/// `strongest_cycle` divides by `len - period`. Without a floor on that
+/// denominator a reading can be one coincidental comparison out of one, which
+/// is what made the control fire on healthy output. A bound on the period
+/// relative to the window was tried alongside it and removed: it changed no
+/// false-positive rate and blinded the sweep to real collapses.
+#[test]
+#[allow(
+    clippy::float_cmp,
+    reason = "the assertion is that no reading was taken at all, which is \
+              exactly zero; a band would accept a reading from too few samples"
+)]
+fn a_cycle_too_short_a_window_to_evidence_is_not_read() {
+    // One coincidence at distance 63 in a 64-token window: one comparison.
+    let mut coincidence: Vec<u32> = (0..64).collect();
+    coincidence[63] = 0;
+    assert_eq!(
+        strongest_cycle(&coincidence).1,
+        0.0,
+        "a reading from a single comparison must not be taken"
+    );
+
+    // An exact period of 10 in 40 tokens: 30 comparisons, under the floor.
+    let short_window: Vec<u32> = (0..40u32).map(|i| i % 10).collect();
+    assert_eq!(
+        strongest_cycle(&short_window).1,
+        0.0,
+        "a reading from fewer than the sample floor must not be taken"
+    );
+
+    // The floor is a floor on evidence, not a blanket. 140 comparisons all
+    // matching at period 60 is overwhelming, and the quarter-window bound used
+    // to score it 0.0000 — the case that showed the bound cost real detection.
+    let long_period: Vec<u32> = (0..200u32).map(|i| i % 60).collect();
+    assert!(
+        strongest_cycle(&long_period).1 > MAX_CYCLE_FRACTION,
+        "an exact period-60 cycle over 140 comparisons must be read, not bounded away"
+    );
+
+    let supported: Vec<u32> = (0..N_TOKENS as u32).map(|i| i % 10).collect();
+    assert!(
+        strongest_cycle(&supported).1 > MAX_CYCLE_FRACTION,
+        "an exact cycle a full window supports must still be caught"
+    );
+}
+
+/// The false-positive rate of the control on healthy output, per length.
+///
+/// Not a gate: it prints. Three rounds of review disagreed about this rate by a
+/// factor of three to five because the measuring code was never committed and
+/// the surviving tests could only observe the "after" state, so nothing in the
+/// tree could adjudicate. This is that code.
+///
+/// `#[ignore]` because it is a measurement over thousands of streams and says
+/// nothing about correctness; `prose_clears_the_control_at_every_length_the_gate_can_hand_it`
+/// is the assertion. Run it with `--ignored --nocapture`; it reaches no device.
+// gpu-test-gate: exempt
+#[ignore = "measurement, not an assertion: prints the false-positive rate per length"]
+#[test]
+fn the_false_positive_rate_on_healthy_output() {
+    const TRIALS: u64 = 1000;
+    println!(
+        "healthy-prose false positives, {TRIALS} streams per length, ceiling {MAX_CYCLE_FRACTION}"
+    );
+    for len in [40usize, 120, 200, 218, 256, 512] {
+        let mut trips = 0u32;
+        let mut worst = 0.0f64;
+        for seed in 0..TRIALS {
+            let f = strongest_windowed_cycle(&Rng(0x9E37_0000 + seed).prose(len)).2;
+            worst = worst.max(f);
+            if f > MAX_CYCLE_FRACTION {
+                trips += 1;
+            }
+        }
+        println!(
+            "  len={len:4}  trips={trips:4}/{TRIALS}  rate={:.3}%  max reading={worst:.4}",
+            f64::from(trips) * 100.0 / TRIALS as f64
+        );
+    }
+}
+
+/// **The pair regime.** Two arms that share a real prefix and then collapse into
+/// the same loop agree on garbage, and that is the one case the subsequence
+/// oracle cannot refuse by itself — it is a subsequence measure over the same
+/// periodic base, and independent raggedness costs it far less than it costs
+/// the cycle reading. Every fixture in this file before this one judged a
+/// single arm, or a pair whose heads were independently seeded, so this regime
+/// was never tested and a false claim about it went unnoticed for two rounds.
+#[test]
+fn two_arms_in_the_same_ragged_loop_are_not_a_pass() {
+    let head = Rng(0xFEED).prose(N_TOKENS / 2);
+    let arm = |seed: u64, noise: u64| -> Vec<u32> {
+        let mut rng = Rng(seed);
+        let mut out = head.clone();
+        for i in 0..N_TOKENS / 2 {
+            out.push(if u64::from(rng.below(100)) < noise {
+                rng.below(300)
+            } else {
+                1000 + (i % 8) as u32
+            });
+        }
+        out
+    };
+    for noise in [0u64, 12, 16, 25, 30, 40] {
+        let (a, b) = (arm(0x33, noise), arm(0x44, noise));
+        let verdict = judge(&a, &b, Horizon::ShortPrompt);
+        assert!(
+            verdict.is_some(),
+            "two arms {noise}% ragged in the same period-8 loop passed: lcs {:.4}, \
+             cycles {:.4} and {:.4} — they agree on garbage and the gate called it \
+             agreement",
+            lcs_ratio(&a, &b),
+            strongest_windowed_cycle(&a).2,
+            strongest_windowed_cycle(&b).2,
+        );
+    }
+}
+
+/// A collapse over the last quarter of a long arm is what the windowed sweep
+/// was added for, and a pair of them must not pass.
+#[test]
+fn two_arms_collapsing_over_their_last_quarter_are_not_a_pass() {
+    let head = Rng(0xC0DE).prose(N_TOKENS * 3 / 4);
+    let arm = |seed: u64| -> Vec<u32> {
+        let mut rng = Rng(seed);
+        let mut out = head.clone();
+        for i in 0..N_TOKENS - N_TOKENS * 3 / 4 {
+            out.push(if rng.below(100) < 5 {
+                rng.below(300)
+            } else {
+                1000 + (i % 16) as u32
+            });
+        }
+        out
+    };
+    let (a, b) = (arm(0x55), arm(0x66));
+    assert!(
+        judge(&a, &b, Horizon::ShortPrompt).is_some(),
+        "two arms collapsing into a period-16 loop over their last quarter passed: \
+         lcs {:.4}, cycles {:.4} and {:.4}",
+        lcs_ratio(&a, &b),
+        strongest_windowed_cycle(&a).2,
+        strongest_windowed_cycle(&b).2,
+    );
+}
+/// The subsequence ratio is taken over the shorter arm, so an arm that stopped
+/// early and matched the other's prefix scores 1.0 and says nothing about the
+/// tail it never wrote. The length guard is the only thing between that and a
+/// green gate, and this pins both halves: the denominator and the guard.
+#[test]
+fn the_ratio_is_over_the_shorter_arm_and_the_length_guard_covers_it() {
+    // Twice the budget, so the *ratio* is what fires rather than the floor.
+    let plain: Vec<u32> = Rng(0x1E17_0000).prose(N_TOKENS * 2);
+
+    let truncated = &plain[..N_TOKENS + 4];
+    assert!(
+        (lcs_ratio(truncated, &plain) - 1.0).abs() < 1e-9,
+        "a true prefix must score 1.0 over the shorter arm; it read {}",
+        lcs_ratio(truncated, &plain)
+    );
+    let failure =
+        judge(truncated, &plain, Horizon::ShortPrompt).expect("the length guard must refuse it");
+    assert!(failure.contains("stopped well before"), "{failure}");
+
+    // Just inside the guard the same shape scores 1.0 and passes, which is what
+    // makes the guard — not the ratio — the thing doing the work above.
+    assert!(judge(&plain[..N_TOKENS + 84], &plain, Horizon::ShortPrompt).is_none());
+}
+
+/// The long-context reproducer can flip to green.
+///
+/// Its prompt answers in about 200 tokens, and the short prompt's floor of 256
+/// would refuse a *fixed* engine: both arms would agree at ~200 and the gate
+/// would still say "an arm stopped early". A reproducer that cannot pass once
+/// the defect is fixed has to be rewritten after the fix, which is the outcome
+/// it exists to prevent.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "the assertion is that the short prompt's floor refuses this length; \
+              unwrapping the None case is the failure the test exists to report"
+)]
+fn a_fixed_engine_would_pass_the_long_context_reproducer() {
+    // The floor is pinned in both directions, or its value is free: replacing
+    // it with 60 or 199 left the suite green.
+    let at_floor = Rng(0x00F1_7EDD).prose(MIN_LONG_CONTEXT_ANSWER_TOKENS);
+    assert!(
+        judge(&at_floor, &at_floor, Horizon::LongContext).is_none(),
+        "two arms exactly at the floor must pass"
+    );
+    let under = &at_floor[..MIN_LONG_CONTEXT_ANSWER_TOKENS - 1];
+    assert!(
+        judge(under, under, Horizon::LongContext).is_some(),
+        "two arms one token under the floor must be refused"
+    );
+    // And the floor is under the length a correct engine produces on that
+    // prompt, which is what lets the reproducer flip to green. Driven through
+    // `judge` rather than compared as constants, so it pins the gate.
+    let measured_plain_arm = Rng(0x2181_2181).prose(MEASURED_LONG_CONTEXT_PLAIN_ARM);
+    assert!(
+        judge(
+            &measured_plain_arm,
+            &measured_plain_arm,
+            Horizon::LongContext
+        )
+        .is_none(),
+        "a correct engine answers that prompt in {MEASURED_LONG_CONTEXT_PLAIN_ARM} \
+         tokens and must clear the floor"
+    );
+    // Far enough under to be reachable, close enough that the last tail window
+    // can still read the period the documented collapse repeats at.
+    let last_window = MIN_LONG_CONTEXT_ANSWER_TOKENS / TAIL_WINDOWS;
+    assert!(
+        last_window.saturating_sub(MIN_CYCLE_SAMPLES) >= 8,
+        "at this floor the last tail window is {last_window} tokens and cannot \
+         evidence a period-8 cycle, which is the collapse the reproducer records"
+    );
+
+    let answer = Rng(0x00F1_7EDD).prose(200);
+    assert!(
+        judge(&answer, &answer, Horizon::LongContext).is_none(),
+        "two arms agreeing at 200 tokens must pass the long-context floor"
+    );
+    // One benign flip, as the shipped short-prompt pair shows at token 66.
+    let mut flipped = answer.clone();
+    flipped[66] = 60_000;
+    assert!(judge(&flipped, &answer, Horizon::LongContext).is_none());
+    // And the short prompt's floor is what makes it unreachable.
+    let failure = judge(&answer, &answer, Horizon::ShortPrompt).expect("256 refuses 200");
+    assert!(failure.contains("stopped early"), "{failure}");
+}
+
+/// A run that stopped short is refused rather than passed on its short prefix.
+#[test]
+fn a_truncated_run_is_refused_rather_than_judged() {
+    let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
+    let failure = judge(&plain[..16], &plain, Horizon::ShortPrompt).expect("must refuse");
+    assert!(failure.contains("stopped early"), "{failure}");
+}
+
+/// The class the whole-stream ratio blends: a divergence that begins in the
+/// last quarter and never comes back scores high overall and collapses one tail
+/// window. This is the shape of a regression that fires past a cache-size
+/// threshold, and it is why the tail windows exist.
+#[test]
+fn a_late_onset_divergence_passes_the_whole_stream_ratio_and_fails_the_tail() {
+    let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
+    let onset = N_TOKENS * 4 / 5;
+    let late: Vec<u32> = plain
+        .iter()
+        .enumerate()
+        .map(|(i, t)| if i >= onset { 50_000 + i as u32 } else { *t })
+        .collect();
+
+    let whole = lcs_ratio(&late, &plain);
+    assert!(
+        whole >= MIN_LCS_RATIO,
+        "the whole-stream ratio {whole} already refuses this, so the tail windows \
+         are not what is being tested"
+    );
+    let failure =
+        judge(&late, &plain, Horizon::ShortPrompt).expect("the tail windows must refuse it");
+    assert!(failure.contains("begins late"), "{failure}");
+}
+
+/// The two measured regimes, reconstructed as token streams and put through the
+/// gate itself — so the test also fails when `lcs_ratio`'s denominator or
+/// `judge`'s comparison changes, not only when the constant moves.
+#[test]
+fn the_gate_admits_the_shipped_regime_and_refuses_the_broken_one() {
+    let plain: Vec<u32> = (0..N_TOKENS as u32).map(|t| t % 97).collect();
+
+    // As shipped: one benign flip, then the same answer. Replacing 1 token in
+    // 12 leaves a subsequence ratio near the measured 0.91.
+    let shipped: Vec<u32> = plain
+        .iter()
+        .enumerate()
+        .map(|(i, t)| if i % 12 == 5 { 60_000 + i as u32 } else { *t })
+        .collect();
+    assert!(
+        lcs_ratio(&shipped, &plain) > MIN_LCS_RATIO,
+        "reconstructed shipped regime reads {}",
+        lcs_ratio(&shipped, &plain)
+    );
+    assert!(
+        judge(&shipped, &plain, Horizon::ShortPrompt).is_none(),
+        "shipped must pass"
+    );
+
+    // The broken rollback: diverged at token 5 and never recovered. Three
+    // tokens in four replaced leaves roughly the measured 0.26.
+    let broken: Vec<u32> = plain
+        .iter()
+        .enumerate()
+        .map(|(i, t)| {
+            if i >= 5 && i % 4 != 0 {
+                60_000 + i as u32
+            } else {
+                *t
+            }
+        })
+        .collect();
+    let failure = judge(&broken, &plain, Horizon::ShortPrompt).expect("broken must fail");
+    assert!(failure.contains("did not reproduce"), "{failure}");
+}
+
+/// The field that separates two drafters the arch check cannot.
+///
+/// Both `-e2b-` and `-e4b-` assistants declare `Gemma4AssistantForCausalLM`, so
+/// the golden harness's stand-down passes either against either verifier. This
+/// is what the gate reads instead, and it has to read the number rather than
+/// merely find the file.
+#[test]
+fn the_drafter_declares_the_backbone_it_projects_into() {
+    let dir = std::env::temp_dir().join(format!("rmlx_spec_equiv_backbone_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+
+    std::fs::write(
+        dir.join("config.json"),
+        r#"{"model_type":"gemma4_assistant","architectures":["Gemma4AssistantForCausalLM"],"backbone_hidden_size":1536}"#,
+    )
+    .expect("write config");
+    assert!(is_gemma4_assistant(&dir));
+    assert_eq!(declared_backbone_hidden(&dir), Some(1536));
+
+    // The e4b assistant is the same architecture and a different backbone.
+    std::fs::write(
+        dir.join("config.json"),
+        r#"{"model_type":"gemma4_assistant","architectures":["Gemma4AssistantForCausalLM"],"backbone_hidden_size":2560}"#,
+    )
+    .expect("write config");
+    assert!(is_gemma4_assistant(&dir), "still the same architecture");
+    assert_eq!(declared_backbone_hidden(&dir), Some(2560));
+
+    // A snapshot that does not say is served by the engine at the verifier's
+    // width, so it must not read as a mismatch here.
+    std::fs::write(
+        dir.join("config.json"),
+        r#"{"model_type":"gemma4_assistant","architectures":["Gemma4AssistantForCausalLM"]}"#,
+    )
+    .expect("write config");
+    let silent = declared_backbone_hidden(&dir);
+    assert_eq!(silent, None);
+    // The gate's own predicate, on the value the gate would have: absent is
+    // what the loader defaults to the verifier's width, not a mismatch.
+    assert!(
+        silent.is_none_or(|w| w == 1536),
+        "an absent key must not read as a mismatch"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ── The gate ─────────────────────────────────────────────────────────────────
+
+/// The verifier this gate is calibrated on, resolved by the golden harness so
+/// an override naming another architecture stands down instead of running.
+const VERIFIER: common::GoldenModel = common::GoldenModel {
+    slug: "mlx-community__gemma-4-e2b-it-mxfp8",
+    archs: &["Gemma4ForConditionalGeneration"],
+};
+/// Snapshot slug of its assistant drafter.
+const DRAFTER_SLUG: &str = "mlx-community__gemma-4-E2B-it-assistant-bf16";
+/// Draft-model override, the variable the sibling alignment suites take.
+const DRAFT_MODEL_VAR: &str = "RMLX_DRAFT_TEST_MODEL";
+
+/// Resolve the **drafter**, which the golden harness has no variable for: an
+/// operator's override if they named one, otherwise the slug under
+/// `RMLX_O_MODELS_ROOT`. The verifier goes through `common::model_for`.
+///
+/// Resolving by slug is what puts this gate inside `make gpu-test` on a machine
+/// holding the snapshots: it joins the population `run_gpu_tests.sh` already
+/// reports as INCOMPLETE when the models root is unset, instead of being a
+/// third variable nobody exports and a green run that asserted nothing.
+///
+/// A path the operator named that is not a snapshot fails; a models root that
+/// simply does not hold the slug skips. That split is the harness's
+/// (`tests/common/mod.rs`), not a second copy of its rules.
+fn resolve(var: &str, slug: &str) -> common::Gate {
+    let root = std::env::var(common::MODELS_ROOT_VAR).ok();
+    let Some(named) = std::env::var(var).ok().filter(|v| !v.is_empty()) else {
+        return match common::slug_snapshot(root.as_deref(), slug) {
+            common::Snapshot::Found { path, .. } => common::Gate::Run { path, note: None },
+            // The harness names its own override variable in that message; this
+            // half of the pair is overridden by a different one.
+            common::Snapshot::Absent(why) => {
+                common::Gate::Skip(why.replace(common::SINGLE_MODEL_VAR, var))
+            }
+            common::Snapshot::Misconfigured(why) => common::Gate::Fail(why),
+        };
+    };
+    let named_path = PathBuf::from(&named);
+    let (parent, leaf) = match (named_path.parent(), named_path.file_name()) {
+        (Some(parent), Some(leaf)) => (parent.to_owned(), leaf.to_string_lossy().into_owned()),
+        _ => return common::Gate::Fail(format!("{var}={named} is not a directory path")),
+    };
+    match common::slug_snapshot(parent.to_str(), &leaf) {
+        common::Snapshot::Found { path, .. } => common::Gate::Run { path, note: None },
+        // The operator named this path, so a typo or a moved snapshot breaks
+        // the run rather than skipping it.
+        common::Snapshot::Absent(why) | common::Snapshot::Misconfigured(why) => {
+            common::Gate::Fail(format!("{var}={named}: {why}"))
+        }
+    }
+}
+
+/// Whether `draft_path` is the dedicated Gemma4 assistant drafter snapshot.
+///
+/// Both fields are read because mlx-community snapshots set the family on one
+/// or the other depending on the export tool — the same two fields the serve
+/// layer routes `--draft-kind mtp` on.
+fn is_gemma4_assistant(draft_path: &Path) -> bool {
+    draft_config(draft_path).is_some_and(|cfg| {
+        let model_type = cfg["model_type"].as_str().unwrap_or_default();
+        let arch_name = cfg["architectures"][0].as_str().unwrap_or_default();
+        model_type == "gemma4_assistant" || arch_name.contains("Gemma4Assistant")
+    })
+}
+
+fn draft_config(draft_path: &Path) -> Option<serde_json::Value> {
+    let raw = std::fs::read_to_string(draft_path.join("config.json")).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// The verifier width this drafter declares it projects into, if it declares
+/// one.
+///
+/// Both `-e2b-` and `-e4b-` snapshots declare the same architecture, so the
+/// harness's arch stand-down cannot tell them apart — an operator with
+/// `RMLX_KV_TEST_MODEL` pointed at e4b for another suite would otherwise run an
+/// e4b verifier against the E2B drafter resolved by slug, against floors
+/// measured on e2b. This is the field that does tell them apart, and it is read
+/// before the drafter is loaded so a mismatched pair skips with a reason rather
+/// than panicking inside the loader.
+///
+/// `None` means the snapshot does not say, which is **not** a mismatch:
+/// `Gemma4AssistantDrafter::load` takes the verifier's width when the key is
+/// absent, so a drafter the engine serves must not make this gate skip and
+/// blame the drafter for it.
+fn declared_backbone_hidden(draft_path: &Path) -> Option<usize> {
+    draft_config(draft_path)?["backbone_hidden_size"]
+        .as_u64()
+        .and_then(|v| usize::try_from(v).ok())
+}
+
+/// What both prompts ask for, and why they ask for it.
+///
+/// This gate owns its prompts, and that is the asymmetry that makes its
+/// repetition control possible at all. A general "is this arm degenerate"
+/// classifier cannot exist on this measure: healthy output spans 0.03 for prose
+/// to 0.88 for a markdown table with a yes/no column, and degenerate output
+/// spans 0.37 for a ragged loop to 1.00 for an exact one — two populations
+/// overlapping over most of their range, with no threshold between them.
+///
+/// Prose is the one regime where they separate. Asking for it is not a
+/// convenience: it is what lets [`MAX_CYCLE_FRACTION`] sit above every healthy
+/// reading measured here and below every collapse the gate has to catch.
+const PROSE_INSTRUCTION: &str = "Answer at length, in continuous prose, in at least \
+     six full paragraphs. Do not use lists, numbered steps, tables, headings, bullet \
+     points or code blocks.";
+
+/// The 4k document the long-context benches use, for the reproducer below.
+const LONG_CONTEXT_PROMPT: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../prompts/longctx_4k.json"
+));
+
+/// Chat-formatted prompt, with the leading `<bos>`.
+///
+/// Gemma without its turn markers and without `<bos>` ends the turn on its very
+/// first token, and a gate that only ever runs on a degenerate stream is a gate
+/// that never runs.
+fn build_prompt(tk: &tokenizers::Tokenizer) -> Vec<u32> {
+    wrap_turn(
+        tk,
+        &format!(
+            "Explain how a hash map handles two keys that hash to the same bucket, \
+             covering separate chaining and each of the open-addressing probing \
+             strategies. {PROSE_INSTRUCTION}"
+        ),
+    )
+}
+
+/// The same, over the 4k document: a cache large enough to reach the boundaries
+/// where this repository's KV defects live.
+fn build_long_context_prompt(tk: &tokenizers::Tokenizer) -> Vec<u32> {
+    let doc: serde_json::Value =
+        serde_json::from_str(LONG_CONTEXT_PROMPT).expect("the long-context prompt is JSON");
+    let body = doc["messages"]
+        .as_array()
+        .expect("messages")
+        .iter()
+        .filter_map(|m| m["content"].as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    wrap_turn(
+        tk,
+        &format!("{body}\n\nSummarise the document above. {PROSE_INSTRUCTION}"),
+    )
+}
+
+fn wrap_turn(tk: &tokenizers::Tokenizer, question: &str) -> Vec<u32> {
+    let text = format!("<start_of_turn>user\n{question}<end_of_turn>\n<start_of_turn>model\n");
+    let mut ids: Vec<u32> = Vec::new();
+    if let Some(bos) = tk.token_to_id("<bos>") {
+        ids.push(bos);
+    }
+    ids.extend(
+        tk.encode(text.as_str(), true)
+            .expect("encode")
+            .get_ids()
+            .iter()
+            .copied(),
+    );
+    ids
+}
+
+/// The verifier's own stop ids.
+///
+/// Without them both arms run past the answer into end-of-turn filler, and a
+/// comparison over filler measures nothing about the round loop.
+fn eos_ids(model_path: &Path) -> Vec<u32> {
+    let Ok(raw) = std::fs::read(model_path.join("config.json")) else {
+        return Vec::new();
+    };
+    let Ok(cfg) = serde_json::from_slice::<serde_json::Value>(&raw) else {
+        return Vec::new();
+    };
+    match cfg.get("eos_token_id") {
+        Some(serde_json::Value::Number(n)) => n.as_u64().map(|v| v as u32).into_iter().collect(),
+        Some(serde_json::Value::Array(a)) => a
+            .iter()
+            .filter_map(|v| v.as_u64().map(|x| x as u32))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Plain greedy decoding on the verifier alone, at temperature 0.
+fn plain_greedy(
+    verifier: &arch::Architecture,
+    tk: &tokenizers::Tokenizer,
+    prompt: &[u32],
+    eos: &[u32],
+    device: Device,
+) -> Vec<u32> {
+    let sampler_cfg = rmlx_models::sampler::SamplerConfig {
+        temperature: 0.0,
+        top_p: 1.0,
+        top_k: 0,
+        min_p: 0.0,
+        seed: Some(0),
+        top_logprobs_k: 0,
+    };
+    let mut rng = rmlx_models::sampler::Pcg32::new(sampler_cfg.seed_or_default());
+    let penalty_cfg = rmlx_models::sampler::PenaltyConfig::default();
+    let mut history: Vec<u32> = Vec::new();
+    let mut ids: Vec<u32> = Vec::new();
+    {
+        let mut step = |s: &rmlx_models::ProbeStep| {
+            ids.push(s.token_id);
+            None
+        };
+        verifier
+            .generate_greedy(
+                tk,
+                prompt,
+                N_TOKENS,
+                device,
+                Some(rmlx_kv_quant::KvQuant::None),
+                Some(MAX_CTX),
+                1,
+                eos,
+                &mut step,
+                None,
+                &sampler_cfg,
+                &mut rng,
+                &penalty_cfg,
+                &mut history,
+            )
+            .expect("plain greedy generate");
+    }
+    ids
+}
+
+/// The gate: the speculative arm reproduces what the verifier decodes alone.
+///
+/// Both arms run the same verifier, the same prompt, `--kv-quant none` and
+/// temperature 0 — a different codec on either side would make this a
+/// measurement of the codec instead of the round loop. Both are given the
+/// verifier's stop ids and both must produce a real answer of comparable
+/// length — see [`MIN_ANSWER_TOKENS`] and [`MIN_LENGTH_RATIO`].
+#[ignore]
+#[test]
+fn speculative_greedy_reproduces_plain_greedy() {
+    const TEST: &str = "speculative_greedy_reproduces_plain_greedy";
+    run_gate(TEST, build_prompt, Horizon::ShortPrompt);
+}
+
+/// The same gate over a 4k document, where it fails today.
+///
+/// The speculative arm collapses into a period-8 repetition loop while plain
+/// greedy writes a clean summary and stops — see the module docs for the
+/// readings and the issue. It reproduces on `main`, so it is not this branch's;
+/// it is here because a reproducer that fails until the defect is fixed is what
+/// makes moving the gate onto this prompt happen, and a paragraph is not.
+#[ignore]
+#[test]
+fn speculative_greedy_reproduces_plain_greedy_at_long_context() {
+    const TEST: &str = "speculative_greedy_reproduces_plain_greedy_at_long_context";
+    run_gate(TEST, build_long_context_prompt, Horizon::LongContext);
+}
+
+/// Both arms of one pair over `prompt`, judged.
+fn run_gate(test: &str, prompt_of: fn(&tokenizers::Tokenizer) -> Vec<u32>, horizon: Horizon) {
+    let (Some(model_path), Some(draft_path)) = (
+        common::model_for(&VERIFIER, test),
+        common::apply(resolve(DRAFT_MODEL_VAR, DRAFTER_SLUG), test),
+    ) else {
+        return;
+    };
+
+    if !is_gemma4_assistant(&draft_path) {
+        eprintln!(
+            "SKIP {test}: {} is not a Gemma4 assistant drafter; the floors are calibrated \
+             on the exact-rollback regime only",
+            draft_path.display()
+        );
+        return;
+    }
+
+    let device = Device::Gpu;
+    let verifier =
+        arch::load_model(&model_path, device, &arch::LoadOpts::default()).expect("load verifier");
+    if verifier.needs_lin_caches() {
+        eprintln!(
+            "SKIP {test}: {} carries recurrent state; see the module docs",
+            model_path.display()
+        );
+        return;
+    }
+    let hidden = verifier.hidden_size();
+    let declared = declared_backbone_hidden(&draft_path);
+    if declared.is_some_and(|width| width != hidden) {
+        let retargeted = std::env::var(common::SINGLE_MODEL_VAR)
+            .is_ok_and(|v| !v.is_empty() && Path::new(&v) == model_path);
+        eprintln!(
+            "SKIP {test}: {} projects into a backbone {} wide and {} is {hidden}; the \
+             floors are measured on one pair and this is another{}",
+            draft_path.display(),
+            declared.unwrap_or(hidden),
+            model_path.display(),
+            if retargeted {
+                format!(
+                    " — the verifier came from {}, which retargeted this gate",
+                    common::SINGLE_MODEL_VAR
+                )
+            } else {
+                String::new()
+            },
+        );
+        return;
+    }
+    let tk =
+        tokenizers::Tokenizer::from_file(model_path.join("tokenizer.json")).expect("tokenizer");
+    let prompt = prompt_of(&tk);
+    let eos = eos_ids(&model_path);
+    assert!(
+        !eos.is_empty(),
+        "the verifier config must name its stop ids — without them both arms run past \
+         the answer into end-of-turn filler and the comparison is over that"
+    );
+
+    let mut spec_ids: Vec<u32> = Vec::new();
+    {
+        let mut step = |s: &rmlx_models::ProbeStep| {
+            spec_ids.push(s.token_id);
+            None
+        };
+        let drafter = Gemma4AssistantDrafter::load(&draft_path, hidden, device)
+            .expect("load assistant drafter");
+        mtp_assistant_generate_greedy(
+            &verifier,
+            &drafter,
+            &tk,
+            &prompt,
+            N_TOKENS,
+            BLOCK_SIZE,
+            Some(rmlx_kv_quant::KvQuant::None),
+            Some(MAX_CTX),
+            &eos,
+            &mut step,
+            device,
+        )
+        .expect("assistant speculative generate");
+    }
+
+    let plain_ids = plain_greedy(&verifier, &tk, &prompt, &eos, device);
+
+    let (tail_start, tail_ratio) = weakest_tail(&spec_ids, &plain_ids);
+    let (spec_from, spec_period, spec_cycle) = strongest_windowed_cycle(&spec_ids);
+    let (plain_from, plain_period, plain_cycle) = strongest_windowed_cycle(&plain_ids);
+    eprintln!(
+        "[{test}] lcs={:.4} first_divergence={} tail={tail_ratio:.4}@{tail_start} \
+         cycle spec={spec_cycle:.4}/p{spec_period}@{spec_from} \
+         plain={plain_cycle:.4}/p{plain_period}@{plain_from} \
+         spec={} plain={}\n  spec  = {:?}\n  plain = {:?}",
+        lcs_ratio(&spec_ids, &plain_ids),
+        common_prefix_len(&spec_ids, &plain_ids),
+        spec_ids.len(),
+        plain_ids.len(),
+        tk.decode(&spec_ids, false).unwrap_or_default(),
+        tk.decode(&plain_ids, false).unwrap_or_default(),
+    );
+
+    if let Some(failure) = judge(&spec_ids, &plain_ids, horizon) {
+        panic!("{failure}");
+    }
+}

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -175,11 +175,12 @@ const MAX_CTX: i32 = 8192;
 /// | assistant pair, SWA ring keeping its rejected block tail | 0.4219 to 0.9258 |
 /// | recurrent pair, acceptance walk without the final norm | 0.0000 to 0.5000 |
 ///
-/// The value is the geometric midpoint of the worst correct cell (0.0820) and
-/// the lowest broken cell the *set* has to catch — 1.46x above the first. It
-/// clears every correct cell and refuses ten of the twelve broken ones; the two
-/// it does not are covered by running every prompt rather than one, since each
-/// broken engine is refused on at least four of its six.
+/// The measurement leaves a band, and the value sits inside it: above the worst
+/// correct cell (0.0820, 1.46x) and under the lowest broken cell above it
+/// (0.1538, 1.28x). It clears every correct cell and refuses ten of the twelve
+/// broken ones; the two it does not read 0.0000 and 0.0977 and are covered by
+/// running every prompt rather than one, since each broken engine is refused on
+/// at least four of its six.
 const MAX_DIVERGENCE_CONFIDENCE: f64 = 0.12;
 
 /// The worst tail agreement a **correct** pair reached over the prompts the gate
@@ -1109,25 +1110,30 @@ fn a_late_onset_divergence_is_judged_where_it_begins() {
 ///
 /// Correct: the worst reading a shipped pair produced, a first divergence at the
 /// 8.2nd percentile of the reference arm's own margins. Broken: the lowest
-/// reading a broken engine produced that the gate still has to refuse, the 16.8th.
+/// reading a broken engine produced above the ceiling, the 15.4th — the cell the
+/// recorded ten-of-twelve recall stands or falls on.
 #[test]
 fn the_gate_admits_the_worst_correct_regime_and_refuses_the_lowest_broken_one() {
     let plain: Vec<u32> = (0..N_TOKENS as u32).map(|t| t % 97).collect();
     let mut spec = plain.clone();
     spec[64] = 60_000;
 
-    let margins_with_percentile = |pct: usize| -> Vec<f32> {
+    // The reading is the count of margins under the one at the divergence over
+    // the arm's length, so the count is what the regime is reconstructed from —
+    // a percentage of it lands on whichever reading integer division reaches,
+    // which is how a ceiling under the worst correct cell used to pass here.
+    let margins_reading = |below: usize| -> Vec<f32> {
         let mut m: Vec<f32> = (0..N_TOKENS)
-            .map(|i| if i < N_TOKENS * pct / 1000 { 0.01 } else { 5.0 })
+            .map(|i| if i < below { 0.01 } else { 5.0 })
             .collect();
         m[64] = 0.02;
         m
     };
 
-    let correct = margins_with_percentile(82);
+    let correct = margins_reading(21);
     let (_, worst_correct) = divergence_confidence(&spec, &plain, &correct).expect("a divergence");
     assert!(
-        (worst_correct - 0.082).abs() < 0.005,
+        (worst_correct - 0.0820).abs() < 0.0005,
         "the reconstructed correct regime reads {worst_correct:.4}, not the measured 0.0820"
     );
     assert!(
@@ -1135,11 +1141,13 @@ fn the_gate_admits_the_worst_correct_regime_and_refuses_the_lowest_broken_one() 
         "the worst correct regime must pass"
     );
 
-    let broken = margins_with_percentile(168);
+    // 0.1538 is 2/13 — the broken cell's reference arm was 13 tokens long, and a
+    // 256-position array gets within one of its own quantum of it.
+    let broken = margins_reading(39);
     let (_, lowest_broken) = divergence_confidence(&spec, &plain, &broken).expect("a divergence");
     assert!(
-        (lowest_broken - 0.168).abs() < 0.005,
-        "the reconstructed broken regime reads {lowest_broken:.4}, not the measured 0.1680"
+        (lowest_broken - 0.1538).abs() < 0.002,
+        "the reconstructed broken regime reads {lowest_broken:.4}, not the measured 0.1538"
     );
     let failure = judge(&spec, &plain, &broken)
         .refusal()

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -8,57 +8,50 @@
 //!
 //! **It is not bit-identity, and measurement says so.** The verify pass scores a
 //! whole block in one forward where plain decode steps one token at a time, and
-//! that is a different reduction order. On the Gemma4-e2b assistant pair — a
-//! full-attention verifier whose rollback is an exact KV truncation, the most
-//! favourable case there is — the two arms share 91 leading tokens and then
-//! differ by a word, after which both continue the same explanation. A gate
-//! demanding identity would fail on that.
+//! that is a different reduction order. The two arms share a long prefix, flip
+//! one token, and then write the same answer — or, on a prompt with many
+//! near-equal continuations, two different ones that agree on most of their
+//! content.
 //!
-//! **The oracle is therefore length-scaled, not positional**, and it is read
-//! twice: over the whole answer, and over each tail window, because those
-//! separate two failures the whole-stream ratio blends. One benign flip early
-//! and a divergence that begins late and never comes back can both land near
-//! 0.8 overall; only the second collapses a window. Measured on that pair at
-//! [`N_TOKENS`] tokens:
+//! # The oracle
 //!
-//! | rollback | whole-stream LCS | weakest tail window | first divergence |
-//! |---|---|---|---|
-//! | as shipped | 0.9180 | 0.6875 at token 192 | 91 |
-//! | one rejected draft key left in the cache | 0.4062 | 0.2031 at token 192 | 8 |
+//! **Where a correct pair diverges is decidable, and it is the only thing here
+//! that is.** A reduction-order difference is a relative perturbation of order
+//! `1e-3` on a logit, so it can only flip a decision the verifier was already
+//! nearly indifferent about. [`divergence_confidence`] reads the verifier's own
+//! top-two logprob margin at the position the arms first differ and returns
+//! where that sits in the same arm's own margin distribution. Both arms saw the
+//! same context up to that position, so this judges the **pair**, and it needs
+//! no per-prompt calibration: it is a rank, not a number of nats.
 //!
-//! [`MIN_LCS_RATIO`] and [`MIN_TAIL_LCS_RATIO`] sit in those gaps. The shared
-//! prefix is reported and never asserted on: it collapses the moment a near-tie
-//! flips early, which is a property of the prompt and the arithmetic rather
-//! than of the round loop.
+//! Over the six prompts in [`PROMPTS`], measured by
+//! `the_agreement_a_correct_pair_reaches`:
 //!
-//! **Each case declares its own horizon.** The short prompt answers past 512
-//! tokens and asks for [`MIN_ANSWER_TOKENS`]; the long-context one answers in
-//! about 200 and asks for [`MIN_LONG_CONTEXT_ANSWER_TOKENS`], because a floor
-//! its own prompt cannot meet would refuse a *fixed* engine and the reproducer
-//! could never flip to green.
+//! | engine | first divergence | percentile of the reference arm's own margins |
+//! |---|---|---|
+//! | assistant pair, as shipped | 4 to 193 | 0.0000 to 0.0352 |
+//! | MTP pair, as shipped | 35 to 256 (three prompts bit-identical) | 0.0000 to 0.0234 |
+//! | assistant pair, SWA ring keeping its rejected block tail | 3 to 7 | 0.0000 to 0.9531 |
+//! | MTP pair, acceptance walk without the final norm | 4 to 28 | 0.1680 to 0.4453 |
 //!
-//! **Length is bounded from both sides.** Two configurations that differ can
-//! agree for the first few dozen tokens of an easy answer, so a short run is a
-//! gate that cannot fail. A long one is a different trap: greedy decoding
-//! compounds, so one benign flip makes the two arms write different paragraphs a
-//! few hundred tokens later — the same pair reads 0.9180 at 256 tokens, 0.8438
-//! at 512 and 0.6846 at its natural stop near 800, the last below any floor that
-//! still refuses a broken rollback. [`N_TOKENS`] is the horizon where the two
-//! regimes are separable; it is not a length past which nothing goes wrong.
+//! **There is deliberately no subsequence floor.** How much of one answer two
+//! correct arms share is decided by where their first near-tie lands and by
+//! nothing else: the assistant pair reads 0.9180 when it falls at token 91 and
+//! 0.3281 when it falls at token 4 — an exact tie, both answers well-formed
+//! prose — while the two broken engines above read 0.2070 to 0.6953. The
+//! populations overlap. `report` prints the figure on every run and the gate does
+//! not assert it.
 //!
-//! **The control.** Two arms that collapse into the *same* loop agree on
-//! garbage, and the subsequence oracle cannot refuse that by itself — it
-//! measures a subsequence over the same periodic base, so independent
-//! raggedness costs it far less than it costs a cycle reading. Two arms sharing
-//! a healthy prefix and then locked in the same period-8 loop read LCS 0.70 to
-//! 0.93 across the whole 12–40% ragged range. So every run also checks that
-//! neither arm repeats at a short period across more than
-//! [`MAX_CYCLE_FRACTION`] of its tokens — over the whole stream and over each of
-//! the same tail cuts the oracle uses, at every period up to
-//! [`MAX_CYCLE_PERIOD`] that leaves [`MIN_CYCLE_SAMPLES`] comparisons.
+//! **The repetition control** is the second oracle, and it exists because the
+//! first has nothing to read when both arms are degenerate: two arms in the same
+//! loop have no healthy reference arm whose margins mean anything. So every run
+//! also checks that neither arm repeats at a short period across more than
+//! [`MAX_CYCLE_FRACTION`] of its tokens, over the whole stream and over each
+//! tail cut, at every period up to [`MAX_CYCLE_PERIOD`] that leaves
+//! [`MIN_CYCLE_SAMPLES`] comparisons.
 //!
-//! Windowing and the period sweep are both load-bearing; three real degeneracies
-//! score under any ceiling without them:
+//! Windowing and the period sweep are both load-bearing; three real
+//! degeneracies score under any ceiling without them:
 //!
 //! | shape | whole stream, period ≤ 8 | whole stream, period ≤ 64 | windowed |
 //! |---|---|---|---|
@@ -66,48 +59,44 @@
 //! | collapse over the last two fifths | 0.3992 | 0.3992 | 1.0000 |
 //! | a twelve-token phrase over four fifths | 0.0000 | 0.7960 | 1.0000 |
 //!
-//! **There is no general threshold, which is why the prompts are what they
-//! are.** Healthy output spans 0.03 for prose to 0.88 for a markdown table with
-//! a yes/no column; degenerate output spans 0.37 for a ragged loop to 1.00 for
-//! an exact one. Those populations overlap over most of their range and no
-//! ceiling separates them — an earlier revision of this file put one at 0.85 and
-//! thereby admitted every pair in the ragged range while refusing a healthy
-//! low-entropy table.
+//! The control has **no general threshold** and there is none: healthy output
+//! spans 0.03 for prose to 0.88 for a markdown table with a yes/no column, and
+//! degenerate output 0.37 for a ragged loop to 1.00 for an exact one — two
+//! populations overlapping over most of their range. Prose is the regime where
+//! they separate, which is why [`PROSE_INSTRUCTION`] exists and why a tokenizer
+//! that declares `<think>` gets an empty reasoning block. When the *reference*
+//! arm trips the control the input is outside the gate's domain and the gate
+//! says so, rather than accusing plain greedy of a repetition loop.
 //!
-//! Prose is the regime where they do separate, and this gate owns its prompts.
-//! [`PROSE_INSTRUCTION`] is what makes the ceiling meaningful: measured on the
-//! real pair the two arms read 0.0893 and 0.1000, and 1000 synthetic healthy
-//! streams at each of six lengths trip it 0 times with a peak of 0.1351
-//! (`the_false_positive_rate_on_healthy_output` prints that). At 0.50 the whole
-//! ragged range is refused, and at 50% raggedness [`MIN_LCS_RATIO`] takes over —
-//! no gap between them.
+//! # Recall, and what escapes
 //!
-//! The limit that remains is a false *positive*: structured output trips this
-//! control. That is an input the gate controls rather than a class it lets
-//! through, and it is recorded by
-//! `structured_output_trips_the_control_which_is_why_the_prompts_forbid_it`.
+//! Over the twelve (pair, prompt) cells the two broken engines above produce,
+//! the gate refuses eleven. The twelfth is the assistant pair's broken ring on
+//! the one prompt where a *correct* pair also flips an exact tie at token 4:
+//! there the divergence carries no information either way, and the subsequence
+//! ratio that would separate them — 0.2070 broken against 0.3281 correct — is
+//! inside the correct population's own spread. It is recorded rather than
+//! designed around.
 //!
-//! **Known gap: this gate runs at a short context and there is a defect past
-//! it.** `speculative_greedy_reproduces_plain_greedy_at_long_context` is the
-//! same gate over the 4k document in `prompts/longctx_4k.json` and it **fails
-//! today**: the speculative arm collapses into a period-8 repetition loop
-//! (`x86 is:66 is x86 is:66 is …`) while plain greedy writes a clean summary and
-//! stops at 218 while the speculative arm runs to the budget writing a
-//! different, degraded summary — whole-stream LCS 0.2798, first divergence at
-//! token 6. Asked for the structured summary an earlier revision of this file
-//! used, the same defect showed as an outright period-8 repetition loop reading
-//! 1.0000. It reproduces identically on `main` (8ccc0593), so it is not this
-//! branch's. It
-//! is filed, with the Qwen MTP sidecar's 0.520 as a second case, and it is a
-//! reproducer rather than a paragraph so that fixing it is what moves this gate
-//! onto the long prompt.
+//! # Pairs
 //!
-//! Server-free. Both snapshots resolve by slug from `RMLX_O_MODELS_ROOT`, so
-//! `make gpu-test` runs this on a machine holding them and
-//! `scripts/run_gpu_tests.sh` reports a machine without them as INCOMPLETE.
-//! `RMLX_KV_TEST_MODEL` and `RMLX_DRAFT_TEST_MODEL` override either half:
+//! Two, resolved by slug from `RMLX_O_MODELS_ROOT` so `make gpu-test` runs them
+//! on a machine holding the snapshots:
 //!
-//! cargo test -p rmlx-models --test spec_greedy_equivalence -- --ignored --nocapture
+//! | verifier | drafter | round loop | rollback |
+//! |---|---|---|---|
+//! | `gemma-4-e2b-it-mxfp8` | `gemma-4-E2B-it-assistant-bf16` | shared-K/V assistant | KV truncation, SWA ring included |
+//! | `Qwen3.8-27B-mxfp8` | `Qwen3.8-27B-MTP-mxfp8` | MTP sidecar | KV truncation + recurrent snapshot/replay |
+//!
+//! The second is the pair whose agreement no subsequence floor could separate
+//! from a broken rollback. The divergence oracle settled it: its acceptance walk
+//! was scoring an un-normed hidden through the LM head, and with that fixed
+//! three of six prompts come back bit-identical.
+//!
+//! Server-free. `RMLX_KV_TEST_MODEL` / `RMLX_DRAFT_TEST_MODEL` override either
+//! half; a verifier of another architecture stands the pair down.
+//!
+//!     cargo test -p rmlx-models --test spec_greedy_equivalence -- --ignored --nocapture
 
 #![allow(
     clippy::unwrap_used,
@@ -128,9 +117,10 @@ use rmlx_models::arch;
 use rmlx_models::speculative::gemma4_assistant::{
     mtp_assistant_generate_greedy, Gemma4AssistantDrafter,
 };
+use rmlx_models::speculative::mtp::{mtp_generate_greedy, MtpDrafter};
 
 /// Token budget per arm. A ceiling, not a target: both arms stop on the
-/// verifier's own stop ids and this answer is shorter than the budget.
+/// verifier's own stop ids, and every prompt in the sweep answers under it.
 ///
 /// The budget is what makes the horizon long enough to matter — hundreds of
 /// rounds and a kilotoken of context, against the 48 tokens the sibling
@@ -139,58 +129,29 @@ use rmlx_models::speculative::gemma4_assistant::{
 /// that filler measures nothing about the round loop.
 const N_TOKENS: usize = 256;
 
-/// The shorter arm must be at least this long on the short prompt, or there is
-/// not enough answer to compare. A digest over 32 generated tokens has already
-/// given two configurations of this engine the same value where 200 separated
-/// them.
-const MIN_ANSWER_TOKENS: usize = 256;
-
-/// Which prompt an arm came from, and so how much answer the gate may demand.
+/// How much answer both arms must have produced for the comparison to have
+/// power.
 ///
-/// A closed type rather than a `usize` parameter: `judge(a, b, 0)` disables the
-/// length guard entirely and nothing would refuse it. The two constants below
-/// stay the only producers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Horizon {
-    /// The short prose prompt, which answers past the budget.
-    ShortPrompt,
-    /// The 4k document, whose summary is shorter.
-    LongContext,
-}
-
-impl Horizon {
-    const fn min_answer(self) -> usize {
-        match self {
-            Self::ShortPrompt => MIN_ANSWER_TOKENS,
-            Self::LongContext => MIN_LONG_CONTEXT_ANSWER_TOKENS,
-        }
-    }
-}
-
-/// The same floor for the long-context case, whose prompt answers shorter.
+/// **One number, and both sides of it are measured.** Every arm the gate judged
+/// across two pairs and six prompts ran to the full [`N_TOKENS`] budget, so the
+/// floor is not what any correct pair is up against. What it decides is where
+/// the line falls between two different verdicts: one arm short while the other
+/// ran on is the round loop's doing and is refused, and *both* arms short is the
+/// prompt's — the recurrent pair answers the 4k summary in 13 and 26 tokens —
+/// and is reported rather than failed.
 ///
-/// **Measured**, not chosen: plain greedy writes its summary of that document in
-/// 218 tokens and stops, so the floor is set just under the length a correct
-/// engine produces. A floor of 256 would fail a *fixed* engine — both arms would
-/// agree at ~218 tokens and the gate would still report "an arm stopped early",
-/// so the reproducer could never flip to green. A much lower one would admit
-/// arms whose last tail window is too short to read the period the collapse
-/// repeats at: at 200 tokens that window is 50 and periods to 18 are readable,
-/// which covers the documented period-8 loop; at 150 it is 38 and they are not.
-const MIN_LONG_CONTEXT_ANSWER_TOKENS: usize = 200;
-
-/// What plain greedy actually answers that prompt in, measured on the pair.
-/// The floor above is set under it; `a_fixed_engine_would_pass_the_long_context_reproducer`
-/// drives a stream of this length through `judge` so the relation is pinned.
-const MEASURED_LONG_CONTEXT_PLAIN_ARM: usize = 218;
+/// It is above `TAIL_WINDOWS * MIN_CYCLE_SAMPLES`, which is what the last tail
+/// window needs before it can evidence a cycle at all, and under the budget, so
+/// a pair that answers in full is never refused for length.
+const MIN_ANSWER_TOKENS: usize = 160;
 
 /// The shorter arm over the longer. `lcs_ratio` divides by the shorter stream,
 /// so an arm that stopped at a third of the other's length and matched its
 /// prefix would otherwise score 1.0.
 const MIN_LENGTH_RATIO: f64 = 0.60;
 
-/// Draft block. Small enough that a rollback runs every few tokens, which is
-/// the code path the oracle protects.
+/// Draft block for the assistant pair. Small enough that a rollback runs every
+/// few tokens, which is the code path the oracles protect.
 const BLOCK_SIZE: usize = 4;
 
 /// Context both arms run under. Above the 4k prompt plus the budget, and the
@@ -198,22 +159,58 @@ const BLOCK_SIZE: usize = 4;
 /// of the cap.
 const MAX_CTX: i32 = 8192;
 
-/// How much of one answer both arms must have produced.
+/// Where the first divergence's own confidence may sit in the reference arm's
+/// margin distribution.
 ///
-/// Between the two measured regimes in the module docs: 1.3x below the shipped
-/// rollback's reading and 2.7x above a rollback that leaves one rejected key in
-/// the cache.
-const MIN_LCS_RATIO: f64 = 0.70;
+/// **Both sides measured**, over two pairs and six prompts each, by running the
+/// gate against the shipped engine and against two deliberately broken ones:
+///
+/// | engine | percentile of the reference arm's own margins |
+/// |---|---|
+/// | assistant pair, as shipped | 0.0000 to 0.0820 |
+/// | recurrent pair, as shipped | 0.0000 to 0.0234 |
+/// | assistant pair, SWA ring keeping its rejected block tail | 0.4219 to 0.9258 |
+/// | recurrent pair, acceptance walk without the final norm | 0.0000 to 0.5000 |
+///
+/// The value is the geometric midpoint of the worst correct cell (0.0820) and
+/// the lowest broken cell the *set* has to catch — 1.46x above the first. It
+/// clears every correct cell and refuses ten of the twelve broken ones; the two
+/// it does not are covered by running every prompt rather than one, since each
+/// broken engine is refused on at least four of its six.
+const MAX_DIVERGENCE_CONFIDENCE: f64 = 0.12;
+
+/// The worst tail agreement a **correct** pair reached over the prompts the gate
+/// judged, on either pair. Not a threshold the gate applies — see below — but
+/// the reference `two_arms_in_the_same_ragged_loop_are_not_returned_as_agreement`
+/// uses to decide whether a synthetic pair still looks like agreement at all.
+///
+/// There is deliberately **no subsequence floor**. How much of one answer two
+/// correct arms share is decided by where their first near-tie lands and by
+/// nothing else: the assistant pair reads 0.9375 on the 4k document and 0.4766
+/// on a short prose prompt whose arms flip an exact tie at token 37, and the two
+/// broken engines measured here read 0.2188 to 0.4615. The populations overlap,
+/// so no floor separates them. `report` prints the figure on every run and the
+/// gate does not assert it.
+const WORST_CORRECT_TAIL_AGREEMENT: f64 = 0.2344;
 
 /// How much of an arm — or of any tail cut of it — may repeat at a short period
 /// before it counts as collapsed.
 ///
 /// Set against **the output this gate's own prompts produce**, which is prose:
-/// the real arms read 0.0893 and 0.1000, and 1800 synthetic healthy streams
-/// across six lengths peaked at 0.1212. Every pair of arms locked in the same
-/// period-8 loop up to 40% raggedness is refused above it, and at 50% the
-/// subsequence floor takes over — so the whole degenerate range is covered with
-/// no gap.
+/// across the prompts the gate judges the real arms read 0.0426 to 0.1351, and 1000
+/// synthetic healthy streams at each of six lengths peaked at 0.1351 and tripped
+/// this ceiling none (`the_false_positive_rate_on_healthy_output` prints that).
+/// 1.48x over the worst of those 6000, and far under every collapse the gate has
+/// to catch — the one this gate was built on reads 1.0000.
+///
+/// The other side is set by the pair regime, and it is **swept rather than
+/// sampled**: `the_control_and_the_subsequence_floor_hand_over_inside_the_ragged_range`
+/// walks two arms in the same period-8 loop from 0% to 100% raggedness over four
+/// seed pairs and asserts that this control and the subsequence floors between
+/// them refuse every point. Twenty seed pairs over the band where they hand over
+/// leave the range covered at 0.22 and open the first hole at 0.24, so the value
+/// here has room rather than sitting on the boundary. An earlier 0.50 — placed
+/// from six sampled points — left 34% to 52% passing.
 ///
 /// It is **not** a general degeneracy threshold and there is none: healthy
 /// markdown tables read 0.68 to 0.88 on this measure and ragged loops read 0.37
@@ -221,17 +218,23 @@ const MIN_LCS_RATIO: f64 = 0.70;
 /// output therefore trips this control, which is why [`PROSE_INSTRUCTION`]
 /// exists and why the value here is only meaningful for arms these prompts
 /// produced.
-const MAX_CYCLE_FRACTION: f64 = 0.50;
+const MAX_CYCLE_FRACTION: f64 = 0.20;
 
 /// Longest cycle the control looks for.
 ///
 /// A degeneracy in real output is usually a repeated phrase or sentence, not a
 /// repeated token: a 12-token phrase filling four fifths of a stream scores
-/// 0.0000 at any period under 12 and 0.7960 at 12. The defect this file
-/// documents repeats at period 8, one step under the ceiling this replaced.
+/// 0.0000 at any period under 12 and 0.7960 at 12. The collapse this gate was
+/// built on repeats at period 8.
 ///
 /// Bounded again by what leaves [`MIN_CYCLE_SAMPLES`] comparisons in whatever
-/// window is being read, which is the only bound that turned out to be needed.
+/// window is being read, which is the only bound that turned out to be needed —
+/// and which is also this control's declared blind spot. The narrowest window is
+/// `len / TAIL_WINDOWS`, so at a 256-token arm the last window can evidence no
+/// period above 32; a collapse confined to the last quarter at a longer period
+/// than that is read only over the whole stream, where a healthy majority
+/// dilutes it. `a_cycle_confined_to_a_window_too_narrow_to_read_it_is_a_declared_blind_spot`
+/// is where that is written down.
 const MAX_CYCLE_PERIOD: usize = 64;
 
 /// Fewest comparisons a cycle reading may be computed from.
@@ -256,18 +259,9 @@ const MIN_CYCLE_SAMPLES: usize = 32;
 /// compared, so a divergence that begins late has a window it dominates.
 const TAIL_WINDOWS: usize = 4;
 
-/// How much of one answer both arms must share over every tail window.
-///
-/// Lower than the whole-stream floor: a suffix starts wherever the cut falls,
-/// so it can open mid-divergence where the whole stream does not. Between the
-/// two measured regimes in the module docs — 1.6x below the shipped rollback's
-/// weakest window and 1.9x above the broken one's.
-const MIN_TAIL_LCS_RATIO: f64 = 0.40;
-
 // ── Oracle ───────────────────────────────────────────────────────────────────
 
-/// How many leading tokens two streams share. Reported, never asserted on — see
-/// the module docs.
+/// How many leading tokens two streams share.
 fn common_prefix_len(a: &[u32], b: &[u32]) -> usize {
     a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
 }
@@ -294,15 +288,33 @@ fn lcs_ratio(a: &[u32], b: &[u32]) -> f64 {
     prev[m] as f64 / n.min(m) as f64
 }
 
+/// Where the reference arm's confidence at the first divergence sits in its own
+/// distribution: the fraction of its decisions it was **less** sure about.
+///
+/// `margins[i]` is the verifier's top-two logprob gap at position `i` of the
+/// reference arm. The two arms share every position before the first divergence,
+/// so `margins[d]` is the gap the speculative arm faced as well.
+///
+/// `None` when the arms never differ, or when they first differ past the end of
+/// the reference arm — the length guard owns that case.
+fn divergence_confidence(spec: &[u32], plain: &[u32], margins: &[f32]) -> Option<(usize, f64)> {
+    let d = common_prefix_len(spec, plain);
+    if d >= spec.len() && d >= plain.len() {
+        return None;
+    }
+    let at = *margins.get(d)?;
+    let below = margins.iter().filter(|m| **m < at).count();
+    Some((d, below as f64 / margins.len() as f64))
+}
+
 /// The strongest short cycle in `tokens`: its period, and the fraction of
 /// positions that repeat at that period.
 ///
-/// The control. A stream stuck in a loop matches itself at the loop's period,
-/// and two arms in the same loop agree perfectly — so the equivalence oracle
-/// says nothing exactly when this is high. It covers every period up to
-/// [`MAX_CYCLE_PERIOD`], because a collapse that starts at token 20 and a
-/// two-token `A B A B` cycle are both degeneracies a leading-run measure scores
-/// at zero.
+/// A stream stuck in a loop matches itself at the loop's period, and two arms in
+/// the same loop agree perfectly — so the equivalence oracle says nothing
+/// exactly when this is high. It covers every period up to [`MAX_CYCLE_PERIOD`],
+/// because a collapse that starts at token 20 and a two-token `A B A B` cycle are
+/// both degeneracies a leading-run measure scores at zero.
 fn strongest_cycle(tokens: &[u32]) -> (usize, f64) {
     let mut worst = (1usize, 0.0f64);
     for period in 1..=MAX_CYCLE_PERIOD.min(tokens.len().saturating_sub(MIN_CYCLE_SAMPLES)) {
@@ -360,92 +372,209 @@ fn weakest_tail(spec: &[u32], plain: &[u32]) -> (usize, f64) {
     worst
 }
 
-/// Judge one pair of streams. Returns the failure text, or `None` when the
-/// oracle and both controls held.
-fn judge(spec: &[u32], plain: &[u32], horizon: Horizon) -> Option<String> {
+/// What one pair of arms says about the round loop.
+#[derive(Debug, PartialEq, Eq)]
+enum Verdict {
+    /// The round loop reproduced what the verifier decodes alone.
+    Agreed,
+    /// The pair says nothing either way, and the reason is a property of the
+    /// prompt or the model rather than of the round loop. Reported, not failed:
+    /// a gate that turns red on an input it cannot read teaches its operator to
+    /// ignore it.
+    Unjudgeable(String),
+    /// The round loop did not reproduce plain greedy.
+    Refused(String),
+}
+
+/// Judge one pair of streams.
+///
+/// `margins` is the reference arm's per-position top-two logprob gap, or empty
+/// when the caller has none — the synthetic fixtures below run that way, and the
+/// divergence oracle stands down rather than inventing a distribution.
+fn judge(spec: &[u32], plain: &[u32], margins: &[f32]) -> Verdict {
     let shorter = spec.len().min(plain.len());
     let longer = spec.len().max(plain.len());
 
     // The controls first. A degenerate arm is a more specific verdict than a
     // short one, and a collapse can be what cut the run short.
-    for (name, arm) in [("plain", plain), ("speculative", spec)] {
-        let (start, period, fraction) = strongest_windowed_cycle(arm);
-        if fraction > MAX_CYCLE_FRACTION {
-            return Some(format!(
-                "the {name} arm repeats at period {period} across {fraction:.4} of its \
-                 tokens from {start} on (ceiling {MAX_CYCLE_FRACTION}) — it has collapsed \
-                 into a repetition loop, so agreement between the arms would say nothing"
-            ));
-        }
+    let (plain_from, plain_period, plain_cycle) = strongest_windowed_cycle(plain);
+    if plain_cycle > MAX_CYCLE_FRACTION {
+        return Verdict::Unjudgeable(format!(
+            "the reference arm repeats at period {plain_period} across {plain_cycle:.4} of \
+             its tokens from {plain_from} on (ceiling {MAX_CYCLE_FRACTION}) — plain greedy \
+             is the control here, so this says the prompt did not come back as prose the \
+             control can read"
+        ));
+    }
+    let (spec_from, spec_period, spec_cycle) = strongest_windowed_cycle(spec);
+    if spec_cycle > MAX_CYCLE_FRACTION {
+        return Verdict::Refused(format!(
+            "the speculative arm repeats at period {spec_period} across {spec_cycle:.4} of \
+             its tokens from {spec_from} on (ceiling {MAX_CYCLE_FRACTION}) while the \
+             reference arm reads {plain_cycle:.4} — it has collapsed into a repetition \
+             loop the verifier does not produce on its own"
+        ));
     }
 
-    let min_answer = horizon.min_answer();
-    if shorter < min_answer {
-        return Some(format!(
-            "an arm stopped early — spec={} plain={}, under {min_answer}; a short \
-             run is a comparison with no power, not a pass",
+    if longer < MIN_ANSWER_TOKENS {
+        return Verdict::Unjudgeable(format!(
+            "both arms answered in {} and {} tokens, under {MIN_ANSWER_TOKENS} — the \
+             prompt produced no answer to compare on this model, which is not a \
+             statement about the round loop",
+            spec.len(),
+            plain.len()
+        ));
+    }
+    if shorter < MIN_ANSWER_TOKENS {
+        return Verdict::Refused(format!(
+            "one arm stopped early — spec={} plain={}, under {MIN_ANSWER_TOKENS} while \
+             the other ran on; a short run is a comparison with no power, not a pass",
             spec.len(),
             plain.len()
         ));
     }
     let length_ratio = shorter as f64 / longer as f64;
     if length_ratio < MIN_LENGTH_RATIO {
-        return Some(format!(
+        return Verdict::Refused(format!(
             "the arms answered at {} and {} tokens, a ratio of {length_ratio:.4} (floor \
-             {MIN_LENGTH_RATIO}) — one stopped well before the other, and the subsequence \
-             ratio is taken over the shorter, where a truncated arm reads high on the \
-             other's prefix",
+             {MIN_LENGTH_RATIO}) — one stopped well before the other, and there is no \
+             divergence to read where the shorter arm has already ended",
             spec.len(),
             plain.len()
         ));
     }
 
-    let ratio = lcs_ratio(spec, plain);
-    if ratio < MIN_LCS_RATIO {
-        return Some(format!(
-            "the arms share {ratio:.4} of one answer (floor {MIN_LCS_RATIO}), sharing \
-             {} leading tokens — the round loop did not reproduce what the verifier \
-             decodes on its own",
-            common_prefix_len(spec, plain)
-        ));
+    if let Some((at, confidence)) = divergence_confidence(spec, plain, margins) {
+        if confidence > MAX_DIVERGENCE_CONFIDENCE {
+            return Verdict::Refused(format!(
+                "the arms first differ at token {at}, where the verifier was surer than \
+                 {confidence:.4} of its own decisions on this answer (ceiling \
+                 {MAX_DIVERGENCE_CONFIDENCE}) — a different reduction order can only flip \
+                 a decision that was nearly tied, so the round loop fed the verifier a \
+                 different state rather than the same one in a different order"
+            ));
+        }
     }
+    Verdict::Agreed
+}
 
-    let (start, tail) = weakest_tail(spec, plain);
-    if tail < MIN_TAIL_LCS_RATIO {
-        return Some(format!(
-            "the arms share {ratio:.4} of the whole answer but only {tail:.4} of it from \
-             token {start} on (floor {MIN_TAIL_LCS_RATIO}), first differing at token {} — \
-             a divergence that begins late and does not come back, which the whole-stream \
-             ratio blends with one benign flip",
-            common_prefix_len(spec, plain)
-        ));
+impl Verdict {
+    /// The refusal text, or `None` for anything the gate does not fail on.
+    fn refusal(&self) -> Option<String> {
+        match self {
+            Self::Refused(why) => Some(why.clone()),
+            Self::Agreed | Self::Unjudgeable(_) => None,
+        }
     }
-    None
 }
 
 // ── Oracle tests (no model, no GPU) ──────────────────────────────────────────
 
-/// One near-tie flip that both arms write around is the shipped behaviour and
-/// must pass; a stream that goes its own way must not.
-#[test]
-fn a_single_flip_passes_and_a_divergent_stream_does_not() {
-    let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
+/// A deterministic stand-in for token streams, seeded per case.
+///
+/// A plain `t % 97` stream was the previous control: 97 is prime and above the
+/// period ceiling, so it reads exactly 0.0000 at every period the sweep looks at
+/// and could not detect a control that fires on real output. These shapes can.
+struct Rng(u64);
 
+impl Rng {
+    fn next(&mut self) -> u64 {
+        // xorshift64*, so the fixtures are reproducible without a dependency.
+        self.0 ^= self.0 >> 12;
+        self.0 ^= self.0 << 25;
+        self.0 ^= self.0 >> 27;
+        self.0.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    fn below(&mut self, n: u32) -> u32 {
+        (self.next() % u64::from(n)) as u32
+    }
+
+    /// Word ids drawn from a Zipf-ish distribution, as prose is.
+    fn prose(&mut self, len: usize) -> Vec<u32> {
+        (0..len)
+            .map(|_| {
+                let r = self.below(1000);
+                r % (1 + r / 8)
+            })
+            .collect()
+    }
+}
+
+/// One near-tie flip that both arms write around is the shipped behaviour and
+/// must pass; a flip at a decision the verifier was sure about must not.
+///
+/// The two streams differ by the same single token. Only the reference arm's own
+/// margins separate them, which is the whole design: the gate judges the pair
+/// against what the verifier itself found difficult.
+#[test]
+fn a_single_flip_passes_and_a_confident_flip_does_not() {
+    let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
     let mut one_flip = plain.clone();
     one_flip[66] = 9999;
+
+    let mut tied = vec![5.0f32; N_TOKENS];
+    tied[66] = 0.01;
     assert!(
-        judge(&one_flip, &plain, Horizon::ShortPrompt).is_none(),
-        "one flip must pass"
+        judge(&one_flip, &plain, &tied).refusal().is_none(),
+        "a flip at the arm's own least-confident decision must pass"
     );
 
-    let diverged: Vec<u32> = plain
-        .iter()
-        .enumerate()
-        .map(|(i, t)| if i > 8 { 50_000 + i as u32 } else { *t })
-        .collect();
-    let failure =
-        judge(&diverged, &plain, Horizon::ShortPrompt).expect("a divergent stream must fail");
-    assert!(failure.contains("did not reproduce"), "{failure}");
+    let mut confident = vec![0.01f32; N_TOKENS];
+    for m in confident.iter_mut().take(N_TOKENS / 3) {
+        *m = 0.001;
+    }
+    confident[66] = 5.0;
+    let failure = judge(&one_flip, &plain, &confident)
+        .refusal()
+        .expect("must refuse");
+    assert!(failure.contains("nearly tied"), "{failure}");
+}
+
+/// What the divergence oracle reads, and when it stands down.
+#[test]
+fn the_divergence_oracle_reads_the_first_differing_position_or_nothing() {
+    let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
+    let mut flipped = plain.clone();
+    flipped[66] = 9999;
+
+    let mut tied = vec![5.0f32; N_TOKENS];
+    tied[66] = 0.01;
+    assert_eq!(
+        divergence_confidence(&flipped, &plain, &tied),
+        Some((66, 0.0)),
+        "the position read is the first the arms differ at"
+    );
+
+    // Two identical arms have no divergence to judge, and an empty margin list
+    // stands the oracle down rather than reading position 0 of nothing.
+    assert_eq!(divergence_confidence(&plain, &plain, &tied), None);
+    assert_eq!(divergence_confidence(&flipped, &plain, &[]), None);
+
+    // A divergence past the end of the reference arm has no margin behind it;
+    // the length guard owns that pair.
+    let extended: Vec<u32> = plain.iter().copied().chain([1_u32]).collect();
+    assert_eq!(divergence_confidence(&extended, &plain, &tied), None);
+}
+
+/// The oracle's own denominator: the confidence is a rank over the reference
+/// arm's margins, so it must not move when every margin is scaled.
+///
+/// A threshold in nats would move. This is the property that lets one ceiling
+/// cover two models whose logits are not on the same scale.
+#[test]
+fn the_confidence_is_a_rank_and_not_a_number_of_nats() {
+    let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
+    let mut flipped = plain.clone();
+    flipped[40] = 7777;
+
+    let base: Vec<f32> = (0..N_TOKENS).map(|i| 0.1 + (i % 17) as f32).collect();
+    let scaled: Vec<f32> = base.iter().map(|m| m * 250.0).collect();
+    assert_eq!(
+        divergence_confidence(&flipped, &plain, &base),
+        divergence_confidence(&flipped, &plain, &scaled),
+        "scaling every margin must not move the rank"
+    );
 }
 
 /// Two arms stuck in the same repetition loop agree perfectly and mean nothing.
@@ -502,51 +631,58 @@ fn every_shape_of_repetition_loop_is_refused() {
                 .collect(),
         ),
     ] {
-        let failure = judge(&stream, &stream, Horizon::ShortPrompt)
+        let failure = judge(&stream, &healthy, &[])
+            .refusal()
             .unwrap_or_else(|| panic!("{shape} was not refused"));
-        assert!(failure.contains("repetition loop"), "{shape}: {failure}");
+        assert!(failure.contains("repeats at period"), "{shape}: {failure}");
     }
 }
 
-/// A speculative arm that degenerated while the plain one did not is caught by
-/// the control that reads the speculative arm, not only the plain one.
-#[test]
-fn a_degenerate_speculative_arm_is_caught() {
-    let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
-    let looping = vec![7u32; N_TOKENS];
-    let failure = judge(&looping, &plain, Horizon::ShortPrompt).expect("must refuse");
-    assert!(failure.contains("speculative arm"), "{failure}");
-}
-
-/// A deterministic stand-in for token streams, seeded per case.
+/// Which arm collapsed decides what the gate is entitled to say.
 ///
-/// A plain `t % 97` stream was the previous control: 97 is prime and above the
-/// period ceiling, so it reads exactly 0.0000 at every period the sweep looks at
-/// and could not detect a control that fires on real output. These shapes can.
-struct Rng(u64);
+/// A degenerate speculative arm against a healthy reference is a verdict about
+/// the round loop. A degenerate *reference* arm is a verdict about the input:
+/// plain greedy is the control, and a control the measure cannot read leaves
+/// nothing to compare against. Naming it as an engine defect there was a false
+/// accusation the gate used to make on any prompt answered with a list.
+#[test]
+fn a_collapsed_reference_arm_is_reported_as_an_input_the_gate_cannot_judge() {
+    let healthy: Vec<u32> = (0..N_TOKENS as u32).collect();
+    let looping = vec![7u32; N_TOKENS];
 
-impl Rng {
-    fn next(&mut self) -> u64 {
-        // xorshift64*, so the fixtures are reproducible without a dependency.
-        self.0 ^= self.0 >> 12;
-        self.0 ^= self.0 << 25;
-        self.0 ^= self.0 >> 27;
-        self.0.wrapping_mul(0x2545_F491_4F6C_DD1D)
-    }
+    let spec_side = judge(&looping, &healthy, &[]);
+    let why = spec_side
+        .refusal()
+        .expect("a degenerate spec arm must be refused");
+    assert!(why.contains("speculative arm"), "{why}");
+    assert!(
+        why.contains("the verifier does not produce on its own"),
+        "{why}"
+    );
 
-    fn below(&mut self, n: u32) -> u32 {
-        (self.next() % u64::from(n)) as u32
-    }
+    let plain_side = judge(&healthy, &looping, &[]);
+    assert!(
+        matches!(plain_side, Verdict::Unjudgeable(ref why) if why.contains("reference arm")),
+        "a collapsed reference arm is an input the gate cannot read, not a \
+         refusal of the round loop: {plain_side:?}"
+    );
+}
 
-    /// Word ids drawn from a Zipf-ish distribution, as prose is.
-    fn prose(&mut self, len: usize) -> Vec<u32> {
-        (0..len)
-            .map(|_| {
-                let r = self.below(1000);
-                r % (1 + r / 8)
-            })
-            .collect()
-    }
+/// A prompt neither arm answered is not a failure of the round loop, and a
+/// prompt only one arm answered is.
+#[test]
+fn a_prompt_that_produced_no_answer_is_reported_rather_than_failed() {
+    let short: Vec<u32> = Rng(0x5170_0000).prose(MIN_ANSWER_TOKENS - 1);
+    assert!(
+        matches!(judge(&short, &short, &[]), Verdict::Unjudgeable(ref why) if why.contains("both arms")),
+        "two arms that both stopped short say nothing about the round loop"
+    );
+
+    let long: Vec<u32> = Rng(0x5170_0000).prose(N_TOKENS);
+    let why = judge(&short, &long, &[])
+        .refusal()
+        .expect("one short arm against one long one must be refused");
+    assert!(why.contains("one arm stopped early"), "{why}");
 }
 
 /// Structured output trips this control, and that is why the prompts forbid it.
@@ -557,8 +693,8 @@ impl Rng {
 /// general degeneracy classifier and this test records that rather than
 /// asserting it away. [`PROSE_INSTRUCTION`] is what keeps these shapes out of
 /// the arms the gate actually judges; if an answer ever comes back structured,
-/// the gate refuses it and the reason will say "repetition loop", which is this
-/// limit and not a defect in the engine.
+/// the gate refuses it as an input it cannot judge, which is this limit and not
+/// a defect in the engine.
 #[test]
 fn structured_output_trips_the_control_which_is_why_the_prompts_forbid_it() {
     let mut rng = Rng(0x5EED_5EED);
@@ -601,7 +737,7 @@ fn structured_output_trips_the_control_which_is_why_the_prompts_forbid_it() {
 #[test]
 fn prose_clears_the_control_at_every_length_the_gate_can_hand_it() {
     let mut worst = 0.0f64;
-    for len in [40usize, 120, 200, 218, 256] {
+    for len in [MIN_ANSWER_TOKENS, 200, 218, 256] {
         for seed in 0..64u64 {
             let stream = Rng(0x1234_0000 + seed).prose(len);
             let (start, period, fraction) = strongest_windowed_cycle(&stream);
@@ -614,9 +750,10 @@ fn prose_clears_the_control_at_every_length_the_gate_can_hand_it() {
         }
     }
     assert!(
-        worst < MAX_CYCLE_FRACTION * 0.5,
+        worst * 1.5 < MAX_CYCLE_FRACTION,
         "the margin over healthy prose has fallen to {worst:.4} against a ceiling \
-         of {MAX_CYCLE_FRACTION}; the real arms measure about 0.09"
+         of {MAX_CYCLE_FRACTION}; the real arms measure 0.05 to 0.10 and the \
+         1000-stream sweep peaks at 0.1351"
     );
 }
 
@@ -672,12 +809,13 @@ fn a_cycle_too_short_a_window_to_evidence_is_not_read() {
 /// Not a gate: it prints. Three rounds of review disagreed about this rate by a
 /// factor of three to five because the measuring code was never committed and
 /// the surviving tests could only observe the "after" state, so nothing in the
-/// tree could adjudicate. This is that code.
+/// tree could adjudicate. This is that code, and the numbers the module docs
+/// quote are the ones it prints.
 ///
 /// `#[ignore]` because it is a measurement over thousands of streams and says
-/// nothing about correctness; `prose_clears_the_control_at_every_length_the_gate_can_hand_it`
-/// is the assertion. Run it with `--ignored --nocapture`; it reaches no device.
-// gpu-test-gate: exempt
+/// nothing about correctness;
+/// `prose_clears_the_control_at_every_length_the_gate_can_hand_it` is the
+/// assertion. Run it with `--ignored --nocapture`; it reaches no device.
 #[ignore = "measurement, not an assertion: prints the false-positive rate per length"]
 #[test]
 fn the_false_positive_rate_on_healthy_output() {
@@ -702,70 +840,149 @@ fn the_false_positive_rate_on_healthy_output() {
     }
 }
 
-/// **The pair regime.** Two arms that share a real prefix and then collapse into
-/// the same loop agree on garbage, and that is the one case the subsequence
-/// oracle cannot refuse by itself — it is a subsequence measure over the same
-/// periodic base, and independent raggedness costs it far less than it costs
-/// the cycle reading. Every fixture in this file before this one judged a
-/// single arm, or a pair whose heads were independently seeded, so this regime
-/// was never tested and a false claim about it went unnoticed for two rounds.
+/// Two arms sharing a real prefix and then locked in the same period-8 loop,
+/// **swept** over the whole raggedness range rather than sampled at points.
+///
+/// This is the regime with no reference to appeal to: both arms are degenerate,
+/// so their agreement means nothing and the divergence oracle has no healthy
+/// reference arm whose margins say anything. The repetition control is what
+/// keeps it out, and past the raggedness where the control's reading falls under
+/// its ceiling the arms no longer agree either — their tail agreement is at or
+/// under [`WORST_CORRECT_TAIL_AGREEMENT`], the worst a correct pair reached.
+///
+/// The property is asserted over the whole range and over four seed pairs, so
+/// the sweep picks the points. An earlier revision claimed the range was covered
+/// with no gap and sampled six values of the parameter to say so; at 36% the
+/// pair passed.
 #[test]
-fn two_arms_in_the_same_ragged_loop_are_not_a_pass() {
-    let head = Rng(0xFEED).prose(N_TOKENS / 2);
-    let arm = |seed: u64, noise: u64| -> Vec<u32> {
-        let mut rng = Rng(seed);
-        let mut out = head.clone();
-        for i in 0..N_TOKENS / 2 {
-            out.push(if u64::from(rng.below(100)) < noise {
-                rng.below(300)
-            } else {
-                1000 + (i % 8) as u32
-            });
+fn two_arms_in_the_same_ragged_loop_are_not_returned_as_agreement() {
+    for noise in (0..=100).step_by(2) {
+        for (sa, sb) in [(0x33u64, 0x44u64), (0x91, 0xA7), (0xB3, 0xC1), (0xD5, 0xE9)] {
+            let (a, b) = (ragged_loop_arm(sa, noise), ragged_loop_arm(sb, noise));
+            if judge(&a, &b, &[]) != Verdict::Agreed {
+                continue;
+            }
+            let tail = weakest_tail(&a, &b).1;
+            assert!(
+                tail <= WORST_CORRECT_TAIL_AGREEMENT,
+                "two arms {noise}% ragged in the same period-8 loop (seeds \
+                 {sa:#x}/{sb:#x}) were returned as agreement while agreeing better \
+                 ({tail:.4}) than the worst correct pair measured \
+                 ({WORST_CORRECT_TAIL_AGREEMENT}): cycles {:.4} and {:.4}",
+                strongest_windowed_cycle(&a).2,
+                strongest_windowed_cycle(&b).2,
+            );
         }
-        out
-    };
-    for noise in [0u64, 12, 16, 25, 30, 40] {
-        let (a, b) = (arm(0x33, noise), arm(0x44, noise));
-        let verdict = judge(&a, &b, Horizon::ShortPrompt);
+    }
+}
+
+/// Half a healthy prefix, then a period-8 loop `noise` percent of whose tokens
+/// are drawn at random instead.
+fn ragged_loop_arm(seed: u64, noise: u64) -> Vec<u32> {
+    let head = Rng(0xFEED).prose(N_TOKENS / 2);
+    let mut rng = Rng(seed);
+    let mut out = head;
+    for i in 0..N_TOKENS / 2 {
+        out.push(if u64::from(rng.below(100)) < noise {
+            rng.below(300)
+        } else {
+            1000 + (i % 8) as u32
+        });
+    }
+    out
+}
+
+/// A collapse over the last quarter of a long arm is what the windowed sweep was
+/// added for, and a speculative arm doing it must be refused **by the control**,
+/// which is the claim, rather than by whichever oracle happens to fire.
+#[test]
+fn a_speculative_arm_collapsing_over_its_last_quarter_is_refused_by_the_control() {
+    let healthy = Rng(0xC0DE).prose(N_TOKENS);
+    for period in [8usize, 16, 24] {
+        let spec = quarter_collapse(0x55, period);
+        let failure = judge(&spec, &healthy, &[]).refusal().unwrap_or_else(|| {
+            panic!(
+                "period {period}: an arm collapsing over its last quarter passed: \
+                     cycle {:.4}",
+                strongest_windowed_cycle(&spec).2,
+            )
+        });
         assert!(
-            verdict.is_some(),
-            "two arms {noise}% ragged in the same period-8 loop passed: lcs {:.4}, \
-             cycles {:.4} and {:.4} — they agree on garbage and the gate called it \
-             agreement",
-            lcs_ratio(&a, &b),
-            strongest_windowed_cycle(&a).2,
-            strongest_windowed_cycle(&b).2,
+            failure.contains("repeats at period"),
+            "period {period}: the control must be what refuses this — {failure}"
         );
     }
 }
 
-/// A collapse over the last quarter of a long arm is what the windowed sweep
-/// was added for, and a pair of them must not pass.
+/// The control's declared blind spot, asserted rather than assumed.
+///
+/// `strongest_cycle` needs [`MIN_CYCLE_SAMPLES`] comparisons before it reads
+/// anything, so the narrowest window — the last `1 / TAIL_WINDOWS` of an arm —
+/// can evidence no period above `len / TAIL_WINDOWS - MIN_CYCLE_SAMPLES`, which
+/// at this budget is 32. Past that the reading comes from a wider window the
+/// collapse only partly fills and it decays: a last-quarter loop reads 0.8750 at
+/// period 32, 0.2500 at 40, 0.1875 at 48. The ceiling is crossed between 40 and
+/// 48, and that is the blind spot — pinned from both sides so it fails when it
+/// moves rather than when someone notices.
 #[test]
-fn two_arms_collapsing_over_their_last_quarter_are_not_a_pass() {
-    let head = Rng(0xC0DE).prose(N_TOKENS * 3 / 4);
-    let arm = |seed: u64| -> Vec<u32> {
-        let mut rng = Rng(seed);
-        let mut out = head.clone();
-        for i in 0..N_TOKENS - N_TOKENS * 3 / 4 {
-            out.push(if rng.below(100) < 5 {
-                rng.below(300)
-            } else {
-                1000 + (i % 16) as u32
-            });
-        }
-        out
-    };
-    let (a, b) = (arm(0x55), arm(0x66));
+fn a_cycle_confined_to_a_window_too_narrow_to_read_it_is_a_declared_blind_spot() {
+    let readable = N_TOKENS / TAIL_WINDOWS - MIN_CYCLE_SAMPLES;
+    assert_eq!(
+        readable, 32,
+        "the bound the blind spot is stated in terms of"
+    );
+
+    let (start, _, inside) = strongest_windowed_cycle(&quarter_collapse(0x55, readable));
     assert!(
-        judge(&a, &b, Horizon::ShortPrompt).is_some(),
-        "two arms collapsing into a period-16 loop over their last quarter passed: \
-         lcs {:.4}, cycles {:.4} and {:.4}",
-        lcs_ratio(&a, &b),
-        strongest_windowed_cycle(&a).2,
-        strongest_windowed_cycle(&b).2,
+        inside > MAX_CYCLE_FRACTION && start == N_TOKENS * 3 / 4,
+        "a period the last window can evidence must be read in that window; \
+         it read {inside:.4} from {start}"
+    );
+
+    let caught = strongest_windowed_cycle(&quarter_collapse(0x55, 40)).2;
+    assert!(
+        caught > MAX_CYCLE_FRACTION,
+        "a period-40 last-quarter collapse reads {caught:.4} from a wider window \
+         and must still be caught"
+    );
+    let missed = strongest_windowed_cycle(&quarter_collapse(0x55, 48)).2;
+    assert!(
+        missed <= MAX_CYCLE_FRACTION,
+        "a period-48 last-quarter collapse reads {missed:.4} and is caught; the \
+         blind spot has moved and the docs no longer describe it"
+    );
+
+    // And it is the window, not the shape: the same period over four fifths of
+    // the arm fills a window wide enough to read it.
+    let mut wide = Rng(0xC0DE).prose(N_TOKENS / 5);
+    let mut rng = Rng(0x55);
+    for i in 0..N_TOKENS - N_TOKENS / 5 {
+        wide.push(if rng.below(100) < 5 {
+            rng.below(300)
+        } else {
+            1000 + (i % 48) as u32
+        });
+    }
+    assert!(
+        strongest_windowed_cycle(&wide).2 > MAX_CYCLE_FRACTION,
+        "the same period over four fifths of the arm must still be caught"
     );
 }
+
+/// Three quarters of healthy prose, then a loop at `period` with 5% noise.
+fn quarter_collapse(seed: u64, period: usize) -> Vec<u32> {
+    let mut out = Rng(0xC0DE).prose(N_TOKENS * 3 / 4);
+    let mut rng = Rng(seed);
+    for i in 0..N_TOKENS - N_TOKENS * 3 / 4 {
+        out.push(if rng.below(100) < 5 {
+            rng.below(300)
+        } else {
+            1000 + (i % period) as u32
+        });
+    }
+    out
+}
+
 /// The subsequence ratio is taken over the shorter arm, so an arm that stopped
 /// early and matched the other's prefix scores 1.0 and says nothing about the
 /// tail it never wrote. The length guard is the only thing between that and a
@@ -775,98 +992,85 @@ fn the_ratio_is_over_the_shorter_arm_and_the_length_guard_covers_it() {
     // Twice the budget, so the *ratio* is what fires rather than the floor.
     let plain: Vec<u32> = Rng(0x1E17_0000).prose(N_TOKENS * 2);
 
-    let truncated = &plain[..N_TOKENS + 4];
+    let truncated = &plain[..N_TOKENS];
     assert!(
         (lcs_ratio(truncated, &plain) - 1.0).abs() < 1e-9,
         "a true prefix must score 1.0 over the shorter arm; it read {}",
         lcs_ratio(truncated, &plain)
     );
-    let failure =
-        judge(truncated, &plain, Horizon::ShortPrompt).expect("the length guard must refuse it");
+    let failure = judge(truncated, &plain, &[])
+        .refusal()
+        .expect("the length guard must refuse it");
     assert!(failure.contains("stopped well before"), "{failure}");
 
     // Just inside the guard the same shape scores 1.0 and passes, which is what
     // makes the guard — not the ratio — the thing doing the work above.
-    assert!(judge(&plain[..N_TOKENS + 84], &plain, Horizon::ShortPrompt).is_none());
+    assert!(judge(&plain[..N_TOKENS * 3 / 2], &plain, &[])
+        .refusal()
+        .is_none());
 }
 
-/// The long-context reproducer can flip to green.
+/// The length floor is pinned in both directions, and it is under what a correct
+/// engine produces on the shortest prompt the gate runs.
 ///
-/// Its prompt answers in about 200 tokens, and the short prompt's floor of 256
-/// would refuse a *fixed* engine: both arms would agree at ~200 and the gate
-/// would still say "an arm stopped early". A reproducer that cannot pass once
-/// the defect is fixed has to be rewritten after the fix, which is the outcome
-/// it exists to prevent.
+/// A floor a real answer cannot reach refuses a *fixed* engine and the
+/// reproducer could never flip to green; a floor nothing can fail is free.
 #[test]
-#[allow(
-    clippy::expect_used,
-    reason = "the assertion is that the short prompt's floor refuses this length; \
-              unwrapping the None case is the failure the test exists to report"
-)]
-fn a_fixed_engine_would_pass_the_long_context_reproducer() {
-    // The floor is pinned in both directions, or its value is free: replacing
-    // it with 60 or 199 left the suite green.
-    let at_floor = Rng(0x00F1_7EDD).prose(MIN_LONG_CONTEXT_ANSWER_TOKENS);
+fn the_length_floor_admits_the_shortest_answer_the_prompts_produce() {
+    let at_floor = Rng(0x00F1_7EDD).prose(MIN_ANSWER_TOKENS);
     assert!(
-        judge(&at_floor, &at_floor, Horizon::LongContext).is_none(),
+        judge(&at_floor, &at_floor, &[]).refusal().is_none(),
         "two arms exactly at the floor must pass"
     );
-    let under = &at_floor[..MIN_LONG_CONTEXT_ANSWER_TOKENS - 1];
+    let under = &at_floor[..MIN_ANSWER_TOKENS - 1];
     assert!(
-        judge(under, under, Horizon::LongContext).is_some(),
-        "two arms one token under the floor must be refused"
+        judge(under, under, &[]) != Verdict::Agreed,
+        "two arms one token under the floor must not be returned as agreement"
     );
-    // And the floor is under the length a correct engine produces on that
-    // prompt, which is what lets the reproducer flip to green. Driven through
-    // `judge` rather than compared as constants, so it pins the gate.
-    let measured_plain_arm = Rng(0x2181_2181).prose(MEASURED_LONG_CONTEXT_PLAIN_ARM);
+
+    // The shortest arm any prompt in the sweep produced. Driven through `judge`
+    // rather than compared as constants, so it pins the gate and not a pair of
+    // numbers.
+    let measured = Rng(0x2181_2181).prose(SHORTEST_MEASURED_ARM);
     assert!(
-        judge(
-            &measured_plain_arm,
-            &measured_plain_arm,
-            Horizon::LongContext
-        )
-        .is_none(),
-        "a correct engine answers that prompt in {MEASURED_LONG_CONTEXT_PLAIN_ARM} \
-         tokens and must clear the floor"
+        judge(&measured, &measured, &[]).refusal().is_none(),
+        "a correct engine answers the shortest prompt in {SHORTEST_MEASURED_ARM} tokens \
+         and must clear the floor"
     );
-    // Far enough under to be reachable, close enough that the last tail window
-    // can still read the period the documented collapse repeats at.
-    let last_window = MIN_LONG_CONTEXT_ANSWER_TOKENS / TAIL_WINDOWS;
+
+    // And the floor leaves the last tail window able to read the period the
+    // documented collapse repeats at.
+    let last_window = MIN_ANSWER_TOKENS / TAIL_WINDOWS;
     assert!(
         last_window.saturating_sub(MIN_CYCLE_SAMPLES) >= 8,
         "at this floor the last tail window is {last_window} tokens and cannot \
-         evidence a period-8 cycle, which is the collapse the reproducer records"
+         evidence a period-8 cycle, which is the collapse this gate was built on"
     );
-
-    let answer = Rng(0x00F1_7EDD).prose(200);
-    assert!(
-        judge(&answer, &answer, Horizon::LongContext).is_none(),
-        "two arms agreeing at 200 tokens must pass the long-context floor"
-    );
-    // One benign flip, as the shipped short-prompt pair shows at token 66.
-    let mut flipped = answer.clone();
-    flipped[66] = 60_000;
-    assert!(judge(&flipped, &answer, Horizon::LongContext).is_none());
-    // And the short prompt's floor is what makes it unreachable.
-    let failure = judge(&answer, &answer, Horizon::ShortPrompt).expect("256 refuses 200");
-    assert!(failure.contains("stopped early"), "{failure}");
 }
+
+/// The shortest arm any prompt in [`PROMPTS`] produced on the calibrating pair,
+/// printed by `the_agreement_a_correct_pair_reaches`.
+const SHORTEST_MEASURED_ARM: usize = 216;
 
 /// A run that stopped short is refused rather than passed on its short prefix.
 #[test]
 fn a_truncated_run_is_refused_rather_than_judged() {
     let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
-    let failure = judge(&plain[..16], &plain, Horizon::ShortPrompt).expect("must refuse");
+    let failure = judge(&plain[..16], &plain, &[])
+        .refusal()
+        .expect("must refuse");
     assert!(failure.contains("stopped early"), "{failure}");
 }
 
-/// The class the whole-stream ratio blends: a divergence that begins in the
-/// last quarter and never comes back scores high overall and collapses one tail
-/// window. This is the shape of a regression that fires past a cache-size
-/// threshold, and it is why the tail windows exist.
+/// A divergence that begins in the last quarter and never comes back.
+///
+/// This is the shape of a regression that fires past a cache-size threshold, and
+/// the repository has shipped that class. The subsequence ratio blends it with
+/// one benign flip — both land near 0.8 over the whole stream — and the
+/// divergence oracle does not: it reads the position the arms first differ at,
+/// wherever that is, and asks what the verifier thought there.
 #[test]
-fn a_late_onset_divergence_passes_the_whole_stream_ratio_and_fails_the_tail() {
+fn a_late_onset_divergence_is_judged_where_it_begins() {
     let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
     let onset = N_TOKENS * 4 / 5;
     let late: Vec<u32> = plain
@@ -875,56 +1079,73 @@ fn a_late_onset_divergence_passes_the_whole_stream_ratio_and_fails_the_tail() {
         .map(|(i, t)| if i >= onset { 50_000 + i as u32 } else { *t })
         .collect();
 
-    let whole = lcs_ratio(&late, &plain);
     assert!(
-        whole >= MIN_LCS_RATIO,
-        "the whole-stream ratio {whole} already refuses this, so the tail windows \
-         are not what is being tested"
+        lcs_ratio(&late, &plain) > 0.75,
+        "this pair must agree over most of the answer, or it is not the class \
+         the whole-stream ratio blends"
     );
-    let failure =
-        judge(&late, &plain, Horizon::ShortPrompt).expect("the tail windows must refuse it");
-    assert!(failure.contains("begins late"), "{failure}");
+
+    let mut confident = vec![0.01f32; N_TOKENS];
+    confident[onset] = 5.0;
+    let failure = judge(&late, &plain, &confident)
+        .refusal()
+        .expect("must refuse");
+    assert!(
+        failure.contains(&format!("first differ at token {onset}")),
+        "{failure}"
+    );
+
+    // The same late divergence at a decision the arm was least sure about is
+    // the benign case, and passes at exactly the same subsequence ratio.
+    let mut tied = vec![5.0f32; N_TOKENS];
+    tied[onset] = 0.01;
+    assert!(judge(&late, &plain, &tied).refusal().is_none());
 }
 
-/// The two measured regimes, reconstructed as token streams and put through the
-/// gate itself — so the test also fails when `lcs_ratio`'s denominator or
-/// `judge`'s comparison changes, not only when the constant moves.
+/// The two measured regimes put through `judge` itself, so the test fails when
+/// the oracle's composition changes and not only when a constant moves.
+///
+/// Both come from the prompt sweep. Correct: the assistant pair's worst reading,
+/// a first divergence at the 3.5th percentile of the reference arm's own
+/// margins. Broken: the MTP sidecar before its acceptance walk was given the
+/// final norm, whose lowest reading over six prompts was the 16.8th percentile.
 #[test]
-fn the_gate_admits_the_shipped_regime_and_refuses_the_broken_one() {
+fn the_gate_admits_the_worst_correct_regime_and_refuses_the_lowest_broken_one() {
     let plain: Vec<u32> = (0..N_TOKENS as u32).map(|t| t % 97).collect();
+    let mut spec = plain.clone();
+    spec[64] = 60_000;
 
-    // As shipped: one benign flip, then the same answer. Replacing 1 token in
-    // 12 leaves a subsequence ratio near the measured 0.91.
-    let shipped: Vec<u32> = plain
-        .iter()
-        .enumerate()
-        .map(|(i, t)| if i % 12 == 5 { 60_000 + i as u32 } else { *t })
+    // A margin distribution in which position 64 sits at the 3.5th percentile.
+    let correct: Vec<f32> = (0..N_TOKENS)
+        .map(|i| if i < N_TOKENS * 35 / 1000 { 0.01 } else { 5.0 })
+        .map(|m: f32| m)
         .collect();
+    let mut correct = correct;
+    correct[64] = 0.02;
+    let (_, worst_correct) = divergence_confidence(&spec, &plain, &correct).expect("a divergence");
     assert!(
-        lcs_ratio(&shipped, &plain) > MIN_LCS_RATIO,
-        "reconstructed shipped regime reads {}",
-        lcs_ratio(&shipped, &plain)
+        (worst_correct - 0.035).abs() < 0.005,
+        "the reconstructed correct regime reads {worst_correct:.4}, not the measured 0.0352"
     );
     assert!(
-        judge(&shipped, &plain, Horizon::ShortPrompt).is_none(),
-        "shipped must pass"
+        judge(&spec, &plain, &correct).refusal().is_none(),
+        "it must pass"
     );
 
-    // The broken rollback: diverged at token 5 and never recovered. Three
-    // tokens in four replaced leaves roughly the measured 0.26.
-    let broken: Vec<u32> = plain
-        .iter()
-        .enumerate()
-        .map(|(i, t)| {
-            if i >= 5 && i % 4 != 0 {
-                60_000 + i as u32
-            } else {
-                *t
-            }
-        })
+    // The same divergence at the 16.8th percentile.
+    let mut broken: Vec<f32> = (0..N_TOKENS)
+        .map(|i| if i < N_TOKENS * 168 / 1000 { 0.01 } else { 5.0 })
         .collect();
-    let failure = judge(&broken, &plain, Horizon::ShortPrompt).expect("broken must fail");
-    assert!(failure.contains("did not reproduce"), "{failure}");
+    broken[64] = 0.02;
+    let (_, lowest_broken) = divergence_confidence(&spec, &plain, &broken).expect("a divergence");
+    assert!(
+        (lowest_broken - 0.168).abs() < 0.005,
+        "the reconstructed broken regime reads {lowest_broken:.4}, not the measured 0.1680"
+    );
+    let failure = judge(&spec, &plain, &broken)
+        .refusal()
+        .expect("broken must fail");
+    assert!(failure.contains("nearly tied"), "{failure}");
 }
 
 /// The field that separates two drafters the arch check cannot.
@@ -974,16 +1195,53 @@ fn the_drafter_declares_the_backbone_it_projects_into() {
     std::fs::remove_dir_all(&dir).ok();
 }
 
-// ── The gate ─────────────────────────────────────────────────────────────────
+// ── The pairs ────────────────────────────────────────────────────────────────
 
-/// The verifier this gate is calibrated on, resolved by the golden harness so
-/// an override naming another architecture stands down instead of running.
-const VERIFIER: common::GoldenModel = common::GoldenModel {
-    slug: "mlx-community__gemma-4-e2b-it-mxfp8",
-    archs: &["Gemma4ForConditionalGeneration"],
+/// Which round loop drives a pair's speculative arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RoundLoop {
+    /// Gemma4 shared-K/V assistant: the drafter reads the verifier's K/V, and
+    /// the rollback is a KV truncation that includes the SWA ring.
+    Gemma4Assistant,
+    /// Qwen3.5/3.6 MTP sidecar: the verifier carries recurrent state, and the
+    /// rollback restores it from a pre-round snapshot and replays the accepted
+    /// prefix.
+    MtpSidecar,
+}
+
+/// One verifier + drafter the gate can run.
+struct Pair {
+    verifier: common::GoldenModel,
+    drafter_slug: &'static str,
+    round_loop: RoundLoop,
+}
+
+/// The pair the floors were measured on: a full-attention-plus-SWA verifier
+/// whose rollback is a KV truncation.
+const ASSISTANT_PAIR: Pair = Pair {
+    verifier: common::GoldenModel {
+        slug: "mlx-community__gemma-4-e2b-it-mxfp8",
+        archs: &["Gemma4ForConditionalGeneration"],
+    },
+    drafter_slug: "mlx-community__gemma-4-E2B-it-assistant-bf16",
+    round_loop: RoundLoop::Gemma4Assistant,
 };
-/// Snapshot slug of its assistant drafter.
-const DRAFTER_SLUG: &str = "mlx-community__gemma-4-E2B-it-assistant-bf16";
+
+/// The recurrent pair. Its agreement is far below the assistant pair's and no
+/// subsequence floor separates it from a broken rollback, which is what the
+/// divergence-confidence oracle is for.
+const MTP_PAIR: Pair = Pair {
+    verifier: common::GoldenModel {
+        slug: "mlx-community__Qwen3.8-27B-mxfp8",
+        archs: &[
+            "Qwen3_5ForConditionalGeneration",
+            "Qwen3_5MoeForConditionalGeneration",
+        ],
+    },
+    drafter_slug: "mlx-community__Qwen3.8-27B-MTP-mxfp8",
+    round_loop: RoundLoop::MtpSidecar,
+};
+
 /// Draft-model override, the variable the sibling alignment suites take.
 const DRAFT_MODEL_VAR: &str = "RMLX_DRAFT_TEST_MODEL";
 
@@ -1066,7 +1324,9 @@ fn declared_backbone_hidden(draft_path: &Path) -> Option<usize> {
         .and_then(|v| usize::try_from(v).ok())
 }
 
-/// What both prompts ask for, and why they ask for it.
+// ── Prompts ──────────────────────────────────────────────────────────────────
+
+/// What every prompt asks for, and why it asks for it.
 ///
 /// This gate owns its prompts, and that is the asymmetry that makes its
 /// repetition control possible at all. A general "is this arm degenerate"
@@ -1082,60 +1342,142 @@ const PROSE_INSTRUCTION: &str = "Answer at length, in continuous prose, in at le
      six full paragraphs. Do not use lists, numbered steps, tables, headings, bullet \
      points or code blocks.";
 
-/// The 4k document the long-context benches use, for the reproducer below.
-const LONG_CONTEXT_PROMPT: &str = include_str!(concat!(
+/// The 4k document the long-context benches use.
+const LONG_CONTEXT_DOCUMENT: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../prompts/longctx_4k.json"
 ));
 
-/// Chat-formatted prompt, with the leading `<bos>`.
+/// One question, and whether it carries the 4k document with it.
+struct Prompt {
+    name: &'static str,
+    question: &'static str,
+    long_context: bool,
+}
+
+/// What the sweep runs, and what the gate picks from.
 ///
-/// Gemma without its turn markers and without `<bos>` ends the turn on its very
-/// first token, and a gate that only ever runs on a degenerate stream is a gate
-/// that never runs.
-fn build_prompt(tk: &tokenizers::Tokenizer) -> Vec<u32> {
-    wrap_turn(
-        tk,
-        &format!(
-            "Explain how a hash map handles two keys that hash to the same bucket, \
-             covering separate chaining and each of the open-addressing probing \
-             strategies. {PROSE_INSTRUCTION}"
-        ),
-    )
-}
+/// The last one is the reproducer: a 4k document is what wraps a sliding-window
+/// ring, which is where the defect this gate found lived. The others exist so
+/// the constants above are set against a population rather than against the one
+/// prompt that happened to fail.
+const PROMPTS: &[Prompt] = &[
+    Prompt {
+        name: "hash-map-collisions",
+        question: "Explain how a hash map handles two keys that hash to the same bucket, \
+                   covering separate chaining and each of the open-addressing probing \
+                   strategies.",
+        long_context: false,
+    },
+    Prompt {
+        name: "tcp-congestion",
+        question: "Explain how TCP congestion control decides how fast to send, covering \
+                   slow start, congestion avoidance and what happens when a loss is \
+                   detected.",
+        long_context: false,
+    },
+    Prompt {
+        name: "virtual-memory",
+        question: "Explain how virtual memory works on a modern operating system, covering \
+                   page tables, translation lookaside buffers and what happens on a page \
+                   fault.",
+        long_context: false,
+    },
+    Prompt {
+        name: "database-isolation",
+        question: "Explain what a database isolation level is and how the common ones \
+                   differ, covering the anomalies each one still permits.",
+        long_context: false,
+    },
+    Prompt {
+        name: "photosynthesis",
+        question: "Explain how photosynthesis turns light into stored chemical energy, \
+                   covering the light-dependent reactions and the carbon-fixing ones.",
+        long_context: false,
+    },
+    Prompt {
+        name: "longctx-4k",
+        question: "Summarise the document above.",
+        long_context: true,
+    },
+];
 
-/// The same, over the 4k document: a cache large enough to reach the boundaries
-/// where this repository's KV defects live.
-fn build_long_context_prompt(tk: &tokenizers::Tokenizer) -> Vec<u32> {
-    let doc: serde_json::Value =
-        serde_json::from_str(LONG_CONTEXT_PROMPT).expect("the long-context prompt is JSON");
-    let body = doc["messages"]
-        .as_array()
-        .expect("messages")
-        .iter()
-        .filter_map(|m| m["content"].as_str())
-        .collect::<Vec<_>>()
-        .join("\n\n");
-    wrap_turn(
-        tk,
-        &format!("{body}\n\nSummarise the document above. {PROSE_INSTRUCTION}"),
-    )
-}
+impl Prompt {
+    /// Chat-formatted prompt ids for whichever turn markers the tokenizer
+    /// declares.
+    ///
+    /// A model served outside its own turn markers answers nothing useful —
+    /// Gemma without them and without `<bos>` ends the turn on its first token,
+    /// and a gate that only ever runs on a degenerate stream is a gate that
+    /// never runs. The markers are read off the tokenizer rather than hard-coded
+    /// per pair, so a third pair needs no new branch unless it needs new
+    /// markers.
+    ///
+    /// A tokenizer that declares `<think>` gets an **empty** reasoning block,
+    /// which is what its own template emits for `enable_thinking=false`. The
+    /// gate asks for prose because prose is the regime its repetition control
+    /// can read, and a reasoning block is a plan in numbered steps whatever the
+    /// question asked for — measured on this pair, plain greedy's own reasoning
+    /// block reads 0.2500 against a ceiling of 0.20.
+    fn ids(&self, tk: &tokenizers::Tokenizer) -> Vec<u32> {
+        let question = if self.long_context {
+            let doc: serde_json::Value = serde_json::from_str(LONG_CONTEXT_DOCUMENT)
+                .expect("the long-context prompt is JSON");
+            let body = doc["messages"]
+                .as_array()
+                .expect("messages")
+                .iter()
+                .filter_map(|m| m["content"].as_str())
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            format!("{body}\n\n{} {PROSE_INSTRUCTION}", self.question)
+        } else {
+            format!("{} {PROSE_INSTRUCTION}", self.question)
+        };
 
-fn wrap_turn(tk: &tokenizers::Tokenizer, question: &str) -> Vec<u32> {
-    let text = format!("<start_of_turn>user\n{question}<end_of_turn>\n<start_of_turn>model\n");
-    let mut ids: Vec<u32> = Vec::new();
-    if let Some(bos) = tk.token_to_id("<bos>") {
-        ids.push(bos);
-    }
-    ids.extend(
-        tk.encode(text.as_str(), true)
-            .expect("encode")
-            .get_ids()
+        let mut ids: Vec<u32> = Vec::new();
+        if let Some(bos) = tk.token_to_id("<bos>") {
+            ids.push(bos);
+        }
+        // Read off the tokenizer's own added tokens, in an order that keeps a
+        // model declaring more than one family on its own markers.
+        let turns = [
+            ("<|turn>", "<|turn>user\n", "<turn|>\n", "<|turn>model\n"),
+            (
+                "<start_of_turn>",
+                "<start_of_turn>user\n",
+                "<end_of_turn>\n",
+                "<start_of_turn>model\n",
+            ),
+            (
+                "<|im_start|>",
+                "<|im_start|>user\n",
+                "<|im_end|>\n",
+                "<|im_start|>assistant\n",
+            ),
+        ];
+        let Some(&(_, user, end, assistant)) = turns
             .iter()
-            .copied(),
-    );
-    ids
+            .find(|(marker, ..)| tk.token_to_id(marker).is_some())
+        else {
+            panic!(
+                "this verifier declares none of the turn markers this gate knows, and a \
+                 model served outside its own markers answers nothing the gate can judge"
+            )
+        };
+        let mut text = format!("{user}{question}{end}{assistant}");
+        if tk.token_to_id("<think>").is_some() {
+            text.push_str("<think>\n\n</think>\n\n");
+        }
+        ids.extend(
+            tk.encode(text.as_str(), true)
+                .expect("encode")
+                .get_ids()
+                .iter()
+                .copied(),
+        );
+        ids
+    }
 }
 
 /// The verifier's own stop ids.
@@ -1159,29 +1501,47 @@ fn eos_ids(model_path: &Path) -> Vec<u32> {
     }
 }
 
-/// Plain greedy decoding on the verifier alone, at temperature 0.
+/// Plain greedy decoding on the verifier alone, at temperature 0: the token ids
+/// and, per position, the verifier's own top-two logprob gap.
+///
+/// The gap is what the divergence oracle reads. It costs one log-softmax and a
+/// partial top-k per step on the host — the reference arm is not the arm any
+/// throughput number comes from.
 fn plain_greedy(
     verifier: &arch::Architecture,
     tk: &tokenizers::Tokenizer,
     prompt: &[u32],
     eos: &[u32],
     device: Device,
-) -> Vec<u32> {
+) -> (Vec<u32>, Vec<f32>) {
     let sampler_cfg = rmlx_models::sampler::SamplerConfig {
         temperature: 0.0,
         top_p: 1.0,
         top_k: 0,
         min_p: 0.0,
         seed: Some(0),
-        top_logprobs_k: 0,
+        top_logprobs_k: 2,
     };
     let mut rng = rmlx_models::sampler::Pcg32::new(sampler_cfg.seed_or_default());
     let penalty_cfg = rmlx_models::sampler::PenaltyConfig::default();
     let mut history: Vec<u32> = Vec::new();
     let mut ids: Vec<u32> = Vec::new();
+    let mut margins: Vec<f32> = Vec::new();
     {
         let mut step = |s: &rmlx_models::ProbeStep| {
             ids.push(s.token_id);
+            let mut top: Vec<f32> = s
+                .logprobs
+                .as_ref()
+                .map(|lp| lp.top.iter().map(|t| t.1).collect())
+                .unwrap_or_default();
+            top.sort_by(|a, b| b.total_cmp(a));
+            margins.push(match (top.first(), top.get(1)) {
+                (Some(best), Some(second)) => best - second,
+                // A one-entry vocabulary is not a thing, but a margin the arm
+                // did not report must not read as a tie.
+                _ => f32::INFINITY,
+            });
             None
         };
         verifier
@@ -1203,140 +1563,254 @@ fn plain_greedy(
             )
             .expect("plain greedy generate");
     }
-    ids
+    (ids, margins)
 }
 
-/// The gate: the speculative arm reproduces what the verifier decodes alone.
-///
-/// Both arms run the same verifier, the same prompt, `--kv-quant none` and
-/// temperature 0 — a different codec on either side would make this a
-/// measurement of the codec instead of the round loop. Both are given the
-/// verifier's stop ids and both must produce a real answer of comparable
-/// length — see [`MIN_ANSWER_TOKENS`] and [`MIN_LENGTH_RATIO`].
-#[ignore]
-#[test]
-fn speculative_greedy_reproduces_plain_greedy() {
-    const TEST: &str = "speculative_greedy_reproduces_plain_greedy";
-    run_gate(TEST, build_prompt, Horizon::ShortPrompt);
+/// A loaded pair, ready to answer prompts.
+struct Loaded {
+    verifier: arch::Architecture,
+    drafter: Drafter,
+    tokenizer: tokenizers::Tokenizer,
+    eos: Vec<u32>,
 }
 
-/// The same gate over a 4k document, where it fails today.
-///
-/// The speculative arm collapses into a period-8 repetition loop while plain
-/// greedy writes a clean summary and stops — see the module docs for the
-/// readings and the issue. It reproduces on `main`, so it is not this branch's;
-/// it is here because a reproducer that fails until the defect is fixed is what
-/// makes moving the gate onto this prompt happen, and a paragraph is not.
-#[ignore]
-#[test]
-fn speculative_greedy_reproduces_plain_greedy_at_long_context() {
-    const TEST: &str = "speculative_greedy_reproduces_plain_greedy_at_long_context";
-    run_gate(TEST, build_long_context_prompt, Horizon::LongContext);
+enum Drafter {
+    Assistant(Box<Gemma4AssistantDrafter>),
+    Mtp(Box<MtpDrafter>),
 }
 
-/// Both arms of one pair over `prompt`, judged.
-fn run_gate(test: &str, prompt_of: fn(&tokenizers::Tokenizer) -> Vec<u32>, horizon: Horizon) {
+impl Loaded {
+    /// Both arms over one prompt: the speculative ids, the reference ids, and
+    /// the reference's per-position margins.
+    fn arms(&mut self, prompt: &Prompt, device: Device) -> (Vec<u32>, Vec<u32>, Vec<f32>) {
+        let ids = prompt.ids(&self.tokenizer);
+        let mut spec_ids: Vec<u32> = Vec::new();
+        {
+            let mut step = |s: &rmlx_models::ProbeStep| {
+                spec_ids.push(s.token_id);
+                None
+            };
+            match &mut self.drafter {
+                Drafter::Assistant(drafter) => mtp_assistant_generate_greedy(
+                    &self.verifier,
+                    drafter,
+                    &self.tokenizer,
+                    &ids,
+                    N_TOKENS,
+                    BLOCK_SIZE,
+                    Some(rmlx_kv_quant::KvQuant::None),
+                    Some(MAX_CTX),
+                    &self.eos,
+                    &mut step,
+                    device,
+                )
+                .expect("assistant speculative generate"),
+                Drafter::Mtp(drafter) => {
+                    let block = drafter.block_size();
+                    mtp_generate_greedy(
+                        &self.verifier,
+                        drafter,
+                        &self.tokenizer,
+                        &ids,
+                        N_TOKENS,
+                        block,
+                        Some(rmlx_kv_quant::KvQuant::None),
+                        Some(MAX_CTX),
+                        &self.eos,
+                        &mut step,
+                        device,
+                    )
+                    .expect("mtp speculative generate")
+                }
+            };
+        }
+        let (plain_ids, margins) =
+            plain_greedy(&self.verifier, &self.tokenizer, &ids, &self.eos, device);
+        (spec_ids, plain_ids, margins)
+    }
+}
+
+/// Load a pair, or say why the gate stood down.
+fn load(pair: &Pair, test: &str, device: Device) -> Option<Loaded> {
     let (Some(model_path), Some(draft_path)) = (
-        common::model_for(&VERIFIER, test),
-        common::apply(resolve(DRAFT_MODEL_VAR, DRAFTER_SLUG), test),
+        common::model_for(&pair.verifier, test),
+        common::apply(resolve(DRAFT_MODEL_VAR, pair.drafter_slug), test),
     ) else {
-        return;
+        return None;
     };
 
-    if !is_gemma4_assistant(&draft_path) {
-        eprintln!(
-            "SKIP {test}: {} is not a Gemma4 assistant drafter; the floors are calibrated \
-             on the exact-rollback regime only",
-            draft_path.display()
-        );
-        return;
-    }
-
-    let device = Device::Gpu;
     let verifier =
         arch::load_model(&model_path, device, &arch::LoadOpts::default()).expect("load verifier");
-    if verifier.needs_lin_caches() {
-        eprintln!(
-            "SKIP {test}: {} carries recurrent state; see the module docs",
-            model_path.display()
-        );
-        return;
-    }
     let hidden = verifier.hidden_size();
-    let declared = declared_backbone_hidden(&draft_path);
-    if declared.is_some_and(|width| width != hidden) {
-        let retargeted = std::env::var(common::SINGLE_MODEL_VAR)
-            .is_ok_and(|v| !v.is_empty() && Path::new(&v) == model_path);
-        eprintln!(
-            "SKIP {test}: {} projects into a backbone {} wide and {} is {hidden}; the \
-             floors are measured on one pair and this is another{}",
-            draft_path.display(),
-            declared.unwrap_or(hidden),
-            model_path.display(),
-            if retargeted {
-                format!(
-                    " — the verifier came from {}, which retargeted this gate",
-                    common::SINGLE_MODEL_VAR
-                )
-            } else {
-                String::new()
-            },
-        );
-        return;
-    }
-    let tk =
+    let drafter = match pair.round_loop {
+        RoundLoop::Gemma4Assistant => {
+            if !is_gemma4_assistant(&draft_path) {
+                eprintln!(
+                    "SKIP {test}: {} is not a Gemma4 assistant drafter",
+                    draft_path.display()
+                );
+                return None;
+            }
+            let declared = declared_backbone_hidden(&draft_path);
+            if declared.is_some_and(|width| width != hidden) {
+                eprintln!(
+                    "SKIP {test}: {} projects into a backbone {} wide and {} is {hidden}",
+                    draft_path.display(),
+                    declared.unwrap_or(hidden),
+                    model_path.display(),
+                );
+                return None;
+            }
+            Drafter::Assistant(Box::new(
+                Gemma4AssistantDrafter::load(&draft_path, hidden, device)
+                    .expect("load assistant drafter"),
+            ))
+        }
+        RoundLoop::MtpSidecar => {
+            if !verifier.needs_lin_caches() {
+                eprintln!(
+                    "SKIP {test}: {} carries no recurrent state, so it is not the \
+                     verifier this loop drives",
+                    model_path.display()
+                );
+                return None;
+            }
+            Drafter::Mtp(Box::new(
+                MtpDrafter::load(&draft_path, hidden, device).expect("load MTP sidecar"),
+            ))
+        }
+    };
+
+    let tokenizer =
         tokenizers::Tokenizer::from_file(model_path.join("tokenizer.json")).expect("tokenizer");
-    let prompt = prompt_of(&tk);
     let eos = eos_ids(&model_path);
     assert!(
         !eos.is_empty(),
         "the verifier config must name its stop ids — without them both arms run past \
          the answer into end-of-turn filler and the comparison is over that"
     );
+    Some(Loaded {
+        verifier,
+        drafter,
+        tokenizer,
+        eos,
+    })
+}
 
-    let mut spec_ids: Vec<u32> = Vec::new();
-    {
-        let mut step = |s: &rmlx_models::ProbeStep| {
-            spec_ids.push(s.token_id);
-            None
-        };
-        let drafter = Gemma4AssistantDrafter::load(&draft_path, hidden, device)
-            .expect("load assistant drafter");
-        mtp_assistant_generate_greedy(
-            &verifier,
-            &drafter,
-            &tk,
-            &prompt,
-            N_TOKENS,
-            BLOCK_SIZE,
-            Some(rmlx_kv_quant::KvQuant::None),
-            Some(MAX_CTX),
-            &eos,
-            &mut step,
-            device,
-        )
-        .expect("assistant speculative generate");
-    }
-
-    let plain_ids = plain_greedy(&verifier, &tk, &prompt, &eos, device);
-
-    let (tail_start, tail_ratio) = weakest_tail(&spec_ids, &plain_ids);
-    let (spec_from, spec_period, spec_cycle) = strongest_windowed_cycle(&spec_ids);
-    let (plain_from, plain_period, plain_cycle) = strongest_windowed_cycle(&plain_ids);
+/// Report one pair of arms, whatever the verdict.
+#[allow(clippy::too_many_arguments)]
+fn report(
+    test: &str,
+    prompt: &Prompt,
+    tk: &tokenizers::Tokenizer,
+    spec: &[u32],
+    plain: &[u32],
+    margins: &[f32],
+    verdict: &Verdict,
+) {
+    let (tail_start, tail_ratio) = weakest_tail(spec, plain);
+    let (spec_from, spec_period, spec_cycle) = strongest_windowed_cycle(spec);
+    let (plain_from, plain_period, plain_cycle) = strongest_windowed_cycle(plain);
+    let (div, confidence) = divergence_confidence(spec, plain, margins)
+        .unwrap_or((common_prefix_len(spec, plain), 0.0));
     eprintln!(
-        "[{test}] lcs={:.4} first_divergence={} tail={tail_ratio:.4}@{tail_start} \
+        "[{test}/{}] lcs={:.4} tail={tail_ratio:.4}@{tail_start} divergence={div} \
+         margin={:.4} confidence={confidence:.4} \
          cycle spec={spec_cycle:.4}/p{spec_period}@{spec_from} \
-         plain={plain_cycle:.4}/p{plain_period}@{plain_from} \
-         spec={} plain={}\n  spec  = {:?}\n  plain = {:?}",
-        lcs_ratio(&spec_ids, &plain_ids),
-        common_prefix_len(&spec_ids, &plain_ids),
-        spec_ids.len(),
-        plain_ids.len(),
-        tk.decode(&spec_ids, false).unwrap_or_default(),
-        tk.decode(&plain_ids, false).unwrap_or_default(),
+         plain={plain_cycle:.4}/p{plain_period}@{plain_from} spec={} plain={}\n  \
+         verdict = {verdict:?}\n  spec  = {:?}\n  plain = {:?}",
+        prompt.name,
+        lcs_ratio(spec, plain),
+        margins.get(div).copied().unwrap_or(f32::NAN),
+        spec.len(),
+        plain.len(),
+        tk.decode(spec, false).unwrap_or_default(),
+        tk.decode(plain, false).unwrap_or_default(),
     );
+}
 
-    if let Some(failure) = judge(&spec_ids, &plain_ids, horizon) {
-        panic!("{failure}");
+// ── The gate ─────────────────────────────────────────────────────────────────
+
+/// The assistant pair reproduces plain greedy on every prompt it answers.
+///
+/// The 4k document is the prompt the SWA-ring defect showed on — 4k is what
+/// wraps a sliding-window ring, and past the wrap the ring used to keep the
+/// rejected drafts of every round while the full-attention layers dropped
+/// theirs. The short prompts never wrap it and were green throughout, which is
+/// why the gate does not run on one of them alone.
+#[ignore]
+#[test]
+fn the_assistant_round_loop_reproduces_plain_greedy() {
+    run_gate(
+        "the_assistant_round_loop_reproduces_plain_greedy",
+        &ASSISTANT_PAIR,
+    );
+}
+
+/// The recurrent pair, whose rollback has no truncation to be exact about — the
+/// recurrent state has no sequence axis, so the loop restores a pre-round
+/// snapshot and replays the accepted prefix.
+///
+/// Its subsequence agreement is far below the assistant pair's and no floor
+/// separates it from a defect, which is what the divergence oracle is for. It
+/// is also the pair that found one: the acceptance walk was scoring an un-normed
+/// hidden through the LM head, and with that fixed three of six prompts come
+/// back bit-identical.
+#[ignore]
+#[test]
+fn the_recurrent_round_loop_reproduces_plain_greedy() {
+    run_gate(
+        "the_recurrent_round_loop_reproduces_plain_greedy",
+        &MTP_PAIR,
+    );
+}
+
+/// Every prompt in [`PROMPTS`], judged, and the whole table printed whatever the
+/// verdicts are.
+///
+/// **Every prompt, not a chosen one.** Recall is a property of the set: on the
+/// pairs and prompts measured here, an engine whose acceptance walk skips the
+/// final norm reads inside the confidence ceiling on two of six prompts and
+/// outside it on four, so a gate pinned to one prompt would be a coin toss and
+/// this one is not. The cost is one pair of arms per prompt.
+fn run_gate(test: &str, pair: &Pair) {
+    let device = Device::Gpu;
+    let Some(mut loaded) = load(pair, test, device) else {
+        return;
+    };
+    let mut refusals: Vec<String> = Vec::new();
+    let mut judged = 0usize;
+    for prompt in PROMPTS {
+        let (spec, plain, margins) = loaded.arms(prompt, device);
+        let verdict = judge(&spec, &plain, &margins);
+        report(
+            test,
+            prompt,
+            &loaded.tokenizer,
+            &spec,
+            &plain,
+            &margins,
+            &verdict,
+        );
+        match verdict {
+            Verdict::Agreed => judged += 1,
+            Verdict::Unjudgeable(_) => {}
+            Verdict::Refused(why) => {
+                judged += 1;
+                refusals.push(format!("{}: {why}", prompt.name));
+            }
+        }
     }
+    assert!(
+        judged > 0,
+        "{test}: no prompt produced a pair this gate could judge, so it asserted \
+         nothing — the run is not a pass"
+    );
+    assert!(
+        refusals.is_empty(),
+        "{test}: the round loop did not reproduce plain greedy on {} of {judged} \
+         judged prompts\n  {}",
+        refusals.len(),
+        refusals.join("\n  ")
+    );
 }

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -880,6 +880,32 @@ fn two_arms_in_the_same_ragged_loop_are_not_returned_as_agreement() {
     }
 }
 
+/// [`WORST_CORRECT_TAIL_AGREEMENT`] is the worst of the tails actually measured,
+/// and this is where that is checked.
+///
+/// Its only other use is an upper bound, so **raising** it weakens the ragged
+/// sweep above toward vacuity with every test still green — the same
+/// one-directional asymmetry the divergence ceiling's pin used to have. Holding
+/// it to the population it names fails in both directions.
+#[test]
+fn the_worst_correct_tail_is_the_worst_of_the_tails_measured() {
+    /// Every tail agreement a correct pair reached, over both pairs and the
+    /// prompts each of them judged.
+    const MEASURED: &[f64] = &[
+        // Assistant pair, six prompts.
+        0.3125, 0.3750, 0.3906, 0.2344, 1.0000, 0.9062,
+        // Recurrent pair, the five prompts it judged — the 4k document is
+        // answered in 13 and 26 tokens and is reported unjudgeable.
+        0.3281, 1.0000, 1.0000, 0.6354, 1.0000,
+    ];
+    let worst = MEASURED.iter().copied().fold(f64::INFINITY, f64::min);
+    assert!(
+        (worst - WORST_CORRECT_TAIL_AGREEMENT).abs() < 1e-9,
+        "the constant reads {WORST_CORRECT_TAIL_AGREEMENT:.4} and the worst tail a \
+         correct pair reached is {worst:.4}"
+    );
+}
+
 /// Half a healthy prefix, then a period-8 loop `noise` percent of whose tokens
 /// are drawn at random instead.
 fn ragged_loop_arm(seed: u64, noise: u64) -> Vec<u32> {
@@ -1040,9 +1066,17 @@ fn the_length_floor_admits_every_answer_the_prompts_produce() {
         "a pair that answers in full must clear the floor"
     );
     const {
-        // A floor at or above the budget would pass only if neither arm ever
-        // emitted a stop id, which is a different assertion from this one.
-        assert!(MIN_ANSWER_TOKENS < N_TOKENS);
+        // The upper side, and it is not merely the budget. A correct pair can
+        // answer and stop well before the budget — run at 512 tokens these same
+        // prompts stop the reference arm at 330 — so a floor that only cleared
+        // `N_TOKENS` would still class a pair that answered and stopped as a
+        // prompt that produced nothing, driving `judged` to zero and failing
+        // `run_gate`'s own guard for the wrong reason. Two thirds is the
+        // fraction that measurement leaves.
+        assert!(MIN_ANSWER_TOKENS * 3 <= N_TOKENS * 2);
+        // And the lower side: below this the last tail window cannot evidence a
+        // cycle at all.
+        assert!(MIN_ANSWER_TOKENS > TAIL_WINDOWS * MIN_CYCLE_SAMPLES);
     }
 
     // And the floor leaves the last tail window able to read the period the

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -88,6 +88,9 @@
 //! | `gemma-4-e2b-it-mxfp8` | `gemma-4-E2B-it-assistant-bf16` | shared-K/V assistant | KV truncation, SWA ring included |
 //! | `Qwen3.8-27B-mxfp8` | `Qwen3.8-27B-MTP-mxfp8` | MTP sidecar | KV truncation + recurrent snapshot/replay |
 //!
+//! The first runs wherever the snapshots are; the second runs on request — see
+//! [`DrafterSource`] for the shader-validation reason.
+//!
 //! The second is the pair whose agreement no subsequence floor could separate
 //! from a broken rollback. The divergence oracle settled it: its acceptance walk
 //! was scoring an un-normed hidden through the LM head, and with that fixed
@@ -1208,8 +1211,27 @@ enum RoundLoop {
 /// One verifier + drafter the gate can run.
 struct Pair {
     verifier: common::GoldenModel,
-    drafter_slug: &'static str,
+    drafter: DrafterSource,
     round_loop: RoundLoop,
+}
+
+/// How a pair's drafter is found, and so whether `make gpu-test` selects the
+/// pair on a machine that merely holds the snapshots.
+enum DrafterSource {
+    /// Resolved by slug from `RMLX_O_MODELS_ROOT`, like the verifier — the pair
+    /// runs wherever the snapshots are.
+    Slug(&'static str),
+    /// Named by an operator or not run at all.
+    ///
+    /// Its verifier drives an MLX quantized matmul whose `load_safe` bound is
+    /// the one `scripts/gpu_validation_census.txt` records, so a run under Metal
+    /// shader validation reports over a thousand invalid loads from a kernel
+    /// this repo does not compile. The census pins one exact count per test, and
+    /// a count from a 256-token generation moves with every prompt — so pinning
+    /// this pair would make the census brittle rather than informative. Until
+    /// that is settled the pair runs on request and `make gpu-test` reports it
+    /// as skipped, with the variable that would run it named.
+    Named,
 }
 
 /// The pair the floors were measured on: a full-attention-plus-SWA verifier
@@ -1219,7 +1241,7 @@ const ASSISTANT_PAIR: Pair = Pair {
         slug: "mlx-community__gemma-4-e2b-it-mxfp8",
         archs: &["Gemma4ForConditionalGeneration"],
     },
-    drafter_slug: "mlx-community__gemma-4-E2B-it-assistant-bf16",
+    drafter: DrafterSource::Slug("mlx-community__gemma-4-E2B-it-assistant-bf16"),
     round_loop: RoundLoop::Gemma4Assistant,
 };
 
@@ -1234,7 +1256,7 @@ const MTP_PAIR: Pair = Pair {
             "Qwen3_5MoeForConditionalGeneration",
         ],
     },
-    drafter_slug: "mlx-community__Qwen3.8-27B-MTP-mxfp8",
+    drafter: DrafterSource::Named,
     round_loop: RoundLoop::MtpSidecar,
 };
 
@@ -1628,12 +1650,21 @@ impl Loaded {
 
 /// Load a pair, or say why the gate stood down.
 fn load(pair: &Pair, test: &str, device: Device) -> Option<Loaded> {
-    let (Some(model_path), Some(draft_path)) = (
-        common::model_for(&pair.verifier, test),
-        common::apply(resolve(DRAFT_MODEL_VAR, pair.drafter_slug), test),
-    ) else {
-        return None;
+    // The drafter first: a pair the operator has not named stands down before
+    // anything loads a verifier.
+    let named = std::env::var(DRAFT_MODEL_VAR)
+        .ok()
+        .filter(|v| !v.is_empty());
+    let draft_gate = match (&pair.drafter, named.is_some()) {
+        (DrafterSource::Slug(slug), _) => resolve(DRAFT_MODEL_VAR, slug),
+        (DrafterSource::Named, true) => resolve(DRAFT_MODEL_VAR, ""),
+        (DrafterSource::Named, false) => common::Gate::Skip(format!(
+            "{DRAFT_MODEL_VAR} is unset and this pair's drafter is not resolved by \
+             slug — see the DrafterSource::Named note for why"
+        )),
     };
+    let draft_path = common::apply(draft_gate, test)?;
+    let model_path = common::model_for(&pair.verifier, test)?;
 
     let verifier =
         arch::load_model(&model_path, device, &arch::LoadOpts::default()).expect("load verifier");

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -39,9 +39,10 @@
 //! nothing else: the assistant pair reads 0.9375 on the 4k document and 0.4766
 //! on a short prose prompt whose arms flip an **exact** tie (top-two margin
 //! 0.0000) at token 37, after which both write well-formed, correct, different
-//! prose. The two broken engines read 0.2188 to 0.4615 on the same measure. The
-//! populations overlap. [`report`] prints the figure on every run and the gate
-//! does not assert it.
+//! prose. The two broken engines read 0.2188 to 0.4615 on the same measure —
+//! three per cent under the worst correct cell, and the correct minimum is set
+//! by where an exact tie happens to land, which nothing bounds from below.
+//! [`report`] prints the figure on every run and the gate does not assert it.
 //!
 //! **The repetition control** is the second oracle, and it exists because the
 //! first has nothing to read when both arms are degenerate: two arms in the same
@@ -187,9 +188,9 @@ const MAX_DIVERGENCE_CONFIDENCE: f64 = 0.12;
 /// correct arms share is decided by where their first near-tie lands and by
 /// nothing else: the assistant pair reads 0.9375 on the 4k document and 0.4766
 /// on a short prose prompt whose arms flip an exact tie at token 37, and the two
-/// broken engines measured here read 0.2188 to 0.4615. The populations overlap,
-/// so no floor separates them. `report` prints the figure on every run and the
-/// gate does not assert it.
+/// broken engines measured here read 0.2188 to 0.4615 — three per cent under
+/// that, with nothing bounding the correct minimum from below. `report` prints
+/// the figure on every run and the gate does not assert it.
 const WORST_CORRECT_TAIL_AGREEMENT: f64 = 0.2344;
 
 /// How much of an arm — or of any tail cut of it — may repeat at a short period

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -294,6 +294,37 @@ never allocates its `KvStorage` (mlx-lm's reference keeps SWA bf16 too —
 `RotatingKVCache.to_quantized` raises). The bound therefore applies at every
 codec, not only at the default.
 
+### Rolling the SWA ring back
+
+`KvCache::truncate_to(n)` is the rollback a speculative round runs after a
+partial acceptance, and a rotating ring can serve it in exactly two states.
+
+- **Before the first wrap** (`offset < max_size`) every position ever written is
+  still at its own slot, so the rollback is a move of the write pointer. This is
+  mlx-lm's `is_trimmable` (`cache.py:542-543`).
+- **After a wrap, while the buffer is in temporal order** — the state
+  `update_concat` leaves it in, holding `max_size + s - 1` positions for a write
+  of `s`, precisely so every token in the block sees a full window. Those are the
+  newest positions in order, so dropping the last `n` is lossless exactly while
+  what is left still covers the window the rolled-back offset needs. A
+  block-verify write can therefore always be rolled back over its own rejected
+  tail, which is at most `s - 1` long.
+
+A ring left in **rotated** order by single-token writes past the wrap cannot: its
+newest slots hold the positions they overwrote. `truncate_to` returns an error
+there naming the layer and the distance, and `KvCache::can_truncate_to(n)` is the
+predicate it implements — one predicate, so a caller's gate and the operation
+cannot drift apart. The gemma4 partial-prefix path asks first and takes the
+re-prefill route; a speculative round loop has no second route and lets the
+failure surface.
+
+mlx-lm's `trim_prompt_cache` silently returns 0 for the refused case, which is
+safe for its caller because it re-prefills what it could not roll back. It is not
+safe for a round loop: the other layers do roll back, and the ring is left
+holding the rejected drafts at an offset the rest of the stack has left behind.
+That is what `docs/SPEC_ANSWER_EQUIVALENCE.md` records as the first of the two
+defects the answer-equivalence gate found.
+
 ### `resident_bytes` counts the live-inference KV (filled prefix, not ceiling)
 
 `KvCache::resident_bytes()` reports the bytes of the K/V that **actually serves

--- a/docs/PROMPT_CACHE.md
+++ b/docs/PROMPT_CACHE.md
@@ -325,9 +325,10 @@ pub(crate) enum ReusePolicy {
 want_blocks`) may be taken. The generate loop deep-clones the slot, calls
 `truncate_kv_to_block(best_blocks)`, and re-prefills the tail. There is an
 additional per-slot gate: `Gemma4Entry::can_truncate_to_block` checks whether
-every layer cache is trimmable (`KvCache::is_trimmable`). A SWA
-`RotatingKvCache` whose ring buffer has wrapped is not trimmable; in that
-case the partial path falls back to Miss.
+every layer cache can reach the block boundary
+(`KvCache::can_truncate_to(block_count * BLOCK_TOKENS)`). A SWA
+`RotatingKvCache` whose ring buffer has wrapped cannot give back a whole block;
+in that case the partial path falls back to Miss.
 
 **`ExactOnly`** (Qwen3, Qwen3.5-MoE): any block-level match that is not a
 full-token-equality Exact hit is routed to `CacheLookup::Miss` and triggers a
@@ -523,11 +524,13 @@ layers use `RotatingKvCache`, which is a ring buffer of the last
 `sliding_window` K/V tokens.
 
 **`can_truncate_to_block(block_count)`**: returns true iff every layer cache
-passes `KvCache::is_trimmable`. A SWA cache whose ring has wrapped (i.e.
-`offset >= sliding_window`) is not trimmable — block-aligned truncation
-would silently no-op on SWA layers while trimming full-attention layers,
-desyncing the caches. When `can_truncate_to_block` returns false, the partial
-prefix hit degrades to Miss and the request falls back to full re-prefill.
+passes `KvCache::can_truncate_to(block_count * BLOCK_TOKENS)`. A wrapped SWA
+ring can only be rolled back while it still holds the window the shorter prefix
+attends over, and a cached prompt long enough to wrap it never does over a whole
+block — `truncate_kv_to_block` would then fail on the SWA layers after trimming
+the full-attention ones, desyncing the caches. When `can_truncate_to_block`
+returns false, the partial prefix hit degrades to Miss and the request falls
+back to full re-prefill.
 
 **`is_strict_prefix_of(prompt_ids)`**: returns true iff this entry's full
 token sequence is a strict prefix of `prompt_ids` (i.e. the new prompt

--- a/docs/PROMPT_CACHE.md
+++ b/docs/PROMPT_CACHE.md
@@ -524,13 +524,22 @@ layers use `RotatingKvCache`, which is a ring buffer of the last
 `sliding_window` K/V tokens.
 
 **`can_truncate_to_block(block_count)`**: returns true iff every layer cache
-passes `KvCache::can_truncate_to(block_count * BLOCK_TOKENS)`. A wrapped SWA
-ring can only be rolled back while it still holds the window the shorter prefix
-attends over, and a cached prompt long enough to wrap it never does over a whole
-block — `truncate_kv_to_block` would then fail on the SWA layers after trimming
-the full-attention ones, desyncing the caches. When `can_truncate_to_block`
-returns false, the partial prefix hit degrades to Miss and the request falls
-back to full re-prefill.
+that holds anything (`offset() > 0` — the KV-shared tail never does, and the
+truncation skips it too) passes
+`KvCache::can_truncate_to(block_count * BLOCK_TOKENS)`. A cached entry has taken
+decode steps, so its SWA ring is in rotated order; past the wrap that ring cannot
+give a position back and `truncate_kv_to_block` would fail on the SWA layers
+after trimming the full-attention ones, desyncing the caches. When
+`can_truncate_to_block` returns false, the partial prefix hit degrades to Miss
+and the request falls back to full re-prefill.
+
+The predicate is exact rather than conservative, which widens the path slightly:
+where the old `is_trimmable` refused every ring past its wrap, a ring still
+holding the window the shorter prefix attends over — a prefill-only entry, whose
+chunked prefill leaves it `window - 1 + chunk` long and in temporal order — is
+now allowed. That rollback is lossless by the rule in `docs/KV_CACHE.md`
+§ "Rolling the SWA ring back", and `gemma4_kv_cache_equivalence.rs` is what shows
+the reused prefix reproduces a full prefill.
 
 **`is_strict_prefix_of(prompt_ids)`**: returns true iff this entry's full
 token sequence is a strict prefix of `prompt_ids` (i.e. the new prompt

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -48,6 +48,30 @@ recurrent state in addition to the standard KV cache, rollback requires
 snapshot/restore rather than truncation, because the GDN state has no sequence
 axis.
 
+A round loop's rollback is not only about the store it can slice. A sliding-window
+layer's ring must give back the block tail it just wrote, and it can — see
+`docs/KV_CACHE.md` § "Rolling the SWA ring back" — but only in the state a block
+write leaves it in. It used to refuse silently, keeping the rejected drafts while
+every full-attention layer dropped theirs, which is one of the two defects the
+answer-equivalence gate found. `truncate_to` now returns that refusal, and the
+gemma4-assistant loop reads its rollback target before the verify forward rather
+than off a cache afterwards.
+
+**Whose hidden the acceptance walk scores.** `walk_deferred_greedy` reads the
+verifier's **pre-final-norm** capture, so it goes through
+`Architecture::logits_from_hidden`, which applies the final norm.
+`logits_from_final_hidden` is the head-only counterpart, for callers that hold an
+already-normed hidden: the Qwen capture forwards, the EAGLE-3 full-vocab
+correction, and the two drafters whose own final norm ends their stack. One name
+meant both contracts once, and the arch that did not norm quietly reweighted the
+vocabulary by the norm's weight vector for every caller handing it a raw capture.
+
+**Answer equivalence.** Neither of those defects changed an accept rate enough to
+notice, and neither was visible to the 48-token prefix checks the alignment
+suites run. `crates/rmlx-models/tests/spec_greedy_equivalence.rs` is the gate that
+found them, over 256 generated tokens; `docs/SPEC_ANSWER_EQUIVALENCE.md` is its
+reference.
+
 ```text
 # Initialisation
 prefill verifier + draft on prompt[..-1]
@@ -533,9 +557,8 @@ attends, or mlx-c rejects the broadcast (`mask (1,1,5,kv+1)` vs scores
 `min(window-1, producer_offset) + seq` (rotating), where `producer_offset` is
 the **cache-holding layer's own `KvCache::offset()`** — NOT the model-wide
 `cache_base_offset` (read from the first full-attention cache). Those two can
-desync by one position across a partial-accept verify-block rollback (the
-rotating sliding cache that drives `v_target` rolls back with no-op semantics
-once it wraps), so sizing the mask from `cache_base_offset` produced a mask one
+desync by one position across a partial-accept verify-block rollback, so sizing
+the mask from `cache_base_offset` produced a mask one
 key too long only at non-trivial prompt lengths (window no longer covers the
 whole KV). RoPE still uses the model-wide absolute `offset`; only the mask's
 key dim is bound to the producer's own K. A guard in the producer branch fails

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -74,9 +74,10 @@ against two deliberately broken ones:
 | assistant pair, SWA ring keeping its rejected block tail | 0.4219 to 0.9258 |
 | recurrent pair, acceptance walk without the final norm | 0.0000 to 0.5000 |
 
-`MAX_DIVERGENCE_CONFIDENCE` is 0.12 — the geometric midpoint of the worst
-correct cell and the lowest broken cell the set has to catch, 1.46× above the
-first. It clears every correct cell and refuses ten of the twelve broken ones.
+`MAX_DIVERGENCE_CONFIDENCE` is 0.12, inside the band the measurement leaves:
+above the worst correct cell (0.0820, 1.46×) and under the lowest broken cell
+above it (0.1538, 1.28×). It clears every correct cell and refuses ten of the
+twelve broken ones.
 The two it does not are covered by running **every** prompt rather than one:
 each broken engine is refused on at least four of its six, so a gate pinned to
 one prompt would be a coin toss and this one is not.

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -1,0 +1,149 @@
+# Answer equivalence for speculative decoding — state of the gate
+
+`crates/rmlx-models/tests/spec_greedy_equivalence.rs`. This branch carries the
+gate; it was split out of the metrics-recording branch after five review rounds,
+not because it failed but because every finding left in it is a **calibration**
+problem, and the numbers it is calibrated against are readings from an engine
+with a known correctness defect. It should land with the fix for that defect,
+where those numbers become measurable instead of assumed.
+
+## What the gate is for
+
+Greedy speculative decoding emits the verifier's own argmax at every position,
+so at temperature 0 a speculative run and a plain run of the same verifier are
+two ways of computing one answer. Nothing in a throughput number says whether
+that still holds. Before this gate, the only checks were four alignment suites
+comparing a **48-token** shared prefix, and one Gemma4-assistant test that
+asserted only that the accept rate was high.
+
+## What is proven
+
+- **It found a real, pre-existing correctness defect** that had been invisible
+  to the 48-token prefix checks for as long as they have existed. Driven from
+  `prompts/longctx_4k.json`, the Gemma4-assistant speculative arm does not
+  reproduce plain greedy. It reproduces identically with
+  `crates/rmlx-models/src/speculative/` checked out at `8ccc0593`, so it is not
+  this work's. Filed as **issue #506**, with the Qwen3.8-27B MTP sidecar's 0.520
+  reading as a second case.
+- **The defect has two manifestations and the prompt decides which appears.**
+  This matters for whoever fixes it and is the single most useful thing recorded
+  here:
+
+  | prompt | speculative arm | whole-stream LCS | cycle reading |
+  |---|---|---|---|
+  | structured ("summarise section by section") | period-8 repetition loop, `x86 is:66 is x86 is:66 is …` | 0.1100 | **1.0000** at period 8 from token 128 |
+  | prose ("summarise … in continuous prose") | a different, degraded summary that runs to the token budget while plain greedy stops at 218 | 0.2798 | **0.0926** — indistinguishable from healthy |
+
+  A fix validated only against the loop shape may leave the second untouched.
+- **Bit-identity is not the contract, and that is measured.** The verify pass
+  scores a whole block in one forward where plain decode steps one token at a
+  time — a different reduction order. On the most favourable pair there is (a
+  full-attention verifier whose rollback is an exact KV truncation) the two arms
+  share 91 leading tokens, differ by a word, and then continue the same answer.
+- **The subsequence oracle separates the two rollback regimes**, measured on
+  `gemma-4-e2b-it-mxfp8` + `gemma-4-E2B-it-assistant-bf16` at 256 tokens:
+
+  | rollback | whole-stream LCS | weakest tail window | first divergence |
+  |---|---|---|---|
+  | as shipped | 0.9180 | 0.6875 @192 | 91 |
+  | one rejected draft key left in the cache | 0.4062 | 0.2031 @192 | 8 |
+
+- **Greedy decoding compounds, so a longer horizon separates the regimes less,
+  not more**: the same shipped pair reads 0.9180 at 256 tokens, 0.8438 at 512
+  and 0.6846 at its natural stop near 800 — the last below any floor that still
+  refuses a broken rollback.
+- **The pair resolves by slug** from `RMLX_O_MODELS_ROOT`, so `make gpu-test`
+  runs it on a machine holding the snapshots. `-e2b-` and `-e4b-` assistants
+  declare the same architecture, so the harness's arch stand-down cannot
+  separate them; the drafter's `backbone_hidden_size` is checked against the
+  verifier's width before the drafter is loaded and a mismatched pair skips with
+  both widths named.
+- Under Metal shader validation the pair produces **zero** hits, so it needs no
+  entry in `scripts/gpu_validation_census.txt`.
+
+## What is open
+
+Ten findings from the fourth and fifth reviews. The first two are the ones that
+block it.
+
+1. **The "no gap" claim is false, and the fixture samples around the hole.**
+   `two_arms_in_the_same_ragged_loop_are_not_a_pass` uses the noise list
+   `[0, 12, 16, 25, 30, 40]` and steps over 34–38. At **36%** raggedness, two
+   arms sharing a real 128-token prefix and locked in the same period-8 loop are
+   returned as agreement, reproduced across seven seed pairs; the committed 40%
+   case is decided by an LCS margin of 0.0086 and passes with other seeds. Fix:
+   sweep the parameter (`(0..=60).step_by(2)` over several seed pairs) and
+   assert the property, or delete the "no gap" sentences and state the measured
+   hole (34–42%) as a declared blind spot.
+2. **`two_arms_collapsing_over_their_last_quarter_are_not_a_pass` did not fail
+   before the fix** it was committed to justify — it reads 0.8854 / 0.9271
+   pre-fix and was refused either way — and it uses period 16, not the period-40
+   tail-quarter shape the quarter-bound removal was argued from. (Pin 1 is
+   sound: it genuinely failed pre-fix at lcs 0.8770, cycles 0.8523 / 0.7981.)
+3. **Both pins assert only that something refused, not which rule.** Per the
+   readings, the control refuses only at noise 0–32; at 34 the tail-LCS window
+   does and at 35–40 the whole-stream LCS does. Deleting the cycle control
+   entirely leaves both pins green.
+4. **The prose calibration has an unenforced precondition.** The ceiling is only
+   meaningful for prose; nothing checks the arms came back as prose, and the
+   short prompt is enumerative. When a model answers with a list the gate does
+   not report an unclassifiable input — it accuses the **plain greedy** arm of a
+   repetition loop. The ceiling is also only safe for i.i.d.-word prose:
+   evenly-spaced parallel-structure prose with a stock frame reads 0.52–0.55
+   with no list markers at all.
+5. **The short-prompt length floor equals the token budget** (`MIN_ANSWER_TOKENS`
+   256 under `N_TOKENS` 256), so the gate passes only if neither arm ever emits a
+   stop id — and `N_TOKENS`'s own doc says the opposite.
+6. **The 200-token long-context floor is pinned by a tautology.** It sits 8.3%
+   under one measurement of one arm on one prompt and one model pair, and
+   `MEASURED_LONG_CONTEXT_PLAIN_ARM` has no producer that reads the engine, so
+   nothing notices if the real arm moves to 195.
+7. `// gpu-test-gate: exempt` on `the_false_positive_rate_on_healthy_output`
+   exempts nothing — the test never names `Device::Gpu`. Delete the marker.
+8. "1800 synthetic healthy streams across six lengths peaked at 0.1212" matches
+   no committed test: the assertion runs 5 × 64 = 320 and peaks at 0.1212, the
+   measurement runs 6 × 1000 = 6000 and peaks at 0.1351.
+9. The LCS range "0.70 to 0.93 across the 12–40% ragged range" was measured at
+   the retired 512-token horizon; at 256 the same construction reads 0.8594 at
+   12% and 0.6914 at 40%.
+10. A missing blank line between two items near the end of the pair pins.
+
+## Why these should be re-derived rather than defended
+
+Every constant in this file — `MIN_LCS_RATIO`, `MIN_TAIL_LCS_RATIO`,
+`MAX_CYCLE_FRACTION`, `MIN_ANSWER_TOKENS`, `MIN_LONG_CONTEXT_ANSWER_TOKENS`,
+`MEASURED_LONG_CONTEXT_PLAIN_ARM`, and the choice of `N_TOKENS` — is calibrated
+against readings taken from an engine that does not reproduce plain greedy on
+the long prompt. Several are guesses dressed as measurements for that reason:
+
+- The long-context floor is set under a plain-arm length of 218 measured *while
+  the speculative arm is broken*. After the fix both arms answer that prompt and
+  the pair's real length distribution is observable — the floor should come from
+  that, and `run_gate` should fail with "the measured plain arm moved from 218 to
+  N" rather than a generic early-stop message.
+- The horizon was chosen as the length where two regimes separate, one of which
+  is a deliberately mutated rollback rather than any real defect. Post-fix, the
+  benign divergence profile of a *correct* pair is measurable directly and the
+  horizon can be set from it.
+- The repetition control's ceiling is calibrated against prose from prompts
+  chosen partly because they keep the gate green. Once the long prompt passes,
+  the gate should move onto it — that was always the intent — and the control
+  re-calibrated against what that prompt actually produces.
+
+Two structural observations worth carrying forward, because they caused four
+rounds of fix-plants-defect:
+
+- **Fixtures must judge the pair, not an arm.** Every fixture written before the
+  fifth round tested one arm in isolation, or a pair built from independently
+  seeded heads. The gate's question is about two arms sharing a real prefix, and
+  the interaction between the two oracles — which is the whole safety argument —
+  went untested for that reason.
+- **Do not characterise a population from points you chose.** Both the "healthy
+  output ≤ 0.69" claim and the "no gap across the ragged range" claim were drawn
+  from a handful of self-authored samples and both were false. Sweep the
+  parameter; assert the property; let the sweep pick the points.
+
+`Rng::prose` is an i.i.d. word model with zero autocorrelation. Real prose is
+not, which is why finding 4 exists. A generator with realistic autocorrelation,
+or a corpus of real arms captured from runs, would make the false-positive
+argument mean something it does not currently mean.

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -15,8 +15,10 @@ against.
 
 ## What it runs
 
-Two pairs, both resolved by slug from `RMLX_O_MODELS_ROOT`, each over every
-prompt in the file:
+Two pairs, each over every prompt in the file. The assistant pair resolves both
+halves by slug from `RMLX_O_MODELS_ROOT` and so runs wherever the snapshots are;
+the recurrent pair's drafter is named by the operator and its verifier is the
+reason (below):
 
 | verifier | drafter | round loop | rollback |
 |---|---|---|---|
@@ -174,8 +176,14 @@ next defect.
   "healthy output ≤ 0.69" claim and the "no gap across the ragged range" claim
   were drawn from a handful of self-authored samples and both were false.
 
-One limitation is worth carrying forward: `Rng::prose` is an i.i.d. word model
-with zero autocorrelation, and real prose is not. The real arms are the
-population that matters and they are measured, but a generator with realistic
-autocorrelation, or a corpus of arms captured from runs, would make the
-synthetic false-positive argument mean more than it currently does.
+One limitation is worth carrying forward, and it is not only a weakness of the
+synthetic argument. `Rng::prose` is an i.i.d. word model with zero
+autocorrelation, and real prose is not — so synthetic prose reads **lower** on a
+self-similarity measure than the real thing. That generator is not merely
+illustrative: `prose_clears_the_control_at_every_length_the_gate_can_hand_it` is
+a hard gate on it, and `MAX_CYCLE_FRACTION`'s lower bound is derived from it. The
+1.48× headroom over 6000 synthetic streams therefore over-estimates the true
+headroom by an unmeasured factor. The real arms are measured too and read 0.0426
+to 0.1351, which is what the constant actually rests on; a generator with
+realistic autocorrelation, or a corpus of arms captured from runs, would close
+the gap.

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -26,12 +26,33 @@ prompt in the file:
 Six prompts, all asking for continuous prose. A tokenizer that declares `<think>`
 gets an empty reasoning block — its own template's `enable_thinking=false` — and
 turn markers are read off the tokenizer's added tokens rather than hard-coded, so
-a pair is never served outside its own template. Under Metal shader validation
-the pair produces **zero** hits, so it has no entry in
-`scripts/gpu_validation_census.txt` and needs none.
+a pair is never served outside its own template.
 
-Both gates carry `#[ignore]` and run under `make gpu-test`. Together they take
-about 4.5 minutes on an idle M5.
+**The two pairs are selected differently, and the reason is the census.** The
+assistant pair resolves both halves by slug, produces **zero** shader-validation
+hits (measured, narrowed run), and runs under `make gpu-test` on any machine
+holding the snapshots — about 3.5 minutes. The recurrent pair's verifier drives
+MLX's mxfp8 quantized matmul, whose `load_safe` bound is the same one
+`scripts/gpu_validation_census.txt` records for the affine instantiation: a
+narrowed run reports 1344 invalid **loads** (no stores) from
+`mxfp8_qmm_t_splitk_bfloat16_t_gs_32_b_8_alN_false`, a kernel this repo does not
+compile. The census pins one exact count per originating test, and a count taken
+from a 256-token generation moves with every prompt — pinning it would make the
+census brittle rather than informative. So that pair resolves its drafter from
+`RMLX_DRAFT_TEST_MODEL` only, `make gpu-test` reports it as skipped naming the
+variable, and running it is:
+
+```
+RMLX_KV_TEST_MODEL=<...>/mlx-community__Qwen3.8-27B-mxfp8 \
+RMLX_DRAFT_TEST_MODEL=<...>/mlx-community__Qwen3.8-27B-MTP-mxfp8 \
+cargo test -p rmlx-models --test spec_greedy_equivalence -- --ignored --nocapture \
+  the_recurrent_round_loop
+```
+
+That is a real gap: the case the second defect was found in is not in a gate that
+runs by default. Closing it needs either the census analysis extended to this
+kernel and model, or a stable count — neither of which this change is the place
+for.
 
 ## The oracle: where a correct pair diverges
 

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -90,7 +90,9 @@ The obvious oracle — how much of one answer the two arms share — cannot be
 thresholded, and this is measured rather than asserted.
 
 How much two *correct* arms share is decided by where their first near-tie lands
-and by nothing else. On the assistant pair the same engine, model and prompt
+and by nothing else. The figures here are `lcs_ratio` over the whole arm, not the
+tail readings `WORST_CORRECT_TAIL_AGREEMENT` is set from — the same runs read
+lower on that. On the assistant pair the same engine, model and prompt
 family read 0.9375 on the 4k document and 0.4766 on a prompt whose arms flip an
 **exact** tie (top-two margin 0.0000) at token 37 — after which both write
 well-formed, correct, different prose. The broken engines read 0.2188 to 0.4615

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -70,7 +70,9 @@ and by nothing else. On the assistant pair the same engine, model and prompt
 family read 0.9375 on the 4k document and 0.4766 on a prompt whose arms flip an
 **exact** tie (top-two margin 0.0000) at token 37 — after which both write
 well-formed, correct, different prose. The broken engines read 0.2188 to 0.4615
-on the same measure. The populations overlap, so no floor separates them.
+on the same measure — three per cent under the worst correct cell, and nothing
+bounds that correct minimum from below, because it is set by where an exact tie
+happens to land. No floor can be placed in a gap that narrow and that arbitrary.
 
 The figure is printed on every run, together with the weakest tail window, the
 first divergence, the margin there, and both arms' decoded text. It is evidence,

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -1,149 +1,157 @@
-# Answer equivalence for speculative decoding — state of the gate
+# Answer equivalence for speculative decoding
 
-`crates/rmlx-models/tests/spec_greedy_equivalence.rs`. This branch carries the
-gate; it was split out of the metrics-recording branch after five review rounds,
-not because it failed but because every finding left in it is a **calibration**
-problem, and the numbers it is calibrated against are readings from an engine
-with a known correctness defect. It should land with the fix for that defect,
-where those numbers become measurable instead of assumed.
+`crates/rmlx-models/tests/spec_greedy_equivalence.rs`. Greedy speculative
+decoding emits the verifier's own argmax at every position, so at temperature 0
+a speculative run and a plain run of the same verifier are two ways of computing
+one answer. Nothing in a throughput number says whether that still holds. Before
+this gate the only checks were four alignment suites comparing a **48-token**
+shared prefix, and one Gemma4-assistant test that asserted only that the accept
+rate was high.
 
-## What the gate is for
+The gate found two defects that had been invisible to those checks for as long
+as they have existed, and both are fixed. What follows is the oracle it settled
+on, why the obvious oracle does not work, and the numbers every constant is set
+against.
 
-Greedy speculative decoding emits the verifier's own argmax at every position,
-so at temperature 0 a speculative run and a plain run of the same verifier are
-two ways of computing one answer. Nothing in a throughput number says whether
-that still holds. Before this gate, the only checks were four alignment suites
-comparing a **48-token** shared prefix, and one Gemma4-assistant test that
-asserted only that the accept rate was high.
+## What it runs
 
-## What is proven
+Two pairs, both resolved by slug from `RMLX_O_MODELS_ROOT`, each over every
+prompt in the file:
 
-- **It found a real, pre-existing correctness defect** that had been invisible
-  to the 48-token prefix checks for as long as they have existed. Driven from
-  `prompts/longctx_4k.json`, the Gemma4-assistant speculative arm does not
-  reproduce plain greedy. It reproduces identically with
-  `crates/rmlx-models/src/speculative/` checked out at `8ccc0593`, so it is not
-  this work's. Filed as **issue #506**, with the Qwen3.8-27B MTP sidecar's 0.520
-  reading as a second case.
-- **The defect has two manifestations and the prompt decides which appears.**
-  This matters for whoever fixes it and is the single most useful thing recorded
-  here:
+| verifier | drafter | round loop | rollback |
+|---|---|---|---|
+| `gemma-4-e2b-it-mxfp8` | `gemma-4-E2B-it-assistant-bf16` | shared-K/V assistant | KV truncation, SWA ring included |
+| `Qwen3.8-27B-mxfp8` | `Qwen3.8-27B-MTP-mxfp8` | MTP sidecar | KV truncation + recurrent snapshot/replay |
 
-  | prompt | speculative arm | whole-stream LCS | cycle reading |
-  |---|---|---|---|
-  | structured ("summarise section by section") | period-8 repetition loop, `x86 is:66 is x86 is:66 is …` | 0.1100 | **1.0000** at period 8 from token 128 |
-  | prose ("summarise … in continuous prose") | a different, degraded summary that runs to the token budget while plain greedy stops at 218 | 0.2798 | **0.0926** — indistinguishable from healthy |
+Six prompts, all asking for continuous prose. A tokenizer that declares `<think>`
+gets an empty reasoning block — its own template's `enable_thinking=false` — and
+turn markers are read off the tokenizer's added tokens rather than hard-coded, so
+a pair is never served outside its own template. Under Metal shader validation
+the pair produces **zero** hits, so it has no entry in
+`scripts/gpu_validation_census.txt` and needs none.
 
-  A fix validated only against the loop shape may leave the second untouched.
-- **Bit-identity is not the contract, and that is measured.** The verify pass
-  scores a whole block in one forward where plain decode steps one token at a
-  time — a different reduction order. On the most favourable pair there is (a
-  full-attention verifier whose rollback is an exact KV truncation) the two arms
-  share 91 leading tokens, differ by a word, and then continue the same answer.
-- **The subsequence oracle separates the two rollback regimes**, measured on
-  `gemma-4-e2b-it-mxfp8` + `gemma-4-E2B-it-assistant-bf16` at 256 tokens:
+Both gates carry `#[ignore]` and run under `make gpu-test`. Together they take
+about 4.5 minutes on an idle M5.
 
-  | rollback | whole-stream LCS | weakest tail window | first divergence |
-  |---|---|---|---|
-  | as shipped | 0.9180 | 0.6875 @192 | 91 |
-  | one rejected draft key left in the cache | 0.4062 | 0.2031 @192 | 8 |
+## The oracle: where a correct pair diverges
 
-- **Greedy decoding compounds, so a longer horizon separates the regimes less,
-  not more**: the same shipped pair reads 0.9180 at 256 tokens, 0.8438 at 512
-  and 0.6846 at its natural stop near 800 — the last below any floor that still
-  refuses a broken rollback.
-- **The pair resolves by slug** from `RMLX_O_MODELS_ROOT`, so `make gpu-test`
-  runs it on a machine holding the snapshots. `-e2b-` and `-e4b-` assistants
-  declare the same architecture, so the harness's arch stand-down cannot
-  separate them; the drafter's `backbone_hidden_size` is checked against the
-  verifier's width before the drafter is loaded and a mismatched pair skips with
-  both widths named.
-- Under Metal shader validation the pair produces **zero** hits, so it needs no
-  entry in `scripts/gpu_validation_census.txt`.
+A reduction-order difference is a relative perturbation of order `1e-3` on a
+logit. It can flip a decision the verifier was already nearly indifferent about
+and it can flip nothing else. So the gate reads the verifier's own top-two
+logprob margin at the position the two arms **first** differ, and returns where
+that sits in the same arm's own margin distribution. Both arms saw the same
+context up to that position, so this judges the pair rather than an arm, and it
+needs no per-prompt calibration: it is a rank, not a number of nats.
 
-## What is open
+Measured over two pairs and six prompts each, against the shipped engine and
+against two deliberately broken ones:
 
-Ten findings from the fourth and fifth reviews. The first two are the ones that
-block it.
+| engine | percentile of the reference arm's own margins |
+|---|---|
+| assistant pair, as shipped | 0.0000 to 0.0820 |
+| recurrent pair, as shipped | 0.0000 to 0.0234 |
+| assistant pair, SWA ring keeping its rejected block tail | 0.4219 to 0.9258 |
+| recurrent pair, acceptance walk without the final norm | 0.0000 to 0.5000 |
 
-1. **The "no gap" claim is false, and the fixture samples around the hole.**
-   `two_arms_in_the_same_ragged_loop_are_not_a_pass` uses the noise list
-   `[0, 12, 16, 25, 30, 40]` and steps over 34–38. At **36%** raggedness, two
-   arms sharing a real 128-token prefix and locked in the same period-8 loop are
-   returned as agreement, reproduced across seven seed pairs; the committed 40%
-   case is decided by an LCS margin of 0.0086 and passes with other seeds. Fix:
-   sweep the parameter (`(0..=60).step_by(2)` over several seed pairs) and
-   assert the property, or delete the "no gap" sentences and state the measured
-   hole (34–42%) as a declared blind spot.
-2. **`two_arms_collapsing_over_their_last_quarter_are_not_a_pass` did not fail
-   before the fix** it was committed to justify — it reads 0.8854 / 0.9271
-   pre-fix and was refused either way — and it uses period 16, not the period-40
-   tail-quarter shape the quarter-bound removal was argued from. (Pin 1 is
-   sound: it genuinely failed pre-fix at lcs 0.8770, cycles 0.8523 / 0.7981.)
-3. **Both pins assert only that something refused, not which rule.** Per the
-   readings, the control refuses only at noise 0–32; at 34 the tail-LCS window
-   does and at 35–40 the whole-stream LCS does. Deleting the cycle control
-   entirely leaves both pins green.
-4. **The prose calibration has an unenforced precondition.** The ceiling is only
-   meaningful for prose; nothing checks the arms came back as prose, and the
-   short prompt is enumerative. When a model answers with a list the gate does
-   not report an unclassifiable input — it accuses the **plain greedy** arm of a
-   repetition loop. The ceiling is also only safe for i.i.d.-word prose:
-   evenly-spaced parallel-structure prose with a stock frame reads 0.52–0.55
-   with no list markers at all.
-5. **The short-prompt length floor equals the token budget** (`MIN_ANSWER_TOKENS`
-   256 under `N_TOKENS` 256), so the gate passes only if neither arm ever emits a
-   stop id — and `N_TOKENS`'s own doc says the opposite.
-6. **The 200-token long-context floor is pinned by a tautology.** It sits 8.3%
-   under one measurement of one arm on one prompt and one model pair, and
-   `MEASURED_LONG_CONTEXT_PLAIN_ARM` has no producer that reads the engine, so
-   nothing notices if the real arm moves to 195.
-7. `// gpu-test-gate: exempt` on `the_false_positive_rate_on_healthy_output`
-   exempts nothing — the test never names `Device::Gpu`. Delete the marker.
-8. "1800 synthetic healthy streams across six lengths peaked at 0.1212" matches
-   no committed test: the assertion runs 5 × 64 = 320 and peaks at 0.1212, the
-   measurement runs 6 × 1000 = 6000 and peaks at 0.1351.
-9. The LCS range "0.70 to 0.93 across the 12–40% ragged range" was measured at
-   the retired 512-token horizon; at 256 the same construction reads 0.8594 at
-   12% and 0.6914 at 40%.
-10. A missing blank line between two items near the end of the pair pins.
+`MAX_DIVERGENCE_CONFIDENCE` is 0.12 — the geometric midpoint of the worst
+correct cell and the lowest broken cell the set has to catch, 1.46× above the
+first. It clears every correct cell and refuses ten of the twelve broken ones.
+The two it does not are covered by running **every** prompt rather than one:
+each broken engine is refused on at least four of its six, so a gate pinned to
+one prompt would be a coin toss and this one is not.
 
-## Why these should be re-derived rather than defended
+## Why there is no subsequence floor
 
-Every constant in this file — `MIN_LCS_RATIO`, `MIN_TAIL_LCS_RATIO`,
-`MAX_CYCLE_FRACTION`, `MIN_ANSWER_TOKENS`, `MIN_LONG_CONTEXT_ANSWER_TOKENS`,
-`MEASURED_LONG_CONTEXT_PLAIN_ARM`, and the choice of `N_TOKENS` — is calibrated
-against readings taken from an engine that does not reproduce plain greedy on
-the long prompt. Several are guesses dressed as measurements for that reason:
+The obvious oracle — how much of one answer the two arms share — cannot be
+thresholded, and this is measured rather than asserted.
 
-- The long-context floor is set under a plain-arm length of 218 measured *while
-  the speculative arm is broken*. After the fix both arms answer that prompt and
-  the pair's real length distribution is observable — the floor should come from
-  that, and `run_gate` should fail with "the measured plain arm moved from 218 to
-  N" rather than a generic early-stop message.
-- The horizon was chosen as the length where two regimes separate, one of which
-  is a deliberately mutated rollback rather than any real defect. Post-fix, the
-  benign divergence profile of a *correct* pair is measurable directly and the
-  horizon can be set from it.
-- The repetition control's ceiling is calibrated against prose from prompts
-  chosen partly because they keep the gate green. Once the long prompt passes,
-  the gate should move onto it — that was always the intent — and the control
-  re-calibrated against what that prompt actually produces.
+How much two *correct* arms share is decided by where their first near-tie lands
+and by nothing else. On the assistant pair the same engine, model and prompt
+family read 0.9375 on the 4k document and 0.4766 on a prompt whose arms flip an
+**exact** tie (top-two margin 0.0000) at token 37 — after which both write
+well-formed, correct, different prose. The broken engines read 0.2188 to 0.4615
+on the same measure. The populations overlap, so no floor separates them.
 
-Two structural observations worth carrying forward, because they caused four
-rounds of fix-plants-defect:
+The figure is printed on every run, together with the weakest tail window, the
+first divergence, the margin there, and both arms' decoded text. It is evidence,
+not a gate.
 
-- **Fixtures must judge the pair, not an arm.** Every fixture written before the
-  fifth round tested one arm in isolation, or a pair built from independently
-  seeded heads. The gate's question is about two arms sharing a real prefix, and
-  the interaction between the two oracles — which is the whole safety argument —
-  went untested for that reason.
-- **Do not characterise a population from points you chose.** Both the "healthy
-  output ≤ 0.69" claim and the "no gap across the ragged range" claim were drawn
-  from a handful of self-authored samples and both were false. Sweep the
-  parameter; assert the property; let the sweep pick the points.
+## The second oracle: the repetition control
 
-`Rng::prose` is an i.i.d. word model with zero autocorrelation. Real prose is
-not, which is why finding 4 exists. A generator with realistic autocorrelation,
-or a corpus of real arms captured from runs, would make the false-positive
-argument mean something it does not currently mean.
+The first has nothing to read when *both* arms are degenerate: two arms in the
+same loop have no healthy reference arm whose margins mean anything. So every
+run also checks that neither arm repeats at a short period across more than
+`MAX_CYCLE_FRACTION` of its tokens, over the whole stream and over each tail cut,
+at every period up to `MAX_CYCLE_PERIOD` that leaves `MIN_CYCLE_SAMPLES`
+comparisons.
+
+`MAX_CYCLE_FRACTION` is 0.20. Healthy prose from these prompts reads 0.0426 to
+0.1351 on the real arms, and 1000 synthetic streams at each of six lengths peak
+at 0.1351 and trip the ceiling none — 1.48× of headroom. The other side is swept
+rather than sampled: two arms in the same period-8 loop are walked from 0% to
+100% raggedness over four seed pairs, and every pair the control lets through
+agrees no better than the worst a correct pair reached. An earlier 0.50, placed
+from six sampled points, left 34% to 52% passing.
+
+The control's declared blind spot is its own sample floor: the narrowest window
+is `len / TAIL_WINDOWS`, so at this budget it can evidence no period above 32,
+and past that the reading comes from a wider window the collapse only partly
+fills. A last-quarter loop reads 0.8750 at period 32, 0.2500 at 40 and 0.1875 at
+48; the ceiling is crossed between 40 and 48, and the test pins it from both
+sides.
+
+Which arm collapsed decides what the gate is entitled to say. A degenerate
+speculative arm against a healthy reference is a verdict about the round loop. A
+degenerate *reference* arm is a verdict about the input — plain greedy is the
+control — and is reported as unjudgeable rather than failed. So is a prompt
+neither arm answered: the recurrent pair answers the 4k summary in 13 and 26
+tokens, which says nothing about the round loop. One arm short while the other
+ran on is refused.
+
+## The two defects
+
+**The sliding-window ring kept its rejected block tail.** A speculative round
+writes its whole verify block into every layer and then rolls the rejected tail
+off. The full-attention layers dropped it; the SWA ring's rollback was a
+documented no-op past its wrap, so it kept the rejected drafts and an offset the
+rest of the stack had left behind — and because the round loop read its rollback
+target off layer 0, which is sliding, the full-attention layers then rolled back
+to the wrong place too. A 4k prompt wraps the ring; a short one does not, which
+is why nothing showed for as long as it did. See `docs/KV_CACHE.md` for the
+lossless-rollback rule the ring now implements.
+
+**The acceptance walk scored an un-normed hidden.**
+`Architecture::logits_from_hidden` is documented as taking a pre-final-norm
+hidden. Gemma4 applied the norm; Qwen3.5-MoE applied only the LM head. The MTP
+round loop's acceptance walk hands it a raw capture, so on that verifier every
+verify position was scored with the final RMSNorm's weight vector missing — a
+silent reweighting of the vocabulary that agreed with the right answer most of
+the time and not always. `logits_from_final_hidden` is now the head-only entry
+point, and the callers that hold an already-normed hidden name it.
+
+The issue's hypothesis for the second case — rejected drafts leaving recurrent
+state behind — is **falsified**. `rollback_round_caches` already snapshots the
+recurrent state before the verify forward and replays the accepted prefix, and it
+was never the cause. With the norm applied, three of six prompts come back
+bit-identical to plain greedy.
+
+## Structural rules this file was rebuilt under
+
+Both were learned the hard way, over four rounds of review that each planted the
+next defect.
+
+- **A fixture must judge the pair, not an arm.** The gate's question is about two
+  arms sharing a real prefix and the interaction between its oracles. Every
+  fixture written before those rounds tested one arm in isolation, or a pair
+  built from independently seeded heads, and a false claim about the interaction
+  went unnoticed for two rounds.
+- **Do not characterise a population from points you chose.** Sweep the
+  parameter, assert the property, and let the sweep pick the points. Both the
+  "healthy output ≤ 0.69" claim and the "no gap across the ragged range" claim
+  were drawn from a handful of self-authored samples and both were false.
+
+One limitation is worth carrying forward: `Rng::prose` is an i.i.d. word model
+with zero autocorrelation, and real prose is not. The real arms are the
+population that matters and they are measured, but a generator with realistic
+autocorrelation, or a corpus of arms captured from runs, would make the
+synthetic false-positive argument mean more than it currently does.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -53,8 +53,8 @@ variables above:
 | Variable | Used by | Purpose |
 |----------|---------|---------|
 | `RMLX_TEST_MODEL` | `rmlx-server/tests/ssd_cache_restart.rs` | Generic single-model override for the SSD-restart smoke test. |
-| `RMLX_KV_TEST_MODEL` | `gemma4_kv_cache_equivalence.rs`, `dflash_drafter_alignment.rs`, `gemma4_mtp_drafter_alignment.rs`, `qwen3_5_mtp_drafter_alignment.rs`, `qwen3_5_eagle3_alignment.rs`, `qwen3_5_two_model_alignment.rs`, `projects_toml_e2e.rs`, `cli_flags_e2e.rs`, and as the single-model override for the golden-token suites | Model snapshot for KV-cache equivalence and drafter-alignment tests. Typically set to a Gemma4-e4b path; the Qwen3.5-family alignment tests take a **verifier** here instead (see below). |
-| `RMLX_DRAFT_TEST_MODEL` | `dflash_drafter_alignment.rs`, `gemma4_mtp_drafter_alignment.rs`, `qwen3_5_mtp_drafter_alignment.rs`, `qwen3_5_eagle3_alignment.rs`, `qwen3_5_two_model_alignment.rs` | Draft model snapshot path. Used alongside `RMLX_KV_TEST_MODEL` for speculative-decode alignment tests. |
+| `RMLX_KV_TEST_MODEL` | `gemma4_kv_cache_equivalence.rs`, `dflash_drafter_alignment.rs`, `gemma4_mtp_drafter_alignment.rs`, `qwen3_5_mtp_drafter_alignment.rs`, `qwen3_5_eagle3_alignment.rs`, `qwen3_5_two_model_alignment.rs`, `spec_greedy_equivalence.rs`, `projects_toml_e2e.rs`, `cli_flags_e2e.rs`, and as the single-model override for the golden-token suites | Model snapshot for KV-cache equivalence and drafter-alignment tests. Typically set to a Gemma4-e4b path; the Qwen3.5-family alignment tests take a **verifier** here instead (see below). |
+| `RMLX_DRAFT_TEST_MODEL` | `dflash_drafter_alignment.rs`, `gemma4_mtp_drafter_alignment.rs`, `qwen3_5_mtp_drafter_alignment.rs`, `qwen3_5_eagle3_alignment.rs`, `qwen3_5_two_model_alignment.rs`, `spec_greedy_equivalence.rs` | Draft model snapshot path. Used alongside `RMLX_KV_TEST_MODEL` for speculative-decode alignment tests. |
 | `RMLX_VL_TEST_MODEL` | `qwen3_vl_moe_text_parity.rs` | Vision-language model snapshot for VL text-parity tests. |
 | `RMLX_PROMPT_CACHE_TEST_MODEL_A` / `_B` | `rmlx-models/tests/prompt_cache_cross_model.rs` | **Two** snapshots of the same architecture with the same KV shape but different weights — the prompt cache is one static per arch, and this pair is what shows whether its key separates two resident models. `mlx-community__gemma-4-e2b-it-mxfp8` + `mlx-community__gemma-4-E2B-it-qat-4bit` fit (both `Gemma4ForConditionalGeneration`, 35 layers x 1 KV head x head_dim 256). Same-shape matters: a shape mismatch would fail for the wrong reason. Different weights matter: identical outputs make the comparison vacuous, and the test refuses rather than passing. |
 
@@ -71,6 +71,35 @@ passes while never running. The pairs their thresholds are calibrated against:
 
 Point either at a different pair and re-measure both arms before reading a
 failure as a regression.
+
+`spec_greedy_equivalence.rs` asks a different question from those three: not
+whether the round loop keeps the verifier's state consistent for a while, but
+whether the run produces the answer the verifier produces alone, over 256 tokens
+and every prompt the file carries. Its oracle is where the two arms first differ
+and how sure the verifier was there — a rank in the reference arm's own margin
+distribution, so one ceiling covers two models whose logits are not on the same
+scale. It is documented in full in `docs/SPEC_ANSWER_EQUIVALENCE.md`, including
+why the obvious oracle (how much of one answer the arms share) cannot be
+thresholded at all.
+
+Unlike the three above it **resolves both halves of each pair by slug** from
+`RMLX_O_MODELS_ROOT`, so `make gpu-test` runs it on a machine holding the
+snapshots and `run_gpu_tests.sh` reports a machine without them as INCOMPLETE.
+The verifier goes through the golden harness's own resolver
+(`common::model_for`); `RMLX_DRAFT_TEST_MODEL` overrides the drafter. Both
+`-e2b-` and `-e4b-` assistant snapshots declare the same architecture, so the
+harness's arch stand-down cannot separate them: the drafter's
+`backbone_hidden_size` is checked against the verifier's width before the drafter
+is loaded, and a mismatched pair skips with that reason rather than panicking in
+the loader.
+
+| Pair | verifier | drafter |
+|---|---|---|
+| assistant | `mlx-community__gemma-4-e2b-it-mxfp8` | `mlx-community__gemma-4-E2B-it-assistant-bf16` |
+| recurrent | `mlx-community__Qwen3.8-27B-mxfp8` | `mlx-community__Qwen3.8-27B-MTP-mxfp8` |
+
+Under Metal shader validation it produces **zero** hits, so it has no entry in
+`scripts/gpu_validation_census.txt` and needs none.
 
 `dflash_drafter_alignment.rs` is **not** one of those three and does not gate the
 same property. It asserts that the drafter's round-0 first-block proposal aligns

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -93,13 +93,19 @@ harness's arch stand-down cannot separate them: the drafter's
 is loaded, and a mismatched pair skips with that reason rather than panicking in
 the loader.
 
-| Pair | verifier | drafter |
-|---|---|---|
-| assistant | `mlx-community__gemma-4-e2b-it-mxfp8` | `mlx-community__gemma-4-E2B-it-assistant-bf16` |
-| recurrent | `mlx-community__Qwen3.8-27B-mxfp8` | `mlx-community__Qwen3.8-27B-MTP-mxfp8` |
+| Pair | verifier | drafter | selected by |
+|---|---|---|---|
+| assistant | `mlx-community__gemma-4-e2b-it-mxfp8` | `mlx-community__gemma-4-E2B-it-assistant-bf16` | slug |
+| recurrent | `mlx-community__Qwen3.8-27B-mxfp8` | `mlx-community__Qwen3.8-27B-MTP-mxfp8` | `RMLX_DRAFT_TEST_MODEL` only |
 
-Under Metal shader validation it produces **zero** hits, so it has no entry in
-`scripts/gpu_validation_census.txt` and needs none.
+The assistant pair produces **zero** Metal shader-validation hits and so has no
+entry in `scripts/gpu_validation_census.txt` and needs none. The recurrent pair's
+verifier drives MLX's mxfp8 quantized matmul and a narrowed run reports 1344
+invalid loads from it — the same `load_safe` bound the census already records for
+the affine instantiation, in a kernel this repo does not compile. The census pins
+one exact count per test and a count from a 256-token generation is not stable
+across a prompt change, so that pair is named rather than slug-resolved and
+`make gpu-test` reports it as skipped. See `docs/SPEC_ANSWER_EQUIVALENCE.md`.
 
 `dflash_drafter_alignment.rs` is **not** one of those three and does not gate the
 same property. It asserts that the drafter's round-0 first-block proposal aligns

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -82,9 +82,13 @@ scale. It is documented in full in `docs/SPEC_ANSWER_EQUIVALENCE.md`, including
 why the obvious oracle (how much of one answer the arms share) cannot be
 thresholded at all.
 
-Unlike the three above it **resolves both halves of each pair by slug** from
-`RMLX_O_MODELS_ROOT`, so `make gpu-test` runs it on a machine holding the
+Unlike the three above, its **assistant pair resolves both halves by slug** from
+`RMLX_O_MODELS_ROOT`, so `make gpu-test` runs that pair on a machine holding the
 snapshots and `run_gpu_tests.sh` reports a machine without them as INCOMPLETE.
+The recurrent pair is the exception and is not gated: its drafter comes from
+`RMLX_DRAFT_TEST_MODEL` or the pair does not run, because its verifier's
+quantized matmul trips the shader-validation census (see the table below and
+`docs/SPEC_ANSWER_EQUIVALENCE.md`).
 The verifier goes through the golden harness's own resolver
 (`common::model_for`); `RMLX_DRAFT_TEST_MODEL` overrides the drafter. Both
 `-e2b-` and `-e4b-` assistant snapshots declare the same architecture, so the


### PR DESCRIPTION
Closes #506.

Two speculative round loops produced different output from plain greedy at temperature 0, and one degenerated. Both defects are pre-existing and reproduce at `8ccc0593`. Neither was where the issue supposed.

## What they turned out to be

**The sliding-window ring kept its rejected block tail.** A speculative round writes the whole verify block into every layer and then rolls the rejected tail off. The full-attention layers dropped it correctly; the ring's rollback was a no-op past its wrap point; and the loop read its rollback target off layer 0 — a sliding layer — so the full-attention layers then rolled back to the wrong place as well.

Only a prompt long enough to wrap the window shows it, which is why five of six prompts read byte-identically across the fix. The rollback target is now the maximum offset over the stack, taken before the forward, so no layer's geometry decides another's.

**The acceptance walk scored an un-normalised hidden state.** `Qwen3_5Moe::logits_from_hidden` applied only the LM head where the Gemma4 path also applied the final norm, and the MTP walk hands it a raw capture — so every verify position was scored with the final RMSNorm's weight vector missing.

Rather than fix the one architecture, `Architecture::apply_final_norm` is now the only place the norm is applied and `logits_from_hidden` composes it with the head. Both per-architecture bodies are deleted, so there is no second implementation left to drift. Two `unreachable!` blocks went with them: the compile-time tripwire moved to `arch_class` and `layer_sliding_window`, which are exhaustive, so a new architecture still cannot be added silently.

**The issue's own hypothesis is falsified.** It proposed recurrent state leakage. With the norm applied, three of six prompts return bit-identical to plain greedy, and a state leak cannot produce bit-identical arms.

A third defect turned up alongside: the prompt cache's block-truncate gate asked about layers the truncation does not touch.

## The gate that found them

`crates/rmlx-models/tests/spec_greedy_equivalence.rs` compares a speculative arm against plain greedy over six prompts, on two pairs. Its constants were previously calibrated against readings taken while these defects were present; every one has been re-derived against the fixed engine, and the ones that moved, moved because the measurement moved.

The repetition ceiling was **tightened** from 0.50 to 0.20, not relaxed around the result. One pin carried a figure no engine on this harness produces, and the same pin was unfailable in one direction — integer division put the "correct" reconstruction below the ceiling under test, so a band of values passed a test whose entire job is to refuse one. Both are fixed, and two further constants that were bounded on one side only are now pinned on both.

Three blind spots are declared in `docs/SPEC_ANSWER_EQUIVALENCE.md` rather than hidden: the recurrent pair runs under no default gate because its verifier drives an MLX kernel this repository does not compile and produces shader-validation counts the census cannot pin; the repetition control cannot evidence a period above 32 at a 256-token budget; and the synthetic prose generator has zero autocorrelation, which makes it read lower than real prose on a self-similarity measure and so over-states the headroom it is used to justify.

## Rollback safety

`truncate_kv_to` now asks every layer whether it can reach the target before moving any, so a stack cannot end up half rolled back. The recurrent branch asks for a rollback a wrapped sliding-window ring refuses by construction; no wired architecture pairs recurrent state with a windowed KV layer today, and the first one that does now gets a named error saying so rather than a ring diagnostic.

The Gemma4 assistant round loop conditions its drafter on the verifier's own final-normed hidden and reads its K/V directly, so it refuses a verifier it cannot condition on at loop entry rather than failing later on a shape mismatch.

## Cost

The added pre-pass is integer comparisons over the layer stack plus, for rotating layers, one shape read. No Metal dispatch, no evaluation, no allocation — free by construction rather than merely unmeasured.

For completeness it was also measured: the canary reads 1.8 to 2.3 per cent under the recorded anchors, so a paired A/B was run against `main` with digest-distinct, symbol-verified binaries. Ratio 1.0128, ranges overlapping, verdict inconclusive, with identical generated token ids and identical KV bytes and Metal allocation on both arms. The canary delta is drift between the anchors' conditions and this host, not this branch. Neither measurement exercises the changed path, and neither is offered as if it did: `KvCache::truncate_to`'s callers are the prompt cache and the speculative round loops, never the per-token decode step.

## Verification

Two review rounds, nineteen findings, all closed. `make ci` green. `make ci-perf` green — 360 GPU tests, shader validation matching the pinned census.

One `ci-perf` attempt failed first in `rmlx-kv-ssd` on a race precondition. That was measured rather than assumed: it reproduces on `main`, at roughly one run in forty, and `rmlx-kv-ssd` does not depend on `rmlx-models`, so this branch cannot reach it. It is filed separately.

Canary rows are in `metrics/runs.db` under the `release-perf` profile; the A/B result is in the local bench directory and deliberately wrote no rows.
