### PR TITLE
fix(metrics): a champion row names the run that produced its values

### DIFF
--- a/crates/rmlx-metrics/src/export.rs
+++ b/crates/rmlx-metrics/src/export.rs
@@ -346,15 +346,17 @@ fn render_speculative_table(all: &[BestRow]) -> String {
             backend_display(backend),
             kv_quant_display(kv_quant)
         );
+        let mut rendered: Vec<(&str, &BestRow)> = Vec::new();
         for col in SPEC_METRIC_COLUMNS {
             match metric_map.get(col.db_name) {
                 Some(r) => {
                     let _ = write!(row, "| {} ", fmt_value(r.value, col.decimals));
+                    rendered.push((col.db_name, r));
                 }
                 None => row.push_str("| - "),
             }
         }
-        let _ = writeln!(row, "| {} |", updated_summary(metric_map));
+        let _ = writeln!(row, "| {} |", updated_summary(&rendered));
         out.push_str(&row);
     }
     out.push('\n');
@@ -571,10 +573,12 @@ fn render_model_table(
             .reduce(f64::min);
 
         let mut row = format!("| {backend_label} | {kv_label} | {decode_label} ");
+        let mut rendered: Vec<(&str, &BestRow)> = Vec::new();
         for col in METRIC_COLUMNS {
             match metric_map.get(col.db_name) {
                 Some(r) => {
                     let _ = write!(row, "| {} ", fmt_value(r.value, col.decimals));
+                    rendered.push((col.db_name, r));
                     *total_cells += 1;
                 }
                 None => row.push_str("| - "),
@@ -582,7 +586,7 @@ fn render_model_table(
         }
         let _ = write!(row, "| {} ", fmt_kv_gb(kv_bytes_quant));
         let _ = write!(row, "| {} ", fmt_reduction(kv_bytes_quant, kv_bytes_bf16));
-        let _ = writeln!(row, "| {} |", updated_summary(metric_map));
+        let _ = writeln!(row, "| {} |", updated_summary(&rendered));
         out.push_str(&row);
     }
 
@@ -617,23 +621,47 @@ fn best_of(existing: &BestRow, candidate: &BestRow) -> bool {
     }
 }
 
-/// Pick the most recent ts_utc + run_id + (truncated) notes among the cell's metrics.
-fn updated_summary(metric_map: &BTreeMap<String, &BestRow>) -> String {
-    let mut newest: Option<&BestRow> = None;
-    for r in metric_map.values() {
-        match newest {
-            None => newest = Some(r),
-            Some(n) if r.ts_utc > n.ts_utc => newest = Some(r),
-            _ => {}
+/// Provenance for the metric columns of one row: the runs that produced the
+/// values printed beside it.
+///
+/// Every metric column is resolved against `bests` on its own, so two columns
+/// of one row can come from two runs. When they do there is no single run to
+/// name, and the cell says so and names each run beside the columns it backs —
+/// picking one of them would put a run id and its notes next to a number that
+/// run does not contain, which reads as provenance and is not.
+///
+/// Scope is the metric columns, and the caller passes exactly the ones it
+/// printed. `KV GB` and `reduction vs bf16` are minima over every matching
+/// cell and back to no single observation, so they are not represented here.
+///
+/// `rendered` is in column order; runs appear in the order their first column
+/// does.
+fn updated_summary(rendered: &[(&str, &BestRow)]) -> String {
+    let mut runs: Vec<(&BestRow, Vec<&str>)> = Vec::new();
+    for (metric, row) in rendered {
+        match runs.iter_mut().find(|(seen, _)| seen.run_id == row.run_id) {
+            Some((_, metrics)) => metrics.push(metric),
+            None => runs.push((row, vec![metric])),
         }
     }
-    let Some(r) = newest else {
-        return "-".into();
+
+    let [(row, _)] = runs.as_slice() else {
+        if runs.is_empty() {
+            return "-".into();
+        }
+        let mut out = String::from("no single run —");
+        for (i, (row, metrics)) in runs.iter().enumerate() {
+            let sep = if i == 0 { " " } else { ", " };
+            // write!(String) is infallible — let _ discards the unit Ok.
+            let _ = write!(out, "{sep}`{}` ({})", row.run_id, metrics.join(", "));
+        }
+        return out;
     };
-    let date = r.ts_utc.split('T').next().unwrap_or(&r.ts_utc);
-    let run = &r.run_id;
+
+    let date = row.ts_utc.split('T').next().unwrap_or(&row.ts_utc);
+    let run = &row.run_id;
     let mut note_part = String::new();
-    if let Some(n) = r.notes.as_deref().filter(|s| !s.is_empty()) {
+    if let Some(n) = row.notes.as_deref().filter(|s| !s.is_empty()) {
         // `legacy_run_key=...` is migration bookkeeping; skip those notes.
         if !n.starts_with("legacy_run_key=") {
             let snippet: String = n.chars().take(80).collect();

--- a/crates/rmlx-metrics/src/export_tests.rs
+++ b/crates/rmlx-metrics/src/export_tests.rs
@@ -1020,3 +1020,278 @@ fn a_database_with_no_drafter_renders_no_speculative_section() {
     let md = export_markdown(&conn, None).unwrap();
     assert!(!md.contains("## Speculative decoding"), "{md}");
 }
+
+// ── Row provenance ───────────────────────────────────────────────────────────
+
+/// One run in a fixed cell, with its own timestamp, notes and metric set.
+/// Returns the minted run id, so a test can name the run it expects a row to
+/// point at rather than matching a substring of the table.
+fn seed_run(
+    conn: &mut Connection,
+    ts_utc: &str,
+    notes: &str,
+    decode_config: Option<&str>,
+    metrics: &[(&str, f64)],
+) -> String {
+    let mut rec = Recorder::new(conn, "test@0.0.1");
+    let run = RunRecord {
+        schema_version: crate::ingest::RECORD_SCHEMA_VERSION,
+        backend: "rmlx".into(),
+        backend_version: Some("0.4.1".into()),
+        model_namespace: "mlx-community".into(),
+        model: "Qwen3.8-27B-mxfp8".into(),
+        weight_quant: "mxfp8".into(),
+        kv_quant: "none".into(),
+        ctx_max: 16384,
+        prompt: PromptRef::ByBody {
+            name: "p".into(),
+            body: json!("x"),
+            notes: None,
+            tokens_approx: Some(1),
+        },
+        ts_utc: ts_utc.into(),
+        git_sha: None,
+        build_profile: None,
+        hardware_tag: "m5_max_128gb".into(),
+        prompt_tokens: None,
+        max_tokens: None,
+        temperature: Some(0.0),
+        seed: None,
+        n_warmups: None,
+        n_measure: None,
+        output_first_64: None,
+        notes: Some(notes.into()),
+        description: None,
+        decode_config: decode_config.map(ToOwned::to_owned),
+        metrics: metrics
+            .iter()
+            .map(|(name, value)| MetricEntry {
+                name: (*name).to_owned(),
+                value: Some(*value),
+                stddev: None,
+            })
+            .collect(),
+    };
+    rec.record_run(&run).unwrap().run_id
+}
+
+/// What "the newest metric in the cell" answers for `decode_config` — the rule
+/// the `Updated` column used to follow.
+///
+/// The provenance fixtures assert this is *not* the run they expect to read.
+/// A fixture where the two rules agree cannot tell them apart, and would pass
+/// against the behaviour it exists to reject.
+fn newest_run_in_cell(conn: &Connection, decode_config: Option<&str>) -> String {
+    let mut newest: Option<BestRow> = None;
+    for r in all_bests(conn).unwrap() {
+        if r.cell.decode_config.as_deref() != decode_config {
+            continue;
+        }
+        match &newest {
+            Some(n) if n.ts_utc >= r.ts_utc => {}
+            _ => newest = Some(r),
+        }
+    }
+    newest.expect("the cell holds at least one champion").run_id
+}
+
+/// The `Records` half of the table — everything before the speculative section.
+fn records_section(md: &str) -> &str {
+    md.split("## Speculative decoding")
+        .next()
+        .expect("split yields at least one part")
+}
+
+fn row_containing<'a>(section: &'a str, needle: &str) -> &'a str {
+    section
+        .lines()
+        .find(|l| l.starts_with("| rmlx ") && l.contains(needle))
+        .unwrap_or_else(|| panic!("no row matching {needle} in:\n{section}"))
+}
+
+/// A row names the run behind its own values, and a later run in the same cell
+/// backing none of them does not displace it.
+///
+/// The later run here records `accept_rate`, which this table has no column
+/// for: its id and its notes reached the `Updated` cell of a row it contributed
+/// no printed number to.
+#[test]
+fn a_row_names_the_run_behind_its_values_not_the_newest_in_the_cell() {
+    let mut conn = test_conn();
+    let arm = Some("mtp/block=3");
+    let measured = seed_run(
+        &mut conn,
+        "2026-09-01T10:00:00Z",
+        "code prompt, 200 tokens",
+        arm,
+        &[("decode_tps_warm", 38.73), ("peak_rss_mb", 9000.0)],
+    );
+    let later = seed_run(
+        &mut conn,
+        "2026-09-04T10:00:00Z",
+        "accept-rate sweep",
+        arm,
+        &[("accept_rate", 0.91)],
+    );
+
+    // The fixture separates the two rules: the newest run in the cell is not
+    // the run behind the row's values.
+    assert_ne!(measured, later);
+    assert_eq!(newest_run_in_cell(&conn, arm), later);
+
+    let md = export_markdown(&conn, None).unwrap();
+    let row = row_containing(records_section(&md), "mtp/block=3");
+
+    assert!(row.contains("38.73"), "{row}");
+    assert!(
+        row.contains(&format!("`{measured}`")),
+        "the row does not name the run that produced its values: {row}"
+    );
+    assert!(
+        !row.contains(&later),
+        "the row carries the newest run in the cell instead: {row}"
+    );
+    assert!(row.contains("code prompt, 200 tokens"), "{row}");
+    assert!(
+        !row.contains("accept-rate sweep"),
+        "the row borrowed a note from a run none of its numbers came from: {row}"
+    );
+}
+
+/// Two runs, one row: the decode record is one run's and the memory record the
+/// other's, so no single run produced the row. The column says so and names
+/// both beside the columns they back, rather than taking whichever landed later
+/// and putting its notes next to a number it does not contain.
+#[test]
+fn a_row_built_from_two_runs_says_it_has_no_single_run() {
+    let mut conn = test_conn();
+    let fast = seed_run(
+        &mut conn,
+        "2026-09-01T10:00:00Z",
+        "code prompt, 200 tokens",
+        None,
+        &[("decode_tps_warm", 38.73), ("peak_rss_mb", 9000.0)],
+    );
+    let lean = seed_run(
+        &mut conn,
+        "2026-09-04T10:00:00Z",
+        "prose prompt, 200 tokens",
+        None,
+        &[("decode_tps_warm", 33.67), ("peak_rss_mb", 8000.0)],
+    );
+
+    // Distinguishing: the newest run backs one printed column and not the other.
+    assert_eq!(newest_run_in_cell(&conn, None), lean);
+
+    let md = export_markdown(&conn, None).unwrap();
+    let row = row_containing(records_section(&md), "| plain ");
+
+    assert!(row.contains("38.73"), "{row}");
+    assert!(row.contains("8000"), "{row}");
+    assert!(
+        row.contains("no single run"),
+        "a row blended from two runs claims one: {row}"
+    );
+    assert!(
+        row.contains(&format!("`{fast}` (decode_tps_warm)")),
+        "{row}"
+    );
+    assert!(row.contains(&format!("`{lean}` (peak_rss_mb)")), "{row}");
+    assert!(
+        !row.contains("prompt, 200 tokens"),
+        "a note belongs to one run and this row has two: {row}"
+    );
+}
+
+/// The speculative table resolves its columns the same way and needs the same
+/// rule — a fix applied to one renderer and not the other fails here.
+#[test]
+fn the_speculative_row_names_the_runs_behind_its_round_figures() {
+    let mut conn = test_conn();
+    let arm = Some("mtp/block=3");
+    let fast = seed_run(
+        &mut conn,
+        "2026-09-01T10:00:00Z",
+        "code prompt, 200 tokens",
+        arm,
+        &[("decode_tps_warm", 38.73)],
+    );
+    let accepting = seed_run(
+        &mut conn,
+        "2026-09-04T10:00:00Z",
+        "prose prompt, 200 tokens",
+        arm,
+        &[("decode_tps_warm", 33.67), ("accept_rate", 0.91)],
+    );
+
+    assert_eq!(newest_run_in_cell(&conn, arm), accepting);
+
+    let md = export_markdown(&conn, None).unwrap();
+    let section = md
+        .split("## Speculative decoding")
+        .nth(1)
+        .expect("section present");
+    let row = section
+        .lines()
+        .find(|l| l.contains("mtp/block=3"))
+        .expect("the arm's row");
+
+    assert!(row.contains("38.73"), "{row}");
+    assert!(row.contains("0.910"), "{row}");
+    assert!(row.contains("no single run"), "{row}");
+    assert!(
+        row.contains(&format!("`{fast}` (decode_tps_warm)")),
+        "{row}"
+    );
+    assert!(
+        row.contains(&format!("`{accepting}` (accept_rate)")),
+        "{row}"
+    );
+}
+
+/// The ordinary case is unchanged: one run behind every printed value keeps the
+/// date, the run id and that run's notes.
+#[test]
+fn a_row_from_one_run_still_shows_its_date_and_notes() {
+    let mut conn = test_conn();
+    let only = seed_run(
+        &mut conn,
+        "2026-09-01T10:00:00Z",
+        "code prompt, 200 tokens",
+        None,
+        &[("decode_tps_warm", 38.73), ("peak_rss_mb", 9000.0)],
+    );
+
+    let md = export_markdown(&conn, None).unwrap();
+    let row = row_containing(records_section(&md), "| plain ");
+
+    assert!(
+        row.contains(&format!("2026-09-01 `{only}` — code prompt, 200 tokens")),
+        "{row}"
+    );
+    assert!(!row.contains("no single run"), "{row}");
+}
+
+/// A row printing no metric column of its own has no provenance to show, and
+/// says nothing rather than reaching for a run in the cell that backs a column
+/// the row does not print.
+#[test]
+fn a_row_with_no_printed_metric_shows_no_run() {
+    let mut conn = test_conn();
+    let sweep = seed_run(
+        &mut conn,
+        "2026-09-01T10:00:00Z",
+        "accept-rate sweep",
+        Some("mtp/block=3"),
+        &[("accept_rate", 0.91)],
+    );
+
+    let md = export_markdown(&conn, None).unwrap();
+    let row = row_containing(records_section(&md), "mtp/block=3");
+
+    assert!(
+        !row.contains(&sweep),
+        "a row printing none of the run's metrics still names it: {row}"
+    );
+    assert!(row.trim_end().ends_with("| - |"), "{row}");
+}

--- a/docs/METRICS_DB.md
+++ b/docs/METRICS_DB.md
@@ -1733,9 +1733,33 @@ This:
 1. Queries `bests` for the canonical 5-model × N-KV grid.
 2. Renders cells per the existing layout in `BENCHMARK_CHAMPIONS.md`.
 3. Marks unsupported cells `N/A`, broken-output cells `x` (manual flag in `description`).
-4. Footer lines list the run_id + git_sha behind each champion cell.
+4. Names, in each row's `Updated` column, the run behind that row's metric columns.
 
 The hand-edit rule remains: if you didn't run a bench, don't touch the file. Now: if you didn't UPSERT a strictly-better row, the file won't change.
+
+### 9.1 What the `Updated` column means
+
+Every metric column of a row is a separate `bests` lookup — one partition per
+cell **and metric** (§3.3) — so a row's decode record and its memory record can
+come from two runs, and often do once a cell has been measured more than once.
+The column therefore reports provenance for the metric columns and nothing
+else:
+
+- **One run behind all of them** — its date, its `run_id` and its notes.
+- **More than one** — `no single run —` followed by each `run_id` and the
+  columns it backs. There is no single run to name and the column says so;
+  naming the newest, or any other one of them, would put a run id and its notes
+  beside numbers that run does not contain, which reads as provenance and is
+  not.
+- **No metric column printed at all** — `-`.
+
+`git_sha` is not in this column. It reaches `--csv`, `--json` and `--jsonl`,
+which emit one record per champion row and so carry it per value; from a
+markdown row, `run_id` is the key to look it up in `observations`.
+
+`KV GB` and `reduction vs bf16` are outside the column's scope. Both are minima
+over every cell matching the model, across backends and prompts, and back to no
+single observation.
 
 ---
 


### PR DESCRIPTION
Closes #514.

## Where the defect actually lived

In the renderer, not in `bests` and not at ingest. Both of those are fine and I
checked them before changing anything:

- `bests` partitions on the cell **plus the metric** and ranks by value, tie
  broken by timestamp. Each champion row it returns carries the winning
  observation's own `run_id`, `ts_utc`, `git_sha` and notes, so every row
  already knows where it came from.
- The recorder writes one `observations` row per metric, all of them stamped
  with the same minted `run_id`. Nothing is lost on the way in.

`updated_summary` in `crates/rmlx-metrics/src/export.rs` then threw that away.
It scanned every metric in the cell and printed the one with the newest
timestamp, so the run id and notes beside a row were the newest run's, not the
run behind the numbers printed on that row. The issue is right about the
location and right about it being deliberate as written.

There were two independent ways it went wrong, and the fix needed both halves:

1. **Scope.** It considered metrics the row does not print. A cell's
   `accept_rate` has no column in the per-model table, and an `accept_rate`
   sweep recorded later put its id and its notes on a row it contributed no
   printed number to.
2. **Attribution.** Even restricted to the printed columns, a row is often
   built from several runs — the decode record from one, the memory record from
   another — and there is then no single run to name.

## What it does now

The column is built from the champion rows the row actually printed:

- one run behind all of them → that run's date, id and notes, as before;
- several → `no single run —` and then each `run_id` beside the columns it
  backs;
- none printed → `-`.

`KV GB` and `reduction vs bf16` are deliberately outside the column's scope:
both are minima over every cell matching the model, across backends and
prompts, and back to no single observation. That is written down in
`docs/METRICS_DB.md` §9.1 rather than left to be rediscovered.

`git_sha` is not in the markdown column and was not before. It reaches `--csv`,
`--json` and `--jsonl`, which emit one record per champion row and so already
carry it per value; from a markdown row the `run_id` is the key to look it up.
Adding a second identifier to every row buys nothing the run id does not
already give, so I left it out and said so in the doc.

## Existing rows

None need remedying. `observations` was never wrong — the values, run ids,
timestamps and notes in it are all correct and correctly associated. Only the
rendering mis-paired them, and `BENCHMARK_CHAMPIONS.md` is a derived artifact.
The remedy is to regenerate it; nothing has to be edited in an append-only
table, which is fortunate because it could not be.

## Tests

Five, in `export_tests.rs`. Four fail against the previous behaviour, each
naming the specific wrong attribution rather than just exiting non-zero — for
instance `the row does not name the run that produced its values: | rmlx |
bf16 KV | mtp/block=3 | 38.73 | ... | 2026-09-04 <run> — accept-rate sweep |`,
which is the issue's symptom exactly.

Each half of the fix is separately load-bearing, checked by mutation:

| mutation | fails |
|---|---|
| the whole previous renderer | 4 of the 5 |
| announcement dropped, scope kept | the two blended-row tests, in both tables |
| scope dropped, announcement kept | the two scope tests |

The fifth test is a positive control — one run behind every printed value —
and passes under all of them, which is what makes the other four mean
something.

**Why the fixtures are not vacuous.** A provenance test goes vacuous when the
cell holds one run: "the newest" and "the right one" then have the same answer
and the test passes against the bug. Each fixture here puts a second run in the
same cell that is strictly newer and backs a *different* set of columns, and
asserts that separation from the database rather than assuming it —
`newest_run_in_cell()` re-derives the old rule's answer from `bests` and every
fixture asserts it is not the run it expects to read.

## Found while in there, not fixed

The per-model table keys its rows on `(backend, kv_quant, decode_config)` and
drops `ctx_max` and `prompt_id`, which the speculative table's row key keeps
and has a test for. Two contexts of one arm therefore collapse into a single
row. Probed on this branch: 4k and 128k runs of one arm render as one row
carrying the 4k decode rate, the 128k peak RSS, and a `KV GB` figure looked up
at whichever context the alphabetically-first metric's champion happened to
carry — `metric_map.values().next().map_or(8192, ...)`, whose `8192` is a
fabricated plausible default in a branch nothing can currently reach. The table
has no context column, so nothing on the row says which. That is the
substitute-a-plausible-value shape and it is a separate defect; this change
makes it *visible* (such a row now says `no single run`) but does not fix it.
Worth its own issue.

## Not checked

No GPU, no model, no benchmark — nothing here touches an inference path. I ran
`cargo test -p rmlx-metrics` (289 pass), `cargo clippy -p rmlx-metrics
--all-targets --all-features -D warnings`, `cargo fmt`,
`make check-doc-source-citations` and `make check-no-inline-tests`. I did not
run `make ci` or `make ci-perf`.
