### PR TITLE
spec: rebuild a partly-accepted round's recurrent state from a tape, not a replay

### DIFF
--- a/crates/rmlx-kv-quant/src/lib.rs
+++ b/crates/rmlx-kv-quant/src/lib.rs
@@ -13,7 +13,8 @@
 //!   update + SDPA dispatch.
 //! * `storage` — `QuantK` / `QuantV` / `QuantPlanarV` / `KvStorage` enum.
 //! * `kvcache` — `KvCache`, the per-layer cache struct.
-//! * `linear_attn` — `LinearAttnCache`, recurrent state for GatedDeltaNet.
+//! * `linear_attn` — `LinearAttnCache`, recurrent state for GatedDeltaNet, and
+//!   the `GdnTape` a speculative round arms to roll that state back.
 //! * `paged` — paged-KV block table + page allocator.
 //!
 //! Higher-level wiring (`KvQuant`, `KvCacheBuilder`, SSD spill/hydrate, arch
@@ -117,7 +118,7 @@ pub mod turboquant_msl;
 // than opening the whole module: the rest of `flash_decode_common` is internal.
 pub use flash_decode_common::VMirror;
 pub use kvcache::{KvCache, SharedKv};
-pub use linear_attn::LinearAttnCache;
+pub use linear_attn::{GdnTape, GdnTapeSegment, LinearAttnCache};
 pub use quant::{
     validate_mixed_side, validate_rotor_k_asym_v, KvQuant, KvQuantParseError, ALL_KV_QUANTS,
     KV_MAX_SEQ_DEFAULT,

--- a/crates/rmlx-kv-quant/src/linear_attn.rs
+++ b/crates/rmlx-kv-quant/src/linear_attn.rs
@@ -12,6 +12,8 @@
 //! # Public API
 //!
 //! - [`LinearAttnCache`] — the recurrent state holder.
+//! - [`GdnTape`] / [`GdnTapeSegment`] — the round tape a speculative loop arms
+//!   so a partly-accepted round can be rolled back without a second forward.
 //!
 //! # See also
 //!
@@ -54,6 +56,9 @@ pub struct LinearAttnCache {
     /// `None` until the first prefill call, in which case the layer starts at
     /// zero.
     pub delta_state: Option<Array>,
+    /// The recurrence inputs of the forwards taken since [`LinearAttnCache::arm_tape`],
+    /// or `None` when nothing is recording. See [`GdnTape`].
+    pub tape: Option<GdnTape>,
 }
 
 impl LinearAttnCache {
@@ -62,6 +67,7 @@ impl LinearAttnCache {
         Self {
             conv_state: None,
             delta_state: None,
+            tape: None,
         }
     }
 
@@ -69,46 +75,22 @@ impl LinearAttnCache {
     pub fn reset(&mut self) {
         self.conv_state = None;
         self.delta_state = None;
+        self.tape = None;
     }
 
-    /// Conceptual "truncate to sequence position N" — NOT implementable by slicing.
+    /// Start recording a round tape, discarding any the previous round left.
     ///
-    /// # Why truncate_to cannot work for LinearAttnCache
-    ///
-    /// `KvCache::truncate_to(n)` works because K/V tensors have an explicit
-    /// sequence axis: positions `[0..n]` are simply sliced off and returned.
-    ///
-    /// `LinearAttnCache` has **no sequence axis**: `conv_state` and `delta_state`
-    /// are the *compressed* recurrent state at the end of the most recent call.
-    /// There is no way to recover the state at an earlier position `n` by slicing —
-    /// the recurrence has consumed and discarded the intermediate states.
-    ///
-    /// The correct rollback mechanism is [`snapshot`] + [`restore_snapshot`]:
-    /// take a deep clone of the state before the speculative draft round, then
-    /// call `restore_snapshot` on partial rejection.
-    ///
-    /// This method exists so that callers can discover the semantic gap at
-    /// compile time. It panics unconditionally. Do NOT call it on a live cache.
-    ///
-    /// # L36 context
-    ///
-    /// The spec decoder must call `snapshot()` before each draft round and
-    /// `restore_snapshot()` on partial acceptance. See
-    /// `docs/research/L36-spec-decoding-design.md` §1.3.
-    #[allow(dead_code)]
-    #[allow(
-        clippy::panic,
-        reason = "LinearAttnCache::truncate_to is structurally non-implementable: the GDN \
-                  recurrent state has no sequence axis to truncate. Any caller must use \
-                  snapshot()/restore_snapshot() instead; this panic surfaces misuse at \
-                  call sites that have not yet been ported."
-    )]
-    pub fn truncate_to(&self, _n: i32) {
-        panic!(
-            "LinearAttnCache::truncate_to is not implementable: GDN recurrent state has no \
-             sequence axis. Use snapshot() + restore_snapshot() for speculative decoding rollback. \
-             See docs/research/L36-spec-decoding-design.md §1.3."
-        );
+    /// While a tape is armed every GDN forward through this cache appends its
+    /// recurrence inputs to it, which is what makes [`GdnTape`] able to rebuild
+    /// the state at an interior position. Arm it once per speculative round,
+    /// before the forwards that round takes.
+    pub fn arm_tape(&mut self) {
+        self.tape = Some(GdnTape::new());
+    }
+
+    /// Stop recording and hand back what was recorded, if anything.
+    pub fn take_tape(&mut self) -> Option<GdnTape> {
+        self.tape.take()
     }
 
     /// Resident RAM held by this recurrent state, in bytes.
@@ -120,7 +102,11 @@ impl LinearAttnCache {
     /// as the attention caches, and a hard-coded item size is how such a sum
     /// silently drifts away from the memory it claims to measure.
     ///
-    /// Returns 0 if neither field has been populated yet.
+    /// Returns 0 if neither state has been populated yet.
+    ///
+    /// An armed [`GdnTape`] counts: it holds real buffers for as long as a
+    /// speculative round is open, and a total that ignored them would read low
+    /// for exactly the rounds that allocate the most.
     ///
     /// The exhaustive destructure is the drift guard: a new buffer cannot be
     /// added to this struct without this failing to compile.
@@ -128,38 +114,11 @@ impl LinearAttnCache {
         let Self {
             conv_state,
             delta_state,
+            tape,
         } = self;
         crate::bytes::opt_array_bytes(conv_state.as_ref())
             + crate::bytes::opt_array_bytes(delta_state.as_ref())
-    }
-
-    /// Snapshot the recurrent state at the start of a speculative round.
-    ///
-    /// Returns a deep clone of both `conv_state` and `delta_state` as they
-    /// stand at the current end-of-sequence position. The caller must store
-    /// this snapshot and call `restore_snapshot` if the spec round is partially
-    /// rejected.
-    ///
-    /// # M23 / L36 design note
-    ///
-    /// `LinearAttnCache` holds fixed-shape recurrent state, not per-position
-    /// tensors. There is no sequence-position axis to slice into — state at
-    /// position N is produced by running the GDN recurrence from 0 to N.
-    ///
-    /// dflash's `RecurrentRollbackCache` solves this by recording a QKV/K/G
-    /// *tape* during the spec draft round and then replaying the recurrence
-    /// forward from the pre-round snapshot via a Metal `tape_replay_kernel`.
-    /// Porting that approach to rMLX requires (a) making the GDN kernel
-    /// callable from inside `LinearAttnCache` and (b) plumbing tape recording
-    /// through the decode hot path — both are multi-day L36 work.
-    ///
-    /// For now (M23 audit result), spec decoding on Qwen3.5MoE GDN layers is
-    /// deferred. Gemma4 (which has NO GDN layers) uses `KvCache::truncate_to`
-    /// for spec rollback and is unaffected by this gap. This `snapshot` /
-    /// `restore_snapshot` pair is the correct future interface; it will be
-    /// wired through the speculative decoder in L36.
-    pub fn snapshot(&self) -> Result<Self> {
-        self.try_deep_clone()
+            + tape.as_ref().map_or(0, GdnTape::resident_bytes)
     }
 
     /// Materialize this cache's GPU `Array` buffers on the calling (inference)
@@ -175,16 +134,10 @@ impl LinearAttnCache {
         Ok(())
     }
 
-    /// Restore previously snapshotted recurrent state (see [`snapshot`]).
-    ///
-    /// Replaces both `conv_state` and `delta_state` with the values from
-    /// `snap`. The snapshot is consumed.
-    pub fn restore_snapshot(&mut self, snap: Self) {
-        self.conv_state = snap.conv_state;
-        self.delta_state = snap.delta_state;
-    }
-
     /// Deep clone of the recurrent state (used by prompt cache).
+    ///
+    /// The clone carries no tape: a tape describes one speculative round of one
+    /// live cache, and a stored prompt-cache entry is neither.
     pub fn try_deep_clone(&self) -> Result<Self> {
         Ok(Self {
             conv_state: match &self.conv_state {
@@ -195,11 +148,147 @@ impl LinearAttnCache {
                 Some(a) => Some(a.try_clone()?),
                 None => None,
             },
+            tape: None,
         })
     }
 }
 
 impl Default for LinearAttnCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// -- GdnTape (speculative-round rollback) ------------------------------------
+
+/// One GDN forward's recurrence inputs, in the shapes the recurrence kernel
+/// takes them.
+///
+/// Every field is a handle on an array the forward had already built, so
+/// recording a segment copies nothing.
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "internal closed record - the fields are exactly the recurrence kernel's inputs; adding one means the kernel takes another argument"
+)]
+#[allow(missing_debug_implementations)]
+pub struct GdnTapeSegment {
+    /// `[B, T, Hk, Dk]` - query, normalised and scaled.
+    pub q: Array,
+    /// `[B, T, Hk, Dk]` - key, normalised and scaled.
+    pub k: Array,
+    /// `[B, T, Hv, Dv]` - value.
+    pub v: Array,
+    /// `[B, T, Hv]` f32 - the per-position decay.
+    pub g: Array,
+    /// `[B, T, Hv]` - the per-position update weight.
+    pub beta: Array,
+    /// `[B, kernel - 1 + T, conv_dim]` - the depthwise-conv1d input this call
+    /// ran over, the tail carried in from the previous call included.
+    pub conv_input: Array,
+    /// Positions this call consumed: `T`.
+    pub len: usize,
+}
+
+impl GdnTapeSegment {
+    /// Resident RAM this segment's handles keep alive, in bytes.
+    ///
+    /// The exhaustive destructure is the drift guard, as in
+    /// [`LinearAttnCache::resident_bytes`].
+    pub fn resident_bytes(&self) -> u64 {
+        let Self {
+            q,
+            k,
+            v,
+            g,
+            beta,
+            conv_input,
+            len: _,
+        } = self;
+        [q, k, v, g, beta, conv_input]
+            .into_iter()
+            .map(crate::bytes::array_bytes)
+            .sum()
+    }
+}
+
+/// The recurrence inputs of every GDN forward a speculative round took, plus
+/// the state the round started from.
+///
+/// # Why a tape rather than a snapshot
+///
+/// The recurrent state has no sequence axis, so a partly-accepted round cannot
+/// slice it back to the accepted position the way a K/V cache is truncated. The
+/// rollback used to restore a pre-round snapshot and re-run the accepted prefix
+/// through the whole layer stack - a second full read of the model's weights,
+/// paid on every partial round.
+///
+/// The inputs the recurrence consumes are causal and per-position: the value
+/// the forward computed at position `i` does not depend on any position after
+/// it, so the ones a shorter forward would have produced are exactly the ones
+/// this forward already produced. Keeping them lets the accepted prefix be
+/// re-folded by the recurrence kernel alone, reading no weights at all.
+///
+/// # Accumulating across forwards
+///
+/// A round is not always one forward. A two-model loop's drafter takes one
+/// forward per drafted token and rolls back across the lot of them, so segments
+/// accumulate in call order and the prefix to refold may span several. The
+/// pre-round state is recorded once, at the first segment.
+#[allow(missing_debug_implementations)]
+pub struct GdnTape {
+    state_in: Option<Array>,
+    segments: Vec<GdnTapeSegment>,
+}
+
+impl GdnTape {
+    /// An armed, empty tape.
+    pub fn new() -> Self {
+        Self {
+            state_in: None,
+            segments: Vec::new(),
+        }
+    }
+
+    /// Record one forward's recurrence inputs.
+    ///
+    /// `state_in` is the recurrent state that forward started from; it is kept
+    /// from the first call only, because that is the state the round started
+    /// from and every later segment starts where its predecessor ended.
+    pub fn push(&mut self, state_in: &Array, segment: GdnTapeSegment) -> Result<()> {
+        if self.state_in.is_none() {
+            self.state_in = Some(state_in.try_clone()?);
+        }
+        self.segments.push(segment);
+        Ok(())
+    }
+
+    /// Positions recorded, over every segment.
+    pub fn positions(&self) -> usize {
+        self.segments.iter().map(|s| s.len).sum()
+    }
+
+    /// The recurrent state the round started from, or `None` on an empty tape.
+    pub fn state_in(&self) -> Option<&Array> {
+        self.state_in.as_ref()
+    }
+
+    /// The recorded forwards, in the order they ran.
+    pub fn segments(&self) -> &[GdnTapeSegment] {
+        &self.segments
+    }
+
+    /// Resident RAM this tape keeps alive, in bytes.
+    pub fn resident_bytes(&self) -> u64 {
+        crate::bytes::opt_array_bytes(self.state_in.as_ref())
+            + self
+                .segments
+                .iter()
+                .map(GdnTapeSegment::resident_bytes)
+                .sum::<u64>()
+    }
+}
+
+impl Default for GdnTape {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/rmlx-kv-quant/src/linear_attn_tests.rs
+++ b/crates/rmlx-kv-quant/src/linear_attn_tests.rs
@@ -27,10 +27,22 @@ fn read(a: &Array) -> Vec<f32> {
         .collect()
 }
 
-/// snapshot() deep-clones the recurrent state; mutating the live cache
-/// afterwards must NOT change the snapshot, and restore_snapshot() must
-/// bring the live cache back to the snapshotted values exactly. This is
-/// the spec-rollback invariant for the GDN recurrent state.
+fn seg(len: usize) -> GdnTapeSegment {
+    GdnTapeSegment {
+        q: arr(&[1.0]),
+        k: arr(&[2.0]),
+        v: arr(&[3.0]),
+        g: arr(&[4.0]),
+        beta: arr(&[5.0]),
+        conv_input: arr(&[6.0]),
+        len,
+    }
+}
+
+/// A tape records the state the round started from once, at its first segment,
+/// and keeps counting positions as later forwards append to it. That first
+/// state is what an accepted prefix is refolded from, so a later segment
+/// overwriting it would silently refold from the wrong place.
 #[test]
 #[allow(
     clippy::expect_used,
@@ -40,45 +52,104 @@ fn read(a: &Array) -> Vec<f32> {
     clippy::unwrap_used,
     reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
 )]
-fn snapshot_restore_round_trip() {
-    let mut cache = LinearAttnCache::new();
-    cache.conv_state = Some(arr(&[1.0, 2.0, 3.0]));
-    cache.delta_state = Some(arr(&[10.0, 20.0]));
+fn tape_keeps_the_first_state_and_counts_every_segment() {
+    let mut tape = GdnTape::new();
+    assert_eq!(tape.positions(), 0);
+    assert!(tape.state_in().is_none());
 
-    let snap = cache.snapshot().expect("snapshot");
+    tape.push(&arr(&[10.0, 20.0]), seg(2)).expect("first push");
+    tape.push(&arr(&[70.0, 80.0]), seg(1)).expect("second push");
 
-    // Advance the live cache (simulating a speculative draft round).
-    cache.conv_state = Some(arr(&[7.0, 8.0, 9.0]));
-    cache.delta_state = Some(arr(&[70.0, 80.0]));
-
-    // Snapshot must be independent of the post-advance mutation.
-    assert_eq!(read(snap.conv_state.as_ref().unwrap()), vec![1.0, 2.0, 3.0]);
-    assert_eq!(read(snap.delta_state.as_ref().unwrap()), vec![10.0, 20.0]);
-
-    // Roll back: live cache returns to the snapshotted values.
-    cache.restore_snapshot(snap);
-    assert_eq!(
-        read(cache.conv_state.as_ref().unwrap()),
-        vec![1.0, 2.0, 3.0]
-    );
-    assert_eq!(read(cache.delta_state.as_ref().unwrap()), vec![10.0, 20.0]);
+    assert_eq!(tape.positions(), 3);
+    assert_eq!(tape.segments().len(), 2);
+    assert_eq!(read(tape.state_in().unwrap()), vec![10.0, 20.0]);
 }
 
-/// Snapshot/restore must survive `None` fields (pre-first-forward state).
+/// Arming clears whatever the previous round left, and taking the tape
+/// disarms the cache: a forward after that records nothing.
 #[test]
 #[allow(
     clippy::expect_used,
     reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
 )]
-fn snapshot_restore_empty() {
-    let cache = LinearAttnCache::new();
-    let snap = cache.snapshot().expect("snapshot empty");
-    assert!(snap.conv_state.is_none());
-    assert!(snap.delta_state.is_none());
+fn arm_clears_and_take_disarms() {
+    let mut cache = LinearAttnCache::new();
+    assert!(cache.tape.is_none());
 
-    let mut live = LinearAttnCache::new();
-    live.conv_state = Some(arr(&[1.0]));
-    live.restore_snapshot(snap);
-    assert!(live.conv_state.is_none());
-    assert!(live.delta_state.is_none());
+    cache.arm_tape();
+    cache
+        .tape
+        .as_mut()
+        .expect("armed")
+        .push(&arr(&[1.0]), seg(4))
+        .expect("push");
+    assert_eq!(cache.tape.as_ref().expect("armed").positions(), 4);
+
+    cache.arm_tape();
+    assert_eq!(cache.tape.as_ref().expect("re-armed").positions(), 0);
+
+    cache.arm_tape();
+    assert!(cache.take_tape().is_some());
+    assert!(cache.tape.is_none());
+    assert!(cache.take_tape().is_none());
+}
+
+/// The tape is resident memory for as long as a round is open, and
+/// `resident_bytes` is the sum every K/V total is built from.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
+)]
+fn resident_bytes_counts_an_armed_tape() {
+    let mut cache = LinearAttnCache::new();
+    cache.conv_state = Some(arr(&[1.0, 2.0, 3.0]));
+    cache.delta_state = Some(arr(&[10.0, 20.0]));
+    let bare = cache.resident_bytes();
+    assert_eq!(bare, 5 * 4);
+
+    cache.arm_tape();
+    assert_eq!(cache.resident_bytes(), bare);
+
+    cache
+        .tape
+        .as_mut()
+        .expect("armed")
+        .push(&arr(&[0.0, 0.0]), seg(1))
+        .expect("push");
+    // One f32 in each of the six segment buffers, plus the two-element
+    // pre-round state the tape kept.
+    assert_eq!(cache.resident_bytes(), bare + (6 + 2) * 4);
+}
+
+/// A prompt-cache clone is not a live round: it carries the recurrent state and
+/// no tape.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn deep_clone_drops_the_tape() {
+    let mut cache = LinearAttnCache::new();
+    cache.conv_state = Some(arr(&[1.0, 2.0, 3.0]));
+    cache.delta_state = Some(arr(&[10.0, 20.0]));
+    cache.arm_tape();
+    cache
+        .tape
+        .as_mut()
+        .expect("armed")
+        .push(&arr(&[1.0]), seg(1))
+        .expect("push");
+
+    let clone = cache.try_deep_clone().expect("deep clone");
+    assert!(clone.tape.is_none());
+    assert_eq!(
+        read(clone.conv_state.as_ref().unwrap()),
+        vec![1.0, 2.0, 3.0]
+    );
+    assert_eq!(read(clone.delta_state.as_ref().unwrap()), vec![10.0, 20.0]);
 }

--- a/crates/rmlx-kv-quant/src/rotating.rs
+++ b/crates/rmlx-kv-quant/src/rotating.rs
@@ -154,9 +154,9 @@ impl RotatingState {
     ///   still covers the window the rolled-back offset needs. A block-verify
     ///   write of `s` positions can therefore always be rolled back over its own
     ///   rejected tail, which is at most `s - 1` long. Rolling the whole block
-    ///   back is one position too far and is refused — a caller that needs it
-    ///   (a recurrent round loop replaying from its pre-round offset) has no
-    ///   route through here.
+    ///   back is one position too far and is refused, and no round loop asks
+    ///   for it: a recurrent loop rebuilds its state from the round tape and
+    ///   truncates K/V to the same target a full-attention loop does.
     ///
     /// A ring left in rotated order by a single-token write
     /// (`update_in_place` past the wrap) is **not** rollable: the newest slots

--- a/crates/rmlx-kv-quant/src/rotating_tests.rs
+++ b/crates/rmlx-kv-quant/src/rotating_tests.rs
@@ -167,13 +167,11 @@ fn snapshot_restore_multitoken_tail_wrapped() {
 /// without dropping the rejected keys reads the same offset and the wrong keys.
 ///
 /// The last case is the boundary: a rollback of the *whole* block would leave
-/// the ring one position short of its window, and is refused. The assistant
-/// round loop never asks for it — the bonus token is always kept — so the
-/// guarantee it needs is exactly "any tail up to `block - 1`". A **recurrent**
-/// round loop does ask for the whole block, because it replays from the
-/// pre-round offset its state snapshot was taken at, and would be refused here;
-/// no architecture wired today pairs recurrent state with a windowed KV layer,
-/// and `rollback_round_caches` is where the first one that does will say so.
+/// the ring one position short of its window, and is refused. No round loop asks
+/// for it — the bonus token is always kept — so the guarantee they need is
+/// exactly "any tail up to `block - 1`". That covers the recurrent loops too:
+/// they rebuild their recurrent state from the round tape and truncate K/V to
+/// the same target a full-attention loop does.
 #[test]
 #[allow(
     clippy::unwrap_used,

--- a/crates/rmlx-models/src/qwen3_5_moe/gated_delta_net.rs
+++ b/crates/rmlx-models/src/qwen3_5_moe/gated_delta_net.rs
@@ -25,7 +25,7 @@ use rmlx_mlx::{
     add, concatenate, conv1d, exp, log1p, multiply, rms_norm, sigmoid, silu, Array, Device, Dtype,
 };
 
-use rmlx_kv_quant::LinearAttnCache;
+use rmlx_kv_quant::{GdnTapeSegment, LinearAttnCache};
 
 use super::layers::Linear;
 
@@ -280,6 +280,24 @@ impl GatedDeltaNet {
         // mlx-lm reference: `cache[1] = state` and
         // `cache[0] = mx.contiguous(conv_input[:, -n_keep:, :])`.
         if let Some(c) = cache {
+            // A speculative round arms this so a partly-accepted round can be
+            // rolled back by refolding the accepted prefix through the kernel
+            // alone. Every array here was built above; recording them copies
+            // nothing. See `GdnTape`.
+            if let Some(tape) = c.tape.as_mut() {
+                tape.push(
+                    &state_in,
+                    GdnTapeSegment {
+                        q: q4_scaled_full.try_clone()?,
+                        k: k4_scaled_full.try_clone()?,
+                        v: v4.try_clone()?,
+                        g: g_f32.try_clone()?,
+                        beta: beta_full.try_clone()?,
+                        conv_input: qkv_padded.try_clone()?,
+                        len: ts,
+                    },
+                )?;
+            }
             c.delta_state = Some(state_out);
 
             // Save the last (kernel-1) tokens of qkv_padded as the new

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -32,7 +32,7 @@
 //! `norm`, all 8 `DFlashDecoderLayer`s, **YARN RoPE** ([`crate::rope::compute_yarn_freqs`]),
 //! the drafter forward [`DFlashDrafter::draft_block`], the block-size schedule
 //! [`dflash_next_block_size`], the acceptance walk [`walk_block_greedy`], the
-//! [`DFlashRoundState`] GDN rollback, and the full round-loop
+//! GDN rollback, and the full round-loop
 //! [`dflash_generate`]. The three verifier-side seams are wired on
 //! [`crate::arch::Architecture`] for the Qwen3.6-MoE verifier:
 //!
@@ -542,56 +542,6 @@ impl DFlashDrafter {
     }
 }
 
-/// Per-generation GDN rollback bookkeeping for the DFlash round loop.
-///
-/// Wraps the verifier's `LinearAttnCache` snapshot/restore round-trip: take a
-/// snapshot of every GDN cache before a draft round, restore them on partial
-/// acceptance. This is the GDN-aware analogue of the Gemma4 spec path's
-/// `KvCache::truncate_to` rollback — GDN recurrent state has no sequence axis,
-/// so it cannot be truncated (see `linear_attn.rs`).
-#[allow(
-    clippy::exhaustive_structs,
-    reason = "internal closed rollback-state struct — private snapshots field; public API is snapshot() and restore_if_partial(); adding a field requires updating snapshot() and restore_if_partial()"
-)]
-#[allow(missing_debug_implementations)]
-pub struct DFlashRoundState {
-    /// Snapshot of each GDN cache taken at round start (index-aligned with the
-    /// verifier's linear-attention caches).
-    snapshots: Vec<LinearAttnCache>,
-}
-
-impl DFlashRoundState {
-    /// Snapshot all GDN caches before a draft round.
-    pub fn snapshot(lin_caches: &[LinearAttnCache]) -> Result<Self> {
-        let snapshots = lin_caches
-            .iter()
-            .map(|c| c.snapshot())
-            .collect::<Result<Vec<_>>>()?;
-        Ok(Self { snapshots })
-    }
-
-    /// Number of GDN caches snapshotted.
-    pub fn len(&self) -> usize {
-        self.snapshots.len()
-    }
-
-    /// True when no GDN cache was snapshotted (non-GDN verifier).
-    pub fn is_empty(&self) -> bool {
-        self.snapshots.is_empty()
-    }
-
-    /// Consume the round state and hand back the per-layer snapshots.
-    ///
-    /// Restoring them is only one third of a partial-accept rollback — it also
-    /// has to roll the KV caches back and replay the retained prefix through
-    /// them — so the snapshots are handed to the shared rollback rather than
-    /// restored here (mirrors `lm.rollback_speculative_cache` followed by the
-    /// next round's verify in `_dflash_rounds`).
-    pub fn into_snapshots(self) -> Vec<LinearAttnCache> {
-        self.snapshots
-    }
-}
-
 /// One greedy DFlash acceptance walk over a drafted block (port of the
 /// `_speculative_walk` half of `_dflash_rounds`).
 ///
@@ -812,8 +762,8 @@ pub fn dflash_generate(
         total_draft += draft_tokens.len();
 
         // -- Phase B: verifier scores [b, draft...] + captures hidden in one pass.
-        // Snapshot GDN state before the verify forward.
-        let round_snap = DFlashRoundState::snapshot(&v_lin)?;
+        // Arm the GDN round tape before the verify forward.
+        super::arm_lin_tapes(Some(&mut v_lin));
         let mut v_input: Vec<u32> = Vec::with_capacity(1 + draft_tokens.len());
         v_input.push(b);
         v_input.extend_from_slice(&draft_tokens);
@@ -856,8 +806,8 @@ pub fn dflash_generate(
         // -- Phase D: rollback + next-round setup. ---------------------------
         // Committed positions this round = new_tokens.len(); the verifier
         // consumed v_k positions. On partial accept (accept < bs-1) the GDN
-        // recurrent state ran ahead — restore the snapshot and replay the
-        // kept prefix so it matches the truncated KV exactly.
+        // recurrent state ran ahead — refold the kept prefix from the round tape
+        // so it matches the truncated KV exactly.
         let n_committed = new_tokens.len();
         // Read the post-verify sequence offset from a FullAttention layer:
         // GDN (linear-attn) layers never advance their KvCache::offset (it
@@ -874,10 +824,8 @@ pub fn dflash_generate(
         if v_target < v_offset_before {
             let v_pre_round_offset = v_offset_before - v_k as i32;
             super::rollback_round_caches(
-                verifier,
                 &mut v_caches,
                 Some(&mut v_lin),
-                Some(round_snap.into_snapshots()),
                 &v_input,
                 v_pre_round_offset,
                 v_target,
@@ -886,8 +834,8 @@ pub fn dflash_generate(
                 device,
             )?;
         } else {
-            // Full accept — GDN already correct; drop the snapshot.
-            drop(round_snap);
+            // Full accept — GDN already correct; drop the tape.
+            super::disarm_lin_tapes(Some(&mut v_lin));
         }
 
         // Append this round's committed verifier hidden to the accumulated

--- a/crates/rmlx-models/src/speculative/dflash/tests.rs
+++ b/crates/rmlx-models/src/speculative/dflash/tests.rs
@@ -99,97 +99,11 @@ fn walk_respects_budget() {
     assert_eq!(emit, vec![10, 11]);
 }
 
-// --- DFlashRoundState rollback round-trip (GDN snapshot/restore) ---
-
-use rmlx_mlx::{Array, Dtype};
-
-#[allow(
-    clippy::expect_used,
-    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
-)]
-fn arr(vals: &[f32]) -> Array {
-    let bytes: Vec<u8> = vals.iter().flat_map(|v| v.to_le_bytes()).collect();
-    Array::from_bytes(&bytes, &[vals.len() as i32], Dtype::F32).expect("from_bytes")
-}
-
-#[allow(
-    clippy::expect_used,
-    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
-)]
-#[allow(
-    clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
-)]
-fn read(a: &Array) -> Vec<f32> {
-    Array::eval(a).expect("materialise");
-    a.to_bytes()
-        .expect("to_bytes")
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
-        .collect()
-}
-
-/// Snapshot a GDN cache before a round, mutate it (simulate a draft round
-/// advancing the recurrence), then restore on partial rejection — the
-/// cache must come back to the pre-round state exactly.
-#[test]
-#[allow(
-    clippy::expect_used,
-    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
-)]
-#[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
-#[allow(
-    clippy::unwrap_used,
-    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
-)]
-fn round_state_rollback_round_trip() {
-    let mut caches = vec![LinearAttnCache {
-        conv_state: Some(arr(&[1.0, 2.0, 3.0])),
-        delta_state: Some(arr(&[4.0, 5.0])),
-    }];
-    let round = DFlashRoundState::snapshot(&caches).expect("snapshot");
-    assert_eq!(round.len(), 1);
-    assert!(!round.is_empty());
-
-    // Simulate the draft round advancing the recurrent state.
-    caches[0].conv_state = Some(arr(&[9.0, 9.0, 9.0]));
-    caches[0].delta_state = Some(arr(&[8.0, 8.0]));
-
-    // Partial rejection -> restore.
-    for (c, snap) in caches.iter_mut().zip(round.into_snapshots()) {
-        c.restore_snapshot(snap);
-    }
-    assert_eq!(
-        read(caches[0].conv_state.as_ref().unwrap()),
-        vec![1.0, 2.0, 3.0]
-    );
-    assert_eq!(
-        read(caches[0].delta_state.as_ref().unwrap()),
-        vec![4.0, 5.0]
-    );
-}
-
-#[test]
-#[allow(
-    clippy::expect_used,
-    reason = "structural invariant: value present by construction in calling context; .expect() message documents the invariant"
-)]
-fn round_state_empty_for_non_gdn() {
-    let caches: Vec<LinearAttnCache> = vec![];
-    let round = DFlashRoundState::snapshot(&caches).expect("snapshot");
-    assert!(round.is_empty());
-    assert_eq!(round.len(), 0);
-}
-
 /// Compile-check: the public DFlash surface exists with expected sigs.
 #[test]
 fn dflash_module_compiles() {
     let _load = DFlashDrafter::load;
     let _bs = dflash_next_block_size;
     let _walk = walk_block_greedy;
-    let _snap = DFlashRoundState::snapshot;
-    let _ = (_load, _bs, _walk, _snap);
+    let _ = (_load, _bs, _walk);
 }

--- a/crates/rmlx-models/src/speculative/dflash2/round.rs
+++ b/crates/rmlx-models/src/speculative/dflash2/round.rs
@@ -48,11 +48,10 @@ use rmlx_mlx::{Array, Device};
 use super::DFlash2Drafter;
 use crate::arch::Architecture;
 use crate::decode_loop::ProbeStep;
-use crate::speculative::dflash::DFlashRoundState;
 use crate::speculative::{
-    accept_prefix, emit_step, guard_verifier_prefill_logits, phases_charged, rollback_round_caches,
-    verifier_context, verifier_kv_bytes, DecodeWindow, RoundPhases, RoundStats, SpecLoop,
-    VerifierDraw,
+    accept_prefix, arm_lin_tapes, disarm_lin_tapes, emit_step, guard_verifier_prefill_logits,
+    phases_charged, rollback_round_caches, verifier_context, verifier_kv_bytes, DecodeWindow,
+    RoundPhases, RoundStats, SpecLoop, VerifierDraw,
 };
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 
@@ -296,7 +295,7 @@ pub fn dflash2_generate(
 
         // The verifier scores the carry token and every proposal in one pass,
         // capturing the conditioning hidden for the same positions.
-        let round_snap = DFlashRoundState::snapshot(&v_lin)?;
+        arm_lin_tapes(Some(&mut v_lin));
         let mut v_input: Vec<u32> = Vec::with_capacity(1 + draft_tokens.len());
         v_input.push(b);
         v_input.extend_from_slice(&draft_tokens);
@@ -353,14 +352,12 @@ pub fn dflash2_generate(
         let t0 = Instant::now();
         let v_offset_before = v_caches.iter().map(KvCache::offset).max().unwrap_or(0);
         let v_target = v_offset_before - (draft_tokens.len() as i32 - accept as i32);
-        let replayed = v_target < v_offset_before;
-        if replayed {
+        let refolded = v_target < v_offset_before;
+        if refolded {
             let v_pre_round_offset = v_offset_before - v_k as i32;
             rollback_round_caches(
-                verifier,
                 &mut v_caches,
                 Some(&mut v_lin),
-                Some(round_snap.into_snapshots()),
                 &v_input,
                 v_pre_round_offset,
                 v_target,
@@ -368,7 +365,7 @@ pub fn dflash2_generate(
                 device,
             )?;
         } else {
-            drop(round_snap);
+            disarm_lin_tapes(Some(&mut v_lin));
         }
         let round_rollback_ns = t0.elapsed().as_nanos();
 
@@ -411,7 +408,7 @@ pub fn dflash2_generate(
             verify_ns: round_verify_ns,
             walk_ns: round_walk_ns,
             rollback_ns: round_rollback_ns,
-            replayed,
+            refolded,
             charged: charge_phases,
         }
         .log(

--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -52,8 +52,8 @@
 //!    concatenated along the feature axis in one cached forward. We capture at
 //!    `[id - 1]` for each `eagle_aux_hidden_state_layer_ids` id (mlx-vlm
 //!    `capture_layer_ids`), i.e. `[2, 18, 34]`.
-//! 2. **GDN rollback** — reuses [`super::dflash::DFlashRoundState`]
-//!    snapshot/restore + kept-prefix replay on partial acceptance (GDN recurrent
+//! 2. **GDN rollback** — reuses the shared round tape
+//!    a round tape refolded over the kept prefix on partial acceptance (GDN recurrent
 //!    state has no sequence axis; it cannot be truncated).
 //! 3. **Raw embed accessor** — [`Architecture::embed_tokens_raw`] (the verifier
 //!    `embed_tokens` is the EAGLE-3 `bind()` target; the checkpoint ships no
@@ -122,7 +122,6 @@ use std::path::Path;
 use rmlx_core::error::{Error, Result};
 use rmlx_mlx::{add, argmax, concatenate, rope, Array, Device};
 
-use super::dflash::DFlashRoundState;
 use super::{emit_step, DecodeWindow};
 use crate::arch::Architecture;
 use crate::decode_loop::ProbeStep;
@@ -1048,7 +1047,7 @@ pub fn eagle3_generate(
         total_draft += draft_tokens.len();
 
         // -- Phase B: verifier scores [b, draft...] + captures multi-aux hidden. --
-        let round_snap = DFlashRoundState::snapshot(&v_lin)?;
+        super::arm_lin_tapes(Some(&mut v_lin));
         let mut v_input: Vec<u32> = Vec::with_capacity(1 + draft_tokens.len());
         v_input.push(b);
         v_input.extend_from_slice(&draft_tokens);
@@ -1207,17 +1206,15 @@ pub fn eagle3_generate(
 
         // -- Phase D: roll back verifier KV/GDN caches on partial accept. --
         // The verifier consumed v_k positions; keep the committed prefix
-        // (pre-round + accept + 1 carry rows). Roll FA KV caches back, restore +
-        // replay the GDN recurrence.
+        // (pre-round + accept + 1 carry rows). Roll FA KV caches back and refold
+        // the GDN recurrence over the kept prefix.
         let v_offset_before = v_caches.iter().map(|c| c.offset()).max().unwrap_or(0);
         let v_target = v_offset_before - (draft_tokens.len() as i32 - accept as i32);
         if v_target < v_offset_before {
             let v_pre_round_offset = v_offset_before - v_k as i32;
             super::rollback_round_caches(
-                verifier,
                 &mut v_caches,
                 Some(&mut v_lin),
-                Some(round_snap.into_snapshots()),
                 &v_input,
                 v_pre_round_offset,
                 v_target,
@@ -1226,7 +1223,7 @@ pub fn eagle3_generate(
                 device,
             )?;
         } else {
-            drop(round_snap);
+            super::disarm_lin_tapes(Some(&mut v_lin));
         }
 
         // -- Phase E: drafter accept-and-reseed. --

--- a/crates/rmlx-models/src/speculative/gemma4_assistant.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant.rs
@@ -922,9 +922,7 @@ pub fn mtp_assistant_generate(
         let rejected = v_k as i32 - (accept as i32 + 1);
         if rejected > 0 {
             super::rollback_round_caches(
-                verifier,
                 &mut caches,
-                None,
                 None,
                 &verify_input,
                 pre_round_offset,
@@ -981,8 +979,8 @@ pub fn mtp_assistant_generate(
             verify_ns: round_verify_ns,
             walk_ns: round_walk_ns,
             rollback_ns: round_rollback_ns,
-            // Full attention: the rollback is a K/V tail slice, never a replay.
-            replayed: false,
+            // Full attention: the rollback is a K/V tail slice, never a refold.
+            refolded: false,
             charged: charge_phases,
         }
         .log(

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -1841,13 +1841,19 @@ fn rollback_round_caches(
 /// Rebuild every recurrent layer's state at `kept` positions into this round
 /// from the tape its forwards recorded.
 ///
-/// `round_len` is how many positions the round fed. Each layer's tape must hold
-/// exactly that many, and this refuses the round rather than refolding when one
-/// does not: a tape that is short recorded fewer forwards than the round took —
-/// armed late, or a forward that ran with recording off — and refolding it
-/// would leave the recurrent state describing a different prefix from the K/V
-/// stack beside it, which no later call can detect and which shows up only as
-/// wrong tokens.
+/// `round_len` is how many positions the round fed. Each recurrent layer's tape
+/// must hold exactly that many, and this refuses the round rather than refolding
+/// when one does not: a tape that is short recorded fewer forwards than the
+/// round took — armed late, or a forward that ran with recording off — and
+/// refolding it would leave the recurrent state describing a different prefix
+/// from the K/V stack beside it, which no later call can detect and which shows
+/// up only as wrong tokens.
+///
+/// `lin` carries one slot per decoder layer, and on a hybrid most of them belong
+/// to full-attention layers that never touch a recurrence. Those record nothing
+/// and hold no state, and are skipped. Holding no state is what separates them
+/// from a recurrent layer whose forward failed to record: that one has a state
+/// this round advanced, and an empty tape for it is the defect above.
 fn refold_lin_tapes(
     lin: &mut [LinearAttnCache],
     round_len: usize,
@@ -1865,6 +1871,9 @@ fn refold_lin_tapes(
             )));
         };
         let taped = tape.positions();
+        if taped == 0 && cache.conv_state.is_none() && cache.delta_state.is_none() {
+            continue;
+        }
         if taped != round_len {
             return Err(Error::Model(format!(
                 "refold_lin_tapes: recurrent layer {idx} taped {taped} positions over \

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -43,13 +43,13 @@ use std::path::Path;
 use std::time::Instant;
 
 use rmlx_core::error::{Error, Result};
-use rmlx_mlx::{argmax, Array, Device, Dtype};
+use rmlx_mlx::{argmax, concatenate, Array, Device, Dtype};
 use rmlx_runtime::{count_nan_in_bytes, max_abs_from_bytes};
 
 use crate::arch::{load_model, Architecture, LoadOpts};
 use crate::decode_loop::ProbeStep;
 pub use draft_kind::{Declared, DraftKind};
-use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
+use rmlx_kv_quant::{GdnTape, GdnTapeSegment, KvCache, KvQuant, LinearAttnCache};
 pub(crate) use round_stats::{phases_charged, RoundPhases, RoundStats, SpecLoop};
 
 /// Resolve the context bounds a speculative pair runs under.
@@ -714,16 +714,13 @@ impl SpeculativeDispatcher {
             // -- GDN rollback prep. ------------------------------------
             // The GatedDeltaNet recurrent state has NO sequence axis, so
             // `KvCache::truncate_to` cannot roll it back to an intermediate
-            // position on partial acceptance. We snapshot the pre-round GDN
-            // state for both models here. On partial acceptance the state is
-            // restored from the snapshot and then re-advanced ("replay") over
-            // the kept tokens with a single forward, leaving the GDN state
-            // exactly consistent with the truncated KvCache. On full
-            // acceptance no rollback is needed (state is already correct).
-            // Snapshots are deep clones of the small fixed-shape conv/delta
-            // tensors — cheap relative to a verifier forward.
-            let verifier_lin_snap = snapshot_lin(verifier_lin.as_deref())?;
-            let draft_lin_snap = snapshot_lin(draft_lin.as_deref())?;
+            // position on partial acceptance. Arm a round tape on both models
+            // instead: their forwards record the recurrence inputs, and a
+            // partial acceptance refolds the accepted prefix from those. The
+            // drafter takes one forward per drafted token, so its tape
+            // accumulates across the round.
+            arm_lin_tapes(verifier_lin.as_deref_mut());
+            arm_lin_tapes(draft_lin.as_deref_mut());
 
             // -- Phase A: draft generates `num_draft` tokens via cache. -
             let t0 = Instant::now();
@@ -829,15 +826,12 @@ impl SpeculativeDispatcher {
             let v_target = v_offset_before - (draft_tokens.len() as i32 - accept as i32);
             // On a PARTIAL accept the KV keeps `v_target` positions and the GDN
             // recurrent state — which advanced by `v_k` and cannot be sliced —
-            // is rebuilt from the pre-round snapshot by replaying the retained
-            // prefix through the real caches. On a FULL accept nothing was
-            // dropped and the snapshot is discarded.
+            // is refolded from the round tape over the retained prefix. On a
+            // FULL accept nothing was dropped and the tape is discarded.
             if v_target < v_offset_before {
                 rollback_round_caches(
-                    &self.verifier,
                     &mut verifier_caches,
                     verifier_lin.as_deref_mut(),
-                    verifier_lin_snap,
                     &v_input,
                     v_offset_before - v_k as i32,
                     v_target,
@@ -846,7 +840,7 @@ impl SpeculativeDispatcher {
                     device,
                 )?;
             } else {
-                drop(verifier_lin_snap);
+                disarm_lin_tapes(verifier_lin.as_deref_mut());
             }
 
             // Draft cache: it processed num_draft tokens (1 carry + K-1
@@ -860,8 +854,9 @@ impl SpeculativeDispatcher {
             let d_target = d_offset_before - d_drop;
             // `draft_decode_n` fed `d_seed ++ draft_tokens[..num_draft-1]`
             // (each step's input is the prior step's output; the last output is
-            // never fed back), so that is the token sequence the rollback
-            // replays the retained prefix of.
+            // never fed back), so that is the token sequence the rollback keeps
+            // the retained prefix of — and the length its accumulated tape has
+            // to match.
             if d_target < d_offset_before {
                 let mut d_fed: Vec<u32> = Vec::with_capacity(d_seed.len() + draft_tokens.len());
                 d_fed.extend_from_slice(&d_seed);
@@ -870,10 +865,8 @@ impl SpeculativeDispatcher {
                 }
                 let d_pre_round_offset = d_offset_before - d_fed.len() as i32;
                 rollback_round_caches(
-                    draft,
                     &mut draft_caches,
                     draft_lin.as_deref_mut(),
-                    draft_lin_snap,
                     &d_fed,
                     d_pre_round_offset,
                     d_target,
@@ -882,7 +875,7 @@ impl SpeculativeDispatcher {
                     device,
                 )?;
             } else {
-                drop(draft_lin_snap);
+                disarm_lin_tapes(draft_lin.as_deref_mut());
             }
 
             // Setup next round's carry tokens. Verifier carry is always
@@ -1113,8 +1106,8 @@ impl SpeculativeDispatcher {
             let remaining = n_tokens - emitted.len();
             let num_draft = remaining.min(k).max(1);
 
-            let verifier_lin_snap = snapshot_lin(verifier_lin.as_deref())?;
-            let draft_lin_snap = snapshot_lin(draft_lin.as_deref())?;
+            arm_lin_tapes(verifier_lin.as_deref_mut());
+            arm_lin_tapes(draft_lin.as_deref_mut());
 
             // -- Phase A: draft samples `num_draft` tokens, recording q_i. ---
             let t0 = Instant::now();
@@ -1257,10 +1250,8 @@ impl SpeculativeDispatcher {
             let v_target = v_offset_before - (draft_tokens.len() as i32 - accept as i32);
             if v_target < v_offset_before {
                 rollback_round_caches(
-                    &self.verifier,
                     &mut verifier_caches,
                     verifier_lin.as_deref_mut(),
-                    verifier_lin_snap,
                     &v_input,
                     v_offset_before - v_k as i32,
                     v_target,
@@ -1269,7 +1260,7 @@ impl SpeculativeDispatcher {
                     device,
                 )?;
             } else {
-                drop(verifier_lin_snap);
+                disarm_lin_tapes(verifier_lin.as_deref_mut());
             }
 
             let d_offset_before = draft_caches.iter().map(KvCache::offset).max().unwrap_or(0);
@@ -1283,10 +1274,8 @@ impl SpeculativeDispatcher {
                 }
                 let d_pre_round_offset = d_offset_before - d_fed.len() as i32;
                 rollback_round_caches(
-                    draft,
                     &mut draft_caches,
                     draft_lin.as_deref_mut(),
-                    draft_lin_snap,
                     &d_fed,
                     d_pre_round_offset,
                     d_target,
@@ -1295,7 +1284,7 @@ impl SpeculativeDispatcher {
                     device,
                 )?;
             } else {
-                drop(draft_lin_snap);
+                disarm_lin_tapes(draft_lin.as_deref_mut());
             }
 
             v_carry = vec![next_y_token];
@@ -1578,23 +1567,28 @@ fn prefill_chunked_with(
     Ok(())
 }
 
-/// Deep-clone snapshot of a per-layer GDN recurrent-state slice, if present.
+/// Arm a round tape on every recurrent cache in `lin`, discarding whatever the
+/// previous round left on it.
 ///
-/// Returns `None` for FullAttention-only archs (no `lin_caches`). The clone
-/// is a fixed-shape conv/delta tensor pair per layer — cheap relative to a
-/// forward. Used by the speculative loop to capture the pre-round GDN state
-/// before draft + verifier forwards, so partial-acceptance rollback can
-/// restore + replay (the recurrent state has no sequence axis to truncate).
-fn snapshot_lin(lin: Option<&[LinearAttnCache]>) -> Result<Option<Vec<LinearAttnCache>>> {
-    match lin {
-        None => Ok(None),
-        Some(caches) => {
-            let mut snap = Vec::with_capacity(caches.len());
-            for c in caches {
-                snap.push(c.snapshot()?);
-            }
-            Ok(Some(snap))
-        }
+/// A no-op for full-attention archs, which have no recurrent caches. Call it
+/// once per round, before the forwards that round takes: every GDN forward
+/// through an armed cache records its recurrence inputs, and
+/// [`rollback_round_caches`] refolds them when the round is partly rejected.
+fn arm_lin_tapes(lin: Option<&mut [LinearAttnCache]>) {
+    for c in lin.into_iter().flatten() {
+        c.arm_tape();
+    }
+}
+
+/// Drop the round tapes on every recurrent cache in `lin`.
+///
+/// A fully accepted round keeps the state its forwards produced and has nothing
+/// to refold, so its tape is dead the moment the round ends. Holding it to the
+/// next round's arming would keep a block's worth of activations per layer alive
+/// for no reader.
+fn disarm_lin_tapes(lin: Option<&mut [LinearAttnCache]>) {
+    for c in lin.into_iter().flatten() {
+        let _ = c.take_tape();
     }
 }
 
@@ -1789,60 +1783,44 @@ pub(crate) fn accept_prefix(
 /// acceptance — both the full-attention `kv` stack and, when the arch has one,
 /// the GDN recurrent state in `lin`.
 ///
-/// `pre_round_offset` is the KV offset before this round's verify forward ran;
-/// `round_tokens` are the tokens that forward consumed, in order, so that
+/// `pre_round_offset` is the KV offset before this round's forwards ran;
+/// `round_tokens` are the tokens those forwards consumed, in order, so that
 /// `round_tokens[..target_offset - pre_round_offset]` is exactly the retained
 /// prefix.
 ///
 /// **Full-attention arch** (`lin` empty or absent): every layer's KvCache
 /// carries the whole round, so dropping the rejected tail is the entire
-/// rollback — `kv` is truncated straight to `target_offset`.
+/// rollback.
 ///
 /// **GDN hybrid**: the recurrent state has no sequence axis (see
-/// `LinearAttnCache::truncate_to`), so it cannot be sliced to an intermediate
-/// position. It is restored from the pre-round `snapshot` and replayed over the
-/// retained prefix instead. That replay runs the WHOLE layer stack, and in this
-/// hybrid the full-attention layers are interleaved between the GDN layers:
-/// their output is the residual a later GDN layer consumes. So the replay must
-/// see the real KV caches at their real sequence offsets — replaying through a
-/// fresh scratch stack makes those FA layers attend a `kept`-token prefix at
-/// positions `0..kept`, and every downstream GDN layer then advances on a wrong
-/// hidden. The rollback therefore truncates `kv` to `pre_round_offset` and
-/// replays into it; the caches land on `target_offset` exactly as the direct
-/// truncation would have, and the GDN state lands byte-consistent with them.
+/// `LinearAttnCache`), so it cannot be sliced to an intermediate position. It is
+/// rebuilt instead, from the round tape the loop armed before its forwards:
+/// the recurrence inputs at the retained positions are the ones the forward
+/// already computed, so the state is refolded by the recurrence kernel over
+/// those alone. That reads no weights and takes no second forward, which is
+/// what makes a partly-accepted round cost the same as a fully accepted one.
 ///
-/// Truncation is guarded by `offset() >= n` because a GDN layer's KvCache never
-/// advances (it stays at 0); truncating it to a positive `n` would leave it
-/// reporting positions it does not hold.
+/// The K/V stack is truncated straight to `target_offset` on both arms. A
+/// windowed layer therefore only ever has to give back this round's rejected
+/// tail, which is inside any ring's reach.
 ///
 /// Call this only when the round actually dropped positions
 /// (`target_offset < offset_before`); on a full accept there is nothing to roll
-/// back and the snapshot is simply dropped.
+/// back and the tapes are dropped with [`disarm_lin_tapes`].
 ///
 /// `charge` is the calling loop's per-request answer from
 /// [`phases_charged`], not a decision this function makes. Seven loops share it
 /// and three of them time their phases; reading the switch here would change the
 /// schedule of the other four with nothing on their records saying so.
-#[allow(clippy::too_many_arguments)]
-#[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
 fn rollback_round_caches(
-    arch: &Architecture,
     kv: &mut [KvCache],
     lin: Option<&mut [LinearAttnCache]>,
-    snapshot: Option<Vec<LinearAttnCache>>,
     round_tokens: &[u32],
     pre_round_offset: i32,
     target_offset: i32,
     charge: bool,
     device: Device,
 ) -> Result<()> {
-    let Some((lin, snapshot)) = lin.zip(snapshot).filter(|(l, _)| !l.is_empty()) else {
-        return truncate_kv_to(kv, target_offset);
-    };
-
     let kept = (target_offset - pre_round_offset).max(0) as usize;
     if kept > round_tokens.len() {
         return Err(Error::Model(format!(
@@ -1853,41 +1831,183 @@ fn rollback_round_caches(
             round_tokens.len(),
         )));
     }
-
-    // The whole verify block, not the rejected tail: the recurrent state has no
-    // sequence axis to truncate, so it is restored from the pre-round snapshot
-    // and the accepted prefix replayed into KV caches that must start where the
-    // snapshot does. A sliding-window ring cannot serve that past its wrap — it
-    // can give back a rejected tail but not the block that established its
-    // window — so this branch and a sliding layer are mutually exclusive. No
-    // architecture wired today pairs the two (`Architecture::layer_sliding_window`
-    // names only the Gemma families, and neither carries recurrent state); the
-    // first one that does lands here rather than anywhere subtler.
-    truncate_kv_to(kv, pre_round_offset).map_err(|e| {
-        Error::Model(format!(
-            "rollback_round_caches: a recurrent verifier rolls the whole verify block off \
-             and replays the accepted prefix, which a sliding-window layer cannot do past \
-             its wrap — this architecture pairs recurrent state with a windowed KV layer \
-             and the round loop has no rollback for that combination: {e}"
-        ))
-    })?;
-    for (c, snap) in lin.iter_mut().zip(snapshot) {
-        c.restore_snapshot(snap);
-    }
-    if kept == 0 {
-        // Nothing retained beyond the pre-round state — the snapshot is
-        // already the answer and the caches are already at `target_offset`.
+    truncate_kv_to(kv, target_offset)?;
+    let Some(lin) = lin.filter(|l| !l.is_empty()) else {
         return Ok(());
+    };
+    refold_lin_tapes(lin, round_tokens.len(), kept, charge, device)
+}
+
+/// Rebuild every recurrent layer's state at `kept` positions into this round
+/// from the tape its forwards recorded.
+///
+/// `round_len` is how many positions the round fed. Each layer's tape must hold
+/// exactly that many, and this refuses the round rather than refolding when one
+/// does not: a tape that is short recorded fewer forwards than the round took —
+/// armed late, or a forward that ran with recording off — and refolding it
+/// would leave the recurrent state describing a different prefix from the K/V
+/// stack beside it, which no later call can detect and which shows up only as
+/// wrong tokens.
+fn refold_lin_tapes(
+    lin: &mut [LinearAttnCache],
+    round_len: usize,
+    kept: usize,
+    charge: bool,
+    device: Device,
+) -> Result<()> {
+    let mut refolded: Vec<Array> = Vec::new();
+    for (idx, cache) in lin.iter_mut().enumerate() {
+        let Some(tape) = cache.take_tape() else {
+            return Err(Error::Model(format!(
+                "refold_lin_tapes: recurrent layer {idx} has no round tape, so the \
+                 {round_len} positions this round fed through it were never recorded \
+                 and its state cannot be rolled back to {kept}"
+            )));
+        };
+        let taped = tape.positions();
+        if taped != round_len {
+            return Err(Error::Model(format!(
+                "refold_lin_tapes: recurrent layer {idx} taped {taped} positions over \
+                 {} forwards but the round fed {round_len} — the tape does not describe \
+                 this round",
+                tape.segments().len(),
+            )));
+        }
+        let Some(state_in) = tape.state_in() else {
+            return Err(Error::Model(format!(
+                "refold_lin_tapes: recurrent layer {idx} taped {taped} positions with no \
+                 pre-round state"
+            )));
+        };
+        let conv = concat_tape_conv_input(&tape, device)?;
+        // What the conv1d carries into the next call is the `kernel - 1`
+        // positions before its next input, and the tape's conv input opens with
+        // exactly those, so the round's own carry sits at `kept`.
+        let pad = seq_len(&conv)? - taped as i32;
+        cache.conv_state = Some(seq_range(&conv, kept as i32, kept as i32 + pad, device)?);
+        cache.delta_state = Some(if kept == 0 {
+            state_in.try_clone()?
+        } else {
+            let (_y, state_out) = crate::gated_delta_msl::gated_delta_step_gpu(
+                &tape_prefix(&tape, |s| &s.q, kept, device)?,
+                &tape_prefix(&tape, |s| &s.k, kept, device)?,
+                &tape_prefix(&tape, |s| &s.v, kept, device)?,
+                &tape_prefix(&tape, |s| &s.g, kept, device)?,
+                &tape_prefix(&tape, |s| &s.beta, kept, device)?,
+                state_in,
+                device,
+            )?;
+            state_out
+        });
+        if charge {
+            // Nothing reads the refolded state until the next round's forward,
+            // so with nothing forcing it here the whole refold is billed to that
+            // round. See `phases_charged`. Issued for every layer first and
+            // waited on afterwards: draining each layer in turn would price the
+            // rollback at the cost of serialising it.
+            for a in [&cache.conv_state, &cache.delta_state]
+                .into_iter()
+                .flatten()
+            {
+                a.async_eval()?;
+                refolded.push(a.try_clone()?);
+            }
+        }
     }
-    let replayed =
-        arch.forward_seq_last_k_with_cache(&round_tokens[..kept], 1, kv, Some(lin), device)?;
-    if charge {
-        // Nothing reads this replay until the next round's verify forward, so
-        // with nothing forcing it here the whole second weight read is billed
-        // to that round's verify span. See `phases_charged`.
-        replayed.eval()?;
+    for a in &refolded {
+        a.eval()?;
     }
     Ok(())
+}
+
+/// The round's conv1d input across every taped forward, carried prefix included.
+///
+/// Each forward's input opens with the `kernel - 1` positions it carried in from
+/// its predecessor, and those are already in that predecessor's segment, so only
+/// the first segment contributes its prefix.
+fn concat_tape_conv_input(tape: &GdnTape, device: Device) -> Result<Array> {
+    let Some((first, rest)) = tape.segments().split_first() else {
+        return Err(Error::Model(
+            "concat_tape_conv_input: empty round tape".into(),
+        ));
+    };
+    if rest.is_empty() {
+        return first.conv_input.try_clone();
+    }
+    let pad = seq_len(&first.conv_input)? - first.len as i32;
+    let mut parts: Vec<Array> = Vec::with_capacity(rest.len() + 1);
+    parts.push(first.conv_input.try_clone()?);
+    for seg in rest {
+        let len = seq_len(&seg.conv_input)?;
+        parts.push(seq_range(&seg.conv_input, pad, len, device)?);
+    }
+    concatenate(&parts.iter().collect::<Vec<_>>(), 1, device)
+}
+
+/// One recurrence input over the round's first `kept` positions, joined across
+/// whatever forwards produced them.
+///
+/// `kept` is at most the tape's position count, checked by the caller.
+fn tape_prefix(
+    tape: &GdnTape,
+    field: fn(&GdnTapeSegment) -> &Array,
+    kept: usize,
+    device: Device,
+) -> Result<Array> {
+    let mut parts: Vec<Array> = Vec::new();
+    let mut taken = 0usize;
+    for seg in tape.segments() {
+        if taken >= kept {
+            break;
+        }
+        let want = (kept - taken).min(seg.len);
+        parts.push(seq_range(field(seg), 0, want as i32, device)?);
+        taken += want;
+    }
+    match parts.len() {
+        1 => parts
+            .pop()
+            .ok_or_else(|| Error::Model("tape_prefix: a one-part join lost its part".into())),
+        _ => concatenate(&parts.iter().collect::<Vec<_>>(), 1, device),
+    }
+}
+
+/// Length of `a`'s sequence axis, which every taped recurrence input carries at
+/// axis 1.
+fn seq_len(a: &Array) -> Result<i32> {
+    a.shape().get(1).copied().ok_or_else(|| {
+        Error::Model(format!(
+            "seq_len: a taped recurrence input carries its positions on axis 1, \
+             and this one has shape {:?}",
+            a.shape()
+        ))
+    })
+}
+
+/// `a[:, from..to, ...]` — a range of a taped recurrence input's positions.
+fn seq_range(a: &Array, from: i32, to: i32, device: Device) -> Result<Array> {
+    let len = seq_len(a)?;
+    if from < 0 || from > to || to > len {
+        return Err(Error::Model(format!(
+            "seq_range: positions {from}..{to} are not inside a taped input of \
+             length {len}"
+        )));
+    }
+    if from == 0 && to == len {
+        return a.try_clone();
+    }
+    let shape = a.shape();
+    let start: Vec<i32> = shape
+        .iter()
+        .enumerate()
+        .map(|(axis, _)| if axis == 1 { from } else { 0 })
+        .collect();
+    let stop: Vec<i32> = shape
+        .iter()
+        .enumerate()
+        .map(|(axis, &dim)| if axis == 1 { to } else { dim })
+        .collect();
+    a.slice(&start, &stop, &vec![1i32; shape.len()], device)
 }
 
 /// Truncate every KV cache in `kv` that actually holds `n` or more positions.

--- a/crates/rmlx-models/src/speculative/mtp.rs
+++ b/crates/rmlx-models/src/speculative/mtp.rs
@@ -586,7 +586,7 @@ use crate::decode_loop::ProbeStep;
 /// [`super::VerifierDraw`] explains why the walk is still exact.
 ///
 /// The verifier is the Qwen3.5/3.6-MoE hybrid (carries GDN linear-attention
-/// state); rollback uses the [`super::dflash::DFlashRoundState`] snapshot/restore.
+/// state); rollback refolds that state from the round tape.
 #[allow(clippy::too_many_arguments)]
 #[allow(
     clippy::indexing_slicing,
@@ -611,7 +611,6 @@ pub fn mtp_generate(
     sampler_cfg: &crate::sampler::SamplerConfig,
     device: Device,
 ) -> Result<Vec<ProbeStep>> {
-    use super::dflash::DFlashRoundState;
     use rmlx_kv_quant::LinearAttnCache;
     use std::time::Instant;
 
@@ -772,8 +771,8 @@ pub fn mtp_generate(
         total_draft += draft_tokens.len();
 
         // -- Phase B: verifier scores [b, draft...] + captures penultimate hidden
-        //    in one pass. Snapshot GDN state before the verify forward. --
-        let round_snap = DFlashRoundState::snapshot(&v_lin)?;
+        //    in one pass. Arm the GDN round tape before the verify forward. --
+        super::arm_lin_tapes(Some(&mut v_lin));
         let mut v_input: Vec<u32> = Vec::with_capacity(1 + draft_tokens.len());
         v_input.push(b);
         v_input.extend_from_slice(&draft_tokens);
@@ -837,10 +836,8 @@ pub fn mtp_generate(
         if v_target < v_offset_before {
             let v_pre_round_offset = v_offset_before - v_k as i32;
             super::rollback_round_caches(
-                verifier,
                 &mut v_caches,
                 Some(&mut v_lin),
-                Some(round_snap.into_snapshots()),
                 &v_input,
                 v_pre_round_offset,
                 v_target,
@@ -848,7 +845,7 @@ pub fn mtp_generate(
                 device,
             )?;
         } else {
-            drop(round_snap);
+            super::disarm_lin_tapes(Some(&mut v_lin));
         }
 
         // Sidecar KV rollback: this round the head wrote `bs - 1` slots starting
@@ -888,7 +885,7 @@ pub fn mtp_generate(
             verify_ns: round_verify_ns,
             walk_ns: round_walk_ns,
             rollback_ns: round_rollback_ns,
-            replayed: v_target < v_offset_before,
+            refolded: v_target < v_offset_before,
             charged: charge_phases,
         }
         .log(

--- a/crates/rmlx-models/src/speculative/round_stats.rs
+++ b/crates/rmlx-models/src/speculative/round_stats.rs
@@ -180,10 +180,10 @@ pub(crate) const PHASE_TARGET: &str = "rmlx::spec::phase";
 ///
 /// The phase spans wrap call sites and this engine evaluates lazily, so a
 /// call's work is paid wherever the next blocking evaluation falls — not
-/// necessarily in the phase that issued it. The rollback replay is the clear
-/// case: its output is discarded and the state it writes is not read until the
-/// next round's verify forward, so with nothing forcing it the whole replay is
-/// billed to that round's verify span.
+/// necessarily in the phase that issued it. The rollback is the clear case: the
+/// recurrent state it refolds is not read until the next round's verify forward,
+/// so with nothing forcing it the whole refold is billed to that round's verify
+/// span.
 ///
 /// At TRACE on [`PHASE_TARGET`] each phase forces its own work before its span
 /// closes and the split becomes attributable. It is then also a different,
@@ -252,11 +252,11 @@ pub(crate) struct RoundPhases {
     /// Time inside the acceptance walk.
     pub(crate) walk_ns: u128,
     /// Time inside the rollback: cache truncation and, on a recurrent
-    /// verifier, the replay.
+    /// verifier, the refold of the accepted prefix.
     pub(crate) rollback_ns: u128,
-    /// Whether the round took the recurrent replay arm of
+    /// Whether the round took the recurrent refold arm of
     /// [`super::rollback_round_caches`].
-    pub(crate) replayed: bool,
+    pub(crate) refolded: bool,
     /// Whether the phases were charged for the work they issued.
     pub(crate) charged: bool,
 }
@@ -325,7 +325,7 @@ impl RoundPhases {
                 round,
                 accept,
                 num_draft,
-                replayed = self.replayed,
+                refolded = self.refolded,
                 charged = self.charged,
                 round_ms = ms(self.round_ns),
                 draft_ms = ms(self.draft_ns),
@@ -343,7 +343,7 @@ impl RoundPhases {
             round,
             accept,
             num_draft,
-            replayed = self.replayed,
+            refolded = self.refolded,
             charged = self.charged,
             round_ms = ms(self.round_ns),
             draft_ms = ms(self.draft_ns),

--- a/crates/rmlx-models/src/speculative/round_stats_tests.rs
+++ b/crates/rmlx-models/src/speculative/round_stats_tests.rs
@@ -517,7 +517,7 @@ fn phases(round_ns: u128, draft_ns: u128, verify_ns: u128) -> super::RoundPhases
         verify_ns,
         walk_ns: 1_000_000,
         rollback_ns: 2_000_000,
-        replayed: true,
+        refolded: true,
         charged: true,
     }
 }
@@ -549,7 +549,7 @@ fn a_round_with_one_phase_and_nothing_else_claims_all_of_it() {
         verify_ns: 0,
         walk_ns: 0,
         rollback_ns: 0,
-        replayed: false,
+        refolded: false,
         charged: false,
     };
     assert_eq!(p.unclaimed_ns(), Some(0));
@@ -652,7 +652,7 @@ fn charged_round(charged: bool) -> super::RoundPhases {
         verify_ns: 4_000_000,
         walk_ns: 1_000_000,
         rollback_ns: 1_000_000,
-        replayed: false,
+        refolded: false,
         charged,
     }
 }

--- a/crates/rmlx-models/src/speculative/tests.rs
+++ b/crates/rmlx-models/src/speculative/tests.rs
@@ -1350,23 +1350,35 @@ fn an_accumulating_tape_refolds_across_its_segment_join() {
 
 // -- Round tape against the replay it replaced, on a real model --------------
 
-/// The hybrid the tape is checked on: a GDN stack whose recurrent layers are
-/// interleaved with full-attention ones, which is the shape that made the
-/// replay run the whole layer stack in the first place.
-const TAPE_REPLAY_SLUG: &str = "mlx-community__Qwen3.8-27B-4bit";
+/// The hybrids the tape is checked on: GDN stacks whose recurrent layers are
+/// interleaved with full-attention ones, which is the shape that made the replay
+/// run the whole layer stack in the first place. One dense, one mixture — the
+/// projections a shorter forward recomputes go through different kernels on the
+/// two, and this equality is a claim about those.
+const TAPE_REPLAY_SLUGS: &[&str] = &[
+    "mlx-community__Qwen3.8-27B-4bit",
+    "mlx-community__Qwen3.6-35B-A3B-8bit",
+];
 
-/// The snapshot, or a named stand-down the GPU runner counts.
-fn tape_replay_model(test: &str) -> Option<std::path::PathBuf> {
+/// The snapshots present on this machine, or a named stand-down the GPU runner
+/// counts for each that is not.
+fn tape_replay_models(test: &str) -> Vec<std::path::PathBuf> {
     let Some(root) = std::env::var_os("RMLX_O_MODELS_ROOT") else {
         eprintln!("SKIP {test}: RMLX_O_MODELS_ROOT is not set");
-        return None;
+        return Vec::new();
     };
-    let path = std::path::PathBuf::from(root).join(TAPE_REPLAY_SLUG);
-    if !path.join("config.json").exists() {
-        eprintln!("SKIP {test}: {TAPE_REPLAY_SLUG} is not under RMLX_O_MODELS_ROOT");
-        return None;
-    }
-    Some(path)
+    let root = std::path::PathBuf::from(root);
+    TAPE_REPLAY_SLUGS
+        .iter()
+        .filter_map(|slug| {
+            let path = root.join(slug);
+            if path.join("config.json").exists() {
+                return Some(path);
+            }
+            eprintln!("SKIP {test}: {slug} is not under RMLX_O_MODELS_ROOT");
+            None
+        })
+        .collect()
 }
 
 /// A fresh unquantized cache stack, so nothing between the two arms differs but
@@ -1413,21 +1425,30 @@ fn tape_replay_state(lin: &[LinearAttnCache], device: Device) -> Vec<f32> {
     out
 }
 
-/// Largest elementwise difference over the larger magnitude, which is the
-/// comparison a bf16 activation path admits.
+/// `||a - b|| / ||a||`, the relative size of the difference between two
+/// states.
+///
+/// A norm and not a worst element: these buffers hold millions of values, most
+/// of them near zero, and an elementwise ratio saturates on any pair of tiny
+/// opposite-signed ones whatever the states as a whole are doing.
 fn tape_replay_rel_err(a: &[f32], b: &[f32]) -> f64 {
     assert_eq!(
         a.len(),
         b.len(),
         "two states of the same stack differ in size"
     );
-    a.iter()
+    let diff: f64 = a
+        .iter()
         .zip(b)
-        .map(|(x, y)| {
-            let scale = x.abs().max(y.abs()).max(1e-6);
-            f64::from((x - y).abs() / scale)
-        })
-        .fold(0.0_f64, f64::max)
+        .map(|(x, y)| f64::from(x - y).powi(2))
+        .sum::<f64>()
+        .sqrt();
+    let scale: f64 = a.iter().map(|x| f64::from(*x).powi(2)).sum::<f64>().sqrt();
+    if scale > 0.0 {
+        diff / scale
+    } else {
+        diff
+    }
 }
 
 /// Twenty-odd deterministic ids well inside any vocabulary. The values do not
@@ -1478,14 +1499,19 @@ fn tape_replay_run(
 /// as a second stack prefilled identically and advanced over the accepted prefix
 /// alone, which is the same computation.
 ///
-/// **Bit-equality, and it is structural.** The projections the recurrence
-/// consumes reduce over the hidden dimension and not over the sequence, and the
-/// recurrence kernel walks positions in order, so what a forward computed at a
-/// position does not depend on how many positions followed it. Measured that
-/// way on this model at every accepted length and both shapes. The control
-/// beside it is what says the comparison has power: the same refold against the
-/// replay one token short of the accepted length, which a refold that folded the
-/// wrong number of positions would match instead.
+/// **How close they can be is the model's own answer, and the run measures it.**
+/// The replay computes the prefix in a forward of its own length; the tape
+/// returns what the round's forward computed at those positions. On the dense
+/// hybrid the two are bit-identical, and the run says so. On the mixture the
+/// model does not reproduce itself that way — one forward over the round and the
+/// same tokens stepped one at a time part company by a couple of percent, which
+/// is a property of that stack and not of this change — so the bound the refold
+/// is held to is that same disagreement, measured beside it in the same process.
+///
+/// The control is what gives the comparison power: the same refold against the
+/// replay one token short of the accepted length, which is where a refold that
+/// folded the wrong number of positions would sit. It reads about 0.5 against a
+/// refold-to-replay agreement of at most a few percent.
 #[test]
 #[ignore = "requires Metal GPU context and a 27B snapshot"]
 #[allow(
@@ -1498,64 +1524,77 @@ fn tape_replay_run(
 )]
 fn a_round_tape_refolds_to_what_the_replay_produced() {
     const NAME: &str = "a_round_tape_refolds_to_what_the_replay_produced";
-    let Some(path) = tape_replay_model(NAME) else {
-        return;
-    };
     let device = Device::Gpu;
-    let arch = load_model(&path, device, &LoadOpts::default()).expect("load verifier");
-    assert!(
-        arch.needs_lin_caches(),
-        "{TAPE_REPLAY_SLUG} must carry recurrent state or this test proves nothing"
-    );
-
     let round = TAPE_REPLAY_ROUND;
     let per_token: Vec<&[u32]> = round.iter().map(std::slice::from_ref).collect();
 
-    for (shape, chunks) in [
-        ("one verify forward", vec![round]),
-        ("a forward per token", per_token),
-    ] {
-        for kept in 1..round.len() {
-            let (_kv, mut taped) =
-                tape_replay_run(&arch, TAPE_REPLAY_PROMPT, &chunks, true, device);
-            refold_lin_tapes(&mut taped, round.len(), kept, false, device).expect("refold");
-            let refolded = tape_replay_state(&taped, device);
+    for path in tape_replay_models(NAME) {
+        let model = path.file_name().unwrap_or_default().to_string_lossy();
+        let arch = load_model(&path, device, &LoadOpts::default()).expect("load verifier");
+        assert!(
+            arch.needs_lin_caches(),
+            "{model} must carry recurrent state or this test proves nothing"
+        );
 
-            let (_kv, replayed) = tape_replay_run(
-                &arch,
-                TAPE_REPLAY_PROMPT,
-                &[round.get(..kept).expect("kept prefix")],
-                false,
-                device,
-            );
-            let agreement = tape_replay_rel_err(&refolded, &tape_replay_state(&replayed, device));
+        // What this model's own two regimes make of the same tokens: the round
+        // in one forward against the round stepped. It is the bound the refold
+        // is held to, because no rebuild of a prefix can be closer to a forward
+        // over that prefix than the model is to itself.
+        let (_kv, batched) = tape_replay_run(&arch, TAPE_REPLAY_PROMPT, &[round], false, device);
+        let (_kv, stepped) = tape_replay_run(&arch, TAPE_REPLAY_PROMPT, &per_token, false, device);
+        let regime = tape_replay_rel_err(
+            &tape_replay_state(&batched, device),
+            &tape_replay_state(&stepped, device),
+        );
+        eprintln!("[{NAME}/{model}] one forward against stepped: {regime:.6}");
 
-            let (_kv, off_by_one) = tape_replay_run(
-                &arch,
-                TAPE_REPLAY_PROMPT,
-                &[round.get(..kept - 1).expect("shorter prefix")],
-                false,
-                device,
-            );
-            let control = tape_replay_rel_err(&refolded, &tape_replay_state(&off_by_one, device));
+        for (shape, chunks) in [
+            ("one verify forward", vec![round]),
+            ("a forward per token", per_token.clone()),
+        ] {
+            for kept in 1..round.len() {
+                let (_kv, mut taped) =
+                    tape_replay_run(&arch, TAPE_REPLAY_PROMPT, &chunks, true, device);
+                refold_lin_tapes(&mut taped, round.len(), kept, false, device).expect("refold");
+                let refolded = tape_replay_state(&taped, device);
 
-            eprintln!(
-                "[{NAME}/{shape}] kept={kept} agreement={agreement:.6} \
-                 one-token-short={control:.6}"
-            );
-            assert!(
-                agreement <= 0.0,
-                "{shape} at kept={kept}: the refold and the replay of the same \
-                 {kept} tokens differ by {agreement}, and this comparison is exact \
-                 by construction"
-            );
-            assert!(
-                control > 0.0,
-                "{shape} at kept={kept}: the refold matches the replay of {} tokens \
-                 as well as the replay of {kept}, so this cell would pass whatever \
-                 the refold folded",
-                kept - 1
-            );
+                let (_kv, replayed) = tape_replay_run(
+                    &arch,
+                    TAPE_REPLAY_PROMPT,
+                    &[round.get(..kept).expect("kept prefix")],
+                    false,
+                    device,
+                );
+                let agreement =
+                    tape_replay_rel_err(&refolded, &tape_replay_state(&replayed, device));
+                let (_kv, off_by_one) = tape_replay_run(
+                    &arch,
+                    TAPE_REPLAY_PROMPT,
+                    &[round.get(..kept - 1).expect("shorter prefix")],
+                    false,
+                    device,
+                );
+                let control =
+                    tape_replay_rel_err(&refolded, &tape_replay_state(&off_by_one, device));
+
+                eprintln!(
+                    "[{NAME}/{shape}] kept={kept} agreement={agreement:.6} \
+                     one-token-short={control:.6}"
+                );
+                assert!(
+                    agreement <= regime,
+                    "{model}, {shape} at kept={kept}: the refold and the replay of the \
+                     same {kept} tokens differ by {agreement}, and this model \
+                     reproduces itself to {regime}"
+                );
+                assert!(
+                    agreement * 10.0 < control,
+                    "{model}, {shape} at kept={kept}: the refold is no nearer the replay \
+                     of {kept} tokens ({agreement}) than the replay of {} ({control}), \
+                     so this cell would pass whatever the refold folded",
+                    kept - 1
+                );
+            }
         }
     }
 }

--- a/crates/rmlx-models/src/speculative/tests.rs
+++ b/crates/rmlx-models/src/speculative/tests.rs
@@ -984,3 +984,578 @@ fn a_sampled_draw_is_neither_the_argmax_nor_irreproducible() {
         "four near-equal logits must reach more than two ids over sixty-four draws: {first:?}"
     );
 }
+
+// -- Round tape: the recurrent rollback's evidence ---------------------------
+
+/// A deterministic ramp, so every position of every taped buffer is distinct
+/// and a join that lands one position out is visible in the bytes.
+fn ramp(seed: f32, n: usize) -> Vec<f32> {
+    (0..n).map(|i| seed + i as f32 * 0.125).collect()
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: an Array this test just built from a slice of its own is present by construction, and the panic names it"
+)]
+fn tape_arr(seed: f32, shape: &[i32]) -> Array {
+    let n: i32 = shape.iter().product();
+    Array::from_f32_slice(&ramp(seed, n as usize), shape).expect("from_f32_slice")
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: an Array this test just built from a slice of its own is present by construction, and the panic names it"
+)]
+fn tape_bytes(a: &Array) -> Vec<u8> {
+    a.eval().expect("eval");
+    a.to_bytes().expect("to_bytes")
+}
+
+/// Shapes the recurrence kernel accepts: `Dk` a multiple of 32, `Hv` a multiple
+/// of `Hk`.
+const TAPE_HK: i32 = 1;
+const TAPE_HV: i32 = 2;
+const TAPE_D: i32 = 32;
+/// The depthwise conv1d's carried tail, `kernel - 1`.
+const TAPE_PAD: i32 = 3;
+const TAPE_CONV_DIM: i32 = 2;
+
+/// One taped forward over `len` positions, its arrays cut from a longer ramp
+/// starting at `from` so segments of one round line up end to end.
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: an Array this test just built from a slice of its own is present by construction, and the panic names it"
+)]
+fn tape_segment(from: usize, len: usize) -> GdnTapeSegment {
+    let pos = |seed: f32, per: i32| -> Array {
+        let per = per as usize;
+        let all = ramp(seed, (from + len) * per);
+        let shape_len = len as i32;
+        let tail = all.get(from * per..).expect("ramp covers the segment");
+        Array::from_f32_slice(tail, &[1, shape_len, per as i32]).expect("from_f32_slice")
+    };
+    let heads = |seed: f32, h: i32| -> Array {
+        let flat = pos(seed, h * TAPE_D);
+        flat.reshape(&[1, len as i32, h, TAPE_D], Device::Cpu)
+            .expect("reshape")
+    };
+    GdnTapeSegment {
+        q: heads(0.5, TAPE_HK),
+        k: heads(1.5, TAPE_HK),
+        v: heads(2.5, TAPE_HV),
+        g: pos(0.25, TAPE_HV),
+        beta: pos(0.75, TAPE_HV),
+        // The conv input opens with the `kernel - 1` positions carried in from
+        // the previous call, so a segment starting at `from` covers the global
+        // conv rows `from .. from + pad + len`.
+        conv_input: {
+            let per = TAPE_CONV_DIM as usize;
+            let rows = TAPE_PAD as usize + len;
+            let all = ramp(9.0, (from + rows) * per);
+            let tail = all.get(from * per..).expect("ramp covers the segment");
+            Array::from_f32_slice(tail, &[1, rows as i32, TAPE_CONV_DIM]).expect("from_f32_slice")
+        },
+        len,
+    }
+}
+
+/// The whole round as one segment, which is what the refold must reproduce
+/// from however many segments actually recorded it.
+fn tape_zero_state() -> Array {
+    tape_arr(0.0, &[1, TAPE_HV, TAPE_D, TAPE_D])
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: an Array this test just built from a slice of its own is present by construction, and the panic names it"
+)]
+fn armed(segments: Vec<GdnTapeSegment>, state_in: &Array) -> LinearAttnCache {
+    let mut cache = LinearAttnCache::new();
+    cache.arm_tape();
+    let tape = cache.tape.as_mut().expect("armed");
+    for (idx, seg) in segments.into_iter().enumerate() {
+        // Only the first forward starts from the round's state. Later forwards
+        // start where their predecessor ended, and a tape that kept one of
+        // those would refold from the wrong place — so they are handed a state
+        // no correct refold can produce.
+        let state = if idx == 0 {
+            state_in.try_clone().expect("clone round state")
+        } else {
+            tape_arr(7.0, &[1, TAPE_HV, TAPE_D, TAPE_D])
+        };
+        tape.push(&state, seg).expect("push");
+    }
+    cache
+}
+
+/// A layer whose tape was never armed cannot be rolled back, and says so rather
+/// than leaving the recurrent state where the rejected drafts left it.
+///
+/// This is the mutation that matters: without the check, the refold has nothing
+/// to fold and the obvious implementation leaves the state untouched — a silent
+/// no-op that reads as a successful rollback and produces wrong tokens with no
+/// error anywhere.
+#[test]
+fn refold_refuses_a_layer_whose_tape_was_never_armed() {
+    let mut lin = vec![armed(vec![tape_segment(0, 3)], &tape_zero_state())];
+    // The mutation: this round's arming never reached the layer.
+    let _ = lin.get_mut(0).map(LinearAttnCache::take_tape);
+
+    let err = refold_lin_tapes(&mut lin, 3, 2, false, Device::Cpu)
+        .err()
+        .map_or_else(String::new, |e| e.to_string());
+    assert!(
+        err.contains("recurrent layer 0 has no round tape"),
+        "an unarmed layer must be refused by name; got: {err:?}"
+    );
+}
+
+/// A tape that covers fewer positions than the round fed describes a different
+/// round, and refolding it would leave the recurrent state at a prefix the K/V
+/// stack beside it does not agree with.
+#[test]
+fn refold_refuses_a_tape_that_is_short_of_the_round() {
+    // The mutation: the round fed five positions across two forwards and only
+    // the first was recorded.
+    let mut lin = vec![armed(vec![tape_segment(0, 2)], &tape_zero_state())];
+
+    let err = refold_lin_tapes(&mut lin, 5, 3, false, Device::Cpu)
+        .err()
+        .map_or_else(String::new, |e| e.to_string());
+    assert!(
+        err.contains("taped 2 positions over 1 forwards but the round fed 5"),
+        "a short tape must be refused with both counts; got: {err:?}"
+    );
+}
+
+/// The offsets the caller passes have to describe the round it is rolling back.
+#[test]
+fn rollback_refuses_offsets_that_overrun_the_round() {
+    let mut lin = vec![armed(vec![tape_segment(0, 3)], &tape_zero_state())];
+    let err = rollback_round_caches(
+        &mut [],
+        Some(&mut lin),
+        &[1, 2, 3],
+        100,
+        105,
+        false,
+        Device::Cpu,
+    )
+    .err()
+    .map_or_else(String::new, |e| e.to_string());
+    assert!(
+        err.contains("retained prefix 5 exceeds the 3 tokens"),
+        "offsets that overrun the round must be refused; got: {err:?}"
+    );
+}
+
+/// A hybrid hands one recurrent slot per decoder layer, and most of them belong
+/// to full-attention layers. Those record nothing and hold no state, and the
+/// refold walks past them.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: an Array this test just built from a slice of its own is present by construction, and the panic names it"
+)]
+fn a_layer_that_holds_no_recurrence_is_walked_past() {
+    let state_in = tape_zero_state();
+    let mut lin = vec![
+        armed(vec![tape_segment(0, 3)], &state_in),
+        // A full-attention layer's slot: armed with the rest of the stack, and
+        // no forward ever came through it.
+        armed(vec![], &state_in),
+    ];
+
+    refold_lin_tapes(&mut lin, 3, 0, false, Device::Cpu).expect("refold");
+
+    let unused = lin.get(1).expect("two layers");
+    assert!(
+        unused.conv_state.is_none() && unused.delta_state.is_none(),
+        "a slot that holds no recurrence must be left alone, not given one"
+    );
+}
+
+/// A layer that DOES hold recurrent state and recorded nothing is the defect
+/// that skip must not swallow: its state advanced with the round and there is
+/// nothing to roll it back with.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: an Array this test just built from a slice of its own is present by construction, and the panic names it"
+)]
+fn a_recurrent_layer_that_recorded_nothing_is_still_refused() {
+    let state_in = tape_zero_state();
+    let mut lin = vec![armed(vec![], &state_in)];
+    // The mutation: the round advanced this layer's recurrence and the tape
+    // missed every forward that did it.
+    lin.get_mut(0).expect("one layer").delta_state = Some(tape_zero_state());
+
+    let err = refold_lin_tapes(&mut lin, 3, 1, false, Device::Cpu)
+        .err()
+        .map_or_else(String::new, |e| e.to_string());
+    assert!(
+        err.contains("taped 0 positions over 0 forwards but the round fed 3"),
+        "a recurrent layer with an empty tape must be refused; got: {err:?}"
+    );
+}
+
+/// A round that kept nothing goes back to the state it started from, and the
+/// conv tail goes back to the one the round carried in — with no kernel call,
+/// because there is nothing to fold.
+#[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: an Array this test just built from a slice of its own is present by construction, and the panic names it"
+)]
+fn refold_at_zero_kept_restores_what_the_round_started_from() {
+    let state_in = tape_zero_state();
+    let seg = tape_segment(0, 3);
+    let carried = seq_range(&seg.conv_input, 0, TAPE_PAD, Device::Cpu).expect("carried tail");
+    let mut lin = vec![armed(vec![seg], &state_in)];
+
+    refold_lin_tapes(&mut lin, 3, 0, false, Device::Cpu).expect("refold");
+
+    let cache = lin.first().expect("one layer");
+    assert_eq!(
+        tape_bytes(cache.delta_state.as_ref().expect("delta restored")),
+        tape_bytes(&state_in),
+        "a zero-kept refold must restore the pre-round recurrent state"
+    );
+    assert_eq!(
+        tape_bytes(cache.conv_state.as_ref().expect("conv restored")),
+        tape_bytes(&carried),
+        "a zero-kept refold must restore the conv tail the round carried in"
+    );
+    assert!(
+        cache.tape.is_none(),
+        "the refold consumes the tape it folded"
+    );
+}
+
+/// Refolding a one-forward tape at `kept` gives exactly the state a forward
+/// over `kept` positions would have left.
+///
+/// The recurrence is sequential in position, so the state after position `kept`
+/// does not depend on how many positions came after it — which is the whole
+/// reason the accepted prefix can be rebuilt from what the round already
+/// computed. Bytes, not a tolerance: same kernel, same inputs, same order.
+#[test]
+#[ignore = "requires Metal GPU context (gated_delta recurrence kernel)"]
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: an Array this test just built from a slice of its own is present by construction, and the panic names it"
+)]
+fn a_one_forward_tape_refolds_to_the_shorter_forward() {
+    let device = Device::Gpu;
+    let round = 5usize;
+    let state_in = tape_zero_state();
+
+    for kept in 1..=round {
+        let seg = tape_segment(0, round);
+        let want = {
+            let (_y, state) = crate::gated_delta_msl::gated_delta_step_gpu(
+                &seq_range(&seg.q, 0, kept as i32, device).expect("q"),
+                &seq_range(&seg.k, 0, kept as i32, device).expect("k"),
+                &seq_range(&seg.v, 0, kept as i32, device).expect("v"),
+                &seq_range(&seg.g, 0, kept as i32, device).expect("g"),
+                &seq_range(&seg.beta, 0, kept as i32, device).expect("beta"),
+                &state_in,
+                device,
+            )
+            .expect("reference recurrence");
+            state
+        };
+        let conv_want = seq_range(&seg.conv_input, kept as i32, kept as i32 + TAPE_PAD, device)
+            .expect("conv tail");
+
+        let mut lin = vec![armed(vec![tape_segment(0, round)], &state_in)];
+        refold_lin_tapes(&mut lin, round, kept, false, device).expect("refold");
+        let cache = lin.first().expect("one layer");
+
+        assert_eq!(
+            tape_bytes(cache.delta_state.as_ref().expect("delta")),
+            tape_bytes(&want),
+            "refold at kept={kept} must equal a forward over {kept} positions"
+        );
+        assert_eq!(
+            tape_bytes(cache.conv_state.as_ref().expect("conv")),
+            tape_bytes(&conv_want),
+            "refold at kept={kept} must leave the conv tail at that position"
+        );
+    }
+}
+
+/// The two-model draft rollback spans a forward per drafted token, so its tape
+/// accumulates. Refolding across the join must give the same state a single
+/// forward over the same positions would.
+///
+/// The prefix is walked over every `kept` in the round, so the case that lands
+/// exactly on a segment boundary and the ones either side are all covered — a
+/// join that took one position too many or too few from a segment moves the
+/// state and shows up here.
+#[test]
+#[ignore = "requires Metal GPU context (gated_delta recurrence kernel)"]
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: an Array this test just built from a slice of its own is present by construction, and the panic names it"
+)]
+fn an_accumulating_tape_refolds_across_its_segment_join() {
+    let device = Device::Gpu;
+    let (first, second) = (2usize, 3usize);
+    let round = first + second;
+    let state_in = tape_zero_state();
+    let whole = tape_segment(0, round);
+
+    for kept in 1..=round {
+        let want = {
+            let (_y, state) = crate::gated_delta_msl::gated_delta_step_gpu(
+                &seq_range(&whole.q, 0, kept as i32, device).expect("q"),
+                &seq_range(&whole.k, 0, kept as i32, device).expect("k"),
+                &seq_range(&whole.v, 0, kept as i32, device).expect("v"),
+                &seq_range(&whole.g, 0, kept as i32, device).expect("g"),
+                &seq_range(&whole.beta, 0, kept as i32, device).expect("beta"),
+                &state_in,
+                device,
+            )
+            .expect("reference recurrence");
+            state
+        };
+        let conv_want = seq_range(
+            &whole.conv_input,
+            kept as i32,
+            kept as i32 + TAPE_PAD,
+            device,
+        )
+        .expect("conv tail");
+
+        let mut lin = vec![armed(
+            vec![tape_segment(0, first), tape_segment(first, second)],
+            &state_in,
+        )];
+        refold_lin_tapes(&mut lin, round, kept, false, device).expect("refold");
+        let cache = lin.first().expect("one layer");
+
+        assert_eq!(
+            tape_bytes(cache.delta_state.as_ref().expect("delta")),
+            tape_bytes(&want),
+            "a two-segment refold at kept={kept} must equal one forward over {kept} positions"
+        );
+        assert_eq!(
+            tape_bytes(cache.conv_state.as_ref().expect("conv")),
+            tape_bytes(&conv_want),
+            "a two-segment refold at kept={kept} must leave the conv tail at that position"
+        );
+    }
+}
+
+// -- Round tape against the replay it replaced, on a real model --------------
+
+/// The hybrid the tape is checked on: a GDN stack whose recurrent layers are
+/// interleaved with full-attention ones, which is the shape that made the
+/// replay run the whole layer stack in the first place.
+const TAPE_REPLAY_SLUG: &str = "mlx-community__Qwen3.8-27B-4bit";
+
+/// The snapshot, or a named stand-down the GPU runner counts.
+fn tape_replay_model(test: &str) -> Option<std::path::PathBuf> {
+    let Some(root) = std::env::var_os("RMLX_O_MODELS_ROOT") else {
+        eprintln!("SKIP {test}: RMLX_O_MODELS_ROOT is not set");
+        return None;
+    };
+    let path = std::path::PathBuf::from(root).join(TAPE_REPLAY_SLUG);
+    if !path.join("config.json").exists() {
+        eprintln!("SKIP {test}: {TAPE_REPLAY_SLUG} is not under RMLX_O_MODELS_ROOT");
+        return None;
+    }
+    Some(path)
+}
+
+/// A fresh unquantized cache stack, so nothing between the two arms differs but
+/// the way the recurrent state got where it is.
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: a cache stack sized from the model just loaded is present by construction, and the panic names it"
+)]
+fn tape_replay_stack(arch: &Architecture) -> (Vec<KvCache>, Vec<LinearAttnCache>) {
+    let n = arch.num_hidden_layers();
+    (
+        (0..n).map(|_| KvCache::with_quant(KvQuant::None)).collect(),
+        (0..n).map(|_| LinearAttnCache::new()).collect(),
+    )
+}
+
+/// Every recurrent buffer in the stack, read back as f32 in layer order.
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: an Array the model just wrote is present by construction, and the panic names it"
+)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "Mutex critical section is panic-free, so PoisonError is structurally unreachable; remaining Option/Result unwrap is on values established by construction earlier in this fn"
+)]
+fn tape_replay_state(lin: &[LinearAttnCache], device: Device) -> Vec<f32> {
+    let mut out = Vec::new();
+    for cache in lin {
+        for buf in [&cache.delta_state, &cache.conv_state]
+            .into_iter()
+            .flatten()
+        {
+            let f32_buf = buf.astype(Dtype::F32, device).expect("astype f32");
+            f32_buf.eval().expect("materialise");
+            out.extend(
+                f32_buf
+                    .to_bytes()
+                    .expect("to_bytes")
+                    .chunks_exact(4)
+                    .map(|b| f32::from_le_bytes(b.try_into().unwrap())),
+            );
+        }
+    }
+    out
+}
+
+/// Largest elementwise difference over the larger magnitude, which is the
+/// comparison a bf16 activation path admits.
+fn tape_replay_rel_err(a: &[f32], b: &[f32]) -> f64 {
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "two states of the same stack differ in size"
+    );
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| {
+            let scale = x.abs().max(y.abs()).max(1e-6);
+            f64::from((x - y).abs() / scale)
+        })
+        .fold(0.0_f64, f64::max)
+}
+
+/// Twenty-odd deterministic ids well inside any vocabulary. The values do not
+/// matter; that both arms see the same ones does.
+const TAPE_REPLAY_PROMPT: &[u32] = &[
+    2, 9707, 11, 1879, 13, 576, 6722, 315, 9625, 374, 12095, 13, 576, 6722, 315, 6323, 374, 26867,
+    13,
+];
+/// The round's own tokens: a verify block's worth.
+const TAPE_REPLAY_ROUND: &[u32] = &[785, 6722, 315, 15236, 374];
+
+/// Advance a stack over `tokens` the way a round's forwards do, and hand back
+/// the recurrent state the round leaves.
+///
+/// `chunks` is how the round split those tokens between forwards: one chunk for
+/// a verify block, one chunk per drafted token for a two-model drafter. An empty
+/// chunk is a round that advanced nothing, which is the control at `kept == 1`.
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: a forward over ids this test chose is expected to succeed, and the panic names it"
+)]
+fn tape_replay_run(
+    arch: &Architecture,
+    prompt: &[u32],
+    chunks: &[&[u32]],
+    arm_tapes: bool,
+    device: Device,
+) -> (Vec<KvCache>, Vec<LinearAttnCache>) {
+    let (mut kv, mut lin) = tape_replay_stack(arch);
+    arch.forward_seq_last_k_with_cache(prompt, 1, &mut kv, Some(&mut lin), device)
+        .expect("prefill");
+    if arm_tapes {
+        arm_lin_tapes(Some(&mut lin));
+    }
+    for chunk in chunks.iter().filter(|c| !c.is_empty()) {
+        arch.forward_seq_last_k_with_cache(chunk, 1, &mut kv, Some(&mut lin), device)
+            .expect("round forward");
+    }
+    (kv, lin)
+}
+
+/// The tape rebuilds the state the replay used to rebuild, on a real recurrent
+/// stack — for a round taken as one verify forward, and for one taken as a
+/// forward per token.
+///
+/// The replay arm is what this change removed: restore the pre-round state and
+/// run the accepted prefix through the whole layer stack. It is reproduced here
+/// as a second stack prefilled identically and advanced over the accepted prefix
+/// alone, which is the same computation.
+///
+/// **Bit-equality, and it is structural.** The projections the recurrence
+/// consumes reduce over the hidden dimension and not over the sequence, and the
+/// recurrence kernel walks positions in order, so what a forward computed at a
+/// position does not depend on how many positions followed it. Measured that
+/// way on this model at every accepted length and both shapes. The control
+/// beside it is what says the comparison has power: the same refold against the
+/// replay one token short of the accepted length, which a refold that folded the
+/// wrong number of positions would match instead.
+#[test]
+#[ignore = "requires Metal GPU context and a 27B snapshot"]
+#[allow(
+    clippy::expect_used,
+    reason = "test-only: a model this test has already checked for existence but cannot load is a broken checkout, and the panic names it"
+)]
+#[allow(
+    clippy::print_stderr,
+    reason = "test-only: stand-down notice and the measured agreement, both read by the operator"
+)]
+fn a_round_tape_refolds_to_what_the_replay_produced() {
+    const NAME: &str = "a_round_tape_refolds_to_what_the_replay_produced";
+    let Some(path) = tape_replay_model(NAME) else {
+        return;
+    };
+    let device = Device::Gpu;
+    let arch = load_model(&path, device, &LoadOpts::default()).expect("load verifier");
+    assert!(
+        arch.needs_lin_caches(),
+        "{TAPE_REPLAY_SLUG} must carry recurrent state or this test proves nothing"
+    );
+
+    let round = TAPE_REPLAY_ROUND;
+    let per_token: Vec<&[u32]> = round.iter().map(std::slice::from_ref).collect();
+
+    for (shape, chunks) in [
+        ("one verify forward", vec![round]),
+        ("a forward per token", per_token),
+    ] {
+        for kept in 1..round.len() {
+            let (_kv, mut taped) =
+                tape_replay_run(&arch, TAPE_REPLAY_PROMPT, &chunks, true, device);
+            refold_lin_tapes(&mut taped, round.len(), kept, false, device).expect("refold");
+            let refolded = tape_replay_state(&taped, device);
+
+            let (_kv, replayed) = tape_replay_run(
+                &arch,
+                TAPE_REPLAY_PROMPT,
+                &[round.get(..kept).expect("kept prefix")],
+                false,
+                device,
+            );
+            let agreement = tape_replay_rel_err(&refolded, &tape_replay_state(&replayed, device));
+
+            let (_kv, off_by_one) = tape_replay_run(
+                &arch,
+                TAPE_REPLAY_PROMPT,
+                &[round.get(..kept - 1).expect("shorter prefix")],
+                false,
+                device,
+            );
+            let control = tape_replay_rel_err(&refolded, &tape_replay_state(&off_by_one, device));
+
+            eprintln!(
+                "[{NAME}/{shape}] kept={kept} agreement={agreement:.6} \
+                 one-token-short={control:.6}"
+            );
+            assert!(
+                agreement <= 0.0,
+                "{shape} at kept={kept}: the refold and the replay of the same \
+                 {kept} tokens differ by {agreement}, and this comparison is exact \
+                 by construction"
+            );
+            assert!(
+                control > 0.0,
+                "{shape} at kept={kept}: the refold matches the replay of {} tokens \
+                 as well as the replay of {kept}, so this cell would pass whatever \
+                 the refold folded",
+                kept - 1
+            );
+        }
+    }
+}

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -35,7 +35,7 @@ dropped; callers import the items directly from `rmlx_kv_quant`:
 | `KvQuant`, `KvQuantParseError`             | `rmlx_kv_quant::quant`                       |
 | `KV_MAX_SEQ_DEFAULT`                       | `rmlx_kv_quant::quant`                       |
 | `KvCache`                                  | `rmlx_kv_quant::kvcache`                     |
-| `LinearAttnCache`                          | `rmlx_kv_quant::linear_attn`                 |
+| `LinearAttnCache`, `GdnTape`, `GdnTapeSegment` | `rmlx_kv_quant::linear_attn`             |
 | `KvStorage`, `QuantK`, `QuantV`, `QuantPlanarV` | `rmlx_kv_quant::storage`                |
 | `MixedKvState`, `MixedTuple`               | `rmlx_kv_quant::mixed_quant`                 |
 | `PagedKStorage`, `PagedVStorage`, `PagedPlanarVStorage`, `install_paged_kv`, `resolve_paged_kv`, `resolve_paged_kv_page_tokens` | `rmlx_kv_quant::paged` |

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1419,8 +1419,8 @@ Properties:
   (e.g. 5 layers for Qwen3.6-MoE), projects the concatenation `5H → H` through
   the drafter `fc`.
 - **Adaptive block size.** Grows/shrinks based on acceptance history.
-- **GDN-aware rollback.** Snapshot/restore of `LinearAttnCache` + prefix replay
-  on partial acceptance.
+- **GDN-aware rollback.** A round tape over the `LinearAttnCache` stack, refolded
+  over the accepted prefix on partial acceptance.
 - **YARN RoPE** in the drafter layers (required for numeric alignment).
 - Target verifier: `Qwen3_5Moe` (`Architecture::forward_verify_capture`,
   `embed_tokens_raw`, `logits_from_hidden`).
@@ -1450,7 +1450,7 @@ Properties:
   concatenated hidden and the final RMSNorm'd hidden in one cached pass;
   `hot_logits_from_final_hidden` then computes restricted-vocab logits against
   only the `hot_ids` rows of the LM head.
-- **GDN rollback** reuses `DFlashRoundState` infrastructure.
+- **GDN rollback** reuses the shared round tape (`GdnTape`).
 - Target verifier: `Qwen3_5Moe`.
 - Status: reference-alignment pass complete (three structural divergences from
   mlx-vlm patched). Measured accept rate 0.263-0.362 against the

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -88,9 +88,9 @@ caches with `KvCache::truncate_to`-based rollback on partial acceptance. This
 cuts per-round verifier cost from O(prompt\_len) to O(K).
 
 For hybrid architectures (Qwen3.5/3.6-MoE) that carry a GatedDeltaNet (GDN)
-recurrent state in addition to the standard KV cache, rollback requires
-snapshot/restore rather than truncation, because the GDN state has no sequence
-axis.
+recurrent state in addition to the standard KV cache, the recurrent half cannot
+be truncated — that state has no sequence axis — so it is rebuilt from a round
+tape instead. See § "One rollback, and the tape it rebuilds from".
 
 A round loop's rollback is not only about the store it can slice. A sliding-window
 layer's ring must give back the block tail it just wrote, and it can — see
@@ -126,7 +126,7 @@ ds = prompt[-1]   # draft seed
 
 # Per-round
 loop until n_tokens emitted:
-  if hybrid (GDN): snapshot_lin(verifier_lin), snapshot_lin(draft_lin)
+  if hybrid (GDN): arm_lin_tapes(verifier_lin), arm_lin_tapes(draft_lin)
 
   # Phase A — draft
   draft_tokens = draft.decode_n(ds, K, draft_caches, draft_lin)
@@ -146,9 +146,9 @@ loop until n_tokens emitted:
   # Phase D — cache rollback (one helper, both sides)
   v_drop = K - accept          # positions to discard from verifier cache
   d_drop = max(K - accept - 1, 0)
-  rollback_round_caches(verifier, verifier_caches, verifier_lin, verifier_lin_snap,
+  rollback_round_caches(verifier_caches, verifier_lin,
                         v_input, v_pre_round_offset, offset - v_drop)
-  rollback_round_caches(draft, draft_caches, draft_lin, draft_lin_snap,
+  rollback_round_caches(draft_caches, draft_lin,
                         d_fed, d_pre_round_offset, offset - d_drop)
 
   if accept == K:
@@ -260,18 +260,20 @@ numbers:
   sidecar loop used to close its span on the unevaluated forward and re-derive
   the LM head position by position afterwards, which put most of the verify
   forward into the residual and made the two loops' residuals incomparable.
-- **Uncharged, the drafter's span pays for the round before it.** The rollback
-  replay's output is discarded, the trimmed K/V and the extended conditioning
-  are not read until the next round drafts, and the drafter is the first thing
-  to block on any of them — so a partial-accept round's second weight read lands
-  in the *next* round's `draft_ms`. Measured on the three loops below.
+- **Uncharged, the drafter's span pays for the round before it.** The rollback's
+  rebuilt recurrent state, the trimmed K/V and the extended conditioning are not
+  read until the next round drafts, and the drafter is the first thing to block
+  on any of them — so a partial-accept round's rollback lands in the *next*
+  round's `draft_ms`. The figures below were measured when that rollback was a
+  second full read of the verifier's weights; the effect is the same shape now
+  and much smaller.
 
 Per-round attribution comes from the `speculative round` event, target
 `rmlx::spec::phase`, one per round at `debug`, emitted by one shared
 `RoundPhases::log` so the three loops cannot drift into three record shapes:
 
 ```
-loop_kind round accept num_draft replayed charged
+loop_kind round accept num_draft refolded charged
 round_ms draft_ms verify_ms walk_ms rollback_ms other_ms
 ```
 
@@ -279,7 +281,7 @@ round_ms draft_ms verify_ms walk_ms rollback_ms other_ms
 host bookkeeping. The four phases are disjoint sub-spans of the round, so
 claiming more than the round has means a timer started outside it — that is an
 `error!` naming the phases rather than an `other_ms` near zero that reads like
-rounding. `replayed` says whether that round took the GDN replay arm of
+rounding. `refolded` says whether that round took the recurrent arm of
 `rollback_round_caches`.
 
 `charged` is the field that says how to read the rest. At `debug` the phases are
@@ -296,8 +298,8 @@ charged run's `round_ms` against an uncharged one's before trusting either.
 record.** `phases_charged()` is read at the loop head and passed down — to
 `rollback_round_caches` as an argument, and onto `RoundStats::charged`, which
 every loop's `done` line carries. Two things depend on that.
-`rollback_round_caches` is shared by seven loops and only three of them time
-their phases; a switch it read on its own behalf would change how the other four
+`rollback_round_caches` is shared by eight call sites across seven loops and
+only three of those loops time their phases; a switch it read on its own behalf would change how the other four
 schedule work, with nothing on their records saying so — they pass `false` and
 report `charged=false`.
 
@@ -368,14 +370,15 @@ the uncharged ratio *overstated* that gap. It understates it, and by more than
 the gap the two loops were being compared on.
 
 **The mechanism, isolated within one run.** Group a round's `draft_ms` by
-whether the *previous* round took the rollback replay. Uncharged, DFlash 2
-drafts for 24.09 ms after a replay against 20.33 ms after a full accept, and the
-sidecar 8.55 against 4.12 — the previous round's replay, paid inside this
-round's drafting. Charged, those differences are 0.35 ms and 0.004 ms. The
-comparison is between two figures from one run, so it does not depend on the
-host being quiet. The assistant loop is full attention and replayed on none of
-its 114 rounds, which is why its gap is the smallest of the three and is the
-K/V trim rather than a replay.
+whether the *previous* round rolled back. Uncharged, DFlash 2 drafted for
+24.09 ms after a rollback against 20.33 ms after a full accept, and the sidecar
+8.55 against 4.12 — the previous round's rollback, paid inside this round's
+drafting. Charged, those differences are 0.35 ms and 0.004 ms. The comparison is
+between two figures from one run, so it does not depend on the host being quiet.
+The assistant loop is full attention and rolled back its K/V tail on none of its
+114 rounds, which is why its gap is the smallest of the three. These readings
+predate the tape: the rollback they group by was the layer-stack replay, so the
+gap they show is an upper bound on what the same grouping would show now.
 
 **Three omissions in the charge, each now inside that check.** The MTP sidecar
 charged its rollback and never its capture: before that was fixed, a charged run's
@@ -476,7 +479,7 @@ gates both the FFN-shape probe and the greedy-tracking property. The round-loop
 round-0 penultimate-hidden + first-bonus capture → per-round autoregressive
 `draft_n` (RoPE offset = sidecar `_next_position` = verifier prefix length +
 appended count) → one combined verify forward → `accept_prefix` walk over the
-verifier's own argmax → emit → GDN snapshot/restore verifier-KV rollback +
+verifier's own argmax → emit → recurrent refold + verifier-KV truncation +
 sidecar-KV `truncate_to` on partial acceptance.
 
 `draft_n` proposes `block_size - 1` tokens but only ever feeds back `block_size - 2`
@@ -499,42 +502,53 @@ so a default would load a top-8 checkpoint at top-1 and show up only as a quietl
 worse accept rate. It is carried as an `Option` and refused by name in the MoE
 branch of `MtpLayer::load`, which is the only branch that reads it.
 
-The GDN half of that rollback is not a truncation: the recurrent state has no
-sequence axis, so it is restored from a pre-round snapshot and **replayed** over
-the kept prefix. That replay runs the whole layer stack, and on this hybrid the
-full-attention layers sit between GDN layers — layer 3's output is the residual
-layers 4-6 consume. It therefore replays through the **real** KV caches, rolled
-back to the pre-round offset first, so the FA layers attend their true prefix at
-their true positions and land back on `v_target`. Replaying through a fresh
-scratch KV stack instead makes those FA layers attend a `v_kept`-token prefix at
-positions `0..v_kept`, and every downstream GDN layer advances on a wrong
-hidden.
+#### One rollback, and the tape it rebuilds from
 
-Every round loop that can partially accept goes through **one** implementation of
-this — `speculative::rollback_round_caches`. It owns the whole rollback: the
-full-attention `truncate_to` loop, the GDN snapshot restore, and the replay.
-A full-attention arch (`lin` absent or empty) takes its short arm and truncates
-straight to the target; a GDN hybrid takes the replay arm. Its seven callers are
-`mtp_generate`, `dflash_generate`, `eagle3_generate`, and
-the classic two-model loop's four (verifier + drafter, greedy + stochastic).
-There is deliberately no second copy: the defect below lived in four independent
+The GDN half of that rollback is not a truncation: the recurrent state has no
+sequence axis to slice. It is rebuilt instead, from a **round tape** the loop
+arms before its forwards.
+
+While a tape is armed, every GDN layer records the recurrence inputs it built —
+the normalised and scaled q and k, v, the per-position decay and update weight,
+and the depthwise-conv1d input with its carried tail — together with the state
+the round started from. Those inputs are causal and per-position: what the
+forward computed at position `i` does not depend on any position after it, so
+they are the same values a shorter forward would have produced. When the round is
+partly rejected the accepted prefix is folded back through the recurrence kernel
+alone, reading no weights and taking no second forward, and the full-attention
+K/V is truncated straight to the target the way it is on a full-attention arch.
+
+A round is not always one forward. A two-model loop's drafter takes one forward
+per drafted token and rolls back across the lot of them, so a tape accumulates
+segments in call order and the prefix to refold may span several; the pre-round
+state is recorded once, at the first. `GdnTape` in
+`crates/rmlx-kv-quant/src/linear_attn.rs` holds both shapes.
+
+Every round loop that can partially accept goes through **one** implementation —
+`speculative::rollback_round_caches`. A full-attention arch (`lin` absent or
+empty) truncates and stops; a GDN hybrid also refolds. Its eight call sites are
+`mtp_generate`, `dflash_generate`, `dflash2_generate`, `eagle3_generate`,
+`mtp_assistant_generate` (full attention, so truncation only) and the classic
+two-model loop's three recurrent ones — greedy verifier, greedy drafter and
+stochastic verifier — plus the stochastic drafter. There is deliberately no
+second copy: the defect the replay was written to fix lived in four independent
 implementations at once, and a rollback inlined per loop is how it got there.
 
-Measured, greedy, temp=0, one plain-greedy arm per pair (`common prefix` from the
-alignment suites in `crates/rmlx-models/tests/`), scratch-stack replay vs
-real-cache replay:
+The refold is checked against the replay it replaced —
+`a_round_tape_refolds_to_what_the_replay_produced` in
+`crates/rmlx-models/src/speculative/tests.rs` — on a dense hybrid and a mixture
+one, for a round taken as one verify forward and one taken as a forward per
+token. On the dense hybrid the two agree bit for bit at every accepted length.
+On the mixture they agree to about 2-4% relative, which is that stack's own
+disagreement between computing the round in one forward and stepping it: the
+test measures that disagreement in the same process and holds the refold to it,
+rather than to a constant.
 
-| Round loop | Pair | Scratch stack | Real caches |
-|---|---|---|---|
-| MTP sidecar | Qwen3.8-27B + its MTP sidecar | 4 / 31 | 31 / 31 |
-| EAGLE-3 | Qwen3.6-35B-A3B + specdrift eagle3 | 13 / 96 | 93 / 96 |
-| Two-model | Qwen3.8-27B + ornith-1.0-9b | 17 / 96 | 96 / 96 |
-
-The corrupted arm also degenerated into a repetition loop on longer prompts. The
-remaining flips in the correct arms are ordinary near-ties — the verify pass
-scores a whole block in one forward, which is a different reduction order from a
-one-token-at-a-time decode — which is why those gates assert a threshold and not
-bit-identity.
+That difference is worth knowing when reading an equivalence run on a mixture
+verifier. Recomputing the accepted prefix put its committed state in the stepped
+regime; keeping what the round computed puts it in the batched one, which is the
+regime the emitted tokens were chosen in and the one a fully accepted round has
+always been in.
 
 The classic two-model loop needed one more thing to reach the rollback at all: it
 read the pre-round offset from `caches[0]`, and on a GDN hybrid layer 0 is a
@@ -630,10 +644,10 @@ pinned by a test that verifies `mscale = 1.4158...` and specific frequency
 values against the mlx-lm reference output.
 
 **GDN-aware rollback.** The Qwen3.6-MoE verifier carries GDN (GatedDeltaNet)
-recurrent layers in addition to its KV cache. On partial acceptance,
-`DFlashRoundState::snapshot` captures all GDN layer states before the verify
-forward; `DFlashRoundState::restore` + a kept-prefix replay re-aligns the GDN
-state with the truncated KV cache.
+recurrent layers in addition to its KV cache. The loop arms a round tape on them
+before the verify forward, and on partial acceptance `rollback_round_caches`
+refolds the accepted prefix out of it to re-align the recurrent state with the
+truncated KV cache.
 
 **Accumulated conditioning context.** The drafter conditions on the
 accumulated verifier hidden across all rounds (equivalent to the Python
@@ -738,8 +752,8 @@ Dogacel checkpoint (it uses the configured block ceiling capped to the
 remaining budget). The DFlash adaptive schedule fires only when
 `adaptive_max_block_size` is present in the config.
 
-**GDN rollback.** Identical to the DFlash path: `DFlashRoundState::snapshot`
-before each verify forward, `restore` + kept-prefix replay on partial accept.
+**GDN rollback.** Identical to the DFlash path: a round tape armed before each
+verify forward, refolded over the accepted prefix on partial accept.
 
 Per-step trace is available via `RUST_LOG=rmlx_models::speculative::eagle3=trace`.
 
@@ -1001,13 +1015,12 @@ forward with `forward_seq_last_k_with_cache` discarding the returned logits;
 between chunks the KV cache state is flushed via `eval_prefill_state`. The
 `enter_prefill` / `exit_prefill` bracket optimises cache memory layout.
 
-GDN recurrent state is snapshotted before every draft round using
-`snapshot_lin`. On partial acceptance (`accept < K`), `rollback_round_caches`
-rolls the KV caches back to the pre-round offset, restores the pre-round GDN
-state, and re-runs the forward over the kept token prefix **through those same
-production caches** — which lands them on the truncated target and the GDN state
-byte-consistent with them. It must not be a throwaway scratch stack; see the
-partial-accept rollback section above for what that costs.
+A round tape is armed on the GDN recurrent state before every draft round with
+`arm_lin_tapes`, and dropped with `disarm_lin_tapes` when the round is fully
+accepted. On partial acceptance (`accept < K`), `rollback_round_caches` truncates
+the KV caches to the retained target and refolds the accepted prefix into the
+recurrent state from the tape — no second forward, and no weights read. See the
+partial-accept rollback section above.
 
 ## CLI
 
@@ -1452,28 +1465,28 @@ measuring it.
 **Those `draft ms` figures are upper bounds, and the sidecar's are the looser
 of the two.** Every row carries `charged=false`, which means each phase is timed
 but not forced, and this engine evaluates lazily, so the previous round's
-rollback replay and conditioning work are paid inside the next round's `draft
+rollback and conditioning work are paid inside the next round's `draft
 ms`. Both sidecar loops have that shape and the sidecar has it worse: § "What
 the charge moves, measured" prices the same two configurations charged, and the
 `draft ms` ratio between them goes from 3.1× to 4.5×. It was expected to go the
 other way, on the reasoning that this drafter's capture is
 `len(target_layer_ids) = 5` times as wide as the MTP sidecar's single hidden and
 so skews its column more. The capture is real but small — 1.51 ms per round on
-the sidecar; what dominates is the rollback replay, and the sidecar replays on
-73% of its rounds. Before optimising against this split, take it charged.
+the sidecar; what dominated was the rollback replay, and the sidecar rolled back
+on 73% of its rounds. Before optimising against this split, take it charged.
 
 Drafting costs 19.5–24.4 ms per round almost independently of block and of
 prompt, against the sidecar's 5.9–6.9 ms. Two costs the port does not pay down
 explain that floor: the forward re-projects the conditioning over as many rows as
 the drafter's window reaches back over (2047 here) every round rather than over
 the new rows only, and the drafter's 3.85 GB of bf16 weights are read every round.
-Removing the loop residual entirely — more than the remaining accepted-prefix
-replay work would do — takes the block-8 code round to 106.8 ms and 2.05×, and
-also bringing drafting to the sidecar's cost takes it to 90.6 ms and 2.42×. Both
-are computed from the rows above, not measured.
+Removing the loop residual entirely — more than removing the accepted-prefix
+replay would do — takes the block-8 code round to 106.8 ms and 2.05×, and also
+bringing drafting to the sidecar's cost takes it to 90.6 ms and 2.42×. Both are
+computed from the rows above, not measured.
 
-**The loop-overhead work is not landed** — its first half is, the accepted-prefix
-replay fix is not. Every number in this section was taken in that state.
+**Every number in this section was taken before the accepted-prefix replay was
+removed**, so the residual they price is the one the round tape sheds.
 
 Greedy losslessness holds through all of it: on the code prompt the plain arm,
 the block-5 arm and the block-8 arm return the same 429 characters under one
@@ -1708,7 +1721,7 @@ Qwen3.8-27B-4bit + MTP-4bit — GDN hybrid, plain step **30.77 ms** (32.5 t/s):
 | implied step cost vs plain | 1.39× | 1.89× |
 
 Gemma4-e4b-it-mxfp8 + E4B assistant — full attention, plain step **11.9 ms**
-(84 t/s), no recurrent state and so no replay:
+(84 t/s), no recurrent state and so no refold:
 
 | Phase | block 2 | block 6 |
 |---|---:|---:|
@@ -1721,14 +1734,17 @@ Gemma4-e4b-it-mxfp8 + E4B assistant — full attention, plain step **11.9 ms**
 
 Four things those say:
 
-- **The GDN replay is the sidecar loop's entire residual.** A partial-accept
-  round pays 31–32 ms for `rollback_round_caches`, a second full weight read of
-  the verifier; a full-accept round pays 0.027 ms. Everything else the residual
-  was ever suspected of — the 48-layer `LinearAttnCache` snapshot and restore,
-  the emission, the cache truncation — is 0.06 ms together.
-- **`kept` is never zero in these loops**, so the early return in
+- **The GDN replay was the sidecar loop's entire residual.** A partial-accept
+  round paid 31–32 ms for `rollback_round_caches`, a second full weight read of
+  the verifier; a full-accept round paid 0.027 ms. Everything else the residual
+  was ever suspected of — the 48-layer recurrent snapshot and restore, the
+  emission, the cache truncation — is 0.06 ms together. That replay is what the
+  round tape replaced; the table above is the measurement that scoped the work,
+  and the rows it attributes to the replay no longer describe the engine.
+- **`kept` is never zero in these loops**, so the zero-kept path in
   `rollback_round_caches` is unreachable from them and every partial round
-  replays. The retained prefix is `1 + accept`: the carry token is always kept.
+  rolls back. The retained prefix is `1 + accept`: the carry token is always
+  kept.
 - **Verifying one more position costs about a quarter of a plain step**, on both
   architectures: 7.27 ms against a 30.77 ms step on the 27B (0.236), 2.88 ms
   against an 11.9 ms step on e4b (0.242). A weight-bandwidth roofline says a
@@ -1757,11 +1773,12 @@ Four things those say:
   block 3 are the only two settings those pairs have, and 2 measured faster than
   3 on all three prompt classes for Qwen3.8-27B at both weight formats. The `block_size` field on the
   `mtp_generate: done` line reports the value actually used.
-- **The step cost the round loop pays is 1.39× a plain step at block 2 and 1.89×
-  at block 3** on Qwen3.8-27B-4bit, against 32.47 / 32.54 t/s no-drafter and
-  39.70 / 37.00 t/s with the sidecar. The split above says where the growth goes:
-  roughly half to the replay's rising partial-round fraction, roughly half to the
-  verify forward's per-position cost.
+- **The step cost the round loop paid was 1.39× a plain step at block 2 and
+  1.89× at block 3** on Qwen3.8-27B-4bit, against 32.47 / 32.54 t/s no-drafter
+  and 39.70 / 37.00 t/s with the sidecar. The split above says where the growth
+  went: roughly half to the replay's rising partial-round fraction, roughly half
+  to the verify forward's per-position cost. The first half is what the round
+  tape removes; these figures predate it and have not been re-measured.
 - **DFlash and EAGLE-3 are net decode losses on this verifier at every prompt
   class measured**, DFlash by 3-22% and EAGLE-3 by 26-39%. Both run correctly and
   accept real tokens; neither clears its own round-loop overhead.
@@ -1779,7 +1796,7 @@ Four things those say:
 ## See also
 
 - `docs/KV_CACHE.md` — KvCache asymmetric K/V quant, `truncate_to`, sliding
-  window cache, and `LinearAttnCache` GDN rollback.
+  window cache, and `LinearAttnCache` recurrent state.
 - `docs/MODELS.md` — architecture loading, `Architecture` trait surface, the
   verifier-side seams (`forward_verify_capture`, `forward_hidden_states_multi`,
   `embed_tokens_raw`, `hot_logits_from_final_hidden`).


### PR DESCRIPTION
Closes the remaining half of #496: the accepted-prefix replay.

## What it does

When a speculative round is partly rejected the recurrent state has to go back
to the accepted position, and it has no sequence axis to slice. Until now the
loop restored a pre-round snapshot and re-ran the accepted prefix through the
whole layer stack — a second full read of the model's weights, paid on every
partial round. The issue measures it at 12.7 ms per round at block 3 on the
4-bit 27B pair, and it is the whole of that loop's residual.

The inputs the recurrence consumes are causal and per-position, so the values a
shorter forward would have produced are the ones the forward already produced. A
round loop now arms a **tape** on each recurrent cache before its forwards; the
GDN layer records the recurrence inputs it built, and the rollback folds the
accepted prefix back through the recurrence kernel alone. No weights are read
and no second forward is taken.

The tape accumulates across forwards, which is what the two-model draft-side
rollback needs — that one spans a forward per drafted token, and its segments
are joined before the single kernel call.

With the state rebuilt rather than replayed, the K/V stack truncates straight to
the target on both arms. A windowed layer now only ever has to give back this
round's rejected tail, so recurrent state and a sliding-window layer stop being
mutually exclusive.

## Call sites

`rollback_round_caches` has eight call sites. Seven can reach recurrent state:
the MTP sidecar, DFlash, DFlash 2, EAGLE-3, and the two-model loop's verifier
and drafter sides in both the greedy and the stochastic loop. Six are served by
a tape built from one verify forward; the two draft-side ones accumulate. The
Gemma4 assistant is full attention and only truncates. `arch` and the round's
tokens are no longer needed for the recurrent arm, so the signature lost them.

## Deleted

`DFlashRoundState`, `LinearAttnCache::snapshot` / `restore_snapshot`, the
non-implementable `LinearAttnCache::truncate_to` placeholder that existed to
document the gap the tape now closes, and `snapshot_lin`.
`RoundPhases::replayed` becomes `refolded`.

## Correctness

**Against the replay it replaced, on real models.** A second stack, prefilled
identically and advanced over the accepted prefix alone, is the computation this
change removes. On `Qwen3.8-27B-4bit` the refold and that replay agree **bit for
bit** at every accepted length, for a round taken as one verify forward and for
one taken as a forward per token. On `Qwen3.6-35B-A3B-8bit` they agree to
0.020–0.037 relative, inside that stack's own 0.0416 disagreement between
computing the round in one forward and stepping it — which the test measures in
the same process and holds the refold to, rather than to a constant. The control
beside it — the same refold against the replay one token short — reads 0.53–0.76.

**Equivalence pairs, 6 prompts × 256 tokens per arm.** `spec_greedy_equivalence`
agrees on the assistant (Gemma4-e2b), recurrent (Qwen3.8-27B + MTP), block
(Qwen3.8-27B-4bit + DFlash 2), adaptive (Qwen3.6-35B-A3B + DFlash) and two-model
(Qwen3.8-27B + 27B-4bit) pairs. Four alignment suites pass on real pairs.

**Mutations.** Eight deliberate breakages, each checked against the case that
should catch it: a refold that leaves the state alone, a missing length guard, a
missing tape guard, a conv join that duplicates its carried rows, a prefix that
takes whole segments, and three ways of using a one-shot tape where the round
needs an accumulating one — keeping the last forward's state instead of the
first, stopping the prefix at the first segment, and dropping the conv join. The
last three leave the one-forward shape exact and break the per-token one, which
is the separation the accumulating case needed.

**Guards.** A layer whose tape was never armed, a tape covering fewer positions
than the round fed, offsets that do not describe the round, and a recurrent
layer that recorded nothing — the last separated from a full-attention layer's
unused slot by whether it holds recurrent state. Each test asserts its own
reason rather than an exit code.

## Two things this measurement found, neither introduced here

**A mixture verifier does not reproduce itself across forward lengths.** On
`Qwen3.6-35B-A3B-8bit` one forward over five tokens and the same tokens stepped
one at a time disagree by 1.1–3.0% relative on the logits, enough to flip an
argmax at one of five positions. On `Qwen3.8-27B-4bit` they are bit-identical.
That is a property of the mixture stack and is present on `main`. It matters
here because the old rollback recomputed the accepted prefix in the stepped
regime while the tape keeps the batched one — the regime the emitted tokens were
chosen in, and the one a fully accepted round has always been in.

**The EAGLE-3 equivalence gate refuses on this branch, and the field that
explains it is already in its own output.** `the_restricted_vocab_round_loop_reproduces_plain_greedy`
passes on `main` (divergence at token 25, `divergence_unnameable=false`,
confidence 0.0234) and refuses here (divergence at token 100,
`divergence_unnameable=true`, confidence 0.2617 against a 0.12 ceiling). The arm
tracks plain greedy *longer* than `main`'s does — lcs 0.6523 against 0.6016 —
and then parts at a position where the drafter's restricted vocabulary cannot
name the verifier's own token, which is the declared inexactness that pair
documents and no other pair here has. The gate computes `divergence_unnameable`
and prints it; its verdict does not read it.

I have deliberately not touched the gate's ceiling or its verdict rule — making
a gate green by changing what it calls a pass is the failure mode, not the fix.
This needs an owner decision: either the restricted-vocabulary pair's verdict
should read the field it already computes, or the change is accepted and that
cell re-calibrated.

## Not measured

No performance number was taken. The owner reserved this machine's performance
measurement for a quiet host. What should be measured, and against what: the
per-round split at `RUST_LOG=info,rmlx::spec::phase=trace` on Qwen3.8-27B-4bit +
MTP-4bit, code prompt, 200 tokens, block 2 and block 3, against the rows in
docs/SPECULATIVE.md § "Where a round's time actually goes" — specifically that
the `rollback` row on the rounds that take it falls from ~31–32 ms to the
kernel-only cost, and what that does to the round total and the implied step
cost. The issue projects ~1.56× on that pair before #516.
