### PR TITLE
docs: twin rule + Removals convention (#481)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,11 @@
 
 -
 
+## Removals
+
+<!-- What this change makes deletable: code, a gate, a flag, a doc section.
+     "Nothing" is a valid answer — write it down. -->
+
 ## Checklist
 
 - [ ] `make ci` green locally (fmt + clippy + test + deny + audit)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,7 @@ is gone.
 3. **Straight-forward core backend.** Inference path is sequential, sync, explicit. Async only at HTTP/file-I/O boundaries (already in coding style above).
 4. **Inline beats premature factoring.** Extract to a function/module only when 2+ real callers exist. Three similar lines is better than a wrong abstraction.
 5. **No env-gated one-caller knobs.** Prefer a fixed default or a CLI flag with a real second caller. Env vars are invisible config — each is a support and repro burden. Keep the existing env surface minimal; new env vars need explicit justification (and are an "Ask before" item).
+6. **No twins, and every change names its removals.** Two types, functions, kernels, or files whose bodies differ only in a compile-time constant (`bits`, `head_dim`, group size, a codebook) or in a component's name are one item and a parameter, not two — a const-generic or a trait-bound blanket impl, never a copy per caller (rule 1's "no premature generics" still governs the single-instantiation case). Standing violation: the speculative round loop exists once per drafter, and a cross-cutting change to it is made once per copy. A change that adds an item without deleting the twin it replaces is not done — every PR description says what it deletes, and "nothing" is a valid answer only if it is written down.
 
 ## Common commands (Makefile)
 
@@ -349,6 +350,21 @@ hand — keeps the CI gate and the local gate identical.
 | `make model-check-full MODEL=…` | `cargo test -p rmlx-{models,runtime,quant}` (note: **not** `rmlx-kv-quant`) + golden-token integration tests. Pass one model path; each golden reads `config.json` and skips gracefully when arch does not match — matching arch runs+passes, others skip. Target is green for any single test-target model. |
 
 `MODEL` and `PORT` override at the CLI: `make info MODEL=/path/to/snapshot`.
+
+**A draft-side change is not proven by byte equality.** Greedy verification
+emits the verifier's own argmax at every position regardless of what the
+drafter proposed, so a byte-identical stream after a drafter change shows that
+run's near-ties happened not to move, not that the round loop is unaffected.
+Judge it with one of three checks, each blind to something different: an
+identity-row CPU test on the drafter's own math (blind to the round loop and
+the verifier); the accept stream (`accept_rate`, `tokens_per_round` — a signal
+that moves on near-ties, not an oracle; blind to whether a moved rate is a
+defect or a legitimate flip); or an equivalence pair judged by the
+divergence-confidence oracle in
+[`docs/SPEC_ANSWER_EQUIVALENCE.md`](docs/SPEC_ANSWER_EQUIVALENCE.md) (judges
+near-tie vs. defect; blind wherever a pair is not gated by default — see its
+Coverage table). Full argument there and in
+[`docs/SPECULATIVE.md`](docs/SPECULATIVE.md).
 
 Run `make ci` before push, plus `make ci-perf` when the change touches
 `rmlx-kv-quant`, a `.metal` kernel, or a KV/decode path — `make ci` runs no GPU

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,31 @@ of the recorded decode TPS.
    blocks — `make check-no-inline-tests` enforces this).
 4. `make ci` green locally — plus `make ci-perf` for codec-layer / `.metal`
    changes (see §Build & test).
-5. Open a PR into `main`. Fill in the PR template.
+5. Open a PR into `main`. Fill in the PR template, including the `Removals`
+   section — see below.
 
 `main` is protected: changes land via PR with CI green, not direct pushes.
+
+### No twins
+
+Before adding a second copy of something, ask whether it is really a second
+thing. Two types, functions, kernels, or files whose bodies differ only in a
+compile-time constant (`bits`, `head_dim`, group size, a codebook) or in a
+component's name are one item and a parameter — a const-generic or a
+trait-bound blanket impl — not a file per variant. (This does not license a
+generic with a single caller; that is still premature, see `CLAUDE.md`
+§Simplicity rules.)
+
+If your change touches speculative decoding's draft side, byte equality of
+the greedy stream is not evidence — see the oracle rule in `CLAUDE.md` and
+[`docs/SPEC_ANSWER_EQUIVALENCE.md`](docs/SPEC_ANSWER_EQUIVALENCE.md).
+
+### Removals
+
+Every PR names what it makes deletable — code, a gate, a flag, a doc section
+— in the `Removals` section of the PR template. "Nothing" is a valid answer,
+but write it down: deletion is a deliverable, not something that happens to
+get scheduled later.
 
 ## Commit messages
 


### PR DESCRIPTION
## Summary

Lands #481 as written, extended project-wide (not KV-codec-only):

- `CLAUDE.md` §Simplicity rules gets rule 6: no two items (type/function/kernel/file) that differ only in a compile-time constant or a component's name — that is one item and a parameter, not two. Names the standing violation in one clause: the speculative round loop exists once per drafter, and cross-cutting changes are made once per copy. Also: every PR names what it deletes; "nothing" is a valid answer but must be written down.
- `CLAUDE.md`, near the `make check-spec-sampling` row: the draft-side oracle rule — byte equality of the greedy stream is not evidence for a drafter change, since greedy verification emits the verifier's own argmax regardless of what the drafter proposed. Names three checks and what each is blind to (identity-row CPU test, accept stream, equivalence pair judged by `docs/SPEC_ANSWER_EQUIVALENCE.md`), citing that file and `docs/SPECULATIVE.md` rather than restating them — both already carry this correctly post-#545, no contradicting sentence found.
- `CONTRIBUTING.md` §Workflow: the same two rules in contributor voice (`### No twins`, `### Removals`), plus a pointer from step 5 to the PR template's new section.
- `.github/PULL_REQUEST_TEMPLATE.md`: new `## Removals` section.

## Removals

Nothing. Docs-only change; no code, gate, flag, or doc section is deleted.

## Verification

- `make check-doc-source-citations` — OK, 206 cited source paths resolve.
- Manually confirmed both new doc links (`docs/SPEC_ANSWER_EQUIVALENCE.md`, `docs/SPECULATIVE.md`) resolve.

Closes #481.