### PR TITLE
spec: equivalence pairs for the three uncovered round loops, and the divergence settled

### DIFF
--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -81,29 +81,39 @@
 //!
 //! # Recall
 //!
-//! Over the twelve (pair, prompt) cells each broken engine above produces, the
-//! gate refuses six of six on the assistant pair and four of six on the
-//! recurrent one. The two it does not refuse read 0.0000 and 0.0977 — inside the
-//! ceiling — and are why the gate runs **every** prompt rather than one: recall
-//! is a property of the set. Both broken engines turn both gates red. The block
-//! pair's own two broken engines are refused on six of six prompts each.
+//! Over the (pair, prompt) cells each broken engine above produces, the gate
+//! refuses six of six on the assistant pair and four of six on the recurrent
+//! one. The two it does not refuse read 0.0000 and 0.0977 — inside the ceiling —
+//! and are why the gate runs **every** prompt rather than one: recall is a
+//! property of the set. Both broken engines turn both gates red. The block pair's
+//! own two broken engines are refused on six of six prompts each; the adaptive
+//! and restricted-vocabulary pairs refuse a rollback off by one on all five
+//! prompts they judge, and the two-model pair on all six.
 //!
 //! # Pairs
 //!
-//! Three, whose verifiers resolve by slug from `RMLX_O_MODELS_ROOT`:
+//! Six, whose verifiers resolve by slug from `RMLX_O_MODELS_ROOT`:
 //!
 //! | verifier | drafter | round loop | rollback |
 //! |---|---|---|---|
 //! | `gemma-4-e2b-it-mxfp8` | `gemma-4-E2B-it-assistant-bf16` | shared-K/V assistant | KV truncation, SWA ring included |
 //! | `Qwen3.8-27B-mxfp8` | `Qwen3.8-27B-MTP-mxfp8` | MTP sidecar | KV truncation + recurrent snapshot/replay |
 //! | `Qwen3.8-27B-4bit` | `Qwen3.8-27B-DFlash2` | DFlash 2 block drafter | KV truncation + recurrent snapshot/replay |
+//! | `Qwen3.6-35B-A3B-8bit` | `Qwen3.6-35B-A3B-DFlash` | DFlash 1, adaptive block | KV truncation + recurrent snapshot/replay |
+//! | `Qwen3.6-35B-A3B-8bit` | `specdrift-qwen3.6-35b-a3b-eagle3` | EAGLE-3 | KV truncation + recurrent snapshot/replay |
+//! | `Qwen3.8-27B-mxfp8` | `ornith-1.0-9b-mxfp8-mlx` | two full models, greedy | both models' KV + recurrent state |
 //!
-//! The first runs wherever the snapshots are; the other two run on request —
-//! see [`DrafterSource`] for the shader-validation reason. `RMLX_DRAFT_TEST_MODEL`
-//! names one drafter, so the pair it does not belong to stands down on the kind
+//! The first runs wherever the snapshots are; the others run on request — see
+//! [`DrafterSource`] for the shader-validation reason. `RMLX_DRAFT_TEST_MODEL`
+//! names one drafter, so a pair it does not belong to stands down on the kind
 //! its snapshot declares rather than loading it as something else.
 //!
-//! The second is the pair whose agreement no subsequence floor could separate
+//! The seventh round loop the engine ships is the two-model **stochastic** one,
+//! and it can have no pair here: it runs only above temperature 0, where neither
+//! arm is a function of the model alone. `two_model_stochastic.rs` gates it on a
+//! different property.
+//!
+//! The MTP pair is the one whose agreement no subsequence floor could separate
 //! from a broken rollback. The divergence oracle settled it: its acceptance walk
 //! was scoring an un-normed hidden through the LM head, and with that fixed
 //! three of six prompts come back bit-identical.

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -179,30 +179,47 @@ const MAX_CTX: i32 = 8192;
 /// Where the first divergence's own confidence may sit in the reference arm's
 /// margin distribution.
 ///
-/// **Both sides measured**, over two pairs and six prompts each, by running the
-/// gate against the shipped engine and against two deliberately broken ones:
+/// **Both sides measured**, over six pairs and six prompts each, by running the
+/// gate against the shipped engine and against a deliberately broken one per
+/// loop — two on the block pair and two on the restricted-vocabulary one:
 ///
 /// | engine | percentile of the reference arm's own margins |
 /// |---|---|
 /// | assistant pair, as shipped | 0.0000 to 0.0820 |
 /// | recurrent pair, as shipped | 0.0000 to 0.0234 |
+/// | block pair, as shipped | 0.0000 to 0.0273 |
+/// | adaptive pair, as shipped | 0.0000 to 0.0234 |
+/// | restricted-vocabulary pair, as shipped | 0.0000 to 0.0703 |
+/// | two-model pair, as shipped | 0.0000 to 0.0234 |
 /// | assistant pair, SWA ring keeping its rejected block tail | 0.4219 to 0.9258 |
 /// | recurrent pair, acceptance walk without the final norm | 0.0000 to 0.5000 |
+/// | block pair, rejected tail never rolled off | 0.0117 to 0.9297 |
+/// | block pair, one rejected draft kept every partial round | 0.1758 to 0.6406 |
+/// | adaptive pair, one rejected draft kept every partial round | 0.0703 to 0.8320 |
+/// | restricted-vocabulary pair, one rejected draft kept every round | 0.0000 to 0.8320 |
+/// | restricted-vocabulary pair, correction left on the restricted argmax | 0.0000 to 0.8828 |
+/// | two-model pair, one rejected draft kept every partial round | 0.0000 to 0.6680 |
 ///
 /// The measurement leaves a band, and the value sits inside it: above the worst
 /// correct cell (0.0820, 1.46x) and under the lowest broken cell above it
-/// (0.1538, 1.28x). It clears every correct cell and refuses ten of the twelve
-/// broken ones; the two it does not read 0.0000 and 0.0977 and are covered by
-/// running every prompt rather than one, since each broken engine is refused on
-/// at least four of its six.
+/// (0.1445, 1.20x). It clears every correct cell, and every broken engine here
+/// is refused on at least four of the prompts the gate judged for it — which is
+/// what running every prompt rather than one buys, since no broken engine is
+/// refused on all of them by this oracle alone.
+///
+/// The exception is the last row, and it is a property of the defect rather than
+/// of the ceiling: leaving the correction on the restricted argmax only changes
+/// an answer where that vocabulary falls short of the verifier's, which the
+/// runs measure at one to five tokens per answer. It is refused on one prompt of
+/// six, at 0.8828, at a position the drafter's vocabulary cannot name.
 const MAX_DIVERGENCE_CONFIDENCE: f64 = 0.12;
 
 /// The worst [`weakest_tail`] reading a **correct** pair reached over the prompts
-/// the gate judged, on either pair. Not a threshold the gate applies — see below
-/// — but the reference `two_arms_in_the_same_ragged_loop_are_not_returned_as_agreement`
-/// uses to decide whether a synthetic pair still looks like agreement at all.
+/// the gate judged, on any pair. Not a threshold the gate applies — see below —
+/// but the reference `two_arms_in_the_same_ragged_loop_are_refused_until_they_are_no_longer_one_loop`
+/// reads to say how far the two populations overlap on this measure.
 /// `the_worst_correct_tail_is_the_worst_of_the_tails_measured` holds it to that
-/// population.
+/// population, and it moved from 0.2344 to here when four more pairs joined it.
 ///
 /// The paragraph below is about a **different measure** and its figures are not
 /// comparable to the one above: [`lcs_ratio`] over the whole arm, where the same
@@ -216,7 +233,7 @@ const MAX_DIVERGENCE_CONFIDENCE: f64 = 0.12;
 /// broken engines measured here read 0.2188 to 0.4615 — three per cent under
 /// that, with nothing bounding the correct minimum from below. `report` prints
 /// the figure on every run and the gate does not assert it.
-const WORST_CORRECT_TAIL_AGREEMENT: f64 = 0.2344;
+const WORST_CORRECT_TAIL_AGREEMENT: f64 = 0.1094;
 
 /// How much of an arm — or of any tail cut of it — may repeat at a short period
 /// before it counts as collapsed.
@@ -229,13 +246,15 @@ const WORST_CORRECT_TAIL_AGREEMENT: f64 = 0.2344;
 /// to catch — the one this gate was built on reads 1.0000.
 ///
 /// The other side is set by the pair regime, and it is **swept rather than
-/// sampled**: `the_control_and_the_subsequence_floor_hand_over_inside_the_ragged_range`
+/// sampled**: `two_arms_in_the_same_ragged_loop_are_refused_until_they_are_no_longer_one_loop`
 /// walks two arms in the same period-8 loop from 0% to 100% raggedness over four
-/// seed pairs and asserts that this control and the subsequence floors between
-/// them refuse every point. Twenty seed pairs over the band where they hand over
-/// leave the range covered at 0.22 and open the first hole at 0.24, so the value
-/// here has room rather than sitting on the boundary. An earlier 0.50 — placed
-/// from six sampled points — left 34% to 52% passing.
+/// seed pairs and pins where this control stops refusing them — 60%, past which
+/// the arms are more noise than loop. Twenty seed pairs over that band leave the
+/// range covered at 0.22 and open the first hole at 0.24, so the value here has
+/// room rather than sitting on the boundary. An earlier 0.50 — placed from six
+/// sampled points — left 34% to 52% passing. Nothing takes over past 60%: what
+/// the control admits there agrees better than the worst correct pair does, which
+/// is the measurement behind having no subsequence floor.
 ///
 /// It is **not** a general degeneracy threshold and there is none: healthy
 /// markdown tables read 0.68 to 0.88 on this measure and ragged loops read 0.37
@@ -894,36 +913,59 @@ fn the_false_positive_rate_on_healthy_output() {
 /// **swept** over the whole raggedness range rather than sampled at points.
 ///
 /// This is the regime with no reference to appeal to: both arms are degenerate,
-/// so their agreement means nothing and the divergence oracle has no healthy
-/// reference arm whose margins say anything. The repetition control is what
-/// keeps it out, and past the raggedness where the control's reading falls under
-/// its ceiling the arms no longer agree either — their tail agreement is at or
-/// under [`WORST_CORRECT_TAIL_AGREEMENT`], the worst a correct pair reached.
+/// so their agreement means nothing. The margins are empty on purpose, so the
+/// repetition control is the only oracle in play and the sweep reads it alone.
 ///
-/// The property is asserted over the whole range and over four seed pairs, so
-/// the sweep picks the points. An earlier revision claimed the range was covered
-/// with no gap and sampled six values of the parameter to say so; at 36% the
-/// pair passed.
+/// It refuses every pair up to [`FIRST_ADMITTED`]% raggedness, and past that the
+/// arms are more noise than loop and it admits them. **The tail measure does not
+/// take over there**: what the control admits agrees up to
+/// [`WORST_ADMITTED_TAIL`], twice the worst reading a correct pair reached. That
+/// is the "no subsequence floor" claim as a measurement rather than an
+/// assertion, and it is why [`WORST_CORRECT_TAIL_AGREEMENT`] is a recorded
+/// figure and not a threshold.
+///
+/// Both edges are pinned, so the sweep fails when either moves. An earlier
+/// revision claimed the range was covered with no gap and sampled six values of
+/// the parameter to say so; at 36% the pair passed. A later one closed the gap
+/// against a worst-correct figure measured over two pairs — four more pairs took
+/// that figure from 0.2344 to 0.1094 and the gap opened again, which is the
+/// state recorded here.
 #[test]
-fn two_arms_in_the_same_ragged_loop_are_not_returned_as_agreement() {
+fn two_arms_in_the_same_ragged_loop_are_refused_until_they_are_no_longer_one_loop() {
+    /// Raggedness, in per cent, of the first pair the control admits.
+    const FIRST_ADMITTED: u64 = 60;
+    /// The best tail agreement any admitted pair reached.
+    const WORST_ADMITTED_TAIL: f64 = 0.2188;
+
+    let mut worst_admitted = 0.0f64;
+    let mut first_admitted = None;
     for noise in (0..=100).step_by(2) {
         for (sa, sb) in [(0x33u64, 0x44u64), (0x91, 0xA7), (0xB3, 0xC1), (0xD5, 0xE9)] {
             let (a, b) = (ragged_loop_arm(sa, noise), ragged_loop_arm(sb, noise));
             if judge(&a, &b, &[]) != Verdict::Agreed {
                 continue;
             }
-            let tail = weakest_tail(&a, &b).1;
-            assert!(
-                tail <= WORST_CORRECT_TAIL_AGREEMENT,
-                "two arms {noise}% ragged in the same period-8 loop (seeds \
-                 {sa:#x}/{sb:#x}) were returned as agreement while agreeing better \
-                 ({tail:.4}) than the worst correct pair measured \
-                 ({WORST_CORRECT_TAIL_AGREEMENT}): cycles {:.4} and {:.4}",
-                strongest_windowed_cycle(&a).2,
-                strongest_windowed_cycle(&b).2,
-            );
+            first_admitted = first_admitted.or(Some(noise));
+            worst_admitted = worst_admitted.max(weakest_tail(&a, &b).1);
         }
     }
+    assert_eq!(
+        first_admitted,
+        Some(FIRST_ADMITTED),
+        "the control admits its first ragged pair at {first_admitted:?}% raggedness, \
+         not the recorded {FIRST_ADMITTED}%"
+    );
+    assert!(
+        (worst_admitted - WORST_ADMITTED_TAIL).abs() < 1e-4,
+        "the pairs the control admits agree up to {worst_admitted:.4}, not the recorded \
+         {WORST_ADMITTED_TAIL}"
+    );
+    assert!(
+        worst_admitted > WORST_CORRECT_TAIL_AGREEMENT,
+        "what the control admits agrees no better than the worst correct pair \
+         ({WORST_CORRECT_TAIL_AGREEMENT}), so a subsequence floor would separate the \
+         two populations after all and this file should have one"
+    );
 }
 
 /// [`WORST_CORRECT_TAIL_AGREEMENT`] is the worst of the tails actually measured,
@@ -935,15 +977,29 @@ fn two_arms_in_the_same_ragged_loop_are_not_returned_as_agreement() {
 /// it to the population it names fails in both directions.
 #[test]
 fn the_worst_correct_tail_is_the_worst_of_the_tails_measured() {
-    /// Every [`weakest_tail`] reading a correct pair reached, over both pairs and
-    /// the prompts each of them judged. These are tails, not [`lcs_ratio`] over
-    /// the whole arm — the same runs read 0.4766 to 1.0000 on that measure, and
-    /// the two figures the "no subsequence floor" paragraphs quote come from it.
+    /// Every [`weakest_tail`] reading a correct pair reached, over all six pairs
+    /// and the prompts each of them judged. These are tails, not [`lcs_ratio`]
+    /// over the whole arm — the same runs read 0.4766 to 1.0000 on that measure,
+    /// and the two figures the "no subsequence floor" paragraphs quote come from
+    /// it.
     const MEASURED: &[f64] = &[
         // Assistant pair, six prompts.
         0.3125, 0.3750, 0.3906, 0.2344, 1.0000, 0.9062,
         // Recurrent pair, the five prompts it judged — the 4k document is
         // answered in 13 and 26 tokens and is reported unjudgeable.
+        0.3281, 1.0000, 1.0000, 0.6354, 1.0000,
+        // Block pair, six prompts. The worst reading of the whole population is
+        // here, and it was outside this list until the pairs below were built.
+        0.4323, 0.4844, 0.3021, 0.6562, 0.1094, 0.5938,
+        // Adaptive pair, the five it judged — its verifier answers the 4k
+        // document in 52 tokens, and both arms reproduce that answer exactly.
+        0.2969, 0.2188, 0.4115, 0.3906, 0.2656,
+        // Restricted-vocabulary pair, the five it judged — same verifier, and on
+        // the 4k document its arms part at the one lowest-margin token in that
+        // 52-token answer.
+        0.1406, 0.2656, 0.3594, 0.4844, 0.3984,
+        // Two-model pair, the five it judged. Its verifier is the recurrent
+        // pair's, and on this measure the two loops read alike.
         0.3281, 1.0000, 1.0000, 0.6354, 1.0000,
     ];
     let worst = MEASURED.iter().copied().fold(f64::INFINITY, f64::min);
@@ -1236,8 +1292,8 @@ fn a_late_onset_divergence_is_judged_where_it_begins() {
 ///
 /// Correct: the worst reading a shipped pair produced, a first divergence at the
 /// 8.2nd percentile of the reference arm's own margins. Broken: the lowest
-/// reading a broken engine produced above the ceiling, the 15.4th — the cell the
-/// recorded ten-of-twelve recall stands or falls on.
+/// reading a broken engine produced above the ceiling, the 14.5th — the cell the
+/// recorded recall stands or falls on.
 #[test]
 fn the_gate_admits_the_worst_correct_regime_and_refuses_the_lowest_broken_one() {
     let plain: Vec<u32> = (0..N_TOKENS as u32).map(|t| t % 97).collect();
@@ -1267,13 +1323,13 @@ fn the_gate_admits_the_worst_correct_regime_and_refuses_the_lowest_broken_one() 
         "the worst correct regime must pass"
     );
 
-    // 0.1538 is 2/13 — the broken cell's reference arm was 13 tokens long, and a
-    // 256-position array gets within one of its own quantum of it.
-    let broken = margins_reading(39);
+    // 0.1445 is 37/256 — the two-model pair's rollback mutation on the
+    // congestion prompt, whose reference arm ran the full budget.
+    let broken = margins_reading(37);
     let (_, lowest_broken) = divergence_confidence(&spec, &plain, &broken).expect("a divergence");
     assert!(
-        (lowest_broken - 0.1538).abs() < 0.002,
-        "the reconstructed broken regime reads {lowest_broken:.4}, not the measured 0.1538"
+        (lowest_broken - 0.1445).abs() < 0.002,
+        "the reconstructed broken regime reads {lowest_broken:.4}, not the measured 0.1445"
     );
     let failure = judge(&spec, &plain, &broken)
         .refusal()

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -129,10 +129,12 @@ mod common;
 
 use rmlx_mlx::Device;
 use rmlx_models::arch;
+use rmlx_models::speculative::dflash::{dflash_generate, DFlashDrafter};
 use rmlx_models::speculative::dflash2::{dflash2_generate, DFlash2Drafter};
+use rmlx_models::speculative::eagle3::{eagle3_generate, Eagle3Drafter};
 use rmlx_models::speculative::gemma4_assistant::{mtp_assistant_generate, Gemma4AssistantDrafter};
 use rmlx_models::speculative::mtp::{mtp_generate, MtpDrafter};
-use rmlx_models::{Declared, DraftKind};
+use rmlx_models::{Declared, DraftKind, SpeculativeDispatcher};
 
 /// Token budget per arm. A ceiling, not a target: both arms stop on the
 /// verifier's own stop ids, and every prompt in the sweep answers under it.
@@ -448,7 +450,32 @@ fn judge(spec: &[u32], plain: &[u32], margins: &[f32]) -> Verdict {
             plain.len()
         ));
     }
-    if shorter < MIN_ANSWER_TOKENS {
+    if plain.len() < MIN_ANSWER_TOKENS {
+        // The reference arm is the control, and it answered this prompt in
+        // fewer tokens than the gate can read. One shape is still about the
+        // round loop: the speculative arm gave the whole reference answer back
+        // and then carried on, which says it did not stop where the verifier
+        // stopped. An arm that parted from the reference *inside* that answer
+        // and then wrote a longer one is a different answer, not a longer
+        // version of this one, and there is no answer here to judge it against.
+        if spec.starts_with(plain) {
+            return Verdict::Refused(format!(
+                "the reference arm ended at {} tokens and the speculative arm reproduced \
+                 it and ran on to {} — the round loop did not stop where the verifier \
+                 stopped",
+                plain.len(),
+                spec.len()
+            ));
+        }
+        return Verdict::Unjudgeable(format!(
+            "the reference arm answered in {} tokens, under {MIN_ANSWER_TOKENS}, and the \
+             arms parted inside that answer — plain greedy is the control, so what this \
+             says is that the prompt produced no answer to compare on this model, \
+             whatever the speculative arm went on to write",
+            plain.len()
+        ));
+    }
+    if spec.len() < MIN_ANSWER_TOKENS {
         return Verdict::Refused(format!(
             "one arm stopped early — spec={} plain={}, under {MIN_ANSWER_TOKENS} while \
              the other ran on; a short run is a comparison with no power, not a pass",
@@ -1118,6 +1145,52 @@ fn a_truncated_run_is_refused_rather_than_judged() {
     assert!(failure.contains("stopped early"), "{failure}");
 }
 
+/// Which arm is short decides what the gate is entitled to say, and all three
+/// shapes are pinned.
+///
+/// A *speculative* arm under the floor while the reference ran on is the round
+/// loop cutting its own run, and is refused. A *reference* arm under the floor
+/// is the prompt — plain greedy is the control, and the same asymmetry the
+/// repetition control already applies is what the divergence oracle needs here.
+/// The one shape that is still about the loop is a speculative arm that
+/// reproduced the whole reference answer and then carried on: that is a loop
+/// that did not stop where the verifier stopped, and it is separable from a loop
+/// that parted inside the answer and wrote a different, longer one.
+///
+/// This is the case the restricted-vocabulary pair brought: on its verifier the
+/// 4k document is answered in 52 tokens, and two other round loops reproduce
+/// that answer exactly while EAGLE-3 flips the single lowest-margin token in it
+/// and writes on.
+#[test]
+fn a_short_reference_arm_is_the_prompt_unless_the_other_arm_only_ran_past_it() {
+    let plain: Vec<u32> = Rng(0x5AFE_5AFE).prose(MIN_ANSWER_TOKENS - 1);
+
+    let mut ran_on = plain.clone();
+    ran_on.extend(Rng(0x0BAD_0BAD).prose(N_TOKENS));
+    let failure = judge(&ran_on, &plain, &[])
+        .refusal()
+        .expect("an arm that reproduced the whole reference answer and kept going must be refused");
+    assert!(
+        failure.contains("did not stop where the verifier stopped"),
+        "{failure}"
+    );
+
+    let mut parted = plain[..4].to_vec();
+    parted.extend(Rng(0x0F1F_0F1F).prose(N_TOKENS));
+    match judge(&parted, &plain, &[]) {
+        Verdict::Unjudgeable(why) => assert!(why.contains("parted inside that answer"), "{why}"),
+        other @ (Verdict::Agreed | Verdict::Refused(_)) => {
+            panic!("a reference arm under the floor is the prompt, not the loop: {other:?}")
+        }
+    }
+
+    let long_plain: Vec<u32> = Rng(0x1C1C_1C1C).prose(N_TOKENS);
+    let failure = judge(&long_plain[..16], &long_plain, &[])
+        .refusal()
+        .expect("a speculative arm under the floor while the reference ran on must be refused");
+    assert!(failure.contains("stopped early"), "{failure}");
+}
+
 /// A divergence that begins in the last quarter and never comes back.
 ///
 /// This is the shape of a regression that fires past a cache-size threshold, and
@@ -1267,10 +1340,22 @@ enum RoundLoop {
     /// rollback restores it from a pre-round snapshot and replays the accepted
     /// prefix.
     MtpSidecar,
+    /// DFlash 1 block drafter: the same recurrent rollback, and the only loop
+    /// here whose block size changes between rounds — it is set from the accept
+    /// rate of the recent ones, so a run walks a range of verify widths rather
+    /// than repeating one.
+    DFlash1,
     /// DFlash 2 block drafter: the same recurrent rollback, and a drafter that
     /// denoises a whole block at once from the verifier's multi-layer hidden
     /// states rather than stepping through it.
     DFlash2,
+    /// EAGLE-3: the same recurrent rollback, and an acceptance walk that scores
+    /// intermediate positions over the drafter's reduced vocabulary rather than
+    /// the verifier's whole one. See [`EAGLE3_PAIR`] for what that costs.
+    Eagle3,
+    /// Two full models, greedy acceptance: no sidecar head, a second complete
+    /// model with its own KV cache rolled back alongside the verifier's.
+    TwoModelGreedy,
 }
 
 impl RoundLoop {
@@ -1284,7 +1369,10 @@ impl RoundLoop {
         match self {
             RoundLoop::Gemma4Assistant => None,
             RoundLoop::MtpSidecar => Some(DraftKind::Mtp),
+            RoundLoop::DFlash1 => Some(DraftKind::DFlash),
             RoundLoop::DFlash2 => Some(DraftKind::DFlash2),
+            RoundLoop::Eagle3 => Some(DraftKind::Eagle3),
+            RoundLoop::TwoModelGreedy => Some(DraftKind::TwoModel),
         }
     }
 }
@@ -1359,6 +1447,75 @@ const DFLASH2_PAIR: Pair = Pair {
     },
     drafter: DrafterSource::Named,
     round_loop: RoundLoop::DFlash2,
+};
+
+/// The adaptive pair. Its drafter carries no dynamic convolution and no
+/// selector, and its loop sets each round's block from the accept rate of the
+/// recent ones — so it is the only pair here whose verify width changes between
+/// rounds, and the only one that reaches a block wider than 8.
+///
+/// Named for the same reason [`MTP_PAIR`] is: an 8-bit verifier drives the same
+/// MLX quantized matmul the census records for the affine instantiation.
+const DFLASH1_PAIR: Pair = Pair {
+    verifier: common::GoldenModel {
+        slug: "mlx-community__Qwen3.6-35B-A3B-8bit",
+        archs: &[
+            "Qwen3_5ForConditionalGeneration",
+            "Qwen3_5MoeForConditionalGeneration",
+        ],
+    },
+    drafter: DrafterSource::Named,
+    round_loop: RoundLoop::DFlash1,
+};
+
+/// The restricted-vocabulary pair, and the one place this gate reads a
+/// **declared inexactness** rather than a defect.
+///
+/// EAGLE-3's verify pass scores the whole block against the drafter's reduced
+/// vocabulary — 32000 target ids plus the verifier's stop ids — and computes the
+/// verifier's full-vocabulary argmax at one position only: the first the draft
+/// missed, or the bonus when it missed none. An accepted position is therefore
+/// emitted as the draft's token whenever the draft agrees with the *restricted*
+/// argmax, and at a position whose true argmax lies outside that set those two
+/// are not the same token. The upstream implementation does this too, so it is a
+/// design boundary rather than a port defect — but it is still an answer change
+/// at temperature 0, which is what this gate reads.
+///
+/// [`Loaded::outside_draft_vocab`] measures the exposure on every run: how many
+/// of the reference arm's own tokens the drafter's vocabulary cannot name. Each
+/// one is a position where the boundary could fire; none of them is a position
+/// where it must.
+const EAGLE3_PAIR: Pair = Pair {
+    verifier: common::GoldenModel {
+        slug: "mlx-community__Qwen3.6-35B-A3B-8bit",
+        archs: &[
+            "Qwen3_5ForConditionalGeneration",
+            "Qwen3_5MoeForConditionalGeneration",
+        ],
+    },
+    drafter: DrafterSource::Named,
+    round_loop: RoundLoop::Eagle3,
+};
+
+/// The two-model pair: no sidecar head at all, a second complete model of the
+/// same family whose own KV cache is rolled back beside the verifier's every
+/// partial round. Both halves are GDN hybrids, so a round rolls back two kinds
+/// of state on each of two models.
+///
+/// Named, and its drafter is the one kind [`RoundLoop::declares`] cannot pin to
+/// a snapshot: `two_model` is an inference from the architecture registry, which
+/// every full model satisfies. [`declared_vocab_size`] is the discriminator that
+/// stands a mismatched pair down before either model is read.
+const TWO_MODEL_PAIR: Pair = Pair {
+    verifier: common::GoldenModel {
+        slug: "mlx-community__Qwen3.8-27B-mxfp8",
+        archs: &[
+            "Qwen3_5ForConditionalGeneration",
+            "Qwen3_5MoeForConditionalGeneration",
+        ],
+    },
+    drafter: DrafterSource::Named,
+    round_loop: RoundLoop::TwoModelGreedy,
 };
 
 /// Draft-model override, the variable the sibling alignment suites take.
@@ -1455,6 +1612,21 @@ fn draft_config(draft_path: &Path) -> Option<serde_json::Value> {
 fn declared_backbone_hidden(draft_path: &Path) -> Option<usize> {
     draft_config(draft_path)?["backbone_hidden_size"]
         .as_u64()
+        .and_then(|v| usize::try_from(v).ok())
+}
+
+/// The vocabulary a snapshot declares, from its own config or its text tower's.
+///
+/// The two-model pair needs this because its loop's kind is an inference from
+/// the architecture registry rather than a marker: every full model declares
+/// itself a `two_model` drafter, so the kind check cannot tell one family's from
+/// another's. A draft whose vocabulary is not the verifier's is refused inside
+/// `load_speculative`, which would fail the run rather than stand it down.
+fn declared_vocab_size(path: &Path) -> Option<usize> {
+    let cfg = draft_config(path)?;
+    cfg["vocab_size"]
+        .as_u64()
+        .or_else(|| cfg["text_config"]["vocab_size"].as_u64())
         .and_then(|v| usize::try_from(v).ok())
 }
 
@@ -1648,13 +1820,11 @@ fn plain_greedy(
     eos: &[u32],
     device: Device,
 ) -> (Vec<u32>, Vec<f32>) {
+    // The speculative arms' configuration, plus the top-two read-back only this
+    // arm needs — one temperature-0 setting, and the one field that differs.
     let sampler_cfg = rmlx_models::sampler::SamplerConfig {
-        temperature: 0.0,
-        top_p: 1.0,
-        top_k: 0,
-        min_p: 0.0,
-        seed: Some(0),
         top_logprobs_k: 2,
+        ..GREEDY
     };
     let mut rng = rmlx_models::sampler::Pcg32::new(sampler_cfg.seed_or_default());
     let penalty_cfg = rmlx_models::sampler::PenaltyConfig::default();
@@ -1714,16 +1884,41 @@ const GREEDY: rmlx_models::sampler::SamplerConfig = rmlx_models::sampler::Sample
 
 /// A loaded pair, ready to answer prompts.
 struct Loaded {
-    verifier: arch::Architecture,
-    drafter: Drafter,
+    engine: Engine,
     tokenizer: tokenizers::Tokenizer,
     eos: Vec<u32>,
+}
+
+/// The verifier, and whatever drives the speculative arm against it.
+///
+/// A sidecar head reads the verifier and is held beside it. The two-model
+/// dispatcher owns both models, so that pair holds the dispatcher and lends the
+/// verifier back for the reference arm.
+enum Engine {
+    Sidecar {
+        verifier: Box<arch::Architecture>,
+        drafter: Drafter,
+    },
+    TwoModel(Box<SpeculativeDispatcher>),
+}
+
+impl Engine {
+    /// The model the reference arm decodes with, whichever half of the pair
+    /// holds it.
+    fn verifier(&self) -> &arch::Architecture {
+        match self {
+            Engine::Sidecar { verifier, .. } => verifier,
+            Engine::TwoModel(dispatcher) => &dispatcher.verifier,
+        }
+    }
 }
 
 enum Drafter {
     Assistant(Box<Gemma4AssistantDrafter>),
     Mtp(Box<MtpDrafter>),
+    DFlash1(Box<DFlashDrafter>),
     DFlash2(Box<DFlash2Drafter>),
+    Eagle3(Box<Eagle3Drafter>),
 }
 
 impl Loaded {
@@ -1737,31 +1932,15 @@ impl Loaded {
                 spec_ids.push(s.token_id);
                 None
             };
-            match &mut self.drafter {
-                Drafter::Assistant(drafter) => mtp_assistant_generate(
-                    &self.verifier,
-                    drafter,
-                    &self.tokenizer,
-                    &ids,
-                    N_TOKENS,
-                    BLOCK_SIZE,
-                    Some(rmlx_kv_quant::KvQuant::None),
-                    Some(MAX_CTX),
-                    &self.eos,
-                    &mut step,
-                    &GREEDY,
-                    device,
-                )
-                .expect("assistant speculative generate"),
-                Drafter::Mtp(drafter) => {
-                    let block = drafter.block_size();
-                    mtp_generate(
-                        &self.verifier,
+            match &mut self.engine {
+                Engine::Sidecar { verifier, drafter } => match drafter {
+                    Drafter::Assistant(drafter) => mtp_assistant_generate(
+                        verifier,
                         drafter,
                         &self.tokenizer,
                         &ids,
                         N_TOKENS,
-                        block,
+                        BLOCK_SIZE,
                         Some(rmlx_kv_quant::KvQuant::None),
                         Some(MAX_CTX),
                         &self.eos,
@@ -1769,34 +1948,133 @@ impl Loaded {
                         &GREEDY,
                         device,
                     )
-                    .expect("mtp speculative generate")
-                }
-                // The block the drafter was trained at, not the harness's: the
-                // whole point of a block drafter is the block, and this is the
-                // width its selector chain is defined over.
-                Drafter::DFlash2(drafter) => {
-                    let block = drafter.cfg.block_size;
-                    dflash2_generate(
-                        &self.verifier,
-                        drafter,
+                    .expect("assistant speculative generate"),
+                    Drafter::Mtp(drafter) => {
+                        let block = drafter.block_size();
+                        mtp_generate(
+                            verifier,
+                            drafter,
+                            &self.tokenizer,
+                            &ids,
+                            N_TOKENS,
+                            block,
+                            Some(rmlx_kv_quant::KvQuant::None),
+                            Some(MAX_CTX),
+                            &self.eos,
+                            &mut step,
+                            &GREEDY,
+                            device,
+                        )
+                        .expect("mtp speculative generate")
+                    }
+                    // The drafter's own ceiling, which its loop then halves and
+                    // grows from the recent accept rate: asking for a narrower
+                    // one would take the varying schedule out of the run, and
+                    // the schedule is what this pair covers that no other does.
+                    Drafter::DFlash1(drafter) => {
+                        let block = drafter.block_size();
+                        dflash_generate(
+                            verifier,
+                            drafter,
+                            &self.tokenizer,
+                            &ids,
+                            N_TOKENS,
+                            block,
+                            Some(rmlx_kv_quant::KvQuant::None),
+                            Some(MAX_CTX),
+                            &self.eos,
+                            &mut step,
+                            &GREEDY,
+                            device,
+                        )
+                        .expect("dflash speculative generate")
+                    }
+                    // The block the drafter was trained at, not the harness's: the
+                    // whole point of a block drafter is the block, and this is the
+                    // width its selector chain is defined over.
+                    Drafter::DFlash2(drafter) => {
+                        let block = drafter.cfg.block_size;
+                        dflash2_generate(
+                            verifier,
+                            drafter,
+                            &self.tokenizer,
+                            &ids,
+                            N_TOKENS,
+                            block,
+                            Some(rmlx_kv_quant::KvQuant::None),
+                            Some(MAX_CTX),
+                            &self.eos,
+                            &mut step,
+                            &GREEDY,
+                            device,
+                        )
+                        .expect("dflash2 speculative generate")
+                    }
+                    Drafter::Eagle3(drafter) => {
+                        let block = drafter.block_size();
+                        eagle3_generate(
+                            verifier,
+                            drafter,
+                            &self.tokenizer,
+                            &ids,
+                            N_TOKENS,
+                            block,
+                            Some(rmlx_kv_quant::KvQuant::None),
+                            Some(MAX_CTX),
+                            &self.eos,
+                            &mut step,
+                            &GREEDY,
+                            device,
+                        )
+                        .expect("eagle3 speculative generate")
+                    }
+                },
+                Engine::TwoModel(dispatcher) => dispatcher
+                    .spec_generate_greedy(
                         &self.tokenizer,
                         &ids,
                         N_TOKENS,
-                        block,
+                        BLOCK_SIZE,
                         Some(rmlx_kv_quant::KvQuant::None),
                         Some(MAX_CTX),
+                        0,
                         &self.eos,
                         &mut step,
+                        None,
                         &GREEDY,
-                        device,
                     )
-                    .expect("dflash2 speculative generate")
-                }
+                    .expect("two-model speculative generate"),
             };
         }
-        let (plain_ids, margins) =
-            plain_greedy(&self.verifier, &self.tokenizer, &ids, &self.eos, device);
+        let (plain_ids, margins) = plain_greedy(
+            self.engine.verifier(),
+            &self.tokenizer,
+            &ids,
+            &self.eos,
+            device,
+        );
         (spec_ids, plain_ids, margins)
+    }
+
+    /// The target-vocabulary ids this pair's drafter can name, or `None` when it
+    /// can name every one the verifier can.
+    ///
+    /// Only EAGLE-3 answers. Its verify pass takes the argmax over the drafter's
+    /// reduced vocabulary at every position except the correction, and a
+    /// restricted argmax equals the true one **exactly** when the true one is in
+    /// the set. So a position whose reference token is in here cannot have been
+    /// changed by the restriction, and a position whose reference token is not
+    /// can have been.
+    fn draft_vocab(&self) -> Option<std::collections::HashSet<u32>> {
+        let Engine::Sidecar {
+            drafter: Drafter::Eagle3(drafter),
+            ..
+        } = &self.engine
+        else {
+            return None;
+        };
+        let hot: std::collections::HashSet<u32> = drafter.hot_ids_host().iter().copied().collect();
+        (!hot.is_empty()).then_some(hot)
     }
 }
 
@@ -1828,20 +2106,86 @@ fn load(pair: &Pair, test: &str, device: Device) -> Option<Loaded> {
         }
     }
     let model_path = common::model_for(&pair.verifier, test)?;
+    // The two-model loop's kind is an inference from the architecture registry,
+    // so a full model of any family declares itself this pair's drafter. The
+    // vocabulary is what separates them, and reading it here stands a mismatched
+    // pair down instead of failing inside the dispatcher's own check.
+    if pair.round_loop == RoundLoop::TwoModelGreedy {
+        let (draft_vocab, verifier_vocab) = (
+            declared_vocab_size(&draft_path),
+            declared_vocab_size(&model_path),
+        );
+        if draft_vocab.is_some() && draft_vocab != verifier_vocab {
+            eprintln!(
+                "SKIP {test}: {} declares a {:?}-token vocabulary and {} declares {:?}, \
+                 so the two are not a two-model pair",
+                draft_path.display(),
+                draft_vocab.unwrap_or(0),
+                model_path.display(),
+                verifier_vocab.unwrap_or(0),
+            );
+            return None;
+        }
+    }
+
+    let tokenizer =
+        tokenizers::Tokenizer::from_file(model_path.join("tokenizer.json")).expect("tokenizer");
+    let eos = eos_ids(&model_path);
+    assert!(
+        !eos.is_empty(),
+        "the verifier config must name its stop ids — without them both arms run past \
+         the answer into end-of-turn filler and the comparison is over that"
+    );
 
     let verifier =
         arch::load_model(&model_path, device, &arch::LoadOpts::default()).expect("load verifier");
+    let engine = engine_for(
+        pair.round_loop,
+        test,
+        verifier,
+        &draft_path,
+        &model_path,
+        &eos,
+        device,
+    )?;
+
+    Some(Loaded {
+        engine,
+        tokenizer,
+        eos,
+    })
+}
+
+/// Build the pair's speculative half around an already-loaded verifier, or say
+/// why the gate stood down.
+///
+/// The drafter is what a pair is, and everything a loader can refuse about it is
+/// checked here: whether the verifier is the kind this loop drives, and whether
+/// the drafter's own declarations agree with the verifier it was resolved
+/// against.
+#[allow(clippy::too_many_arguments)]
+fn engine_for(
+    round_loop: RoundLoop,
+    test: &str,
+    verifier: arch::Architecture,
+    draft_path: &Path,
+    model_path: &Path,
+    eos: &[u32],
+    device: Device,
+) -> Option<Engine> {
     let hidden = verifier.hidden_size();
-    let drafter = match pair.round_loop {
+    let vocab = verifier.vocab_size();
+    let verifier = Box::new(verifier);
+    let engine = match round_loop {
         RoundLoop::Gemma4Assistant => {
-            if !is_gemma4_assistant(&draft_path) {
+            if !is_gemma4_assistant(draft_path) {
                 eprintln!(
                     "SKIP {test}: {} is not a Gemma4 assistant drafter",
                     draft_path.display()
                 );
                 return None;
             }
-            let declared = declared_backbone_hidden(&draft_path);
+            let declared = declared_backbone_hidden(draft_path);
             if declared.is_some_and(|width| width != hidden) {
                 eprintln!(
                     "SKIP {test}: {} projects into a backbone {} wide and {} is {hidden}",
@@ -1851,10 +2195,13 @@ fn load(pair: &Pair, test: &str, device: Device) -> Option<Loaded> {
                 );
                 return None;
             }
-            Drafter::Assistant(Box::new(
-                Gemma4AssistantDrafter::load(&draft_path, hidden, device)
-                    .expect("load assistant drafter"),
-            ))
+            Engine::Sidecar {
+                verifier,
+                drafter: Drafter::Assistant(Box::new(
+                    Gemma4AssistantDrafter::load(draft_path, hidden, device)
+                        .expect("load assistant drafter"),
+                )),
+            }
         }
         RoundLoop::MtpSidecar => {
             if !verifier.needs_lin_caches() {
@@ -1865,9 +2212,28 @@ fn load(pair: &Pair, test: &str, device: Device) -> Option<Loaded> {
                 );
                 return None;
             }
-            Drafter::Mtp(Box::new(
-                MtpDrafter::load(&draft_path, hidden, device).expect("load MTP sidecar"),
-            ))
+            Engine::Sidecar {
+                verifier,
+                drafter: Drafter::Mtp(Box::new(
+                    MtpDrafter::load(draft_path, hidden, device).expect("load MTP sidecar"),
+                )),
+            }
+        }
+        RoundLoop::DFlash1 => {
+            if !verifier.needs_lin_caches() {
+                eprintln!(
+                    "SKIP {test}: {} carries no recurrent state, so it is not the \
+                     verifier this loop drives",
+                    model_path.display()
+                );
+                return None;
+            }
+            Engine::Sidecar {
+                verifier,
+                drafter: Drafter::DFlash1(Box::new(
+                    DFlashDrafter::load(draft_path, hidden, device).expect("load DFlash 1 drafter"),
+                )),
+            }
         }
         RoundLoop::DFlash2 => {
             if !verifier.needs_lin_caches() {
@@ -1878,26 +2244,42 @@ fn load(pair: &Pair, test: &str, device: Device) -> Option<Loaded> {
                 );
                 return None;
             }
-            Drafter::DFlash2(Box::new(
-                DFlash2Drafter::load(&draft_path, hidden, device).expect("load DFlash 2 drafter"),
+            Engine::Sidecar {
+                verifier,
+                drafter: Drafter::DFlash2(Box::new(
+                    DFlash2Drafter::load(draft_path, hidden, device)
+                        .expect("load DFlash 2 drafter"),
+                )),
+            }
+        }
+        RoundLoop::Eagle3 => {
+            if !verifier.needs_lin_caches() {
+                eprintln!(
+                    "SKIP {test}: {} carries no recurrent state, so it is not the \
+                     verifier this loop drives",
+                    model_path.display()
+                );
+                return None;
+            }
+            // The verifier's stop ids join the drafter's reduced vocabulary, so
+            // the restricted argmax can still end a turn. They are the same ids
+            // both arms stop on.
+            let drafter = Eagle3Drafter::load(draft_path, hidden, vocab, eos, device)
+                .expect("load EAGLE-3 drafter");
+            Engine::Sidecar {
+                verifier,
+                drafter: Drafter::Eagle3(Box::new(drafter)),
+            }
+        }
+        RoundLoop::TwoModelGreedy => {
+            let draft = arch::load_model(draft_path, device, &arch::LoadOpts::default())
+                .expect("load draft model");
+            Engine::TwoModel(Box::new(
+                SpeculativeDispatcher::new(*verifier, draft, device).expect("two-model dispatcher"),
             ))
         }
     };
-
-    let tokenizer =
-        tokenizers::Tokenizer::from_file(model_path.join("tokenizer.json")).expect("tokenizer");
-    let eos = eos_ids(&model_path);
-    assert!(
-        !eos.is_empty(),
-        "the verifier config must name its stop ids — without them both arms run past \
-         the answer into end-of-turn filler and the comparison is over that"
-    );
-    Some(Loaded {
-        verifier,
-        drafter,
-        tokenizer,
-        eos,
-    })
+    Some(engine)
 }
 
 /// Report one pair of arms, whatever the verdict.
@@ -1909,6 +2291,7 @@ fn report(
     spec: &[u32],
     plain: &[u32],
     margins: &[f32],
+    draft_vocab: Option<&std::collections::HashSet<u32>>,
     verdict: &Verdict,
 ) {
     let (tail_start, tail_ratio) = weakest_tail(spec, plain);
@@ -1916,9 +2299,20 @@ fn report(
     let (plain_from, plain_period, plain_cycle) = strongest_windowed_cycle(plain);
     let (div, confidence) = divergence_confidence(spec, plain, margins)
         .unwrap_or((common_prefix_len(spec, plain), 0.0));
+    // For a pair whose drafter names a reduced vocabulary: how much of the
+    // reference answer that vocabulary cannot say, and whether the token it
+    // could not say is the one the arms parted on.
+    let outside = match draft_vocab {
+        Some(vocab) => format!(
+            " unnameable={} divergence_unnameable={}",
+            plain.iter().filter(|id| !vocab.contains(id)).count(),
+            plain.get(div).is_some_and(|id| !vocab.contains(id)),
+        ),
+        None => String::new(),
+    };
     eprintln!(
         "[{test}/{}] lcs={:.4} tail={tail_ratio:.4}@{tail_start} divergence={div} \
-         margin={:.4} confidence={confidence:.4} \
+         margin={:.4} confidence={confidence:.4}{outside} \
          cycle spec={spec_cycle:.4}/p{spec_period}@{spec_from} \
          plain={plain_cycle:.4}/p{plain_period}@{plain_from} spec={} plain={}\n  \
          verdict = {verdict:?}\n  spec  = {:?}\n  plain = {:?}",
@@ -1982,6 +2376,54 @@ fn the_block_round_loop_reproduces_plain_greedy() {
     );
 }
 
+/// The adaptive pair, and the only one whose verify width is not fixed.
+///
+/// Its loop halves and grows the block from the accept rate of the recent
+/// rounds, so a run truncates an 8-wide append and follows it with a 4- or
+/// 6-wide one — a sequence of shapes no other pair here produces, over the same
+/// rollback the recurrent and block pairs use. Every individual width is
+/// exercised elsewhere; the schedule is not.
+#[ignore]
+#[test]
+fn the_adaptive_round_loop_reproduces_plain_greedy() {
+    run_gate(
+        "the_adaptive_round_loop_reproduces_plain_greedy",
+        &DFLASH1_PAIR,
+    );
+}
+
+/// The restricted-vocabulary pair.
+///
+/// It is judged by the same oracle as every other pair, and it carries one
+/// inexactness they do not: an accepted position is emitted as the draft's
+/// token, and the verifier's full-vocabulary argmax is computed at the
+/// correction position only. Where those two differ the arms differ, by design
+/// and in agreement with the upstream implementation. The run prints how many
+/// of the reference arm's tokens the drafter's vocabulary cannot name, which is
+/// the count of positions where that can happen at all.
+#[ignore]
+#[test]
+fn the_restricted_vocab_round_loop_reproduces_plain_greedy() {
+    run_gate(
+        "the_restricted_vocab_round_loop_reproduces_plain_greedy",
+        &EAGLE3_PAIR,
+    );
+}
+
+/// The two-model pair: two complete models, and the loop with no sidecar head.
+///
+/// Both halves are GDN hybrids, so a partial round rolls back a KV cache and a
+/// recurrent state on the verifier and the draft alike — four restores where
+/// the sidecar pairs do two.
+#[ignore]
+#[test]
+fn the_two_model_round_loop_reproduces_plain_greedy() {
+    run_gate(
+        "the_two_model_round_loop_reproduces_plain_greedy",
+        &TWO_MODEL_PAIR,
+    );
+}
+
 /// Every prompt in [`PROMPTS`], judged, and the whole table printed whatever the
 /// verdicts are.
 ///
@@ -1995,6 +2437,7 @@ fn run_gate(test: &str, pair: &Pair) {
     let Some(mut loaded) = load(pair, test, device) else {
         return;
     };
+    let draft_vocab = loaded.draft_vocab();
     let mut refusals: Vec<String> = Vec::new();
     let mut judged = 0usize;
     for prompt in PROMPTS {
@@ -2007,6 +2450,7 @@ fn run_gate(test: &str, pair: &Pair) {
             &spec,
             &plain,
             &margins,
+            draft_vocab.as_ref(),
             &verdict,
         );
         match verdict {

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -114,7 +114,9 @@ vocabulary by the norm's weight vector for every caller handing it a raw capture
 notice, and neither was visible to the 48-token prefix checks the alignment
 suites run. `crates/rmlx-models/tests/spec_greedy_equivalence.rs` is the gate that
 found them, over 256 generated tokens; `docs/SPEC_ANSWER_EQUIVALENCE.md` is its
-reference.
+reference. It carries a pair for six of the seven round loops below; the seventh
+is the two-model stochastic one, which runs only above temperature 0 and so has
+no arm this gate can compare.
 
 ```text
 # Initialisation
@@ -748,8 +750,15 @@ in `runs.db` under `decode_config = two_model/block=5`: `gemma-4-e4b-it-mxfp8`
 drafted by `gemma-4-e2b-it-mxfp8` runs at 72.95 TPS against 83.12 with no
 drafter (accept rate 0.66, 3.56 tokens/round); `Qwen3.8-27B-mxfp8` drafted by
 `ornith-1.0-9b-mxfp8-mlx` at 10.71 against 18.89 (accept rate 0.36, 51.5 ms of
-rollback per round on the GDN pair). Neither pair pays at this block; both
-reproduce the no-drafter arm's text.
+rollback per round on the GDN pair). Neither pair pays at this block.
+
+Both were byte-identical to the no-drafter arm at 128 tokens, which is a weaker
+statement than it reads as: no correct speculative arm on this engine is
+byte-identical to plain greedy in general, so byte-equality is evidence and not a
+test. The GDN pair is now in the answer-equivalence gate
+(`the_two_model_round_loop_reproduces_plain_greedy`), which judges it over 256
+tokens and six prompts by where the arms first differ; it agrees on the five it
+judges, three of them bit-identical. See `docs/SPEC_ANSWER_EQUIVALENCE.md`.
 
 ### Gemma4 Assistant Drafter
 

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -753,12 +753,17 @@ drafter (accept rate 0.66, 3.56 tokens/round); `Qwen3.8-27B-mxfp8` drafted by
 rollback per round on the GDN pair). Neither pair pays at this block.
 
 Both were byte-identical to the no-drafter arm at 128 tokens, which is a weaker
-statement than it reads as: no correct speculative arm on this engine is
-byte-identical to plain greedy in general, so byte-equality is evidence and not a
-test. The GDN pair is now in the answer-equivalence gate
-(`the_two_model_round_loop_reproduces_plain_greedy`), which judges it over 256
-tokens and six prompts by where the arms first differ; it agrees on the five it
-judges, three of them bit-identical. See `docs/SPEC_ANSWER_EQUIVALENCE.md`.
+statement about the loop than it reads as: no correct speculative arm on this
+engine is byte-identical to plain greedy in general, so a run that is says the
+two arms happened not to meet a near-tie, not that the loop is right. The bench
+refuses a differing answer anyway, and that is a different job — it is deciding
+whether to *file a row*, and a row taken from an arm that answered something
+else is not a faster answer to the same question. Deciding whether a difference
+is a legitimate near-tie or a defect is the equivalence gate's job, and the GDN
+pair is now in it (`the_two_model_round_loop_reproduces_plain_greedy`): 256
+tokens over six prompts, judged by where the arms first differ and how sure the
+verifier was there; it agrees on the five it judges, three of them bit-identical.
+See `docs/SPEC_ANSWER_EQUIVALENCE.md`.
 
 ### Gemma4 Assistant Drafter
 
@@ -1534,20 +1539,27 @@ at the top level. The DFlash 2 loader defaults nothing — a key it needs and
 cannot find is a refusal naming the key, because a default is indistinguishable
 from the checkpoint's own value once a run is recorded.
 
-**That arm also did not reproduce its verifier's answer.** At temperature 0 on
-the code prompt it diverged from the no-drafter arm at the fourth token and
-stayed diverged, where the MTP sidecar on the same verifier and prompt is
-byte-identical over 160 tokens. Greedy acceptance emits only the verifier's
-argmax, so no drafter — however badly it proposes, and whatever tensors it was
-built without — can change the answer; a changed answer is the round loop, and
-the DFlash 1 loop is one of the three the answer-equivalence gate does not cover
-(`docs/SPEC_ANSWER_EQUIVALENCE.md` § What it runs). That arm cannot be
-reproduced on this pair at all now — the checkpoint declares itself `dflash2`
-and no longer reaches the DFlash 1 loader — so the loop is reproduced where it
-still runs: `z-lab/Qwen3.6-35B-A3B-DFlash` on its own verifier drives the same
-`dflash_generate`. **The observation is about DFlash 1, not this
-checkpoint**: the DFlash 2 loop on the same verifier is a pair in that gate and
-agrees with plain greedy on six of six prompts.
+**That arm also read as not reproducing its verifier's answer, and it did.** At
+temperature 0 on the code prompt it diverged from the no-drafter arm near the
+start and stayed diverged, where the MTP sidecar on the same verifier and prompt
+is byte-identical over 160 tokens. Read as byte-equality that says the round
+loop changed the answer. Measured against the oracle that judges a divergence
+rather than only detecting one, it does not: the verifier's top-two gap at the
+position the arms parted is the **smallest** of all 160 in that answer, rank
+0.0000 against a ceiling of 0.12. It is a near-tie flip, and
+`docs/SPEC_ANSWER_EQUIVALENCE.md` § The divergence this gate was named for
+carries the measurement. That is also the distinction between the two checks:
+`scripts/spec_bench.sh` refuses a row whose arms answered differently at all,
+because a bench row is optional and a refused one costs nothing; the
+equivalence gate is what decides whether a difference is a near-tie or a defect.
+
+That arm cannot be reproduced on this pair at all now — the checkpoint declares
+itself `dflash2` and no longer reaches the DFlash 1 loader, which would refuse it
+for the unread tensors anyway. **The observation was about DFlash 1, not this
+checkpoint**, and both loops are now pairs in that gate: DFlash 2 on this
+verifier agrees with plain greedy on six of six prompts, and DFlash 1 on
+`z-lab/Qwen3.6-35B-A3B-DFlash` and its own verifier agrees on the five it judges
+and reproduces the sixth exactly.
 
 ### Qwen3.6-35B-A3B-8bit — three drafters (GDN hybrid, MoE)
 

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -15,9 +15,9 @@ against.
 
 ## What it runs
 
-Three pairs, each over every prompt in the file. The assistant pair resolves both
+Six pairs, each over every prompt in the file. The assistant pair resolves both
 halves by slug from `RMLX_O_MODELS_ROOT` and so runs wherever the snapshots are;
-the other two have their drafter named by the operator and their verifier is the
+the other five have their drafter named by the operator and their verifier is the
 reason (below):
 
 | verifier | drafter | round loop | rollback |
@@ -25,64 +25,113 @@ reason (below):
 | `gemma-4-e2b-it-mxfp8` | `gemma-4-E2B-it-assistant-bf16` | shared-K/V assistant | KV truncation, SWA ring included |
 | `Qwen3.8-27B-mxfp8` | `Qwen3.8-27B-MTP-mxfp8` | MTP sidecar | KV truncation + recurrent snapshot/replay |
 | `Qwen3.8-27B-4bit` | `Qwen3.8-27B-DFlash2` | DFlash 2 block drafter | KV truncation + recurrent snapshot/replay |
+| `Qwen3.6-35B-A3B-8bit` | `Qwen3.6-35B-A3B-DFlash` | DFlash 1 block drafter | KV truncation + recurrent snapshot/replay |
+| `Qwen3.6-35B-A3B-8bit` | `specdrift-qwen3.6-35b-a3b-eagle3` | EAGLE-3 | KV truncation + recurrent snapshot/replay |
+| `Qwen3.8-27B-mxfp8` | `ornith-1.0-9b-mxfp8-mlx` | two full models, greedy | both models' KV + recurrent state |
 
 `RMLX_DRAFT_TEST_MODEL` names one drafter, so a pair whose loop does not drive
 the kind that snapshot declares stands down naming both rather than handing
-another drafter's tensors to a loader.
+another drafter's tensors to a loader. The two-model loop is the one kind that
+cannot be pinned that way — `two_model` is an inference from the architecture
+registry and every full model satisfies it — so that pair reads the vocabulary
+both snapshots declare and stands down when they differ.
+
+The DFlash 1 pair is the only one whose verify width is not fixed: its loop sets
+each round's block from the accept rate of the recent ones, so a run truncates an
+8-wide append and follows it with a 4- or 6-wide one. Every individual width is
+exercised by some other pair; that sequence is not.
 
 Six prompts, all asking for continuous prose. A tokenizer that declares `<think>`
 gets an empty reasoning block — its own template's `enable_thinking=false` — and
 turn markers are read off the tokenizer's added tokens rather than hard-coded, so
 a pair is never served outside its own template.
 
-**The two pairs are selected differently, and the reason is the census.** The
+**One pair is selected differently from the other five, and the reason is the
+census.** The
 assistant pair resolves both halves by slug, produces **zero** shader-validation
 hits (measured, narrowed run), and runs under `make gpu-test` on any machine
-holding the snapshots — about 3.5 minutes. The recurrent pair's verifier drives
-MLX's mxfp8 quantized matmul, whose `load_safe` bound is the same one
+holding the snapshots — about 3.5 minutes. Every other pair's verifier drives
+MLX's mxfp8 or affine quantized matmul, whose `load_safe` bound is the same one
 `scripts/gpu_validation_census.txt` records for the affine instantiation: a
 narrowed run reports 1344 invalid **loads** (no stores) from
 `mxfp8_qmm_t_splitk_bfloat16_t_gs_32_b_8_alN_false`, a kernel this repo does not
 compile. The census pins one exact count per originating test, and a count taken
 from a 256-token generation moves with every prompt — pinning it would make the
-census brittle rather than informative. So that pair resolves its drafter from
-`RMLX_DRAFT_TEST_MODEL` only, `make gpu-test` reports it as skipped naming the
-variable, and running it is:
+census brittle rather than informative. So those pairs resolve their drafter from
+`RMLX_DRAFT_TEST_MODEL` only, `make gpu-test` reports them as skipped naming the
+variable, and running one is:
 
 ```
-RMLX_KV_TEST_MODEL=<...>/mlx-community__Qwen3.8-27B-mxfp8 \
 RMLX_DRAFT_TEST_MODEL=<...>/mlx-community__Qwen3.8-27B-MTP-mxfp8 \
 cargo test -p rmlx-models --test spec_greedy_equivalence -- --ignored --nocapture \
   the_recurrent_round_loop
 ```
 
-That is a real gap: the case the second defect was found in is not in a gate that
-runs by default. Closing it needs either the census analysis extended to this
-kernel and model, or a stable count — neither of which this change is the place
-for.
+The verifier comes from `RMLX_O_MODELS_ROOT` by slug; `RMLX_KV_TEST_MODEL` still
+overrides it when it names a snapshot of an architecture the pair covers.
 
-**Three of the round loops that exist are outside the gate entirely.** It
-covers the Gemma4 assistant loop, the Qwen3.5-family MTP sidecar loop and the
-DFlash 2 block loop. The DFlash 1, EAGLE-3 and two-model loops have no pair
-here, and the property is not transitive across loops — each one has its own
-rollback and its own acceptance walk, which is what the gate reads.
+That is a real gap: five of the six pairs — including the case the second defect
+was found in — are not in a gate that runs by default. Closing it needs either
+the census analysis extended to these kernels and models, or a stable count.
 
-That boundary is not hypothetical. Served at temperature 0 on the code prompt,
-`Qwen3.8-27B-4bit` drafted by `z-lab/Qwen3.8-27B-DFlash2` at block 8 diverged
-from the same verifier's no-drafter answer at the fourth token — "We need to
-respond to user:" against "We need answer user's request:" — and stayed
-diverged; the MTP sidecar on the same verifier, same prompt and same 160-token
-budget is byte-identical to it. A greedy speculative loop can only emit the
-verifier's own argmax, so a drafter proposing badly costs throughput and cannot
-change the answer. A changed answer is the loop, not the drafter.
+## Coverage
 
-**That arm was the DFlash 1 loop wearing the checkpoint's name**, and it no
-longer exists: the checkpoint declares itself a DFlash 2 drafter and routes to
-its own loader and its own round loop, which is now a pair in this gate and
-agrees with plain greedy on six of six prompts. What the observation is still
-evidence about is DFlash 1, which drives `z-lab/Qwen3.6-35B-A3B-DFlash` on its
-own verifier and remains uncovered — that is the pair a DFlash 1 case here would
-be built on.
+Seven round loops exist. Six have a pair here. The seventh **cannot have one**:
+`spec_generate_stochastic_cached` is the two-model loop's Leviathan acceptance
+rule, which only runs at `temperature > 0`. There is no temperature-0 arm of it
+to compare against plain greedy, and at any other temperature neither arm is a
+function of the model alone. Its own gate is
+`crates/rmlx-models/tests/two_model_stochastic.rs`, which pins that one seed
+reproduces one sequence while a second seed and temperature 0 do not — a
+different property, and the only one available.
+
+| round loop | pair | how it is gated |
+|---|---|---|
+| Gemma4 shared-K/V assistant | `the_assistant_round_loop_reproduces_plain_greedy` | slug-resolved, runs under `make gpu-test` |
+| Qwen3.5-family MTP sidecar | `the_recurrent_round_loop_reproduces_plain_greedy` | `RMLX_DRAFT_TEST_MODEL` |
+| DFlash 2 block | `the_block_round_loop_reproduces_plain_greedy` | `RMLX_DRAFT_TEST_MODEL` |
+| DFlash 1 block | `the_adaptive_round_loop_reproduces_plain_greedy` | `RMLX_DRAFT_TEST_MODEL` |
+| EAGLE-3 | `the_restricted_vocab_round_loop_reproduces_plain_greedy` | `RMLX_DRAFT_TEST_MODEL` |
+| two full models, greedy | `the_two_model_round_loop_reproduces_plain_greedy` | `RMLX_DRAFT_TEST_MODEL` |
+| two full models, stochastic | none, and none is possible | `two_model_stochastic.rs`, a different property |
+
+The property is not transitive across loops — each has its own rollback and its
+own acceptance walk, which is what the gate reads — so each of the six is its own
+pair rather than an inference from a neighbour.
+
+## The divergence this gate was named for, settled
+
+Served at temperature 0 on the code prompt, `Qwen3.8-27B-4bit` drafted by
+`z-lab/Qwen3.8-27B-DFlash2` at block 8 diverged from the same verifier's
+no-drafter answer near the start — "We need to respond to user:" against "We need
+answer user's request:" — and stayed diverged, while the MTP sidecar on the same
+verifier and prompt was byte-identical to the no-drafter arm. Read as
+byte-equality against plain greedy, that says the loop changed the answer.
+
+**Byte-equality is the oracle this file rejects**, and the measurement says why.
+Plain greedy on that verifier and that prompt, at 160 tokens with the top two
+logprobs per position, reproduces the no-drafter arm exactly and gives the margin
+at every decision in it. The arms part at "answer" against "to", the third token;
+the top-two gap there is 0.2500 nats — the **smallest** of all 160, against a
+median of 10.3750. Its rank in the arm's own margins is 0.0000, against a ceiling
+of 0.12. The position after it reads 2.1250 nats and rank 0.0875, also inside the
+band. Whichever of the two positions the report meant, the divergence sits at the
+floor of the distribution correct pairs occupy. It is a near-tie flip, not a
+changed answer.
+
+The arm that produced it also no longer exists. At that commit the checkpoint's
+`DFlash2DraftModel` was read as a DFlash 1 drafter, and the DFlash 1 loader built
+58 of its 81 tensors — every dynamic convolution and the whole candidate selector
+went unread. That is refused outright now: the checkpoint declares itself a
+DFlash 2 drafter and routes to its own loader and its own round loop, and a
+loader that leaves a tensor unread refuses rather than serving an architecture
+that is not the checkpoint's.
+
+What the observation was evidence about is the DFlash 1 loop, and that now has a
+pair. On `Qwen3.6-35B-A3B-8bit` drafted by `z-lab/Qwen3.6-35B-A3B-DFlash` at its
+own block of 16, with the adaptive schedule running, it agrees with plain greedy
+on the five prompts it judges and reproduces the sixth exactly. Its first
+divergences read 0.0000 to 0.0234.
 
 ## The oracle: where a correct pair diverges
 
@@ -94,31 +143,103 @@ that sits in the same arm's own margin distribution. Both arms saw the same
 context up to that position, so this judges the pair rather than an arm, and it
 needs no per-prompt calibration: it is a rank, not a number of nats.
 
-Measured over three pairs and six prompts each, against the shipped engine and
-against a deliberately broken one per pair — two on the block pair:
+Measured over six pairs and six prompts each, against the shipped engine and
+against a deliberately broken one per pair — two on the block pair and two on the
+restricted-vocabulary one:
 
-| engine | percentile of the reference arm's own margins |
-|---|---|
-| assistant pair, as shipped | 0.0000 to 0.0820 |
-| recurrent pair, as shipped | 0.0000 to 0.0234 |
-| block pair, as shipped | 0.0000 to 0.0273 |
-| assistant pair, SWA ring keeping its rejected block tail | 0.4219 to 0.9258 |
-| recurrent pair, acceptance walk without the final norm | 0.0000 to 0.5000 |
-| block pair, rejected tail never rolled off | 0.0117 to 0.9297 |
-| block pair, one rejected draft kept every partial round | 0.1758 to 0.6406 |
+| engine | percentile of the reference arm's own margins | refused on |
+|---|---|---|
+| assistant pair, as shipped | 0.0000 to 0.0820 | — |
+| recurrent pair, as shipped | 0.0000 to 0.0234 | — |
+| block pair, as shipped | 0.0000 to 0.0273 | — |
+| adaptive pair, as shipped | 0.0000 to 0.0234 | — |
+| restricted-vocabulary pair, as shipped | 0.0000 to 0.0703 | — |
+| two-model pair, as shipped | 0.0000 to 0.0234 | — |
+| assistant pair, SWA ring keeping its rejected block tail | 0.4219 to 0.9258 | 4 of 6 |
+| recurrent pair, acceptance walk without the final norm | 0.0000 to 0.5000 | 4 of 6 |
+| block pair, rejected tail never rolled off | 0.0117 to 0.9297 | 6 of 6 |
+| block pair, one rejected draft kept every partial round | 0.1758 to 0.6406 | 6 of 6 |
+| adaptive pair, one rejected draft kept every partial round | 0.0703 to 0.8320 | 5 of 5 judged |
+| restricted-vocabulary pair, one rejected draft kept every partial round | 0.0000 to 0.8320 | 5 of 5 judged |
+| restricted-vocabulary pair, correction left on the restricted argmax | 0.0000 to 0.8828 | 1 of 6 |
+| two-model pair, one rejected draft kept every partial round | 0.0000 to 0.6680 | 6 of 6 |
 
 `MAX_DIVERGENCE_CONFIDENCE` is 0.12, inside the band the measurement leaves:
 above the worst correct cell (0.0820, 1.46×) and under the lowest broken cell
-above it (0.1538, 1.28×). It clears every correct cell and refuses ten of the
-first twelve broken ones.
-The two it does not are covered by running **every** prompt rather than one:
-each broken engine is refused on at least four of its six, so a gate pinned to
-one prompt would be a coin toss and this one is not.
+above it (0.1445, 1.20×). It clears every correct cell, and no broken engine is
+refused on every prompt by this oracle alone — which is why the gate runs **every**
+prompt rather than one, and why the repetition control runs beside it. The
+block pair's two broken engines are refused on six of six; one of their twelve
+cells reads 0.0117, inside the ceiling, and it is the control that refuses it,
+reading 1.0000. On the four broken engines added with the new pairs the split
+runs the same way: the confidence ceiling fires on 4, 3, 1 and 4 of the judged
+cells and the control takes the rest.
 
-The block pair's two broken engines are refused on six of six each. One of their
-twelve cells reads 0.0117, inside the ceiling, and is refused by the repetition
-control instead — which reads 1.0000 on it. The two oracles cover each other and
-neither alone gives that recall.
+The last row is the exception and it is a property of the defect, not of the
+ceiling — see the boundary below.
+
+## A declared boundary: EAGLE-3's restricted vocabulary
+
+EAGLE-3's verify pass does not score the whole block against the verifier's
+vocabulary. It takes the argmax over the drafter's reduced one — 32000 target
+ids, plus the verifier's stop ids so a turn can still end — at every position,
+and computes the verifier's full-vocabulary argmax at exactly one: the first
+position the draft missed, or the bonus when it missed none. An accepted position
+is therefore emitted as the *draft's* token, and that token is the verifier's own
+argmax only when the verifier's argmax is inside the restricted set. A restricted
+argmax equals the true one exactly when the true one is in the set, so the whole
+inexactness lives on the positions where it is not.
+
+That mirrors the upstream implementation, so it is a design boundary rather than
+a port defect. It is still an answer change at temperature 0, which is what this
+gate reads, so the gate measures the exposure rather than assuming it away. Every
+run of that pair prints two figures per prompt: `unnameable`, how many of the
+reference arm's own tokens the drafter's vocabulary cannot say, and
+`divergence_unnameable`, whether the token the arms parted on is one of them.
+
+Measured over the six prompts: `unnameable` reads 1, 2, 2, 3, 4 and 5 tokens —
+under 2% of a 256-token answer — and `divergence_unnameable` is **false on all
+six**. The boundary exists and did not fire at any first divergence here; every
+one of them is at a token the drafter can name, so the restriction cannot explain
+it and the confidence oracle judges it as it judges any other pair.
+
+The gate has power over the boundary when it does bite. Left with the correction
+position on the restricted argmax as well — which widens the same inexactness
+from "sometimes at an accepted position" to "always at the correction" — the pair
+is refused on one prompt of six, at confidence 0.8828, with
+`divergence_unnameable` true on exactly that cell. One of six is what the
+exposure predicts, and it is why that pair carries a second broken engine: with
+its rollback target off by one it is refused on five of the five prompts it
+judges.
+
+## Which arm is short
+
+`MIN_ANSWER_TOKENS` is 160 and both arms are read against it, but not
+symmetrically, and the restricted-vocabulary pair is what forced the asymmetry to
+be written down.
+
+A **speculative** arm under the floor while the reference ran on is the round
+loop cutting its own run, and is refused. A **reference** arm under the floor is
+the prompt: plain greedy is the control here, exactly as it is for the repetition
+control, and a prompt it answered in 52 tokens leaves no answer to compare. The
+one shape that is still about the loop is a speculative arm that reproduced the
+whole reference answer and then carried on — a loop that did not stop where the
+verifier stopped — and that is separable by inspection: the arms are identical up
+to the reference's end.
+
+The case: on `Qwen3.6-35B-A3B-8bit` the 4k document is summarised in 52 tokens.
+The MTP sidecar and DFlash 1 loops reproduce that answer exactly. EAGLE-3 parts
+from it at the fourth token — the single lowest-margin decision in those 52, rank
+0.0000 — and writes a longer, well-formed summary instead. Under the old rule
+that was refused as a truncation; it is two different answers, and the shorter of
+them is one the gate cannot read.
+
+The class this gives up is a loop that runs past the verifier's stop *on a prompt
+whose reference answer is under the floor*. It costs nothing on the prompts whose
+reference arms run the full budget, which is five of six on every pair here, and
+the identical-prefix test keeps the plain form of it. It was also checked
+directly: served with the EAGLE-3 drafter, the loop stops on the verifier's stop
+ids and returns `finish_reason: stop`.
 
 ## Why there is no subsequence floor
 
@@ -140,6 +261,17 @@ The figure is printed on every run, together with the weakest tail window, the
 first divergence, the margin there, and both arms' decoded text. It is evidence,
 not a gate.
 
+**The three pairs added since made that concrete rather than merely argued.**
+`WORST_CORRECT_TAIL_AGREEMENT` — the worst tail reading a correct pair reached —
+was 0.2344, measured over two pairs. Over all six it is 0.1094, and the worst
+reading of the whole population belongs to the block pair, which had never been
+added to it. At the old figure the ragged-loop sweep could assert that everything
+the repetition control admits agrees no better than the worst correct pair. At
+the true one it cannot: past 60% raggedness the control admits pairs agreeing up
+to 0.2188, twice the worst correct reading. The sweep now pins both edges and
+asserts the overlap. That is the same claim this section makes, arrived at from
+the other side.
+
 ## The second oracle: the repetition control
 
 The first has nothing to read when *both* arms are degenerate: two arms in the
@@ -153,9 +285,11 @@ comparisons.
 0.1351 on the real arms, and 1000 synthetic streams at each of six lengths peak
 at 0.1351 and trip the ceiling none — 1.48× of headroom. The other side is swept
 rather than sampled: two arms in the same period-8 loop are walked from 0% to
-100% raggedness over four seed pairs, and every pair the control lets through
-agrees no better than the worst a correct pair reached. An earlier 0.50, placed
-from six sampled points, left 34% to 52% passing.
+100% raggedness over four seed pairs, and the control refuses every pair up to
+60%, past which the arms are more noise than loop. An earlier 0.50, placed from
+six sampled points, left 34% to 52% passing. **Nothing takes over past 60%** —
+see the subsequence section above for what the pairs the control admits there
+agree at.
 
 The control's declared blind spot is its own sample floor: the narrowest window
 is `len / TAIL_WINDOWS`, so at this budget it can evidence no period above 32,
@@ -169,8 +303,8 @@ speculative arm against a healthy reference is a verdict about the round loop. A
 degenerate *reference* arm is a verdict about the input — plain greedy is the
 control — and is reported as unjudgeable rather than failed. So is a prompt
 neither arm answered: the recurrent pair answers the 4k summary in 13 and 26
-tokens, which says nothing about the round loop. One arm short while the other
-ran on is refused.
+tokens, which says nothing about the round loop. The length floor reads the same
+asymmetry — see "Which arm is short" above.
 
 ## The two defects
 

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -13,6 +13,16 @@ as they have existed, and both are fixed. What follows is the oracle it settled
 on, why the obvious oracle does not work, and the numbers every constant is set
 against.
 
+**This is not the bench's arm-equality refusal, and the two should not be read
+as one check.** `scripts/spec_bench.sh` digests each measured run's completion
+and refuses to file a speculative row whose answer differs from the plain arm's
+at all. That is a decision about whether a *throughput row* is worth recording,
+and it is right to be absolute: a bench row is optional and a refused one costs
+nothing. This gate answers the question the bench cannot — whether a difference
+is a near-tie the arithmetic permits or a defect in the round loop — and it
+exists because byte-equality cannot answer it. No correct speculative arm here is
+byte-identical to plain greedy in general.
+
 ## What it runs
 
 Six pairs, each over every prompt in the file. The assistant pair resolves both
@@ -133,6 +143,12 @@ own block of 16, with the adaptive schedule running, it agrees with plain greedy
 on the five prompts it judges and reproduces the sixth exactly. Its first
 divergences read 0.0000 to 0.0234.
 
+None of that makes the observation a false alarm about the *bench*. A row taken
+from an arm whose answer differs is not a faster answer to the same question
+however benign the difference, and `scripts/spec_bench.sh` now refuses one. What
+this section settles is the other question — whether the difference was the round
+loop — and the answer is that it was not.
+
 ## The oracle: where a correct pair diverges
 
 A reduction-order difference is a relative perturbation of order `1e-3` on a
@@ -192,7 +208,16 @@ inexactness lives on the positions where it is not.
 
 That mirrors the upstream implementation, so it is a design boundary rather than
 a port defect. It is still an answer change at temperature 0, which is what this
-gate reads, so the gate measures the exposure rather than assuming it away. Every
+gate reads, so the gate measures the exposure rather than assuming it away.
+
+`docs/SPECULATIVE.md` says the restricted read-back is sound at temperature 0 and
+only there, and that is a claim about *sampling*: a distribution needs the whole
+row's normalising constant, so a sampled request cannot take the reduction at
+all. This section is about what remains at temperature 0 — the reduced argmax is
+the true argmax on the ids the drafter can name, and only on those. Both are
+true and neither implies the other.
+
+Every
 run of that pair prints two figures per prompt: `unnameable`, how many of the
 reference arm's own tokens the drafter's vocabulary cannot say, and
 `divergence_unnameable`, whether the token the arms parted on is one of them.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -135,11 +135,11 @@ thresholded at all.
 Unlike the three above, its **assistant pair resolves both halves by slug** from
 `RMLX_O_MODELS_ROOT`, so `make gpu-test` runs that pair on a machine holding the
 snapshots and `run_gpu_tests.sh` reports a machine without them as INCOMPLETE.
-The recurrent and block pairs are the exceptions and are not gated: their
+The other five pairs are the exceptions and are not gated: their
 drafter comes from `RMLX_DRAFT_TEST_MODEL` or the pair does not run, because
 their verifiers' quantized matmuls trip the shader-validation census (see the
 table below and `docs/SPEC_ANSWER_EQUIVALENCE.md`). That one variable names one
-drafter, so the pair whose loop does not drive the kind that snapshot declares
+drafter, so a pair whose loop does not drive the kind that snapshot declares
 stands down naming both. Its drafter resolution does not go through
 `slug_snapshot` either, for the tokenizer reason above.
 The verifier goes through the golden harness's own resolver
@@ -148,29 +148,36 @@ The verifier goes through the golden harness's own resolver
 harness's arch stand-down cannot separate them: the drafter's
 `backbone_hidden_size` is checked against the verifier's width before the drafter
 is loaded, and a mismatched pair skips with that reason rather than panicking in
-the loader.
+the loader. The two-model pair has the same problem in a different form —
+`two_model` is inferred from the architecture registry, which every full model
+satisfies — and the declared vocabulary is what separates those.
 
 | Pair | verifier | drafter | selected by |
 |---|---|---|---|
 | assistant | `mlx-community__gemma-4-e2b-it-mxfp8` | `mlx-community__gemma-4-E2B-it-assistant-bf16` | slug |
 | recurrent | `mlx-community__Qwen3.8-27B-mxfp8` | `mlx-community__Qwen3.8-27B-MTP-mxfp8` | `RMLX_DRAFT_TEST_MODEL` only |
+| block | `mlx-community__Qwen3.8-27B-4bit` | `z-lab__Qwen3.8-27B-DFlash2` | `RMLX_DRAFT_TEST_MODEL` only |
+| adaptive | `mlx-community__Qwen3.6-35B-A3B-8bit` | `z-lab__Qwen3.6-35B-A3B-DFlash` | `RMLX_DRAFT_TEST_MODEL` only |
+| restricted-vocabulary | `mlx-community__Qwen3.6-35B-A3B-8bit` | `Dogacel__specdrift-qwen3.6-35b-a3b-eagle3` | `RMLX_DRAFT_TEST_MODEL` only |
+| two-model | `mlx-community__Qwen3.8-27B-mxfp8` | `sahilchachra__ornith-1.0-9b-mxfp8-mlx` | `RMLX_DRAFT_TEST_MODEL` only |
 
 The assistant pair produces **zero** Metal shader-validation hits and so has no
-entry in `scripts/gpu_validation_census.txt` and needs none. The recurrent pair's
-verifier drives MLX's mxfp8 quantized matmul and a narrowed run reports 1344
-invalid loads from it — the same `load_safe` bound the census already records for
-the affine instantiation, in a kernel this repo does not compile. The census pins
-one exact count per test and a count from a 256-token generation is not stable
-across a prompt change, so that pair is named rather than slug-resolved and
-`make gpu-test` reports it as skipped. See `docs/SPEC_ANSWER_EQUIVALENCE.md`.
+entry in `scripts/gpu_validation_census.txt` and needs none. The other pairs'
+verifiers drive MLX's mxfp8 or affine quantized matmul and a narrowed run reports
+1344 invalid loads from it — the same `load_safe` bound the census already records
+for the affine instantiation, in a kernel this repo does not compile. The census
+pins one exact count per test and a count from a 256-token generation is not
+stable across a prompt change, so those pairs are named rather than slug-resolved
+and `make gpu-test` reports them as skipped. See
+`docs/SPEC_ANSWER_EQUIVALENCE.md`.
 
 `dflash_drafter_alignment.rs` is **not** one of those three and does not gate the
 same property. It asserts that the drafter's round-0 first-block proposal aligns
 with the verifier's greedy continuation (`accept > 0`) and that the live loop
 emits coherent prose — a round-0 check, taken before any partial-accept rollback
 has happened. It cannot see a rollback that corrupts the verifier state part-way
-through a run, which is what the three suites above exist to catch. DFlash on a
-GDN hybrid therefore has no greedy-tracking gate.
+through a run. What does, for DFlash 1 on a GDN hybrid, is
+`the_adaptive_round_loop_reproduces_plain_greedy` in `spec_greedy_equivalence.rs`.
 
 The Whisper audio integration tests (`crates/rmlx-audio/tests/transcribe.rs`)
 deliberately use **no** dedicated env var — they resolve the

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -122,7 +122,8 @@ without the request's filters — the last of which the surprise test does not
 refuse on its own, which is why the file carries a second oracle over the tokens
 that carry no target mass.
 
-`spec_greedy_equivalence.rs` asks a different question from those three: not
+`spec_greedy_equivalence.rs` asks a different question from the three alignment
+suites: not
 whether the round loop keeps the verifier's state consistent for a while, but
 whether the run produces the answer the verifier produces alone, over 256 tokens
 and every prompt the file carries. Its oracle is where the two arms first differ
@@ -132,7 +133,7 @@ scale. It is documented in full in `docs/SPEC_ANSWER_EQUIVALENCE.md`, including
 why the obvious oracle (how much of one answer the arms share) cannot be
 thresholded at all.
 
-Unlike the three above, its **assistant pair resolves both halves by slug** from
+Unlike those suites, its **assistant pair resolves both halves by slug** from
 `RMLX_O_MODELS_ROOT`, so `make gpu-test` runs that pair on a machine holding the
 snapshots and `run_gpu_tests.sh` reports a machine without them as INCOMPLETE.
 The other five pairs are the exceptions and are not gated: their
@@ -140,8 +141,10 @@ drafter comes from `RMLX_DRAFT_TEST_MODEL` or the pair does not run, because
 their verifiers' quantized matmuls trip the shader-validation census (see the
 table below and `docs/SPEC_ANSWER_EQUIVALENCE.md`). That one variable names one
 drafter, so a pair whose loop does not drive the kind that snapshot declares
-stands down naming both. Its drafter resolution does not go through
-`slug_snapshot` either, for the tokenizer reason above.
+stands down naming both. Its drafter goes through the same
+`slug_snapshot` at `Role::Sidecar` that `dflash2_loader.rs` does — one copy of
+the rules, and the role a drafter checkpoint can satisfy — and every stand-down
+names the test function it happened in, so `run_gpu_tests.sh` can attribute it.
 The verifier goes through the golden harness's own resolver
 (`common::model_for`); `RMLX_DRAFT_TEST_MODEL` overrides the drafter. Both
 `-e2b-` and `-e4b-` assistant snapshots declare the same architecture, so the
@@ -171,7 +174,8 @@ stable across a prompt change, so those pairs are named rather than slug-resolve
 and `make gpu-test` reports them as skipped. See
 `docs/SPEC_ANSWER_EQUIVALENCE.md`.
 
-`dflash_drafter_alignment.rs` is **not** one of those three and does not gate the
+`dflash_drafter_alignment.rs` is **not** one of the alignment suites above and
+does not gate the
 same property. It asserts that the drafter's round-0 first-block proposal aligns
 with the verifier's greedy continuation (`accept > 0`) and that the live loop
 emits coherent prose — a round-0 check, taken before any partial-accept rollback


### PR DESCRIPTION
Closes #513.

The issue made two claims: that the DFlash round loop changes the answer at
temperature 0, and that three round loops have no equivalence pair. The first
does not hold. The second did, and does not any more.

## The divergence

The reported arm was `Qwen3.8-27B-4bit` drafted by `z-lab/Qwen3.8-27B-DFlash2`,
judged by byte-equality against plain greedy over 160 tokens. Byte-equality is
the oracle `docs/SPEC_ANSWER_EQUIVALENCE.md` rejects, and the measurement says
why.

Plain greedy on that verifier and that prompt, with the top two logprobs per
position, reproduces the no-drafter arm exactly — "We need answer user's
request:" — and gives the margin at every decision in it. The arms part at
"answer" against "to", the third token. The top-two gap there is 0.2500 nats:
the smallest of all 160, against a median of 10.3750. Its rank in the arm's own
margin distribution is 0.0000, against a ceiling of 0.12. The next position
reads 2.1250 nats and rank 0.0875, also inside the band. Whichever position the
report meant, the divergence sits at the floor of the distribution correct pairs
occupy. It is a near-tie flip.

The arm also no longer exists. At the commit it was taken on, the checkpoint's
`DFlash2DraftModel` was read as a DFlash 1 drafter, and the DFlash 1 loader built
58 of its 81 tensors — every dynamic convolution and the whole candidate selector
went unread. Both halves of that are refused now.

The loop the observation was really about is DFlash 1, and it now has a pair:
on its own verifier at its own block of 16, with the adaptive schedule running,
it agrees with plain greedy on the five prompts it judges and reproduces the
sixth exactly, at confidences 0.0000 to 0.0234.

## The pairs

Three added, so six of the seven round loops now have one:

| pair | verifier | drafter | result |
|---|---|---|---|
| adaptive (DFlash 1) | `Qwen3.6-35B-A3B-8bit` | `Qwen3.6-35B-A3B-DFlash` | 5 agreed, 1 bit-identical and unjudgeable |
| restricted-vocabulary (EAGLE-3) | `Qwen3.6-35B-A3B-8bit` | `specdrift-qwen3.6-35b-a3b-eagle3` | 5 agreed, 1 unjudgeable |
| two-model greedy | `Qwen3.8-27B-mxfp8` | `ornith-1.0-9b-mxfp8-mlx` | 5 agreed, 3 of them bit-identical, 1 unjudgeable |

The seventh is the two-model **stochastic** loop, and it can have no
temperature-0 pair by construction: it runs only above temperature 0, where
neither arm is a function of the model alone. It is named as uncoverable, with
that reason, in the coverage table.

Each new pair ships with a mutation, run against a real model rather than
asserted. Rolling the verifier back one row short of its target — one rejected
draft kept every partial round — is refused on 5 of 5 judged prompts by the
adaptive pair, 5 of 5 by the EAGLE-3 pair and 6 of 6 by the two-model pair.

## The EAGLE-3 boundary

EAGLE-3 accepts on the argmax over the drafter's reduced vocabulary — 32000
target ids plus the verifier's stop ids — at every position, and computes the
verifier's full-vocabulary argmax at exactly one. An accepted position is emitted
as the draft's token, which is the verifier's own argmax only when that argmax is
inside the restricted set. This mirrors the upstream implementation, so it is a
design boundary, but it is still a temperature-0 answer change.

The exposure is measured on every run rather than assumed. Of the reference arm's
own tokens, 1 to 5 per answer are outside the drafter's vocabulary — under 2% —
and the token the arms parted on is inside it on all six prompts. So the boundary
exists and did not fire at any first divergence here.

The gate has power over it when it does bite: leaving the correction position on
the restricted argmax as well is refused on one prompt of six, at confidence
0.8828, at a position the drafter cannot name. One of six is what the exposure
predicts, which is why that pair carries a second, broader mutation as well.

## Two things the new pairs changed about the gate itself

**A short reference arm is now the prompt, not the loop.** On the EAGLE-3
verifier the 4k document is summarised in 52 tokens. MTP and DFlash 1 reproduce
that answer exactly; EAGLE-3 parts from it at its single lowest-margin token and
writes a longer summary. The old rule refused that as a truncation. Plain greedy
is the control — the repetition control already says so — and a reference answer
under the floor leaves nothing to compare. The one shape that is still the loop's
is a speculative arm that reproduced the whole reference answer and carried on,
and that is tested for explicitly. Checked separately: served with this drafter,
the loop does stop on the verifier's stop ids.

**A recorded constant was wrong and a claim built on it was false.**
`WORST_CORRECT_TAIL_AGREEMENT` — the worst tail agreement a correct pair reaches
— was 0.2344, measured over two pairs; the block pair had never been added to it
and holds the worst reading of the population. Over all six it is 0.1094. At the
true value the ragged-loop sweep can no longer claim that everything the
repetition control admits agrees no better than the worst correct pair: past 60%
raggedness it admits pairs agreeing up to 0.2188. The sweep now pins both edges
and asserts the overlap, which is what the file's own "no subsequence floor"
section has always argued.

The confidence ceiling stays at 0.12 and still sits inside the band, but the band
is tighter: the lowest broken cell above it is 0.1445 rather than 0.1538.

## Verification

All six pairs run green on the committed code on this machine. No engine source
is modified; the mutations were applied, run and reverted under digest check.

## Rebased onto the bench's arm-equality refusal

`main` moved under this branch: the bench now digests each measured run and
refuses a speculative row whose answer differs from the plain arm's, and the
sidecar loops were renamed and given the request's sampler.

The two checks do different jobs and the docs now say so rather than leaving them
to read as one. The bench refuses a *differing* answer, absolutely, because a
bench row is optional and a refused one costs nothing. This suite decides whether
a difference is a near-tie the arithmetic permits or a defect in the round loop —
the question byte-equality cannot answer. The finding above does not make the
bench's refusal wrong; it makes it a refusal about a row rather than a verdict
about the loop.

Three claims the landing left stale are corrected with it: the equivalence
harness resolves its drafter through the shared `slug_snapshot` at the sidecar
role, like `dflash2_loader.rs` now does; DFlash 1 is no longer one of the loops
this gate does not cover; and the restricted-vocabulary section says how it
relates to the sampling claim beside it, since "sound at temperature 0" is about
a normalising constant and this is about which ids the reduced argmax ranges
over.

The temperature-0 path is unchanged by the refactor, and that is measured rather
than read off the diff: the assistant and adaptive pairs re-run after the rebase
reproduce their pre-rebase readings digit for digit on every prompt.
