### PR TITLE
spec(refactor): one acceptance walk and one verifier cache stack

### DIFF
--- a/crates/rmlx-models/src/context_tests.rs
+++ b/crates/rmlx-models/src/context_tests.rs
@@ -235,11 +235,12 @@ fn absurd_scaling_saturates() {
 
 // ── One resolution, enumerated ───────────────────────────────────────────────
 
-/// Every consumer of the context ceiling, by workspace-relative path.
+/// Every place a context ceiling is **resolved**, by workspace-relative path.
 ///
-/// Adding a call site is fine; leaving it off this list is not. The list is
-/// what makes "one resolution" checkable — a reviewer reads it and sees every
-/// place a context bound is decided.
+/// Not every place one is applied — a bound is read far more widely than it is
+/// decided, and this list is the deciding. Adding a call site is fine; leaving
+/// it off is not. The list is what makes "one resolution" checkable: a reviewer
+/// reads it and sees every place a context bound is arrived at.
 const CEILING_CONSUMERS: &[&str] = &[
     // KV ring sizing, one per architecture generate path.
     "crates/rmlx-models/src/gemma4/generate/mod.rs",
@@ -254,10 +255,8 @@ const CEILING_CONSUMERS: &[&str] = &[
     // CLI: the default `--max-prompt-tokens` cap.
     "crates/rmlx-cli/src/commands/baseline.rs",
     "crates/rmlx-cli/src/commands/bench.rs",
-    // Speculative: the verifier's limits bound the pair. `speculative/mod.rs`
-    // holds the `verifier_context` wrapper, and `round_common.rs` is where every
-    // round loop resolves its verifier's ceiling and cache stack.
-    "crates/rmlx-models/src/speculative/mod.rs",
+    // Speculative: the verifier's limits bound the pair, and every round loop
+    // resolves them here, with the cache stack they size.
     "crates/rmlx-models/src/speculative/round_common.rs",
 ];
 
@@ -374,7 +373,6 @@ fn files_containing(needle: &str) -> Vec<String> {
 #[test]
 fn ceiling_consumers_are_enumerated() {
     let mut found = files_containing("resolve_context(");
-    found.extend(files_containing("verifier_context("));
     found.sort();
     found.dedup();
     let mut expected: Vec<String> = CEILING_CONSUMERS.iter().map(|s| (*s).to_owned()).collect();

--- a/crates/rmlx-models/src/context_tests.rs
+++ b/crates/rmlx-models/src/context_tests.rs
@@ -255,13 +255,10 @@ const CEILING_CONSUMERS: &[&str] = &[
     "crates/rmlx-cli/src/commands/baseline.rs",
     "crates/rmlx-cli/src/commands/bench.rs",
     // Speculative: the verifier's limits bound the pair. `speculative/mod.rs`
-    // holds the `verifier_context` wrapper the five sidecar drivers call.
-    "crates/rmlx-models/src/speculative/dflash/mod.rs",
-    "crates/rmlx-models/src/speculative/dflash2/round.rs",
-    "crates/rmlx-models/src/speculative/eagle3/mod.rs",
-    "crates/rmlx-models/src/speculative/gemma4_assistant.rs",
+    // holds the `verifier_context` wrapper, and `round_common.rs` is where every
+    // round loop resolves its verifier's ceiling and cache stack.
     "crates/rmlx-models/src/speculative/mod.rs",
-    "crates/rmlx-models/src/speculative/mtp.rs",
+    "crates/rmlx-models/src/speculative/round_common.rs",
 ];
 
 /// The only places allowed to name `max_position_embeddings` at all — the

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -660,26 +660,11 @@ pub fn dflash_generate(
         drafter.cfg.block_size,
     );
 
-    // Same constant the verifier resolves — a spec pair must not run two
-    // different caches.
-    let kv_quant = kv_quant_override.unwrap_or(crate::kv_cache::DEFAULT_KV_QUANT);
-    // The verifier's limits bound the pair; an over-capacity `--max-ctx` is
-    // refused here rather than overflowing a cache mid-round.
-    let ctx = crate::speculative::verifier_context(verifier, max_ctx_override)?;
-    let max_seq = ctx.ceiling;
-
-    let mut v_caches: Vec<KvCache> = (0..verifier.num_hidden_layers())
-        .map(|i| {
-            let window = verifier.layer_sliding_window(i);
-            KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                .with_max_seq_ceiling(ctx.ceiling)
-                .with_layer_idx(i)
-                // The verifier stack decides whether its layers read each
-                // other's K/V, and so whether Mixed/RotK keep their bf16
-                // mirror. A spec pair must not run two different caches.
-                .with_shares_kv(verifier.shares_kv_across_layers())
-        })
-        .collect();
+    let (kv_quant, _, mut v_caches) = crate::speculative::round_common::verifier_cache_stack(
+        verifier,
+        kv_quant_override,
+        max_ctx_override,
+    )?;
     let mut v_lin: Vec<LinearAttnCache> = (0..verifier.num_hidden_layers())
         .map(|_| LinearAttnCache::new())
         .collect();

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -76,6 +76,7 @@ use rmlx_mlx::{
 use super::{emit_step, DecodeWindow};
 use crate::arch::Architecture;
 use crate::layers::{Activation, Linear, Mlp, RmsNorm};
+use crate::speculative::round_common::verifier_cache_stack;
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 
 /// Choose the next DFlash verify block size from recent acceptance.
@@ -654,11 +655,8 @@ pub fn dflash_generate(
         drafter.cfg.block_size,
     );
 
-    let (kv_quant, _, mut v_caches) = crate::speculative::round_common::verifier_cache_stack(
-        verifier,
-        kv_quant_override,
-        max_ctx_override,
-    )?;
+    let (kv_quant, _, mut v_caches) =
+        verifier_cache_stack(verifier, kv_quant_override, max_ctx_override)?;
     let mut v_lin: Vec<LinearAttnCache> = (0..verifier.num_hidden_layers())
         .map(|_| LinearAttnCache::new())
         .collect();

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -63,12 +63,6 @@
     clippy::too_many_lines,
     clippy::used_underscore_binding
 )]
-// kv-layer-quants: uniform — speculative scratch stack. The drafter/verifier
-// caches a round builds live for that round only: they are never pushed to the
-// prompt cache, never spilled, and never keyed by `layout_key`, so no on-disk
-// description has to match them. Applying the boundary promotion here would
-// change the codec of a stack whose only reader is the round that built it.
-
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::path::Path;

--- a/crates/rmlx-models/src/speculative/dflash/mod.rs
+++ b/crates/rmlx-models/src/speculative/dflash/mod.rs
@@ -36,8 +36,8 @@
 //! ([`DFlashDrafter::load`] + [`load_dflash`]) — `fc` (`5H->H`), `hidden_norm`,
 //! `norm`, all 8 `DFlashDecoderLayer`s, **YARN RoPE** ([`crate::rope::compute_yarn_freqs`]),
 //! the drafter forward [`DFlashDrafter::draft_block`], the block-size schedule
-//! [`dflash_next_block_size`], the acceptance walk [`walk_block_greedy`], the
-//! GDN rollback, and the full round-loop
+//! [`dflash_next_block_size`], the acceptance walk
+//! [`crate::speculative::accept_prefix`], the GDN rollback, and the full round-loop
 //! [`dflash_generate`]. The three verifier-side seams are wired on
 //! [`crate::arch::Architecture`] for the Qwen3.6-MoE verifier:
 //!
@@ -594,39 +594,6 @@ impl DFlashDrafter {
     }
 }
 
-/// One greedy DFlash acceptance walk over a drafted block (port of the
-/// `_speculative_walk` half of `_dflash_rounds`).
-///
-/// Accept drafted tokens up to the first mismatch with the verifier's greedy
-/// choice, then take the verifier's correction/bonus at that position. Returns
-/// `(accepted, new_tokens)` capped at `budget`. `target_tokens` are the
-/// verifier's greedy predictions for positions `[seed, d0, d1, ...]` — i.e.
-/// `draft_tokens.len() + 1` of them.
-#[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
-pub fn walk_block_greedy(
-    draft_tokens: &[u32],
-    target_tokens: &[u32],
-    budget: usize,
-) -> (usize, Vec<u32>) {
-    let n_draft = draft_tokens.len();
-    let mut accepted = n_draft;
-    for (i, (&d, &t)) in draft_tokens.iter().zip(target_tokens.iter()).enumerate() {
-        if d != t {
-            accepted = i;
-            break;
-        }
-    }
-    let mut new_tokens: Vec<u32> = draft_tokens[..accepted].to_vec();
-    if accepted < target_tokens.len() {
-        new_tokens.push(target_tokens[accepted]);
-    }
-    new_tokens.truncate(budget);
-    (accepted, new_tokens)
-}
-
 use crate::decode_loop::ProbeStep;
 
 /// DFlash speculative-decoding round-loop (greedy / temp=0).
@@ -854,7 +821,7 @@ pub fn dflash_generate(
         verifier_ns += t0.elapsed().as_nanos();
 
         // -- Phase C: acceptance walk. ---------------------------------------
-        let (accept, new_tokens) = walk_block_greedy(&draft_tokens, &v_tokens, remaining);
+        let (accept, new_tokens) = super::accept_prefix(&v_tokens, &draft_tokens, remaining)?;
         total_accept += accept;
         recent.push((accept, draft_tokens.len()));
 

--- a/crates/rmlx-models/src/speculative/dflash/tests.rs
+++ b/crates/rmlx-models/src/speculative/dflash/tests.rs
@@ -67,49 +67,10 @@ fn block_size_holds_on_moderate_acceptance() {
     assert_eq!(next, 11);
 }
 
-// --- walk_block_greedy acceptance ---
-
-#[test]
-fn walk_all_accepted_emits_bonus() {
-    let draft = [10, 11, 12];
-    let target = [10, 11, 12, 99]; // n_draft + 1 predictions
-    let (acc, emit) = walk_block_greedy(&draft, &target, 8);
-    assert_eq!(acc, 3);
-    assert_eq!(emit, vec![10, 11, 12, 99]);
-}
-
-#[test]
-fn walk_partial_accept_emits_correction() {
-    let draft = [10, 11, 12];
-    let target = [10, 11, 55, 0]; // diverge at pos 2
-    let (acc, emit) = walk_block_greedy(&draft, &target, 8);
-    assert_eq!(acc, 2);
-    assert_eq!(emit, vec![10, 11, 55]);
-}
-
-#[test]
-fn walk_zero_accept_emits_only_correction() {
-    let draft = [10, 11];
-    let target = [42, 0, 0];
-    let (acc, emit) = walk_block_greedy(&draft, &target, 8);
-    assert_eq!(acc, 0);
-    assert_eq!(emit, vec![42]);
-}
-
-#[test]
-fn walk_respects_budget() {
-    let draft = [10, 11, 12];
-    let target = [10, 11, 12, 99];
-    let (acc, emit) = walk_block_greedy(&draft, &target, 2);
-    assert_eq!(acc, 3);
-    assert_eq!(emit, vec![10, 11]);
-}
-
 /// Compile-check: the public DFlash surface exists with expected sigs.
 #[test]
 fn dflash_module_compiles() {
     let _load = DFlashDrafter::load;
     let _bs = dflash_next_block_size;
-    let _walk = walk_block_greedy;
-    let _ = (_load, _bs, _walk);
+    let _ = (_load, _bs);
 }

--- a/crates/rmlx-models/src/speculative/dflash2/round.rs
+++ b/crates/rmlx-models/src/speculative/dflash2/round.rs
@@ -39,12 +39,6 @@
 //! this one is greedy, and the serve layer routes a sidecar request to it
 //! whatever the request's temperature.
 
-// kv-layer-quants: uniform — speculative scratch stack. The drafter/verifier
-// caches a round builds live for that round only: they are never pushed to the
-// prompt cache, never spilled, and never keyed by `layout_key`, so no on-disk
-// description has to match them. Applying the boundary promotion here would
-// change the codec of a stack whose only reader is the round that built it.
-
 use std::time::Instant;
 
 use rmlx_core::error::{Error, Result};

--- a/crates/rmlx-models/src/speculative/dflash2/round.rs
+++ b/crates/rmlx-models/src/speculative/dflash2/round.rs
@@ -53,12 +53,13 @@ use rmlx_mlx::{concatenate, Array, Device};
 use super::DFlash2Drafter;
 use crate::arch::Architecture;
 use crate::decode_loop::ProbeStep;
+use crate::speculative::round_common::verifier_cache_stack;
 use crate::speculative::{
     accept_prefix, arm_lin_tapes, block_capped_by_checkpoint, committed_rows,
     conditioning_residual, disarm_lin_tapes, emit_step, guard_round_conditioning,
     guard_verifier_prefill_logits, phases_charged, rollback_round_caches,
-    rollback_target_from_tail, round_block, verifier_context, verifier_kv_bytes, DecodeWindow,
-    RoundPhases, RoundStats, SpecLoop, VerifierDraw,
+    rollback_target_from_tail, round_block, verifier_kv_bytes, DecodeWindow, RoundPhases,
+    RoundStats, SpecLoop, VerifierDraw,
 };
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 
@@ -142,26 +143,8 @@ pub fn dflash2_generate(
     let condition_width = (drafter.cfg.hidden_size * target_layer_ids.len()) as i32;
     let block_total = block_capped_by_checkpoint(requested_block_total, drafter.cfg.block_size);
 
-    // Same constant the verifier resolves — a spec pair must not run two
-    // different caches.
-    let kv_quant = kv_quant_override.unwrap_or(crate::kv_cache::DEFAULT_KV_QUANT);
-    // The verifier's limits bound the pair; an over-capacity `--max-ctx` is
-    // refused here rather than overflowing a cache mid-round.
-    let ctx = verifier_context(verifier, max_ctx_override)?;
-    let max_seq = ctx.ceiling;
-
-    let mut v_caches: Vec<KvCache> = (0..verifier.num_hidden_layers())
-        .map(|i| {
-            let window = verifier.layer_sliding_window(i);
-            KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                .with_max_seq_ceiling(ctx.ceiling)
-                .with_layer_idx(i)
-                // The verifier stack decides whether its layers read each
-                // other's K/V, and so whether Mixed/RotK keep their bf16
-                // mirror. A spec pair must not run two different caches.
-                .with_shares_kv(verifier.shares_kv_across_layers())
-        })
-        .collect();
+    let (kv_quant, _, mut v_caches) =
+        verifier_cache_stack(verifier, kv_quant_override, max_ctx_override)?;
     let mut v_lin: Vec<LinearAttnCache> = (0..verifier.num_hidden_layers())
         .map(|_| LinearAttnCache::new())
         .collect();

--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -851,26 +851,11 @@ pub fn eagle3_generate(
         drafter.cfg.block_size,
     );
 
-    // Same constant the verifier resolves — a spec pair must not run two
-    // different caches.
-    let kv_quant = kv_quant_override.unwrap_or(crate::kv_cache::DEFAULT_KV_QUANT);
-    // The verifier's limits bound the pair; an over-capacity `--max-ctx` is
-    // refused here rather than overflowing a cache mid-round.
-    let ctx = crate::speculative::verifier_context(verifier, max_ctx_override)?;
-    let max_seq = ctx.ceiling;
-
-    let mut v_caches: Vec<KvCache> = (0..verifier.num_hidden_layers())
-        .map(|i| {
-            let window = verifier.layer_sliding_window(i);
-            KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                .with_max_seq_ceiling(ctx.ceiling)
-                .with_layer_idx(i)
-                // The verifier stack decides whether its layers read each
-                // other's K/V, and so whether Mixed/RotK keep their bf16
-                // mirror. A spec pair must not run two different caches.
-                .with_shares_kv(verifier.shares_kv_across_layers())
-        })
-        .collect();
+    let (kv_quant, max_seq, mut v_caches) = crate::speculative::round_common::verifier_cache_stack(
+        verifier,
+        kv_quant_override,
+        max_ctx_override,
+    )?;
     let mut v_lin: Vec<LinearAttnCache> = (0..verifier.num_hidden_layers())
         .map(|_| LinearAttnCache::new())
         .collect();

--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -128,6 +128,7 @@ use super::{emit_step, DecodeWindow};
 use crate::arch::Architecture;
 use crate::decode_loop::ProbeStep;
 use crate::layers::{Activation, Linear, Mlp, RmsNorm};
+use crate::speculative::round_common::verifier_cache_stack;
 use rmlx_kv_quant::{KvCache, KvQuant, LinearAttnCache};
 
 /// Target of this loop's per-position step trace.
@@ -852,11 +853,8 @@ pub fn eagle3_generate(
         drafter.cfg.block_size,
     );
 
-    let (kv_quant, max_seq, mut v_caches) = crate::speculative::round_common::verifier_cache_stack(
-        verifier,
-        kv_quant_override,
-        max_ctx_override,
-    )?;
+    let (kv_quant, max_seq, mut v_caches) =
+        verifier_cache_stack(verifier, kv_quant_override, max_ctx_override)?;
     let mut v_lin: Vec<LinearAttnCache> = (0..verifier.num_hidden_layers())
         .map(|_| LinearAttnCache::new())
         .collect();

--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -112,12 +112,13 @@
     clippy::too_many_lines,
     clippy::used_underscore_binding
 )]
-// kv-layer-quants: uniform — the one cache built here is the drafter's own, a
-// single unquantized cache for a single-layer head rather than a per-layer
-// stack, and it lives for one request: never pushed to the prompt cache, never
-// spilled, never keyed by `layout_key`, so no on-disk description has to match
-// it. The verifier's stack is built by `speculative::round_common`, which
-// carries its own declaration.
+// kv-layer-quants: uniform — the caches built here are the drafter's own and
+// never a per-layer stack: one unquantized cache for a single-layer head, made
+// at load and re-made per request by `Eagle3Drafter::reset`. It lives for that
+// one request — never pushed to the prompt cache, never spilled, never keyed by
+// `layout_key` — so no on-disk description has to match it. The verifier's
+// stack is built by `speculative::round_common`, which carries its own
+// declaration.
 
 use std::path::Path;
 

--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -112,11 +112,12 @@
     clippy::too_many_lines,
     clippy::used_underscore_binding
 )]
-// kv-layer-quants: uniform — speculative scratch stack. The drafter/verifier
-// caches a round builds live for that round only: they are never pushed to the
-// prompt cache, never spilled, and never keyed by `layout_key`, so no on-disk
-// description has to match them. Applying the boundary promotion here would
-// change the codec of a stack whose only reader is the round that built it.
+// kv-layer-quants: uniform — the one cache built here is the drafter's own, a
+// single unquantized cache for a single-layer head rather than a per-layer
+// stack, and it lives for one request: never pushed to the prompt cache, never
+// spilled, never keyed by `layout_key`, so no on-disk description has to match
+// it. The verifier's stack is built by `speculative::round_common`, which
+// carries its own declaration.
 
 use std::path::Path;
 

--- a/crates/rmlx-models/src/speculative/eagle3/mod.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/mod.rs
@@ -5,7 +5,8 @@
 //!
 //! Port of mlx-vlm `mlx_vlm/speculative/drafters/eagle3/eagle3.py`
 //! (`Eagle3DraftModel`) and the round-loop in `mlx_vlm/speculative/eagle3.py`
-//! (`_eagle3_next_block_size`, `_eagle3_rounds`, `_eagle3_walk`). The
+//! (`_eagle3_next_block_size`, `_eagle3_rounds`, `_eagle3_walk`, whose walk is
+//! the shared [`crate::speculative::accept_prefix`] here). The
 //! authoritative weight layout is the mainline SpecForge
 //! `LlamaForCausalLMEagle3` model
 //! (`sgl-project/SpecForge:specforge/modeling/draft/llama3_eagle.py`).
@@ -141,38 +142,6 @@ pub(crate) const STEP_TARGET: &str = "rmlx_models::speculative::eagle3";
 /// the stream the loop emits by default.
 pub(crate) fn step_trace_enabled() -> bool {
     tracing::enabled!(target: STEP_TARGET, tracing::Level::TRACE)
-}
-
-/// One greedy EAGLE-3 acceptance walk over a drafted block.
-///
-/// Pure port of `_eagle3_walk`: accept drafted tokens up to the first mismatch
-/// with the verifier's greedy choice, then take the verifier's correction/bonus
-/// at that position. Returns `(accepted, new_tokens)` capped at `budget`.
-/// `target_tokens` are the verifier's greedy predictions for positions
-/// `[b, d0, d1, ...]` — `draft_tokens.len() + 1` of them.
-#[allow(
-    clippy::indexing_slicing,
-    reason = "bounds established by construction: buffer sized at init, loop indices bounded by slice length, or layer index validated before call"
-)]
-pub fn eagle3_walk(
-    draft_tokens: &[u32],
-    target_tokens: &[u32],
-    budget: usize,
-) -> (usize, Vec<u32>) {
-    let n_draft = draft_tokens.len();
-    let mut accepted = n_draft;
-    for (i, (&d, &t)) in draft_tokens.iter().zip(target_tokens.iter()).enumerate() {
-        if d != t {
-            accepted = i;
-            break;
-        }
-    }
-    let mut new_tokens: Vec<u32> = draft_tokens[..accepted].to_vec();
-    if accepted < target_tokens.len() {
-        new_tokens.push(target_tokens[accepted]);
-    }
-    new_tokens.truncate(budget);
-    (accepted, new_tokens)
 }
 
 /// Find the first position where the restricted-vocab verifier token differs from the
@@ -1169,7 +1138,7 @@ pub fn eagle3_generate(
         };
 
         // -- Phase C: greedy acceptance walk. --
-        let (accept, new_tokens) = eagle3_walk(&draft_tokens, &v_tokens, remaining);
+        let (accept, new_tokens) = super::accept_prefix(&v_tokens, &draft_tokens, remaining)?;
         total_accept += accept;
         let n_committed = new_tokens.len();
 

--- a/crates/rmlx-models/src/speculative/eagle3/tests.rs
+++ b/crates/rmlx-models/src/speculative/eagle3/tests.rs
@@ -1,42 +1,6 @@
 use super::*;
 
 #[test]
-fn walk_all_accepted_emits_bonus() {
-    let draft = [10, 11, 12];
-    let target = [10, 11, 12, 99];
-    let (acc, emit) = eagle3_walk(&draft, &target, 8);
-    assert_eq!(acc, 3);
-    assert_eq!(emit, vec![10, 11, 12, 99]);
-}
-
-#[test]
-fn walk_partial_accept_emits_correction() {
-    let draft = [10, 11, 12];
-    let target = [10, 11, 55, 0];
-    let (acc, emit) = eagle3_walk(&draft, &target, 8);
-    assert_eq!(acc, 2);
-    assert_eq!(emit, vec![10, 11, 55]);
-}
-
-#[test]
-fn walk_zero_accept_emits_only_correction() {
-    let draft = [10, 11];
-    let target = [42, 0, 0];
-    let (acc, emit) = eagle3_walk(&draft, &target, 8);
-    assert_eq!(acc, 0);
-    assert_eq!(emit, vec![42]);
-}
-
-#[test]
-fn walk_respects_budget() {
-    let draft = [10, 11, 12];
-    let target = [10, 11, 12, 99];
-    let (acc, emit) = eagle3_walk(&draft, &target, 2);
-    assert_eq!(acc, 3);
-    assert_eq!(emit, vec![10, 11]);
-}
-
-#[test]
 fn d2t_remap_offsets_draft_to_target() {
     // target = draft + d2t[draft].
     let d2t = vec![0, 5, 100, -3];
@@ -63,11 +27,10 @@ fn d2t_out_of_range_passes_through() {
 #[test]
 fn eagle3_module_compiles() {
     let _load = Eagle3Drafter::load;
-    let _walk = eagle3_walk;
     let _d2t = draft_to_target;
     let _ffp = find_full_pos;
     let _gen = eagle3_generate;
-    let _ = (_load, _walk, _d2t, _ffp, _gen);
+    let _ = (_load, _d2t, _ffp, _gen);
 }
 
 // -----------------------------------------------------------------------

--- a/crates/rmlx-models/src/speculative/gemma4_assistant.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant.rs
@@ -775,26 +775,11 @@ pub fn mtp_assistant_generate(
     }
     let mut emitted: Vec<ProbeStep> = Vec::with_capacity(n_tokens);
 
-    // Same constant the verifier resolves — a spec pair must not run two
-    // different caches.
-    let kv_quant = kv_quant_override.unwrap_or(crate::kv_cache::DEFAULT_KV_QUANT);
-    // The verifier's limits bound the pair; an over-capacity `--max-ctx` is
-    // refused here rather than overflowing a cache mid-round.
-    let ctx = crate::speculative::verifier_context(verifier, max_ctx_override)?;
-    let max_seq = ctx.ceiling;
-
-    let mut caches: Vec<KvCache> = (0..verifier.num_hidden_layers())
-        .map(|i| {
-            let window = verifier.layer_sliding_window(i);
-            KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                .with_max_seq_ceiling(ctx.ceiling)
-                .with_layer_idx(i)
-                // The verifier stack decides whether its layers read each
-                // other's K/V, and so whether Mixed/RotK keep their bf16
-                // mirror. A spec pair must not run two different caches.
-                .with_shares_kv(verifier.shares_kv_across_layers())
-        })
-        .collect();
+    let (kv_quant, _, mut caches) = crate::speculative::round_common::verifier_cache_stack(
+        verifier,
+        kv_quant_override,
+        max_ctx_override,
+    )?;
 
     let mut draw = super::VerifierDraw::new(sampler_cfg);
 

--- a/crates/rmlx-models/src/speculative/gemma4_assistant.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant.rs
@@ -73,6 +73,7 @@ use super::{emit_step, DecodeWindow, MAX_BLOCK_SIZE};
 use crate::arch::Architecture;
 use crate::gemma4::LayerType;
 use crate::layers::{Embedding, Linear, Mlp, RmsNorm};
+use crate::speculative::round_common::verifier_cache_stack;
 
 /// One drafter decoder layer (Gemma4 shape, Q-only - K/V are shared).
 #[allow(missing_debug_implementations)]
@@ -769,11 +770,8 @@ pub fn mtp_assistant_generate(
     }
     let mut emitted: Vec<ProbeStep> = Vec::with_capacity(n_tokens);
 
-    let (kv_quant, _, mut caches) = crate::speculative::round_common::verifier_cache_stack(
-        verifier,
-        kv_quant_override,
-        max_ctx_override,
-    )?;
+    let (kv_quant, _, mut caches) =
+        verifier_cache_stack(verifier, kv_quant_override, max_ctx_override)?;
 
     let mut draw = super::VerifierDraw::new(sampler_cfg);
 

--- a/crates/rmlx-models/src/speculative/gemma4_assistant.rs
+++ b/crates/rmlx-models/src/speculative/gemma4_assistant.rs
@@ -61,12 +61,6 @@
 //! kv_offset`), mirroring `draft_block`'s single-position multi-token generator.
 
 #![allow(clippy::cognitive_complexity, clippy::too_many_lines)]
-// kv-layer-quants: uniform — speculative scratch stack. The drafter/verifier
-// caches a round builds live for that round only: they are never pushed to the
-// prompt cache, never spilled, and never keyed by `layout_key`, so no on-disk
-// description has to match them. Applying the boundary promotion here would
-// change the codec of a stack whose only reader is the round that built it.
-
 use std::path::Path;
 
 use rmlx_core::error::{Error, Result};

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -39,12 +39,6 @@ pub(crate) mod draft_kind;
 pub(crate) mod round_common;
 pub(crate) mod round_stats;
 
-// kv-layer-quants: uniform — speculative scratch stack. The drafter/verifier
-// caches a round builds live for that round only: they are never pushed to the
-// prompt cache, never spilled, and never keyed by `layout_key`, so no on-disk
-// description has to match them. Applying the boundary promotion here would
-// change the codec of a stack whose only reader is the round that built it.
-
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use std::time::Instant;
@@ -709,15 +703,7 @@ impl SpeculativeDispatcher {
         );
 
         // --- Allocate per-layer caches for the draft model. ------------
-        let mut draft_caches: Vec<KvCache> = (0..draft.num_hidden_layers())
-            .map(|i| {
-                let window = draft.layer_sliding_window(i);
-                KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                    .with_max_seq_ceiling(max_seq)
-                    .with_layer_idx(i)
-                    .with_shares_kv(draft.shares_kv_across_layers())
-            })
-            .collect();
+        let mut draft_caches = round_common::cache_stack(draft, kv_quant, max_seq);
 
         // --- Recurrent (GatedDeltaNet) caches for hybrid archs. --------
         // Only Qwen3.5MoE needs these; Gemma4 leaves them None and the
@@ -1119,15 +1105,7 @@ impl SpeculativeDispatcher {
             "spec_generate_stochastic_cached: starting (Leviathan stochastic acceptance)"
         );
 
-        let mut draft_caches: Vec<KvCache> = (0..draft.num_hidden_layers())
-            .map(|i| {
-                let window = draft.layer_sliding_window(i);
-                KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                    .with_max_seq_ceiling(max_seq)
-                    .with_layer_idx(i)
-                    .with_shares_kv(draft.shares_kv_across_layers())
-            })
-            .collect();
+        let mut draft_caches = round_common::cache_stack(draft, kv_quant, max_seq);
 
         let mut verifier_lin: Option<Vec<LinearAttnCache>> = if self.verifier.needs_lin_caches() {
             Some(

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -53,27 +53,6 @@ pub use draft_kind::{Declared, DraftKind};
 use rmlx_kv_quant::{GdnTape, GdnTapeSegment, KvCache, KvQuant, LinearAttnCache};
 pub(crate) use round_stats::{phases_charged, RoundPhases, RoundStats, SpecLoop};
 
-/// Resolve the context bounds a speculative pair runs under.
-///
-/// The verifier owns the KV geometry — the drafter inherits its cache sizing
-/// and its positional limit — so the verifier's [`crate::context::ContextLimits`]
-/// are what bound the round loop. Routing through
-/// [`crate::context::resolve_context`] keeps the speculative path on the one
-/// resolution every other context cap reads, and gives it the same refusal:
-/// a `--max-ctx` above the verifier's positional capacity used to be taken
-/// verbatim here and only surfaced as a cache overflow mid-round.
-///
-/// # Errors
-///
-/// [`rmlx_core::error::Error::ContextCeilingExceeded`] when `max_ctx_override`
-/// is above the verifier's positional capacity.
-pub(crate) fn verifier_context(
-    verifier: &Architecture,
-    max_ctx_override: Option<i32>,
-) -> Result<crate::context::ResolvedContext> {
-    crate::context::resolve_context(&verifier.context_limits(), max_ctx_override)
-}
-
 /// Guard the one verifier logit row a speculative driver selects from at
 /// prefill.
 ///
@@ -680,13 +659,6 @@ impl SpeculativeDispatcher {
         let mut draft_ns: u128 = 0;
         let mut verifier_ns: u128 = 0;
 
-        // A layer that reports a sliding window gets the RotatingKvCache port
-        // whatever codec it is handed — the branch is `window > 0` alone
-        // (`KvCache::with_quant_max_seq_window`), so an SWA layer here is bf16
-        // at `sliding_window` tokens under every `kv_quant`, and only the
-        // full-attention layers quantize. A block-verify write leaves that ring
-        // holding its window plus the block, which is what lets the rollback
-        // below drop the rejected tail out of it losslessly.
         let (kv_quant, max_seq, mut verifier_caches) = round_common::verifier_cache_stack(
             &self.verifier,
             kv_quant_override,

--- a/crates/rmlx-models/src/speculative/mod.rs
+++ b/crates/rmlx-models/src/speculative/mod.rs
@@ -36,6 +36,7 @@ pub mod gemma4_assistant;
 pub mod mtp;
 
 pub(crate) mod draft_kind;
+pub(crate) mod round_common;
 pub(crate) mod round_stats;
 
 // kv-layer-quants: uniform — speculative scratch stack. The drafter/verifier
@@ -685,14 +686,18 @@ impl SpeculativeDispatcher {
         let mut draft_ns: u128 = 0;
         let mut verifier_ns: u128 = 0;
 
-        // Resolve KV quant — same value for verifier and draft. The drafter
-        // stack resolves its own default, so it must read the same constant the
-        // verifier does or a spec pair runs two different caches.
-        let kv_quant = kv_quant_override.unwrap_or(crate::kv_cache::DEFAULT_KV_QUANT);
-        // The verifier's limits bound the pair; an over-capacity `--max-ctx`
-        // is refused here rather than overflowing a cache mid-round.
-        let ctx = verifier_context(&self.verifier, max_ctx_override)?;
-        let max_seq = ctx.ceiling;
+        // A layer that reports a sliding window gets the RotatingKvCache port
+        // whatever codec it is handed — the branch is `window > 0` alone
+        // (`KvCache::with_quant_max_seq_window`), so an SWA layer here is bf16
+        // at `sliding_window` tokens under every `kv_quant`, and only the
+        // full-attention layers quantize. A block-verify write leaves that ring
+        // holding its window plus the block, which is what lets the rollback
+        // below drop the rejected tail out of it losslessly.
+        let (kv_quant, max_seq, mut verifier_caches) = round_common::verifier_cache_stack(
+            &self.verifier,
+            kv_quant_override,
+            max_ctx_override,
+        )?;
 
         tracing::info!(
             k,
@@ -703,30 +708,12 @@ impl SpeculativeDispatcher {
             "spec_generate_greedy_cached: starting — persistent caches + truncate_to"
         );
 
-        // --- Allocate per-layer caches for verifier and draft. ---------
-        // A layer that reports a sliding window gets the RotatingKvCache port
-        // whatever codec it is handed — the branch is `window > 0` alone
-        // (`KvCache::with_quant_max_seq_window`), so an SWA layer here is bf16
-        // at `sliding_window` tokens under every `kv_quant`, and only the
-        // full-attention layers quantize. A block-verify write leaves that ring
-        // holding its window plus the block, which is what lets the rollback
-        // below drop the rejected tail out of it losslessly.
-        let mut verifier_caches: Vec<KvCache> = (0..self.verifier.num_hidden_layers())
-            .map(|i| {
-                let window = self.verifier.layer_sliding_window(i);
-                KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                    .with_max_seq_ceiling(ctx.ceiling)
-                    .with_layer_idx(i)
-                    // The stack decides whether its layers read each other's
-                    // K/V, and so whether Mixed/RotK keep their bf16 mirror.
-                    .with_shares_kv(self.verifier.shares_kv_across_layers())
-            })
-            .collect();
+        // --- Allocate per-layer caches for the draft model. ------------
         let mut draft_caches: Vec<KvCache> = (0..draft.num_hidden_layers())
             .map(|i| {
                 let window = draft.layer_sliding_window(i);
                 KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                    .with_max_seq_ceiling(ctx.ceiling)
+                    .with_max_seq_ceiling(max_seq)
                     .with_layer_idx(i)
                     .with_shares_kv(draft.shares_kv_across_layers())
             })
@@ -1113,11 +1100,11 @@ impl SpeculativeDispatcher {
         let mut draft_ns: u128 = 0;
         let mut verifier_ns: u128 = 0;
 
-        // Same constant the verifier resolves — a spec pair must not run two
-        // different caches.
-        let kv_quant = kv_quant_override.unwrap_or(crate::kv_cache::DEFAULT_KV_QUANT);
-        let ctx = verifier_context(&self.verifier, max_ctx_override)?;
-        let max_seq = ctx.ceiling;
+        let (kv_quant, max_seq, mut verifier_caches) = round_common::verifier_cache_stack(
+            &self.verifier,
+            kv_quant_override,
+            max_ctx_override,
+        )?;
 
         tracing::info!(
             k,
@@ -1132,22 +1119,11 @@ impl SpeculativeDispatcher {
             "spec_generate_stochastic_cached: starting (Leviathan stochastic acceptance)"
         );
 
-        let mut verifier_caches: Vec<KvCache> = (0..self.verifier.num_hidden_layers())
-            .map(|i| {
-                let window = self.verifier.layer_sliding_window(i);
-                KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                    .with_max_seq_ceiling(ctx.ceiling)
-                    .with_layer_idx(i)
-                    // The stack decides whether its layers read each other's
-                    // K/V, and so whether Mixed/RotK keep their bf16 mirror.
-                    .with_shares_kv(self.verifier.shares_kv_across_layers())
-            })
-            .collect();
         let mut draft_caches: Vec<KvCache> = (0..draft.num_hidden_layers())
             .map(|i| {
                 let window = draft.layer_sliding_window(i);
                 KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                    .with_max_seq_ceiling(ctx.ceiling)
+                    .with_max_seq_ceiling(max_seq)
                     .with_layer_idx(i)
                     .with_shares_kv(draft.shares_kv_across_layers())
             })

--- a/crates/rmlx-models/src/speculative/mtp.rs
+++ b/crates/rmlx-models/src/speculative/mtp.rs
@@ -676,26 +676,11 @@ pub fn mtp_generate(
 
     let block_total = block_from_request(requested_block_total, drafter.block_size());
 
-    // Same constant the verifier resolves — a spec pair must not run two
-    // different caches.
-    let kv_quant = kv_quant_override.unwrap_or(crate::kv_cache::DEFAULT_KV_QUANT);
-    // The verifier's limits bound the pair; an over-capacity `--max-ctx` is
-    // refused here rather than overflowing a cache mid-round.
-    let ctx = crate::speculative::verifier_context(verifier, max_ctx_override)?;
-    let max_seq = ctx.ceiling;
-
-    let mut v_caches: Vec<KvCache> = (0..verifier.num_hidden_layers())
-        .map(|i| {
-            let window = verifier.layer_sliding_window(i);
-            KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                .with_max_seq_ceiling(ctx.ceiling)
-                .with_layer_idx(i)
-                // The verifier stack decides whether its layers read each
-                // other's K/V, and so whether Mixed/RotK keep their bf16
-                // mirror. A spec pair must not run two different caches.
-                .with_shares_kv(verifier.shares_kv_across_layers())
-        })
-        .collect();
+    let (kv_quant, _, mut v_caches) = crate::speculative::round_common::verifier_cache_stack(
+        verifier,
+        kv_quant_override,
+        max_ctx_override,
+    )?;
     let mut v_lin: Vec<LinearAttnCache> = (0..verifier.num_hidden_layers())
         .map(|_| LinearAttnCache::new())
         .collect();

--- a/crates/rmlx-models/src/speculative/mtp.rs
+++ b/crates/rmlx-models/src/speculative/mtp.rs
@@ -43,12 +43,6 @@
     clippy::unused_self,
     clippy::used_underscore_binding
 )]
-// kv-layer-quants: uniform — speculative scratch stack. The drafter/verifier
-// caches a round builds live for that round only: they are never pushed to the
-// prompt cache, never spilled, and never keyed by `layout_key`, so no on-disk
-// description has to match them. Applying the boundary promotion here would
-// change the codec of a stack whose only reader is the round that built it.
-
 use std::path::Path;
 
 use rmlx_core::error::{Error, Result};

--- a/crates/rmlx-models/src/speculative/mtp.rs
+++ b/crates/rmlx-models/src/speculative/mtp.rs
@@ -52,6 +52,7 @@ use super::{emit_step, DecodeWindow, MAX_BLOCK_SIZE};
 use crate::arch::Architecture;
 use crate::layers::{Linear, RmsNorm};
 use crate::qwen3_5_moe::{MtpLayer, MtpLayerDims};
+use crate::speculative::round_common::verifier_cache_stack;
 use rmlx_kv_quant::{KvCache, KvQuant};
 
 /// Loaded MTP-head sidecar weights (Qwen3.5 `mtp.*`, prefix stripped).
@@ -670,11 +671,8 @@ pub fn mtp_generate(
 
     let block_total = block_from_request(requested_block_total, drafter.block_size());
 
-    let (kv_quant, _, mut v_caches) = crate::speculative::round_common::verifier_cache_stack(
-        verifier,
-        kv_quant_override,
-        max_ctx_override,
-    )?;
+    let (kv_quant, _, mut v_caches) =
+        verifier_cache_stack(verifier, kv_quant_override, max_ctx_override)?;
     let mut v_lin: Vec<LinearAttnCache> = (0..verifier.num_hidden_layers())
         .map(|_| LinearAttnCache::new())
         .collect();

--- a/crates/rmlx-models/src/speculative/round_common.rs
+++ b/crates/rmlx-models/src/speculative/round_common.rs
@@ -1,0 +1,41 @@
+//! What every speculative round loop sets up the same way.
+
+use rmlx_core::error::Result;
+use rmlx_kv_quant::{KvCache, KvQuant};
+
+use crate::arch::Architecture;
+
+/// The KV codec, context ceiling and per-layer cache stack a round loop runs
+/// its verifier on.
+///
+/// The codec is the request's override or the same constant the verifier's own
+/// decode path resolves — a spec pair must not run two different caches — and
+/// the ceiling comes from the verifier's context limits, so an over-capacity
+/// `--max-ctx` is refused here rather than overflowing a cache mid-round. Each
+/// layer's cache carries that layer's sliding window, the ceiling, and whether
+/// the verifier stack's layers read each other's K/V, which is what decides
+/// whether Mixed/RotK keep their bf16 mirror.
+///
+/// # Errors
+///
+/// [`rmlx_core::error::Error::ContextCeilingExceeded`] when `max_ctx_override`
+/// is above the verifier's positional capacity.
+pub(crate) fn verifier_cache_stack(
+    verifier: &Architecture,
+    kv_quant_override: Option<KvQuant>,
+    max_ctx_override: Option<i32>,
+) -> Result<(KvQuant, i32, Vec<KvCache>)> {
+    let kv_quant = kv_quant_override.unwrap_or(crate::kv_cache::DEFAULT_KV_QUANT);
+    let ctx = super::verifier_context(verifier, max_ctx_override)?;
+    let max_seq = ctx.ceiling;
+    let caches = (0..verifier.num_hidden_layers())
+        .map(|i| {
+            let window = verifier.layer_sliding_window(i);
+            KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
+                .with_max_seq_ceiling(ctx.ceiling)
+                .with_layer_idx(i)
+                .with_shares_kv(verifier.shares_kv_across_layers())
+        })
+        .collect();
+    Ok((kv_quant, max_seq, caches))
+}

--- a/crates/rmlx-models/src/speculative/round_common.rs
+++ b/crates/rmlx-models/src/speculative/round_common.rs
@@ -1,4 +1,10 @@
 //! What every speculative round loop sets up the same way.
+//!
+//! Nothing here has a unit test, and cannot: an [`Architecture`] is only
+//! reachable by loading weights. What gates it is a round-loop run against a
+//! real pair — `the_assistant_round_loop_reproduces_plain_greedy` in
+//! `crates/rmlx-models/tests/spec_greedy_equivalence.rs` is the cheapest — and
+//! the per-round event stream that run writes.
 
 // kv-layer-quants: uniform — speculative scratch stack. The drafter/verifier
 // caches a round builds live for that round only: they are never pushed to the
@@ -15,12 +21,15 @@ use crate::arch::Architecture;
 /// its verifier on.
 ///
 /// The codec is the request's override or the same constant the verifier's own
-/// decode path resolves — a spec pair must not run two different caches — and
-/// the ceiling comes from the verifier's context limits, so an over-capacity
-/// `--max-ctx` is refused here rather than overflowing a cache mid-round. Each
-/// layer's cache carries that layer's sliding window, the ceiling, and whether
-/// the verifier stack's layers read each other's K/V, which is what decides
-/// whether Mixed/RotK keep their bf16 mirror.
+/// decode path resolves — a spec pair must not run two different caches.
+///
+/// The ceiling is the verifier's: it owns the KV geometry, the drafter inherits
+/// its cache sizing and its positional limit, so the verifier's
+/// [`crate::context::ContextLimits`] are what bound the round loop. Routing
+/// through [`crate::context::resolve_context`] keeps the speculative path on
+/// the one resolution every other context cap reads, and gives it the same
+/// refusal: a `--max-ctx` above the verifier's positional capacity used to be
+/// taken verbatim here and only surfaced as a cache overflow mid-round.
 ///
 /// # Errors
 ///
@@ -32,11 +41,23 @@ pub(crate) fn verifier_cache_stack(
     max_ctx_override: Option<i32>,
 ) -> Result<(KvQuant, i32, Vec<KvCache>)> {
     let kv_quant = kv_quant_override.unwrap_or(crate::kv_cache::DEFAULT_KV_QUANT);
-    let max_seq = super::verifier_context(verifier, max_ctx_override)?.ceiling;
+    let max_seq =
+        crate::context::resolve_context(&verifier.context_limits(), max_ctx_override)?.ceiling;
     Ok((kv_quant, max_seq, cache_stack(verifier, kv_quant, max_seq)))
 }
 
 /// One model's per-layer cache stack for one speculative request.
+///
+/// Each layer's cache carries that layer's sliding window, the ceiling, and
+/// whether the stack's layers read each other's K/V — which is what decides
+/// whether Mixed/RotK keep their bf16 mirror.
+///
+/// A layer that reports a sliding window gets the RotatingKvCache port whatever
+/// codec it is handed — the branch is `window > 0` alone — so an SWA layer is
+/// bf16 at `sliding_window` tokens under every `kv_quant` and only the
+/// full-attention layers quantize. A block-verify write leaves that ring
+/// holding its window plus the block, which is what lets a round's rollback
+/// drop the rejected tail out of it losslessly.
 ///
 /// The two-model loops build a second one of these for the draft model, at the
 /// verifier's codec and the verifier's ceiling: the verifier owns the KV

--- a/crates/rmlx-models/src/speculative/round_common.rs
+++ b/crates/rmlx-models/src/speculative/round_common.rs
@@ -1,5 +1,11 @@
 //! What every speculative round loop sets up the same way.
 
+// kv-layer-quants: uniform — speculative scratch stack. The drafter/verifier
+// caches a round builds live for that round only: they are never pushed to the
+// prompt cache, never spilled, and never keyed by `layout_key`, so no on-disk
+// description has to match them. Applying the boundary promotion here would
+// change the codec of a stack whose only reader is the round that built it.
+
 use rmlx_core::error::Result;
 use rmlx_kv_quant::{KvCache, KvQuant};
 

--- a/crates/rmlx-models/src/speculative/round_common.rs
+++ b/crates/rmlx-models/src/speculative/round_common.rs
@@ -32,16 +32,24 @@ pub(crate) fn verifier_cache_stack(
     max_ctx_override: Option<i32>,
 ) -> Result<(KvQuant, i32, Vec<KvCache>)> {
     let kv_quant = kv_quant_override.unwrap_or(crate::kv_cache::DEFAULT_KV_QUANT);
-    let ctx = super::verifier_context(verifier, max_ctx_override)?;
-    let max_seq = ctx.ceiling;
-    let caches = (0..verifier.num_hidden_layers())
+    let max_seq = super::verifier_context(verifier, max_ctx_override)?.ceiling;
+    Ok((kv_quant, max_seq, cache_stack(verifier, kv_quant, max_seq)))
+}
+
+/// One model's per-layer cache stack for one speculative request.
+///
+/// The two-model loops build a second one of these for the draft model, at the
+/// verifier's codec and the verifier's ceiling: the verifier owns the KV
+/// geometry of a pair, so the draft's stack is the same stack against a
+/// different layer count.
+pub(crate) fn cache_stack(arch: &Architecture, kv_quant: KvQuant, max_seq: i32) -> Vec<KvCache> {
+    (0..arch.num_hidden_layers())
         .map(|i| {
-            let window = verifier.layer_sliding_window(i);
+            let window = arch.layer_sliding_window(i);
             KvCache::with_quant_max_seq_window(kv_quant, max_seq, window)
-                .with_max_seq_ceiling(ctx.ceiling)
+                .with_max_seq_ceiling(max_seq)
                 .with_layer_idx(i)
-                .with_shares_kv(verifier.shares_kv_across_layers())
+                .with_shares_kv(arch.shares_kv_across_layers())
         })
-        .collect();
-    Ok((kv_quant, max_seq, caches))
+        .collect()
 }

--- a/crates/rmlx-models/src/speculative/round_skeleton_tests.rs
+++ b/crates/rmlx-models/src/speculative/round_skeleton_tests.rs
@@ -80,33 +80,29 @@
 //! copy, at absolute values, so an extraction is judged against something that
 //! can fail rather than against a re-derivation of itself.
 
-use super::dflash::{dflash_next_block_size, walk_block_greedy};
-use super::eagle3::eagle3_walk;
+use super::dflash::dflash_next_block_size;
 use super::{
     accept_prefix, draft_rows_to_drop, rollback_target_from_head, rollback_target_from_tail,
     round_block, two_model_drafts_per_round, MAX_BLOCK_SIZE,
 };
 
-/// One acceptance walk over a drafted block, spelled three times.
+/// One acceptance walk over a drafted block, and the rows the three spellings
+/// agreed on before it was one.
 ///
-/// `dflash::walk_block_greedy` and `eagle3::eagle3_walk` are the same source
-/// under two names; `accept_prefix` reaches the same answer from the verifier's
-/// side. The extraction keeps one of them, so what has to survive is the answer
-/// all three give — accepted count and committed tokens — and the fact that
-/// `budget` caps the emission without capping the acceptance.
+/// The two block walks are gone and [`accept_prefix`] is what every round loop
+/// calls, so what these rows pin is the answer the collapse had to preserve —
+/// accepted count and committed tokens — and the fact that `budget` caps the
+/// emission without capping the acceptance. The empty-proposal row is the shape
+/// the loops' own guard refuses before a walk ever sees it.
 ///
-/// Each walk's own behaviour is pinned in `tests.rs` and `eagle3/tests.rs`; what
-/// is here is only what a collapse of the three has to preserve about all of
-/// them at once.
-///
-/// Mutation: in `eagle3_walk`, change `new_tokens.truncate(budget)` to
-/// `new_tokens.truncate(budget + 1)`.
+/// Mutation: change `new_tokens.truncate(budget)`'s equivalent in
+/// [`accept_prefix`] — `if emit.len() < budget` — to `<= budget`.
 #[test]
 #[allow(
     clippy::expect_used,
     reason = "the fixture rows below are same-length by construction, so accept_prefix's length guard cannot fire on them"
 )]
-fn the_three_acceptance_walks_commit_the_same_rows() {
+fn the_acceptance_walk_commits_the_rows_the_three_spellings_agreed_on() {
     // (drafted, verifier's own tokens, budget, expected accepted, expected commit)
     let cases: [(&[u32], &[u32], usize, usize, &[u32]); 4] = [
         // The budget caps the commit and leaves the acceptance alone — the
@@ -124,22 +120,10 @@ fn the_three_acceptance_walks_commit_the_same_rows() {
         (&[], &[4], 8, 0, &[4]),
     ];
     for (draft, verifier, budget, want_accept, want_commit) in cases {
-        let (a1, c1) = walk_block_greedy(draft, verifier, budget);
-        let (a2, c2) = eagle3_walk(draft, verifier, budget);
-        let (a3, c3) = accept_prefix(verifier, draft, budget)
+        let (accepted, commit) = accept_prefix(verifier, draft, budget)
             .expect("verifier rows are one longer than the proposals in every case above");
         assert_eq!(
-            (a1, c1.as_slice()),
-            (want_accept, want_commit),
-            "walk_block_greedy on {draft:?} against {verifier:?} at budget {budget}"
-        );
-        assert_eq!(
-            (a2, c2.as_slice()),
-            (want_accept, want_commit),
-            "eagle3_walk on {draft:?} against {verifier:?} at budget {budget}"
-        );
-        assert_eq!(
-            (a3, c3.as_slice()),
+            (accepted, commit.as_slice()),
             (want_accept, want_commit),
             "accept_prefix on {draft:?} against {verifier:?} at budget {budget}"
         );

--- a/crates/rmlx-models/src/speculative/round_skeleton_tests.rs
+++ b/crates/rmlx-models/src/speculative/round_skeleton_tests.rs
@@ -114,9 +114,9 @@ fn the_acceptance_walk_commits_the_rows_the_three_spellings_agreed_on() {
         // A single proposal, held.
         (&[7], &[7, 5], 8, 1, &[7, 5]),
         // No proposals at all: the shape the loops' empty-chain guard exists to
-        // refuse before it reaches a walk. All three still agree on it, so the
-        // guard is the only thing standing between a broken drafter and a round
-        // that silently emits one token.
+        // refuse before it reaches a walk. The walk answers it rather than
+        // refusing, so the guard is the only thing standing between a broken
+        // drafter and a round that silently emits one token.
         (&[], &[4], 8, 0, &[4]),
     ];
     for (draft, verifier, budget, want_accept, want_commit) in cases {

--- a/crates/rmlx-models/src/speculative/tests.rs
+++ b/crates/rmlx-models/src/speculative/tests.rs
@@ -755,30 +755,6 @@ fn accept_prefix_refuses_a_block_that_is_not_its_proposals_plus_a_bonus() {
     assert!(accept_prefix(&[10, 11, 12, 99, 0], &[10, 11, 12], 8).is_err());
 }
 
-/// The block walks answer a call `accept_prefix` refuses, and the refusal is the
-/// behaviour a collapse of the three must keep.
-///
-/// `dflash::walk_block_greedy` and `eagle3::eagle3_walk` are the same source
-/// under two names, and neither checks that the verifier's block is the
-/// proposals plus one bonus slot. Handed the arguments the wrong way round they
-/// report **four proposals accepted where three were made** — a count that then
-/// drives a KV rollback past the position the round actually committed. Whoever
-/// collapses the three onto one walk inherits `accept_prefix`'s refusal, which
-/// is the point of writing this down rather than leaving it to be discovered.
-#[test]
-fn the_block_walks_answer_the_call_accept_prefix_refuses() {
-    let verifier = [10u32, 11, 12, 99];
-    let draft = [10u32, 11, 12];
-    assert!(accept_prefix(&draft, &verifier, 8).is_err());
-    let bogus = (4, vec![10, 11, 12, 99]);
-    assert_eq!(
-        dflash::walk_block_greedy(&verifier, &draft, 8),
-        bogus,
-        "recorded, not required: this is the answer the refusal exists to prevent"
-    );
-    assert_eq!(eagle3::eagle3_walk(&verifier, &draft, 8), bogus);
-}
-
 // ---------------------------------------------------------------------------
 // Reading the verifier's argmax back
 // ---------------------------------------------------------------------------

--- a/docs/KV_CACHE.md
+++ b/docs/KV_CACHE.md
@@ -857,8 +857,11 @@ storage variants regardless of `--paged-kv`):
 When neither `--kv-quant` nor the primitives are passed, the codec is
 `rmlx_models::kv_cache::DEFAULT_KV_QUANT` - unquantised bf16 - for every
 architecture, every checkpoint and every prompt length. One constant, read by
-the CLI, the server load path, the image branch, the arch dispatcher and all
-six speculative drafter stacks.
+the CLI, the server load path, the image branch, the arch dispatcher and
+`speculative::round_common::verifier_cache_stack`
+(`crates/rmlx-models/src/speculative/round_common.rs`), which is the only
+reader on the speculative side: every round loop's verifier stack comes from
+it, and the two-model loops' draft stacks from the same builder.
 
 It replaced a per-arch table (keyed on arch class, `hidden_size`, the MoE flag,
 the PARO flag and `quantization.bits`) and a separate per-prompt-length server

--- a/docs/KV_QUANT.md
+++ b/docs/KV_QUANT.md
@@ -3264,9 +3264,13 @@ parallel `cargo test`.
 **unquantised bf16** (`KvQuant::None`), for every architecture, every
 checkpoint and every prompt length. One constant,
 `rmlx_models::kv_cache::DEFAULT_KV_QUANT`, is the only producer; the CLI, the
-server load path, the image branch, the arch dispatcher and all six
-speculative drafter stacks read it and nothing else. There is no per-arch table
-and no per-context re-selection behind it.
+server load path, the image branch, the arch dispatcher and
+`speculative::round_common::verifier_cache_stack`
+(`crates/rmlx-models/src/speculative/round_common.rs`) read it and nothing
+else. That last is the only reader on the speculative side: every round loop's
+verifier stack comes from it, and the two-model loops' draft stacks from the
+same builder. There is no per-arch table and no per-context re-selection behind
+it.
 
 Two things this replaced, both removed rather than retuned:
 

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -1052,11 +1052,16 @@ The verifier and draft KV caches are allocated at round-loop entry with
 layers receive their layer-specific `window` value; full-attention layers
 receive `max_seq`. The `max_seq` bound is the ceiling
 `rmlx_models::context::resolve_context` produced for the pair — the verifier
-owns the KV geometry, so its `ContextLimits` are what bound the round loop, and
-`speculative::verifier_context` is the one wrapper all six drivers call. A
-`--max-ctx` above the verifier's positional capacity is refused there, with the
-same message the non-speculative paths give, instead of being taken verbatim
-and overflowing a cache mid-round. See `docs/CLI.md` § "Context ceiling".
+owns the KV geometry, so its `ContextLimits` are what bound the round loop.
+There is one producer of all of it:
+`speculative::round_common::verifier_cache_stack`
+(`crates/rmlx-models/src/speculative/round_common.rs`) resolves the codec and
+the ceiling and builds the verifier's stack, and every round loop calls it; the
+two-model loops build the draft model's stack from the same builder at the
+verifier's codec and ceiling. A `--max-ctx` above the verifier's positional
+capacity is refused there, with the same message the non-speculative paths
+give, instead of being taken verbatim and overflowing a cache mid-round. See
+`docs/CLI.md` § "Context ceiling".
 
 Verifier prefill (all paths) uses `prefill_chunked`, which gates how much
 sequence length is dispatched per Metal command buffer. The chunk is the


### PR DESCRIPTION
The two pieces of the round skeleton that were already pinned by identity, extracted and nothing else. The `RoundStats` assembly, the emit loop, the rollback, the KV-bytes report, the seed emit and the per-round events are untouched — each loop's three exits keep their exact current behaviour.

## 1. One acceptance walk

`dflash::walk_block_greedy` and `eagle3::eagle3_walk` were byte-identical bodies under two names, and neither checked that the verified block is the proposals plus one bonus slot: handed the arguments the wrong way round they answered, reporting four proposals accepted where three were made, and that count drives a KV rollback. Both call sites now take `accept_prefix`, which refuses that call. Every call site was read first: both build the verifier's rows as `v_k = 1 + draft_tokens.len()` positions, so no call site relied on the permissive answer.

## 2. One producer for the verifier's cache stack

The seven round loops each carried a byte-identical copy of the codec resolution, the context resolve and the per-layer cache stack. One `pub(crate)` function in `speculative/round_common.rs`, seven call sites. It returns the codec, the ceiling and the stack — `max_seq` and `ctx.ceiling` were the same value at every site and nothing else read `ctx`.

The context-ceiling consumer list in `context_tests.rs` collapses from six speculative entries to one: the place that resolves.

## Removals

Added in the review round:

- `speculative::verifier_context` — one caller left after the extraction; inlined into `verifier_cache_stack`, and the `verifier_context(` needle in `ceiling_consumers_are_enumerated` with it
- the `// kv-layer-quants: uniform — …` declaration from `dflash/mod.rs`, `dflash2/round.rs`, `gemma4_assistant.rs`, `mtp.rs` and `speculative/mod.rs` — none of the five builds a cache any more, so each was declaring a policy for code that had left
- the two inline `draft_caches` blocks in the two-model loops — the eighth and ninth copies of the same stack
- one more `CEILING_CONSUMERS` entry (`speculative/mod.rs`)

- `dflash::walk_block_greedy`, its four unit tests and its `dflash_module_compiles` entry
- `eagle3::eagle3_walk`, its four unit tests and its `eagle3_module_compiles` entry
- `tests.rs::the_block_walks_answer_the_call_accept_prefix_refuses` — the "recorded, not required" pin on the answer the two walks gave to a swapped call; its subject is gone and the refusal itself is still pinned by `accept_prefix_refuses_a_block_that_is_not_its_proposals_plus_a_bonus`
- seven copies of the verifier cache-stack allocation, and the five `verifier_context` call sites they held
- four `CEILING_CONSUMERS` entries

## Proof

- `make check-spec-charge`: 7 loops, census `charge_phases:3 false:4`
- `make check-spec-sampling`: 6 drivers, 6 arms
- `make check`, `make lint`, `make fmt-check`, `make check-no-inline-tests`, `make check-gpu-tests-ignored`, `make check-doc-source-citations`: green
- `cargo test -p rmlx-models`: green (857 lib tests)
- All six equivalence pairs run one at a time on an idle machine, then `spec_round_stream_compare.py verify`: **36 of 36 cells match the checked-in manifest, exit 0**. Every judged cell `Agreed`; the four `Unjudgeable` verdicts are the prompt-length and restricted-vocabulary ones the gate already reports.

Two mutations, each shown failing and restored from a sha256-verified snapshot:

1. `accept_prefix`'s guard weakened from `!=` to `<` → `accept_prefix_refuses_a_block_that_is_not_its_proposals_plus_a_bonus` fails on the over-long block.
2. the shared stack allocated one layer short → the assistant pair refuses at the first forward: `gemma4: cache slice holds 34 entries but layer 34 needs its own slot`.

`make debt-report`: the file-pair section is byte-identical — no pair gained. The driver group's pairwise similarity falls on every sidecar pair (dflash↔mtp 64.4→62.9, dflash↔dflash2 59.2→56.4, dflash2↔mtp 56.9→54.0, eagle3↔mtp 47.6→45.5, assistant↔mtp 49.2→46.6); the two cached two-model loops hold at 71.7% because the same lines left both.

## Two pins that had to change, and why

Both name the deleted functions by construction, so neither could stay as written. No pinned value moved:

- `round_skeleton_tests.rs::the_three_acceptance_walks_commit_the_same_rows` → `the_acceptance_walk_commits_the_rows_the_three_spellings_agreed_on`: the same four rows at the same absolute values, with the two calls to the deleted twins dropped.
- `context_tests.rs::ceiling_consumers_are_enumerated`: the list is a scan of the tree, and the extraction moved four call sites into one file.


---

# Review round

Three commits, one per requested item.

**1 — the uniformity declaration follows the cache stack** (`054fe8c8`). The marker moves to `round_common.rs`; the four files that no longer build a stack lose theirs; EAGLE-3's is reworded to name what it is now about (the drafter's own single unquantized cache, not a per-layer stack). `make check-kv-layer-quants` green.

**2 — one builder for every stack** (`8de8f2ff`). `cache_stack(arch, kv_quant, max_seq) -> Vec<KvCache>` is the builder; `verifier_cache_stack` returns it beside the codec and the ceiling; both two-model draft sites call it. Three callers, no trait. The shared closure body is **token-identical** to both inline ones after `draft` → `arch` — checked mechanically, not by eye — so no pair was re-run. `speculative/mod.rs` then builds no cache at all, and its own marker goes with the code, same rule as item 1.

**3 — truth of comments and docs** (`4ead4276`). `docs/SPECULATIVE.md` names `round_common::verifier_cache_stack` as the one producer and cites the file, so the citation gate holds it. The SWA-ring paragraph moves from the greedy two-model loop into `cache_stack`'s doc, where it is about the code beside it. `verifier_context` is inlined into its one caller. `CEILING_CONSUMERS`'s header now says it enumerates where a ceiling is *resolved*, not everywhere one is applied. `round_common.rs`'s module doc records that nothing in it can have a unit test — an `Architecture` needs weights — and names the cheapest real-model gate. The four full-path call sites import the name; the stale "all three still agree" comment is corrected.

Gates after the three commits: `make check-kv-layer-quants`, `make check`, `make lint`, `make fmt-check`, `make check-spec-charge` (7 loops, `charge_phases:3 false:4`), `make check-spec-sampling` (6 drivers, 6 arms), `make check-doc-source-citations` (207 paths), `cargo test -p rmlx-models` — all green.
