### PR TITLE
spec: the declared vocabulary boundary is read, not refused

### DIFF
--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -780,7 +780,37 @@ impl Eagle3Drafter {
 // Round-loop
 // ---------------------------------------------------------------------------
 
+/// Which vocabulary decided one emitted token.
+///
+/// The verify pass takes its argmax over the drafter's reduced target ids at
+/// every position it may accept, and over the verifier's whole vocabulary at
+/// the round's correction and at the prefill seed. The two argmaxes are the
+/// same token exactly when the verifier's own choice is one the drafter can
+/// name, so this is the only thing that says whether the restriction could have
+/// changed a token — and the token stream cannot express it.
+#[allow(
+    clippy::exhaustive_enums,
+    reason = "closed two-valued distinction: a verify position is scored over the drafter's ids or over the verifier's, and there is no third vocabulary"
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecidedBy {
+    /// The drafter's reduced vocabulary — an accepted draft token. It differs
+    /// from the verifier's own argmax exactly when that argmax is a token the
+    /// drafter cannot name.
+    RestrictedVocab,
+    /// The verifier's whole vocabulary — a round's correction, the prefill
+    /// seed, or any position of a request that does not take the restricted
+    /// read-back at all. The restriction cannot have changed this token.
+    FullVocab,
+}
+
 /// EAGLE-3 speculative-decoding round-loop (greedy / temp=0).
+///
+/// `decided_by` is filled with one [`DecidedBy`] per emitted token, in
+/// emission order, and is cleared first. A caller that only wants the tokens
+/// passes a scratch vector; the answer-equivalence gate reads it, because
+/// whether the restriction could have changed a token is a property of the
+/// round the token came out of and not of the token.
 ///
 /// Port of `_eagle3_rounds` (mlx-vlm), now with correctness fixes:
 ///
@@ -816,10 +846,13 @@ pub fn eagle3_generate(
     max_ctx_override: Option<i32>,
     eos_ids: &[u32],
     step_fn: &mut dyn FnMut(&ProbeStep) -> Option<u32>,
+    decided_by: &mut Vec<DecidedBy>,
     sampler_cfg: &crate::sampler::SamplerConfig,
     device: Device,
 ) -> Result<Vec<ProbeStep>> {
     use std::time::Instant;
+
+    decided_by.clear();
 
     if prompt_ids.len() < 2 {
         return Err(Error::Model(
@@ -870,6 +903,10 @@ pub fn eagle3_generate(
     drafter.reset(max_seq);
 
     let mut draw = super::VerifierDraw::new(sampler_cfg);
+    // Whether this request takes the restricted-vocabulary read-back at all. A
+    // sampled one cannot, so every position it emits is decided over the whole
+    // vocabulary.
+    let hot_path = drafter.hot_path_active() && !draw.sampling();
 
     let mut total_draft = 0usize;
     let mut total_accept = 0usize;
@@ -944,6 +981,7 @@ pub fn eagle3_generate(
     let prefill_ns = prefill_t0.elapsed().as_nanos();
 
     emit_step(tokenizer, b, step_fn, &mut emitted, &mut window);
+    decided_by.push(DecidedBy::FullVocab);
     if eos_ids.contains(&b) {
         // The stop token arrived before a round could run. The request still
         // happened, so it still leaves exactly one record.
@@ -978,7 +1016,7 @@ pub fn eagle3_generate(
         temperature = sampler_cfg.temperature,
         // A sampled request cannot take the restricted-vocabulary read-back, so
         // report whether this one did rather than whether the drafter offers it.
-        hot_path = drafter.hot_path_active() && !draw.sampling(),
+        hot_path,
         "eagle3_generate: starting (Qwen3.6-MoE verifier + EAGLE-3 drafter)"
     );
 
@@ -1041,7 +1079,7 @@ pub fn eagle3_generate(
         // only there. Sampled requests pay the full-vocabulary projection at
         // every verified position.
         let t0 = Instant::now();
-        let (v_tokens, v_hidden) = if drafter.hot_path_active() && !draw.sampling() {
+        let (v_tokens, v_hidden) = if hot_path {
             let (v_hidden, v_final_hidden) = verifier.forward_verify_capture_hot(
                 &v_input,
                 v_k,
@@ -1144,11 +1182,19 @@ pub fn eagle3_generate(
 
         // -- Emit accepted prefix + 1 correction/bonus. --
         let mut hit_eos = false;
-        for &id in &new_tokens {
+        for (i, &id) in new_tokens.iter().enumerate() {
             if emitted.len() >= n_tokens {
                 break;
             }
             emit_step(tokenizer, id, step_fn, &mut emitted, &mut window);
+            // `new_tokens[..accept]` are the draft's own tokens, which the
+            // restricted argmax confirmed; `new_tokens[accept]` is the
+            // correction, taken over the whole vocabulary.
+            decided_by.push(if hot_path && i < accept {
+                DecidedBy::RestrictedVocab
+            } else {
+                DecidedBy::FullVocab
+            });
             emitted_in_rounds += 1;
             if eos_ids.contains(&id) {
                 hit_eos = true;

--- a/crates/rmlx-models/tests/qwen3_5_eagle3_alignment.rs
+++ b/crates/rmlx-models/tests/qwen3_5_eagle3_alignment.rs
@@ -152,6 +152,7 @@ fn eagle3_greedy_tracks_plain_greedy_for_a_long_prefix() {
             spec_ids.push(s.token_id);
             None
         };
+        let mut decided_by = Vec::new();
         eagle3_generate(
             &verifier,
             &mut drafter,
@@ -163,6 +164,7 @@ fn eagle3_greedy_tracks_plain_greedy_for_a_long_prefix() {
             None,
             &eos,
             &mut step_fn,
+            &mut decided_by,
             &sampler_cfg,
             device,
         )

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -90,6 +90,22 @@
 //! and restricted-vocabulary pairs refuse a rollback off by one on all five
 //! prompts they judge, and the two-model pair on all six.
 //!
+//! # A declared boundary, and the only waiver
+//!
+//! EAGLE-3's verify pass scores every position it may accept over the drafter's
+//! reduced vocabulary, so where the verifier's own answer is a token that
+//! vocabulary cannot name the arm emits the drafter's argmax instead. That is
+//! upstream's design and no correct loop of this kind avoids it, so a divergence
+//! there is reported rather than refused.
+//!
+//! **Only there.** Widening the same inexactness to the round's correction
+//! changes an answer at exactly that kind of token — indistinguishable in the
+//! two token streams — and is refused. Which position the loop was at is the
+//! only thing that separates them, so the loop reports it per emitted token
+//! rather than the gate inferring it from the answer. [`Restriction`] carries
+//! the rule; `docs/SPEC_ANSWER_EQUIVALENCE.md` carries the measurements and
+//! `scripts/spec_broken_engine.sh` takes them again.
+//!
 //! # Pairs
 //!
 //! Six, whose verifiers resolve by slug from `RMLX_O_MODELS_ROOT`:
@@ -220,8 +236,11 @@ const MAX_CTX: i32 = 8192;
 /// The exception is the last row, and it is a property of the defect rather than
 /// of the ceiling: leaving the correction on the restricted argmax only changes
 /// an answer where that vocabulary falls short of the verifier's, which the
-/// runs measure at one to five tokens per answer. It is refused on one prompt of
-/// six, at 0.8828, at a position the drafter's vocabulary cannot name.
+/// runs measure at one to five tokens per answer. It is refused on one of the
+/// five prompts the gate judges, at 0.8828, at a token the drafter's vocabulary
+/// cannot name — and at the round's **correction**, which is the only thing that
+/// keeps it refused now the boundary at an accepted position is not. See
+/// [`Restriction`].
 const MAX_DIVERGENCE_CONFIDENCE: f64 = 0.12;
 
 /// The worst [`weakest_tail`] reading a **correct** pair reached over the prompts
@@ -1753,10 +1772,11 @@ const DFLASH1_PAIR: Pair = Pair {
 /// design boundary rather than a port defect — but it is still an answer change
 /// at temperature 0, which is what this gate reads.
 ///
-/// [`Loaded::outside_draft_vocab`] measures the exposure on every run: how many
-/// of the reference arm's own tokens the drafter's vocabulary cannot name. Each
-/// one is a position where the boundary could fire; none of them is a position
-/// where it must.
+/// [`Loaded::draft_vocab`] measures the exposure on every run: how many of the
+/// reference arm's own tokens the drafter's vocabulary cannot name — one to five
+/// per answer. Each is a position where the boundary could fire; none is a
+/// position where it must, because it fires only where the drafter also proposed
+/// the restricted argmax. [`Restriction`] is what the verdict does with that.
 const EAGLE3_PAIR: Pair = Pair {
     verifier: common::GoldenModel {
         slug: "mlx-community__Qwen3.6-35B-A3B-8bit",
@@ -2690,9 +2710,9 @@ fn the_adaptive_round_loop_reproduces_plain_greedy() {
 /// inexactness they do not: an accepted position is emitted as the draft's
 /// token, and the verifier's full-vocabulary argmax is computed at the
 /// correction position only. Where those two differ the arms differ, by design
-/// and in agreement with the upstream implementation. The run prints how many
-/// of the reference arm's tokens the drafter's vocabulary cannot name, which is
-/// the count of positions where that can happen at all.
+/// and in agreement with the upstream implementation, so a divergence there is
+/// reported rather than refused — but only there, and [`Restriction`] says why
+/// the position and not the token is what decides it.
 #[ignore]
 #[test]
 fn the_restricted_vocab_round_loop_reproduces_plain_greedy() {

--- a/crates/rmlx-models/tests/spec_greedy_equivalence.rs
+++ b/crates/rmlx-models/tests/spec_greedy_equivalence.rs
@@ -141,7 +141,7 @@ use rmlx_mlx::Device;
 use rmlx_models::arch;
 use rmlx_models::speculative::dflash::{dflash_generate, DFlashDrafter};
 use rmlx_models::speculative::dflash2::{dflash2_generate, DFlash2Drafter};
-use rmlx_models::speculative::eagle3::{eagle3_generate, Eagle3Drafter};
+use rmlx_models::speculative::eagle3::{eagle3_generate, DecidedBy, Eagle3Drafter};
 use rmlx_models::speculative::gemma4_assistant::{mtp_assistant_generate, Gemma4AssistantDrafter};
 use rmlx_models::speculative::mtp::{mtp_generate, MtpDrafter};
 use rmlx_models::{Declared, DraftKind, SpeculativeDispatcher};
@@ -426,15 +426,50 @@ fn weakest_tail(spec: &[u32], plain: &[u32]) -> (usize, f64) {
     worst
 }
 
+/// What a pair's loop could and could not have said at each of its positions.
+///
+/// Only the restricted-vocabulary pair builds one. Its verify pass emits the
+/// drafter's own argmax at a position it accepted, and that argmax is the
+/// verifier's exactly when the verifier's is a token the drafter can name — so
+/// a divergence at an accepted position whose reference token is unnameable is
+/// the declared boundary and could be nothing else. The round's correction is
+/// taken over the whole vocabulary, so a divergence there is a divergence like
+/// any other pair's and is judged like one.
+///
+/// **That distinction is the whole of the rule, and dropping it forgives the
+/// defect the pair exists to catch.** Widening the restriction to the
+/// correction as well changes an answer at exactly the same kind of token, so
+/// the two are indistinguishable in the token streams; what separates them is
+/// which position the loop was at, which only the loop knows.
+struct Restriction<'a> {
+    /// Target ids the drafter can name.
+    vocab: &'a std::collections::HashSet<u32>,
+    /// Which vocabulary decided each token of the speculative arm.
+    decided_by: &'a [DecidedBy],
+}
+
+impl Restriction<'_> {
+    /// Whether the declared boundary is what parted the arms at `at`.
+    fn explains(&self, at: usize, plain: &[u32]) -> bool {
+        self.decided_by.get(at) == Some(&DecidedBy::RestrictedVocab)
+            && plain.get(at).is_some_and(|id| !self.vocab.contains(id))
+    }
+
+    /// How many of the reference arm's own tokens the drafter cannot name.
+    fn unnameable(&self, plain: &[u32]) -> usize {
+        plain.iter().filter(|id| !self.vocab.contains(id)).count()
+    }
+}
+
 /// What one pair of arms says about the round loop.
 #[derive(Debug, PartialEq, Eq)]
 enum Verdict {
     /// The round loop reproduced what the verifier decodes alone.
     Agreed,
     /// The pair says nothing either way, and the reason is a property of the
-    /// prompt or the model rather than of the round loop. Reported, not failed:
-    /// a gate that turns red on an input it cannot read teaches its operator to
-    /// ignore it.
+    /// prompt, the model or the pair's own declared vocabulary rather than of
+    /// the round loop. Reported, not failed: a gate that turns red on an input
+    /// it cannot read teaches its operator to ignore it.
     Unjudgeable(String),
     /// The round loop did not reproduce plain greedy.
     Refused(String),
@@ -445,7 +480,15 @@ enum Verdict {
 /// `margins` is the reference arm's per-position top-two logprob gap, or empty
 /// when the caller has none — the synthetic fixtures below run that way, and the
 /// divergence oracle stands down rather than inventing a distribution.
-fn judge(spec: &[u32], plain: &[u32], margins: &[f32]) -> Verdict {
+///
+/// `restriction` is `None` for every pair whose loop scores each position over
+/// the verifier's whole vocabulary, which is all of them but one.
+fn judge(
+    spec: &[u32],
+    plain: &[u32],
+    margins: &[f32],
+    restriction: Option<&Restriction<'_>>,
+) -> Verdict {
     let shorter = spec.len().min(plain.len());
     let longer = spec.len().max(plain.len());
 
@@ -525,6 +568,16 @@ fn judge(spec: &[u32], plain: &[u32], margins: &[f32]) -> Verdict {
 
     if let Some((at, confidence)) = divergence_confidence(spec, plain, margins) {
         if confidence > MAX_DIVERGENCE_CONFIDENCE {
+            if restriction.is_some_and(|r| r.explains(at, plain)) {
+                return Verdict::Unjudgeable(format!(
+                    "the arms first differ at token {at}, which the round loop emitted from \
+                     the drafter's own argmax and where the verifier's answer is a token \
+                     the drafter's vocabulary cannot name — the declared restricted-\
+                     vocabulary boundary parted them and no correct loop of this kind could \
+                     have said anything else there, so this prompt says nothing about the \
+                     round loop"
+                ));
+            }
             return Verdict::Refused(format!(
                 "the arms first differ at token {at}, where the verifier was surer than \
                  {confidence:.4} of its own decisions on this answer (ceiling \
@@ -595,7 +648,7 @@ fn a_single_flip_passes_and_a_confident_flip_does_not() {
     let mut tied = vec![5.0f32; N_TOKENS];
     tied[66] = 0.01;
     assert!(
-        judge(&one_flip, &plain, &tied).refusal().is_none(),
+        judge(&one_flip, &plain, &tied, None).refusal().is_none(),
         "a flip at the arm's own least-confident decision must pass"
     );
 
@@ -604,7 +657,7 @@ fn a_single_flip_passes_and_a_confident_flip_does_not() {
         *m = 0.001;
     }
     confident[66] = 5.0;
-    let failure = judge(&one_flip, &plain, &confident)
+    let failure = judge(&one_flip, &plain, &confident, None)
         .refusal()
         .expect("must refuse");
     assert!(failure.contains("nearly tied"), "{failure}");
@@ -634,6 +687,157 @@ fn the_divergence_oracle_reads_the_first_differing_position_or_nothing() {
     // the length guard owns that pair.
     let extended: Vec<u32> = plain.iter().copied().chain([1_u32]).collect();
     assert_eq!(divergence_confidence(&extended, &plain, &tied), None);
+}
+
+/// One pair of arms parting at token 66, at a decision the verifier was sure
+/// about, with everything the restricted-vocabulary rule reads left to the
+/// caller: the reference token there, and which vocabulary decided the
+/// speculative one.
+///
+/// Every case below is this pair with one of those two moved, so the verdict is
+/// the only thing that can differ between them.
+fn restricted_case(
+    reference_token_nameable: bool,
+    decided: DecidedBy,
+) -> (
+    Vec<u32>,
+    Vec<u32>,
+    Vec<f32>,
+    std::collections::HashSet<u32>,
+    Vec<DecidedBy>,
+) {
+    let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
+    let mut spec = plain.clone();
+    spec[66] = 9999;
+
+    // Sure enough at token 66 that the confidence oracle refuses it: every other
+    // decision in the arm was a closer call than this one.
+    let mut margins = vec![0.01f32; N_TOKENS];
+    for m in margins.iter_mut().take(N_TOKENS / 3) {
+        *m = 0.001;
+    }
+    margins[66] = 5.0;
+
+    // The drafter names every id in play except, when the case asks for it, the
+    // reference arm's own token at the divergence. Two other reference tokens
+    // are unnameable throughout, so a rule that read the answer rather than the
+    // divergence would not tell the cases apart.
+    let mut vocab: std::collections::HashSet<u32> = plain.iter().copied().collect();
+    vocab.insert(9999);
+    vocab.remove(&12);
+    vocab.remove(&200);
+    if !reference_token_nameable {
+        vocab.remove(&66);
+    }
+
+    let mut decided_by = vec![DecidedBy::FullVocab; N_TOKENS];
+    decided_by[66] = decided;
+
+    (spec, plain, margins, vocab, decided_by)
+}
+
+/// The declared boundary: the loop emitted the drafter's own argmax at the
+/// position the arms parted on, and the verifier's answer there is a token that
+/// vocabulary cannot say. No correct loop of this kind could have said anything
+/// else, so the prompt is reported rather than refused.
+#[test]
+fn a_divergence_the_restricted_vocabulary_forced_is_not_a_refusal() {
+    let (spec, plain, margins, vocab, decided_by) =
+        restricted_case(false, DecidedBy::RestrictedVocab);
+    let verdict = judge(
+        &spec,
+        &plain,
+        &margins,
+        Some(&Restriction {
+            vocab: &vocab,
+            decided_by: &decided_by,
+        }),
+    );
+    assert!(verdict.refusal().is_none(), "{verdict:?}");
+    let Verdict::Unjudgeable(why) = &verdict else {
+        panic!("the boundary is not a statement about the round loop: {verdict:?}");
+    };
+    assert!(why.contains("cannot name"), "{why}");
+    assert!(why.contains("says nothing about the round loop"), "{why}");
+}
+
+/// **The mutation this rule has to survive.** Widening the same inexactness to
+/// the round's correction changes an answer at exactly the kind of token the
+/// boundary does — same reference token, same speculative token, same
+/// confidence — and the only thing that separates the two is the position the
+/// loop was at. A rule keyed on the token alone forgives it; this one refuses
+/// it, for the reason it refuses any other pair.
+#[test]
+fn the_same_divergence_at_the_correction_is_refused() {
+    let (spec, plain, margins, vocab, decided_by) = restricted_case(false, DecidedBy::FullVocab);
+    let failure = judge(
+        &spec,
+        &plain,
+        &margins,
+        Some(&Restriction {
+            vocab: &vocab,
+            decided_by: &decided_by,
+        }),
+    )
+    .refusal()
+    .expect("the correction reads the whole vocabulary, so the restriction cannot excuse it");
+    assert!(failure.contains("nearly tied"), "{failure}");
+}
+
+/// A divergence at a token the drafter could have named is judged the old way,
+/// wherever the loop was: the restricted argmax and the true one are the same
+/// token on the ids the drafter can name, so the restriction explains nothing
+/// there.
+#[test]
+fn a_divergence_the_drafter_could_have_named_is_judged_as_before() {
+    for decided in [DecidedBy::RestrictedVocab, DecidedBy::FullVocab] {
+        let (spec, plain, margins, vocab, decided_by) = restricted_case(true, decided);
+        let failure = judge(
+            &spec,
+            &plain,
+            &margins,
+            Some(&Restriction {
+                vocab: &vocab,
+                decided_by: &decided_by,
+            }),
+        )
+        .refusal()
+        .unwrap_or_else(|| panic!("a nameable divergence must still refuse, at {decided:?}"));
+        assert!(failure.contains("nearly tied"), "{failure}");
+
+        // And a pair that declares no reduced vocabulary reads the same pair the
+        // same way, which is what "judged as before" means.
+        let plain_rule = judge(&spec, &plain, &margins, None)
+            .refusal()
+            .expect("no restriction, no waiver");
+        assert_eq!(plain_rule, failure);
+    }
+}
+
+/// The waiver is scoped to the divergence oracle and reaches neither of the
+/// other two verdicts. A speculative arm that collapsed, or one that stopped
+/// early, is refused whatever the restriction would have said about where the
+/// arms part.
+#[test]
+fn the_boundary_excuses_no_other_refusal() {
+    let (_, plain, margins, vocab, decided_by) = restricted_case(false, DecidedBy::RestrictedVocab);
+    let restriction = Restriction {
+        vocab: &vocab,
+        decided_by: &decided_by,
+    };
+
+    let mut collapsed: Vec<u32> = plain[..66].to_vec();
+    collapsed.extend(std::iter::repeat_n([7_u32, 8].into_iter(), N_TOKENS).flatten());
+    collapsed.truncate(N_TOKENS);
+    let failure = judge(&collapsed, &plain, &margins, Some(&restriction))
+        .refusal()
+        .expect("a collapsed speculative arm is refused whatever parted the arms");
+    assert!(failure.contains("repetition loop"), "{failure}");
+
+    let failure = judge(&plain[..16], &plain, &margins, Some(&restriction))
+        .refusal()
+        .expect("a short speculative arm is refused whatever parted the arms");
+    assert!(failure.contains("stopped early"), "{failure}");
 }
 
 /// The oracle's own denominator: the confidence is a rank over the reference
@@ -710,7 +914,7 @@ fn every_shape_of_repetition_loop_is_refused() {
                 .collect(),
         ),
     ] {
-        let failure = judge(&stream, &healthy, &[])
+        let failure = judge(&stream, &healthy, &[], None)
             .refusal()
             .unwrap_or_else(|| panic!("{shape} was not refused"));
         assert!(failure.contains("repeats at period"), "{shape}: {failure}");
@@ -729,7 +933,7 @@ fn a_collapsed_reference_arm_is_reported_as_an_input_the_gate_cannot_judge() {
     let healthy: Vec<u32> = (0..N_TOKENS as u32).collect();
     let looping = vec![7u32; N_TOKENS];
 
-    let spec_side = judge(&looping, &healthy, &[]);
+    let spec_side = judge(&looping, &healthy, &[], None);
     let why = spec_side
         .refusal()
         .expect("a degenerate spec arm must be refused");
@@ -739,7 +943,7 @@ fn a_collapsed_reference_arm_is_reported_as_an_input_the_gate_cannot_judge() {
         "{why}"
     );
 
-    let plain_side = judge(&healthy, &looping, &[]);
+    let plain_side = judge(&healthy, &looping, &[], None);
     assert!(
         matches!(plain_side, Verdict::Unjudgeable(ref why) if why.contains("reference arm")),
         "a collapsed reference arm is an input the gate cannot read, not a \
@@ -753,12 +957,12 @@ fn a_collapsed_reference_arm_is_reported_as_an_input_the_gate_cannot_judge() {
 fn a_prompt_that_produced_no_answer_is_reported_rather_than_failed() {
     let short: Vec<u32> = Rng(0x5170_0000).prose(MIN_ANSWER_TOKENS - 1);
     assert!(
-        matches!(judge(&short, &short, &[]), Verdict::Unjudgeable(ref why) if why.contains("both arms")),
+        matches!(judge(&short, &short, &[], None), Verdict::Unjudgeable(ref why) if why.contains("both arms")),
         "two arms that both stopped short say nothing about the round loop"
     );
 
     let long: Vec<u32> = Rng(0x5170_0000).prose(N_TOKENS);
-    let why = judge(&short, &long, &[])
+    let why = judge(&short, &long, &[], None)
         .refusal()
         .expect("one short arm against one long one must be refused");
     assert!(why.contains("one arm stopped early"), "{why}");
@@ -952,7 +1156,7 @@ fn two_arms_in_the_same_ragged_loop_are_refused_until_they_are_no_longer_one_loo
     for noise in (0..=100).step_by(2) {
         for (sa, sb) in [(0x33u64, 0x44u64), (0x91, 0xA7), (0xB3, 0xC1), (0xD5, 0xE9)] {
             let (a, b) = (ragged_loop_arm(sa, noise), ragged_loop_arm(sb, noise));
-            if judge(&a, &b, &[]) != Verdict::Agreed {
+            if judge(&a, &b, &[], None) != Verdict::Agreed {
                 continue;
             }
             first_admitted = first_admitted.or(Some(noise));
@@ -1044,13 +1248,15 @@ fn a_speculative_arm_collapsing_over_its_last_quarter_is_refused_by_the_control(
     let healthy = Rng(0xC0DE).prose(N_TOKENS);
     for period in [8usize, 16, 24] {
         let spec = quarter_collapse(0x55, period);
-        let failure = judge(&spec, &healthy, &[]).refusal().unwrap_or_else(|| {
-            panic!(
-                "period {period}: an arm collapsing over its last quarter passed: \
+        let failure = judge(&spec, &healthy, &[], None)
+            .refusal()
+            .unwrap_or_else(|| {
+                panic!(
+                    "period {period}: an arm collapsing over its last quarter passed: \
                      cycle {:.4}",
-                strongest_windowed_cycle(&spec).2,
-            )
-        });
+                    strongest_windowed_cycle(&spec).2,
+                )
+            });
         assert!(
             failure.contains("repeats at period"),
             "period {period}: the control must be what refuses this — {failure}"
@@ -1142,14 +1348,14 @@ fn the_ratio_is_over_the_shorter_arm_and_the_length_guard_covers_it() {
         "a true prefix must score 1.0 over the shorter arm; it read {}",
         lcs_ratio(truncated, &plain)
     );
-    let failure = judge(truncated, &plain, &[])
+    let failure = judge(truncated, &plain, &[], None)
         .refusal()
         .expect("the length guard must refuse it");
     assert!(failure.contains("stopped well before"), "{failure}");
 
     // Just inside the guard the same shape scores 1.0 and passes, which is what
     // makes the guard — not the ratio — the thing doing the work above.
-    assert!(judge(&plain[..N_TOKENS * 3 / 2], &plain, &[])
+    assert!(judge(&plain[..N_TOKENS * 3 / 2], &plain, &[], None)
         .refusal()
         .is_none());
 }
@@ -1163,12 +1369,12 @@ fn the_ratio_is_over_the_shorter_arm_and_the_length_guard_covers_it() {
 fn the_length_floor_admits_every_answer_the_prompts_produce() {
     let at_floor = Rng(0x00F1_7EDD).prose(MIN_ANSWER_TOKENS);
     assert!(
-        judge(&at_floor, &at_floor, &[]).refusal().is_none(),
+        judge(&at_floor, &at_floor, &[], None).refusal().is_none(),
         "two arms exactly at the floor must pass"
     );
     let under = &at_floor[..MIN_ANSWER_TOKENS - 1];
     assert!(
-        judge(under, under, &[]) != Verdict::Agreed,
+        judge(under, under, &[], None) != Verdict::Agreed,
         "two arms one token under the floor must not be returned as agreement"
     );
 
@@ -1176,7 +1382,7 @@ fn the_length_floor_admits_every_answer_the_prompts_produce() {
     // them. Driven through `judge` rather than compared as constants.
     let budget = Rng(0x2181_2181).prose(N_TOKENS);
     assert!(
-        judge(&budget, &budget, &[]).refusal().is_none(),
+        judge(&budget, &budget, &[], None).refusal().is_none(),
         "a pair that answers in full must clear the floor"
     );
     // Both sides of the floor, at compile time, and each is the tightest form
@@ -1205,7 +1411,7 @@ fn the_length_floor_admits_every_answer_the_prompts_produce() {
 #[test]
 fn a_truncated_run_is_refused_rather_than_judged() {
     let plain: Vec<u32> = (0..N_TOKENS as u32).collect();
-    let failure = judge(&plain[..16], &plain, &[])
+    let failure = judge(&plain[..16], &plain, &[], None)
         .refusal()
         .expect("must refuse");
     assert!(failure.contains("stopped early"), "{failure}");
@@ -1233,7 +1439,7 @@ fn a_short_reference_arm_is_the_prompt_unless_the_other_arm_only_ran_past_it() {
 
     let mut ran_on = plain.clone();
     ran_on.extend(Rng(0x0BAD_0BAD).prose(N_TOKENS));
-    let failure = judge(&ran_on, &plain, &[])
+    let failure = judge(&ran_on, &plain, &[], None)
         .refusal()
         .expect("an arm that reproduced the whole reference answer and kept going must be refused");
     assert!(
@@ -1243,7 +1449,7 @@ fn a_short_reference_arm_is_the_prompt_unless_the_other_arm_only_ran_past_it() {
 
     let mut parted = plain[..4].to_vec();
     parted.extend(Rng(0x0F1F_0F1F).prose(N_TOKENS));
-    match judge(&parted, &plain, &[]) {
+    match judge(&parted, &plain, &[], None) {
         Verdict::Unjudgeable(why) => assert!(why.contains("parted inside that answer"), "{why}"),
         other @ (Verdict::Agreed | Verdict::Refused(_)) => {
             panic!("a reference arm under the floor is the prompt, not the loop: {other:?}")
@@ -1251,7 +1457,7 @@ fn a_short_reference_arm_is_the_prompt_unless_the_other_arm_only_ran_past_it() {
     }
 
     let long_plain: Vec<u32> = Rng(0x1C1C_1C1C).prose(N_TOKENS);
-    let failure = judge(&long_plain[..16], &long_plain, &[])
+    let failure = judge(&long_plain[..16], &long_plain, &[], None)
         .refusal()
         .expect("a speculative arm under the floor while the reference ran on must be refused");
     assert!(failure.contains("stopped early"), "{failure}");
@@ -1282,7 +1488,7 @@ fn a_late_onset_divergence_is_judged_where_it_begins() {
 
     let mut confident = vec![0.01f32; N_TOKENS];
     confident[onset] = 5.0;
-    let failure = judge(&late, &plain, &confident)
+    let failure = judge(&late, &plain, &confident, None)
         .refusal()
         .expect("must refuse");
     assert!(
@@ -1294,7 +1500,7 @@ fn a_late_onset_divergence_is_judged_where_it_begins() {
     // the benign case, and passes at exactly the same subsequence ratio.
     let mut tied = vec![5.0f32; N_TOKENS];
     tied[onset] = 0.01;
-    assert!(judge(&late, &plain, &tied).refusal().is_none());
+    assert!(judge(&late, &plain, &tied, None).refusal().is_none());
 }
 
 /// The two measured regimes put through `judge` itself, so the test fails when
@@ -1329,7 +1535,7 @@ fn the_gate_admits_the_worst_correct_regime_and_refuses_the_lowest_broken_one() 
         "the reconstructed correct regime reads {worst_correct:.4}, not the measured 0.0820"
     );
     assert!(
-        judge(&spec, &plain, &correct).refusal().is_none(),
+        judge(&spec, &plain, &correct, None).refusal().is_none(),
         "the worst correct regime must pass"
     );
 
@@ -1341,7 +1547,7 @@ fn the_gate_admits_the_worst_correct_regime_and_refuses_the_lowest_broken_one() 
         (lowest_broken - 0.1445).abs() < 0.002,
         "the reconstructed broken regime reads {lowest_broken:.4}, not the measured 0.1445"
     );
-    let failure = judge(&spec, &plain, &broken)
+    let failure = judge(&spec, &plain, &broken, None)
         .refusal()
         .expect("the lowest broken regime must be refused");
     assert!(failure.contains("nearly tied"), "{failure}");
@@ -1988,11 +2194,20 @@ enum Drafter {
 }
 
 impl Loaded {
-    /// Both arms over one prompt: the speculative ids, the reference ids, and
-    /// the reference's per-position margins.
-    fn arms(&mut self, prompt: &Prompt, device: Device) -> (Vec<u32>, Vec<u32>, Vec<f32>) {
+    /// Both arms over one prompt: the speculative ids, the reference ids, the
+    /// reference's per-position margins, and which vocabulary decided each
+    /// speculative token.
+    ///
+    /// The last is empty for every loop that scores each position over the
+    /// verifier's whole vocabulary, which is all of them but the restricted one.
+    fn arms(
+        &mut self,
+        prompt: &Prompt,
+        device: Device,
+    ) -> (Vec<u32>, Vec<u32>, Vec<f32>, Vec<DecidedBy>) {
         let ids = prompt.ids(&self.tokenizer);
         let mut spec_ids: Vec<u32> = Vec::new();
+        let mut decided_by: Vec<DecidedBy> = Vec::new();
         {
             let mut step = |s: &rmlx_models::ProbeStep| {
                 spec_ids.push(s.token_id);
@@ -2089,6 +2304,7 @@ impl Loaded {
                             Some(MAX_CTX),
                             &self.eos,
                             &mut step,
+                            &mut decided_by,
                             &GREEDY,
                             device,
                         )
@@ -2119,7 +2335,14 @@ impl Loaded {
             &self.eos,
             device,
         );
-        (spec_ids, plain_ids, margins)
+        assert!(
+            decided_by.is_empty() || decided_by.len() == spec_ids.len(),
+            "the loop reported which vocabulary decided {} tokens and emitted {} — the \
+             verdict indexes one by the other",
+            decided_by.len(),
+            spec_ids.len()
+        );
+        (spec_ids, plain_ids, margins, decided_by)
     }
 
     /// The target-vocabulary ids this pair's drafter can name, or `None` when it
@@ -2357,7 +2580,7 @@ fn report(
     spec: &[u32],
     plain: &[u32],
     margins: &[f32],
-    draft_vocab: Option<&std::collections::HashSet<u32>>,
+    restriction: Option<&Restriction<'_>>,
     verdict: &Verdict,
 ) {
     let (tail_start, tail_ratio) = weakest_tail(spec, plain);
@@ -2366,13 +2589,16 @@ fn report(
     let (div, confidence) = divergence_confidence(spec, plain, margins)
         .unwrap_or((common_prefix_len(spec, plain), 0.0));
     // For a pair whose drafter names a reduced vocabulary: how much of the
-    // reference answer that vocabulary cannot say, and whether the token it
-    // could not say is the one the arms parted on.
-    let outside = match draft_vocab {
-        Some(vocab) => format!(
-            " unnameable={} divergence_unnameable={}",
-            plain.iter().filter(|id| !vocab.contains(id)).count(),
-            plain.get(div).is_some_and(|id| !vocab.contains(id)),
+    // reference answer that vocabulary cannot say, whether the token it could
+    // not say is the one the arms parted on, and which vocabulary decided the
+    // speculative arm's token there — the two together are what the verdict
+    // reads.
+    let outside = match restriction {
+        Some(r) => format!(
+            " unnameable={} divergence_unnameable={} divergence_decided_by={:?}",
+            r.unnameable(plain),
+            plain.get(div).is_some_and(|id| !r.vocab.contains(id)),
+            r.decided_by.get(div),
         ),
         None => String::new(),
     };
@@ -2507,8 +2733,12 @@ fn run_gate(test: &str, pair: &Pair) {
     let mut refusals: Vec<String> = Vec::new();
     let mut judged = 0usize;
     for prompt in PROMPTS {
-        let (spec, plain, margins) = loaded.arms(prompt, device);
-        let verdict = judge(&spec, &plain, &margins);
+        let (spec, plain, margins, decided_by) = loaded.arms(prompt, device);
+        let restriction = draft_vocab.as_ref().map(|vocab| Restriction {
+            vocab,
+            decided_by: &decided_by,
+        });
+        let verdict = judge(&spec, &plain, &margins, restriction.as_ref());
         report(
             test,
             prompt,
@@ -2516,7 +2746,7 @@ fn run_gate(test: &str, pair: &Pair) {
             &spec,
             &plain,
             &margins,
-            draft_vocab.as_ref(),
+            restriction.as_ref(),
             &verdict,
         );
         match verdict {

--- a/crates/rmlx-server/src/engine/speculative.rs
+++ b/crates/rmlx-server/src/engine/speculative.rs
@@ -879,6 +879,9 @@ impl Generator for SpeculativeGenerator {
             let result = match &drafter {
                 Drafter::Eagle3(drafter_arc) => {
                     let mut drafter = drafter_arc.lock();
+                    // Which vocabulary decided each token. The answer-equivalence
+                    // gate reads it; a served response does not.
+                    let mut decided_by = Vec::new();
                     rmlx_models::speculative::eagle3::eagle3_generate(
                         &dispatcher.verifier,
                         &mut drafter,
@@ -890,6 +893,7 @@ impl Generator for SpeculativeGenerator {
                         max_ctx_override,
                         &eos_ids,
                         &mut step_fn,
+                        &mut decided_by,
                         &spec_sampler_cfg,
                         dispatcher.device(),
                     )

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -710,7 +710,12 @@ list so EOS can be selected at intermediate positions.
    replace the token at that position with the full-vocab correction.
 
 This avoids materialising a `[1, K, 248320]` logit tensor for the accepted
-positions.
+positions. It also means an accepted position carries the drafter's argmax and
+not the verifier's, and the two are the same token only when the verifier's is
+one the drafter can name. `eagle3_generate` therefore fills a `DecidedBy` per
+emitted token — restricted at an accepted position, full at the correction and
+the prefill seed — because that is not recoverable from the tokens afterwards.
+`docs/SPEC_ANSWER_EQUIVALENCE.md` is where it is read and what it costs.
 
 **Verifier prefill chunking.** For prompts longer than 1024 tokens, the
 verifier prefill uses `forward_verify_capture_chunked`: non-final chunks run

--- a/docs/SPEC_ANSWER_EQUIVALENCE.md
+++ b/docs/SPEC_ANSWER_EQUIVALENCE.md
@@ -192,7 +192,8 @@ runs the same way: the confidence ceiling fires on 4, 3, 1 and 4 of the judged
 cells and the control takes the rest.
 
 The last row is the exception and it is a property of the defect, not of the
-ceiling — see the boundary below.
+ceiling — see the boundary below. That row is also the one the boundary rule
+below had to be built not to forgive.
 
 ## A declared boundary: EAGLE-3's restricted vocabulary
 
@@ -207,8 +208,9 @@ argmax equals the true one exactly when the true one is in the set, so the whole
 inexactness lives on the positions where it is not.
 
 That mirrors the upstream implementation, so it is a design boundary rather than
-a port defect. It is still an answer change at temperature 0, which is what this
-gate reads, so the gate measures the exposure rather than assuming it away.
+a port defect. It is an answer change at temperature 0 that no correct
+implementation of this loop could avoid, so the gate reads it as a boundary and
+not as a defect — and the whole of the difficulty is telling one from the other.
 
 `docs/SPECULATIVE.md` says the restricted read-back is sound at temperature 0 and
 only there, and that is a claim about *sampling*: a distribution needs the whole
@@ -217,25 +219,68 @@ all. This section is about what remains at temperature 0 — the reduced argmax 
 the true argmax on the ids the drafter can name, and only on those. Both are
 true and neither implies the other.
 
-Every
-run of that pair prints two figures per prompt: `unnameable`, how many of the
-reference arm's own tokens the drafter's vocabulary cannot say, and
-`divergence_unnameable`, whether the token the arms parted on is one of them.
+### The rule, and why the token alone will not carry it
 
-Measured over the six prompts: `unnameable` reads 1, 2, 2, 3, 4 and 5 tokens —
-under 2% of a 256-token answer — and `divergence_unnameable` is **false on all
-six**. The boundary exists and did not fire at any first divergence here; every
-one of them is at a token the drafter can name, so the restriction cannot explain
-it and the confidence oracle judges it as it judges any other pair.
+Every run of that pair prints three figures per prompt: `unnameable`, how many of
+the reference arm's own tokens the drafter's vocabulary cannot say;
+`divergence_unnameable`, whether the token the arms parted on is one of them; and
+`divergence_decided_by`, which vocabulary the round loop used at that position.
 
-The gate has power over the boundary when it does bite. Left with the correction
-position on the restricted argmax as well — which widens the same inexactness
-from "sometimes at an accepted position" to "always at the correction" — the pair
-is refused on one prompt of six, at confidence 0.8828, with
-`divergence_unnameable` true on exactly that cell. One of six is what the
-exposure predicts, and it is why that pair carries a second broken engine: with
-its rollback target off by one it is refused on five of the five prompts it
-judges.
+**The verdict needs all three, and the third is why.** Widening the same
+inexactness to the correction — leaving it on the restricted argmax as well —
+changes an answer at exactly the kind of token the boundary does: same reference
+token, same speculative token, same near-certain margin. Nothing in the two token
+streams tells the two apart. What separates them is which position the loop was
+at: the restriction reaches an accepted position by design and cannot reach the
+correction, which is scored over the whole vocabulary. So `eagle3_generate` fills
+a `DecidedBy` per emitted token, and the rule is:
+
+- first divergence at a position the loop emitted from the drafter's own argmax,
+  whose reference token that vocabulary cannot name — **the boundary**. Reported
+  as unjudgeable, not refused: no correct loop of this kind could have said
+  anything else there, and a prompt where that happened says nothing about the
+  round loop either way.
+- first divergence anywhere else — **judged as any other pair's**, which is the
+  confidence oracle above.
+
+A run whose every prompt landed on the boundary would assert nothing, and
+`run_gate`'s existing floor catches that: it fails on a pair it could judge on no
+prompt at all.
+
+### What the rule was measured against
+
+Four engines, six prompts each, on `Qwen3.6-35B-A3B-8bit` drafted by
+`specdrift-qwen3.6-35b-a3b-eagle3`, five prompts judged and the 4k document
+unjudgeable for length in every one of them:
+
+| engine | verdict | where |
+|---|---|---|
+| as shipped | 5 of 5 agree | `divergence_unnameable` false on all six; confidences 0.0000 to 0.0703 |
+| correction left on the restricted argmax | **refused, 1 of 5 judged** | confidence 0.8828, `divergence_unnameable` **true**, at a **correction** |
+| rollback target one position short | **refused, 5 of 5 judged** | `divergence_unnameable` false on all six; the repetition control takes all five |
+| the recurrent tape (a branch under review) | 5 of 5 agree | one at confidence 0.2617, `divergence_unnameable` **true**, at an **accepted** position |
+
+`unnameable` reads 1, 2, 2, 3, 4 and 5 tokens on the shipped arms — under 2% of a
+256-token answer, and one to five chances per answer for the boundary to fire.
+
+The first two rows are the whole argument. **The widening is refused, and it is
+refused because of where it happened and not what it changed** — its cell has
+`divergence_unnameable` true, so a rule keyed on that field alone would have
+waived precisely the defect the pair exists to catch. Reading the position as
+well keeps it. The third row is the pair's other broken engine and the waiver has
+no purchase on it at all: none of its divergences is at an unnameable token, and
+the refusals come from the repetition control, which the rule does not touch.
+
+The fourth row is the case that forced the rule. That branch rebuilds a partly
+accepted round's recurrent state from a tape rather than replaying it; it does
+not touch the vocabulary restriction. Rebuilding is a different reduction order,
+which moved where the arms part, and it moved onto one of the five tokens the
+drafter cannot name. Without the rule that run is refused as a defect at
+confidence 0.2617; with it the prompt is reported and the other four still carry
+the gate. Both readings were taken.
+
+`scripts/spec_broken_engine.sh` applies each broken engine by name, so those rows
+can be taken again rather than believed.
 
 ## Which arm is short
 

--- a/scripts/spec_broken_engine.sh
+++ b/scripts/spec_broken_engine.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Run the answer-equivalence gate against a deliberately broken round loop.
+#
+# The gate's constants are set against a measured population: every pair as
+# shipped, and a broken engine per pair. Those readings are worth no more than
+# the ability to take them again, so each broken engine is a named edit here
+# rather than a number in a document nobody can regenerate.
+#
+#   scripts/spec_broken_engine.sh <engine> <test-name>
+#
+# Engines, all on the EAGLE-3 round loop:
+#
+#   shipped              the tree as it stands, no edit
+#   correction-restricted  the round's correction left on the drafter's
+#                          restricted argmax, which widens the declared
+#                          vocabulary boundary from "sometimes at an accepted
+#                          position" to "always at the correction"
+#   rejected-draft-kept    the verifier's rollback target one position short,
+#                          so every partial round keeps one rejected draft
+#
+# The edit is applied to a working tree that must be clean of it beforehand:
+# the pattern being replaced has to occur exactly once, and two occurrences is
+# a hard failure rather than a reason to take the first — an edit that lands
+# somewhere other than where the run is named for reports a result that was
+# never taken. The file is restored from a byte snapshot and the restore is
+# verified by digest, so a failed or interrupted run cannot leave the tree
+# mutated.
+#
+# Environment: RMLX_O_MODELS_ROOT and RMLX_DRAFT_TEST_MODEL, as the gate itself
+# documents. No GPU work happens here that the gate would not do on its own.
+set -uo pipefail
+
+readonly ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly TARGET="$ROOT/crates/rmlx-models/src/speculative/eagle3/mod.rs"
+
+engine="${1:-}"
+test_name="${2:-}"
+if [[ -z "$engine" || -z "$test_name" ]]; then
+    sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' >&2
+    exit 2
+fi
+
+case "$engine" in
+shipped)
+    find=""
+    replace=""
+    ;;
+correction-restricted)
+    find='            tokens[full_pos] = u32::from_le_bytes(corr_bytes[..4].try_into().unwrap());'
+    replace='            let _ = &corr_bytes;'
+    ;;
+rejected-draft-kept)
+    find='        let v_target = v_offset_before - (draft_tokens.len() as i32 - accept as i32);'
+    replace='        let v_target = v_offset_before - (draft_tokens.len() as i32 - accept as i32) + 1;'
+    ;;
+*)
+    echo "unknown engine: $engine" >&2
+    exit 2
+    ;;
+esac
+
+snapshot=""
+restore() {
+    [[ -n "$snapshot" ]] || return 0
+    /bin/cp -f "$snapshot" "$TARGET"
+    local now
+    now="$(shasum -a 256 "$TARGET" | cut -d' ' -f1)"
+    if [[ "$now" != "$original_digest" ]]; then
+        echo "FATAL: $TARGET was not restored ($now != $original_digest)" >&2
+        exit 3
+    fi
+    rm -f "$snapshot"
+    echo "restored $TARGET, digest $original_digest"
+}
+
+if [[ -n "$find" ]]; then
+    occurrences="$(grep -cF -- "$find" "$TARGET")"
+    if [[ "$occurrences" != "1" ]]; then
+        echo "FATAL: the '$engine' edit matches $occurrences lines of $TARGET, and it must \
+match exactly one — the run would not be the run it is named for" >&2
+        exit 2
+    fi
+    snapshot="$(mktemp)"
+    /bin/cp -f "$TARGET" "$snapshot"
+    original_digest="$(shasum -a 256 "$snapshot" | cut -d' ' -f1)"
+    trap restore EXIT
+    : >"$TARGET"
+    while IFS= read -r line; do
+        if [[ "$line" == "$find" ]]; then
+            printf '%s\n' "$replace" >>"$TARGET"
+        else
+            printf '%s\n' "$line" >>"$TARGET"
+        fi
+    done <"$snapshot"
+    echo "applied '$engine' to $TARGET"
+fi
+
+echo "running $test_name against the '$engine' engine"
+cargo test -p rmlx-models --test spec_greedy_equivalence -- \
+    --ignored --nocapture --test-threads=1 "$test_name"
+status=$?
+echo "$test_name against '$engine': cargo test exit $status"
+exit "$status"


### PR DESCRIPTION
## The problem

The answer-equivalence gate's EAGLE-3 pair carries an inexactness the other five
do not. Its verify pass takes the argmax over the drafter's reduced vocabulary at
every position it may accept, and the verifier's whole vocabulary only at the
round's correction. Those two argmaxes are the same token exactly when the
verifier's own choice is one the drafter can name — so at a position whose true
token it cannot name, the arm emits the drafter's token and diverges from plain
greedy by construction. That mirrors upstream and no correct implementation of
this loop avoids it.

The suite measured the exposure and printed it (`unnameable`,
`divergence_unnameable`) and the verdict never read it, so such a run was refused
as a defect. That is happening on `perf/spec-accepted-prefix-tape`, which
rebuilds a partly accepted round's recurrent state from a tape: a different
reduction order moved where the arms part, and it landed on one of the five
tokens the drafter cannot name.

## Why reading the field alone would have been wrong

Widening the same inexactness to the correction — the pair's own broken engine —
changes an answer at exactly the kind of token the boundary does. Same reference
token, same speculative token, same near-certain margin. The two are
indistinguishable in the token streams, and the widening's refusal is the *only*
one that pair has against that defect class. A verdict keyed on
`divergence_unnameable` alone would have forgiven precisely the defect the pair
exists to catch, measured: that cell has the field set.

What separates them is which position the loop was at. The restriction reaches an
accepted position by design and cannot reach the correction. So the loop now says
so.

## What changed

`eagle3_generate` fills a `DecidedBy` per emitted token — restricted at an
accepted position, full at the correction and the prefill seed. It is an explicit
parameter rather than a log field or an inference, because the loop genuinely
knows something the token stream cannot express.

The verdict reads it: a first divergence at an accepted position whose reference
token the drafter cannot name is reported as unjudgeable; a divergence anywhere
else, including at the correction, is judged exactly as before. The waiver is
scoped to the divergence oracle and reaches neither the repetition control nor
the length floor, and `run_gate`'s existing floor still fails a pair it could
judge on no prompt.

`scripts/spec_broken_engine.sh` applies each broken engine on that loop by name,
so the doc's rows can be taken again instead of believed. The edit must match
exactly one line, and the file is restored from a byte snapshot verified by
digest.

## Measured, on the pair

`Qwen3.6-35B-A3B-8bit` drafted by `specdrift-qwen3.6-35b-a3b-eagle3`, six prompts,
five judged in every engine (the 4k document's reference answer is under the
length floor):

| engine | verdict | where |
|---|---|---|
| as shipped | 5 of 5 agree | `divergence_unnameable` false on all six, confidences 0.0000 to 0.0703 |
| correction left on the restricted argmax | **refused, 1 of 5** | 0.8828, unnameable **true**, at a **correction** |
| rollback target one position short | **refused, 5 of 5** | unnameable false on all six; the repetition control takes all five |
| the tape branch, merged with this | 5 of 5 agree | one reported at 0.2617, unnameable **true**, at an **accepted** position |

The tape branch alone, without this change, refuses that same cell at the same
divergence and the same confidence.

Four fixtures pin the rule's corners with no model: the boundary is waived, the
same divergence at the correction is refused, a divergence at a nameable token is
judged exactly as a pair with no reduced vocabulary judges it, and the waiver
excuses no other refusal. Deleting the position test from the rule fails exactly
one of them.

## Not checked

The other five pairs were not re-run; none of them builds a `Restriction`, and
their `judge` calls are unchanged apart from passing `None`. No performance
measurement of any kind was taken.
