### PR TITLE
test: a forced eviction for the hydrate race, and a consume that says which miss it took

### DIFF
--- a/crates/rmlx-kv-ssd/src/hydrate_tests.rs
+++ b/crates/rmlx-kv-ssd/src/hydrate_tests.rs
@@ -862,19 +862,27 @@ fn budget_enforcement_racing_hydrates_never_serves_a_foreign_block() {
     let db = dir.join("index.db");
     let fx = Arc::new(seed_race_fixture(&dir, &db, device));
     // Sized so both arms of the race stay well populated: the writer's filler
-    // keeps the namespace over the ceiling (so the budget pass always has work
-    // and lookups keep missing), while the prompt blocks are not crowded down to
-    // a survival rate that would let a slow box reach zero hits and skip the
-    // content check entirely. A hit does touch its block to the back of the
-    // eviction queue, but the writer records fresh filler continuously and every
-    // one of those lands ahead of it, so a prompt block survives only until
-    // enough newer filler arrives — the headroom is what keeps `hits > 0`
-    // robust rather than lucky. Measured: ~32-42% hits over 240 lookups.
-    let budget = fx.block_bytes * (RACE_PROMPTS as u64 * 4);
+    // keeps the namespace over the ceiling (so the budget pass always has work),
+    // while the prompt blocks are not crowded down to a survival rate that would
+    // let a slow box reach zero hits and skip the content check entirely. A hit
+    // touches its block to the back of the eviction queue and the writer's
+    // filler lands ahead of it, so a prompt block survives until enough newer
+    // filler arrives — the headroom is what keeps `hits > 0` robust rather than
+    // lucky. Measured: 228-240 hits of 240 lookups.
+    let budget = fx.block_bytes * RACE_BUDGET_BLOCKS;
+
+    // Seed the namespace over the ceiling before the race starts. Without this
+    // the only thing pushing it over is the writer thread, which has to win
+    // enough rounds against the request thread's 240 lookups to get there; on a
+    // loaded box it does not, and the budget pass then has nothing to evict
+    // through no fault of the code under test.
+    seed_race_filler(&dir, &db, fx.block_bytes, RACE_PRESEED_FILLER);
 
     // Pre-race pass on quiet state: every prompt hits and its content is its
     // own. This is what stops the racing assertions below from passing on a run
-    // that only ever saw misses.
+    // that only ever saw misses. It also touches every prompt block to the back
+    // of the eviction queue, leaving the filler seeded just above as the oldest
+    // rows — so the forced eviction takes filler and the prompts survive it.
     {
         let hydrator = SsdHydrator::with_index(
             MODEL_ID,
@@ -914,9 +922,17 @@ fn budget_enforcement_racing_hydrates_never_serves_a_foreign_block() {
         std::thread::spawn(move || {
             let idx = SsdKvIndex::open_at(&db).unwrap();
             barrier.wait();
-            while stop.load(Ordering::Acquire) == 0 {
+            // At least one pass, always: the stop flag is only raised once the
+            // request thread has finished, but nothing orders this thread's
+            // first read of it against that, and a thread that observed the
+            // raised flag on its first look would leave the seeded
+            // over-ceiling state unenforced.
+            loop {
                 let n = crate::ssd_tier::enforce_namespace_budget(&idx, NS, budget);
                 evicted_total.fetch_add(n, Ordering::AcqRel);
+                if stop.load(Ordering::Acquire) != 0 {
+                    break;
+                }
                 std::thread::yield_now();
             }
         })
@@ -1021,10 +1037,19 @@ fn budget_enforcement_racing_hydrates_never_serves_a_foreign_block() {
         (RACE_PASSES * RACE_PROMPTS) as u64,
         "every racing lookup must resolve to a hit or a miss"
     );
+    // The namespace was seeded `RACE_FORCED_EVICTIONS` blocks over the ceiling
+    // and the budget pass runs at least once, so this floor holds whatever the
+    // three threads' scheduling does. It is not a restatement of the setup: a
+    // budget pass that stopped evicting — an `evict_lru_until` that reads the
+    // footprint wrong, or a namespace whose rows it no longer selects — reaches
+    // the floor from below and fails here, rather than leaving the racing
+    // assertions above to run against a tier nothing was evicting from.
+    let evicted = evicted_total.load(Ordering::Acquire);
     assert!(
-        evicted_total.load(Ordering::Acquire) > 0,
-        "the budget pass must have actually evicted during the race, \
-         otherwise nothing was raced"
+        evicted >= RACE_FORCED_EVICTIONS,
+        "the budget pass evicted {evicted} blocks from a namespace seeded \
+         {RACE_FORCED_EVICTIONS} blocks over its ceiling, so the racing lookups \
+         above ran against a tier nothing was evicting from"
     );
 }
 
@@ -1032,6 +1057,12 @@ fn budget_enforcement_racing_hydrates_never_serves_a_foreign_block() {
 const RACE_PROMPTS: usize = 6;
 /// Layout key the racing-budget fixture spills and probes under.
 const RACE_LK: u64 = 0x00c0_ffee_0000_0001;
+/// Blocks the racing-budget namespace ceiling admits.
+const RACE_BUDGET_BLOCKS: u64 = RACE_PROMPTS as u64 * 4;
+/// Filler blocks seeded before the race, on top of the one block per prompt.
+const RACE_PRESEED_FILLER: u64 = RACE_BUDGET_BLOCKS;
+/// Blocks the ceiling forces out of the seeded state, before the race adds any.
+const RACE_FORCED_EVICTIONS: u64 = RACE_PROMPTS as u64 + RACE_PRESEED_FILLER - RACE_BUDGET_BLOCKS;
 
 /// One indexed block per prompt, plus everything a checker needs to tell those
 /// blocks apart after a round trip through the tier.
@@ -1094,6 +1125,32 @@ fn seed_race_fixture(dir: &std::path::Path, db: &std::path::Path, device: Device
         expected_k,
         kvb_bytes,
         block_bytes,
+    }
+}
+
+/// Record `count` filler blocks of `block_bytes` each into `dir`'s index, so the
+/// namespace starts the race above its ceiling. Filler carries no content
+/// anything reads back; it exists to be evicted.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: fixture setup against a fresh TempDir, where a failure is a broken fixture rather than a result to interpret"
+)]
+fn seed_race_filler(dir: &std::path::Path, db: &std::path::Path, block_bytes: u64, count: u64) {
+    let index = SsdKvIndex::open_at(db).unwrap();
+    for n in 0..count {
+        let key = format!("preseed{n:012x}");
+        let path = dir.join(format!("{key}.kvb"));
+        std::fs::write(&path, vec![0u8; block_bytes as usize]).unwrap();
+        index
+            .record(
+                &key,
+                RACE_LK,
+                &path,
+                MODEL_ID,
+                &QUANT.to_string(),
+                block_bytes,
+            )
+            .unwrap();
     }
 }
 

--- a/crates/rmlx-models/src/prompt_cache.rs
+++ b/crates/rmlx-models/src/prompt_cache.rs
@@ -1344,9 +1344,12 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
     ///    clones (+ truncates) for reuse. Hook `None` or an incomplete hydrate
     ///    degrades to `Miss`.
     ///
-    /// Every degrade branch emits exactly one `debug!{branch, reason}` so the
-    /// decision is reconstructable from a single run's log — the cached arches
-    /// previously had silent degrade arms.
+    /// Every arm that resolves to `Miss` emits exactly one
+    /// `debug!{branch, reason}`, including the two that carry no degrade — the
+    /// plain no-slot-match (`no_match`) and the not-yet-built cache
+    /// (`no_cache`). A silent `Miss` is worse than an unlogged one: a reader
+    /// counting branch events cannot tell it from an event that was emitted and
+    /// lost, so the two failures look identical in a captured stream.
     ///
     /// `n_layers` is the asking model's decoder-layer count — it sizes the
     /// per-layer mixture folded into the seed, so it must be the same count the
@@ -1395,8 +1398,17 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
         // the value instead of re-reading a global.
         let dispatch_policy = rmlx_core::dispatch_policy();
 
-        self.with_inner_mut(|guard| match guard.as_mut() {
-            Some(cache) => Self::decide_locked(
+        self.with_inner_mut(|guard| {
+            let Some(cache) = guard.as_mut() else {
+                tracing::debug!(
+                    arch,
+                    branch = "no_cache",
+                    reason = "no cache built for this arch yet — prefill",
+                    prompt_len = prompt_ids.len(),
+                );
+                return Consumed::Miss;
+            };
+            Self::decide_locked(
                 arch,
                 policy,
                 cache,
@@ -1404,8 +1416,7 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
                 kv_quant,
                 seed,
                 dispatch_policy,
-            ),
-            None => Consumed::Miss,
+            )
         })
     }
 
@@ -1446,33 +1457,35 @@ impl<E: PromptCacheEntry> ArchPromptCache<E> {
 
         // (4) Quant-mismatch guard. The snapshot is only safe to
         // reuse when the stored KvQuant equals the runtime quant.
-        let (slot_idx, block_count) = match raw_match {
-            Some((slot_idx, block_count)) => {
-                let stored = cache.slots[slot_idx].entry.kv_quant();
-                if stored == Some(kv_quant) {
-                    (slot_idx, block_count)
-                } else {
-                    tracing::debug!(
-                        arch,
-                        branch = "quant_mismatch",
-                        reason = "stored KV quant differs from runtime — evict + re-prefill",
-                        stored = ?stored,
-                        runtime = ?kv_quant,
-                        prompt_len = prompt_ids.len(),
-                    );
-                    tracing::warn!(
-                        stored = ?stored,
-                        runtime = ?kv_quant,
-                        prompt_len = prompt_ids.len(),
-                        "prompt cache KV quant mismatch — evicting entry, \
-                         degrading to re-prefill"
-                    );
-                    cache.evict_slot(slot_idx);
-                    return Consumed::Miss;
-                }
-            }
-            None => return Consumed::Miss,
+        let Some((slot_idx, block_count)) = raw_match else {
+            tracing::debug!(
+                arch,
+                branch = "no_match",
+                reason = "no stored slot shares a block-aligned prefix with this prompt — prefill",
+                prompt_len = prompt_ids.len(),
+            );
+            return Consumed::Miss;
         };
+        let stored = cache.slots[slot_idx].entry.kv_quant();
+        if stored != Some(kv_quant) {
+            tracing::debug!(
+                arch,
+                branch = "quant_mismatch",
+                reason = "stored KV quant differs from runtime — evict + re-prefill",
+                stored = ?stored,
+                runtime = ?kv_quant,
+                prompt_len = prompt_ids.len(),
+            );
+            tracing::warn!(
+                stored = ?stored,
+                runtime = ?kv_quant,
+                prompt_len = prompt_ids.len(),
+                "prompt cache KV quant mismatch — evicting entry, \
+                 degrading to re-prefill"
+            );
+            cache.evict_slot(slot_idx);
+            return Consumed::Miss;
+        }
 
         let entry = &cache.slots[slot_idx].entry;
         let is_ssd_hydrated = entry.is_ssd_hydrated();

--- a/crates/rmlx-models/src/prompt_cache_tests.rs
+++ b/crates/rmlx-models/src/prompt_cache_tests.rs
@@ -2545,6 +2545,41 @@ fn consume_degrade_branches_each_emit_one_debug() {
     );
 }
 
+/// The two `Miss` arms that carry no degrade name themselves too.
+///
+/// They used to return silently, and a silent arm is what makes a captured
+/// branch stream ambiguous: a run where one scenario took an unlogged path is
+/// indistinguishable from a run where its event was emitted and lost, because
+/// both come back one branch short. Naming them turns the first case into a
+/// list that says which path ran.
+#[test]
+fn consume_miss_arms_that_are_not_degrades_still_name_their_branch() {
+    let prompt = make_ids(2 * BLOCK_TOKENS);
+
+    let branches = capture_branches(|| {
+        // Cache built, nothing stored: no slot shares a prefix.
+        {
+            let arch: ArchPromptCache<TestEntry> =
+                ArchPromptCache::new("test", ReusePolicy::ExactOnly, false);
+            arch.with_inner_mut(|g| *g = Some(PromptCache::new(4)));
+            let _ = arch.consume(&prompt, TEST_QUANT, TEST_LAYERS, false, TEST_SIG);
+        }
+        // No cache built for this arch at all.
+        {
+            let arch: ArchPromptCache<TestEntry> =
+                ArchPromptCache::new("test", ReusePolicy::ExactOnly, false);
+            let _ = arch.consume(&prompt, TEST_QUANT, TEST_LAYERS, false, TEST_SIG);
+        }
+    });
+
+    assert_eq!(
+        branches,
+        vec!["no_match".to_owned(), "no_cache".to_owned()],
+        "a consume that resolves to Miss without degrading must still say which \
+         arm it took"
+    );
+}
+
 // ── ensure() + the zero-slot cache ──────────────────────────────────────────
 //
 // `ensure` runs once per generation on every arch, so its "already the right


### PR DESCRIPTION
Two intermittently-failing tests, #510 and #526. They do not share a cause, and one of them did not reproduce. Both are on this branch because they were investigated together; the commits are separate and can be read separately.

## #510 — the SSD hydrate race, fixed

**Rate, measured on this branch's parent, whole `rmlx-kv-ssd` lib suite under `release-perf`:**

| condition | pre | post |
|---|---|---|
| one suite at a time, 200 / 300 runs | 7 failures (3.5%) | 0 |
| four suites concurrently, 300 runs each | 63 failures (21%) | 0 |

All 63 loaded-run failures were the same assertion, so the ticket's "roughly one in forty" is right for a quiet box and understates it for a busy one.

**Mechanism.** The failing line asserted that the budget pass evicted something during the race, but nothing arranged for it to have anything to evict. The namespace only went over its ceiling if the writer thread recorded 19 filler blocks before the request thread finished its 240 lookups. Instrumenting the loop showed the failing runs are exactly the ones where the writer got 1 to 11 rows in while the evictor spun thousands of passes over an under-ceiling namespace. Nothing about the code under test was involved.

**Fix.** The namespace is seeded a fixed number of blocks over its ceiling before the race starts, and the budget thread runs one pass unconditionally before it first reads the stop flag. The eviction the test needs now happens whatever the three threads' scheduling does, so no timeout and no retry. The precondition became a floor rather than a "greater than zero": a budget pass that stopped evicting reaches the floor from below and fails, instead of leaving the racing content checks to run against a tier nothing was evicting from — which is a stronger claim than the assertion it replaces, not a weaker one.

The filler is seeded after the prompt blocks and before the quiet-state pass, which touches every prompt to the back of the eviction queue, so the forced eviction takes filler and the prompt blocks survive it. Measured hit rate over the race is unchanged at 228-240 of 240; the fixture's comment said 32-42% and is corrected.

**Mutations**, both deterministic:

- budget pass returns without evicting → `the budget pass evicted 0 blocks from a namespace seeded 6 blocks over its ceiling`, 20 of 20 runs
- index lookup drops the hash predicate and serves the lowest-sorting row → `hydrate served prompt 0 a block whose K content is not its own (max err 0.9986016)`

## #526 — the prompt-cache branch capture: not reproduced, hypothesis falsified

**Rate.** 1700 processes of the `rmlx-models` lib suite, zero recurrences: 200 serial, 400 at four suites concurrently, 800 at eight, 300 at `--test-threads=64`. That puts a 95% upper bound of about 0.18% per run. One unrelated SIGSEGV appeared in the serial batch (binary dies mid-suite, no failing test named — the known MLX command-encoder hazard, not this test).

**The shared-subscriber hypothesis in the ticket is wrong for this subscriber.** Read through `tracing-core` 0.1.36 and then checked it with a standalone reproducer that models this binary: 3000 distinct callsites, 8 threads firing them, 4 threads installing and dropping scoped `with_default` subscribers, one thread installing the process-global tee at a jittered offset, then a sweep counting which callsites can still reach the tee. No callsite was ever lost, at any offset from 0 to 2 ms, over 40 trials.

The reason is structural. `set_global_default` goes through `Dispatch::new`, which registers the dispatcher and rebuilds the interest of every callsite already in the registry; the tee answers `register_callsite` with `always` and is never uninstalled; and once it is the global default, `get_default` on any thread that is not itself inside a scoped subscriber returns it. A callsite can only end up cached as `never` if every live dispatcher declines it, and the tee is live and declines nothing. So no other test can withhold from this stream, and because the sink is thread-local, none can contribute to it either. The capture is sound; the ticket's stated worry — that the same mechanism could make the assertion pass while observing the wrong events — does not apply.

**What the investigation did find.** Every input to the six scenarios is local and deterministic. `install_prefix_index_kind` and `install_ram_cap` are the only process globals the consume path reads, and no test calls either, so both sit at their defaults. That leaves one shape that can produce "a capture one branch short" without any event being dropped: a scenario taking a `Miss` arm that emits nothing. Two such arms existed — the plain no-slot-match, and the arch whose cache has not been built — and the doc above `consume` claimed there were none.

That is fixed in the second commit. It is a diagnosability fix, not a fix for the flake: I am not claiming it is the cause, because I could not make the failure happen. What it buys is that the next occurrence is readable. A short list now means an event was lost; a list containing `no_match` means a scenario took a path that does not match, and those want opposite investigations.

**Mutations:**

- `no_match` emission removed → `["no_cache"]` vs `["no_match", "no_cache"]`
- `no_cache` emission removed → `["no_match"]` vs `["no_match", "no_cache"]`
- `hydrated_declined_to_exact` emission removed → the existing degrade test names that branch as the one missing (the ticket's own requirement 4)

## What I deliberately did not do

No test was serialised, no assertion loosened, no retry added. No timeouts. No new env vars, no new dependencies.

## Not checked

`make ci` and `make ci-perf` were not run here. Verified in the foreground: `cargo test --workspace` (3609 passed), `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings` on both touched crates, and `check-no-inline-tests`, `check-gpu-tests-ignored`, `check-doc-source-citations`. No GPU test was run and no benchmark of any kind was taken.

The SIGSEGV seen once in 200 serial `rmlx-models` runs is out of scope and unfiled here.

Closes #510
