### PR TITLE
test/ci: a suite that could not run stops reporting what a suite that passed reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A suite that could not run no longer reports what a suite that passed
+  reports.** Two halves of one defect. The shared snapshot probe in the model
+  test harness required a `tokenizer.json` of every directory it was asked
+  about, and a drafter sidecar is decoded with the verifier's tokenizer and
+  ships none — so it read as absent on the machine holding it, and an absence
+  stands a gate down while libtest prints `ok`. The probe now takes the role the
+  caller is asking for: a sidecar needs its config and its weights, a model the
+  harness tokenizes with needs a tokenizer too. And `scripts/run_gpu_tests.sh`
+  now harvests every `SKIP <test>: <why>` notice on every run, lists each with
+  the reason its own gate gave, counts the notices that named no test, and marks
+  the run INCOMPLETE — which `make ci-perf` reports instead of printing
+  `ci-perf ok` over it. A stand-down is still not a failure; a developer without
+  the weights must not be blocked. The six speculative alignment suites, which
+  announced their stand-downs in a form nothing read, now use the form the
+  runner counts.
+
 - **The bench scripts record the decode rate the engine measured, not one they
   derive themselves.** `scripts/spec_bench.sh` read the speculative round loop's
   `done` line and divided `emitted` by `elapsed_ms`. That elapsed covers the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,7 @@ hand — keeps the CI gate and the local gate identical.
 | `make build` | `cargo build --workspace --release`. |
 | `make check` | `cargo check --workspace --all-targets` (fast). |
 | `make test` | `cargo test --workspace` — **skips every `#[ignore]` GPU test**. |
-| `make gpu-test` | Run the GPU/Metal `#[ignore]` tests, `--test-threads=1` (`CRATE=` / `FILTER=` narrow). Needs exclusive machine access. Under Metal shader validation (`--nocapture`, so the tests' own skip notices reach the scan): the hits it observes are diffed against `scripts/gpu_validation_census.txt`, which pins one count per originating test; the expectation is the sum over the tests that ran, an exact match passes and prints what it accepted, any deviation fails naming the delta. Part of `make ci-perf`, not `make ci`. |
+| `make gpu-test` | Run the GPU/Metal `#[ignore]` tests, `--test-threads=1` (`CRATE=` / `FILTER=` narrow). Needs exclusive machine access. Under Metal shader validation (`--nocapture`, so the tests' own skip notices reach the scan): the hits it observes are diffed against `scripts/gpu_validation_census.txt`, which pins one count per originating test; the expectation is the sum over the tests that ran, an exact match passes and prints what it accepted, any deviation fails naming the delta. A cell that stood down for want of a snapshot is listed with the reason its `SKIP <test>: <why>` notice gave and counted on the final line as INCOMPLETE — a test that could not run is not a test that passed, and libtest reports both as `ok`. Part of `make ci-perf`, not `make ci`. |
 | `make fmt` / `make fmt-check` | Write / check `cargo fmt`. |
 | `make lint` | `cargo clippy -D warnings`. |
 | `make audit` | `cargo audit` with RustSec ignores from `deny.toml`. |
@@ -311,7 +311,7 @@ hand — keeps the CI gate and the local gate identical.
 | `make precommit` | `pre-commit run --all-files`. |
 | `make hooks` | Install the git `pre-commit` hook. |
 | `make ci` | `fmt-check + lint + test + deny + audit` — pre-merge gate. |
-| `make ci-perf` | `test-perf` under `release-perf` + the serialized GPU/Metal suite. Requires an idle GPU; without the snapshots the pinned entries' tests skip and are reported as not enforced in full rather than failing. Run before merging perf-sensitive or codec-layer changes (~21 min). |
+| `make ci-perf` | `test-perf` under `release-perf` + the serialized GPU/Metal suite. Requires an idle GPU; without the snapshots the pinned entries' tests skip and are reported as not enforced in full rather than failing, and the run ends in `ci-perf INCOMPLETE` naming what stood down instead of `ci-perf ok`. Run before merging perf-sensitive or codec-layer changes (~21 min). |
 | `make check-kv-layer-quants` | CI gate (in `make ci`): the per-layer KV codec vector has one producer (`kv_layer_quants`) — no second `kv_quant_for_layer` loop, and every per-layer cache stack either uses it or declares itself uniform. |
 | `make check-kv-codec-disposition` | CI gate (in `make ci`): the `--kv-quant` / `--kv-bits` help and the `docs/KV_QUANT.md` INERT banners agree with each codec's runtime disposition, derived from `ALL_KV_QUANTS` + `decode_reads_packed_store` / `feeds_bf16_{k,v}_at_decode`. |
 | `make check-kv-codec-disposition-fixtures` | CI gate (in `make ci`): recall test for the above, 18 synthetic scan roots (one edit each), each asserting which rule fired and exit 2 vs exit 1. |

--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,12 @@ test-perf:       ## cargo test --profile release-perf (release-perf profile, pan
 #     visits five crates and holds the GPU while it does. Fail on the broad,
 #     shareable step before spending exclusive-GPU minutes.
 #
+# The last line reads the runner's own verdict rather than asserting one. A
+# suite whose snapshot is not on disk stands down, which is not a failure and
+# has no exit code — so a `ci-perf ok` printed after it claimed a gate had held
+# when it had never been asked. The runner marks such a run INCOMPLETE on its
+# final line and lists what stood down; this target says so instead of `ok`.
+#
 # The runner is invoked directly rather than through `$(MAKE) gpu-test`. Make
 # propagates command-line variables to sub-makes, so `make ci-perf CRATE=…` or
 # `VALIDATE=0` would silently reach the runner and narrow or disarm the gate:
@@ -268,8 +274,14 @@ test-perf:       ## cargo test --profile release-perf (release-perf profile, pan
 ci-perf:         ## pre-push gate under release-perf + the serialized GPU/Metal suite (separate from make ci; run before merging perf-sensitive or codec-layer changes)
 	@bash scripts/run_gpu_tests.sh --preflight
 	$(MAKE) test-perf
-	@bash scripts/run_gpu_tests.sh
-	@echo "ci-perf ok"
+	@log="$$(mktemp)"; rc="$$(mktemp)"; \
+	{ bash scripts/run_gpu_tests.sh; echo $$? >"$$rc"; } | tee "$$log"; \
+	code="$$(cat "$$rc")"; rm -f "$$rc"; \
+	if [ "$$code" -ne 0 ]; then rm -f "$$log"; exit "$$code"; fi; \
+	if grep -q INCOMPLETE "$$log"; then \
+	  echo "ci-perf INCOMPLETE — the GPU suite did not run every gate it names (see above)"; \
+	else echo "ci-perf ok"; fi; \
+	rm -f "$$log"
 
 # gpu-test: the execution step for the tests `check-gpu-tests-ignored` mandates.
 # Every test reaching Device::Gpu must carry #[ignore] (a shared Metal context

--- a/crates/rmlx-models/tests/common/mod.rs
+++ b/crates/rmlx-models/tests/common/mod.rs
@@ -228,10 +228,33 @@ pub fn regen_verdict(
     }
 }
 
-/// Files every snapshot must carry. Both are opened BY NAME: `config.json` by
-/// [`model_arch`] and `arch::load_model`, `tokenizer.json` by
+/// What the caller will open in the snapshot it is asking for.
+///
+/// A drafter sidecar has no tokenizer of its own — it proposes ids for a
+/// verifier and is decoded with the verifier's — and mlx-community ships those
+/// snapshots without one. Requiring a `tokenizer.json` of every snapshot turns
+/// such a checkpoint into an absence on the machine that holds it, and an
+/// absence is a skip: the suite reports green having asserted nothing. So the
+/// caller says which shape it needs, and the probe requires exactly the files
+/// that shape is opened for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    /// A model the caller tokenizes with: config, its own tokenizer, weights.
+    Standalone,
+    /// A drafter sidecar: config and weights. It shares the verifier's
+    /// tokenizer and ships none.
+    Sidecar,
+}
+
+/// Files a snapshot in this role must carry. Each is opened BY NAME:
+/// `config.json` by [`model_arch`] and `arch::load_model`, `tokenizer.json` by
 /// [`run_golden_test`]'s `Tokenizer::from_file`.
-const REQUIRED_FILES: [&str; 2] = ["config.json", "tokenizer.json"];
+fn required_files(role: Role) -> &'static [&'static str] {
+    match role {
+        Role::Standalone => &["config.json", "tokenizer.json"],
+        Role::Sidecar => &["config.json"],
+    }
+}
 
 /// Weight entrypoints. `rmlx_loader::load_shard_index` tries these two in this
 /// order and errors if neither exists.
@@ -265,19 +288,19 @@ fn has_any_shard(dir: &Path) -> bool {
     })
 }
 
-/// A directory is a snapshot when every file the harness opens by name is
-/// there: both JSONs, an entrypoint `load_shard_index` accepts, and at least
-/// one actual shard behind it.
-fn is_snapshot_dir(dir: &Path) -> bool {
-    REQUIRED_FILES.iter().all(|f| dir.join(f).is_file())
+/// A directory is a snapshot when every file the caller opens by name is
+/// there: the JSONs its role needs, an entrypoint `load_shard_index` accepts,
+/// and at least one actual shard behind it.
+fn is_snapshot_dir(dir: &Path, role: Role) -> bool {
+    required_files(role).iter().all(|f| dir.join(f).is_file())
         && WEIGHT_ENTRYPOINTS.iter().any(|f| dir.join(f).exists())
         && has_any_shard(dir)
 }
 
 /// Name what is missing, so a diagnosis says what to look at rather than just
 /// "not a snapshot".
-fn missing_file(dir: &Path) -> String {
-    if let Some(f) = REQUIRED_FILES.iter().find(|f| !dir.join(f).is_file()) {
+fn missing_file(dir: &Path, role: Role) -> String {
+    if let Some(f) = required_files(role).iter().find(|f| !dir.join(f).is_file()) {
         return (*f).to_owned();
     }
     if !WEIGHT_ENTRYPOINTS.iter().any(|f| dir.join(f).exists()) {
@@ -297,16 +320,16 @@ fn missing_file(dir: &Path) -> String {
 /// A value that does not name a runnable snapshot is [`Snapshot::Misconfigured`]:
 /// the operator named this path, so a typo or a moved snapshot must break the
 /// run rather than skip it.
-pub fn override_snapshot(single_model: Option<&str>) -> Option<Snapshot> {
+pub fn override_snapshot(single_model: Option<&str>, role: Role) -> Option<Snapshot> {
     let p = single_model.filter(|p| !p.is_empty())?;
     let path = PathBuf::from(p);
-    if is_snapshot_dir(&path) {
+    if is_snapshot_dir(&path, role) {
         let arch = model_arch(&path);
         return Some(Snapshot::Found { path, arch });
     }
     Some(Snapshot::Misconfigured(format!(
         "{SINGLE_MODEL_VAR}={p} is not a runnable snapshot directory (no {} in it)",
-        missing_file(&path)
+        missing_file(&path, role)
     )))
 }
 
@@ -317,7 +340,7 @@ pub fn override_snapshot(single_model: Option<&str>) -> Option<Snapshot> {
 /// once, which is the widest blast radius in this harness and the last thing
 /// that should report success by skipping. An existing root that simply does
 /// not hold this slug is [`Snapshot::Absent`]: nobody holds every snapshot.
-pub fn slug_snapshot(models_root: Option<&str>, slug: &str) -> Snapshot {
+pub fn slug_snapshot(models_root: Option<&str>, slug: &str, role: Role) -> Snapshot {
     let Some(root) = models_root.filter(|r| !r.is_empty()) else {
         return Snapshot::Absent(format!(
             "no snapshot configured — set {MODELS_ROOT_VAR} (holding {slug}) or {SINGLE_MODEL_VAR}"
@@ -330,14 +353,14 @@ pub fn slug_snapshot(models_root: Option<&str>, slug: &str) -> Snapshot {
         ));
     }
     let path = root_path.join(slug);
-    if is_snapshot_dir(&path) {
+    if is_snapshot_dir(&path, role) {
         let arch = model_arch(&path);
         return Snapshot::Found { path, arch };
     }
     Snapshot::Absent(format!(
         "{MODELS_ROOT_VAR}={root} does not hold a runnable {slug} (no {} in it); put the \
          snapshot, or a symlink to it, there",
-        missing_file(&path)
+        missing_file(&path, role)
     ))
 }
 
@@ -493,8 +516,8 @@ pub fn skip_if_arch_mismatch(model_dir: &Path, test_name: &str, expected: &[&str
 pub fn model_for(model: &GoldenModel, test_name: &str) -> Option<PathBuf> {
     let single = std::env::var(SINGLE_MODEL_VAR).ok();
     let root = std::env::var(MODELS_ROOT_VAR).ok();
-    let over = override_snapshot(single.as_deref());
-    let slug = slug_snapshot(root.as_deref(), model.slug);
+    let over = override_snapshot(single.as_deref(), Role::Standalone);
+    let slug = slug_snapshot(root.as_deref(), model.slug, Role::Standalone);
     apply(choose(over, slug, model, regen_requested()), test_name)
 }
 

--- a/crates/rmlx-models/tests/common/snapshot_tests.rs
+++ b/crates/rmlx-models/tests/common/snapshot_tests.rs
@@ -25,7 +25,7 @@
 
 use std::path::{Path, PathBuf};
 
-use super::{apply, choose, override_snapshot, slug_snapshot, Gate, GoldenModel, Snapshot};
+use super::{apply, choose, override_snapshot, slug_snapshot, Gate, GoldenModel, Role, Snapshot};
 
 const SLUG: &str = "vendor__model-8b-2bit";
 const ARCH: &str = "ExampleForCausalLM";
@@ -50,6 +50,12 @@ const RECORDING: bool = true;
 ///   `model.safetensors.index.json`, else `model.safetensors`, else errors.
 const HARNESS_OPENS_ALL: [&str; 2] = ["config.json", "tokenizer.json"];
 const HARNESS_OPENS_ANY: [&str; 2] = ["model.safetensors.index.json", "model.safetensors"];
+
+/// What a drafter's loader opens, transcribed the same way: every
+/// `<Kind>Drafter::load` in `rmlx_models::speculative` reads `config.json` and
+/// the weights, and none of them constructs a tokenizer — the round loop is
+/// handed the verifier's.
+const SIDECAR_OPENS_ALL: [&str; 1] = ["config.json"];
 
 /// Create `<parent>/<name>/` holding every file a runnable snapshot needs,
 /// with `architectures[0]` set to `arch`.
@@ -80,36 +86,42 @@ fn as_str(p: &Path) -> &str {
 #[test]
 fn a_dir_built_from_the_constants_satisfies_every_harness_call_site() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let dir = tmp.path().join("exactly-the-constants");
-    std::fs::create_dir_all(&dir).expect("create dir");
-    for f in super::REQUIRED_FILES {
-        std::fs::write(dir.join(f), b"{}").expect("write required file");
-    }
-    // The sharded shape, because it is the one every large snapshot uses: the
-    // index entrypoint plus the shard it names.
-    std::fs::write(dir.join("model.safetensors.index.json"), b"{}").expect("write index");
-    std::fs::write(dir.join("model-00001-of-00001.safetensors"), b"").expect("write shard");
+    for (role, opened_all) in [
+        (Role::Standalone, &HARNESS_OPENS_ALL[..]),
+        (Role::Sidecar, &SIDECAR_OPENS_ALL[..]),
+    ] {
+        let dir = tmp.path().join(format!("exactly-the-constants-{role:?}"));
+        std::fs::create_dir_all(&dir).expect("create dir");
+        for f in super::required_files(role) {
+            std::fs::write(dir.join(f), b"{}").expect("write required file");
+        }
+        // The sharded shape, because it is the one every large snapshot uses: the
+        // index entrypoint plus the shard it names.
+        std::fs::write(dir.join("model.safetensors.index.json"), b"{}").expect("write index");
+        std::fs::write(dir.join("model-00001-of-00001.safetensors"), b"").expect("write shard");
 
-    for opened in HARNESS_OPENS_ALL {
+        for opened in opened_all {
+            assert!(
+                dir.join(opened).exists(),
+                "a {role:?} caller opens {opened} by name, but the minimum directory the \
+                 constants describe does not contain it"
+            );
+        }
         assert!(
-            dir.join(opened).exists(),
-            "the harness opens {opened} by name, but the minimum directory the \
-             constants describe does not contain it"
+            HARNESS_OPENS_ANY.iter().any(|f| dir.join(f).exists()),
+            "load_shard_index needs one of {HARNESS_OPENS_ANY:?}, but the minimum \
+             directory contains neither"
+        );
+        assert!(
+            super::has_any_shard(&dir),
+            "an entrypoint names weights that must exist; the minimum directory has none"
+        );
+        assert!(
+            super::is_snapshot_dir(&dir, role),
+            "the minimum {role:?} directory the constants describe must satisfy the check \
+             that reads them"
         );
     }
-    assert!(
-        HARNESS_OPENS_ANY.iter().any(|f| dir.join(f).exists()),
-        "load_shard_index needs one of {HARNESS_OPENS_ANY:?}, but the minimum \
-         directory contains neither"
-    );
-    assert!(
-        super::has_any_shard(&dir),
-        "an entrypoint names weights that must exist; the minimum directory has none"
-    );
-    assert!(
-        super::is_snapshot_dir(&dir),
-        "the minimum directory the constants describe must satisfy the check that reads them"
-    );
 }
 
 /// The majority half-written shape: JSONs and the index all present, shards
@@ -130,10 +142,10 @@ fn an_index_naming_shards_that_are_absent_is_not_runnable() {
     std::fs::write(dir.join("model.safetensors.index.json"), b"{}").expect("write index");
 
     assert!(
-        !super::is_snapshot_dir(&dir),
+        !super::is_snapshot_dir(&dir, Role::Standalone),
         "an index with no shard behind it is a download in flight, not a snapshot"
     );
-    let got = slug_snapshot(Some(as_str(root.path())), SLUG);
+    let got = slug_snapshot(Some(as_str(root.path())), SLUG, Role::Standalone);
     assert!(
         matches!(got, Snapshot::Absent(_)),
         "got {got:?} for a sharded snapshot whose shards have not arrived"
@@ -152,7 +164,7 @@ fn models_root_alone_resolves_the_snapshot() {
     let dir = make_snapshot(root.path(), SLUG, ARCH);
 
     assert_eq!(
-        slug_snapshot(Some(as_str(root.path())), SLUG),
+        slug_snapshot(Some(as_str(root.path())), SLUG, Role::Standalone),
         Snapshot::Found {
             path: dir,
             arch: ARCH.to_owned()
@@ -169,7 +181,7 @@ fn a_root_without_the_slug_is_absent() {
     let root = tempfile::tempdir().expect("tempdir");
     make_snapshot(root.path(), "some-other-model", ARCH);
 
-    let got = slug_snapshot(Some(as_str(root.path())), SLUG);
+    let got = slug_snapshot(Some(as_str(root.path())), SLUG, Role::Standalone);
 
     assert!(
         matches!(got, Snapshot::Absent(_)),
@@ -185,7 +197,7 @@ fn a_root_that_does_not_exist_is_misconfigured() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().join("o-modles-typo");
 
-    let got = slug_snapshot(Some(as_str(&root)), SLUG);
+    let got = slug_snapshot(Some(as_str(&root)), SLUG, Role::Standalone);
 
     assert!(
         matches!(got, Snapshot::Misconfigured(_)),
@@ -200,7 +212,7 @@ fn a_root_that_is_a_file_is_misconfigured() {
     let root = tmp.path().join("not-a-dir");
     std::fs::write(&root, b"x").expect("write file");
 
-    let got = slug_snapshot(Some(as_str(&root)), SLUG);
+    let got = slug_snapshot(Some(as_str(&root)), SLUG, Role::Standalone);
 
     assert!(matches!(got, Snapshot::Misconfigured(_)), "got {got:?}");
 }
@@ -224,12 +236,77 @@ fn a_half_written_snapshot_under_the_root_is_absent() {
             std::fs::write(partial.join(f), b"{}").expect("write partial file");
         }
 
-        let got = slug_snapshot(Some(as_str(root.path())), SLUG);
+        let got = slug_snapshot(Some(as_str(root.path())), SLUG, Role::Standalone);
 
         assert!(
             matches!(got, Snapshot::Absent(_)),
             "a snapshot holding only {present:?} must not resolve as runnable; got {got:?}"
         );
+    }
+}
+
+/// Create `<parent>/<name>/` the way mlx-community ships a drafter sidecar:
+/// config and weights, no tokenizer of its own.
+fn make_sidecar(parent: &Path, name: &str, arch: &str) -> PathBuf {
+    let dir = parent.join(name);
+    std::fs::create_dir_all(&dir).expect("create sidecar dir");
+    std::fs::write(
+        dir.join("config.json"),
+        format!(r#"{{"architectures":["{arch}"]}}"#),
+    )
+    .expect("write config.json");
+    std::fs::write(dir.join("model.safetensors"), b"").expect("write weights");
+    dir
+}
+
+/// A drafter is decoded with the verifier's tokenizer and ships none, so
+/// requiring one of it turns a checkpoint that is on disk into an absence — and
+/// an absence stands the gate down while it reports `ok`. Both directions are
+/// asserted here: the sidecar resolves, and the same directory asked for as a
+/// standalone model does not, naming the file it lacks.
+#[test]
+fn a_sidecar_resolves_without_the_tokenizer_it_does_not_ship() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let dir = make_sidecar(root.path(), SLUG, ARCH);
+
+    assert_eq!(
+        slug_snapshot(Some(as_str(root.path())), SLUG, Role::Sidecar),
+        Snapshot::Found {
+            path: dir,
+            arch: ARCH.to_owned()
+        },
+        "a drafter sidecar must resolve from the root that holds it"
+    );
+
+    let got = slug_snapshot(Some(as_str(root.path())), SLUG, Role::Standalone);
+    match got {
+        Snapshot::Absent(why) => assert!(
+            why.contains("tokenizer.json"),
+            "a standalone caller stands down because the tokenizer is missing, and must \
+             say which file: {why}"
+        ),
+        other => panic!("a snapshot with no tokenizer cannot serve a standalone caller: {other:?}"),
+    }
+}
+
+/// The sidecar role drops the tokenizer requirement and nothing else. Each
+/// case names the file it is missing, because the whole point of the split is
+/// that a diagnosis says what to put on disk.
+#[test]
+fn a_sidecar_still_needs_its_config_and_its_weights() {
+    for missing in ["config.json", "model.safetensors"] {
+        let root = tempfile::tempdir().expect("tempdir");
+        let dir = make_sidecar(root.path(), SLUG, ARCH);
+        std::fs::remove_file(dir.join(missing)).expect("remove the file under test");
+
+        let got = slug_snapshot(Some(as_str(root.path())), SLUG, Role::Sidecar);
+        match got {
+            Snapshot::Absent(why) => assert!(
+                why.contains(missing) || why.contains("model.safetensors[.index.json]"),
+                "a sidecar without {missing} must name what it lacks: {why}"
+            ),
+            other => panic!("a sidecar without {missing} is not runnable: {other:?}"),
+        }
     }
 }
 
@@ -266,7 +343,7 @@ fn both_real_weight_layouts_complete_a_snapshot() {
 
         assert!(
             matches!(
-                slug_snapshot(Some(as_str(root.path())), SLUG),
+                slug_snapshot(Some(as_str(root.path())), SLUG, Role::Standalone),
                 Snapshot::Found { .. }
             ),
             "the {what} layout must resolve"
@@ -277,10 +354,13 @@ fn both_real_weight_layouts_complete_a_snapshot() {
 /// No configuration at all — a developer without weights, and the hosted CI.
 #[test]
 fn nothing_configured_is_absent() {
-    let got = slug_snapshot(None, SLUG);
+    let got = slug_snapshot(None, SLUG, Role::Standalone);
     assert!(matches!(got, Snapshot::Absent(_)), "got {got:?}");
     assert!(
-        matches!(slug_snapshot(Some(""), SLUG), Snapshot::Absent(_)),
+        matches!(
+            slug_snapshot(Some(""), SLUG, Role::Standalone),
+            Snapshot::Absent(_)
+        ),
         "an empty root must not resolve to the filesystem root"
     );
 }
@@ -290,8 +370,8 @@ fn nothing_configured_is_absent() {
 /// Unset, or the empty string a shell uses to mean unset.
 #[test]
 fn an_unset_or_empty_override_is_none() {
-    assert!(override_snapshot(None).is_none());
-    assert!(override_snapshot(Some("")).is_none());
+    assert!(override_snapshot(None, Role::Standalone).is_none());
+    assert!(override_snapshot(Some(""), Role::Standalone).is_none());
 }
 
 #[test]
@@ -300,7 +380,7 @@ fn an_override_naming_a_runnable_snapshot_is_found() {
     let dir = make_snapshot(tmp.path(), "single", OTHER_ARCH);
 
     assert_eq!(
-        override_snapshot(Some(as_str(&dir))),
+        override_snapshot(Some(as_str(&dir)), Role::Standalone),
         Some(Snapshot::Found {
             path: dir,
             arch: OTHER_ARCH.to_owned()
@@ -339,7 +419,7 @@ fn an_override_naming_anything_unrunnable_is_misconfigured() {
         .expect("write index");
 
     for dir in [&absent, &empty, &config_only, &no_shards, &index_no_shards] {
-        let got = override_snapshot(Some(as_str(dir)));
+        let got = override_snapshot(Some(as_str(dir)), Role::Standalone);
         assert!(
             matches!(got, Some(Snapshot::Misconfigured(_))),
             "{} must be a hard failure, got {got:?}",

--- a/crates/rmlx-models/tests/dflash_drafter_alignment.rs
+++ b/crates/rmlx-models/tests/dflash_drafter_alignment.rs
@@ -69,7 +69,10 @@ fn dflash_round0_first_token_aligns() {
         env_path("RMLX_KV_TEST_MODEL"),
         env_path("RMLX_DRAFT_TEST_MODEL"),
     ) else {
-        eprintln!("[dflash_align] verifier/draft model unset/absent - skipping");
+        eprintln!(
+            "SKIP dflash_round0_first_token_aligns: RMLX_KV_TEST_MODEL and \
+             RMLX_DRAFT_TEST_MODEL must both name an existing snapshot directory"
+        );
         return;
     };
     let device = Device::Gpu;
@@ -190,7 +193,10 @@ fn dflash_live_loop_emits_coherent() {
         env_path("RMLX_KV_TEST_MODEL"),
         env_path("RMLX_DRAFT_TEST_MODEL"),
     ) else {
-        eprintln!("[dflash_align] verifier/draft model unset/absent - skipping");
+        eprintln!(
+            "SKIP dflash_live_loop_emits_coherent: RMLX_KV_TEST_MODEL and \
+             RMLX_DRAFT_TEST_MODEL must both name an existing snapshot directory"
+        );
         return;
     };
     let device = Device::Gpu;

--- a/crates/rmlx-models/tests/gemma4_mtp_drafter_alignment.rs
+++ b/crates/rmlx-models/tests/gemma4_mtp_drafter_alignment.rs
@@ -63,7 +63,10 @@ fn l2(bytes: &[u8]) -> f32 {
 #[test]
 fn embed_token_raw_applies_sqrt_hidden_scale() {
     let Some(model_path) = env_path("RMLX_KV_TEST_MODEL") else {
-        eprintln!("[mtp_align] RMLX_KV_TEST_MODEL unset/absent - skipping");
+        eprintln!(
+            "SKIP embed_token_raw_applies_sqrt_hidden_scale: RMLX_KV_TEST_MODEL does not \
+             name an existing snapshot directory"
+        );
         return;
     };
     let device = Device::Gpu;
@@ -97,7 +100,10 @@ fn mtp_assistant_accept_rate_is_high() {
         env_path("RMLX_KV_TEST_MODEL"),
         env_path("RMLX_DRAFT_TEST_MODEL"),
     ) else {
-        eprintln!("[mtp_align] verifier/draft model unset/absent - skipping");
+        eprintln!(
+            "SKIP mtp_assistant_accept_rate_is_high: RMLX_KV_TEST_MODEL and \
+             RMLX_DRAFT_TEST_MODEL must both name an existing snapshot directory"
+        );
         return;
     };
     let device = Device::Gpu;

--- a/crates/rmlx-models/tests/qwen3_5_eagle3_alignment.rs
+++ b/crates/rmlx-models/tests/qwen3_5_eagle3_alignment.rs
@@ -100,12 +100,16 @@ fn eagle3_greedy_tracks_plain_greedy_for_a_long_prefix() {
         env_path("RMLX_KV_TEST_MODEL"),
         env_path("RMLX_DRAFT_TEST_MODEL"),
     ) else {
-        eprintln!("[qwen35_eagle3_align] verifier/drafter unset or absent - skipping");
+        eprintln!(
+            "SKIP eagle3_greedy_tracks_plain_greedy_for_a_long_prefix: RMLX_KV_TEST_MODEL \
+             and RMLX_DRAFT_TEST_MODEL must both name an existing snapshot directory"
+        );
         return;
     };
     if !is_eagle3_drafter(&draft_path) {
         eprintln!(
-            "[qwen35_eagle3_align] RMLX_DRAFT_TEST_MODEL is not an EAGLE-3 drafter - skipping"
+            "SKIP eagle3_greedy_tracks_plain_greedy_for_a_long_prefix: \
+             RMLX_DRAFT_TEST_MODEL is not an EAGLE-3 drafter"
         );
         return;
     }

--- a/crates/rmlx-models/tests/qwen3_5_mtp_drafter_alignment.rs
+++ b/crates/rmlx-models/tests/qwen3_5_mtp_drafter_alignment.rs
@@ -104,7 +104,10 @@ fn mtp_sidecar_loads_whatever_ffn_it_carries() {
         env_path("RMLX_KV_TEST_MODEL"),
         env_path("RMLX_DRAFT_TEST_MODEL"),
     ) else {
-        eprintln!("[qwen35_mtp_align] verifier/sidecar unset or absent - skipping");
+        eprintln!(
+            "SKIP mtp_sidecar_loads_whatever_ffn_it_carries: RMLX_KV_TEST_MODEL and \
+             RMLX_DRAFT_TEST_MODEL must both name an existing snapshot directory"
+        );
         return;
     };
     let device = Device::Gpu;
@@ -144,7 +147,10 @@ fn mtp_greedy_tracks_plain_greedy_for_a_long_prefix() {
         env_path("RMLX_KV_TEST_MODEL"),
         env_path("RMLX_DRAFT_TEST_MODEL"),
     ) else {
-        eprintln!("[qwen35_mtp_align] verifier/sidecar unset or absent - skipping");
+        eprintln!(
+            "SKIP mtp_greedy_tracks_plain_greedy_for_a_long_prefix: RMLX_KV_TEST_MODEL and \
+             RMLX_DRAFT_TEST_MODEL must both name an existing snapshot directory"
+        );
         return;
     };
     let device = Device::Gpu;

--- a/crates/rmlx-models/tests/qwen3_5_two_model_alignment.rs
+++ b/crates/rmlx-models/tests/qwen3_5_two_model_alignment.rs
@@ -105,20 +105,26 @@ fn two_model_greedy_tracks_plain_greedy_for_a_long_prefix() {
         env_path("RMLX_KV_TEST_MODEL"),
         env_path("RMLX_DRAFT_TEST_MODEL"),
     ) else {
-        eprintln!("[qwen35_two_model_align] verifier/draft unset or absent - skipping");
+        eprintln!(
+            "SKIP two_model_greedy_tracks_plain_greedy_for_a_long_prefix: \
+             RMLX_KV_TEST_MODEL and RMLX_DRAFT_TEST_MODEL must both name an existing \
+             snapshot directory"
+        );
         return;
     };
     if !is_gdn_hybrid(&model_path) || !is_gdn_hybrid(&draft_path) {
         eprintln!(
-            "[qwen35_two_model_align] pair is not a GDN hybrid on both sides - skipping \
-             (a full-attention pair exercises no GDN rollback)"
+            "SKIP two_model_greedy_tracks_plain_greedy_for_a_long_prefix: the pair is not \
+             a GDN hybrid on both sides, and a full-attention pair exercises no GDN \
+             rollback"
         );
         return;
     }
     if model_path.canonicalize().ok() == draft_path.canonicalize().ok() {
         eprintln!(
-            "[qwen35_two_model_align] verifier and draft name one snapshot - skipping \
-             (load_speculative refuses that pair; point the two vars at different models)"
+            "SKIP two_model_greedy_tracks_plain_greedy_for_a_long_prefix: the verifier and \
+             the draft name one snapshot, which load_speculative refuses; point the two \
+             variables at different models"
         );
         return;
     }

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -123,7 +123,7 @@
     clippy::ignore_without_reason
 )]
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 mod common;
 
@@ -1377,67 +1377,38 @@ const DRAFT_MODEL_VAR: &str = "RMLX_DRAFT_TEST_MODEL";
 ///
 /// A path the operator named that is not a snapshot fails; a models root that
 /// simply does not hold the slug skips. That split is the harness's
-/// (`tests/common/mod.rs`), and the outcomes here match it.
+/// (`tests/common/mod.rs`), not a second copy of its rules.
 ///
-/// It cannot go **through** the harness, though: `common::slug_snapshot`
-/// requires a `tokenizer.json`, and a drafter sidecar does not ship one — it
-/// runs against the verifier's, which is the tokenizer both arms are compared
-/// under. Routing a drafter through it made a pair stand down on a machine
-/// holding both halves of it, which is a green run that asserted nothing.
+/// Both probes ask for a [`common::Role::Sidecar`]: a drafter is decoded with
+/// the verifier's tokenizer and ships none of its own, so requiring one would
+/// turn a checkpoint sitting on this machine's disk into a skip — and a skip in
+/// this gate reads exactly like the equivalence holding. The harness names its
+/// own override variable in the messages it builds; this half of the pair is
+/// overridden by a different one, so that name is substituted.
 fn resolve(var: &str, slug: &str) -> common::Gate {
     let Some(named) = std::env::var(var).ok().filter(|v| !v.is_empty()) else {
-        let Some(root) = std::env::var(common::MODELS_ROOT_VAR)
-            .ok()
-            .filter(|r| !r.is_empty())
-        else {
-            return common::Gate::Skip(format!(
-                "no drafter configured — set {} (holding {slug}) or {var}",
-                common::MODELS_ROOT_VAR
-            ));
-        };
-        if !Path::new(&root).is_dir() {
-            return common::Gate::Fail(format!(
-                "{}={root} is not an existing directory",
-                common::MODELS_ROOT_VAR
-            ));
-        }
-        let path = Path::new(&root).join(slug);
-        return match drafter_snapshot(&path) {
-            Ok(()) => common::Gate::Run { path, note: None },
-            Err(why) => common::Gate::Skip(format!(
-                "{}={root} does not hold a runnable {slug}: {why}; put the snapshot, or \
-                 a symlink to it, there",
-                common::MODELS_ROOT_VAR
-            )),
+        let root = std::env::var(common::MODELS_ROOT_VAR).ok();
+        return match common::slug_snapshot(root.as_deref(), slug, common::Role::Sidecar) {
+            common::Snapshot::Found { path, .. } => common::Gate::Run { path, note: None },
+            common::Snapshot::Absent(why) => {
+                common::Gate::Skip(why.replace(common::SINGLE_MODEL_VAR, var))
+            }
+            common::Snapshot::Misconfigured(why) => common::Gate::Fail(why),
         };
     };
-    let path = PathBuf::from(&named);
     // The operator named this path, so a typo or a moved snapshot breaks the
-    // run rather than skipping it.
-    match drafter_snapshot(&path) {
-        Ok(()) => common::Gate::Run { path, note: None },
-        Err(why) => common::Gate::Fail(format!("{var}={named}: {why}")),
+    // run rather than skipping it. `override_snapshot` reports only an unset or
+    // empty value as `None`, and this branch holds a non-empty one.
+    let probed =
+        common::override_snapshot(Some(&named), common::Role::Sidecar).unwrap_or_else(|| {
+            common::Snapshot::Misconfigured(format!("{var} is set to an empty value"))
+        });
+    match probed {
+        common::Snapshot::Found { path, .. } => common::Gate::Run { path, note: None },
+        common::Snapshot::Absent(why) | common::Snapshot::Misconfigured(why) => {
+            common::Gate::Fail(why.replace(common::SINGLE_MODEL_VAR, var))
+        }
     }
-}
-
-/// Whether `path` is a drafter this gate can load, or what it is missing.
-///
-/// A drafter needs a `config.json` and weights behind an entrypoint
-/// `rmlx_loader::load_shard_index` accepts. It does **not** need a tokenizer:
-/// every drafter here embeds and scores through the verifier's own.
-fn drafter_snapshot(path: &Path) -> Result<(), String> {
-    if !path.join("config.json").is_file() {
-        return Err(format!("no config.json in {}", path.display()));
-    }
-    let entrypoints = ["model.safetensors.index.json", "model.safetensors"];
-    if !entrypoints.iter().any(|f| path.join(f).exists()) {
-        return Err(format!(
-            "no {} in {}",
-            entrypoints.join(" or "),
-            path.display()
-        ));
-    }
-    Ok(())
 }
 
 /// Whether `draft_path` is the dedicated Gemma4 assistant drafter snapshot.

--- a/crates/rmlx-models/tests/two_model_stochastic.rs
+++ b/crates/rmlx-models/tests/two_model_stochastic.rs
@@ -63,7 +63,7 @@ const K: usize = 4;
 /// root is a failure — see `tests/common/mod.rs`.
 fn snapshot(slug: &str) -> Result<PathBuf, String> {
     let root = std::env::var(common::MODELS_ROOT_VAR).ok();
-    match common::slug_snapshot(root.as_deref(), slug) {
+    match common::slug_snapshot(root.as_deref(), slug, common::Role::Standalone) {
         common::Snapshot::Found { path, .. } => Ok(path),
         common::Snapshot::Absent(why) => Err(why),
         common::Snapshot::Misconfigured(why) => panic!("{why}"),

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -311,13 +311,24 @@ The run / skip / fail rule:
 | `RMLX_O_MODELS_ROOT` is set but is not an existing directory | **fail** — one keystroke disarms all five gates |
 | the slug under the models root is a snapshot of the wrong arch | **fail** |
 
-"Runnable" means the directory holds every file the harness opens **by name**:
+"Runnable" means the directory holds every file the caller opens **by name**,
+and which files those are depends on what the caller will do with it. The probe
+takes that as a `Role`:
 
-| file | opened by |
-|---|---|
-| `config.json` | `model_arch`, `arch::load_model` |
-| `tokenizer.json` | `run_golden_test`'s `Tokenizer::from_file` |
-| `model.safetensors.index.json` **or** `model.safetensors` | `rmlx_loader::load_shard_index`, which tries them in that order and errors if neither exists |
+| file | opened by | `Standalone` | `Sidecar` |
+|---|---|---|---|
+| `config.json` | `model_arch`, `arch::load_model`, every `<Kind>Drafter::load` | required | required |
+| `tokenizer.json` | `run_golden_test`'s `Tokenizer::from_file` | required | — |
+| `model.safetensors.index.json` **or** `model.safetensors` | `rmlx_loader::load_shard_index`, which tries them in that order and errors if neither exists | required | required |
+
+`Sidecar` is the drafter case, and it exists because a drafter has no tokenizer:
+it proposes ids for a verifier and is decoded with the verifier's, and
+mlx-community ships those snapshots without one. Requiring a `tokenizer.json` of
+a drafter turned a checkpoint sitting on disk into an absence — which is a skip,
+and a skip in `spec_greedy_equivalence.rs` reads exactly like the equivalence
+holding. `two_model_stochastic.rs` resolves both of its models as `Standalone`,
+because there both sides are full models and the pair is loaded through
+`load_speculative`, which reads a tokenizer from each.
 
 The weight entrypoints are not padding. A download writes the small JSON files
 first and the multi-GB shards last, so `config.json` + `tokenizer.json` + no
@@ -341,10 +352,11 @@ Metal context, and `make ci` passes no `--ignored`. `make gpu-test` /
 classifies them as GPU tests through the cross-file `common::run_golden_test`
 helper, and `scripts/run_gpu_tests.sh` runs everything that classifier names.
 
-**Residual, stated rather than papered over:** libtest discards a passing test's
-output, so a golden that *skipped* prints its reason into a stream nothing shows.
-The gate cannot report "0 goldens checked" from inside a normal run. Add
-`--nocapture` when you need to see which ones stood down:
+libtest discards a passing test's output, so a golden that *skipped* prints its
+reason into a stream a bare `cargo test` does not show. `make gpu-test` and
+`make ci-perf` pass `--nocapture` and report every stand-down by name — see *A
+cell that stood down is reported* below. Running the golden by hand, add the
+flag yourself when you need to see which ones stood down:
 
 ```bash
 cargo test -p rmlx-models --test bonsai_golden_tokens -- --ignored --nocapture
@@ -826,6 +838,49 @@ It is fail-closed in three ways:
 * **Exclusive GPU.** It refuses to start while another MLX process holds the
   Metal context (CLAUDE.md hard rule 8).
 
+#### A cell that stood down is reported, and it is not a pass
+
+A model-gated cell whose snapshot is not on disk returns before asserting
+anything, and libtest prints `ok` for it exactly as for a cell that ran. That
+is the difference this runner reports rather than folds away:
+
+```
+stood down — these selected GPU tests announced they did not run:
+  rmlx-models the_recurrent_round_loop_reproduces_plain_greedy: RMLX_DRAFT_TEST_MODEL is unset …
+
+OK: 1 GPU tests passed across 1 workspace member(s) … — INCOMPLETE: 1 selected
+GPU test(s) stood down and 0 further notice(s) named no test; they asserted
+nothing (listed above)
+```
+
+The notice is the cell's own: **`SKIP <test>: <why>`**, printed to stderr and
+visible because the runner passes `--nocapture`. The name is what makes it
+attributable, and the reason is where the variable or the snapshot that would
+arm the cell is named — so both are printed. The same notice is what lets the
+census pin below drop that cell's hit count instead of waiving the entry, which
+is why an entry's test must print one.
+
+**A stand-down is not a failure and has no exit code.** A developer without the
+weights must not be blocked by this suite, and turning an absent snapshot red
+would do exactly that. What it must not do is look identical to a run that
+checked the cell, which is how a green `ci-perf` came to be quoted over
+speculative answer-equivalence gates that had never been asked. `make ci-perf`
+reads the runner's final line and prints `ci-perf INCOMPLETE` rather than
+`ci-perf ok` when it carries that marker.
+
+Both directions are pinned in `scripts/run_gpu_tests_selftest.sh`
+(`make gpu-runner-selftest`): a stand-down is listed with its reason, the final
+line of a run that stood a test down differs from the same run without it, the
+report survives `--no-shader-validation`, and a notice that named no test is
+counted without being attributed to whichever test was nearby.
+
+**Residual, stated rather than papered over.** A notice that names no test —
+`SKIP: <why>`, the older spelling still in much of the tree — cannot be
+attributed, so it is counted and not listed. The count is on the final line for
+the same reason the named ones are: a report that silently dropped them would
+claim a completeness it does not have. Converting the remaining sites is a
+mechanical change nobody has finished; write new ones in the named form.
+
 **No test in this suite is known-red on `main`, and this runner tracks no
 known-red list of tests.** (Shader-validation hits are the one thing it does
 track a baseline for, and that baseline is exact — see the census pin below. It
@@ -884,14 +939,16 @@ means.
 
 #### Where it runs: `make ci-perf`, not `make ci`
 
-`make ci-perf` is three lines, and it is the only shared gate that executes the
-GPU tests:
+`make ci-perf` is the only shared gate that executes the GPU tests. In order: a
+preflight on the environment, the `release-perf` workspace suite, the GPU suite,
+and a final line that reports the GPU suite's verdict rather than asserting one
+— `ci-perf ok` only when that run did not mark itself INCOMPLETE:
 
 ```make
 ci-perf:
 	@bash scripts/run_gpu_tests.sh --preflight
 	$(MAKE) test-perf
-	@bash scripts/run_gpu_tests.sh
+	@… bash scripts/run_gpu_tests.sh …   # then: ok, or INCOMPLETE if it stood cells down
 ```
 
 It is deliberately **not** in `make ci`. Two costs rule that out: the suite needs

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -874,12 +874,17 @@ line of a run that stood a test down differs from the same run without it, the
 report survives `--no-shader-validation`, and a notice that named no test is
 counted without being attributed to whichever test was nearby.
 
-**Residual, stated rather than papered over.** A notice that names no test —
-`SKIP: <why>`, the older spelling still in much of the tree — cannot be
-attributed, so it is counted and not listed. The count is on the final line for
-the same reason the named ones are: a report that silently dropped them would
-claim a completeness it does not have. Converting the remaining sites is a
-mechanical change nobody has finished; write new ones in the named form.
+**The shape is not the attribution.** A notice is attributed only when the name
+it carries is a classified GPU test in that crate. `SKIP: <why>` — the older
+spelling still in much of the tree — names nothing; `SKIP <suite or file>:
+<why>` names something no libtest filter reaches, which in a report is worse
+than saying nothing, because the reader tries to run it. Both are counted with
+the reason they could not be attributed and left off the list. The count rides
+on the final line for the same reason the named ones do: a report that silently
+dropped them would claim a completeness it does not have.
+
+Write new ones as `SKIP <its own test fn>: <why>`. Converting the sites that
+predate this is mechanical and unfinished.
 
 **No test in this suite is known-red on `main`, and this runner tracks no
 known-red list of tests.** (Shader-validation hits are the one thing it does

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -549,6 +549,16 @@ for crate in "${crates[@]}"; do
         [ -z "${notice}" ] && continue
         skip_test="${notice%%:*}"
         skip_test="${skip_test#SKIP }"
+        # The shape is not the attribution: a notice naming a suite, a file or a
+        # helper passes the pattern and names nothing this runner can select, so
+        # listing it would put a name in the report that no filter reaches.
+        # Checked against the whole classification rather than the selection,
+        # since an over-matching filter can run a classified test the selection
+        # did not ask for.
+        case $'\n'"${listing}"$'\n' in
+            *$'\n'"${crate}"$'\t'"${skip_test}"$'\n'*) ;;
+            *) n_unattributed=$((n_unattributed + 1)); continue ;;
+        esac
         stood_down="${stood_down}  ${crate} ${skip_test}: ${notice#*: }"$'\n'
         validation_skips="${validation_skips}${crate}"$'\t'"${skip_test}"$'\n'
         n_stood_down=$((n_stood_down + 1))
@@ -617,8 +627,9 @@ if [ "${n_stood_down}" -gt 0 ] || [ "${n_unattributed}" -gt 0 ]; then
     echo "stood down — these selected GPU tests announced they did not run:"
     printf '%s' "${stood_down}"
     if [ "${n_unattributed}" -gt 0 ]; then
-        echo "  ${n_unattributed} further stand-down notice(s) named no test and could not be"
-        echo "  attributed. A cell that stands down must print 'SKIP <test>: <why>', or its"
+        echo "  ${n_unattributed} further stand-down notice(s) named no test, or named something"
+        echo "  that is not a classified GPU test in that crate, and could not be attributed."
+        echo "  A cell that stands down must print 'SKIP <its own test fn>: <why>', or its"
         echo "  absence is invisible here and to the census pin. See docs/TESTING.md."
     fi
     echo

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -53,7 +53,12 @@
 #
 #   Model-gated cells that skip because no snapshot is present still count as
 #   executed; that is the suite's own documented contract and is not a
-#   process-wide off switch.
+#   process-wide off switch. They are REPORTED, though: every `SKIP <test>:
+#   <why>` notice is harvested, listed with its reason and counted on the final
+#   line as INCOMPLETE. A test that could not run is not a test that passed, and
+#   libtest prints `ok` for both — the answer-equivalence gates for speculative
+#   decoding are in that population, so a run that skipped them looked exactly
+#   like one where the equivalence held.
 #
 # SHADER VALIDATION (--shader-validation, on by default)
 #   An out-of-bounds device store from a Metal kernel is silently dropped: the
@@ -121,7 +126,9 @@
 #
 # Exit 0 = every selected GPU test passed and every shader-validation hit was
 # one the census pin accounts for. Exit 1 = a failing test, a hit the pin does
-# not account for, or a run that executed nothing.
+# not account for, or a run that executed nothing. A stand-down is not an exit
+# code — a developer without the weights must not be blocked — but it is on the
+# final line, marked INCOMPLETE.
 
 # No `-e`: cargo's exit code is captured explicitly via PIPESTATUS, and one
 # failing crate must not abort the remaining crates. The `[ ... ] && echo` guard
@@ -212,6 +219,18 @@ VALIDATION_BANNER='Metal GPU Validation Enabled'
 # to start a line. Requiring one of the two markers within a bounded distance
 # is what keeps a test's own "invalid" wording from forging a hit.
 VALIDATION_DIAGNOSTIC='Invalid .{0,120}(at offset [0-9]+|executing kernel function:)'
+
+# A cell that returns before asserting anything announces `SKIP <test>: <why>`.
+# The name is what makes the notice attributable — to the census expectation
+# below, and to the stand-down report the operator reads — so the two scans
+# share one definition of it: a run where they disagreed would list a notice as
+# attributed and count it as unattributed at the same time. Neither is anchored
+# at line start, because under --nocapture the notice lands after libtest's
+# `test some::name ... ` prefix.
+NAMED_SKIP='SKIP [A-Za-z_][A-Za-z0-9_]*:'
+# Any stand-down announcement, named or not. The surrounding character classes
+# keep `RMLX_SKIP_GPU` and words merely containing the letters from counting.
+ANY_SKIP='(^|[^A-Za-z0-9_])SKIP([^A-Za-z0-9_]|$)'
 
 # One `<kind><TAB><kernel>` record per diagnostic, read from stdin one
 # diagnostic per line.
@@ -369,6 +388,9 @@ validation_hits=""
 validation_kinds=""
 validation_records=""
 validation_skips=""
+stood_down=""
+n_stood_down=0
+n_unattributed=0
 
 if [ "${SHADER_VALIDATION}" = "1" ]; then
     echo "shader validation: ON (invalid Metal memory access fails this run)"
@@ -511,15 +533,35 @@ for crate in "${crates[@]}"; do
                                                       | awk -F'\t' -v c="${crate}" \
                                                             'NF == 2 { print c "\t" $0 }')"$'\n'
         fi
-        # A model-gated cell announces its own skip. Harvesting it is what lets
-        # the census expectation drop that cell's count instead of waiving the
-        # whole entry on a guess about which snapshots are installed. The notice
-        # routinely shares a line with libtest's `test <name> ... ` prefix under
-        # --nocapture, so this is not line-anchored.
-        validation_skips="${validation_skips}$(grep -Eo 'SKIP [A-Za-z_][A-Za-z0-9_]*:' "${log}" \
-            | awk -v c="${crate}" '{ sub(/^SKIP /, ""); sub(/:$/, ""); print c "\t" $0 }' \
-            | sort -u)"$'\n'
     fi
+
+    # A model-gated cell announces its own stand-down as `SKIP <test>: <why>`.
+    # It is harvested on every run, instrumented or not: a test that did not run
+    # is the same non-event either way, and the census expectation below drops
+    # that cell's count from it rather than waiving the whole entry on a guess
+    # about which snapshots are installed. The notice routinely shares a line
+    # with libtest's `test <name> ... ` prefix under --nocapture, so this is not
+    # line-anchored; a validation diagnostic can land appended to it, so the
+    # reason is cut there rather than carrying a second event's text.
+    crate_skips="$(grep -Eo "${NAMED_SKIP}.*" "${log}" \
+        | sed -E 's/Invalid (device|threadgroup).*$//; s/[[:space:]]+$//' | sort -u)"
+    while IFS= read -r notice; do
+        [ -z "${notice}" ] && continue
+        skip_test="${notice%%:*}"
+        skip_test="${skip_test#SKIP }"
+        stood_down="${stood_down}  ${crate} ${skip_test}: ${notice#*: }"$'\n'
+        validation_skips="${validation_skips}${crate}"$'\t'"${skip_test}"$'\n'
+        n_stood_down=$((n_stood_down + 1))
+    done <<< "${crate_skips}"
+
+    # A notice that names no test cannot be attributed, so it can be counted but
+    # not listed — and a report that silently drops it claims a completeness it
+    # does not have. Counted per occurrence rather than deduplicated: the point
+    # is how much of this run went unaccounted for.
+    all_notices="$(grep -Eo "${ANY_SKIP}" "${log}" | grep -c '')"
+    named_notices="$(grep -Eo "${NAMED_SKIP}" "${log}" | grep -c '')"
+    n_unattributed=$((n_unattributed + all_notices - named_notices))
+
     rm -f "${log}"
     crate_passed=${counts% *}
     crate_failed=${counts#* }
@@ -563,6 +605,24 @@ echo
 # the same run. Each crate's log is deleted inside the loop, so what is not
 # printed here is gone.
 red=0
+
+# A test that could not run is not a test that passed, and libtest reports both
+# as `ok`. So every stand-down this run observed is printed here, with the
+# reason its own gate gave — which is where the variable or the snapshot that
+# would arm it is named. It is not a failure: a developer without the weights
+# must not be blocked by this suite. It is the distinction between a suite that
+# held and one that was never asked, and it also reaches the final line, because
+# a summary read as green has to say what it did not check.
+if [ "${n_stood_down}" -gt 0 ] || [ "${n_unattributed}" -gt 0 ]; then
+    echo "stood down — these selected GPU tests announced they did not run:"
+    printf '%s' "${stood_down}"
+    if [ "${n_unattributed}" -gt 0 ]; then
+        echo "  ${n_unattributed} further stand-down notice(s) named no test and could not be"
+        echo "  attributed. A cell that stands down must print 'SKIP <test>: <why>', or its"
+        echo "  absence is invisible here and to the census pin. See docs/TESTING.md."
+    fi
+    echo
+fi
 
 # An invalid access is a failure even though every test reported `ok` and cargo
 # exited 0 — that is the whole point: the access never reaches the buffer, and
@@ -758,13 +818,17 @@ if [ "${red}" = "1" ]; then
     exit 1
 fi
 
-# The note rides on the OK line, not only on stderr: a summary an operator reads
+# The notes ride on the OK line, not only on stderr: a summary an operator reads
 # as "green" has to say what it did not check, or the next reader repeats the
-# mistake of quoting the exit code.
+# mistake of quoting the exit code. The word INCOMPLETE is the marker
+# `make ci-perf` reads to decide whether its own last line may say `ok`, so it
+# stays on this line whichever clause put it there.
+incomplete=""
 if [ -n "${snapshot_root_note}" ]; then
     incomplete=" — INCOMPLETE: ${snapshot_root_note}"
-else
-    incomplete=""
+fi
+if [ "${n_stood_down}" -gt 0 ] || [ "${n_unattributed}" -gt 0 ]; then
+    incomplete="${incomplete} — INCOMPLETE: ${n_stood_down} selected GPU test(s) stood down and $((n_unattributed)) further notice(s) named no test; they asserted nothing (listed above)"
 fi
 if [ "${SHADER_VALIDATION}" = "1" ] && [ -n "${census_notes}" ]; then
     echo "OK: ${total_passed} GPU tests passed across ${#crates[@]} workspace member(s), shader-validation census NOT enforced in full (see above).${incomplete}"

--- a/scripts/run_gpu_tests_selftest.sh
+++ b/scripts/run_gpu_tests_selftest.sh
@@ -858,6 +858,26 @@ expect_out "INCOMPLETE: 0 selected GPU test(s) stood down"
 expect_no_out "rmlx-models spec_alpha:"
 
 # ---------------------------------------------------------------------------
+# A notice whose name is not a test is not an attribution either. A suite that
+# announces itself by file or helper name passes the pattern and names nothing
+# a libtest filter reaches, so listing it would put a name in the report that
+# the reader cannot run. It is counted with the nameless ones.
+new_case named_notice_that_is_not_a_test_is_not_attributed || exit 1
+classify "${CASE_ROOT}" rmlx-models spec_alpha
+crate_log "${CASE_ROOT}" rmlx-models 0 <<'LOG'
+Metal GPU Validation Enabled
+running 1 test
+test loader::published ... SKIP dflash2_loader: the published checkpoint is not on this machine
+ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 0
+expect_out "1 further stand-down notice(s)"
+expect_out "INCOMPLETE: 0 selected GPU test(s) stood down"
+expect_no_out "rmlx-models dflash2_loader:"
+
+# ---------------------------------------------------------------------------
 # The harness's own positive control: with nothing wrong, the same stubs produce
 # a green run. Without this, every case above could be passing because the stub
 # crates never ran at all.

--- a/scripts/run_gpu_tests_selftest.sh
+++ b/scripts/run_gpu_tests_selftest.sh
@@ -760,6 +760,104 @@ expect_no_out "has no classified GPU test"
 expect_no_out "not found"
 
 # ---------------------------------------------------------------------------
+# A cell that stood down is reported as itself. libtest prints `ok` for a test
+# that returned before asserting anything, so without this the operator cannot
+# tell a suite that held from one that was never asked — the shape that let a
+# green `ci-perf` be quoted over speculative answer-equivalence gates that had
+# not run.
+#
+# The reason is asserted, not just the name: it is where the variable that would
+# arm the cell is named, and a report that drops it sends the reader hunting.
+new_case stand_down_is_named_with_its_reason || exit 1
+classify "${CASE_ROOT}" rmlx-models spec_alpha spec_beta
+crate_log "${CASE_ROOT}" rmlx-models 0 <<'LOG'
+Metal GPU Validation Enabled
+running 2 tests
+test spec::alpha ... SKIP spec_alpha: RMLX_DRAFT_TEST_MODEL is unset and this pair's drafter is not resolved by slug
+ok
+test spec::beta ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 0
+expect_out "stood down"
+expect_out "rmlx-models spec_alpha: RMLX_DRAFT_TEST_MODEL is unset"
+expect_out "INCOMPLETE: 1 selected GPU test(s) stood down"
+expect_no_out "spec_beta:"
+
+# ---------------------------------------------------------------------------
+# The pair that makes the report falsifiable: the same crate, the same two
+# tests, run once with a stand-down and once without. The final line an operator
+# quotes must differ between them — if it does not, the notice above is
+# decoration.
+new_case stand_down_changes_the_final_line || exit 1
+classify "${CASE_ROOT}" rmlx-models spec_alpha spec_beta
+crate_log "${CASE_ROOT}" rmlx-models 0 <<'LOG'
+Metal GPU Validation Enabled
+running 2 tests
+test spec::alpha ... SKIP spec_alpha: RMLX_O_MODELS_ROOT does not hold a runnable snapshot
+ok
+test spec::beta ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 0
+stood_down_line="$(printf '%s\n' "${OUT}" | grep '^OK:')"
+crate_log "${CASE_ROOT}" rmlx-models 0 <<'LOG'
+Metal GPU Validation Enabled
+running 2 tests
+test spec::alpha ... ok
+test spec::beta ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 0
+ran_line="$(printf '%s\n' "${OUT}" | grep '^OK:')"
+[ "${stood_down_line}" = "${ran_line}" ] &&
+    fail "a run that stood a test down ends in the same line as one that ran it: ${ran_line}"
+case "${ran_line}" in
+    *INCOMPLETE*) fail "a run with nothing stood down must not be marked INCOMPLETE: ${ran_line}" ;;
+esac
+expect_no_out "stood down"
+
+# ---------------------------------------------------------------------------
+# A stand-down is not a property of the Metal validation layer, and harvesting
+# it only when that layer is on would leave `--no-shader-validation` reporting
+# an unqualified pass over cells that never ran.
+new_case stand_down_survives_uninstrumented || exit 1
+classify "${CASE_ROOT}" rmlx-models spec_alpha
+crate_log "${CASE_ROOT}" rmlx-models 0 <<'LOG'
+running 1 test
+test spec::alpha ... SKIP spec_alpha: RMLX_DRAFT_TEST_MODEL is unset
+ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}" --no-shader-validation
+expect_status 0
+expect_out "rmlx-models spec_alpha: RMLX_DRAFT_TEST_MODEL is unset"
+expect_out "INCOMPLETE: 1 selected GPU test(s) stood down"
+
+# ---------------------------------------------------------------------------
+# A notice that names no test cannot be attributed. It is counted rather than
+# dropped — a report that omits it claims to have seen every stand-down when it
+# has not — and it must not be attributed to whichever test happened to be
+# nearby, which would be worse than saying nothing.
+new_case unattributed_stand_down_is_counted || exit 1
+classify "${CASE_ROOT}" rmlx-models spec_alpha
+crate_log "${CASE_ROOT}" rmlx-models 0 <<'LOG'
+Metal GPU Validation Enabled
+running 1 test
+test spec::alpha ... SKIP: RMLX_TEST_MODEL_QWEN36 not set
+ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+LOG
+run_case "${CASE_ROOT}"
+expect_status 0
+expect_out "1 further stand-down notice(s) named no test"
+expect_out "INCOMPLETE: 0 selected GPU test(s) stood down"
+expect_no_out "rmlx-models spec_alpha:"
+
+# ---------------------------------------------------------------------------
 # The harness's own positive control: with nothing wrong, the same stubs produce
 # a green run. Without this, every case above could be passing because the stub
 # crates never ran at all.


### PR DESCRIPTION
Closes #517. Closes #522.

Two issues, one defect: a test that could not run reports exactly what a test
that passed reports. libtest prints `ok` for both, and the runner above them
folded the two together.

## What was wrong

**The resolver (#522).** The shared snapshot probe in `tests/common/mod.rs`
required a `tokenizer.json` of every directory it was asked about. A drafter
sidecar has no tokenizer — it proposes ids for a verifier and is decoded with
the verifier's — and mlx-community ships those snapshots without one. So the
probe reported such a checkpoint as absent on the machine holding it, and an
absence is a skip. Two sidecars in the current test set carry no tokenizer, and
the suite that resolves its drafter this way is the answer-equivalence gate,
whose whole purpose is catching a speculative arm that changes the answer.

**The report (#517).** `scripts/run_gpu_tests.sh` harvested the tests' own
`SKIP <test>: <why>` notices, but only to compute the shader-validation census
expectation, and only when that layer was on. Nothing printed them. A run that
stood a suite down and a run in which it held ended in the same line, and
`make ci-perf` printed `ci-perf ok` after either.

## What this does

* The probe takes the **role** the caller is asking for. `Standalone` keeps the
  three files the golden harness opens by name; `Sidecar` drops the tokenizer
  and keeps the config and the weights, which is exactly what every
  `<Kind>Drafter::load` reads. Both directions are pinned: a tokenizer-less
  directory resolves as a sidecar and does not resolve as a standalone model,
  naming the file it lacks; a sidecar missing its config or its weights still
  does not resolve.
* The runner **reports every stand-down**, on every run, instrumented or not —
  each with the reason its own gate gave, which is where the variable or the
  snapshot that would arm it is named — counts the notices that named no test
  and could not be attributed, and marks the final line INCOMPLETE. `make
  ci-perf` reads that line and says so instead of `ci-perf ok`.
* A stand-down is deliberately **not** a failure and has no exit code: a
  developer without the weights must not be blocked by this suite. What it must
  not do is look identical to a run that checked the cell.
* The six speculative alignment suites announced their stand-downs in a form
  nothing read (a tag, a dash, "skipping"). Same conditions, now in the form
  the runner counts.

## Why not the alternatives

A **count the suite must reach**, or a **manifest of pairs that must run**,
would have to be maintained beside the classifier that already derives the
population, and would go red on any partial mirror — nobody holds every
snapshot. A **resolver that fails on a present-but-unusable directory** is
already the rule for a path an operator named, and is deliberately *not* the
rule for a slug under the models root: a half-written download is the modal
shape and turning it red blocks the developer this suite must not block. What
was actually missing was that a skip be **reported and counted** rather than
printed into a stream nothing reads, which is the shape the shader-validation
census already uses one layer down.

## Evidence

Every guard lands with a mutation case that asserts the reason, not the exit
code.

* `cargo test -p rmlx-models` — with `Sidecar` put back to requiring a
  tokenizer, the two new resolver cases fail naming `tokenizer.json`.
* `make gpu-runner-selftest` — four new cases (a stand-down named with its
  reason; the final line of a run that stood a test down differs from the same
  run without it; the report survives `--no-shader-validation`; a nameless
  notice is counted without being attributed to a nearby test). Mutated four
  ways — dropping the INCOMPLETE clause, harvesting only under shader
  validation, printing the count without the names, and relaxing what counts as
  a named notice — each fails the case it should and no other.
* **On the real thing.** A models root was assembled from the real
  `gemma-4-e2b` verifier and the real `E2B-it-assistant-bf16` drafter with its
  `tokenizer.json` withheld. The equivalence gate **runs** and agrees on all six
  prompts (113 s of decode). With the pre-change probe the same setup prints
  `SKIP the_assistant_round_loop_reproduces_plain_greedy: … no tokenizer.json in
  it` and `test result: ok. 1 passed` — the defect, on a machine with the
  checkpoint on disk.
* The runner, on this tree: the recurrent pair stands down and the run ends in
  `— INCOMPLETE: 1 selected GPU test(s) stood down …` naming the test and
  `RMLX_DRAFT_TEST_MODEL`; the assistant pair, pointed at the doctored root,
  runs and ends without the marker. An instrumented run of a small crate
  confirms the shader-validation canary and census path are unaffected.

## Residual, stated rather than papered over

A notice that names no test — `SKIP: <why>`, the older spelling still in much of
the tree — cannot be attributed, so it is counted and not listed. The count is
on the final line for the same reason the named ones are. Converting the
remaining sites is mechanical and out of scope here.

Not run: `make ci` and `make ci-perf` (the orchestrator owns those), and no
benchmark, A/B or timing comparison — this change produces correctness
evidence, not numbers.