### PR TITLE
eval(ppl): a scorer for the hybrid family, and the first 4-bit speculative numbers

### DIFF
--- a/crates/rmlx-cli/src/commands/eval.rs
+++ b/crates/rmlx-cli/src/commands/eval.rs
@@ -111,7 +111,7 @@ pub(crate) fn run_ppl(
         |e| match e {
             ppl::PplError::ArchUnsupported { arch } => anyhow::anyhow!(
                 "ppl: arch '{arch}' is not yet supported by the perplexity scorer \
-                 (Qwen3 only; see crates/rmlx-models/src/ppl.rs)"
+                 (Qwen3, Gemma4, Qwen3.5; see crates/rmlx-models/src/ppl.rs)"
             ),
             other => anyhow::anyhow!("ppl: {other}"),
         },

--- a/crates/rmlx-cli/src/main.rs
+++ b/crates/rmlx-cli/src/main.rs
@@ -1551,7 +1551,7 @@ enum EvalCmd {
     /// Compute perplexity over a text corpus using sliding-window NLL.
     ///
     /// Loads `--model`, tokenizes `--text-file`, and runs the native PPL
-    /// scorer (Qwen3 family only — Bonsai is the smoke target).
+    /// scorer (Qwen3, Gemma4 and Qwen3.5 — Bonsai is the smoke target).
     /// Prints one JSON line to stdout: `{"ppl":..,"mean_nll":..,"scored_tokens":..,"windows":..}`.
     /// When `--corpus wikitext-2` (or any non-empty value) is supplied, also
     /// ingests one §8.5 universal `RunRecord` into `<RMLX_HOME>/metrics/runs.db`

--- a/crates/rmlx-models/src/ppl.rs
+++ b/crates/rmlx-models/src/ppl.rs
@@ -70,7 +70,9 @@ pub enum PplError {
     /// reports and a checkpoint's `config.json` carries, so an operator can
     /// grep the message for what their snapshot declares.
     #[error(
-        "ppl: architecture '{arch}' is not supported (supported:          Qwen3ForCausalLM, Gemma4ForConditionalGeneration,          Qwen3_5ForConditionalGeneration, Qwen3_5MoeForConditionalGeneration)"
+        "ppl: architecture '{arch}' is not supported (supported: \
+Qwen3ForCausalLM, Gemma4ForConditionalGeneration, \
+Qwen3_5ForConditionalGeneration, Qwen3_5MoeForConditionalGeneration)"
     )]
     ArchUnsupported {
         /// The architecture name that is not yet supported.
@@ -83,7 +85,10 @@ pub enum PplError {
     /// reading the module docs at that moment and "no cached scorer" alone
     /// reads as "not implemented yet".
     #[error(
-        "ppl: architecture '{arch}' has no cached scorer: its GatedDeltaNet          layers hold a recurrent state no KV codec touches, so a number scored          through a codec there would describe only the full-attention layers.          Drop the KV-codec flags to score it cacheless"
+        "ppl: architecture '{arch}' has no cached scorer: its GatedDeltaNet \
+layers hold a recurrent state no KV codec touches, so a number scored through a \
+codec there would describe only the full-attention layers. Drop the KV-codec \
+flags to score it cacheless"
     )]
     CachedScorerUnsupported {
         /// The architecture name whose scorer keeps no cache.
@@ -296,7 +301,7 @@ fn accumulate_position_nll(
 #[allow(clippy::too_many_arguments)]
 #[allow(
     clippy::indexing_slicing,
-    reason = "every index below is behind the `warmup + 1 < win.len()` guard at the top or the loop's own `t < last_scored` bound"
+    reason = "every index below is behind the `warmup + 1 < win.len()` guard at the top or the loop's own `t < last_scored` bound; `host[..vocab]` is bounded by read_logits_3d_into having just filled it to `1 * vocab`"
 )]
 fn score_window_through_cache(
     win: &[u32],
@@ -329,9 +334,14 @@ fn score_window_through_cache(
         arch,
         &mut forward,
     )?;
+    // `&host[..vocab]`, not `host`: the buffer is the caller's and outlives this
+    // window, so its length is whatever the widest window so far needed.
+    // `neg_log_softmax_at` sums `exp()` over every element it is handed, so
+    // passing the whole buffer would make the softmax denominator depend on a
+    // previous window's shape. The cacheless scorer slices for the same reason.
     read_logits_3d_into(&prefill_logits, 1, vocab, host)?;
     accumulate_position_nll(
-        host,
+        &host[..vocab],
         win[warmup + 1] as usize,
         vocab,
         warmup,
@@ -342,7 +352,14 @@ fn score_window_through_cache(
     for t in (warmup + 1)..last_scored {
         let logits = forward(&win[t..=t], caches)?;
         read_logits_3d_into(&logits, 1, vocab, host)?;
-        accumulate_position_nll(host, win[t + 1] as usize, vocab, t, sum_nll, count);
+        accumulate_position_nll(
+            &host[..vocab],
+            win[t + 1] as usize,
+            vocab,
+            t,
+            sum_nll,
+            count,
+        );
     }
     Ok(())
 }
@@ -909,7 +926,7 @@ pub(crate) fn neg_log_softmax_at(row: &[f32], idx: usize) -> f32 {
 )]
 #[allow(
     clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+    reason = "both unwraps are `try_into` on a statically sized chunk — `chunks_exact(4)` yields exactly 4 bytes and the bf16 slice is indexed as `o..o + 2`; neither can be the wrong width"
 )]
 #[allow(
     clippy::wildcard_enum_match_arm,

--- a/crates/rmlx-models/src/ppl.rs
+++ b/crates/rmlx-models/src/ppl.rs
@@ -30,8 +30,15 @@
 //!    next-token id at `t+1`), compute `log_softmax(logits[t])[tokens[t+1]]`
 //!    and accumulate `-logprob`.
 //! 4. `warmup` for the first window is `0`; for subsequent windows it is
-//!    `ctx_window - stride` so already-scored positions are not double-counted.
+//!    `ctx_window - stride - 1`. Slot `t` scores corpus position
+//!    `start + t + 1`, so the first slot whose target the previous window did
+//!    not already score is one earlier than the overlap. Skipping the overlap
+//!    itself leaves one corpus position unscored per window boundary.
 //! 5. `PPL = exp(sum(nll) / count)`.
+//!
+//! The Gemma4 scorer prepends BOS to every window, which shifts each target one
+//! slot: there slot `t` scores `start + t`, and its warm-up is the same
+//! expression for the opposite reason. See [`compute_ppl_gemma4`].
 //!
 //! Compute is sync per the project's "compute sync, async only at boundaries"
 //! rule. One GPU-to-host transfer per window for the logits buffer.
@@ -59,14 +66,25 @@ pub enum PplError {
     /// The model architecture does not yet have the `forward_seq_logits_all`
     /// path the scorer needs. See module docs.
     ///
-    #[error("ppl: architecture '{arch}' is not supported (supported: Qwen3, Gemma4, Qwen3_5Moe)")]
+    /// The supported list spells the same strings `Architecture::arch_class()`
+    /// reports and a checkpoint's `config.json` carries, so an operator can
+    /// grep the message for what their snapshot declares.
+    #[error(
+        "ppl: architecture '{arch}' is not supported (supported:          Qwen3ForCausalLM, Gemma4ForConditionalGeneration,          Qwen3_5ForConditionalGeneration, Qwen3_5MoeForConditionalGeneration)"
+    )]
     ArchUnsupported {
         /// The architecture name that is not yet supported.
         arch: String,
     },
     /// The architecture has a cacheless scorer but no cached one, so a KV
     /// codec cannot be scored through it. See the module docs.
-    #[error("ppl: architecture '{arch}' has no cached scorer; drop the KV-codec flags to score it cacheless")]
+    ///
+    /// The message carries the reason, because the operator reading it is not
+    /// reading the module docs at that moment and "no cached scorer" alone
+    /// reads as "not implemented yet".
+    #[error(
+        "ppl: architecture '{arch}' has no cached scorer: its GatedDeltaNet          layers hold a recurrent state no KV codec touches, so a number scored          through a codec there would describe only the full-attention layers.          Drop the KV-codec flags to score it cacheless"
+    )]
     CachedScorerUnsupported {
         /// The architecture name whose scorer keeps no cache.
         arch: String,
@@ -102,13 +120,75 @@ pub struct PplReport {
     pub windows: usize,
 }
 
+#[cfg(test)]
+pub(crate) use guard::CACHED_SCORER_ARCHES;
+pub(crate) use guard::{cached_scorer_codec, ScoredThrough};
+
+/// A privacy boundary around the codec refusal, and the only reason this module
+/// exists.
+///
+/// [`ScoredThrough`]'s field is private to it and [`cached_scorer_codec`] is the
+/// only thing inside that builds one, so nothing elsewhere in this file can
+/// conjure the value every scorer arm requires. Deleting the refusal from
+/// [`compute_ppl`] is then a compile error rather than a silently widened
+/// scorer — which matters because what a widened scorer produces is a
+/// `ppl_wikitext2_cached` row, in an append-only table, naming a codec that
+/// scored a quarter of the model.
+mod guard {
+    use super::{KvQuant, PplError};
+
+    /// The architecture classes whose scorer can hold a KV cache, spelled as
+    /// `Architecture::arch_class` reports them and as a checkpoint's
+    /// `config.json` declares them.
+    ///
+    /// Keyed on the string rather than the enum variant so the decision is a
+    /// pure function testable without a loaded model. That keying fails closed:
+    /// an arch whose class string is renamed drops out of the list and is
+    /// refused, which is loud, rather than admitted, which would be permanent.
+    pub(crate) const CACHED_SCORER_ARCHES: [&str; 2] =
+        ["Qwen3ForCausalLM", "Gemma4ForConditionalGeneration"];
+
+    /// The codec a scorer arm will run its cache at, once the architecture has
+    /// been checked for having a cached scorer at all.
+    #[derive(Debug, Clone, Copy)]
+    pub(crate) struct ScoredThrough(Option<KvQuant>);
+
+    impl ScoredThrough {
+        /// The codec, or `None` for the cacheless scorer.
+        pub(crate) fn codec(self) -> Option<KvQuant> {
+            self.0
+        }
+    }
+
+    /// Refuse a KV codec on an architecture whose scorer keeps no cache;
+    /// otherwise hand the codec on.
+    ///
+    /// The single producer of that decision. Qwen3.5 is the refused case:
+    /// sixteen of its sixty-four layers are full attention and the rest carry a
+    /// GatedDeltaNet recurrent state no KV codec touches, so a number scored
+    /// "through" a codec there would describe a quarter of the model.
+    pub(crate) fn cached_scorer_codec(
+        arch_class: &str,
+        kv_quant: Option<KvQuant>,
+    ) -> Result<ScoredThrough, PplError> {
+        if kv_quant.is_some() && !CACHED_SCORER_ARCHES.contains(&arch_class) {
+            return Err(PplError::CachedScorerUnsupported {
+                arch: arch_class.to_owned(),
+            });
+        }
+        Ok(ScoredThrough(kv_quant))
+    }
+}
+
 /// Sliding-window PPL scorer.
 ///
 /// `ctx_window` -- number of tokens forwarded per window (e.g. 4096).
 /// `stride` -- gap between consecutive window starts. When
-/// `stride < ctx_window` each window's first
-/// `(ctx_window - stride)` positions are skipped (they were
-/// already scored in the previous window).
+/// `stride < ctx_window` each window's first `(ctx_window - stride - 1)` slots
+/// are skipped, because slot `t` scores corpus position `start + t + 1` and
+/// the previous window's last scored target sits one slot earlier than the
+/// overlap. Skipping the overlap itself leaves one corpus position unscored
+/// per window boundary.
 ///
 /// `tokens` must be the corpus tokenized end-to-end. Returns
 /// `Err(PplError::ArchUnsupported)` for any architecture other than Qwen3,
@@ -149,15 +229,16 @@ pub fn compute_ppl(
     device: Device,
     kv_quant: Option<KvQuant>,
 ) -> std::result::Result<PplReport, PplError> {
+    let scored_through = cached_scorer_codec(arch.arch_class(), kv_quant)?;
     match arch {
         Architecture::Qwen3(m) => {
-            compute_ppl_qwen3(m, tokens, ctx_window, stride, device, kv_quant)
+            compute_ppl_qwen3(m, tokens, ctx_window, stride, device, scored_through)
         }
         Architecture::Gemma4(m) => {
-            compute_ppl_gemma4(m, tokens, ctx_window, stride, device, kv_quant)
+            compute_ppl_gemma4(m, tokens, ctx_window, stride, device, scored_through)
         }
         Architecture::Qwen3_5Moe(m) => {
-            compute_ppl_qwen3_5_moe(m, tokens, ctx_window, stride, device, kv_quant)
+            compute_ppl_qwen3_5_moe(m, tokens, ctx_window, stride, device, scored_through)
         }
         other => Err(PplError::ArchUnsupported {
             arch: other.arch_class().to_string(),
@@ -226,6 +307,7 @@ fn score_window_through_cache(
     device: Device,
     sum_nll: &mut f64,
     count: &mut usize,
+    host: &mut Vec<f32>,
     mut forward: impl FnMut(&[u32], &mut Vec<KvCache>) -> Result<Array>,
 ) -> Result<()> {
     // A window whose warm-up prefix reaches its last position has no scored
@@ -247,9 +329,9 @@ fn score_window_through_cache(
         arch,
         &mut forward,
     )?;
-    let host = logits_3d_to_host_f32(&prefill_logits, 1, vocab)?;
+    read_logits_3d_into(&prefill_logits, 1, vocab, host)?;
     accumulate_position_nll(
-        &host,
+        host,
         win[warmup + 1] as usize,
         vocab,
         warmup,
@@ -259,8 +341,8 @@ fn score_window_through_cache(
 
     for t in (warmup + 1)..last_scored {
         let logits = forward(&win[t..=t], caches)?;
-        let host = logits_3d_to_host_f32(&logits, 1, vocab)?;
-        accumulate_position_nll(&host, win[t + 1] as usize, vocab, t, sum_nll, count);
+        read_logits_3d_into(&logits, 1, vocab, host)?;
+        accumulate_position_nll(host, win[t + 1] as usize, vocab, t, sum_nll, count);
     }
     Ok(())
 }
@@ -308,7 +390,18 @@ fn sliding_window_ppl(
     let mut first = true;
     while start < tokens.len() {
         let end = (start + ctx_window).min(tokens.len());
-        let window = tokens.get(start..end).unwrap_or_default();
+        // `start < tokens.len()` is the loop condition and `end` is clamped to
+        // the length, so the range is valid. Defaulting to an empty slice would
+        // instead trip the `len() < 2` break below and return a quietly
+        // truncated perplexity if that ever stopped holding.
+        let window = tokens
+            .get(start..end)
+            .ok_or_else(|| PplError::InvalidWindow {
+                msg: format!(
+                    "window range {start}..{end} is outside a corpus of {} tokens",
+                    tokens.len()
+                ),
+            })?;
         if window.len() < 2 {
             break;
         }
@@ -379,20 +472,33 @@ fn sliding_window_ppl(
 }
 
 /// Score one window off a `[1, seq, vocab]` logit tensor computed in one
-/// cacheless forward: position `t` predicts `win[t + 1]`.
+/// cacheless forward.
+///
+/// Slot `t` holds the distribution over the token that follows `win[t]`, so it
+/// scores `win[t + 1]`, and the last slot has no such target — hence
+/// `warmup..(win.len() - 1)`. The two decisions in that sentence are the whole
+/// function and both are asserted in `ppl_tests.rs`: scoring `win[t]` instead
+/// would compare each position against its own logits and pull the perplexity
+/// toward 1.0, and starting at `0` instead of `warmup` would count the
+/// overlapped positions twice.
+///
+/// `host` is a scratch buffer the caller owns across windows: on the widest
+/// vocabulary in the matrix one window's worth is about 2 GB, and allocating
+/// that per window on a unified-memory machine is not free.
 #[allow(
     clippy::indexing_slicing,
-    reason = "the row slice is bounded by the loop's own `t < win.len() - 1` and the host buffer is sized `win.len() * vocab` by logits_3d_to_host_f32"
+    reason = "the row slice is bounded by the loop's own `t < win.len() - 1` and the host buffer is filled to `win.len() * vocab` by read_logits_3d_into"
 )]
 fn score_window_cacheless(
     logits: &Array,
     win: &[u32],
     warmup: usize,
     vocab: usize,
+    host: &mut Vec<f32>,
     sum_nll: &mut f64,
     count: &mut usize,
 ) -> Result<()> {
-    let host = logits_3d_to_host_f32(logits, win.len(), vocab)?;
+    read_logits_3d_into(logits, win.len(), vocab, host)?;
     for t in warmup..(win.len() - 1) {
         let row = &host[t * vocab..(t + 1) * vocab];
         accumulate_position_nll(row, win[t + 1] as usize, vocab, t, sum_nll, count);
@@ -407,9 +513,11 @@ fn compute_ppl_qwen3(
     ctx_window: usize,
     stride: usize,
     device: Device,
-    kv_quant: Option<KvQuant>,
+    scored_through: ScoredThrough,
 ) -> std::result::Result<PplReport, PplError> {
     let vocab = model.cfg.vocab_size;
+    let kv_quant = scored_through.codec();
+    let mut host: Vec<f32> = Vec::new();
     sliding_window_ppl(
         tokens,
         ctx_window,
@@ -418,7 +526,9 @@ fn compute_ppl_qwen3(
             match kv_quant {
                 None => {
                     let logits = model.forward_seq_logits_all(window, device)?;
-                    score_window_cacheless(&logits, window, warmup, vocab, sum_nll, count)?;
+                    score_window_cacheless(
+                        &logits, window, warmup, vocab, &mut host, sum_nll, count,
+                    )?;
                 }
                 Some(q) => {
                     let mut caches = qwen3_ppl_caches(model, q, window.len());
@@ -431,6 +541,7 @@ fn compute_ppl_qwen3(
                         device,
                         sum_nll,
                         count,
+                        &mut host,
                         |ids, cs| {
                             model.forward_seq_with_cache(ids, Some(cs.as_mut_slice()), device)
                         },
@@ -447,7 +558,8 @@ fn compute_ppl_qwen3(
 /// Cacheless only. The window is one `forward_seq_logits_all` call with no KV
 /// cache and no recurrent state carried in, so every layer kind sees the window
 /// as a fresh document — the same contract the other two cacheless scorers
-/// keep. A KV codec cannot be scored here; see [`PplError::CachedScorerUnsupported`].
+/// keep. A codec never reaches here: [`cached_scorer_codec`] refuses it, and
+/// this arm ignores the one it is handed for that reason.
 #[instrument(skip(model, tokens), fields(n_tokens = tokens.len(), ctx_window, stride))]
 fn compute_ppl_qwen3_5_moe(
     model: &Qwen3_5MoeText,
@@ -455,21 +567,21 @@ fn compute_ppl_qwen3_5_moe(
     ctx_window: usize,
     stride: usize,
     device: Device,
-    kv_quant: Option<KvQuant>,
+    scored_through: ScoredThrough,
 ) -> std::result::Result<PplReport, PplError> {
-    if kv_quant.is_some() {
-        return Err(PplError::CachedScorerUnsupported {
-            arch: model.arch_class().to_owned(),
-        });
-    }
+    debug_assert!(
+        scored_through.codec().is_none(),
+        "cached_scorer_codec refuses a codec on this arch before the dispatch reaches here"
+    );
     let vocab = model.cfg.vocab_size;
+    let mut host: Vec<f32> = Vec::new();
     sliding_window_ppl(
         tokens,
         ctx_window,
         stride,
         |window, warmup, sum_nll, count| {
             let logits = model.forward_seq_logits_all(window, device)?;
-            score_window_cacheless(&logits, window, warmup, vocab, sum_nll, count)?;
+            score_window_cacheless(&logits, window, warmup, vocab, &mut host, sum_nll, count)?;
             Ok(())
         },
     )
@@ -486,14 +598,17 @@ fn compute_ppl_qwen3_5_moe(
 /// window at corpus position `start`, the forward input is
 /// `[BOS, tokens[start], ..., tokens[start + ctx_window - 2]]` (length
 /// `ctx_window`). This ensures the model always starts from a known
-/// start-of-document state. The warmup positions (first `ctx_window - stride`
-/// positions in each non-first window) are skipped in scoring as usual — only
-/// the second half of each window is scored — so BOS context is always present
-/// for scored positions.
+/// start-of-document state. The warmup positions (first
+/// `ctx_window - stride - 1` slots in each non-first window) are skipped in
+/// scoring as usual, so BOS context is always present for scored positions.
+/// The subtracted one is the BOS shift: slot `t` here scores `start + t`, one
+/// earlier than the non-BOS scorers' `start + t + 1`, so the last target the
+/// previous window scored sits one slot further into the overlap.
 ///
 /// The scored positions in window i (BOS-prefixed view, 0-indexed):
 /// - window 0: positions `[0..ctx_window-2]` (predicts `tokens[0..ctx_window-1]`)
-/// - window i>0: positions `[warmup..ctx_window-2]` where `warmup = ctx_window - stride`
+/// - window i>0: positions `[warmup..ctx_window-2]` where
+///   `warmup = ctx_window - stride - 1`
 ///
 /// Each scored position `t` predicts `bos_window[t+1] = tokens[start + t]` —
 /// the corpus token immediately following position `t`.
@@ -513,8 +628,9 @@ fn compute_ppl_gemma4(
     ctx_window: usize,
     stride: usize,
     device: Device,
-    kv_quant: Option<KvQuant>,
+    scored_through: ScoredThrough,
 ) -> std::result::Result<PplReport, PplError> {
+    let kv_quant = scored_through.codec();
     if ctx_window < 2 {
         return Err(PplError::InvalidWindow {
             msg: format!("ctx_window must be >= 2, got {ctx_window}"),
@@ -539,6 +655,8 @@ fn compute_ppl_gemma4(
     // Reusable BOS-prefixed window buffer.  Allocated once and reused across
     // windows to avoid per-window heap allocation for a ctx_window-sized Vec.
     let mut bos_window: Vec<u32> = Vec::with_capacity(ctx_window);
+    // One host-side logits buffer for the whole run; see `score_window_cacheless`.
+    let mut host: Vec<f32> = Vec::new();
 
     let vocab = model.cfg.vocab_size;
     let mut sum_nll: f64 = 0.0;
@@ -588,6 +706,7 @@ fn compute_ppl_gemma4(
                     &bos_window,
                     warmup,
                     vocab,
+                    &mut host,
                     &mut sum_nll,
                     &mut count,
                 )?;
@@ -603,6 +722,7 @@ fn compute_ppl_gemma4(
                     device,
                     &mut sum_nll,
                     &mut count,
+                    &mut host,
                     |ids, cs| model.forward_seq_with_cache(ids, Some(cs.as_mut_slice()), device),
                 )?;
             }
@@ -795,10 +915,12 @@ pub(crate) fn neg_log_softmax_at(row: &[f32], idx: usize) -> f32 {
     clippy::wildcard_enum_match_arm,
     reason = "wildcard arm is the correct fallthrough for unsupported arch/quant variants; exhaustive expansion would require updating on every new variant"
 )]
-fn logits_3d_to_host_f32(logits: &Array, seq: usize, vocab: usize) -> Result<Vec<f32>> {
+fn read_logits_3d_into(logits: &Array, seq: usize, vocab: usize, out: &mut Vec<f32>) -> Result<()> {
     logits.eval()?;
     let bytes = logits.to_bytes()?;
     let total = seq * vocab;
+    out.clear();
+    out.reserve(total);
     match logits.dtype() {
         Dtype::F32 => {
             if bytes.len() < total * 4 {
@@ -808,11 +930,12 @@ fn logits_3d_to_host_f32(logits: &Array, seq: usize, vocab: usize) -> Result<Vec
                     total * 4
                 )));
             }
-            let out: Vec<f32> = bytes[..total * 4]
-                .chunks_exact(4)
-                .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
-                .collect();
-            Ok(out)
+            out.extend(
+                bytes[..total * 4]
+                    .chunks_exact(4)
+                    .map(|c| f32::from_le_bytes(c.try_into().unwrap())),
+            );
+            Ok(())
         }
         Dtype::Bf16 => {
             if bytes.len() < total * 2 {
@@ -822,13 +945,12 @@ fn logits_3d_to_host_f32(logits: &Array, seq: usize, vocab: usize) -> Result<Vec
                     total * 2
                 )));
             }
-            let mut out = Vec::with_capacity(total);
             for i in 0..total {
                 let o = i * 2;
                 let raw = u16::from_le_bytes(bytes[o..o + 2].try_into().unwrap());
                 out.push(f32::from_bits(u32::from(raw) << 16));
             }
-            Ok(out)
+            Ok(())
         }
         other => Err(Error::Other(format!(
             "ppl: unsupported logits dtype {other:?}; expected F32 or BF16"

--- a/crates/rmlx-models/src/ppl.rs
+++ b/crates/rmlx-models/src/ppl.rs
@@ -6,10 +6,16 @@
 //!
 //! # Scope
 //!
-//! Implemented for [`crate::Architecture::Qwen3`] (, Bonsai smoke target)
-//! and [`crate::Architecture::Gemma4`]. Other architectures return
-//! [`PplError::ArchUnsupported`]; adding parity paths for Qwen3.5MoE / Qwen3VL
-//! is a follow-up.
+//! Implemented for [`crate::Architecture::Qwen3`] (Bonsai smoke target),
+//! [`crate::Architecture::Gemma4`] and [`crate::Architecture::Qwen3_5Moe`]
+//! (dense and MoE alike). Other architectures return
+//! [`PplError::ArchUnsupported`].
+//!
+//! The cached scorer (`kv_quant = Some(codec)`) covers the first two only.
+//! Qwen3.5 returns [`PplError::CachedScorerUnsupported`]: its GatedDeltaNet
+//! layers carry a recurrent state that no KV codec touches, so a "scored
+//! through codec X" number there would describe the sixteen full-attention
+//! layers and silently not the other forty-eight.
 //!
 //! # Algorithm
 //!
@@ -44,6 +50,7 @@ use crate::decode_loop::chunked_prefill;
 use crate::gemma4::{Gemma4Text, LayerType};
 use crate::kv_cache::kv_layer_quants;
 use crate::qwen3::Qwen3Text;
+use crate::qwen3_5_moe::Qwen3_5MoeText;
 
 /// Errors that can short-circuit a PPL scoring run.
 #[non_exhaustive]
@@ -52,10 +59,16 @@ pub enum PplError {
     /// The model architecture does not yet have the `forward_seq_logits_all`
     /// path the scorer needs. See module docs.
     ///
-    /// implements Qwen3; adds Gemma4.
-    #[error("ppl: architecture '{arch}' is not supported (supported: Qwen3, Gemma4)")]
+    #[error("ppl: architecture '{arch}' is not supported (supported: Qwen3, Gemma4, Qwen3_5Moe)")]
     ArchUnsupported {
         /// The architecture name that is not yet supported.
+        arch: String,
+    },
+    /// The architecture has a cacheless scorer but no cached one, so a KV
+    /// codec cannot be scored through it. See the module docs.
+    #[error("ppl: architecture '{arch}' has no cached scorer; drop the KV-codec flags to score it cacheless")]
+    CachedScorerUnsupported {
+        /// The architecture name whose scorer keeps no cache.
         arch: String,
     },
     /// Window parameters are not usable (e.g. `stride > ctx_window`, or the
@@ -98,8 +111,8 @@ pub struct PplReport {
 /// already scored in the previous window).
 ///
 /// `tokens` must be the corpus tokenized end-to-end. Returns
-/// `Err(PplError::ArchUnsupported)` for any architecture other than Qwen3 or
-/// Gemma4.
+/// `Err(PplError::ArchUnsupported)` for any architecture other than Qwen3,
+/// Gemma4 or Qwen3.5.
 ///
 /// `kv_quant` selects between the two scorers:
 ///
@@ -142,6 +155,9 @@ pub fn compute_ppl(
         }
         Architecture::Gemma4(m) => {
             compute_ppl_gemma4(m, tokens, ctx_window, stride, device, kv_quant)
+        }
+        Architecture::Qwen3_5Moe(m) => {
+            compute_ppl_qwen3_5_moe(m, tokens, ctx_window, stride, device, kv_quant)
         }
         other => Err(PplError::ArchUnsupported {
             arch: other.arch_class().to_string(),
@@ -249,18 +265,24 @@ fn score_window_through_cache(
     Ok(())
 }
 
-#[instrument(skip(model, tokens), fields(n_tokens = tokens.len(), ctx_window, stride))]
-#[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
-fn compute_ppl_qwen3(
-    model: &Qwen3Text,
+/// The sliding walk the two non-BOS scorers share.
+///
+/// Window bounds, the warm-up that keeps an overlapped position from being
+/// scored twice, and the running accumulators live here once; `score_window`
+/// supplies the architecture's forward and scores positions
+/// `[warmup .. win.len() - 1)`. The Gemma4 scorer does not use it: prepending
+/// BOS to every window shifts each corpus target one slot and gives that arch
+/// a different warm-up and a different stop condition.
+fn sliding_window_ppl(
     tokens: &[u32],
     ctx_window: usize,
     stride: usize,
-    device: Device,
-    kv_quant: Option<KvQuant>,
+    mut score_window: impl FnMut(
+        &[u32],
+        usize,
+        &mut f64,
+        &mut usize,
+    ) -> std::result::Result<(), PplError>,
 ) -> std::result::Result<PplReport, PplError> {
     if ctx_window < 2 {
         return Err(PplError::InvalidWindow {
@@ -278,7 +300,6 @@ fn compute_ppl_qwen3(
         });
     }
 
-    let vocab = model.cfg.vocab_size;
     let mut sum_nll: f64 = 0.0;
     let mut count: usize = 0;
     let mut windows: usize = 0;
@@ -287,53 +308,29 @@ fn compute_ppl_qwen3(
     let mut first = true;
     while start < tokens.len() {
         let end = (start + ctx_window).min(tokens.len());
-        let window = &tokens[start..end];
+        let window = tokens.get(start..end).unwrap_or_default();
         if window.len() < 2 {
             break;
         }
 
-        // warmup = number of leading positions whose NLL was already counted
-        // in the previous window. First window: 0. Subsequent windows: the
-        // overlap = ctx_window - stride.
+        // warmup = number of leading slots whose target was already scored by
+        // the previous window. First window: 0. Otherwise: slot `t` here
+        // scores corpus position `start + t + 1`, and the previous window
+        // stopped at `start - stride + ctx_window - 1`, so the first unscored
+        // slot is `ctx_window - stride - 1`. Skipping `ctx_window - stride`
+        // instead leaves exactly one corpus position unscored per window
+        // boundary, and at `stride == 1` leaves every window after the first
+        // scoring nothing at all.
         let warmup = if first {
             0
         } else {
-            ctx_window.saturating_sub(stride).min(window.len() - 1)
+            ctx_window
+                .saturating_sub(stride)
+                .saturating_sub(1)
+                .min(window.len() - 1)
         };
 
-        // Score positions [warmup .. window.len() - 1) -- predicting token at
-        // window[t+1] from logits[t].
-        match kv_quant {
-            None => {
-                let logits = model.forward_seq_logits_all(window, device)?;
-                let host = logits_3d_to_host_f32(&logits, window.len(), vocab)?;
-                for t in warmup..(window.len() - 1) {
-                    let row = &host[t * vocab..(t + 1) * vocab];
-                    accumulate_position_nll(
-                        row,
-                        window[t + 1] as usize,
-                        vocab,
-                        t,
-                        &mut sum_nll,
-                        &mut count,
-                    );
-                }
-            }
-            Some(q) => {
-                let mut caches = qwen3_ppl_caches(model, q, window.len());
-                score_window_through_cache(
-                    window,
-                    warmup,
-                    vocab,
-                    &mut caches,
-                    "qwen3",
-                    device,
-                    &mut sum_nll,
-                    &mut count,
-                    |ids, cs| model.forward_seq_with_cache(ids, Some(cs.as_mut_slice()), device),
-                )?;
-            }
-        }
+        score_window(window, warmup, &mut sum_nll, &mut count)?;
 
         windows += 1;
         debug!(
@@ -379,6 +376,103 @@ fn compute_ppl_qwen3(
         scored_tokens: count,
         windows,
     })
+}
+
+/// Score one window off a `[1, seq, vocab]` logit tensor computed in one
+/// cacheless forward: position `t` predicts `win[t + 1]`.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "the row slice is bounded by the loop's own `t < win.len() - 1` and the host buffer is sized `win.len() * vocab` by logits_3d_to_host_f32"
+)]
+fn score_window_cacheless(
+    logits: &Array,
+    win: &[u32],
+    warmup: usize,
+    vocab: usize,
+    sum_nll: &mut f64,
+    count: &mut usize,
+) -> Result<()> {
+    let host = logits_3d_to_host_f32(logits, win.len(), vocab)?;
+    for t in warmup..(win.len() - 1) {
+        let row = &host[t * vocab..(t + 1) * vocab];
+        accumulate_position_nll(row, win[t + 1] as usize, vocab, t, sum_nll, count);
+    }
+    Ok(())
+}
+
+#[instrument(skip(model, tokens), fields(n_tokens = tokens.len(), ctx_window, stride))]
+fn compute_ppl_qwen3(
+    model: &Qwen3Text,
+    tokens: &[u32],
+    ctx_window: usize,
+    stride: usize,
+    device: Device,
+    kv_quant: Option<KvQuant>,
+) -> std::result::Result<PplReport, PplError> {
+    let vocab = model.cfg.vocab_size;
+    sliding_window_ppl(
+        tokens,
+        ctx_window,
+        stride,
+        |window, warmup, sum_nll, count| {
+            match kv_quant {
+                None => {
+                    let logits = model.forward_seq_logits_all(window, device)?;
+                    score_window_cacheless(&logits, window, warmup, vocab, sum_nll, count)?;
+                }
+                Some(q) => {
+                    let mut caches = qwen3_ppl_caches(model, q, window.len());
+                    score_window_through_cache(
+                        window,
+                        warmup,
+                        vocab,
+                        &mut caches,
+                        "qwen3",
+                        device,
+                        sum_nll,
+                        count,
+                        |ids, cs| {
+                            model.forward_seq_with_cache(ids, Some(cs.as_mut_slice()), device)
+                        },
+                    )?;
+                }
+            }
+            Ok(())
+        },
+    )
+}
+
+/// Sliding-window PPL scorer for the Qwen3.5 hybrid family, dense and MoE.
+///
+/// Cacheless only. The window is one `forward_seq_logits_all` call with no KV
+/// cache and no recurrent state carried in, so every layer kind sees the window
+/// as a fresh document — the same contract the other two cacheless scorers
+/// keep. A KV codec cannot be scored here; see [`PplError::CachedScorerUnsupported`].
+#[instrument(skip(model, tokens), fields(n_tokens = tokens.len(), ctx_window, stride))]
+fn compute_ppl_qwen3_5_moe(
+    model: &Qwen3_5MoeText,
+    tokens: &[u32],
+    ctx_window: usize,
+    stride: usize,
+    device: Device,
+    kv_quant: Option<KvQuant>,
+) -> std::result::Result<PplReport, PplError> {
+    if kv_quant.is_some() {
+        return Err(PplError::CachedScorerUnsupported {
+            arch: model.arch_class().to_owned(),
+        });
+    }
+    let vocab = model.cfg.vocab_size;
+    sliding_window_ppl(
+        tokens,
+        ctx_window,
+        stride,
+        |window, warmup, sum_nll, count| {
+            let logits = model.forward_seq_logits_all(window, device)?;
+            score_window_cacheless(&logits, window, warmup, vocab, sum_nll, count)?;
+            Ok(())
+        },
+    )
 }
 
 /// Sliding-window PPL scorer for the Gemma4 family.
@@ -489,18 +583,14 @@ fn compute_ppl_gemma4(
         match kv_quant {
             None => {
                 let logits = model.forward_seq_logits_all(&bos_window, device)?;
-                let host = logits_3d_to_host_f32(&logits, win_len, vocab)?;
-                for t in warmup..(win_len - 1) {
-                    let row = &host[t * vocab..(t + 1) * vocab];
-                    accumulate_position_nll(
-                        row,
-                        bos_window[t + 1] as usize,
-                        vocab,
-                        t,
-                        &mut sum_nll,
-                        &mut count,
-                    );
-                }
+                score_window_cacheless(
+                    &logits,
+                    &bos_window,
+                    warmup,
+                    vocab,
+                    &mut sum_nll,
+                    &mut count,
+                )?;
             }
             Some(q) => {
                 let mut caches = gemma4_ppl_caches(model, q, win_len);

--- a/crates/rmlx-models/src/ppl_tests.rs
+++ b/crates/rmlx-models/src/ppl_tests.rs
@@ -184,6 +184,10 @@ fn gemma4_error_message_advertises_support() {
         "error message must mention Gemma4: {msg}"
     );
     assert!(
+        msg.contains("Qwen3_5Moe"),
+        "error message must mention Qwen3_5Moe: {msg}"
+    );
+    assert!(
         msg.contains("LagunaForCausalLM"),
         "error message must include the unsupported arch name: {msg}"
     );
@@ -239,10 +243,10 @@ fn gemma4_dispatch_reaches_compute_fn() {
         "sentinel ArchUnsupported must carry the arch name: {msg}"
     );
     // Confirm the supported-arches list in the error message still includes
-    // both Qwen3 and Gemma4 (regression guard for the error text).
+    // every arch that has a scorer (regression guard for the error text).
     assert!(
-        msg.contains("Qwen3") && msg.contains("Gemma4"),
-        "supported-arches list must mention both Qwen3 and Gemma4: {msg}"
+        msg.contains("Qwen3") && msg.contains("Gemma4") && msg.contains("Qwen3_5Moe"),
+        "supported-arches list must mention Qwen3, Gemma4 and Qwen3_5Moe: {msg}"
     );
 }
 
@@ -286,4 +290,105 @@ fn a_window_with_no_scored_position_dispatches_nothing() {
         (sum_nll - 7.5).abs() < f64::EPSILON,
         "nothing was scored, so the accumulator cannot move"
     );
+}
+
+/// The shared sliding walk covers every scorable corpus position exactly once.
+///
+/// The two non-BOS scorers score positions `[warmup .. win.len() - 1)` of each
+/// window, so a corpus position `c` is scored by the window that owns the slot
+/// predicting it. Overlap is what `warmup` exists to remove: score a position
+/// twice and it is counted twice in a mean whose denominator is the scored
+/// count. No model and no GPU — the walk is index arithmetic and the closure
+/// stands in for the forward.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions: panicking on unexpected values is intentional"
+)]
+fn sliding_walk_scores_each_position_once() {
+    // stride < ctx_window only: at `stride == ctx_window` the position after
+    // each window's last slot has no in-window predecessor and is genuinely
+    // unscorable, so full coverage is not the contract there.
+    let cases: &[(usize, usize, usize)] = &[
+        (10, 4, 1),
+        (20, 8, 4),
+        (100, 16, 8),
+        (25, 8, 5),
+        (17, 6, 4),
+        (3, 2, 1),
+    ];
+
+    for &(n_tokens, ctx_window, stride) in cases {
+        let tokens: Vec<u32> = (0..n_tokens as u32).collect();
+        let mut scored: Vec<usize> = Vec::new();
+        let mut start_of_window = 0_usize;
+
+        let report = sliding_window_ppl(
+            &tokens,
+            ctx_window,
+            stride,
+            |window, warmup, sum_nll, count| {
+                for t in warmup..(window.len() - 1) {
+                    // The corpus index whose NLL this slot contributes.
+                    scored.push(start_of_window + t + 1);
+                    *sum_nll += 1.0;
+                    *count += 1;
+                }
+                start_of_window += stride;
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        let unique: HashSet<usize> = scored.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            scored.len(),
+            "({n_tokens}, {ctx_window}, {stride}): a position was scored twice"
+        );
+        assert_eq!(
+            report.scored_tokens,
+            scored.len(),
+            "({n_tokens}, {ctx_window}, {stride}): report disagrees with the closure"
+        );
+        // Position 0 has no predecessor to predict it; every later one does.
+        let expected: HashSet<usize> = (1..n_tokens).collect();
+        assert_eq!(
+            unique, expected,
+            "({n_tokens}, {ctx_window}, {stride}): coverage is not the whole corpus tail"
+        );
+    }
+}
+
+/// Qwen3.5 has a cacheless scorer and no cached one, and says which.
+///
+/// A KV codec on that arch would describe the full-attention layers and
+/// silently not the GatedDeltaNet ones, so the command refuses. The message
+/// has to name the arch and the way out, or the caller reads it as "no scorer
+/// at all" and stops.
+#[test]
+fn qwen3_5_refuses_a_codec_and_names_the_cacheless_route() {
+    let err = PplError::CachedScorerUnsupported {
+        arch: "Qwen3_5ForConditionalGeneration".to_owned(),
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Qwen3_5ForConditionalGeneration"),
+        "refusal must name the arch: {msg}"
+    );
+    assert!(
+        msg.contains("cacheless"),
+        "refusal must name the route that works: {msg}"
+    );
+
+    // Compile-time existence gate, as for the Gemma4 scorer above.
+    let _ = compute_ppl_qwen3_5_moe
+        as fn(
+            &Qwen3_5MoeText,
+            &[u32],
+            usize,
+            usize,
+            Device,
+            Option<KvQuant>,
+        ) -> std::result::Result<PplReport, PplError>;
 }

--- a/crates/rmlx-models/src/ppl_tests.rs
+++ b/crates/rmlx-models/src/ppl_tests.rs
@@ -502,3 +502,229 @@ fn the_scoring_kernel_scores_the_next_token_from_the_warmup_on() {
         "the fixture cannot tell win[t+1] from win[t] and so cannot gate the shift"
     );
 }
+
+/// A scorer handed a buffer that a longer window already filled scores the
+/// short window and nothing else.
+///
+/// The hoist that made `host` the caller's turned a fresh allocation into
+/// shared mutable state in a numerical path, and `neg_log_softmax_at` sums
+/// `exp()` over every element it is given. A stale tail left behind by a wider
+/// window would therefore inflate the softmax denominator of every later,
+/// narrower one — a wrong perplexity with no error anywhere, which is the whole
+/// failure class this file exists to close.
+///
+/// Cross-shape on purpose: a same-shape reuse cannot see it. Mutation this
+/// fails on: deleting `out.clear()` from `read_logits_3d_into`. The `NAN` fill
+/// makes a surviving tail unmissable — `exp()` of it poisons `sum_nll` — and the
+/// `host.len()` assertion catches it even where the arithmetic would not.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions: panicking on unexpected values is intentional"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "row slices are bounded by the vocab and seq this test constructs"
+)]
+fn a_buffer_a_longer_window_dirtied_does_not_reach_the_next_window() {
+    const VOCAB: usize = 4;
+    let long_win: [u32; 6] = [0, 1, 2, 3, 0, 1];
+    let short_win: [u32; 3] = [2, 3, 0];
+
+    let row_at = |t: usize| -> Vec<f32> {
+        (0..VOCAB)
+            .map(|v| (t * VOCAB + v) as f32 * 0.5 - 1.0)
+            .collect()
+    };
+    let flat_for = |seq: usize| -> Vec<f32> { (0..seq).flat_map(row_at).collect() };
+
+    let long_logits = Array::from_f32_slice(
+        &flat_for(long_win.len()),
+        &[1, long_win.len() as i32, VOCAB as i32],
+    )
+    .unwrap();
+    let short_flat = flat_for(short_win.len());
+    let short_logits =
+        Array::from_f32_slice(&short_flat, &[1, short_win.len() as i32, VOCAB as i32]).unwrap();
+
+    // The answer the short window has on its own, from a buffer nothing touched.
+    let mut clean: Vec<f32> = Vec::new();
+    let mut clean_nll = 0.0_f64;
+    let mut clean_count = 0_usize;
+    score_window_cacheless(
+        &short_logits,
+        &short_win,
+        0,
+        VOCAB,
+        &mut clean,
+        &mut clean_nll,
+        &mut clean_count,
+    )
+    .unwrap();
+
+    // The same window through a buffer the longer one filled, then dirtied
+    // past what the short window needs.
+    let mut reused: Vec<f32> = Vec::new();
+    let mut scratch_nll = 0.0_f64;
+    let mut scratch_count = 0_usize;
+    score_window_cacheless(
+        &long_logits,
+        &long_win,
+        0,
+        VOCAB,
+        &mut reused,
+        &mut scratch_nll,
+        &mut scratch_count,
+    )
+    .unwrap();
+    assert_eq!(
+        reused.len(),
+        long_win.len() * VOCAB,
+        "the wide window must have filled the buffer to its own width"
+    );
+    reused.fill(f32::NAN);
+
+    let mut dirty_nll = 0.0_f64;
+    let mut dirty_count = 0_usize;
+    score_window_cacheless(
+        &short_logits,
+        &short_win,
+        0,
+        VOCAB,
+        &mut reused,
+        &mut dirty_nll,
+        &mut dirty_count,
+    )
+    .unwrap();
+
+    assert_eq!(
+        reused.len(),
+        short_win.len() * VOCAB,
+        "the buffer must be resized down to this window, not left holding the wider one"
+    );
+    assert_eq!(
+        dirty_count, clean_count,
+        "reuse must not change which positions are scored"
+    );
+    assert!(
+        dirty_nll.is_finite(),
+        "a stale NAN tail reached the softmax: sum_nll is {dirty_nll}"
+    );
+    assert!(
+        (dirty_nll - clean_nll).abs() < 1e-9,
+        "reuse changed the answer: {dirty_nll} against {clean_nll} from a fresh buffer"
+    );
+}
+
+/// The messages an operator greps carry no run of whitespace.
+///
+/// Both are wrapped across source lines with `\` continuations, which strip the
+/// newline *and* the indentation that follows it. Dropping one continuation
+/// leaves ten spaces mid-sentence and a search for the phrase either side of the
+/// break finds nothing — which is the property the wrapped messages exist for.
+#[test]
+fn the_operator_facing_messages_are_one_line_of_single_spaces() {
+    let messages = [
+        PplError::ArchUnsupported {
+            arch: "LagunaForCausalLM".to_owned(),
+        }
+        .to_string(),
+        PplError::CachedScorerUnsupported {
+            arch: "Qwen3_5ForConditionalGeneration".to_owned(),
+        }
+        .to_string(),
+    ];
+    for msg in messages {
+        assert!(
+            !msg.contains("  "),
+            "a dropped line continuation left a run of spaces: {msg}"
+        );
+        assert!(
+            !msg.contains('\n'),
+            "the message must render on one line: {msg}"
+        );
+    }
+}
+
+/// The cached scorer scores one position per forward, from a buffer that is
+/// the caller's and starts dirty.
+///
+/// Driven by a stub forward and an empty cache stack, so it needs no model and
+/// no Metal: `chunked_prefill`'s cache sweeps are no-ops over an empty `Vec`
+/// and every array here is built on `Device::Cpu`. Until this existed the
+/// cached path's only test was the one that asserts it dispatches *nothing*.
+///
+/// Mutation this fails on: deleting `out.clear()` from `read_logits_3d_into`,
+/// which leaves the wide starting buffer's `NAN` tail under the softmax. The
+/// companion `&host[..vocab]` slice at the call site is not separately
+/// observable while `out.clear()` stands — the buffer is exactly `vocab` long
+/// there by construction, so the slice and the whole buffer are the same value.
+/// It is defence in depth against the two changing independently, and is
+/// recorded as such rather than as a gated invariant.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions: panicking on unexpected values is intentional"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "row slices are bounded by the vocab and seq this test constructs"
+)]
+fn the_cached_scorer_scores_a_position_per_forward_from_the_callers_buffer() {
+    const VOCAB: usize = 4;
+    let win: [u32; 4] = [0, 1, 2, 3];
+
+    let row_at = |t: usize| -> Vec<f32> {
+        (0..VOCAB)
+            .map(|v| (t * VOCAB + v) as f32 * 0.5 - 1.0)
+            .collect()
+    };
+
+    // The stub answers the n-th forward with row n: the prefill call scores
+    // position `warmup`, and each later single-token call scores its own.
+    let mut call = 0_usize;
+    let mut caches: Vec<KvCache> = Vec::new();
+    // Starts wider than one row and full of NAN — the state a previous, wider
+    // window would leave behind.
+    let mut host: Vec<f32> = vec![f32::NAN; VOCAB * 8];
+    let mut sum_nll = 0.0_f64;
+    let mut count = 0_usize;
+
+    score_window_through_cache(
+        &win,
+        0,
+        VOCAB,
+        &mut caches,
+        "qwen3",
+        Device::Cpu,
+        &mut sum_nll,
+        &mut count,
+        &mut host,
+        |_ids, _cs| {
+            let row = row_at(call);
+            call += 1;
+            Array::from_f32_slice(&row, &[1, 1, VOCAB as i32])
+        },
+    )
+    .unwrap();
+
+    assert_eq!(call, win.len() - 1, "one forward per scored position");
+    assert_eq!(
+        count,
+        win.len() - 1,
+        "every position from the warm-up scores"
+    );
+
+    let mut expected = 0.0_f64;
+    for t in 0..(win.len() - 1) {
+        expected += f64::from(neg_log_softmax_at(&row_at(t), win[t + 1] as usize));
+    }
+    assert!(
+        sum_nll.is_finite(),
+        "the caller's dirty buffer reached the softmax: {sum_nll}"
+    );
+    assert!(
+        (sum_nll - expected).abs() < 1e-9,
+        "cached scorer summed {sum_nll}, expected {expected}"
+    );
+}

--- a/crates/rmlx-models/src/ppl_tests.rs
+++ b/crates/rmlx-models/src/ppl_tests.rs
@@ -175,18 +175,19 @@ fn gemma4_error_message_advertises_support() {
         arch: "LagunaForCausalLM".to_owned(),
     };
     let msg = err.to_string();
-    assert!(
-        msg.contains("Qwen3"),
-        "error message must mention Qwen3: {msg}"
-    );
-    assert!(
-        msg.contains("Gemma4"),
-        "error message must mention Gemma4: {msg}"
-    );
-    assert!(
-        msg.contains("Qwen3_5Moe"),
-        "error message must mention Qwen3_5Moe: {msg}"
-    );
+    // The supported list spells checkpoint architectures, not enum variants,
+    // so an operator can grep it for what their `config.json` declares.
+    for declared in [
+        "Qwen3ForCausalLM",
+        "Gemma4ForConditionalGeneration",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    ] {
+        assert!(
+            msg.contains(declared),
+            "error message must name the checkpoint architecture {declared}: {msg}"
+        );
+    }
     assert!(
         msg.contains("LagunaForCausalLM"),
         "error message must include the unsupported arch name: {msg}"
@@ -201,7 +202,7 @@ fn gemma4_error_message_advertises_support() {
             usize,
             usize,
             Device,
-            Option<KvQuant>,
+            ScoredThrough,
         ) -> std::result::Result<PplReport, PplError>;
 }
 
@@ -245,8 +246,10 @@ fn gemma4_dispatch_reaches_compute_fn() {
     // Confirm the supported-arches list in the error message still includes
     // every arch that has a scorer (regression guard for the error text).
     assert!(
-        msg.contains("Qwen3") && msg.contains("Gemma4") && msg.contains("Qwen3_5Moe"),
-        "supported-arches list must mention Qwen3, Gemma4 and Qwen3_5Moe: {msg}"
+        msg.contains("Qwen3ForCausalLM")
+            && msg.contains("Gemma4ForConditionalGeneration")
+            && msg.contains("Qwen3_5MoeForConditionalGeneration"),
+        "supported-arches list must name every arch with a scorer: {msg}"
     );
 }
 
@@ -278,6 +281,7 @@ fn a_window_with_no_scored_position_dispatches_nothing() {
         Device::Cpu,
         &mut sum_nll,
         &mut count,
+        &mut Vec::new(),
         |_ids, _caches| unreachable!("no scored position, so no forward may run"),
     );
 
@@ -366,29 +370,135 @@ fn sliding_walk_scores_each_position_once() {
 /// silently not the GatedDeltaNet ones, so the command refuses. The message
 /// has to name the arch and the way out, or the caller reads it as "no scorer
 /// at all" and stops.
+/// The codec refusal is a decision, not a message: both directions are driven
+/// through the producer the scorer actually calls.
+///
+/// Mutations this fails on: inverting the `CACHED_SCORER_ARCHES` membership
+/// test (the Qwen3.5 cases stop refusing); dropping the `kv_quant.is_some()`
+/// condition (the no-codec cases start refusing); removing a Qwen3.5 class
+/// string from nothing and instead *adding* one to the allowlist (the refusal
+/// cases stop refusing). Deleting the call in `compute_ppl` does not compile:
+/// the scorer arms take `ScoredThrough`, which only this producer builds.
 #[test]
-fn qwen3_5_refuses_a_codec_and_names_the_cacheless_route() {
-    let err = PplError::CachedScorerUnsupported {
-        arch: "Qwen3_5ForConditionalGeneration".to_owned(),
-    };
-    let msg = err.to_string();
-    assert!(
-        msg.contains("Qwen3_5ForConditionalGeneration"),
-        "refusal must name the arch: {msg}"
-    );
-    assert!(
-        msg.contains("cacheless"),
-        "refusal must name the route that works: {msg}"
-    );
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions: panicking on unexpected values is intentional"
+)]
+fn a_codec_is_refused_on_the_arches_whose_scorer_keeps_no_cache() {
+    let codec = Some(KvQuant::K8V8);
 
-    // Compile-time existence gate, as for the Gemma4 scorer above.
-    let _ = compute_ppl_qwen3_5_moe
-        as fn(
-            &Qwen3_5MoeText,
-            &[u32],
-            usize,
-            usize,
-            Device,
-            Option<KvQuant>,
-        ) -> std::result::Result<PplReport, PplError>;
+    // Both spellings a Qwen3.5 checkpoint can resolve to, dense and MoE.
+    for arch in [
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    ] {
+        let err = cached_scorer_codec(arch, codec).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, PplError::CachedScorerUnsupported { .. }),
+            "{arch} with a codec must be refused as CachedScorerUnsupported, got {msg}"
+        );
+        assert!(msg.contains(arch), "refusal must name the arch: {msg}");
+        assert!(
+            msg.contains("GatedDeltaNet"),
+            "refusal must name the layers that justify it, or it reads as \
+             'not implemented yet': {msg}"
+        );
+        assert!(
+            msg.contains("cacheless"),
+            "refusal must name the route that works: {msg}"
+        );
+
+        // Without a codec there is nothing to refuse.
+        let passed = cached_scorer_codec(arch, None).unwrap().codec();
+        assert!(passed.is_none(), "{arch} cacheless must pass through");
+    }
+
+    // The two arches that do have a cached scorer keep their codec.
+    for arch in CACHED_SCORER_ARCHES {
+        let passed = cached_scorer_codec(arch, codec).unwrap().codec();
+        assert_eq!(passed, codec, "{arch} must be handed its codec unchanged");
+    }
+}
+
+/// The scoring kernel scores the *next* token, and only from `warmup` on.
+///
+/// No model: a hand-built `[1, seq, vocab]` logit tensor on `Device::Cpu` with
+/// one row per position. Mutations this fails on: `win[t + 1]` -> `win[t]`,
+/// which scores each position against its own logits and pulls perplexity
+/// toward 1.0; `warmup..` -> `0..`, which counts the overlap twice.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions: panicking on unexpected values is intentional"
+)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "row slices are bounded by the vocab and seq this test constructs"
+)]
+fn the_scoring_kernel_scores_the_next_token_from_the_warmup_on() {
+    const VOCAB: usize = 4;
+    let win: [u32; 4] = [0, 1, 2, 3];
+    let seq = win.len();
+
+    // Asymmetric rows: no two vocabulary entries share a logit, so scoring the
+    // wrong target or the wrong row lands on a different NLL.
+    let mut flat: Vec<f32> = Vec::with_capacity(seq * VOCAB);
+    for t in 0..seq {
+        for v in 0..VOCAB {
+            flat.push((t * VOCAB + v) as f32 * 0.5 - 1.0);
+        }
+    }
+    let logits = Array::from_f32_slice(&flat, &[1, seq as i32, VOCAB as i32]).unwrap();
+
+    for warmup in 0..seq {
+        let mut host: Vec<f32> = Vec::new();
+        let mut sum_nll = 0.0_f64;
+        let mut count = 0_usize;
+        score_window_cacheless(
+            &logits,
+            &win,
+            warmup,
+            VOCAB,
+            &mut host,
+            &mut sum_nll,
+            &mut count,
+        )
+        .unwrap();
+
+        // Which positions contributed: exactly [warmup .. seq - 1).
+        let expected_count = (seq - 1).saturating_sub(warmup);
+        assert_eq!(
+            count, expected_count,
+            "warmup {warmup}: scored positions must be [warmup .. seq-1)"
+        );
+
+        // What each contributed: the NLL of win[t + 1] under row t.
+        let mut expected_nll = 0.0_f64;
+        for t in warmup..(seq - 1) {
+            let row = &flat[t * VOCAB..(t + 1) * VOCAB];
+            expected_nll += f64::from(neg_log_softmax_at(row, win[t + 1] as usize));
+        }
+        assert!(
+            (sum_nll - expected_nll).abs() < 1e-6,
+            "warmup {warmup}: sum_nll {sum_nll} != {expected_nll} — the scored \
+             target or the scored row is wrong"
+        );
+    }
+
+    // The shift is what separates this from scoring each position against its
+    // own logits, so state that the two differ on this fixture at all.
+    let mut self_scored = 0.0_f64;
+    for t in 0..(seq - 1) {
+        let row = &flat[t * VOCAB..(t + 1) * VOCAB];
+        self_scored += f64::from(neg_log_softmax_at(row, win[t] as usize));
+    }
+    let mut host: Vec<f32> = Vec::new();
+    let mut sum_nll = 0.0_f64;
+    let mut count = 0_usize;
+    score_window_cacheless(&logits, &win, 0, VOCAB, &mut host, &mut sum_nll, &mut count).unwrap();
+    assert!(
+        (sum_nll - self_scored).abs() > 1e-3,
+        "the fixture cannot tell win[t+1] from win[t] and so cannot gate the shift"
+    );
 }

--- a/crates/rmlx-models/src/qwen3_5_moe/model.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/model.rs
@@ -266,19 +266,14 @@ impl Qwen3_5MoeText {
         let ids_i32: Vec<i32> = ids.iter().map(|&x| x as i32).collect();
         let ids_arr = Array::from_i32_slice(&ids_i32, &[seq_i32])?;
 
-        let shared_mask: Option<Array> =
-            if crate::layers::pick_attn_mask_mode(0, seq_i32) == "array" {
-                Some(crate::layers::build_chunked_prefill_mask(
-                    0, seq_i32, device,
-                )?)
-            } else {
-                None
-            };
-
         let h = self.embed_tokens.forward(&ids_arr, device)?;
         let mut h = h.reshape(&[1, seq_i32, self.cfg.hidden_size as i32], device)?;
+        // No prebuilt mask. `pick_attn_mask_mode` answers "causal" for every
+        // `seq` once the offset is 0, so there is no array mask to share;
+        // `forward_arr` builds one because its offset is a runtime value, and
+        // here it is the literal 0.
         for layer in &self.layers {
-            h = layer.forward(&h, 0, None, None, shared_mask.as_ref(), device)?;
+            h = layer.forward(&h, 0, None, None, None, device)?;
         }
         let h = self.final_norm.forward(&h, device)?;
 

--- a/crates/rmlx-models/src/qwen3_5_moe/model.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/model.rs
@@ -245,6 +245,49 @@ impl Qwen3_5MoeText {
         }
     }
 
+    /// Full-sequence forward returning logits at **every** position, shape
+    /// `[1, seq, vocab_size]`. The offline PPL scorer reads the per-position
+    /// log-likelihood of the actual corpus token off this tensor.
+    ///
+    /// Both cache kinds are absent, which on this hybrid means two different
+    /// things: the FullAttention layers recompute K/V inside the window, and
+    /// the GatedDeltaNet layers start from a zero conv tail and zero delta
+    /// state. Together that scores the window as a fresh document, which is
+    /// what a sliding-window scorer needs and what the same call on the two
+    /// non-hybrid architectures already gives.
+    pub fn forward_seq_logits_all(&self, ids: &[u32], device: Device) -> Result<Array> {
+        let seq = ids.len();
+        if seq == 0 {
+            return Err(rmlx_core::error::Error::Model(
+                "forward_seq_logits_all: empty prompt".to_owned(),
+            ));
+        }
+        let seq_i32 = seq as i32;
+        let ids_i32: Vec<i32> = ids.iter().map(|&x| x as i32).collect();
+        let ids_arr = Array::from_i32_slice(&ids_i32, &[seq_i32])?;
+
+        let shared_mask: Option<Array> =
+            if crate::layers::pick_attn_mask_mode(0, seq_i32) == "array" {
+                Some(crate::layers::build_chunked_prefill_mask(
+                    0, seq_i32, device,
+                )?)
+            } else {
+                None
+            };
+
+        let h = self.embed_tokens.forward(&ids_arr, device)?;
+        let mut h = h.reshape(&[1, seq_i32, self.cfg.hidden_size as i32], device)?;
+        for layer in &self.layers {
+            h = layer.forward(&h, 0, None, None, shared_mask.as_ref(), device)?;
+        }
+        let h = self.final_norm.forward(&h, device)?;
+
+        match &self.lm_head {
+            Some(lm) => lm.forward(&h, device),
+            None => self.embed_tokens.as_linear(&h, device),
+        }
+    }
+
     /// Cache-using forward returning logits at the **last `k` positions**
     /// (L36 Phase 4 — speculative verifier path).
     ///

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -1040,7 +1040,17 @@ fn load_dflash(draft_dir: &Path, hidden_size: usize, device: Device) -> Result<D
     let shards = ShardSet::open(draft_dir, &idx)
         .map_err(|e| Error::Model(format!("DFlashDrafter: open: {e}")))?;
 
+    // Which tensor names the loader actually consumed. A drafter checkpoint of
+    // a later DFlash generation carries families this loader has no code for
+    // (a candidate selector, per-layer dynamic convolutions); loading it then
+    // silently yields the earlier architecture built out of the subset it does
+    // recognise, running at an accept rate that is not the checkpoint's. The
+    // set is compared against the snapshot below so that downgrade is stated.
+    let consumed: std::cell::RefCell<std::collections::HashSet<String>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+
     let load = |name: &str| -> Result<Array> {
+        consumed.borrow_mut().insert(name.to_owned());
         for (_, handle) in shards.iter() {
             let st = handle
                 .safetensors()
@@ -1109,6 +1119,29 @@ fn load_dflash(draft_dir: &Path, hidden_size: usize, device: Device) -> Result<D
                 activation: Activation::Silu,
             },
         });
+    }
+
+    let mut unread: Vec<String> = Vec::new();
+    for (_, handle) in shards.iter() {
+        let st = handle
+            .safetensors()
+            .map_err(|e| Error::Model(format!("DFlashDrafter: safetensors: {e}")))?;
+        for name in st.names() {
+            if !consumed.borrow().contains(name) {
+                unread.push(name.to_owned());
+            }
+        }
+    }
+    if !unread.is_empty() {
+        unread.sort();
+        tracing::warn!(
+            unread_count = unread.len(),
+            unread = ?unread,
+            "DFlashDrafter: the snapshot carries tensors this loader does not read; \
+             the drafter built from it is the architecture this loader implements, \
+             not the one the checkpoint was trained as, and its accept rate is that \
+             drafter's rather than the checkpoint's"
+        );
     }
 
     // YARN RoPE: the Qwen3.6 DFlash drafter is trained with rope_scaling

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -972,7 +972,7 @@ pub fn dflash_generate_greedy(
 /// `Result` rather than an `Option<Error>` so a call site that stops propagating
 /// it is an `unused_must_use` warning, which `-D warnings` turns into a build
 /// failure — the guard cannot be un-wired quietly.
-fn unread_tensor_refusal(present: &[String], consumed: &HashSet<String>) -> Result<()> {
+fn unread_tensor_refusal(present: &HashSet<String>, consumed: &HashSet<String>) -> Result<()> {
     let mut unread: Vec<&str> = present
         .iter()
         .map(String::as_str)
@@ -1159,7 +1159,9 @@ fn load_dflash(draft_dir: &Path, hidden_size: usize, device: Device) -> Result<D
         });
     }
 
-    let mut present: Vec<String> = Vec::new();
+    // A set, not a list: a name carried by two shard files would otherwise be
+    // counted and listed twice in the refusal.
+    let mut present: HashSet<String> = HashSet::new();
     for (_, handle) in shards.iter() {
         let st = handle
             .safetensors()

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -64,6 +64,8 @@
 // description has to match them. Applying the boundary promotion here would
 // change the codec of a stack whose only reader is the round that built it.
 
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::path::Path;
 
 use rmlx_core::error::{Error, Result};
@@ -954,6 +956,43 @@ pub fn dflash_generate_greedy(
 // Loader
 // ---------------------------------------------------------------------------
 
+/// Refuse a snapshot carrying tensors this loader never reads.
+///
+/// A DFlash checkpoint of a later generation ships weight families this loader
+/// has no code for — a candidate selector, per-layer dynamic convolutions.
+/// Building the drafter out of the remainder yields **this loader's**
+/// architecture wearing the checkpoint's name, and the accept rate measured
+/// from it is filed under that name: `decode_config` records `dflash/block=N`
+/// either way and cannot tell the two apart, so the row outlives any warning
+/// and cannot be re-attributed afterwards. Refusing is what keeps that row from
+/// being written; it costs the supported checkpoint nothing, which reads every
+/// tensor it ships.
+///
+/// `Ok(())` means every tensor in the snapshot was consumed. It returns a
+/// `Result` rather than an `Option<Error>` so a call site that stops propagating
+/// it is an `unused_must_use` warning, which `-D warnings` turns into a build
+/// failure — the guard cannot be un-wired quietly.
+fn unread_tensor_refusal(present: &[String], consumed: &HashSet<String>) -> Result<()> {
+    let mut unread: Vec<&str> = present
+        .iter()
+        .map(String::as_str)
+        .filter(|name| !consumed.contains(*name))
+        .collect();
+    if unread.is_empty() {
+        return Ok(());
+    }
+    unread.sort_unstable();
+    Err(Error::Model(format!(
+        "DFlashDrafter: the snapshot carries {} tensors this loader does not read \
+         ({}); the drafter built from the rest would be this loader's architecture \
+         and not the checkpoint's, and any accept rate measured from it would be \
+         recorded under the checkpoint's name with nothing in the row to say so. \
+         Refusing rather than serving a drafter that is not the one named.",
+        unread.len(),
+        unread.join(", ")
+    )))
+}
+
 /// Load the DFlash drafter tensors + config from `draft_dir`.
 #[allow(
     clippy::indexing_slicing,
@@ -1046,8 +1085,7 @@ fn load_dflash(draft_dir: &Path, hidden_size: usize, device: Device) -> Result<D
     // silently yields the earlier architecture built out of the subset it does
     // recognise, running at an accept rate that is not the checkpoint's. The
     // set is compared against the snapshot below so that downgrade is stated.
-    let consumed: std::cell::RefCell<std::collections::HashSet<String>> =
-        std::cell::RefCell::new(std::collections::HashSet::new());
+    let consumed: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
 
     let load = |name: &str| -> Result<Array> {
         consumed.borrow_mut().insert(name.to_owned());
@@ -1121,28 +1159,14 @@ fn load_dflash(draft_dir: &Path, hidden_size: usize, device: Device) -> Result<D
         });
     }
 
-    let mut unread: Vec<String> = Vec::new();
+    let mut present: Vec<String> = Vec::new();
     for (_, handle) in shards.iter() {
         let st = handle
             .safetensors()
             .map_err(|e| Error::Model(format!("DFlashDrafter: safetensors: {e}")))?;
-        for name in st.names() {
-            if !consumed.borrow().contains(name) {
-                unread.push(name.to_owned());
-            }
-        }
+        present.extend(st.names().into_iter().map(ToOwned::to_owned));
     }
-    if !unread.is_empty() {
-        unread.sort();
-        tracing::warn!(
-            unread_count = unread.len(),
-            unread = ?unread,
-            "DFlashDrafter: the snapshot carries tensors this loader does not read; \
-             the drafter built from it is the architecture this loader implements, \
-             not the one the checkpoint was trained as, and its accept rate is that \
-             drafter's rather than the checkpoint's"
-        );
-    }
+    unread_tensor_refusal(&present, &consumed.borrow())?;
 
     // YARN RoPE: the Qwen3.6 DFlash drafter is trained with rope_scaling
     // {rope_type: yarn}. Precompute its inverse-freq table + mscale so the

--- a/crates/rmlx-models/src/speculative/dflash/tests.rs
+++ b/crates/rmlx-models/src/speculative/dflash/tests.rs
@@ -213,7 +213,7 @@ fn a_snapshot_this_loader_only_half_reads_is_refused_and_a_whole_one_is_not() {
     let consumed: HashSet<String> = read_by_the_loader.iter().map(|s| (*s).to_owned()).collect();
 
     // Every tensor consumed — the shape of the DFlash 1 checkpoint.
-    let whole: Vec<String> = read_by_the_loader.iter().map(|s| (*s).to_owned()).collect();
+    let whole: HashSet<String> = read_by_the_loader.iter().map(|s| (*s).to_owned()).collect();
     assert!(
         unread_tensor_refusal(&whole, &consumed).is_ok(),
         "a snapshot the loader reads entirely must load"
@@ -221,8 +221,8 @@ fn a_snapshot_this_loader_only_half_reads_is_refused_and_a_whole_one_is_not() {
 
     // Extra weight families — the shape of the DFlash 2 checkpoint.
     let mut partial = whole;
-    partial.push("candidate_selector.successor_codebook".to_owned());
-    partial.push("layers.0.attention_conv.base_kernel".to_owned());
+    partial.insert("candidate_selector.successor_codebook".to_owned());
+    partial.insert("layers.0.attention_conv.base_kernel".to_owned());
     let err = unread_tensor_refusal(&partial, &consumed).unwrap_err();
     let msg = err.to_string();
     assert!(

--- a/crates/rmlx-models/src/speculative/dflash/tests.rs
+++ b/crates/rmlx-models/src/speculative/dflash/tests.rs
@@ -193,3 +193,49 @@ fn dflash_module_compiles() {
     let _snap = DFlashRoundState::snapshot;
     let _ = (_load, _bs, _walk, _snap);
 }
+
+// --- unread_tensor_refusal ---
+
+/// A snapshot every tensor of which was read loads; one carrying tensors this
+/// loader has no code for is refused, naming them.
+///
+/// Both directions, because the quiet direction is what keeps the check from
+/// decaying into noise a reader learns to skip. Mutation this fails on:
+/// `!consumed.contains(name)` -> `consumed.contains(name)`, which refuses the
+/// supported checkpoint and admits the unsupported one.
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions: panicking on unexpected values is intentional"
+)]
+fn a_snapshot_this_loader_only_half_reads_is_refused_and_a_whole_one_is_not() {
+    let read_by_the_loader = ["fc.weight", "hidden_norm.weight", "norm.weight"];
+    let consumed: HashSet<String> = read_by_the_loader.iter().map(|s| (*s).to_owned()).collect();
+
+    // Every tensor consumed — the shape of the DFlash 1 checkpoint.
+    let whole: Vec<String> = read_by_the_loader.iter().map(|s| (*s).to_owned()).collect();
+    assert!(
+        unread_tensor_refusal(&whole, &consumed).is_ok(),
+        "a snapshot the loader reads entirely must load"
+    );
+
+    // Extra weight families — the shape of the DFlash 2 checkpoint.
+    let mut partial = whole;
+    partial.push("candidate_selector.successor_codebook".to_owned());
+    partial.push("layers.0.attention_conv.base_kernel".to_owned());
+    let err = unread_tensor_refusal(&partial, &consumed).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains('2'),
+        "refusal must count the unread tensors: {msg}"
+    );
+    assert!(
+        msg.contains("candidate_selector.successor_codebook")
+            && msg.contains("layers.0.attention_conv.base_kernel"),
+        "refusal must name the unread tensors: {msg}"
+    );
+    assert!(
+        !msg.contains("fc.weight"),
+        "a consumed tensor must not be reported unread: {msg}"
+    );
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1284,7 +1284,11 @@ One-shot idempotent ingestion of legacy JSONL/CSV/Markdown into the DB.
 ### `eval ppl`
 
 Computes perplexity over a text corpus using sliding-window NLL. Supported
-models: Qwen3 family (Bonsai is the smoke target).
+models: Qwen3, Gemma4 and Qwen3.5 (dense and MoE). Bonsai is the smoke
+target. The KV-codec flags below reach the cached scorer, which Qwen3.5 does
+not have — there its GatedDeltaNet layers carry a recurrent state no codec
+touches, so the command refuses rather than reporting a number that describes
+only the full-attention layers.
 
 Prints one JSON line to stdout:
 ```text

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -570,7 +570,7 @@ Source of truth for `observations.metric`, `.unit`, `.direction`. Add to this ta
 | `ssd_hydrate_ms`                 | `ms`    | `lower_better`  | SSD-tier: raw per-hydrate duration observation (on request thread, RAM-miss cold path). One SQLite row per event. Real p50/p99 aggregation via Prometheus histogram `rmlx_ssd_hydrate_us_bucket`. rmlx-only. |
 | `ssd_spill_mb_per_s`             | `mb/s`  | `higher_better` | SSD-tier: spill throughput (bytes_written / dur_us). rmlx-only. |
 | `ssd_hydrate_mb_per_s`           | `mb/s`  | `higher_better` | SSD-tier: hydrate throughput (bytes_read / dur_us). rmlx-only. |
-| `ppl_wikitext2`                  | `ppl`   | `lower_better`  | Sliding-window perplexity over the wikitext-2 raw test split, computed by `rmlx eval ppl`. Architecture support: Qwen3 only (HTTP `echo` follow-up will widen coverage). rmlx-only. |
+| `ppl_wikitext2`                  | `ppl`   | `lower_better`  | Sliding-window perplexity over the wikitext-2 raw test split, computed by `rmlx eval ppl`. Architecture support: Qwen3, Gemma4, Qwen3.5. rmlx-only. |
 | `ppl_mean_nll`                   | `nat`   | `lower_better`  | Per-token mean negative log-likelihood from the same scorer (natural-log nats). Audit field paired with `ppl_*`. rmlx-only. |
 | `ppl_scored_tokens`              | `count` | `higher_better` | Number of corpus positions scored. Audit field. rmlx-only. |
 | `ppl_windows`                    | `count` | `higher_better` | Number of sliding-window forwards the scorer ran. Audit field. rmlx-only. |
@@ -736,6 +736,26 @@ because nothing enforces it.
   WHERE metric = 'ppl_wikitext2'
     AND ts_utc >= '2026-09-03'
     AND prompt_id IN (SELECT id FROM prompts WHERE name LIKE 'wikitext-2_ctx2048%');
+  ```
+
+- **Every `ppl_wikitext2` / `ppl_wikitext2_cached` row taken before the
+  sliding walk's warm-up was corrected** — the non-BOS scorer skipped
+  `ctx_window - stride` leading slots per window where the slot that scores
+  the first unseen corpus position is `ctx_window - stride - 1`, so exactly
+  one corpus position per window boundary was never scored. At the default
+  `--ctx-window 4096 --stride 2048` that is one position in 2048 (0.05% of
+  the denominator) and the resulting shift in `ppl` is far under any gate it
+  has been used for; at `stride == 1` it was total, every window after the
+  first scoring nothing. The Gemma4 scorer was always correct — it prepends
+  BOS, which shifts each target one slot, and it subtracted the one. Rows
+  before and after the correction are the same metric measured over denominators
+  differing by `(windows - 1)` positions; compare them, but do not read a
+  sub-0.1% delta between two eras as a model difference.
+
+  ```sql
+  SELECT * FROM observations
+  WHERE metric LIKE 'ppl_wikitext2%'
+    AND ts_utc < '2026-09-05';
   ```
 
 - **Two synthetic rows from an ingest-refusal probe** — a review of the

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -738,29 +738,42 @@ because nothing enforces it.
     AND prompt_id IN (SELECT id FROM prompts WHERE name LIKE 'wikitext-2_ctx2048%');
   ```
 
-- **35 `ppl_*` rows on `Ternary-Bonsai-8B-mlx-2bit`, scored with a warm-up one
-  slot too late** — the non-BOS scorer skipped `ctx_window - stride` leading
-  slots where the slot that scores the first unseen corpus position is
+- **35 `ppl_*` rows (7 runs) on `Ternary-Bonsai-8B-mlx-2bit`, scored with a
+  warm-up one slot too late** — the non-BOS scorer skipped `ctx_window - stride`
+  leading slots where the slot that scores the first unseen corpus position is
   `ctx_window - stride - 1`, so exactly one corpus position per window boundary
   was never scored. `ppl_scored_tokens` is the metric that moved most: it *is*
   the denominator that changed, by `windows - 1`, and `ppl_mean_nll` and
   `ppl_windows` come off the same runs — which is why the predicate below covers
   the whole `ppl_` family and not just the headline metric.
 
+  The arithmetic, all in rows (a run files five `ppl_*` rows, so run counts are
+  a fifth of these and mixing the two units is what makes the subtraction look
+  wrong): **365 total − 230 Gemma4 − 80 at `stride == ctx_window` − 20 post-fix
+  = 35**.
+
   **Three conditions, all necessary**, and the selector is narrow because a
   predicate that flags good rows is one readers learn to ignore:
 
-  - **Not Gemma4.** That scorer prepends BOS, which shifts each target one slot,
-    and it already subtracted the one. It was always correct. 46 rows.
+  - **Not the Gemma4 scorer.** It prepends BOS, which shifts each target one
+    slot, and it already subtracted the one. It was always correct. 230 rows
+    (46 runs). The predicate names the affected model rather than excluding a
+    `gemma%` prefix: `medgemma-1.5-4b-it-8bit` is already in `observations` and
+    does not start with `gemma`, so a prefix test would flag its future `ppl_*`
+    rows as affected — the exact over-selection this entry exists to avoid.
   - **`stride < ctx_window`.** At `stride == ctx_window` the old expression gives
     `ctx_window - stride = 0` and the new gives `0.saturating_sub(1) = 0`:
     identical, and the scored sets are byte-identical. The whole `2026-09-03`
-    Bonsai batch is in that case. 16 rows.
+    Bonsai batch is in that case. 80 rows (16 runs). `COALESCE(notes, '')`
+    because a bare `LIKE` against a NULL `notes` evaluates to NULL and drops the
+    row from the affected set — a fail-open in the direction that matters, and
+    this predicate is the durable artifact.
   - **A pre-fix binary.** `git_sha` is the discriminator, not the date. This
     change was made on a branch, so a run from a pre-fix binary *after* the fix
     landed files an affected row that no date predicate catches; the four shas
     below are what the DB holds today, and a fifth would have to be added here
-    rather than inferred. No affected row has a NULL `git_sha`.
+    rather than inferred. 20 rows (4 runs) carry the post-fix sha. No affected
+    row has a NULL `git_sha`.
 
   At the default `--ctx-window 4096 --stride 2048` the effect is one position in
   2048 — 0.05% of the denominator — and the resulting shift in `ppl` is far under
@@ -770,8 +783,9 @@ because nothing enforces it.
   ```sql
   SELECT * FROM observations
   WHERE metric LIKE 'ppl_%'
-    AND model NOT LIKE 'gemma%'
-    AND notes NOT LIKE '%ctx_window=' || ctx_max || ' stride=' || ctx_max || '%'
+    AND model = 'Ternary-Bonsai-8B-mlx-2bit'
+    AND COALESCE(notes, '') NOT LIKE
+        '%ctx_window=' || ctx_max || ' stride=' || ctx_max || '%'
     AND git_sha IN ('2bcf206', '2bcf206-dirty', '6eeb4ae-dirty', 'a71d88b-dirty');
   ```
 

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -738,36 +738,55 @@ because nothing enforces it.
     AND prompt_id IN (SELECT id FROM prompts WHERE name LIKE 'wikitext-2_ctx2048%');
   ```
 
-- **Every `ppl_wikitext2` / `ppl_wikitext2_cached` row taken before the
-  sliding walk's warm-up was corrected** — the non-BOS scorer skipped
-  `ctx_window - stride` leading slots per window where the slot that scores
-  the first unseen corpus position is `ctx_window - stride - 1`, so exactly
-  one corpus position per window boundary was never scored. At the default
-  `--ctx-window 4096 --stride 2048` that is one position in 2048 (0.05% of
-  the denominator) and the resulting shift in `ppl` is far under any gate it
-  has been used for; at `stride == 1` it was total, every window after the
-  first scoring nothing. The Gemma4 scorer was always correct — it prepends
-  BOS, which shifts each target one slot, and it subtracted the one. Rows
-  before and after the correction are the same metric measured over denominators
-  differing by `(windows - 1)` positions; compare them, but do not read a
-  sub-0.1% delta between two eras as a model difference.
+- **35 `ppl_*` rows on `Ternary-Bonsai-8B-mlx-2bit`, scored with a warm-up one
+  slot too late** — the non-BOS scorer skipped `ctx_window - stride` leading
+  slots where the slot that scores the first unseen corpus position is
+  `ctx_window - stride - 1`, so exactly one corpus position per window boundary
+  was never scored. `ppl_scored_tokens` is the metric that moved most: it *is*
+  the denominator that changed, by `windows - 1`, and `ppl_mean_nll` and
+  `ppl_windows` come off the same runs — which is why the predicate below covers
+  the whole `ppl_` family and not just the headline metric.
+
+  **Three conditions, all necessary**, and the selector is narrow because a
+  predicate that flags good rows is one readers learn to ignore:
+
+  - **Not Gemma4.** That scorer prepends BOS, which shifts each target one slot,
+    and it already subtracted the one. It was always correct. 46 rows.
+  - **`stride < ctx_window`.** At `stride == ctx_window` the old expression gives
+    `ctx_window - stride = 0` and the new gives `0.saturating_sub(1) = 0`:
+    identical, and the scored sets are byte-identical. The whole `2026-09-03`
+    Bonsai batch is in that case. 16 rows.
+  - **A pre-fix binary.** `git_sha` is the discriminator, not the date. This
+    change was made on a branch, so a run from a pre-fix binary *after* the fix
+    landed files an affected row that no date predicate catches; the four shas
+    below are what the DB holds today, and a fifth would have to be added here
+    rather than inferred. No affected row has a NULL `git_sha`.
+
+  At the default `--ctx-window 4096 --stride 2048` the effect is one position in
+  2048 — 0.05% of the denominator — and the resulting shift in `ppl` is far under
+  any gate it has been used for. At `stride == 1` it was total: every window
+  after the first scored nothing.
 
   ```sql
   SELECT * FROM observations
-  WHERE metric LIKE 'ppl_wikitext2%'
-    AND ts_utc < '2026-09-05';
+  WHERE metric LIKE 'ppl_%'
+    AND model NOT LIKE 'gemma%'
+    AND notes NOT LIKE '%ctx_window=' || ctx_max || ' stride=' || ctx_max || '%'
+    AND git_sha IN ('2bcf206', '2bcf206-dirty', '6eeb4ae-dirty', 'a71d88b-dirty');
   ```
 
-- **`dflash/*` rows measured against a DFlash 2 checkpoint** — the drafter
-  loader implements the earlier DFlash architecture and reads none of the
-  candidate-selector or per-layer dynamic-convolution tensors a DFlash 2
-  snapshot ships. It builds the drafter it can build out of the rest and serves,
-  so the rows are honest measurements of *that* drafter and are not measurements
+- **`dflash/*` rows on `Qwen3.8-27B-4bit`, measured against a DFlash 2
+  checkpoint** — the drafter loader implements the earlier DFlash architecture
+  and reads none of the candidate-selector or per-layer dynamic-convolution
+  tensors a DFlash 2 snapshot ships. It used to build the drafter out of the
+  rest and serve, so the rows are honest measurements of *that* drafter and not
   of the published one. `decode_config` says `dflash/block=N` either way and
-  cannot tell them apart; the load now names the tensors it did not read, so a
-  run log can. On `Qwen3.8-27B-4bit` those are the `2026-09-04` block-16 rows and
-  the `2026-09-05` block-8 ones. Do not compare them against a row taken once the
-  full drafter is implemented.
+  cannot tell them apart, which is why the loader now refuses such a snapshot
+  outright: no further row of this kind can be written. The `2026-09-04`
+  block-16 rows and the `2026-09-05` block-8 ones are the ones already here. Do
+  not compare them against a row taken once the full drafter is implemented.
+  `z-lab/Qwen3.6-35B-A3B-DFlash` reads every tensor it ships and is unaffected
+  by the refusal.
 
   ```sql
   SELECT * FROM observations

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -758,6 +758,23 @@ because nothing enforces it.
     AND ts_utc < '2026-09-05';
   ```
 
+- **`dflash/*` rows measured against a DFlash 2 checkpoint** — the drafter
+  loader implements the earlier DFlash architecture and reads none of the
+  candidate-selector or per-layer dynamic-convolution tensors a DFlash 2
+  snapshot ships. It builds the drafter it can build out of the rest and serves,
+  so the rows are honest measurements of *that* drafter and are not measurements
+  of the published one. `decode_config` says `dflash/block=N` either way and
+  cannot tell them apart; the load now names the tensors it did not read, so a
+  run log can. On `Qwen3.8-27B-4bit` those are the `2026-09-04` block-16 rows and
+  the `2026-09-05` block-8 ones. Do not compare them against a row taken once the
+  full drafter is implemented.
+
+  ```sql
+  SELECT * FROM observations
+  WHERE decode_config LIKE 'dflash/%'
+    AND model = 'Qwen3.8-27B-4bit';
+  ```
+
 - **Two synthetic rows from an ingest-refusal probe** — a review of the
   boundary-layer work exercised the ingest path's refusals by handing it
   near-real records, and two of them were accepted instead of refused. They

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -290,7 +290,8 @@ at temp=0.
 One backbone, three checkpoint shapes — all route to `Architecture::Qwen3_5Moe`:
 
 - **Dense mxfp8 / affine** (`Qwen3_5ForConditionalGeneration`, e.g.
-  `ornith-1.0-9b-mxfp8`) — a plain SwiGLU MLP per layer.
+  `ornith-1.0-9b-mxfp8`, `Qwen3.8-27B-mxfp8`, `Qwen3.8-27B-4bit`) — a plain
+  SwiGLU MLP per layer.
 - **Sparse MoE mxfp8 / affine** (`Qwen3_5MoeForConditionalGeneration`, e.g.
   `ornith-1.0-35b-mxfp8`, `Qwen3.6-35B-A3B`) — `switch_mlp` + `shared_expert` + router.
 - **PARO INT4 dense** (`Qwen3_5ForConditionalGeneration` with a

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -999,6 +999,56 @@ No-drafter baseline 18.98 (code) / 18.77 (prose) / 18.74 (4k) decode TPS.
 | 3 | prose | 0.559 | 0.98× |
 | 3 | 4k | 0.526 | 0.92× |
 
+### Qwen3.8-27B-4bit — MTP sidecar (GDN hybrid, dense)
+
+The published affine-4-bit verifier (`mlx-community/Qwen3.8-27B-4bit`, group 64)
+with its own 4-bit sidecar (`mlx-community/Qwen3.8-27B-MTP-4bit`, `block_size: 3`).
+Same backbone as the mxfp8 rows above at 15.5 GB of resident weights against
+27.7, so the verifier's own step is 1.70× faster here (31.4 against 18.4 decode
+TPS at a 3 892-token prompt, `--kv-quant none`, three runs each) and every fixed
+cost in the round loop is a correspondingly larger share of a round.
+
+No-drafter baseline 32.45 (code) / 32.53 (prose) / 32.03 (4k) decode TPS, each
+measured in the same `scripts/spec_bench.sh` run as the speculative arm beside it.
+
+| Block | Prompt | Accept rate | tokens/round | Decode vs no drafter |
+|---|---|---|---|---|
+| 2 | code | 0.730 | 1.72 | **1.19×** |
+| 2 | 4k | 0.712 | 1.71 | **1.19×** |
+| 2 | prose | 0.608 | 1.61 | 1.04× |
+| 3 | code | 0.576 | 2.15 | 1.11× |
+| 3 | 4k | 0.516 | 2.02 | 0.99× |
+| 3 | prose | 0.477 | 1.95 | 0.95× |
+
+**The drafter does care about the verifier's weight format.** The same sidecar
+architecture against the mxfp8 verifier accepts 0.877 on code at block 2 and
+returns 1.36×; here it accepts 0.730 and returns 1.19×. Acceptance is a
+comparison against the *verifier's* argmax, so re-quantizing the verifier moves
+the target the drafter is being scored against — and the sidecar was
+re-quantized with it, which this pairing cannot separate from that. The speedup
+falls further than the accept rate does, because a 1.70× faster verifier step
+does not make the rollback, the GDN snapshot/restore and the acceptance walk any
+faster: `loop_ms_per_round` is 14.6 ms of a 44.4 ms round at block 2 and 25.1 ms
+of a 63.4 ms round at block 3, a third to two fifths of the round in a residual
+that produces no tokens.
+
+**DFlash on this verifier is not the DFlash 2 algorithm.** `z-lab/Qwen3.8-27B-DFlash2`
+loads, drafts and accepts — 0.530 accept, 2.59 tokens/round, 0.91× on code at
+block 8 — but 23 of its tensors are families this loader has no code for (a
+candidate selector and per-layer two-tap dynamic convolutions), and it names
+them at load. What that row measures is this engine's DFlash drafter built out of
+the subset of a DFlash 2 checkpoint it recognises. It is not a reading of the
+published drafter and must not be quoted as one.
+
+**And that arm does not reproduce its verifier's answer.** At temperature 0 on
+the code prompt it diverges from the no-drafter arm at the fourth token and stays
+diverged, where the MTP sidecar on the same verifier and prompt is byte-identical
+over 160 tokens. Greedy acceptance emits only the verifier's argmax, so no
+drafter — however badly it proposes, and whatever tensors it was built without —
+can change the answer; a changed answer is the round loop. The DFlash loop is one
+of the three the answer-equivalence gate does not cover
+(`docs/SPEC_ANSWER_EQUIVALENCE.md` § What it runs).
+
 ### Qwen3.6-35B-A3B-8bit — three drafters (GDN hybrid, MoE)
 
 No-drafter baseline 102.7 (code) / 102.7 (prose) / 100.0 (paris) / 98.7 (4k)
@@ -1034,11 +1084,12 @@ No-drafter baseline 83.6 (code) / 83.2 (prose) / 79.1 (4k) decode TPS.
 - **MTP pays on both GDN hybrids and is the only drafter that does.** On the MoE
   it wins every prompt class at the shipped block size. On the dense 27B it wins
   every prompt class at block 2 and only the code class at block 3.
-- **`--draft-block-size` is capped by the sidecar's own `block_size`, and both
-  shipped Qwen3.5-family MTP sidecars omit that key** — so they take the loader
-  default of 3 and any request above 3 is silently the same run. Block 2 and
+- **`--draft-block-size` is capped by the sidecar's own `block_size`, and every
+  shipped Qwen3.5-family MTP sidecar declares that key as 3** — the Qwen3.6-35B
+  5-bit one and both Qwen3.8-27B ones, which is also the loader's default when
+  the key is absent. Any request above 3 is silently the same run. Block 2 and
   block 3 are the only two settings those pairs have, and 2 measured faster than
-  3 on all three prompt classes for Qwen3.8-27B. The `block_size` field on the
+  3 on all three prompt classes for Qwen3.8-27B at both weight formats. The `block_size` field on the
   `mtp_generate_greedy: done` line reports the value actually used.
 - **DFlash and EAGLE-3 are net decode losses on this verifier at every prompt
   class measured**, DFlash by 3-22% and EAGLE-3 by 26-39%. Both run correctly and

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -1032,22 +1032,27 @@ faster: `loop_ms_per_round` is 14.6 ms of a 44.4 ms round at block 2 and 25.1 ms
 of a 63.4 ms round at block 3, a third to two fifths of the round in a residual
 that produces no tokens.
 
-**DFlash on this verifier is not the DFlash 2 algorithm.** `z-lab/Qwen3.8-27B-DFlash2`
-loads, drafts and accepts — 0.530 accept, 2.59 tokens/round, 0.91× on code at
-block 8 — but 23 of its tensors are families this loader has no code for (a
-candidate selector and per-layer two-tap dynamic convolutions), and it names
-them at load. What that row measures is this engine's DFlash drafter built out of
-the subset of a DFlash 2 checkpoint it recognises. It is not a reading of the
-published drafter and must not be quoted as one.
+**DFlash 2 on this verifier is refused at load, and the numbers below predate
+the refusal.** 23 of `z-lab/Qwen3.8-27B-DFlash2`'s tensors are weight families
+this loader has no code for — a candidate selector and per-layer two-tap dynamic
+convolutions. It used to build the earlier DFlash architecture out of the
+remainder and serve: 0.530 accept, 2.59 tokens/round, 0.91× on code at block 8.
+Those figures are this engine's DFlash drafter wearing the checkpoint's name, and
+`decode_config` records `dflash/block=8` either way, so a row of them cannot be
+told from a row of the real drafter afterwards. The loader now refuses, naming
+the count and the tensors. `z-lab/Qwen3.6-35B-A3B-DFlash` reads every tensor it
+ships and is unaffected.
 
-**And that arm does not reproduce its verifier's answer.** At temperature 0 on
-the code prompt it diverges from the no-drafter arm at the fourth token and stays
-diverged, where the MTP sidecar on the same verifier and prompt is byte-identical
-over 160 tokens. Greedy acceptance emits only the verifier's argmax, so no
-drafter — however badly it proposes, and whatever tensors it was built without —
-can change the answer; a changed answer is the round loop. The DFlash loop is one
-of the three the answer-equivalence gate does not cover
-(`docs/SPEC_ANSWER_EQUIVALENCE.md` § What it runs).
+**That arm also did not reproduce its verifier's answer.** At temperature 0 on
+the code prompt it diverged from the no-drafter arm at the fourth token and
+stayed diverged, where the MTP sidecar on the same verifier and prompt is
+byte-identical over 160 tokens. Greedy acceptance emits only the verifier's
+argmax, so no drafter — however badly it proposes, and whatever tensors it was
+built without — can change the answer; a changed answer is the round loop, and
+the DFlash loop is one of the three the answer-equivalence gate does not cover
+(`docs/SPEC_ANSWER_EQUIVALENCE.md` § What it runs). Reproducing it on this pair
+now means lifting the refusal; the Qwen3.6 DFlash drafter still loads and drives
+the same loop.
 
 ### Qwen3.6-35B-A3B-8bit — three drafters (GDN hybrid, MoE)
 

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -56,6 +56,23 @@ runs by default. Closing it needs either the census analysis extended to this
 kernel and model, or a stable count — neither of which this change is the place
 for.
 
+**Three of the five round loops are outside the gate entirely.** It covers the
+Gemma4 assistant loop and the Qwen3.5-family MTP sidecar loop. The DFlash,
+EAGLE-3 and two-model loops have no pair here, and the property is not
+transitive across loops — each one has its own rollback and its own acceptance
+walk, which is what the gate reads.
+
+That boundary is not hypothetical. Served at temperature 0 on the code prompt,
+`Qwen3.8-27B-4bit` drafted by `z-lab/Qwen3.8-27B-DFlash2` at block 8 diverges
+from the same verifier's no-drafter answer at the fourth token — "We need to
+respond to user:" against "We need answer user's request:" — and stays diverged;
+the MTP sidecar on the same verifier, same prompt and same 160-token budget is
+byte-identical to it. A greedy speculative loop can only emit the verifier's own
+argmax, so a drafter proposing badly costs throughput and cannot change the
+answer. A changed answer is the loop, not the drafter, and this one is uncovered.
+That the drafter is also being loaded as an earlier architecture than the
+checkpoint (see `docs/SPECULATIVE.md` § Qwen3.8-27B-4bit) does not explain it.
+
 ## The oracle: where a correct pair diverges
 
 A reduction-order difference is a relative perturbation of order `1e-3` on a

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -63,15 +63,22 @@ transitive across loops — each one has its own rollback and its own acceptance
 walk, which is what the gate reads.
 
 That boundary is not hypothetical. Served at temperature 0 on the code prompt,
-`Qwen3.8-27B-4bit` drafted by `z-lab/Qwen3.8-27B-DFlash2` at block 8 diverges
+`Qwen3.8-27B-4bit` drafted by `z-lab/Qwen3.8-27B-DFlash2` at block 8 diverged
 from the same verifier's no-drafter answer at the fourth token — "We need to
-respond to user:" against "We need answer user's request:" — and stays diverged;
-the MTP sidecar on the same verifier, same prompt and same 160-token budget is
-byte-identical to it. A greedy speculative loop can only emit the verifier's own
-argmax, so a drafter proposing badly costs throughput and cannot change the
-answer. A changed answer is the loop, not the drafter, and this one is uncovered.
-That the drafter is also being loaded as an earlier architecture than the
-checkpoint (see `docs/SPECULATIVE.md` § Qwen3.8-27B-4bit) does not explain it.
+respond to user:" against "We need answer user's request:" — and stayed
+diverged; the MTP sidecar on the same verifier, same prompt and same 160-token
+budget is byte-identical to it. A greedy speculative loop can only emit the
+verifier's own argmax, so a drafter proposing badly costs throughput and cannot
+change the answer. A changed answer is the loop, not the drafter, and this one is
+uncovered. That the drafter was also being loaded as an earlier architecture than
+the checkpoint (see `docs/SPECULATIVE.md` § Qwen3.8-27B-4bit) does not explain
+it.
+
+That pair no longer loads: the DFlash loader refuses a snapshot it only half
+reads, for a metrics-attribution reason unrelated to this. Reproducing the
+divergence on it means lifting that refusal. `z-lab/Qwen3.6-35B-A3B-DFlash` reads
+every tensor it ships, loads, and drives the same round loop — it is the pair a
+DFlash case here would be built on.
 
 ## The oracle: where a correct pair diverges
 

--- a/scripts/eval/wikitext2_ppl.py
+++ b/scripts/eval/wikitext2_ppl.py
@@ -54,7 +54,8 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--model",
         required=True,
-        help="Absolute path to an MLX model snapshot directory (Qwen3 family).",
+        help="Absolute path to an MLX model snapshot directory "
+        "(Qwen3, Gemma4 or Qwen3.5).",
     )
     p.add_argument(
         "--ctx-window",

--- a/scripts/eval/wikitext2_ppl.py
+++ b/scripts/eval/wikitext2_ppl.py
@@ -102,6 +102,13 @@ def parse_args() -> argparse.Namespace:
         "`$RMLX_HOME/cache/wikitext-2/` or `$HOME/.rmlx/cache/wikitext-2/`.",
     )
     p.add_argument(
+        "--git-sha",
+        default="",
+        help="Commit SHA stamped on the emitted record's `git_sha` column. "
+        "Provenance the caller supplies -- the binary does not derive it, so "
+        "an omitted flag leaves the column NULL.",
+    )
+    p.add_argument(
         "--plausibility",
         action="store_true",
         help="Gate the result: exit 2 when PPL is outside (1.5, 50.0).",
@@ -196,6 +203,8 @@ def run_ppl(args: argparse.Namespace, text_path: Path, rmlx: Path) -> dict:
         "--max-tokens",
         str(args.max_tokens),
     ]
+    if args.git_sha:
+        cmd += ["--git-sha", args.git_sha]
     print(f"wikitext-2: running: {' '.join(cmd)}", file=sys.stderr)
     proc = subprocess.run(
         cmd,


### PR DESCRIPTION
Closes #503.

The first 4-bit speculative numbers for a published verifier and sidecar pair. Running the perplexity gate the task called for turned out to need a scorer the hybrid family did not have, so most of this diff is that scorer and the recording plumbing around it.

## The gate passed, and two projections did not

The 4-bit verifier is **+2.07%** perplexity against its mxfp8 sibling over 131,071 scored tokens, and +2.68% over 32,767 — both inside the 3% bar, at both sample sizes. No alternate checkpoint was needed.

Two of the issue's expectations are falsified:

**The block-2 speedup came out at 1.19×, not within 5% of the sibling pair's 1.36×** — a 12% shortfall, with acceptance down from 0.877 to 0.730. Acceptance is scored against the *verifier's* argmax, so re-quantising the verifier moves the target; the sidecar was re-quantised too, and this pairing cannot separate the two causes. Separately, a verifier 1.70× faster does not shrink the round-loop residual, so the speedup falls further than acceptance alone explains.

**Blocks 4 through 7 are unreachable.** All three shipped sidecars for this family declare `block_size: 3`, so the whole tokens-per-step projection is untestable until the cap is lifted. The documentation said the sidecars omit the field and inherit a default; they declare it explicitly. The cap is unchanged, the stated reason was wrong.

Plain decode reaches 79.2% of the issue's own ceiling against a ≥80% target. The mxfp8 sibling measured the same hour reads 79.7% of *its* ceiling, so that is a property of the engine at this shape rather than of the checkpoint.

## A measurement bug, fixed rather than blessed

The shared sliding-window walk skipped one corpus position per window, on every perplexity row this backend has ever taken for the affected model. The fix is derived rather than patched: slot `t` scores corpus position `start + t + 1`, so the first unscored slot is one earlier than the overlap.

The affected rows are named in the known-bad register in `docs/METRICS_DB.md`, selected by `git_sha` rather than a date — a date predicate cannot catch a pre-fix binary run after the fix lands. The register's arithmetic is stated in one unit and sums: 365 − 230 − 80 − 20 = 35 rows. It covers the audit metrics too, `ppl_scored_tokens` in particular, which is the metric that moved most because it *is* the denominator that changed.

Every row the evaluation script filed had also carried a NULL `git_sha`. It no longer does.

## What the scorer refuses to do

The cached scorer is refused on this family rather than approximated. Sixteen of sixty-four layers are full attention; the rest carry a recurrent state no KV codec touches, so a figure "scored through codec X" would describe a quarter of the model. The refusal names those layers, so it reads as a decision rather than as an unimplemented feature.

The refusal is enforced by a token that only its own module can construct, so removing the check at the call site is a compile error rather than a silently missing guard.

## A loader that was serving the wrong architecture

The DFlash loader had been **silently half-reading** the DFlash 2 checkpoint — 23 tensors it has no code for — building the earlier architecture from the remainder and serving under the checkpoint's name. Bench rows from it read as the published drafter's, and `decode_config` cannot tell them apart.

It now refuses, naming every unread tensor. Verified on both real snapshots: the DFlash 2 checkpoint is refused, the DFlash 1 checkpoint loads and serves unchanged, and the loader reads a fixed unconditional set so the refusal has no false-positive route.

That makes the checkpoint unloadable until its architecture is ported, which is the intended trade — failing beats serving a different drafter under a published name. The consequence is recorded where it matters: evidence already gathered on that pair is marked as taken before the refusal, with the sibling snapshot that still drives the same round loop named beside it.

## Two defects filed, not fixed here

**#513** — the DFlash round loop changes the answer at temperature 0. Same binary, same prompt, seed 42: the MTP arm is byte-identical to no-drafter, the DFlash arm diverges at the fourth token and stays diverged. Greedy acceptance can only emit the verifier's argmax, so this is the loop rather than drafter quality. The equivalence gate covers two of five round loops; that boundary was undocumented and now is.

**#514** — `metrics export` attributes a row's run id and notes to the newest run in the cell rather than the one that produced the displayed value. Every multi-run cell is affected, and the champions file is generated from it.

## Verification

Two review rounds, nineteen findings, all closed. `make ci` green. Twelve mutations are recorded against the gates they kill; two of them are compile errors rather than test failures, and two survived on first attempt and were closed by a privacy boundary and a `Result` return.

One gate is deliberately *not* claimed: a slice bound added as defence in depth is unobservable while the buffer clear stands, and its comment says so rather than implying coverage it does not have.

Measurement conditions are disclosed per block, including one cell tainted by a 34% foreign process — corroborated by a clean-host cell returning the same ratio.
