### PR TITLE
spec: measure where the round's time actually goes, and check that a charged round handed its work over

### DIFF
--- a/crates/rmlx-mlx/src/lib.rs
+++ b/crates/rmlx-mlx/src/lib.rs
@@ -954,6 +954,29 @@ impl Array {
         unsafe { check_status(status, "Array::eval") }
     }
 
+    /// Whether this array's data is materialised, so reading it would not
+    /// first run a graph.
+    ///
+    /// False while the array is still an unevaluated node — the work it stands
+    /// for has been described and not yet paid for, and whoever blocks on it
+    /// next is who pays. That is the question a wall-clock span around a call
+    /// site cannot answer about itself, and the reason this is exposed at all.
+    ///
+    /// It does not block and does not schedule: an array left mid-flight by
+    /// [`Self::async_eval`] reads false until its event fires.
+    pub fn is_available(&self) -> Result<bool> {
+        install_error_handler();
+        let mut available = false;
+        // SAFETY: inner is a valid mlx_array; the out-pointer is a stack
+        // `bool` we own. This reads the array's status and evaluates nothing,
+        // so it is outside the evaluation lock's remit.
+        let status = unsafe { sys::_mlx_array_is_available(&raw mut available, self.inner) };
+        // SAFETY: called immediately after the C function on the same thread,
+        // whose thread-local error slot it reads.
+        unsafe { check_status(status, "Array::is_available") }?;
+        Ok(available)
+    }
+
     /// Asynchronously schedule this array's compute graph on the GPU stream
     /// without blocking the calling thread. The actual evaluation happens
     /// in the background; subsequent `to_bytes`/`eval` will wait if needed.

--- a/crates/rmlx-mlx/src/lib_tests.rs
+++ b/crates/rmlx-mlx/src/lib_tests.rs
@@ -1052,3 +1052,35 @@ fn failed_reset_reports_nothing_rather_than_a_plausible_number() {
     assert!(ok.measurable());
     assert_eq!(ok.headroom_bytes(), 5_000_000_000);
 }
+
+// ── is_available ─────────────────────────────────────────────────────────
+
+/// Host data is materialised on arrival; the output of an op over it is not,
+/// until something forces it.
+///
+/// Both arms matter. A predicate stuck at `true` would let a span close over
+/// work it never paid for and report nothing; one stuck at `false` would call
+/// every carried array a defect and be switched off.
+#[test]
+fn an_unevaluated_result_is_not_available_and_a_forced_one_is() {
+    let input: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
+    let a = Array::from_bytes(f32_as_bytes(&input), &[2i32, 2], Dtype::F32)
+        .expect("Array::from_bytes failed");
+    assert!(
+        a.is_available().expect("is_available failed on host data"),
+        "an array built from host bytes holds its data already"
+    );
+
+    let sum = add(&a, &a, Device::Cpu).expect("add failed");
+    assert!(
+        !sum.is_available()
+            .expect("is_available failed on a lazy result"),
+        "the result of an op nobody has forced is still a graph node"
+    );
+
+    sum.eval().expect("eval failed");
+    assert!(
+        sum.is_available().expect("is_available failed after eval"),
+        "eval blocks until the data is there, so the answer after it is true"
+    );
+}

--- a/crates/rmlx-models/src/speculative/dflash2/round.rs
+++ b/crates/rmlx-models/src/speculative/dflash2/round.rs
@@ -382,6 +382,15 @@ pub fn dflash2_generate(
             device,
         )?;
         h_ctx = drafter.extend_conditioning(&h_ctx, &committed_hidden)?;
+        if charge_phases {
+            // Extending the context copies every row the drafter's window
+            // reaches back over, at `len(target_layer_ids)` times the hidden
+            // width, and the next round's drafter is the first thing to read
+            // it. Forced here it lands in the round's unclaimed time, which is
+            // where slicing and bookkeeping belong; left lazy it lands in the
+            // drafter. See `phases_charged`.
+            h_ctx.eval()?;
+        }
         b = *new_tokens.last().unwrap_or(&b);
 
         tracing::debug!(
@@ -405,7 +414,13 @@ pub fn dflash2_generate(
             replayed,
             charged: charge_phases,
         }
-        .log(SpecLoop::DFlash2, rounds, accept, draft_tokens.len());
+        .log(
+            SpecLoop::DFlash2,
+            rounds,
+            accept,
+            draft_tokens.len(),
+            &[("h_ctx", &h_ctx)],
+        );
     }
 
     let round_loop_ns = round_loop_t0.elapsed().as_nanos();

--- a/crates/rmlx-models/src/speculative/gemma4_assistant.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant.rs
@@ -957,10 +957,19 @@ pub fn mtp_assistant_generate(
         full_kv = drop_kv_tail(&new_full, rejected, device)?;
         kv_offset = v_target;
         if charge_phases {
-            // The trimmed K/V is not read until the next round's drafter call,
-            // so nothing forces these slices here and the trim is billed to
-            // that round. See `phases_charged`.
-            for a in [&sliding_kv.0, &sliding_kv.1, &full_kv.0, &full_kv.1] {
+            // None of this is read until the next round's drafter call, so
+            // nothing forces it here and the whole next-round setup is billed
+            // to that round. The conditioning is in the list with the trimmed
+            // K/V: the verify span's argmax forced the hidden it is sliced
+            // from, but not the slice, the reshape or the norm over it. See
+            // `phases_charged`.
+            for a in [
+                &hidden,
+                &sliding_kv.0,
+                &sliding_kv.1,
+                &full_kv.0,
+                &full_kv.1,
+            ] {
                 a.eval()?;
             }
         }
@@ -981,6 +990,13 @@ pub fn mtp_assistant_generate(
             rounds,
             accept,
             draft_tokens.len(),
+            &[
+                ("hidden", &hidden),
+                ("sliding_k", &sliding_kv.0),
+                ("sliding_v", &sliding_kv.1),
+                ("full_k", &full_kv.0),
+                ("full_v", &full_kv.1),
+            ],
         );
     }
 

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -1821,8 +1821,8 @@ pub(crate) fn accept_prefix(
 ///
 /// `charge` is the calling loop's per-request answer from
 /// [`phases_charged`], not a decision this function makes. Seven loops share it
-/// and two of them time their phases; reading the switch here would change the
-/// schedule of the other five with nothing on their records saying so.
+/// and three of them time their phases; reading the switch here would change the
+/// schedule of the other four with nothing on their records saying so.
 #[allow(clippy::too_many_arguments)]
 #[allow(
     clippy::indexing_slicing,

--- a/crates/rmlx-models/src/speculative/mtp.rs
+++ b/crates/rmlx-models/src/speculative/mtp.rs
@@ -870,6 +870,15 @@ pub fn mtp_generate(
             &[1, 1, 1],
             device,
         )?;
+        if charge_phases {
+            // Reading the verifier's tokens forced the logits and the trunk
+            // under them, but the capture hangs off a different output of that
+            // forward and this slice off the capture. The next round's drafter
+            // is the first thing to read either, so with nothing forcing them
+            // here the verifier's capture is billed to the drafter. See
+            // `phases_charged`.
+            h_cond.eval()?;
+        }
         b = *new_tokens.last().unwrap_or(&b);
         draft_pos += n_committed as i32;
 
@@ -887,6 +896,7 @@ pub fn mtp_generate(
             rounds,
             accept,
             draft_tokens.len(),
+            &[("h_cond", &h_cond)],
         );
     }
 

--- a/crates/rmlx-models/src/speculative/round_stats.rs
+++ b/crates/rmlx-models/src/speculative/round_stats.rs
@@ -40,6 +40,18 @@
 //! reports, not something this module does behind a reader's back. See
 //! [`phases_charged`], and `charged` on the record and on every per-round
 //! event.
+//!
+//! **A charged round is checked, not trusted.** Charging is a list of
+//! evaluations a loop makes by hand, one per thing it produces, and the failure
+//! mode is an omission: a phase forces four of the five arrays it built and the
+//! fifth is paid for by the next round's drafter, at no cost to any assertion.
+//! [`RoundPhases::log`] therefore takes the arrays the round hands on and, on a
+//! charged round, names any that are still unevaluated — see [`unforced`].
+//! Whether a loop declared everything it carries is not something the check can
+//! know; what it removes is the case where the declaration was right and the
+//! forcing was missing.
+
+use rmlx_mlx::Array;
 
 use crate::speculative::DraftKind;
 
@@ -196,6 +208,32 @@ pub(crate) fn ms(ns: u128) -> f64 {
     (ns as f64) / 1.0e6
 }
 
+/// Which of the arrays a round hands to its successor are still unevaluated,
+/// by the name the round called them.
+///
+/// A charged round's phases each force their own work, but only the work they
+/// can see. An array built after a phase's timer closed — a conditioning
+/// context extended with this round's capture, a trimmed K/V — is nobody's
+/// work until something blocks on it, and the first thing that does is the next
+/// round's drafter. So the drafter's span pays, and the split reads as a
+/// drafter that costs more than it does.
+///
+/// This is the one question that settles it: not how long a span took, but
+/// whether the data it was supposed to leave behind is there.
+fn unforced(carry: &[(&str, &Array)]) -> Vec<String> {
+    carry
+        .iter()
+        .filter_map(|(name, array)| match array.is_available() {
+            Ok(true) => None,
+            Ok(false) => Some((*name).to_owned()),
+            // Not the same finding, and folding the two would report a broken
+            // read as a clean round. An unreadable status is not evidence the
+            // array was forced.
+            Err(e) => Some(format!("{name} (status unreadable: {e})")),
+        })
+        .collect()
+}
+
 /// One round's wall clock, split by the phase that spent it.
 ///
 /// The four phases are disjoint sub-spans of the round, so the round's own
@@ -250,7 +288,36 @@ impl RoundPhases {
     /// the round it is attributed to is a defect in the instrument, and the
     /// only reader who would otherwise notice is one already reading raw
     /// JSON-Lines and already looking for it.
-    pub(crate) fn log(&self, loop_kind: SpecLoop, round: usize, accept: usize, num_draft: usize) {
+    ///
+    /// `carry` is every array this round leaves for the next one's drafter to
+    /// read, each under the name the loop calls it. On a charged round they
+    /// must all be forced by now, and [`unforced`] says which are not — see
+    /// [`phases_charged`]. It is an argument rather than something this module
+    /// works out because only the loop knows what it carries; a loop that
+    /// genuinely carries no array passes an empty slice and says so where a
+    /// reader can see it.
+    pub(crate) fn log(
+        &self,
+        loop_kind: SpecLoop,
+        round: usize,
+        accept: usize,
+        num_draft: usize,
+        carry: &[(&str, &Array)],
+    ) {
+        if self.charged {
+            let unforced = unforced(carry);
+            if !unforced.is_empty() {
+                tracing::error!(
+                    target: PHASE_TARGET,
+                    ?loop_kind,
+                    round,
+                    unforced = %unforced.join(", "),
+                    "a charged round left work for the next round's drafter to pay for: \
+                     these arrays are still unevaluated, so the drafter's span is charged \
+                     the phase that built them"
+                );
+            }
+        }
         let Some(unclaimed_ns) = self.unclaimed_ns() else {
             tracing::error!(
                 target: PHASE_TARGET,

--- a/crates/rmlx-models/src/speculative/round_stats_tests.rs
+++ b/crates/rmlx-models/src/speculative/round_stats_tests.rs
@@ -554,3 +554,187 @@ fn a_round_with_one_phase_and_nothing_else_claims_all_of_it() {
     };
     assert_eq!(p.unclaimed_ns(), Some(0));
 }
+
+// ---------------------------------------------------------------------------
+// What a charged round left behind
+// ---------------------------------------------------------------------------
+
+/// An array holding host data, and the unevaluated result of an op over it.
+///
+/// Everything here runs on the CPU device and forces nothing it does not mean
+/// to: the point of the fixture is an array that is deliberately still a graph
+/// node.
+#[allow(
+    clippy::expect_used,
+    reason = "an array the fixture could not build leaves the test asserting nothing, \
+              so failing here is the right report"
+)]
+fn forced_and_lazy() -> (rmlx_mlx::Array, rmlx_mlx::Array) {
+    let bytes = 1.0f32.to_le_bytes();
+    let seed = rmlx_mlx::Array::from_bytes(&bytes, &[1], rmlx_mlx::Dtype::F32)
+        .expect("Array::from_bytes failed");
+    let lazy = rmlx_mlx::add(&seed, &seed, rmlx_mlx::Device::Cpu).expect("add failed");
+    (seed, lazy)
+}
+
+/// A subscriber that keeps every event's target, level and rendered fields.
+struct EventLog {
+    events: std::sync::Mutex<Vec<(String, tracing::Level, String)>>,
+}
+
+impl EventLog {
+    fn new() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
+            events: std::sync::Mutex::new(Vec::new()),
+        })
+    }
+
+    fn seen(&self) -> Vec<(String, tracing::Level, String)> {
+        self.events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+struct Render(String);
+
+impl tracing::field::Visit for Render {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        use std::fmt::Write as _;
+        let _ = write!(self.0, " {}={value:?}", field.name());
+    }
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        use std::fmt::Write as _;
+        let _ = write!(self.0, " {}={value}", field.name());
+    }
+}
+
+impl tracing::Subscriber for EventLog {
+    fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+        true
+    }
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+    fn event(&self, event: &tracing::Event<'_>) {
+        let mut render = Render(String::new());
+        event.record(&mut render);
+        let meta = event.metadata();
+        self.events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push((meta.target().to_owned(), *meta.level(), render.0));
+    }
+    fn enter(&self, _: &tracing::span::Id) {}
+    fn exit(&self, _: &tracing::span::Id) {}
+}
+
+/// Every error the phase target carried during `f`.
+fn phase_errors(f: impl FnOnce()) -> Vec<String> {
+    let log = EventLog::new();
+    tracing::subscriber::with_default(std::sync::Arc::clone(&log), f);
+    log.seen()
+        .into_iter()
+        .filter(|(target, level, _)| {
+            target == super::PHASE_TARGET && *level == tracing::Level::ERROR
+        })
+        .map(|(_, _, fields)| fields)
+        .collect()
+}
+
+fn charged_round(charged: bool) -> super::RoundPhases {
+    super::RoundPhases {
+        round_ns: 10_000_000,
+        draft_ns: 4_000_000,
+        verify_ns: 4_000_000,
+        walk_ns: 1_000_000,
+        rollback_ns: 1_000_000,
+        replayed: false,
+        charged,
+    }
+}
+
+/// The predicate the whole guard rests on: it separates an array whose data is
+/// there from one whose is not, and names only the second.
+///
+/// A predicate that answered one way for everything would leave the guard
+/// either silent on every real defect or shouting on every clean round, and
+/// both end the same way — with it switched off.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "a forcing step that failed makes the second arm meaningless, so it \
+              must stop the test rather than be reported as a clean round"
+)]
+fn only_the_array_nobody_forced_is_named() {
+    let (forced, lazy) = forced_and_lazy();
+    assert_eq!(
+        super::unforced(&[("forced", &forced), ("lazy", &lazy)]),
+        vec!["lazy".to_owned()],
+        "the host-data array holds its data and the unevaluated sum does not"
+    );
+
+    lazy.eval().expect("eval failed");
+    assert!(
+        super::unforced(&[("forced", &forced), ("lazy", &lazy)]).is_empty(),
+        "once forced, neither array has work left for the next phase to pay for"
+    );
+}
+
+/// A charged round that leaves its conditioning unevaluated says so, and says
+/// which array and whose span will be charged for it.
+#[test]
+fn a_charged_round_that_left_its_carry_lazy_names_it() {
+    let (_, lazy) = forced_and_lazy();
+    let errors = phase_errors(|| {
+        charged_round(true).log(SpecLoop::DFlash2, 7, 3, 4, &[("h_ctx", &lazy)]);
+    });
+    let [reason] = errors.as_slice() else {
+        panic!("exactly one report per round, got: {errors:?}");
+    };
+    assert!(
+        reason.contains("h_ctx"),
+        "the report must name the array a reader has to go and find: {reason}"
+    );
+    assert!(
+        reason.contains("drafter"),
+        "and whose span is charged for it, which is the finding: {reason}"
+    );
+}
+
+/// The same round with its carry forced reports nothing.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "if the forcing step failed the round did leave lazy work behind, and \
+              a silent pass here would read as the guard clearing it"
+)]
+fn a_charged_round_that_forced_its_carry_is_silent() {
+    let (_, lazy) = forced_and_lazy();
+    lazy.eval().expect("eval failed");
+    let errors = phase_errors(|| {
+        charged_round(true).log(SpecLoop::DFlash2, 7, 3, 4, &[("h_ctx", &lazy)]);
+    });
+    assert!(
+        errors.is_empty(),
+        "a round that forced everything it carries has nothing to report: {errors:?}"
+    );
+}
+
+/// Uncharged, every phase leaves lazy work behind by design — that is what
+/// `charged=false` on the record means. Reporting it per round would put an
+/// error on every round of every ordinary run and train readers to skip it.
+#[test]
+fn an_uncharged_round_is_not_asked_where_its_work_went() {
+    let (_, lazy) = forced_and_lazy();
+    let errors = phase_errors(|| {
+        charged_round(false).log(SpecLoop::DFlash2, 7, 3, 4, &[("h_ctx", &lazy)]);
+    });
+    assert!(
+        errors.is_empty(),
+        "the guard is a charged-run instrument, not a running commentary: {errors:?}"
+    );
+}

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -260,14 +260,15 @@ numbers:
   sidecar loop used to close its span on the unevaluated forward and re-derive
   the LM head position by position afterwards, which put most of the verify
   forward into the residual and made the two loops' residuals incomparable.
-- **The rollback replay is still lazy by default.** Its output is discarded and
-  the state it writes is not read until the next round's verify forward, so the
-  second weight read a partial-accept round pays is billed to the *next* round's
-  `verifier_ms`.
+- **Uncharged, the drafter's span pays for the round before it.** The rollback
+  replay's output is discarded, the trimmed K/V and the extended conditioning
+  are not read until the next round drafts, and the drafter is the first thing
+  to block on any of them — so a partial-accept round's second weight read lands
+  in the *next* round's `draft_ms`. Measured on the three loops below.
 
 Per-round attribution comes from the `speculative round` event, target
 `rmlx::spec::phase`, one per round at `debug`, emitted by one shared
-`RoundPhases::log` so the two loops cannot drift into two record shapes:
+`RoundPhases::log` so the three loops cannot drift into three record shapes:
 
 ```
 loop_kind round accept num_draft replayed charged
@@ -295,10 +296,39 @@ charged run's `round_ms` against an uncharged one's before trusting either.
 record.** `phases_charged()` is read at the loop head and passed down — to
 `rollback_round_caches` as an argument, and onto `RoundStats::charged`, which
 every loop's `done` line carries. Two things depend on that.
-`rollback_round_caches` is shared by six loops and only two of them time their
-phases; a switch it read on its own behalf would change how the other four
+`rollback_round_caches` is shared by seven loops and only three of them time
+their phases; a switch it read on its own behalf would change how the other four
 schedule work, with nothing on their records saying so — they pass `false` and
 report `charged=false`.
+
+**Charging is a hand-written list, so a charged round is checked rather than
+trusted.** Each loop forces the things it produces, one call at a time, and the
+way that fails is by omission: four of the five arrays a round builds get forced
+and the fifth is still a graph node when the next round's drafter reads it. No
+timing assertion can see that, because the number it produces is a plausible
+one. `RoundPhases::log` therefore takes the arrays the round hands to its
+successor, under the names the loop calls them, and on a charged round reports
+any that are still unevaluated — `Array::is_available`, which asks MLX for the
+array's status rather than inferring it from a clock. Two omissions were found
+that way and are described below. The check cannot tell whether a loop declared
+everything it carries; what it removes is the case where the declaration was
+right and the forcing was missing. **The standing check is a charged run with no
+`still unevaluated` line in it** — grep the run log for that phrase after any
+change to a round loop's phase spans.
+
+**Which loops this covers.** Three of the seven time their phases and can be
+charged: the Gemma4 MTP assistant, the Qwen3.5-family MTP sidecar and DFlash 2.
+The other four — DFlash 1, EAGLE-3 and the two two-model loops — keep only the
+request-level `draft_ms` and `verifier_ms`, pass `false` to
+`rollback_round_caches` and report `charged=false`, so **their drafter figure
+carries the same inflation and no setting corrects it**. DFlash 1's round has
+the same four phases as DFlash 2's and giving it the instrument is a port of
+that one. EAGLE-3's is not: its drafter re-runs over the accepted prefix in a
+fifth phase (`accept_and_reseed`), whose read-back of the reseed token is what
+forces that round's capture, so its capture lands in the residual rather than in
+the drafter and the four-phase record has no slot for the phase that pays it.
+Deciding where that phase goes is a change to the record's shape for every loop,
+not a port.
 
 And a charged request's `verifier_ms`, `loop_ms_per_round` and `decode_tps`
 describe a differently scheduled engine. `scripts/lib/spec_round_log.py` reads
@@ -312,6 +342,67 @@ enough on its own — `RUST_LOG` takes precedence over the `--log` preset
 (`crates/rmlx-cli/src/startup.rs`), so an ambient
 `RUST_LOG=info,rmlx::spec::phase=trace` reaches a bench run that never asked for
 it. Unset it before benching.
+
+#### What the charge moves, measured
+
+Milliseconds per round, meaned over every round the measured requests logged.
+`release-perf`, M5 Max, `--kv-quant none --max-ctx 8192`, temperature 0, seed
+42, 128 max tokens, one warmup and three measured requests per reading, each
+uncharged/charged pair taken back to back on the same binary.
+
+| Loop, verifier + drafter, block | rounds | | round | draft | verify | walk | rollback | other |
+|---|---:|---|---:|---:|---:|---:|---:|---:|
+| DFlash 2, Qwen3.8-27B-4bit + 27B-DFlash2, 5 | 120 | uncharged | 106.23 | 22.98 | 58.78 | 0.00 | 24.33 | 0.14 |
+| | | charged | 107.93 | 20.88 | 57.38 | 0.00 | 29.01 | 0.67 |
+| MTP sidecar, Qwen3.8-27B-4bit + 27B-MTP-4bit, 3 | 213 | uncharged | 65.89 | 7.36 | 39.75 | 0.00 | 18.72 | 0.05 |
+| | | charged | 70.62 | 4.66 | 41.26 | 0.00 | 24.56 | 0.14 |
+| MTP assistant, gemma-4-e2b-it-mxfp8 + E2B-assistant-bf16, 6 | 114 | uncharged | 18.94 | 4.75 | 14.05 | 0.00 | 0.01 | 0.13 |
+| | | charged | 18.67 | 4.39 | 13.95 | 0.00 | 0.26 | 0.07 |
+
+**The uncharged drafter figure is not the drafter.** It is over-reported by 10%
+on DFlash 2, by 58% on the MTP sidecar and by 8% on the assistant, against the
+charged figure for the same configuration. The gap between the two sidecar
+drafters is where it matters: read uncharged, DFlash 2 drafts for 3.1× what the
+MTP sidecar does; read charged, 4.5×. An earlier revision of this document said
+the uncharged ratio *overstated* that gap. It understates it, and by more than
+the gap the two loops were being compared on.
+
+**The mechanism, isolated within one run.** Group a round's `draft_ms` by
+whether the *previous* round took the rollback replay. Uncharged, DFlash 2
+drafts for 24.09 ms after a replay against 20.33 ms after a full accept, and the
+sidecar 8.55 against 4.12 — the previous round's replay, paid inside this
+round's drafting. Charged, those differences are 0.35 ms and 0.004 ms. The
+comparison is between two figures from one run, so it does not depend on the
+host being quiet. The assistant loop is full attention and replayed on none of
+its 114 rounds, which is why its gap is the smallest of the three and is the
+K/V trim rather than a replay.
+
+**Three omissions in the charge, each now inside that check.** The MTP sidecar charged its
+rollback and never its capture: before that was fixed, a charged run's
+`verify_ms` was indistinguishable from an uncharged one's (39.97 against 40.48,
+the wrong way round), and the conditioning slice the next round's drafter reads
+was unevaluated on every charged round. It now rises by 1.51 ms when the
+drafter's figure falls, which is what the capture costs. DFlash 2 charged its
+capture but not the context it extends with it — a copy of every row the
+drafter's window reaches back over, which is why its charged `other_ms` is 0.67
+against the sidecar's 0.14. The assistant left the final-normed conditioning
+hidden lazy beside the K/V trim it already forced.
+
+**Charging costs the loop something, and how much is not uniform.** Round total
+moves +1.6% on DFlash 2, +7.2% on the sidecar and −1.4% on the assistant. That
+is the drained pipeline, and it is the reason a charged row is not a throughput
+row and the bench refuses to file one.
+
+**TAINTED: the host was not idle.** Other agents' CPU-only work ran throughout;
+the one-minute load average ranged 4.3 to 16.0 across the readings. There was no
+GPU contention — the single-MLX claim was held for every reading and never
+bypassed, and no other MLX process was alive. Thermal state was sampled with
+`pmset -g therm` before and after every reading and recorded no thermal,
+performance or CPU-power warning at any sample; that is the scheduler's
+advertised limits rather than a die temperature, and it is the weakest leg here.
+The per-round *shares* and the within-run replay grouping survive this; the
+absolute round totals should not be compared against readings from another
+session.
 
 ## Per-drafter Deep Dive
 
@@ -1353,19 +1444,18 @@ decode step** where the bandwidth roofline is nearer 4%. That is the ceiling
 every speculative arm on this machine meets, and this is a third drafter kind
 measuring it.
 
-**Those `draft ms` figures are upper bounds, and the sidecar's are less so.**
-Every row carries `charged=false`, which means each phase is timed but not
-forced, and this engine evaluates lazily. The verify forward produces two
-outputs: the logits, which the argmax reads back inside the verify span, and the
-conditioning capture, which hangs off the same forward and stays unevaluated
-until the next round's drafter call touches it — inside `draft ms`. Both sidecar
-loops have the same shape, but this drafter's capture is
-`len(target_layer_ids) = 5` times as wide as the MTP sidecar's single hidden, so
-the two columns are skewed by different amounts and the ratio between them
-overstates the gap. `RUST_LOG=rmlx::spec::phase=trace` forces each phase's work
-before its span closes and re-attributes the capture; those rows carry
-`charged=true` and describe a differently scheduled engine, which is why they are
-not these. Before optimising against this split, take it charged.
+**Those `draft ms` figures are upper bounds, and the sidecar's are the looser
+of the two.** Every row carries `charged=false`, which means each phase is timed
+but not forced, and this engine evaluates lazily, so the previous round's
+rollback replay and conditioning work are paid inside the next round's `draft
+ms`. Both sidecar loops have that shape and the sidecar has it worse: § "What
+the charge moves, measured" prices the same two configurations charged, and the
+`draft ms` ratio between them goes from 3.1× to 4.5×. It was expected to go the
+other way, on the reasoning that this drafter's capture is
+`len(target_layer_ids) = 5` times as wide as the MTP sidecar's single hidden and
+so skews its column more. The capture is real but small — 1.51 ms per round on
+the sidecar; what dominates is the rollback replay, and the sidecar replays on
+73% of its rounds. Before optimising against this split, take it charged.
 
 Drafting costs 19.5–24.4 ms per round almost independently of block and of
 prompt, against the sidecar's 5.9–6.9 ms. Two costs the port does not pay down

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -309,8 +309,8 @@ timing assertion can see that, because the number it produces is a plausible
 one. `RoundPhases::log` therefore takes the arrays the round hands to its
 successor, under the names the loop calls them, and on a charged round reports
 any that are still unevaluated — `Array::is_available`, which asks MLX for the
-array's status rather than inferring it from a clock. Two omissions were found
-that way and are described below. The check cannot tell whether a loop declared
+array's status rather than inferring it from a clock. The three omissions it
+now covers are described below. The check cannot tell whether a loop declared
 everything it carries; what it removes is the case where the declaration was
 right and the forcing was missing. **The standing check is a charged run with no
 `still unevaluated` line in it** — grep the run log for that phrase after any
@@ -377,8 +377,8 @@ host being quiet. The assistant loop is full attention and replayed on none of
 its 114 rounds, which is why its gap is the smallest of the three and is the
 K/V trim rather than a replay.
 
-**Three omissions in the charge, each now inside that check.** The MTP sidecar charged its
-rollback and never its capture: before that was fixed, a charged run's
+**Three omissions in the charge, each now inside that check.** The MTP sidecar
+charged its rollback and never its capture: before that was fixed, a charged run's
 `verify_ms` was indistinguishable from an uncharged one's (39.97 against 40.48,
 the wrong way round), and the conditioning slice the next round's drafter reads
 was unevaluated on every charged round. It now rises by 1.51 ms when the


### PR DESCRIPTION
The speculative round's phase split was said to bill the verifier's
conditioning capture to the drafter. It does, and it bills more than that:
the previous round's rollback replay lands there too, and that is the larger
term by several times. This measures both, completes the charge on the three
loops that carry a phase instrument, and adds a check that says when a
charged round left work behind.

## Is the mis-attribution real, and how big

Measured, not read. Each reading is an uncharged/charged pair on the same
binary, back to back, `release-perf`, `--kv-quant none --max-ctx 8192`,
temperature 0, seed 42, 128 max tokens, one warmup and three measured
requests. The full per-phase table is in `docs/SPECULATIVE.md`
§ "What the charge moves, measured".

Uncharged, the drafter's per-round figure is over-reported against the
charged figure for the same configuration by **10% on DFlash 2**, **58% on
the MTP sidecar** and **8% on the Gemma4 assistant**.

The mechanism is isolated inside a single run, so it does not rest on the
host being quiet: group each round's draft span by whether the *previous*
round took the rollback replay. Uncharged, DFlash 2 drafts for 24.09 ms
after a replay against 20.33 ms after a full accept; the sidecar, 8.55
against 4.12. Charged, those differences are 0.35 ms and 0.004 ms. The
assistant loop is full attention and replayed on none of its 114 rounds,
which is why its gap is the smallest and is the K/V trim instead.

## Does the existing DFlash 2 fix work

Yes, for the part it covers. It removes 91% of the replay-dependent draft
inflation. But its stated mechanism was the wrong one to lead with: the
capture is real and small — 1.51 ms per round on the sidecar — while the
rollback replay is several times that on loops that replay on ~73% of
rounds. And it was incomplete in its own loop: the conditioning context it
extends with the capture, a copy of every row the drafter's window reaches
back over, was still unforced and still billed to the drafter. That now
shows as 0.67 ms of `other_ms` per round.

## The other loops

Three of the seven time their phases. The MTP sidecar's charge never forced
its capture at all: before this change a charged run's `verify_ms` was
indistinguishable from an uncharged one's (39.97 against 40.48 — the wrong
way round), and its conditioning slice was unevaluated on every charged
round. It now rises by 1.51 ms as the drafter's figure falls. The Gemma4
assistant left the final-normed conditioning hidden lazy beside the K/V trim
it already forced.

The other four carry no phase instrument, report `charged=false`, and their
`draft_ms` carries the same inflation with no setting that corrects it.
DFlash 1's round has the same four phases and giving it the instrument is a
port of DFlash 2's. EAGLE-3's is not: its drafter re-runs over the accepted
prefix in a fifth phase whose token read-back is what forces that round's
capture, so its capture lands in the residual and the four-phase record has
no slot for the phase that pays it. That is a record-shape decision for
every loop, so it is out of this change and documented as such.

## The guard

The claim that no test can catch this rested on the array type exposing no
"has this been evaluated" predicate. mlx-c does expose one, so
`Array::is_available` now wraps it — it reads the array's status, evaluates
nothing and takes no evaluation lock.

`RoundPhases::log` takes the arrays a round hands to its successor, under
the names the loop calls them, and on a charged round names any that are
still unevaluated. The signature is what makes it structural: a loop cannot
log a phase split without declaring its carry, and one that genuinely
carries nothing passes an empty slice where a reader can see it. It cannot
tell whether a loop declared everything; what it removes is the case where
the declaration was right and the forcing was missing.

Shown failing three ways in unit tests — a predicate that names nothing, a
guard that stops asking whether the round was charged, and a report that
says how many rather than which — each caught by a different named test. And
shown failing live: with the sidecar's charge removed and the binary
rebuilt, a charged run logs
`loop_kind=MtpSidecar round=1 unforced=h_cond` on 18 of 19 rounds. With the
charge in place, all three loops' charged runs log none.

The standing check for a future reader is in the docs: a charged run with no
`still unevaluated` line in it.

## Docs corrected, not appended

Two claims in `docs/SPECULATIVE.md` were wrong and are rewritten in place.
The rollback replay was said to be billed to the next round's *verify* span;
it is billed to the next round's *drafting*, which is what blocks first. And
the uncharged draft ratio between DFlash 2 and the MTP sidecar was said to
overstate the gap between them, on the reasoning that DFlash 2's capture is
five times as wide; it understates it, 3.1x against 4.5x charged.

## Measurement conditions

**TAINTED: the host was not idle.** Other agents' CPU-only work ran
throughout and the one-minute load average ranged 4.3 to 16.0 across the
readings. There was no GPU contention: the single-MLX claim was held for
every reading and never bypassed, and no other MLX process was alive.
Thermal state was sampled with `pmset -g therm` before and after every
reading and recorded no thermal, performance or CPU-power warning at any
sample — that is the scheduler's advertised limits rather than a die
temperature, and it is the weakest leg. The per-phase shares and the
within-run replay grouping survive it; the absolute round totals should not
be compared against readings from another session.

No throughput benchmark and no A/B was run, and nothing was recorded to
`runs.db`.

## Output unchanged

Every completion is byte-identical across all twelve readings — pre-change
and post-change, charged and uncharged — on two architectures and three
loops: gemma-4-e2b (assistant, full attention, `kv_h == 1`) and
Qwen3.8-27B-4bit (sidecar and DFlash 2, GDN hybrid). Accept rate and tokens
per round are identical too. Everything this change adds sits inside an
`if charge_phases` block or is a new argument to a log call.

## Not checked

`make ci` and `make ci-perf` were not run — the orchestrator owns those.
`cargo test --workspace`, `cargo clippy --workspace --all-targets`,
`cargo fmt --check`, `check_eval_lock`, `check_no_inline_tests`,
`check_gpu_tests_ignored`, `check_spec_sampling` and
`check_doc_source_citations` were, and are green. No GPU test was run.
DFlash 1, EAGLE-3 and the two-model loops were read, not measured.
