### PR TITLE
chore(deps): move off a yanked der patch release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "pem-rfc7468",
  "zeroize",


### PR DESCRIPTION
`make ci` fails at its audit step on every branch, including `main`.

`cargo audit` runs with `--deny warnings`, and `der 0.8.0` was yanked upstream, so the scan reports one denied warning and the gate stops there. Nothing else in `make ci` is affected — fmt, clippy, the test suites and all four `cargo deny` checks pass; the failure is the last step only.

`ureq` is the sole dependant. `der 0.8.1` is the same minor release and needs no code change; this is a lockfile bump and nothing else.

With it, `cargo audit` and `cargo deny --all-features check` both exit 0.

Worth noting for whoever meets this next: a yank is not a RUSTSEC advisory, so the `--ignore RUSTSEC-…` entries already in the audit invocation cannot suppress it. Moving off the yanked version is the only way past it.
