### PR TITLE
spec(design): the round skeleton's interface, its oracle and its mutation list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ areas before touching code:
 | [`docs/PROMPT_CACHE.md`](docs/PROMPT_CACHE.md) | Prompt cache + automatic prefix caching (block hashing, ReusePolicy, prefix index) |
 | [`docs/SPECULATIVE.md`](docs/SPECULATIVE.md) | Speculative decoding (MTP, DFlash, Eagle3 drafters; round-loop; accept-rate gates) |
 | [`docs/SPEC_ANSWER_EQUIVALENCE.md`](docs/SPEC_ANSWER_EQUIVALENCE.md) | Answer equivalence for speculative decoding: the divergence-confidence oracle, why agreement cannot be thresholded |
+| [`docs/SPEC_ROUND_SKELETON.md`](docs/SPEC_ROUND_SKELETON.md) | **Proposal, not implemented**: one round loop and a drafter interface for the seven speculative loops — what it cannot express, the migration order, the oracle and the mutation list |
 | [`docs/SAMPLING.md`](docs/SAMPLING.md) | Per-token sampling (temperature, top-k/p, penalties, thinking budget, constrained decoding) |
 | [`docs/FFI.md`](docs/FFI.md) | rmlx-mlx ↔ mlx-c FFI bridge; MSL kernel surface; unsafe policy |
 | [`docs/METRICS_DB.md`](docs/METRICS_DB.md) | Metrics DB: observations / events / bests; ingest, query, export, deltas |

--- a/crates/rmlx-models/src/speculative/round_skeleton_tests.rs
+++ b/crates/rmlx-models/src/speculative/round_skeleton_tests.rs
@@ -297,17 +297,20 @@ enum ReportSkippedBy {
 enum ChainRefusedBy {
     /// On the proposals themselves, before the verify forward.
     TheProposalChain,
-    /// On the verifier input the empty chain produces, one step later.
+    /// On the verifier input the empty chain produces. The same test, one
+    /// statement later: a two-model round's verifier carry is always one token,
+    /// so the input is under two positions exactly when the chain is empty.
     TheVerifierInput,
 }
 
 /// What each round loop declares at its edges, and the file that holds it.
 ///
 /// This table is the statement; the two tests below are readings of it against
-/// today's source. Both facts become per-drafter declarations in the engine when
-/// the loops collapse, and this table is then re-keyed onto those declarations
-/// with the same seven rows — which is why it is data rather than seven
-/// assertions.
+/// today's source. It is data rather than seven assertions because it is what
+/// survives the collapse: the resident-KV disposition becomes a `RoundDrafter`
+/// declaration, the first migration re-keys the reading onto that declaration,
+/// and each migration drops its own file from [`LOOP_SOURCES`] in the same
+/// commit while these rows stay as they are. See `docs/SPEC_ROUND_SKELETON.md`.
 const DISPOSITIONS: [(SpecLoop, &str, ReportSkippedBy, ChainRefusedBy); 7] = [
     (
         SpecLoop::MtpSidecar,
@@ -399,15 +402,21 @@ const LOOP_SOURCES: [(&str, &str); 6] = [
     ),
 ];
 
-/// The four edge markers, each as the character the reading below renders it as.
+/// The five edge markers, each as the character the reading below renders it as.
 ///
 /// `E` is the early exit, `W` the head of the round loop, `G` either spelling of
-/// the empty-chain refusal, `P` the report of the verifier's resident KV.
-const MARKERS: [(char, &str); 5] = [
+/// the empty-chain refusal, `R` the request record a loop closes on, `P` the
+/// report of the verifier's resident KV.
+///
+/// `R` is what makes the reading see a report moved *into* the round loop: with
+/// four markers a report placed after the refusal reads the same as one at the
+/// tail, because nothing marked where the loop ended.
+const MARKERS: [(char, &str); 6] = [
     ('E', "return Ok((emitted"),
     ('W', "while emitted.len() < n_tokens"),
     ('G', "draft_tokens.is_empty()"),
     ('G', "v_k < 2"),
+    ('R', "log_request_record("),
     ('P', "report_verifier_kv_bytes("),
 ];
 
@@ -439,14 +448,16 @@ fn marker_sequence(src: &str) -> String {
 /// How the markers of one loop fall in source order, given which exit skips the
 /// report.
 ///
-/// A loop that skips it on the seed exit returns before the round loop opens and
-/// reports after it closes; a loop with no seed has its early exit inside the
-/// round loop, past the refusal. Those are two different orderings of the same
-/// four markers, which is what makes this reading positional rather than a count.
+/// A loop that skips it on the seed exit returns before the round loop opens,
+/// then records and reports after it closes. A loop with no seed has its early
+/// exit inside the round loop, past the refusal, and writes its own record
+/// before returning — so its record site appears twice, once on each exit. Those
+/// are two different orderings of the same five markers, which is what makes
+/// this reading positional rather than a count.
 fn expected_pattern(skipped_by: ReportSkippedBy) -> &'static str {
     match skipped_by {
-        ReportSkippedBy::TheSeedExit => "EWGP",
-        ReportSkippedBy::TheInRoundExit => "WGEP",
+        ReportSkippedBy::TheSeedExit => "EWGRP",
+        ReportSkippedBy::TheInRoundExit => "WGRERP",
     }
 }
 
@@ -459,17 +470,19 @@ fn expected_pattern(skipped_by: ReportSkippedBy) -> &'static str {
 /// is the one thing a single shared round loop cannot keep without carrying a
 /// per-drafter flag for it, so a chunk that collapses the loops decides it here.
 ///
-/// The reading is by position and not by count, because the mutation this holds
-/// moves a call rather than adding one: a report hoisted above the seed-EOS
-/// return inverts the disposition and leaves every total unchanged.
+/// The reading is by position and not by count, because the mutations this holds
+/// move a call rather than adding one: a report hoisted above the seed-EOS
+/// return inverts the disposition, and one lowered into the round loop skips it
+/// on both exits, each leaving every total unchanged.
 ///
-/// **It reads text, and the distance to what it claims is exactly between "the
-/// call is written here" and "the call reports the verifier's caches".** A report
-/// computed from the drafter's stack passes this and every other check in the
-/// tree — see the mutation table in `docs/SPEC_ROUND_SKELETON.md`.
+/// **It reads text, in statement order, and is blind past that.** The distance
+/// to what it claims is between "the call is written here" and "the call runs
+/// and reports the verifier's caches": a report at the declared position inside
+/// a branch that never executes reads identical, and so does one handed the
+/// drafter's stack. See the mutation table in `docs/SPEC_ROUND_SKELETON.md`.
 ///
 /// Mutation: move any loop's `report_verifier_kv_bytes` call above its early
-/// return, or delete it.
+/// return, or below the head of its round loop, or delete it.
 #[test]
 fn every_loop_reports_the_verifiers_resident_kv_at_the_exit_it_declares() {
     for (file, src) in LOOP_SOURCES {
@@ -482,8 +495,8 @@ fn every_loop_reports_the_verifiers_resident_kv_at_the_exit_it_declares() {
             marker_sequence(src),
             want,
             "{file}: the early exit (E), the round loop (W), the empty-chain \
-             refusal (G) and the resident-KV report (P) do not fall in the order \
-             the table declares for the loop(s) it holds"
+             refusal (G), the request record (R) and the resident-KV report (P) \
+             do not fall in the order the table declares for the loop(s) it holds"
         );
     }
 }
@@ -497,11 +510,14 @@ fn every_loop_reports_the_verifiers_resident_kv_at_the_exit_it_declares() {
 /// and a request that silently emits one token per round at full cost. Nothing
 /// at runtime covers its loss: no gate serves a drafter that proposes nothing.
 ///
-/// The two spellings are not interchangeable. Five loops refuse the proposals;
-/// the two-model pair refuses the verifier input the empty chain produces, one
-/// step later, having already taken a drafting forward per proposal. A shared
-/// loop has one refusal, so both spellings go at the same moment and one of the
-/// two families changes where it stops.
+/// The two spellings are the same test taken one statement apart, and both
+/// families reach it after every drafting forward the round takes — a two-model
+/// round's verifier carry is always one token, so an input under two positions
+/// is an empty chain and nothing else. Neither family stops anywhere the other
+/// would not, and a shared loop with one refusal moves no request. What it
+/// replaces is seven `Error::Model` texts with one, and what that one still has
+/// to say is that an empty chain is a broken drafter and not the end of the
+/// request.
 ///
 /// Mutation: drop either spelling from any loop, or move a loop from one
 /// spelling to the other without moving its row.

--- a/crates/rmlx-models/src/speculative/round_skeleton_tests.rs
+++ b/crates/rmlx-models/src/speculative/round_skeleton_tests.rs
@@ -21,8 +21,11 @@
 //!   skipped on one EOS exit per loop — the seed EOS for the five sidecar
 //!   loops, the in-round EOS for the two two-model ones. A loop that changed
 //!   which exit it takes reports a different figure, or none, with every token
-//!   identical. Nothing enforces this; pinned by review — a report added on a
-//!   seed-EOS exit leaves every gate green.
+//!   identical. Nothing at runtime enforces this — a report added on a seed-EOS
+//!   exit leaves every gate green — so what holds it is
+//!   [`every_round_loop_has_one_exit_that_reports_the_verifiers_resident_kv`]
+//!   below, which reads the disposition out of the source and is blind to what
+//!   the call does once it is made.
 //! - **`RoundStats::charged`**, which is `phases_charged()` in three loops and a
 //!   literal `false` in four. It decides whether each round forces its carried
 //!   arrays before its span closes, so it moves the phase timings and the work
@@ -269,4 +272,141 @@ fn the_draft_side_keeps_the_carry_and_the_accepted_prefix() {
     assert_eq!(draft_rows_to_drop(7, 6), 0);
     assert_eq!(draft_rows_to_drop(7, 0), 6);
     assert_eq!(draft_rows_to_drop(1, 0), 0);
+}
+
+// ---------------------------------------------------------------------------
+// What the seven loops do at their edges, read out of the source
+// ---------------------------------------------------------------------------
+
+/// The seven round loops, by the file that holds each. `mod.rs` holds two.
+const LOOP_SOURCES: [(&str, &str, usize); 6] = [
+    (
+        "mtp.rs",
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/speculative/mtp.rs"
+        )),
+        1,
+    ),
+    (
+        "dflash/mod.rs",
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/speculative/dflash/mod.rs"
+        )),
+        1,
+    ),
+    (
+        "dflash2/round.rs",
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/speculative/dflash2/round.rs"
+        )),
+        1,
+    ),
+    (
+        "eagle3/mod.rs",
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/speculative/eagle3/mod.rs"
+        )),
+        1,
+    ),
+    (
+        "gemma4_assistant.rs",
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/speculative/gemma4_assistant.rs"
+        )),
+        1,
+    ),
+    (
+        "mod.rs",
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/speculative/mod.rs"
+        )),
+        2,
+    ),
+];
+
+/// How often `needle` appears in code, skipping whole-line comments.
+///
+/// A needle written into the sentence that explains it would otherwise count as
+/// the call it describes — the same reading `scripts/check_spec_charge.sh`
+/// takes, and for the same reason. A trailing comment on a line of code is not
+/// stripped: it would need a quote-aware scan, and no needle here is one a
+/// caller would write at the end of a statement.
+fn code_occurrences(src: &str, needle: &str) -> usize {
+    src.lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .map(|line| line.matches(needle).count())
+        .sum()
+}
+
+/// Each round loop has one exit that reports its verifier's resident KV and one
+/// that does not.
+///
+/// The figure has one writer — a speculative request never goes through
+/// `Architecture::generate_greedy` — so a caller that samples the counter around
+/// the call reads whatever the previous request left when a loop skips it. Which
+/// exit skips it differs today: the five sidecar loops return on the seed EOS
+/// before reaching the report and fall through to it after an in-round EOS, and
+/// the two two-model loops do the opposite, having no seed. That difference is
+/// the one thing a single shared round loop cannot keep without carrying a
+/// per-drafter flag for it, so a chunk that collapses the loops decides it here.
+///
+/// **This reads text, not behaviour**, and the distance is exactly between "the
+/// call is still written" and "the call still reports the verifier's caches". A
+/// report computed from the drafter's stack passes this and every other check in
+/// the tree — see the mutation table in `docs/SPEC_ROUND_SKELETON.md`.
+///
+/// Mutation: delete the `report_verifier_kv_bytes` call from any loop's tail, or
+/// add one on a seed-EOS exit.
+#[test]
+fn every_round_loop_has_one_exit_that_reports_the_verifiers_resident_kv() {
+    for (name, src, loops) in LOOP_SOURCES {
+        assert_eq!(
+            code_occurrences(src, "report_verifier_kv_bytes("),
+            loops,
+            "{name} holds {loops} round loop(s), and each reports its verifier's \
+             resident KV at exactly one exit"
+        );
+        assert_eq!(
+            code_occurrences(src, "return Ok((emitted"),
+            loops,
+            "{name} holds {loops} round loop(s), and each has exactly one early \
+             exit that returns before that report — the seed EOS for a sidecar \
+             loop, the in-round EOS for a two-model one"
+        );
+    }
+}
+
+/// Every round loop refuses a drafter that proposed nothing, before the walk.
+///
+/// The acceptance walk answers an empty chain rather than refusing it — pinned
+/// by [`the_acceptance_walk_commits_the_rows_the_three_spellings_agreed_on`]
+/// above — so the guard is the only thing standing between a broken drafter and
+/// a request that silently emits one token per round at full cost. Nothing at
+/// runtime covers its loss: no gate serves a drafter that proposes nothing.
+///
+/// The two two-model loops refuse the same shape one step later and by a
+/// different measure, on the verifier input the empty chain produces. A shared
+/// loop has one guard, so both spellings go at the same moment; this is what
+/// makes that visible rather than silent.
+///
+/// Mutation: drop the `is_empty` refusal from any sidecar loop, or either
+/// `v_k < 2` from the two-model pair.
+#[test]
+fn every_round_loop_refuses_a_drafter_that_proposed_nothing() {
+    for (name, src, loops) in LOOP_SOURCES {
+        let by_chain = code_occurrences(src, "draft_tokens.is_empty()");
+        let by_input = code_occurrences(src, "v_k < 2");
+        assert_eq!(
+            by_chain + by_input,
+            loops,
+            "{name} holds {loops} round loop(s) and states {by_chain} empty-chain \
+             refusal(s) beside {by_input} on the verifier input"
+        );
+    }
 }

--- a/crates/rmlx-models/src/speculative/round_skeleton_tests.rs
+++ b/crates/rmlx-models/src/speculative/round_skeleton_tests.rs
@@ -21,11 +21,14 @@
 //!   skipped on one EOS exit per loop — the seed EOS for the five sidecar
 //!   loops, the in-round EOS for the two two-model ones. A loop that changed
 //!   which exit it takes reports a different figure, or none, with every token
-//!   identical. Nothing at runtime enforces this — a report added on a seed-EOS
-//!   exit leaves every gate green — so what holds it is
-//!   [`every_round_loop_has_one_exit_that_reports_the_verifiers_resident_kv`]
-//!   below, which reads the disposition out of the source and is blind to what
-//!   the call does once it is made.
+//!   identical, and nothing at runtime sees it — a report added on a seed-EOS
+//!   exit leaves every gate green. What states it is the seven-row
+//!   [`DISPOSITIONS`] table below, one row per loop; what reads that table
+//!   against today's source is
+//!   [`every_loop_reports_the_verifiers_resident_kv_at_the_exit_it_declares`],
+//!   positionally, so a call moved to the other exit fails rather than passing
+//!   on an unchanged total. The reading is of text and is blind to what the call
+//!   does once it is made.
 //! - **`RoundStats::charged`**, which is `phases_charged()` in three loops and a
 //!   literal `false` in four. It decides whether each round forces its carried
 //!   arrays before its span closes, so it moves the phase timings and the work
@@ -88,7 +91,7 @@
 use super::dflash::dflash_next_block_size;
 use super::{
     accept_prefix, draft_rows_to_drop, rollback_target_from_head, rollback_target_from_tail,
-    round_block, two_model_drafts_per_round, MAX_BLOCK_SIZE,
+    round_block, two_model_drafts_per_round, SpecLoop, MAX_BLOCK_SIZE,
 };
 
 /// One acceptance walk over a drafted block, and the rows the three spellings
@@ -275,18 +278,89 @@ fn the_draft_side_keeps_the_carry_and_the_accepted_prefix() {
 }
 
 // ---------------------------------------------------------------------------
-// What the seven loops do at their edges, read out of the source
+// What the seven loops declare at their edges
 // ---------------------------------------------------------------------------
 
-/// The seven round loops, by the file that holds each. `mod.rs` holds two.
-const LOOP_SOURCES: [(&str, &str, usize); 6] = [
+/// Which of a loop's two exits skips the report of the verifier's resident KV.
+#[derive(Debug, Clone, Copy)]
+enum ReportSkippedBy {
+    /// The seed EOS: the loop emits a token out of its prefill forward, and a
+    /// request whose whole output is that token returns before any round.
+    TheSeedExit,
+    /// The in-round EOS: the loop emits nothing before its first round, so the
+    /// only early exit it has is inside one.
+    TheInRoundExit,
+}
+
+/// How a loop refuses a drafter that proposed nothing.
+#[derive(Debug, Clone, Copy)]
+enum ChainRefusedBy {
+    /// On the proposals themselves, before the verify forward.
+    TheProposalChain,
+    /// On the verifier input the empty chain produces, one step later.
+    TheVerifierInput,
+}
+
+/// What each round loop declares at its edges, and the file that holds it.
+///
+/// This table is the statement; the two tests below are readings of it against
+/// today's source. Both facts become per-drafter declarations in the engine when
+/// the loops collapse, and this table is then re-keyed onto those declarations
+/// with the same seven rows — which is why it is data rather than seven
+/// assertions.
+const DISPOSITIONS: [(SpecLoop, &str, ReportSkippedBy, ChainRefusedBy); 7] = [
+    (
+        SpecLoop::MtpSidecar,
+        "mtp.rs",
+        ReportSkippedBy::TheSeedExit,
+        ChainRefusedBy::TheProposalChain,
+    ),
+    (
+        SpecLoop::DFlash,
+        "dflash/mod.rs",
+        ReportSkippedBy::TheSeedExit,
+        ChainRefusedBy::TheProposalChain,
+    ),
+    (
+        SpecLoop::DFlash2,
+        "dflash2/round.rs",
+        ReportSkippedBy::TheSeedExit,
+        ChainRefusedBy::TheProposalChain,
+    ),
+    (
+        SpecLoop::Eagle3,
+        "eagle3/mod.rs",
+        ReportSkippedBy::TheSeedExit,
+        ChainRefusedBy::TheProposalChain,
+    ),
+    (
+        SpecLoop::MtpAssistant,
+        "gemma4_assistant.rs",
+        ReportSkippedBy::TheSeedExit,
+        ChainRefusedBy::TheProposalChain,
+    ),
+    (
+        SpecLoop::TwoModelGreedy,
+        "mod.rs",
+        ReportSkippedBy::TheInRoundExit,
+        ChainRefusedBy::TheVerifierInput,
+    ),
+    (
+        SpecLoop::TwoModelStochastic,
+        "mod.rs",
+        ReportSkippedBy::TheInRoundExit,
+        ChainRefusedBy::TheVerifierInput,
+    ),
+];
+
+/// The files the table names, in the order it names them, each with its source.
+const LOOP_SOURCES: [(&str, &str); 6] = [
     (
         "mtp.rs",
         include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/src/speculative/mtp.rs"
         )),
-        1,
     ),
     (
         "dflash/mod.rs",
@@ -294,7 +368,6 @@ const LOOP_SOURCES: [(&str, &str, usize); 6] = [
             env!("CARGO_MANIFEST_DIR"),
             "/src/speculative/dflash/mod.rs"
         )),
-        1,
     ),
     (
         "dflash2/round.rs",
@@ -302,7 +375,6 @@ const LOOP_SOURCES: [(&str, &str, usize); 6] = [
             env!("CARGO_MANIFEST_DIR"),
             "/src/speculative/dflash2/round.rs"
         )),
-        1,
     ),
     (
         "eagle3/mod.rs",
@@ -310,7 +382,6 @@ const LOOP_SOURCES: [(&str, &str, usize); 6] = [
             env!("CARGO_MANIFEST_DIR"),
             "/src/speculative/eagle3/mod.rs"
         )),
-        1,
     ),
     (
         "gemma4_assistant.rs",
@@ -318,7 +389,6 @@ const LOOP_SOURCES: [(&str, &str, usize); 6] = [
             env!("CARGO_MANIFEST_DIR"),
             "/src/speculative/gemma4_assistant.rs"
         )),
-        1,
     ),
     (
         "mod.rs",
@@ -326,87 +396,142 @@ const LOOP_SOURCES: [(&str, &str, usize); 6] = [
             env!("CARGO_MANIFEST_DIR"),
             "/src/speculative/mod.rs"
         )),
-        2,
     ),
 ];
 
-/// How often `needle` appears in code, skipping whole-line comments.
+/// The four edge markers, each as the character the reading below renders it as.
 ///
-/// A needle written into the sentence that explains it would otherwise count as
-/// the call it describes — the same reading `scripts/check_spec_charge.sh`
+/// `E` is the early exit, `W` the head of the round loop, `G` either spelling of
+/// the empty-chain refusal, `P` the report of the verifier's resident KV.
+const MARKERS: [(char, &str); 5] = [
+    ('E', "return Ok((emitted"),
+    ('W', "while emitted.len() < n_tokens"),
+    ('G', "draft_tokens.is_empty()"),
+    ('G', "v_k < 2"),
+    ('P', "report_verifier_kv_bytes("),
+];
+
+/// Whether a line is code rather than a whole-line comment.
+///
+/// A marker written into the sentence that explains it would otherwise read as
+/// the statement it describes — the same reading `scripts/check_spec_charge.sh`
 /// takes, and for the same reason. A trailing comment on a line of code is not
-/// stripped: it would need a quote-aware scan, and no needle here is one a
-/// caller would write at the end of a statement.
-fn code_occurrences(src: &str, needle: &str) -> usize {
-    src.lines()
-        .filter(|line| !line.trim_start().starts_with("//"))
-        .map(|line| line.matches(needle).count())
-        .sum()
+/// stripped: that needs a quote-aware scan, and no marker here is one a caller
+/// would write at the end of a statement.
+fn is_code(line: &str) -> bool {
+    !line.trim_start().starts_with("//")
 }
 
-/// Each round loop has one exit that reports its verifier's resident KV and one
-/// that does not.
+/// The file's edge markers in source order, as characters.
+fn marker_sequence(src: &str) -> String {
+    let mut seen: Vec<(usize, char)> = Vec::new();
+    for (idx, line) in src.lines().enumerate().filter(|(_, l)| is_code(l)) {
+        for (mark, needle) in MARKERS {
+            if line.contains(needle) {
+                seen.push((idx, mark));
+            }
+        }
+    }
+    seen.sort_unstable();
+    seen.into_iter().map(|(_, mark)| mark).collect()
+}
+
+/// How the markers of one loop fall in source order, given which exit skips the
+/// report.
 ///
-/// The figure has one writer — a speculative request never goes through
-/// `Architecture::generate_greedy` — so a caller that samples the counter around
-/// the call reads whatever the previous request left when a loop skips it. Which
-/// exit skips it differs today: the five sidecar loops return on the seed EOS
-/// before reaching the report and fall through to it after an in-round EOS, and
-/// the two two-model loops do the opposite, having no seed. That difference is
-/// the one thing a single shared round loop cannot keep without carrying a
+/// A loop that skips it on the seed exit returns before the round loop opens and
+/// reports after it closes; a loop with no seed has its early exit inside the
+/// round loop, past the refusal. Those are two different orderings of the same
+/// four markers, which is what makes this reading positional rather than a count.
+fn expected_pattern(skipped_by: ReportSkippedBy) -> &'static str {
+    match skipped_by {
+        ReportSkippedBy::TheSeedExit => "EWGP",
+        ReportSkippedBy::TheInRoundExit => "WGEP",
+    }
+}
+
+/// Every loop's exits fall where the table says they do.
+///
+/// The report of the verifier's resident KV has one writer — a speculative
+/// request never goes through `Architecture::generate_greedy` — so a caller that
+/// samples the counter around the call reads whatever the previous request left
+/// when a loop skips it. Which exit skips it is the drafter's own fact, and it
+/// is the one thing a single shared round loop cannot keep without carrying a
 /// per-drafter flag for it, so a chunk that collapses the loops decides it here.
 ///
-/// **This reads text, not behaviour**, and the distance is exactly between "the
-/// call is still written" and "the call still reports the verifier's caches". A
-/// report computed from the drafter's stack passes this and every other check in
-/// the tree — see the mutation table in `docs/SPEC_ROUND_SKELETON.md`.
+/// The reading is by position and not by count, because the mutation this holds
+/// moves a call rather than adding one: a report hoisted above the seed-EOS
+/// return inverts the disposition and leaves every total unchanged.
 ///
-/// Mutation: delete the `report_verifier_kv_bytes` call from any loop's tail, or
-/// add one on a seed-EOS exit.
+/// **It reads text, and the distance to what it claims is exactly between "the
+/// call is written here" and "the call reports the verifier's caches".** A report
+/// computed from the drafter's stack passes this and every other check in the
+/// tree — see the mutation table in `docs/SPEC_ROUND_SKELETON.md`.
+///
+/// Mutation: move any loop's `report_verifier_kv_bytes` call above its early
+/// return, or delete it.
 #[test]
-fn every_round_loop_has_one_exit_that_reports_the_verifiers_resident_kv() {
-    for (name, src, loops) in LOOP_SOURCES {
+fn every_loop_reports_the_verifiers_resident_kv_at_the_exit_it_declares() {
+    for (file, src) in LOOP_SOURCES {
+        let want: String = DISPOSITIONS
+            .iter()
+            .filter(|(_, f, _, _)| *f == file)
+            .map(|&(_, _, skipped_by, _)| expected_pattern(skipped_by))
+            .collect();
         assert_eq!(
-            code_occurrences(src, "report_verifier_kv_bytes("),
-            loops,
-            "{name} holds {loops} round loop(s), and each reports its verifier's \
-             resident KV at exactly one exit"
-        );
-        assert_eq!(
-            code_occurrences(src, "return Ok((emitted"),
-            loops,
-            "{name} holds {loops} round loop(s), and each has exactly one early \
-             exit that returns before that report — the seed EOS for a sidecar \
-             loop, the in-round EOS for a two-model one"
+            marker_sequence(src),
+            want,
+            "{file}: the early exit (E), the round loop (W), the empty-chain \
+             refusal (G) and the resident-KV report (P) do not fall in the order \
+             the table declares for the loop(s) it holds"
         );
     }
 }
 
-/// Every round loop refuses a drafter that proposed nothing, before the walk.
+/// Every loop refuses a drafter that proposed nothing, by the measure the table
+/// names.
 ///
 /// The acceptance walk answers an empty chain rather than refusing it — pinned
 /// by [`the_acceptance_walk_commits_the_rows_the_three_spellings_agreed_on`]
-/// above — so the guard is the only thing standing between a broken drafter and
-/// a request that silently emits one token per round at full cost. Nothing at
-/// runtime covers its loss: no gate serves a drafter that proposes nothing.
+/// above — so the refusal is the only thing standing between a broken drafter
+/// and a request that silently emits one token per round at full cost. Nothing
+/// at runtime covers its loss: no gate serves a drafter that proposes nothing.
 ///
-/// The two two-model loops refuse the same shape one step later and by a
-/// different measure, on the verifier input the empty chain produces. A shared
-/// loop has one guard, so both spellings go at the same moment; this is what
-/// makes that visible rather than silent.
+/// The two spellings are not interchangeable. Five loops refuse the proposals;
+/// the two-model pair refuses the verifier input the empty chain produces, one
+/// step later, having already taken a drafting forward per proposal. A shared
+/// loop has one refusal, so both spellings go at the same moment and one of the
+/// two families changes where it stops.
 ///
-/// Mutation: drop the `is_empty` refusal from any sidecar loop, or either
-/// `v_k < 2` from the two-model pair.
+/// Mutation: drop either spelling from any loop, or move a loop from one
+/// spelling to the other without moving its row.
 #[test]
-fn every_round_loop_refuses_a_drafter_that_proposed_nothing() {
-    for (name, src, loops) in LOOP_SOURCES {
-        let by_chain = code_occurrences(src, "draft_tokens.is_empty()");
-        let by_input = code_occurrences(src, "v_k < 2");
-        assert_eq!(
-            by_chain + by_input,
-            loops,
-            "{name} holds {loops} round loop(s) and states {by_chain} empty-chain \
-             refusal(s) beside {by_input} on the verifier input"
-        );
+fn every_loop_refuses_a_drafter_that_proposed_nothing_by_its_declared_measure() {
+    for (file, src) in LOOP_SOURCES {
+        for (mark, needle) in MARKERS {
+            if mark != 'G' {
+                continue;
+            }
+            let want = DISPOSITIONS
+                .iter()
+                .filter(|(_, f, _, refused_by)| {
+                    *f == file
+                        && needle
+                            == match refused_by {
+                                ChainRefusedBy::TheProposalChain => "draft_tokens.is_empty()",
+                                ChainRefusedBy::TheVerifierInput => "v_k < 2",
+                            }
+                })
+                .count();
+            let have = src
+                .lines()
+                .filter(|l| is_code(l) && l.contains(needle))
+                .count();
+            assert_eq!(
+                have, want,
+                "{file} states `{needle}` {have} time(s) where the table declares \
+                 {want} loop(s) refusing an empty chain that way"
+            );
+        }
     }
 }

--- a/docs/SPECULATIVE.md
+++ b/docs/SPECULATIVE.md
@@ -118,6 +118,12 @@ reference. It carries a pair for six of the seven round loops below; the seventh
 is the two-model stochastic one, which runs only above temperature 0 and so has
 no arm this gate can compare.
 
+**One loop, proposed.** The seven loops are one algorithm written seven times,
+and `docs/SPEC_ROUND_SKELETON.md` is the proposal that collapses them: the
+drafter interface, what each loop does the interface cannot express, the
+migration order, and the mutations a skeleton could contain beside what catches
+each. It is a proposal — nothing in the tree implements it yet.
+
 ```text
 # Initialisation
 prefill verifier + draft on prompt[..-1]

--- a/docs/SPEC_ROUND_SKELETON.md
+++ b/docs/SPEC_ROUND_SKELETON.md
@@ -29,7 +29,7 @@ remaining budget, propose, arm the recurrent tape, verify, walk the acceptance,
 emit what the round committed, roll the verifier's caches back to the accepted
 prefix, roll the drafter's own state back, condition the next round, log one
 round event; then, after the loop — one request record, one report of the
-verifier's resident KV, and the widest block any round ran.
+verifier's resident KV, and a block figure the caller reads back.
 
 What differs is five things: how a drafter proposes, what it conditions on, how
 it rolls its own state back, which of the verifier's outputs it needs captured,
@@ -43,8 +43,8 @@ implements in its own module.
 
 ```rust
 pub(crate) trait RoundDrafter {
-    /// Prefill, and the token the request emits before its first round.
-    /// `None` is a pair that emits nothing until a round has run.
+    /// Prefill, the token the request emits before its first round, and how long
+    /// the prefill took. `None` is a pair that emits nothing until a round runs.
     fn prefill(&mut self, ctx: &mut RoundCtx<'_>, prompt: &[u32]) -> Result<Prefilled>;
 
     /// The block this round runs. Default `round_block(block_total, remaining)`.
@@ -58,19 +58,31 @@ pub(crate) trait RoundDrafter {
 
     /// Return the drafter's own state to the accepted prefix. `None` is a
     /// drafter that keeps nothing across rounds.
-    fn rollback(&mut self, ctx: &RoundCtx<'_>, v: &Verdict) -> Result<Option<CacheSpan>>;
+    fn rollback(&mut self, ctx: &RoundCtx<'_>, v: &Verdict, emit: RoundEmit)
+        -> Result<Option<CacheSpan>>;
 
     /// Condition the next round on what this one committed. `None` is a drafter
     /// that carries no conditioning buffer.
-    fn condition(&mut self, ctx: &RoundCtx<'_>, v: &Verdict) -> Result<Option<Conditioning>>;
+    fn condition(&mut self, ctx: &RoundCtx<'_>, v: &Verdict, emit: RoundEmit)
+        -> Result<Option<Conditioning>>;
 }
 ```
 
-`Verdict` carries the accepted count, the tokens the round commits, and — for a
-restricted-vocabulary drafter — how long this round's restricted prefix is.
-`RoundCtx` carries the verifier, its cache stacks, the device and the charge
-decision; `rollback` and `condition` take it immutably, so only `prefill` and
-`verify` can advance the verifier's caches.
+`Prefilled` carries the seed, this drafter's own `prefill_ns`, and whether the
+drafter carries a conditioning buffer — see items 9 and 10 below for why the
+last two are the drafter's to state. `Verdict` carries the accepted count, the
+tokens the round commits, and — for a restricted-vocabulary drafter — how long
+this round's restricted prefix is. `RoundEmit` is what
+`round_common::emit_round_tokens` already returns: the committed count and
+whether a token stopped the request.
+
+`RoundCtx` carries the verifier, its two cache stacks, the device, the request's
+`VerifierDraw` and the charge decision. The draw is in it because every `verify`
+draws the verifier's tokens through it and EAGLE-3 additionally reads
+`draw.sampling()` to decide whether the restricted read-back may run at all;
+without it in the context, the loop would hold the sampler and hand it to nobody.
+`rollback` and `condition` take the context immutably, so only `prefill` and
+`verify` can advance the verifier's caches or the draw.
 
 ### Why the fields are paired
 
@@ -81,7 +93,7 @@ half of the report into structs the *drafter* constructs:
 
 ```rust
 pub(crate) struct CacheSpan { pub before: i32, pub target: i32 }
-pub(crate) struct Conditioning { pub rows: i32, pub projected: i32 }
+pub(crate) struct Conditioning { pub rows: Option<i32>, pub projected: Option<i32> }
 ```
 
 A field added to either is a compile error in every drafter that builds one. A
@@ -89,17 +101,32 @@ field added to the loop's own half — the round index, the accept, the committe
 count, the charge, the phases — is one compile error at one site, correctly, so
 no drafter is asked for a fact it does not have.
 
-Both are returned as `Option`, and the `None` arm is a word rather than a
+`projected` is optional because the MTP sidecar reports a conditioning row and
+no projection: it slices one verifier row per round rather than projecting one,
+so `condition_rows` is `Some` and `projected_rows` is `None` on every line it
+writes. A non-optional `projected` would put a number on twelve pinned cells
+that carry none. `rows` is optional for a weaker reason: every loop reads it off
+the buffer's shape and reports whatever that read returned, and making it
+non-optional would introduce either an unwrap or a refusal on a path no cell
+exercises.
+
+Both structs are returned as `Option`, and the `None` arm is a word rather than a
 literal of `None` fields. That is deliberate: a drafter that keeps no cache and
 one that keeps one are two different statements, and only the second owes a
 value when the struct grows. The cost is that a `None` drafter is silent about a
 new field — which is right, since it has none — and the reviewer's job is to
 check that a drafter answering `None` really carries nothing.
 
+**Both structs land in migration chunk 2, not chunk 1.** The Gemma4 assistant
+answers `None` to both, so introducing them with it would land two types with no
+producer. Chunk 1 passes the report's per-drafter half as the `None`s the
+assistant already writes; chunk 2 introduces the structs with the MTP sidecar,
+their first producer, and re-keys the report onto them.
+
 ## What the interface cannot express, and what is proposed for it
 
-Seven things. Five are expressible with no branch in the loop; two are decisions
-the owner has to take.
+Ten things. Seven are expressible with no branch in the loop; three are decisions
+the owner has to take, marked as such.
 
 1. **The stochastic acceptance rule.** `spec_generate_stochastic_cached` does not
    compare tokens: it builds the verifier's post-sampling distribution at every
@@ -124,10 +151,19 @@ the owner has to take.
 4. **DFlash 1's adaptive block.** `dflash_next_block_size` opens with
    `round_block` and then moves the result by the accept rate of the recent
    rounds. Proposed: the `block` method, six defaults and one override.
-5. **The widest block a run reached.** The five sidecar loops return the widest
-   block; the two two-model loops return the widest *proposal count*, which is
-   one less. Proposed: the loop returns the widest block and the two-model entry
-   subtracts one, so the unit difference stays in the module that owns it.
+5. **The block figure the caller reads back, and its two exits.** The five
+   sidecar loops return the widest block any round ran; the two two-model loops
+   return the widest *proposal count*, one less. Both families return something
+   else again on the seed or in-round EOS exit — the *resolved* block, not the
+   widest that ran, which contradicts every one of their doc comments. The server
+   discards the figure for every loop; only
+   `crates/rmlx-models/tests/qwen3_5_mtp_drafter_alignment.rs` reads it, for the
+   MTP sidecar's normal exit. Proposed: the loop returns the widest block that
+   ran on every exit including the EOS ones, and the two-model entry subtracts
+   one, so the unit stays in the module that owns it. Changing the EOS exits'
+   value is a change to a figure with one reader on one loop, and that reader
+   does not exercise an EOS exit — which is why it is listed here rather than
+   done quietly.
 6. **The verifier offset a round reports.** The Gemma4 assistant reads it before
    its verify forward and counts forward over the accepted prefix; the other six
    read it after and count back from the tail. The two spellings name the same
@@ -141,16 +177,21 @@ the owner has to take.
    re-blessed baseline — moves 36 cells for a field whose meaning does not
    change, and costs a full capture.
 
-   The refusal is worth stating on its own: it is a check nothing in the tree
-   performs today, it is free, and it is the only runtime catcher a rollback off
-   by one would have that does not need a GPU.
-
+   The refusal is a new runtime error path taken on every round, and its
+   correctness rests on an invariant nothing asserts: that the verifier's
+   post-forward offset is exactly the pre-round offset plus the positions the
+   round fed. Six loops read that offset as a maximum across the stack precisely
+   because a recurrent layer's `KvCache` never advances, and the assistant's
+   stack mixes sliding-window rings with full-attention layers. The chunk that
+   adds the refusal owes two controls: a positive one, that it fires on a planted
+   off-by-one, and a negative one, that all seven loops pass 36 of 36 cells with
+   it armed. Without both it is a new way for a correct round to fail.
 7. **The exit that reports the verifier's resident KV.** Each loop has exactly
    one exit that calls `round_common::report_verifier_kv_bytes` and exactly one
-   that does not, and *which* exit differs: the five sidecar loops skip it on the
-   seed-EOS exit and reach it after an in-round EOS; the two two-model loops
-   reach it on the normal exit and return before it on an in-round EOS. One loop
-   has one exit shape.
+   that does not, and *which* exit differs: the five sidecar loops return on the
+   seed EOS before reaching the report and fall through to it after an in-round
+   EOS; the two two-model loops do the opposite, having no seed. One loop has one
+   exit shape.
 
    **Proposed, and it is a behaviour change: every exit reports.** The figure has
    one writer — a speculative request never goes through
@@ -161,6 +202,32 @@ the owner has to take.
    This changes no baseline cell, no pair reading and no gate. That is exactly
    why it must be written down here rather than merged: see "the mutation I
    could not catch" below.
+8. **What a round conditions on.** DFlash 1 conditions on the round's *committed*
+   count and DFlash 2 on `accept + 1`, at the same two calls — the row count
+   handed to `committed_rows` and the bound handed to `guard_round_conditioning`.
+   The two agree except when the request's budget cuts the block, and neither
+   derives from the other. The MTP sidecar advances its drafting position by the
+   committed count for the same reason. The committed count is known only after
+   the emission, which happens between `verify` and `condition`. Proposed: the
+   loop's order is verify, emit, verifier rollback, drafter rollback, condition,
+   and the `RoundEmit` the emission returned is passed to the last two.
+9. **Whether a drafter carries a conditioning buffer, before its first round.**
+   The request record's `conditioned_rows` is `Some(0)` on the seed-EOS record of
+   DFlash 1 and DFlash 2 and `None` on the other five — a statement about the
+   drafter, made before any round has run. Fourteen `RoundTotals` literals state
+   it today, and one loop-built literal cannot know it. Proposed: `Prefilled`
+   declares it, and the loop reads that declaration for both the seed record and
+   the tail record. Without the declaration the two `Some(0)`s become `None` and
+   nothing anywhere sees it: `RoundStats::conditioning_violation` is guarded on
+   `None` and passes.
+10. **What `prefill_ns` covers.** The three loops that prefill the prompt less
+    its last token close the span before their round-0 carry forward; DFlash 2
+    closes it after its whole-prompt capture, trim and projection but before the
+    seed draw; EAGLE-3 closes it after the seed draw *and* after its drafter's
+    own KV prefill, which conditions on the verifier's capture. Proposed:
+    `prefill` returns its own `prefill_ns` and the loop does not time it. A loop
+    that timed the call would move the figure on five of seven records and no
+    gate would see it.
 
 ## Migration order
 
@@ -171,24 +238,33 @@ and a byte-identical round stream.
    by slug and runs under `make gpu-test` on any machine holding the snapshots —
    every other pair needs an operator-named `RMLX_DRAFT_TEST_MODEL`, so this is
    the only first choice whose proof a reviewer can reproduce without being told
-   which snapshot to fetch. It exercises the most optional arms of the interface
-   per unit of proof cost: the charged arm (`phases_charged()` and
+   which snapshot to fetch. It exercises the charged arm (`phases_charged()` and
    `RoundPhases`), the head-basis offset of item 6, the `None` recurrent stack,
    a drafter that keeps no cache of its own, and the sliding-window ring's
-   rollback. This chunk also carries the gate re-key below — a migrated entry
-   moves out of the charge gate's derived population the moment its body goes.
-2. **The MTP sidecar.** The complement: a recurrent refold, a drafter cache
-   rolled back by offset, a single conditioning row, and a `d_offset`/`d_target`
-   pair on the round line. Two pairs on one verifier at two blocks.
-3. **DFlash 2.** A conditioning window that slides, a prompt-window capture, and
-   the second charged loop.
-4. **DFlash 1.** The adaptive block, and the one loop whose verify width is not
-   fixed.
-5. **EAGLE-3.** The restricted vocabulary, the attribution buffer, and a drafter
-   that rolls back by re-running.
+   rollback. It answers `None` to both `rollback` and `condition`, so it proves
+   the loop and the two optional arms and nothing about the two paired structs —
+   which is why those wait for chunk 2. This chunk also carries the gate re-key
+   below: a migrated entry leaves the charge gate's derived population the moment
+   its body goes.
+2. **The MTP sidecar.** The complement, and the first producer of `CacheSpan` and
+   `Conditioning`: a recurrent refold, a drafter cache rolled back by offset, a
+   single conditioning row with no projection beside it, and a
+   `d_offset`/`d_target` pair on the round line.
+3. **DFlash 2.** A conditioning window that slides, a prompt-window capture, the
+   second charged loop, and the first drafter to declare a conditioning buffer
+   before its first round.
+4. **DFlash 1.** The adaptive block, the one loop whose verify width is not
+   fixed, and the other half of item 8 — it conditions on the committed count
+   where DFlash 2 conditions on the acceptance.
+5. **EAGLE-3.** The restricted vocabulary, the attribution buffer, a drafter that
+   rolls back by re-running, and the only `verify` that reads `draw.sampling()`
+   to decide which of two read-backs it may take.
 6. **The two-model greedy loop.** Two full models, a draft-side rollback with its
    own tape, no seed, and the resync that prepends the last draft token on a full
-   accept.
+   accept. It is also where the raw `argmax` read-back becomes the context's
+   `VerifierDraw`; the two are the same at temperature 0, and
+   `the_two_model_round_loop_reproduces_plain_greedy` is what says so rather than
+   the claim.
 7. **The two-model stochastic loop.** Last, because it is the only acceptance
    rule that is not the shared one and the only loop with no equivalence pair —
    its gate is `crates/rmlx-models/tests/two_model_stochastic.rs`, which pins
@@ -196,7 +272,7 @@ and a byte-identical round stream.
 
 ## The oracle
 
-Four observables, and each is blind to something different.
+Five observables, and each is blind to something different.
 
 - **The per-round event stream** against the checked-in baseline:
   `python3 scripts/spec_round_stream_compare.py verify <capture>`, 36 of 36 cells
@@ -206,15 +282,26 @@ Four observables, and each is blind to something different.
   spans, the conditioning pair, `refolded`. It is blind to the values inside a
   round: two runs agreeing on every count can be scoring different logits. It is
   blind to `charged`, which reads `false` on both sides by construction. It is
-  blind to anything a loop does not report, the resident-KV figure included.
+  blind to anything a loop does not report, the resident-KV figure included, and
+  it sees no request that ran no round.
+- **The request record**, one `done` line per request, assembled from the
+  `RoundTotals` a loop closes on: `block_size`, `rounds`, `emitted`,
+  `seed_emitted`, `emitted_in_rounds`, `conditioned_rows`, the accept counters,
+  the four spans and `charged`. This is the only observable that covers a request
+  which stopped on its seed, and the only one that carries `conditioned_rows`.
+  Fourteen literals produce it today — five seed-EOS, two in-round EOS, seven
+  tails — and collapsing them to one is owed to this campaign. It is blind to
+  which round moved anything, and its `conditioning_violation` and
+  `emission_violation` are guarded, so a figure that becomes `None` passes.
 - **The equivalence pairs**, judged by the divergence-confidence oracle in
   `docs/SPEC_ANSWER_EQUIVALENCE.md` at the readings recorded there. They see the
   answer. They are blind to every sampled arm, blind to the stochastic loop
   entirely, and blind wherever a pair's drafter is not resolvable on the machine
   running them.
 - **`make check-spec-charge`**, whose census must read `charge_phases:3 false:4`
-  at every step of the campaign — see the gate section. It sees a decision that
-  moved. It cannot see whether the schedule it describes is the right one.
+  over seven charge sites at every step of the campaign — see the gate section.
+  It sees a decision that moved. It cannot see whether the schedule it describes
+  is the right one.
 - **`make check-spec-sampling`**, which sees that a driver was handed the
   request's sampler and read it. It cannot tell a right distribution from a
   wrong one; `crates/rmlx-models/tests/spec_sampled_distribution.rs` does that,
@@ -231,6 +318,8 @@ answer after a draft-side change says that run's near-ties happened not to move.
   same commit with the loop and the reason named.
 - Every equivalence-pair reading in `docs/SPEC_ANSWER_EQUIVALENCE.md`, recorded
   again in each migration PR's body.
+- Every field of the request record, per loop — `conditioned_rows` on the two
+  seed-EOS records that carry `Some(0)` included.
 - The exit behaviour of every loop: the seed-EOS exit that returns before any
   round, the in-round EOS exit that stops the request, the empty-chain refusal,
   and the token budget that caps the emission without capping the acceptance.
@@ -246,43 +335,47 @@ answer after a draft-side change says that run's near-ties happened not to move.
 
 | mutation | catcher | exists today |
 |---|---|---|
-| the rollback target off by one at the loop's call site | round stream `v_target`; the pairs (this is the "rejected tail never rolled off" broken engine, refused 6 of 6); and, proposed above, the loop's own head-against-tail refusal | stream and pairs yes, the refusal is new |
+| the rollback target off by one at the loop's call site | round stream `v_target`; the pairs (this is the "rejected tail never rolled off" broken engine, refused 6 of 6); and, proposed above, the loop's own head-against-tail refusal | stream and pairs yes, the refusal is new and owes two controls |
 | a drafter's condition called on the wrong row | round stream `condition_rows` / `projected_rows`; `guard_round_conditioning` refuses a projection that does not match the commit | yes |
+| a round conditioned on the acceptance where the loop conditions on the commit | round stream `projected_rows`, on a prompt whose budget cuts a block | yes, on that prompt only |
 | a capture handed to the wrong drafter | the type system — each drafter takes its own capture inside its own `verify` | new, structural |
 | the block narrowing dropped, or the adaptive schedule applied to the wrong drafter | round stream `num_draft` | yes |
 | the recurrent tape not armed before the verify | `refold_lin_tapes` refuses a tape that does not describe the round | yes |
 | a seed emitted where none was, or dropped | round stream `emitted_total` shifts on every line; `RoundStats::emission_violation` | yes |
 | the restricted prefix reported for a loop that has no restricted vocabulary | the EAGLE-3 boundary rule in the equivalence gate reads `DecidedBy` per token | yes |
-| the charge token hard-wired across the collapse | `make check-spec-charge`, re-keyed as below | needs the re-key |
+| the charge token hard-wired across the collapse | `make check-spec-charge`, re-keyed as below — the census on one reading, RULE 8 on the other | needs the re-key |
 | the in-round EOS exit stops recording the request | round stream ends early; the request record is absent | yes |
 | **the seed-EOS exit stops returning early** | nothing at runtime: no round runs, so no round line is written, and no gate prompt has an EOS seed | **new, none** |
 | **the resident-KV report moved to another exit, or computed from the wrong caches** | nothing at runtime | **new, none** |
-| **the widest-block return changes unit for the two-model entry** | nothing: the server discards it and no two-model test reads it | **new, none** |
+| **`conditioned_rows` on a seed-EOS record falls from `Some(0)` to `None`** | nothing: `conditioning_violation` is guarded on `None`, the round stream sees no request that ran no round, and no pair has an EOS seed | **new, none** |
+| **the block figure changes unit, or an EOS exit returns the widest instead of the resolved block** | nothing for six of the seven loops: the server discards it, and the one test that reads it reads the MTP sidecar's normal exit | **new, none** |
 | the empty-chain refusal lost | nothing at runtime — a drafter that proposes nothing makes the acceptance walk answer rather than refuse, and the round silently emits one token | **new, none** |
+| `prefill_ns` recomposed by the loop | nothing: five of seven records would move and the figure has no bound to fail | **new, none** |
 
-Two of the four uncatchable rows get a text-level catcher in this chunk, in
-`crates/rmlx-models/src/speculative/round_skeleton_tests.rs`: one test pins that
-every loop has exactly one exit that reports the verifier's resident KV and
-exactly one that does not, and one pins that every loop refuses an empty
-proposal chain before its acceptance walk. Both read source text, so both are
-weaker than a runtime check by exactly the distance between "the call is still
-written" and "the call still does the right thing". What they buy is that a
-migration cannot change either disposition without editing an assertion and
-saying why.
+Two of those rows get a text-level catcher in this chunk, in
+`crates/rmlx-models/src/speculative/round_skeleton_tests.rs`. What holds them is
+a **seven-row table** naming, per loop, which exit skips the resident-KV report
+and how the loop refuses an empty proposal chain; the source scan is a *reading*
+of that table against today's tree, positional rather than by count, so a report
+moved to the other exit fails rather than passing on an unchanged total. The
+table is the part that survives the collapse: when the disposition becomes a
+per-drafter declaration in the engine, the test re-keys onto the declaration and
+keeps the same seven rows.
 
 ### The mutation I could not catch
 
 **The resident-KV report.** Nothing observable in this crate reads it: it is not
 on the round line, the equivalence pairs do not touch it, the accept counters do
 not carry it, and the value only becomes visible in an append-only metrics row
-written by the server. A migration that keeps the call and reports the wrong
-caches — the drafter's instead of the verifier's, say, which is the mistake the
-function's own documentation warns against — produces a plausible figure, a
-green `make ci`, a green `make gpu-test` and 36 of 36 matching round-stream
-cells.
+written by the server. A migration that keeps the call, at the right exit, and
+reports the wrong caches — the drafter's instead of the verifier's, which is the
+mistake the function's own documentation warns against — produces a plausible
+figure, a green `make ci`, a green `make gpu-test` and 36 of 36 matching
+round-stream cells. The table above pins where the call is, and cannot pin what
+it reads.
 
-The proposal in item 7 above is itself in this class, which is the reason it is
-written here as a decision to take rather than merged as a tidy-up.
+The proposal in item 7 is itself in this class, which is the reason it is written
+here as a decision to take rather than merged as a tidy-up.
 
 Naming what would close it, since it is out of this chunk's scope: the figure
 would need a second reader — a request-level assertion that the verifier's
@@ -293,50 +386,133 @@ gpu-test`, not on the CPU side.
 
 ## Gate changes the skeleton needs
 
-**`make check-spec-charge`.** Its population is derived as "carries the `step_fn`
-signature **and** constructs a `RoundTotals`". After the first migration the
-migrated entry keeps its signature and loses its totals, so it drops out of the
-population, the census reads `charge_phases:2 false:4` and RULE 3 fires. The
-re-key therefore lands in the same PR as the first migration, not later, and it
-is a re-key of the *population*, not of any rule's needle:
+### `make check-spec-charge`
 
-- Population (a), the loop: `step_fn` plus a `RoundTotals`. Exactly one fn.
-  RULE 1 reads it as today — the `charge` argument of its `rollback_round` call
-  and the `charged:` of the record it builds are one token, which is the
-  parameter it was handed. RULE 7's "exactly one `log_round(`" reads it too.
-- Population (b), the entries: a fn that constructs the loop's configuration
-  literal. Seven fns, each naming the decision once, at the call that runs the
-  loop, in the drafter's own module. RULE 2 (a `charge_phases` token binds
-  exactly `phases_charged()`), RULE 3 (the census) and RULE 5 (nothing else
-  names a `charged:`) read this population, with the same needles they use now,
-  because the entry writes `charged:` in a literal exactly as a loop does today.
-- During the campaign both populations coexist with the unmigrated loops, which
-  are read by the rules unchanged. **The census is invariant at every step:
-  seven charge sites, `charge_phases:3 false:4`.** What falls, 7 to 1, is the
-  count of fns in population (a), and that is a second number the gate should
-  state rather than infer.
-- RULE 6 is untouched, provided the loop does **not** live in
+Its population is derived as "carries the `step_fn` signature **and** constructs
+a `RoundTotals`", and the census is built from that population alone. After the
+first migration the migrated entry keeps its signature and loses its totals, so
+it leaves the population, and the shared loop enters it carrying a token that is
+neither `phases_charged()` nor a literal. Both readings of the naive re-key fail:
+
+- Keep the loop in the census and the census reads `charge:1 charge_phases:2
+  false:4` mid-campaign. RULE 3 fires on a correct tree.
+- Drop the loop from the census and RULE 1 inside it compares a forwarded token
+  against itself. A loop that writes `let charge = false;` at both its
+  `rollback_round` site and its `RoundTotals` is green while the seven entries
+  still spell 3:4 — which is the "charge token hard-wired" mutation this gate is
+  the only reader of.
+
+**The decision: the token travels as a value, and a new RULE 8 holds the
+forwarded side, exactly as RULE 2 holds the deciding side.**
+
+Three populations, all derived, none a name list:
+
+- **(a) round loops** — the signature plus a `RoundTotals`, unchanged. Within it,
+  a loop whose charge token binds to a field of one of its own parameters is
+  **forwarded**; every other member is **classic**.
+- **(b) entries** — a fn carrying the driver signature that writes exactly one
+  `charged:` field, constructs no `RoundTotals` and calls no `rollback_round`.
+  Seven of them at the end of the campaign, each naming the decision once, at
+  the call that runs the loop, in the drafter's own module.
+- **(c) drafter rollbacks** — a fn outside (a) that calls `rollback_round`.
+
+The rules over them:
+
+- **RULE 1** reads a classic loop as today, and reads a forwarded loop the same
+  way: one token at every `rollback_round` argument and every `charged:` field.
+- **RULE 2** is unchanged and reads populations (a)-classic and (b): a
+  `charge_phases` token binds to exactly `phases_charged()`.
+- **RULE 3**, the census, is computed over **the classic loops' tokens and
+  population (b)'s tokens** — seven sites, `charge_phases:3 false:4`, at every
+  step of the campaign. A forwarded loop's token is not in it.
+- **RULE 4** gains population (c): a rollback outside a round loop is no longer
+  exit 2 outright, but its `charge` argument must be a field of one of its own
+  parameters. A literal or a `phases_charged()` there is a second decision made
+  where nothing can hold it to the loop that ordered it, and is exit 1; an
+  argument the scan cannot read back stays exit 2.
+- **RULE 5** keeps its needle and inverts its verdict for population (b) alone:
+  a `charged:` in a fn with no driver signature is exit 1 exactly as now.
+- **RULE 6** and **RULE 7** are untouched, provided the loop does **not** live in
   `crates/rmlx-models/src/speculative/round_common.rs` — that file's exemption
   for naming the low-level rollback is anchored to its path, and a loop moved
-  into it would inherit an exemption it must not have. Hence `round_loop.rs`.
-- RULE 7's directory scope is untouched for the same reason: the loop stays
-  under `crates/rmlx-models/src/speculative/`.
-- The fixtures for each re-keyed rule move with it, asserting the reason and not
-  only the exit code.
+  into it would inherit an exemption it must not have. Hence `round_loop.rs`,
+  under `crates/rmlx-models/src/speculative/`, which is where RULE 7's directory
+  scan reaches.
+- **RULE 8 (the forwarded decision is the one that was handed over).** A
+  forwarded loop binds its charge token, in the same fn, to exactly the
+  configuration field it was handed — the whole right-hand side, not a prefix —
+  or names that field directly at every site. Anything else is exit 1.
 
-**`make check-spec-sampling`.** RULE 1's population is `pub fn` drivers. The
-seven entries stay `pub` and keep mentioning `sampler_cfg` when they pass it, so
-the gate stays green — while the loop that actually reads the sampler is
-`pub(crate)` and outside it. Widen RULE 1 to any visibility, which is the rule
-`check_spec_charge.sh` already uses, so the one loop is enumerated.
+The two readings are complementary, and the second is what makes the first
+fail-closed: a loop that hard-wires stops binding to a parameter's field, so it
+is no longer forwarded, so it is classic, so its token joins the census and the
+census reads eight sites. RULE 8 fires beside it and names the binding. Neither
+reading alone covers the case — RULE 8 could be edited out, and the census alone
+cannot tell a forwarded token from a hard-wired one, since both are spelled by
+the local's name.
 
-**`make debt-report`.** Its driver group is discovered by the `step_fn`
-signature alone, so it already lists `emit_step`, `emit_round_tokens` and
-`emit_seed_token` beside the loops — eleven fns where the campaign measures
-seven. Narrowing it to the charge gate's population is an open item in its own
-right. At the end of the campaign the group must list one driver plus the
-per-drafter `propose` / `condition` / `rollback` implementations, whose pairwise
-similarity is what their real differences warrant.
+One extractor change goes with it: the token reader reports `?` for anything that
+is not a bare identifier, so `charged: cfg.charged` is unreadable today and would
+exit 2. It must learn to read a field access as a token.
+
+#### The fixture cases the re-key must pass
+
+None of these can run against today's scanner: populations (b) and (c) and
+RULE 8 do not exist in it, and a fixture root asserting them would fail
+`make check-spec-charge-fixtures` today. They are stated here with the exit and
+the reason each must produce, and the re-key chunk turns each into a scan root.
+
+| # | the tree | exit | the reason it must give |
+|---|---|---|---|
+| 1 | mid-campaign: one forwarded loop, six classic loops, one entry | 0 | seven charge sites, census `charge_phases:3 false:4`, one forwarded loop named |
+| 2 | the forwarded loop writes `let charge = false;` at both sites | 1 | RULE 8 names the binding; the census reads eight sites |
+| 3 | the forwarded loop writes `let charge = cfg.charged \|\| x;` | 1 | RULE 8, the whole right-hand side |
+| 4 | the forwarded loop names `cfg.charged` at both sites, no binding | 0 | forwarded, read as one token |
+| 5 | one of the seven entries drops its `charged:` | 1 | census of six sites — excluding the loop must not hide a lost entry |
+| 6 | an entry binds `charge_phases` to a literal | 1 | RULE 2, unchanged |
+| 7 | an entry moves a token from `false` to `phases_charged()` | 1 | RULE 3, census `charge_phases:4 false:3` |
+| 8 | a fn with no driver signature writes `charged:` | 1 | RULE 5, unchanged |
+| 9 | a drafter `rollback()` passes `ctx.charged` | 0 | RULE 4's new arm |
+| 10 | a drafter `rollback()` passes `false` | 1 | RULE 4, a second decision beside the loop's |
+| 11 | a drafter `rollback()` passes an expression the scan cannot read | 2 | unreadable site |
+| 12 | the end state: one forwarded loop, seven entries, no classic loop | 0 | seven charge sites, census `charge_phases:3 false:4` |
+| 13 | the end state with the loop deleted | 2 | no round loop found; a scan that finds nothing must not pass |
+| 14 | the forwarded loop names `rollback_round_caches` | 2 | RULE 6, unchanged |
+| 15 | the forwarded loop calls `log_round` twice | 2 | RULE 7, unchanged |
+
+### `make check-spec-sampling`
+
+RULE 1's population is `pub fn` drivers, which finds six fns today and will keep
+finding the seven entries after the collapse — while the one loop that reads the
+sampler is `pub(crate)` and outside the gate entirely. Widening to "any
+visibility" alone is not free: it enumerates `spec_generate_greedy_cached`, which
+takes no sampler at all, and `emit_step`, `emit_round_tokens` and
+`emit_seed_token`, which are helpers. All four fail condition (a) on the day the
+rule changes.
+
+Widen it to **any visibility and constructs a `RoundTotals`** — the charge gate's
+population (a). That admits the shared loop and excludes the three emit helpers
+by construction. `spec_generate_greedy_cached` is then the one exception, and it
+is a principled one: it is the two-model greedy loop, which runs only at
+temperature 0 and reads the verifier's argmax directly. Record it as an exception
+with that reason, and delete the exception in migration chunk 6, where that loop
+becomes a drafter whose `verify` draws through the context.
+
+Condition (b) — the parameter is read, not merely declared — is satisfied in the
+shared loop by the `VerifierDraw::new(sampler_cfg)` construction in its body, and
+the needle must be that construction rather than a mention of `sampler_cfg`. A
+sampler assigned into a `RoundCtx` field and read by nobody is exactly the shape
+(b) exists to refuse.
+
+### `make debt-report`
+
+Its driver group is discovered by the `step_fn` signature alone, so it already
+lists `emit_step`, `emit_round_tokens` and `emit_seed_token` beside the loops —
+eleven fns where the campaign measures seven. Narrowing it to the charge gate's
+population (a) is an open item in its own right. At the end of the campaign the
+group must list one driver plus the per-drafter `propose` / `condition` /
+`rollback` implementations, whose pairwise similarity is what their real
+differences warrant.
 
 ## Duplication at the base of the campaign
 

--- a/docs/SPEC_ROUND_SKELETON.md
+++ b/docs/SPEC_ROUND_SKELETON.md
@@ -43,6 +43,10 @@ implements in its own module.
 
 ```rust
 pub(crate) trait RoundDrafter {
+    /// Which of this loop's two exits skips the report of the verifier's
+    /// resident KV. A declared per-loop skip — see item 7.
+    const KV_REPORT_SKIPPED_BY: ReportSkippedBy;
+
     /// Prefill, the token the request emits before its first round, and how long
     /// the prefill took. `None` is a pair that emits nothing until a round runs.
     fn prefill(&mut self, ctx: &mut RoundCtx<'_>, prompt: &[u32]) -> Result<Prefilled>;
@@ -58,23 +62,34 @@ pub(crate) trait RoundDrafter {
 
     /// Return the drafter's own state to the accepted prefix. `None` is a
     /// drafter that keeps nothing across rounds.
-    fn rollback(&mut self, ctx: &RoundCtx<'_>, v: &Verdict, emit: RoundEmit)
+    fn rollback(&mut self, ctx: &RoundCtx<'_>, v: &Verdict, out: RoundOutcome)
         -> Result<Option<CacheSpan>>;
 
     /// Condition the next round on what this one committed. `None` is a drafter
     /// that carries no conditioning buffer.
-    fn condition(&mut self, ctx: &RoundCtx<'_>, v: &Verdict, emit: RoundEmit)
+    fn condition(&mut self, ctx: &RoundCtx<'_>, v: &Verdict, out: RoundOutcome)
         -> Result<Option<Conditioning>>;
 }
 ```
 
 `Prefilled` carries the seed, this drafter's own `prefill_ns`, and whether the
-drafter carries a conditioning buffer — see items 9 and 10 below for why the
-last two are the drafter's to state. `Verdict` carries the accepted count, the
-tokens the round commits, and — for a restricted-vocabulary drafter — how long
-this round's restricted prefix is. `RoundEmit` is what
-`round_common::emit_round_tokens` already returns: the committed count and
-whether a token stopped the request.
+drafter projects a conditioning buffer and reports the rows it accumulated — see
+items 9 and 10 below for why the last two are the drafter's to state. `Verdict`
+carries the accepted count, the tokens the round commits, and — for a
+restricted-vocabulary drafter — how long this round's restricted prefix is.
+
+```rust
+pub(crate) struct RoundOutcome { pub emit: RoundEmit, pub verifier_target: i32 }
+```
+
+`RoundEmit` is what `round_common::emit_round_tokens` already returns: the
+committed count and whether a token stopped the request. `verifier_target` is
+where the loop's own rollback left the verifier's caches, and it is handed over
+because the Gemma4 assistant reads it — its next round's shared K/V offset *is*
+that target. Without it in the signature the first migration would re-derive
+`rollback_target_from_head` inside a drafter, which is the duplication this
+campaign exists to remove. One producer, the loop; one consumer today, the
+assistant's `condition`.
 
 `RoundCtx` carries the verifier, its two cache stacks, the device, the request's
 `VerifierDraw` and the charge decision. The draw is in it because every `verify`
@@ -125,8 +140,8 @@ their first producer, and re-keys the report onto them.
 
 ## What the interface cannot express, and what is proposed for it
 
-Ten things. Seven are expressible with no branch in the loop; three are decisions
-the owner has to take, marked as such.
+Eleven things. Nine are expressible with no branch in the loop; one is a declared
+per-loop skip; one is a decision the owner has to take, marked as such.
 
 1. **The stochastic acceptance rule.** `spec_generate_stochastic_cached` does not
    compare tokens: it builds the verifier's post-sampling distribution at every
@@ -151,19 +166,27 @@ the owner has to take, marked as such.
 4. **DFlash 1's adaptive block.** `dflash_next_block_size` opens with
    `round_block` and then moves the result by the accept rate of the recent
    rounds. Proposed: the `block` method, six defaults and one override.
-5. **The block figure the caller reads back, and its two exits.** The five
+5. **The block figure the caller reads back, and the five seed exits.** The five
    sidecar loops return the widest block any round ran; the two two-model loops
-   return the widest *proposal count*, one less. Both families return something
-   else again on the seed or in-round EOS exit — the *resolved* block, not the
-   widest that ran, which contradicts every one of their doc comments. The server
-   discards the figure for every loop; only
-   `crates/rmlx-models/tests/qwen3_5_mtp_drafter_alignment.rs` reads it, for the
-   MTP sidecar's normal exit. Proposed: the loop returns the widest block that
-   ran on every exit including the EOS ones, and the two-model entry subtracts
-   one, so the unit stays in the module that owns it. Changing the EOS exits'
-   value is a change to a figure with one reader on one loop, and that reader
-   does not exercise an EOS exit — which is why it is listed here rather than
-   done quietly.
+   return the widest *proposal count*, one less, and
+   `spec_generate_greedy` adds one back on the way out — the unit boundary is
+   that one `map` at the end of the dispatcher, and the two-model per-loop entry
+   is where the subtraction goes so the value the dispatcher receives is
+   unchanged.
+
+   **This figure is gated, on every arm and every prompt.** The equivalence
+   harness asserts the driver's returned block against the block the pair runs
+   at, for all six pairs, so it is not a figure the collapse may quietly move:
+   it must be byte-identical per loop, and no pair reading is re-blessed for it.
+   The server discards it, and
+   `crates/rmlx-models/tests/qwen3_5_mtp_drafter_alignment.rs` reads it too, but
+   the pairs are what pin it.
+
+   What is *not* gated is the five sidecar **seed** exits, which return the
+   resolved block rather than the widest that ran — a round has not run there, so
+   the two differ, and no gate prompt stops on its seed. The two in-round EOS
+   exits already return the widest that ran. Proposed: the loop returns the
+   widest block that ran on every exit, which changes those five values alone.
 6. **The verifier offset a round reports.** The Gemma4 assistant reads it before
    its verify forward and counts forward over the accepted prefix; the other six
    read it after and count back from the tail. The two spellings name the same
@@ -193,15 +216,26 @@ the owner has to take, marked as such.
    EOS; the two two-model loops do the opposite, having no seed. One loop has one
    exit shape.
 
-   **Proposed, and it is a behaviour change: every exit reports.** The figure has
-   one writer — a speculative request never goes through
-   `Architecture::generate_greedy` — so a request that skips it leaves the
-   previous request's figure readable to a caller that samples around the call.
-   The two exits that skip it today are the two that would read stale.
+   **Proposed: preserved exactly, as a declared per-loop skip.**
+   `KV_REPORT_SKIPPED_BY` is the declaration, and the loop reads it at its two
+   exits. It is the one per-drafter flag the loop branches on, and it is here
+   rather than hidden because the alternative is a behaviour change the campaign
+   is not for.
 
-   This changes no baseline cell, no pair reading and no gate. That is exactly
-   why it must be written down here rather than merged: see "the mutation I
-   could not catch" below.
+   The alternative is worth stating, and it is **not adopted**: the figure has
+   one writer — a speculative request never goes through
+   `Architecture::generate_greedy` — so a request that skips the report leaves
+   the previous request's figure readable to a caller that samples around the
+   call, and the two exits that skip it are the two that would read stale.
+   Unifying them changes no baseline cell, no pair reading and no gate, which is
+   exactly why it is not folded into a refactor whose contract is that nothing
+   moves. It is a separate change, on its own evidence, after the collapse.
+
+   The declaration is also what keeps the test below alive across the campaign:
+   the seven-row table is re-keyed onto `KV_REPORT_SKIPPED_BY` in migration
+   chunk 1, and each chunk drops its own file from the source scan in the same
+   commit. Without the declaration the first migration would delete a loop the
+   test still reads and leave nothing in its place.
 8. **What a round conditions on.** DFlash 1 conditions on the round's *committed*
    count and DFlash 2 on `accept + 1`, at the same two calls — the row count
    handed to `committed_rows` and the bound handed to `guard_round_conditioning`.
@@ -211,15 +245,26 @@ the owner has to take, marked as such.
    the emission, which happens between `verify` and `condition`. Proposed: the
    loop's order is verify, emit, verifier rollback, drafter rollback, condition,
    and the `RoundEmit` the emission returned is passed to the last two.
-9. **Whether a drafter carries a conditioning buffer, before its first round.**
+9. **Whether a drafter projects a conditioning buffer, before its first round.**
    The request record's `conditioned_rows` is `Some(0)` on the seed-EOS record of
    DFlash 1 and DFlash 2 and `None` on the other five — a statement about the
    drafter, made before any round has run. Fourteen `RoundTotals` literals state
    it today, and one loop-built literal cannot know it. Proposed: `Prefilled`
    declares it, and the loop reads that declaration for both the seed record and
-   the tail record. Without the declaration the two `Some(0)`s become `None` and
-   nothing anywhere sees it: `RoundStats::conditioning_violation` is guarded on
-   `None` and passes.
+   the tail record.
+
+   The discriminator is **"projects its conditioning and reports the rows it
+   accumulated"**, not "holds a conditioning buffer". The MTP sidecar holds one —
+   a single verifier row it slices per round — and reports `None`, because it
+   projects nothing and accumulates nothing. A declaration keyed on holding a
+   buffer would move the MTP sidecar's record, which is a cell that may not move.
+
+   The declaration decides `Some` against `None` and nothing else: the value
+   inside is an accumulator the two block loops add each round's projected rows
+   to, under a `.max(0)` clamp, and stays the loop's own running figure.
+
+   Without the declaration the two `Some(0)`s become `None` and nothing anywhere
+   sees it: `RoundStats::conditioning_violation` is guarded on `None` and passes.
 10. **What `prefill_ns` covers.** The three loops that prefill the prompt less
     its last token close the span before their round-0 carry forward; DFlash 2
     closes it after its whole-prompt capture, trim and projection but before the
@@ -228,6 +273,16 @@ the owner has to take, marked as such.
     `prefill` returns its own `prefill_ns` and the loop does not time it. A loop
     that timed the call would move the figure on five of seven records and no
     gate would see it.
+11. **What the empty-chain refusal says.** The two spellings are the same test:
+    a two-model round's verifier carry is always one token, so `v_k < 2` holds
+    exactly when the proposal chain is empty, and both families reach their check
+    after every drafting forward the round takes. Neither family stops anywhere
+    the other would not. What differs is the `Error::Model` message — seven
+    texts, each naming its own loop and its own reason. Proposed: one refusal
+    with one message, and the seven texts are the cost. They are not on any
+    gate's path, so the disposition is recorded here rather than defended: the
+    message that survives must still say that an empty chain is a broken drafter
+    and not the end of the request, which is the part a reader acts on.
 
 ## Migration order
 
@@ -241,11 +296,15 @@ and a byte-identical round stream.
    which snapshot to fetch. It exercises the charged arm (`phases_charged()` and
    `RoundPhases`), the head-basis offset of item 6, the `None` recurrent stack,
    a drafter that keeps no cache of its own, and the sliding-window ring's
-   rollback. It answers `None` to both `rollback` and `condition`, so it proves
-   the loop and the two optional arms and nothing about the two paired structs —
-   which is why those wait for chunk 2. This chunk also carries the gate re-key
-   below: a migrated entry leaves the charge gate's derived population the moment
-   its body goes.
+   rollback, and it is the one consumer of `RoundOutcome::verifier_target`. It
+   answers `None` to both `rollback` and `condition`, so it proves the loop and
+   the two optional arms and nothing about the two paired structs — which is why
+   those wait for chunk 2. This chunk also carries two re-keys: the charge gate
+   below, because a migrated entry leaves its derived population the moment its
+   body goes; and the disposition test below, which moves onto
+   `KV_REPORT_SKIPPED_BY` and drops `gemma4_assistant.rs` from its source scan in
+   the same commit. Every later chunk drops its own file the same way, and the
+   seven-row table is what does not change.
 2. **The MTP sidecar.** The complement, and the first producer of `CacheSpan` and
    `Conditioning`: a recurrent refold, a drafter cache rolled back by offset, a
    single conditioning row with no projection beside it, and a
@@ -258,7 +317,11 @@ and a byte-identical round stream.
    where DFlash 2 conditions on the acceptance.
 5. **EAGLE-3.** The restricted vocabulary, the attribution buffer, a drafter that
    rolls back by re-running, and the only `verify` that reads `draw.sampling()`
-   to decide which of two read-backs it may take.
+   to decide which of two read-backs it may take. Its `accept_and_reseed` is a
+   rollback, a conditioning and a reseed in one call, so all of it goes in
+   `rollback`, `condition` returns `None`, and the drafter-side target is read
+   back off the cache afterwards rather than computed — which is what makes it
+   the cross-check on the verifier's target that the round line calls it.
 6. **The two-model greedy loop.** Two full models, a draft-side rollback with its
    own tape, no seed, and the resync that prepends the last draft token on a full
    accept. It is also where the raw `argmax` read-back becomes the context's
@@ -323,6 +386,11 @@ answer after a draft-side change says that run's near-ties happened not to move.
 - The exit behaviour of every loop: the seed-EOS exit that returns before any
   round, the in-round EOS exit that stops the request, the empty-chain refusal,
   and the token budget that caps the emission without capping the acceptance.
+- The driver's returned block on every normal exit, which the equivalence
+  harness asserts for every arm on every prompt.
+- What the empty-chain refusal tells a reader: seven texts become one, and the
+  one that survives still has to say that an empty chain is a broken drafter and
+  not the end of the request.
 - The sampler read: every driver takes the request's sampler and reads it.
 - `charged` per drafter — three loops charge, four do not, and no migration
   changes which.
@@ -348,7 +416,8 @@ answer after a draft-side change says that run's near-ties happened not to move.
 | **the seed-EOS exit stops returning early** | nothing at runtime: no round runs, so no round line is written, and no gate prompt has an EOS seed | **new, none** |
 | **the resident-KV report moved to another exit, or computed from the wrong caches** | nothing at runtime | **new, none** |
 | **`conditioned_rows` on a seed-EOS record falls from `Some(0)` to `None`** | nothing: `conditioning_violation` is guarded on `None`, the round stream sees no request that ran no round, and no pair has an EOS seed | **new, none** |
-| **the block figure changes unit, or an EOS exit returns the widest instead of the resolved block** | nothing for six of the seven loops: the server discards it, and the one test that reads it reads the MTP sidecar's normal exit | **new, none** |
+| the block figure changes unit on a normal exit | the equivalence harness asserts the driver's returned block on every arm and every prompt | yes |
+| **a seed exit returns the widest that ran instead of the resolved block** | nothing: no gate prompt stops on its seed | **new, none** |
 | the empty-chain refusal lost | nothing at runtime — a drafter that proposes nothing makes the acceptance walk answer rather than refuse, and the round silently emits one token | **new, none** |
 | `prefill_ns` recomposed by the loop | nothing: five of seven records would move and the figure has no bound to fail | **new, none** |
 
@@ -358,9 +427,22 @@ a **seven-row table** naming, per loop, which exit skips the resident-KV report
 and how the loop refuses an empty proposal chain; the source scan is a *reading*
 of that table against today's tree, positional rather than by count, so a report
 moved to the other exit fails rather than passing on an unchanged total. The
-table is the part that survives the collapse: when the disposition becomes a
-per-drafter declaration in the engine, the test re-keys onto the declaration and
-keeps the same seven rows.
+table is the part that survives the collapse: `KV_REPORT_SKIPPED_BY` is the same
+statement in the engine, chunk 1 re-keys the test onto it, and each chunk drops
+its own file from the scan.
+
+Five markers, not four. The reading is of the early exit, the head of the round
+loop, the empty-chain refusal, the tail request record and the resident-KV
+report — measured, `EWGRP` for a loop that skips the report on its seed and
+`WGRERP` for one that skips it in a round, because an in-round EOS exit writes
+its own record before it returns. Four markers left an undeclared escape: a
+report moved *into* the round loop after the refusal read `EWGP`, unchanged,
+because there was no marker for where the loop ends.
+
+**The residual, declared.** The reading is of statement order and not of
+reachability. A report at the position the table names, inside a branch that
+never runs, reads identical — and so does one whose arguments are wrong, which is
+the row below.
 
 ### The mutation I could not catch
 
@@ -374,8 +456,9 @@ figure, a green `make ci`, a green `make gpu-test` and 36 of 36 matching
 round-stream cells. The table above pins where the call is, and cannot pin what
 it reads.
 
-The proposal in item 7 is itself in this class, which is the reason it is written
-here as a decision to take rather than merged as a tidy-up.
+The unification item 7 declines is itself in this class, which is the reason it
+is written there as a change to take on its own evidence rather than folded into
+a refactor.
 
 Naming what would close it, since it is out of this chunk's scope: the figure
 would need a second reader — a request-level assertion that the verifier's
@@ -408,13 +491,21 @@ forwarded side, exactly as RULE 2 holds the deciding side.**
 Three populations, all derived, none a name list:
 
 - **(a) round loops** — the signature plus a `RoundTotals`, unchanged. Within it,
-  a loop whose charge token binds to a field of one of its own parameters is
-  **forwarded**; every other member is **classic**.
-- **(b) entries** — a fn carrying the driver signature that writes exactly one
-  `charged:` field, constructs no `RoundTotals` and calls no `rollback_round`.
-  Seven of them at the end of the campaign, each naming the decision once, at
-  the call that runs the loop, in the drafter's own module.
+  a loop is **forwarded** when its *parameter list* carries the configuration
+  type that holds the charge field, and **classic** otherwise.
+- **(b) entries** — a fn carrying the driver signature that constructs no
+  `RoundTotals` and calls no `rollback_round`. Seven of them at the end of the
+  campaign, each naming the decision once, at the call that runs the loop, in
+  the drafter's own module.
 - **(c) drafter rollbacks** — a fn outside (a) that calls `rollback_round`.
+
+**Membership is read off the signature; the census is keyed on the binding, and
+the two must not be the same reading.** A loop that hard-wires its charge still
+takes the configuration, so it is still forwarded and RULE 8 still reaches it;
+what changes is its binding, which is what puts it back in the census. Defining
+"forwarded" by the binding instead — the first shape this file carried — makes
+RULE 8 unfireable: a loop failing it stops being forwarded and leaves the rule's
+population rather than failing it, and only the census is left.
 
 The rules over them:
 
@@ -422,16 +513,23 @@ The rules over them:
   way: one token at every `rollback_round` argument and every `charged:` field.
 - **RULE 2** is unchanged and reads populations (a)-classic and (b): a
   `charge_phases` token binds to exactly `phases_charged()`.
-- **RULE 3**, the census, is computed over **the classic loops' tokens and
-  population (b)'s tokens** — seven sites, `charge_phases:3 false:4`, at every
-  step of the campaign. A forwarded loop's token is not in it.
+- **RULE 3**, the census, is computed over **every charge token whose binding is
+  not the forwarded configuration field** — the classic loops' and population
+  (b)'s — seven sites, `charge_phases:3 false:4`, at every step of the campaign.
+  A forwarded loop that binds the field it was handed contributes nothing; the
+  same loop hard-wiring a literal contributes one and the census reads eight.
 - **RULE 4** gains population (c): a rollback outside a round loop is no longer
   exit 2 outright, but its `charge` argument must be a field of one of its own
   parameters. A literal or a `phases_charged()` there is a second decision made
   where nothing can hold it to the loop that ordered it, and is exit 1; an
   argument the scan cannot read back stays exit 2.
 - **RULE 5** keeps its needle and inverts its verdict for population (b) alone:
-  a `charged:` in a fn with no driver signature is exit 1 exactly as now.
+  a `charged:` in a fn with no driver signature is exit 1 exactly as now. Over
+  (b) it becomes a rule rather than a membership test — an entry states exactly
+  one `charged:`; zero or two is exit 1 naming the entry, and a field the scan
+  cannot read back is exit 2. Folding the count into membership instead would
+  put an entry with two decisions in no population at all, where no rule reaches
+  it.
 - **RULE 6** and **RULE 7** are untouched, provided the loop does **not** live in
   `crates/rmlx-models/src/speculative/round_common.rs` — that file's exemption
   for naming the low-level rollback is anchored to its path, and a loop moved
@@ -441,19 +539,37 @@ The rules over them:
 - **RULE 8 (the forwarded decision is the one that was handed over).** A
   forwarded loop binds its charge token, in the same fn, to exactly the
   configuration field it was handed — the whole right-hand side, not a prefix —
-  or names that field directly at every site. Anything else is exit 1.
+  or names that field directly at every site. *Every* binding of that token must
+  be that field, so a second one is exit 1 naming it. Anything else is exit 1.
 
-The two readings are complementary, and the second is what makes the first
-fail-closed: a loop that hard-wires stops binding to a parameter's field, so it
-is no longer forwarded, so it is classic, so its token joins the census and the
-census reads eight sites. RULE 8 fires beside it and names the binding. Neither
-reading alone covers the case — RULE 8 could be edited out, and the census alone
-cannot tell a forwarded token from a hard-wired one, since both are spelled by
-the local's name.
+The two readings are complementary and neither alone covers the hard-wire. A
+forwarded loop that writes `let charge = false;` is caught **twice**: by RULE 8,
+because the binding is not the configuration field, and by RULE 3, because a
+token bound to something other than that field is in the census and the census
+then reads eight sites. RULE 8 can be edited out of the script; the census
+cannot, since it is what the gate exists to state. And the census alone names
+only a count, where RULE 8 names the line.
 
-One extractor change goes with it: the token reader reports `?` for anything that
-is not a bare identifier, so `charged: cfg.charged` is unreadable today and would
-exit 2. It must learn to read a field access as a token.
+**Two extractor changes go with it, not one.**
+
+1. The token reader reports `?` for anything that is not a bare identifier, so
+   `charged: cfg.charged` is unreadable today and would exit 2. It must read a
+   field access as a token.
+2. The binding reader records **per binding**, keyed to the loop's own charge
+   token. Today it sets one flag per function with a good binding outranking a
+   bad one, so a shadow passes. **Measured on this tree**: a `mtp.rs` that binds
+   `charge_phases` to `super::phases_charged()` and then rebinds it to `false`
+   on the next line exits 0 with `OK: 7 speculative round loops … census
+   charge_phases:3 false:4` — a loop that charges nothing, counted among the
+   three that ask. That is a live hole on `main`, not a consequence of the
+   re-key, and the re-key chunk closes it.
+
+   Under the per-binding reading a token bound twice in one fn is **exit 1** for
+   a forwarded loop, where RULE 8 has something exact to say about the second
+   binding, and **exit 2** for a classic loop, where RULE 1's same-token reading
+   has become vacuous: with a shadow, the token at the `rollback_round` argument
+   and the token in the `charged:` field can be two different values under one
+   spelling, and nothing in the scan can say which binding governs which site.
 
 #### The fixture cases the re-key must pass
 
@@ -462,10 +578,16 @@ RULE 8 do not exist in it, and a fixture root asserting them would fail
 `make check-spec-charge-fixtures` today. They are stated here with the exit and
 the reason each must produce, and the re-key chunk turns each into a scan root.
 
+Cases 1 and 12 ask for a reason the current success line does not carry: it
+prints the loop count and the census and nothing about populations. The re-key
+changes it to name all three — `N classic, M forwarded, K entries; census …` —
+so a tree that passes says which shape it passed as, and a fixture asserting
+that a loop is forwarded has a line to assert against.
+
 | # | the tree | exit | the reason it must give |
 |---|---|---|---|
 | 1 | mid-campaign: one forwarded loop, six classic loops, one entry | 0 | seven charge sites, census `charge_phases:3 false:4`, one forwarded loop named |
-| 2 | the forwarded loop writes `let charge = false;` at both sites | 1 | RULE 8 names the binding; the census reads eight sites |
+| 2 | the forwarded loop writes `let charge = false;` at both sites | 1 | RULE 8, the binding is not the configuration field — and the census reads eight sites, both readings on one tree |
 | 3 | the forwarded loop writes `let charge = cfg.charged \|\| x;` | 1 | RULE 8, the whole right-hand side |
 | 4 | the forwarded loop names `cfg.charged` at both sites, no binding | 0 | forwarded, read as one token |
 | 5 | one of the seven entries drops its `charged:` | 1 | census of six sites — excluding the loop must not hide a lost entry |
@@ -479,6 +601,8 @@ the reason each must produce, and the re-key chunk turns each into a scan root.
 | 13 | the end state with the loop deleted | 2 | no round loop found; a scan that finds nothing must not pass |
 | 14 | the forwarded loop names `rollback_round_caches` | 2 | RULE 6, unchanged |
 | 15 | the forwarded loop calls `log_round` twice | 2 | RULE 7, unchanged |
+| 16 | the forwarded loop shadows its binding — `let charge = cfg.charged;` then `let charge = false;` | 1 | RULE 8 names the second binding; the same shape on a classic loop is exit 2 |
+| 17 | an entry states two `charged:` fields | 1 | RULE 5 over (b): an entry names one decision |
 
 ### `make check-spec-sampling`
 
@@ -490,19 +614,35 @@ takes no sampler at all, and `emit_step`, `emit_round_tokens` and
 `emit_seed_token`, which are helpers. All four fail condition (a) on the day the
 rule changes.
 
-Widen it to **any visibility and constructs a `RoundTotals`** — the charge gate's
-population (a). That admits the shared loop and excludes the three emit helpers
-by construction. `spec_generate_greedy_cached` is then the one exception, and it
-is a principled one: it is the two-model greedy loop, which runs only at
-temperature 0 and reads the verifier's argmax directly. Record it as an exception
-with that reason, and delete the exception in migration chunk 6, where that loop
-becomes a drafter whose `verify` draws through the context.
+Widen it to **any visibility, over the charge gate's populations (a) and (b)
+together** — the one loop and the seven entries. Narrowing to (a) alone is the
+tempting move and it is wrong: at the end of the campaign the entries are the
+only place a request's sampler can be dropped, since each takes `sampler_cfg`
+and hands it to the loop's configuration, and a gate that stops reading them
+loses its own defect class at the one site that can still commit it. That is the
+rule this campaign already learned once — a re-keyed gate follows a defect class,
+it does not shed one.
 
-Condition (b) — the parameter is read, not merely declared — is satisfied in the
-shared loop by the `VerifierDraw::new(sampler_cfg)` construction in its body, and
-the needle must be that construction rather than a mention of `sampler_cfg`. A
-sampler assigned into a `RoundCtx` field and read by nobody is exactly the shape
-(b) exists to refuse.
+Over (a), condition (b) — the parameter is read, not merely declared — is
+satisfied in the shared loop by the `VerifierDraw::new(sampler_cfg)` construction
+in its body, and the needle must be that construction rather than a mention of
+`sampler_cfg`. Over (b) it is satisfied by the sampler reaching the loop call:
+the needle is the configuration the entry builds carrying the sampler, not the
+name appearing somewhere in the body. A sampler assigned into a `RoundCtx` field
+and read by nobody is exactly the shape (b) exists to refuse, and so is a
+`sampler_cfg` an entry accepts and leaves out of the configuration it hands over.
+
+The census belongs on the success line for the same reason the charge gate's
+does: **one loop and seven entries**. A lost entry is then exit 2 — a scan that
+finds six drivers where the tree has seven has not passed, it has stopped
+looking.
+
+The three emit helpers are excluded by (a) ∪ (b) without an exception, since none
+carries a `RoundTotals` and none is an entry. `spec_generate_greedy_cached` is
+the one real exception: it is the two-model greedy loop, it takes no sampler at
+all, and it runs only at temperature 0 where the verifier's argmax is the draw.
+Record it with that reason and delete the exception in migration chunk 6, where
+that loop becomes a drafter whose `verify` draws through the context.
 
 ### `make debt-report`
 

--- a/docs/SPEC_ROUND_SKELETON.md
+++ b/docs/SPEC_ROUND_SKELETON.md
@@ -1,0 +1,376 @@
+# One speculative round loop: the proposed interface
+
+**Status: proposal.** No engine code exists for any of it. This file is what a
+reviewer judges before the first drafter is migrated, and what each migration
+chunk is held to afterwards.
+
+Seven round loops in `crates/rmlx-models/src/speculative/` run one algorithm:
+
+| loop | file |
+|---|---|
+| `mtp_generate` | `crates/rmlx-models/src/speculative/mtp.rs` |
+| `dflash_generate` | `crates/rmlx-models/src/speculative/dflash/mod.rs` |
+| `dflash2_generate` | `crates/rmlx-models/src/speculative/dflash2/round.rs` |
+| `eagle3_generate` | `crates/rmlx-models/src/speculative/eagle3/mod.rs` |
+| `mtp_assistant_generate` | `crates/rmlx-models/src/speculative/gemma4_assistant.rs` |
+| `spec_generate_greedy_cached` | `crates/rmlx-models/src/speculative/mod.rs` |
+| `spec_generate_stochastic_cached` | `crates/rmlx-models/src/speculative/mod.rs` |
+
+`spec_generate_greedy` in the same file is the two-model entry guard and
+dispatcher, not a loop: it validates a request, resolves the draft count and
+delegates.
+
+## The shared skeleton, read off the seven bodies
+
+Every one of them, in this order: refuse a prompt under two tokens; resolve the
+request's block; build the verifier's cache stack and its recurrent stack;
+prefill; emit a seed or not; then per round — narrow the block against the
+remaining budget, propose, arm the recurrent tape, verify, walk the acceptance,
+emit what the round committed, roll the verifier's caches back to the accepted
+prefix, roll the drafter's own state back, condition the next round, log one
+round event; then, after the loop — one request record, one report of the
+verifier's resident KV, and the widest block any round ran.
+
+What differs is five things: how a drafter proposes, what it conditions on, how
+it rolls its own state back, which of the verifier's outputs it needs captured,
+and — for one loop — what "the verifier accepted this" means.
+
+## The interface
+
+One loop function in a new `round_loop.rs` beside
+`crates/rmlx-models/src/speculative/round_common.rs`, and one trait each drafter
+implements in its own module.
+
+```rust
+pub(crate) trait RoundDrafter {
+    /// Prefill, and the token the request emits before its first round.
+    /// `None` is a pair that emits nothing until a round has run.
+    fn prefill(&mut self, ctx: &mut RoundCtx<'_>, prompt: &[u32]) -> Result<Prefilled>;
+
+    /// The block this round runs. Default `round_block(block_total, remaining)`.
+    fn block(&self, block_total: usize, remaining: usize) -> usize;
+
+    /// This round's proposals. An empty chain is the loop's refusal, not this one's.
+    fn propose(&mut self, ctx: &mut RoundCtx<'_>, carry: u32, block: usize) -> Result<Vec<u32>>;
+
+    /// Score the round and say what it commits.
+    fn verify(&mut self, ctx: &mut RoundCtx<'_>, fed: &[u32], remaining: usize) -> Result<Verdict>;
+
+    /// Return the drafter's own state to the accepted prefix. `None` is a
+    /// drafter that keeps nothing across rounds.
+    fn rollback(&mut self, ctx: &RoundCtx<'_>, v: &Verdict) -> Result<Option<CacheSpan>>;
+
+    /// Condition the next round on what this one committed. `None` is a drafter
+    /// that carries no conditioning buffer.
+    fn condition(&mut self, ctx: &RoundCtx<'_>, v: &Verdict) -> Result<Option<Conditioning>>;
+}
+```
+
+`Verdict` carries the accepted count, the tokens the round commits, and — for a
+restricted-vocabulary drafter — how long this round's restricted prefix is.
+`RoundCtx` carries the verifier, its cache stacks, the device and the charge
+decision; `rollback` and `condition` take it immutably, so only `prefill` and
+`verify` can advance the verifier's caches.
+
+### Why the fields are paired
+
+Today seven `RoundReport` literals each state every field, which is what makes a
+new field seven compile errors. One literal makes it one, and the value then has
+nowhere to come from. Pairing restores the property by moving the per-drafter
+half of the report into structs the *drafter* constructs:
+
+```rust
+pub(crate) struct CacheSpan { pub before: i32, pub target: i32 }
+pub(crate) struct Conditioning { pub rows: i32, pub projected: i32 }
+```
+
+A field added to either is a compile error in every drafter that builds one. A
+field added to the loop's own half — the round index, the accept, the committed
+count, the charge, the phases — is one compile error at one site, correctly, so
+no drafter is asked for a fact it does not have.
+
+Both are returned as `Option`, and the `None` arm is a word rather than a
+literal of `None` fields. That is deliberate: a drafter that keeps no cache and
+one that keeps one are two different statements, and only the second owes a
+value when the struct grows. The cost is that a `None` drafter is silent about a
+new field — which is right, since it has none — and the reviewer's job is to
+check that a drafter answering `None` really carries nothing.
+
+## What the interface cannot express, and what is proposed for it
+
+Seven things. Five are expressible with no branch in the loop; two are decisions
+the owner has to take.
+
+1. **The stochastic acceptance rule.** `spec_generate_stochastic_cached` does not
+   compare tokens: it builds the verifier's post-sampling distribution at every
+   position, tests each proposal against the drafter's own, and samples the
+   extra token. Its `verify` therefore cannot share a body with the other six.
+   Proposed: `verify` owns the acceptance rule; six drafters delegate to one
+   shared greedy body (forward, read back the verifier's own tokens,
+   `accept_prefix`), one has its own. That is a second implementation of one
+   method, not a branch in the loop and not a twin — the shared body exists once.
+2. **The four capture shapes.** Multi-layer hidden capture (the MTP sidecar,
+   both DFlash loops, EAGLE-3 cold), shared K/V plus a raw hidden (the Gemma4
+   assistant), no capture (both two-model loops), and EAGLE-3's restricted
+   read-back with one full-vocabulary correction. Proposed: the forward is inside
+   `verify`, so "what to capture" never reaches the loop as a value it has to
+   branch on.
+3. **EAGLE-3's per-token attribution.** The `&mut Vec<DecidedBy>` is in the
+   public signature and the equivalence gate reads it. Proposed: the loop carries
+   it as one `Option` and hands it to `round_common::emit_round_tokens`, which
+   already takes exactly that argument, with `Verdict::restricted` as the prefix
+   length. The seed's `DecidedBy::FullVocab` becomes a general rule — a loop with
+   an attribution buffer and a seed attributes the seed to the full vocabulary.
+4. **DFlash 1's adaptive block.** `dflash_next_block_size` opens with
+   `round_block` and then moves the result by the accept rate of the recent
+   rounds. Proposed: the `block` method, six defaults and one override.
+5. **The widest block a run reached.** The five sidecar loops return the widest
+   block; the two two-model loops return the widest *proposal count*, which is
+   one less. Proposed: the loop returns the widest block and the two-model entry
+   subtracts one, so the unit difference stays in the module that owns it.
+6. **The verifier offset a round reports.** The Gemma4 assistant reads it before
+   its verify forward and counts forward over the accepted prefix; the other six
+   read it after and count back from the tail. The two spellings name the same
+   position — pinned by `the_two_rollback_spellings_name_the_same_position` in
+   `crates/rmlx-models/src/speculative/round_skeleton_tests.rs` — but they are
+   two different numbers on the round line, and the pinned baseline holds both.
+   Proposed: the loop reads the offset before *and* after the forward, computes
+   the rollback target from the head spelling once, refuses the round when the
+   two spellings disagree, and reports `CacheSpan::before` from a two-valued
+   basis each drafter declares. The alternative — one basis for all seven and a
+   re-blessed baseline — moves 36 cells for a field whose meaning does not
+   change, and costs a full capture.
+
+   The refusal is worth stating on its own: it is a check nothing in the tree
+   performs today, it is free, and it is the only runtime catcher a rollback off
+   by one would have that does not need a GPU.
+
+7. **The exit that reports the verifier's resident KV.** Each loop has exactly
+   one exit that calls `round_common::report_verifier_kv_bytes` and exactly one
+   that does not, and *which* exit differs: the five sidecar loops skip it on the
+   seed-EOS exit and reach it after an in-round EOS; the two two-model loops
+   reach it on the normal exit and return before it on an in-round EOS. One loop
+   has one exit shape.
+
+   **Proposed, and it is a behaviour change: every exit reports.** The figure has
+   one writer — a speculative request never goes through
+   `Architecture::generate_greedy` — so a request that skips it leaves the
+   previous request's figure readable to a caller that samples around the call.
+   The two exits that skip it today are the two that would read stale.
+
+   This changes no baseline cell, no pair reading and no gate. That is exactly
+   why it must be written down here rather than merged: see "the mutation I
+   could not catch" below.
+
+## Migration order
+
+One drafter per chunk after this one, each its own PR, each proving its own pair
+and a byte-identical round stream.
+
+1. **The Gemma4 assistant.** Its pair is the only one that resolves both halves
+   by slug and runs under `make gpu-test` on any machine holding the snapshots —
+   every other pair needs an operator-named `RMLX_DRAFT_TEST_MODEL`, so this is
+   the only first choice whose proof a reviewer can reproduce without being told
+   which snapshot to fetch. It exercises the most optional arms of the interface
+   per unit of proof cost: the charged arm (`phases_charged()` and
+   `RoundPhases`), the head-basis offset of item 6, the `None` recurrent stack,
+   a drafter that keeps no cache of its own, and the sliding-window ring's
+   rollback. This chunk also carries the gate re-key below — a migrated entry
+   moves out of the charge gate's derived population the moment its body goes.
+2. **The MTP sidecar.** The complement: a recurrent refold, a drafter cache
+   rolled back by offset, a single conditioning row, and a `d_offset`/`d_target`
+   pair on the round line. Two pairs on one verifier at two blocks.
+3. **DFlash 2.** A conditioning window that slides, a prompt-window capture, and
+   the second charged loop.
+4. **DFlash 1.** The adaptive block, and the one loop whose verify width is not
+   fixed.
+5. **EAGLE-3.** The restricted vocabulary, the attribution buffer, and a drafter
+   that rolls back by re-running.
+6. **The two-model greedy loop.** Two full models, a draft-side rollback with its
+   own tape, no seed, and the resync that prepends the last draft token on a full
+   accept.
+7. **The two-model stochastic loop.** Last, because it is the only acceptance
+   rule that is not the shared one and the only loop with no equivalence pair —
+   its gate is `crates/rmlx-models/tests/two_model_stochastic.rs`, which pins
+   that one seed reproduces one sequence.
+
+## The oracle
+
+Four observables, and each is blind to something different.
+
+- **The per-round event stream** against the checked-in baseline:
+  `python3 scripts/spec_round_stream_compare.py verify <capture>`, 36 of 36 cells
+  at every chunk, digests from
+  `crates/rmlx-models/tests/fixtures/spec_round_baseline/MANIFEST.sha256`. It
+  sees the round's shape — block, accept, proposals, committed rows, both cache
+  spans, the conditioning pair, `refolded`. It is blind to the values inside a
+  round: two runs agreeing on every count can be scoring different logits. It is
+  blind to `charged`, which reads `false` on both sides by construction. It is
+  blind to anything a loop does not report, the resident-KV figure included.
+- **The equivalence pairs**, judged by the divergence-confidence oracle in
+  `docs/SPEC_ANSWER_EQUIVALENCE.md` at the readings recorded there. They see the
+  answer. They are blind to every sampled arm, blind to the stochastic loop
+  entirely, and blind wherever a pair's drafter is not resolvable on the machine
+  running them.
+- **`make check-spec-charge`**, whose census must read `charge_phases:3 false:4`
+  at every step of the campaign — see the gate section. It sees a decision that
+  moved. It cannot see whether the schedule it describes is the right one.
+- **`make check-spec-sampling`**, which sees that a driver was handed the
+  request's sampler and read it. It cannot tell a right distribution from a
+  wrong one; `crates/rmlx-models/tests/spec_sampled_distribution.rs` does that,
+  on one pair.
+
+**The greedy digest is not evidence.** Greedy verification emits the verifier's
+own argmax at every position whatever the drafter proposed, so a byte-identical
+answer after a draft-side change says that run's near-ties happened not to move.
+
+## What cannot move
+
+- Every cell of the pinned round stream: 36 cells, their round counts, and the
+  digest of each. A cell that moves for a legitimate reason is re-blessed in the
+  same commit with the loop and the reason named.
+- Every equivalence-pair reading in `docs/SPEC_ANSWER_EQUIVALENCE.md`, recorded
+  again in each migration PR's body.
+- The exit behaviour of every loop: the seed-EOS exit that returns before any
+  round, the in-round EOS exit that stops the request, the empty-chain refusal,
+  and the token budget that caps the emission without capping the acceptance.
+- The sampler read: every driver takes the request's sampler and reads it.
+- `charged` per drafter — three loops charge, four do not, and no migration
+  changes which.
+- The two request shapes that reach no loop: a request carrying a sampler
+  constraint is refused at the speculative entry, and no loop consults or
+  publishes a prompt-cache slot. A shared loop that accepted a pre-filled cache
+  would open a path no observable here can see.
+
+## The mutations, and what catches each
+
+| mutation | catcher | exists today |
+|---|---|---|
+| the rollback target off by one at the loop's call site | round stream `v_target`; the pairs (this is the "rejected tail never rolled off" broken engine, refused 6 of 6); and, proposed above, the loop's own head-against-tail refusal | stream and pairs yes, the refusal is new |
+| a drafter's condition called on the wrong row | round stream `condition_rows` / `projected_rows`; `guard_round_conditioning` refuses a projection that does not match the commit | yes |
+| a capture handed to the wrong drafter | the type system — each drafter takes its own capture inside its own `verify` | new, structural |
+| the block narrowing dropped, or the adaptive schedule applied to the wrong drafter | round stream `num_draft` | yes |
+| the recurrent tape not armed before the verify | `refold_lin_tapes` refuses a tape that does not describe the round | yes |
+| a seed emitted where none was, or dropped | round stream `emitted_total` shifts on every line; `RoundStats::emission_violation` | yes |
+| the restricted prefix reported for a loop that has no restricted vocabulary | the EAGLE-3 boundary rule in the equivalence gate reads `DecidedBy` per token | yes |
+| the charge token hard-wired across the collapse | `make check-spec-charge`, re-keyed as below | needs the re-key |
+| the in-round EOS exit stops recording the request | round stream ends early; the request record is absent | yes |
+| **the seed-EOS exit stops returning early** | nothing at runtime: no round runs, so no round line is written, and no gate prompt has an EOS seed | **new, none** |
+| **the resident-KV report moved to another exit, or computed from the wrong caches** | nothing at runtime | **new, none** |
+| **the widest-block return changes unit for the two-model entry** | nothing: the server discards it and no two-model test reads it | **new, none** |
+| the empty-chain refusal lost | nothing at runtime — a drafter that proposes nothing makes the acceptance walk answer rather than refuse, and the round silently emits one token | **new, none** |
+
+Two of the four uncatchable rows get a text-level catcher in this chunk, in
+`crates/rmlx-models/src/speculative/round_skeleton_tests.rs`: one test pins that
+every loop has exactly one exit that reports the verifier's resident KV and
+exactly one that does not, and one pins that every loop refuses an empty
+proposal chain before its acceptance walk. Both read source text, so both are
+weaker than a runtime check by exactly the distance between "the call is still
+written" and "the call still does the right thing". What they buy is that a
+migration cannot change either disposition without editing an assertion and
+saying why.
+
+### The mutation I could not catch
+
+**The resident-KV report.** Nothing observable in this crate reads it: it is not
+on the round line, the equivalence pairs do not touch it, the accept counters do
+not carry it, and the value only becomes visible in an append-only metrics row
+written by the server. A migration that keeps the call and reports the wrong
+caches — the drafter's instead of the verifier's, say, which is the mistake the
+function's own documentation warns against — produces a plausible figure, a
+green `make ci`, a green `make gpu-test` and 36 of 36 matching round-stream
+cells.
+
+The proposal in item 7 above is itself in this class, which is the reason it is
+written here as a decision to take rather than merged as a tidy-up.
+
+Naming what would close it, since it is out of this chunk's scope: the figure
+would need a second reader — a request-level assertion that the verifier's
+resident bytes are non-zero after any request that ran a round, and that they
+describe the verifier's stack rather than the drafter's. That is a test needing
+two loaded models, so it belongs with the equivalence pairs under `make
+gpu-test`, not on the CPU side.
+
+## Gate changes the skeleton needs
+
+**`make check-spec-charge`.** Its population is derived as "carries the `step_fn`
+signature **and** constructs a `RoundTotals`". After the first migration the
+migrated entry keeps its signature and loses its totals, so it drops out of the
+population, the census reads `charge_phases:2 false:4` and RULE 3 fires. The
+re-key therefore lands in the same PR as the first migration, not later, and it
+is a re-key of the *population*, not of any rule's needle:
+
+- Population (a), the loop: `step_fn` plus a `RoundTotals`. Exactly one fn.
+  RULE 1 reads it as today — the `charge` argument of its `rollback_round` call
+  and the `charged:` of the record it builds are one token, which is the
+  parameter it was handed. RULE 7's "exactly one `log_round(`" reads it too.
+- Population (b), the entries: a fn that constructs the loop's configuration
+  literal. Seven fns, each naming the decision once, at the call that runs the
+  loop, in the drafter's own module. RULE 2 (a `charge_phases` token binds
+  exactly `phases_charged()`), RULE 3 (the census) and RULE 5 (nothing else
+  names a `charged:`) read this population, with the same needles they use now,
+  because the entry writes `charged:` in a literal exactly as a loop does today.
+- During the campaign both populations coexist with the unmigrated loops, which
+  are read by the rules unchanged. **The census is invariant at every step:
+  seven charge sites, `charge_phases:3 false:4`.** What falls, 7 to 1, is the
+  count of fns in population (a), and that is a second number the gate should
+  state rather than infer.
+- RULE 6 is untouched, provided the loop does **not** live in
+  `crates/rmlx-models/src/speculative/round_common.rs` — that file's exemption
+  for naming the low-level rollback is anchored to its path, and a loop moved
+  into it would inherit an exemption it must not have. Hence `round_loop.rs`.
+- RULE 7's directory scope is untouched for the same reason: the loop stays
+  under `crates/rmlx-models/src/speculative/`.
+- The fixtures for each re-keyed rule move with it, asserting the reason and not
+  only the exit code.
+
+**`make check-spec-sampling`.** RULE 1's population is `pub fn` drivers. The
+seven entries stay `pub` and keep mentioning `sampler_cfg` when they pass it, so
+the gate stays green — while the loop that actually reads the sampler is
+`pub(crate)` and outside it. Widen RULE 1 to any visibility, which is the rule
+`check_spec_charge.sh` already uses, so the one loop is enumerated.
+
+**`make debt-report`.** Its driver group is discovered by the `step_fn`
+signature alone, so it already lists `emit_step`, `emit_round_tokens` and
+`emit_seed_token` beside the loops — eleven fns where the campaign measures
+seven. Narrowing it to the charge gate's population is an open item in its own
+right. At the end of the campaign the group must list one driver plus the
+per-drafter `propose` / `condition` / `rollback` implementations, whose pairwise
+similarity is what their real differences warrant.
+
+## Duplication at the base of the campaign
+
+Measured at the merge base with `scripts/lib/debt_report.py`'s own extractor
+over the seven loop bodies — 2326 lines summed, 21 pairs:
+
+```
+dflash_generate      <-> dflash2_generate                : 58.2%
+dflash_generate      <-> eagle3_generate                 : 47.0%
+dflash_generate      <-> mtp_assistant_generate          : 45.3%
+dflash_generate      <-> spec_generate_greedy_cached     :  5.7%
+dflash_generate      <-> spec_generate_stochastic_cached :  6.0%
+dflash_generate      <-> mtp_generate                    : 62.2%
+dflash2_generate     <-> eagle3_generate                 : 38.4%
+dflash2_generate     <-> mtp_assistant_generate          : 43.7%
+dflash2_generate     <-> spec_generate_greedy_cached     :  5.3%
+dflash2_generate     <-> spec_generate_stochastic_cached :  5.6%
+dflash2_generate     <-> mtp_generate                    : 55.6%
+eagle3_generate      <-> mtp_assistant_generate          : 35.5%
+eagle3_generate      <-> spec_generate_greedy_cached     :  8.9%
+eagle3_generate      <-> spec_generate_stochastic_cached :  9.4%
+eagle3_generate      <-> mtp_generate                    : 45.3%
+mtp_assistant_generate <-> spec_generate_greedy_cached   :  4.8%
+mtp_assistant_generate <-> spec_generate_stochastic_cached: 5.1%
+mtp_assistant_generate <-> mtp_generate                  : 53.1%
+spec_generate_greedy_cached <-> spec_generate_stochastic_cached: 72.7%
+spec_generate_greedy_cached <-> mtp_generate             :  3.8%
+spec_generate_stochastic_cached <-> mtp_generate         :  4.1%
+```
+
+**Summed matched lines over the 21 pairs: 2032.** Two extraction chunks raised
+this figure while lowering nothing — a shared helper called from seven places
+leaves seven identical call sites where seven different bodies used to be. Each
+migration chunk reports the figure again, and a chunk that raises it has moved
+duplication rather than removed it. The figure only falls when a loop body is
+deleted, which is what this campaign is for: after the last migration there is
+one body and no pair.

--- a/docs/SPEC_ROUND_SKELETON.md
+++ b/docs/SPEC_ROUND_SKELETON.md
@@ -86,7 +86,8 @@ pub(crate) struct RoundOutcome { pub emit: RoundEmit, pub verifier_target: i32 }
 committed count and whether a token stopped the request. `verifier_target` is
 where the loop's own rollback left the verifier's caches, and it is handed over
 because the Gemma4 assistant reads it — its next round's shared K/V offset *is*
-that target. Without it in the signature the first migration would re-derive
+that target. It has one consumer and that consumer is `condition`, so `rollback`
+takes the `RoundEmit` alone until a migration finds a second one. Without it in the signature the first migration would re-derive
 `rollback_target_from_head` inside a drafter, which is the duplication this
 campaign exists to remove. One producer, the loop; one consumer today, the
 assistant's `condition`.
@@ -119,8 +120,8 @@ no drafter is asked for a fact it does not have.
 `projected` is optional because the MTP sidecar reports a conditioning row and
 no projection: it slices one verifier row per round rather than projecting one,
 so `condition_rows` is `Some` and `projected_rows` is `None` on every line it
-writes. A non-optional `projected` would put a number on twelve pinned cells
-that carry none. `rows` is optional for a weaker reason: every loop reads it off
+writes. A non-optional `projected` would put a number on the six pinned cells of the
+recurrent pair, which carry none. `rows` is optional for a weaker reason: every loop reads it off
 the buffer's shape and reports whatever that read returned, and making it
 non-optional would introduce either an unwrap or a refusal on a path no cell
 exercises.
@@ -236,6 +237,14 @@ per-loop skip; one is a decision the owner has to take, marked as such.
    chunk 1, and each chunk drops its own file from the source scan in the same
    commit. Without the declaration the first migration would delete a loop the
    test still reads and leave nothing in its place.
+
+   **A declaration needs two readers, and chunk 1 owes the second.** That each
+   drafter declares an exit is one fact; that the loop honours what it declared
+   is another, and a drafter can declare the exit the loop ignores. The second
+   reader is the same marker reading, over `round_loop.rs`: its two exits, and
+   the two arms the constant is read at. So the source scan gains that file in
+   the very commit that drops the first migrated one, and its declared pattern is
+   the loop's own, not a drafter's.
 8. **What a round conditions on.** DFlash 1 conditions on the round's *committed*
    count and DFlash 2 on `accept + 1`, at the same two calls — the row count
    handed to `committed_rows` and the bound handed to `guard_round_conditioning`.
@@ -310,8 +319,9 @@ and a byte-identical round stream.
    single conditioning row with no projection beside it, and a
    `d_offset`/`d_target` pair on the round line.
 3. **DFlash 2.** A conditioning window that slides, a prompt-window capture, the
-   second charged loop, and the first drafter to declare a conditioning buffer
-   before its first round.
+   third charged loop — so the charged arm is exercised by chunk 1 and chunk 2
+   before it reaches here — and the first drafter to declare a conditioning
+   buffer before its first round.
 4. **DFlash 1.** The adaptive block, the one loop whose verify width is not
    fixed, and the other half of item 8 — it conditions on the committed count
    where DFlash 2 conditions on the acceptance.
@@ -332,6 +342,13 @@ and a byte-identical round stream.
    rule that is not the shared one and the only loop with no equivalence pair —
    its gate is `crates/rmlx-models/tests/two_model_stochastic.rs`, which pins
    that one seed reproduces one sequence.
+
+   It also closes the campaign in the docs, and names what it deletes: the
+   `CLAUDE.md` documentation-map row and the paragraph in `docs/SPECULATIVE.md`
+   both stop calling this file a proposal and describe the loop the tree has, the
+   seventh loop body goes, the sampling gate's `spec_generate_greedy_cached`
+   exception goes with chunk 6's, and the migration order above goes — a
+   completed order is a stale plan, not a reference.
 
 ## The oracle
 
@@ -494,9 +511,15 @@ Three populations, all derived, none a name list:
   a loop is **forwarded** when its *parameter list* carries the configuration
   type that holds the charge field, and **classic** otherwise.
 - **(b) entries** — a fn carrying the driver signature that constructs no
-  `RoundTotals` and calls no `rollback_round`. Seven of them at the end of the
-  campaign, each naming the decision once, at the call that runs the loop, in
-  the drafter's own module.
+  `RoundTotals`, calls no `rollback_round`, **and constructs the loop's
+  configuration type**. Seven of them at the end of the campaign, each naming the
+  decision once, at the call that runs the loop, in the drafter's own module.
+  The last conjunct is the discriminator, not a detail: without it the population
+  admits `spec_generate_greedy`, which validates a request and delegates, and the
+  three emit helpers, none of which decides anything — and the rule below would
+  report four fns as entries missing their decision, for ever. An entry that
+  stops constructing the configuration leaves the population, which is what makes
+  a dropped decision read as a lost entry rather than as a clean scan.
 - **(c) drafter rollbacks** — a fn outside (a) that calls `rollback_round`.
 
 **Membership is read off the signature; the census is keyed on the binding, and
@@ -513,11 +536,12 @@ The rules over them:
   way: one token at every `rollback_round` argument and every `charged:` field.
 - **RULE 2** is unchanged and reads populations (a)-classic and (b): a
   `charge_phases` token binds to exactly `phases_charged()`.
-- **RULE 3**, the census, is computed over **every charge token whose binding is
-  not the forwarded configuration field** — the classic loops' and population
-  (b)'s — seven sites, `charge_phases:3 false:4`, at every step of the campaign.
-  A forwarded loop that binds the field it was handed contributes nothing; the
-  same loop hard-wiring a literal contributes one and the census reads eight.
+- **RULE 3**, the census, is computed over **every charge token that is not the
+  forwarded configuration field — whether named directly at its sites or bound to
+  it in the same fn** — which is the classic loops' and population (b)'s: seven
+  sites, `charge_phases:3 false:4`, at every step of the campaign. A forwarded
+  loop that names or binds the field it was handed contributes nothing; the same
+  loop hard-wiring a literal contributes one and the census reads eight.
 - **RULE 4** gains population (c): a rollback outside a round loop is no longer
   exit 2 outright, but its `charge` argument must be a field of one of its own
   parameters. A literal or a `phases_charged()` there is a second decision made
@@ -541,6 +565,18 @@ The rules over them:
   configuration field it was handed — the whole right-hand side, not a prefix —
   or names that field directly at every site. *Every* binding of that token must
   be that field, so a second one is exit 1 naming it. Anything else is exit 1.
+  The parameter is resolved by its **declared type**, the configuration type, not
+  by RULE 4's looser "a field of one of its own parameters": a loop that took a
+  second parameter with a `charged` field could otherwise satisfy the rule from
+  the wrong one.
+
+  **And the configuration the loop was handed is read-only inside it.** RULE 8
+  constrains the token; without this it constrains nothing, because the value can
+  be moved instead. A `let` that rebinds the parameter's own name — the loop
+  building its own configuration and forwarding faithfully from that — writes no
+  `charged:` site and passes every reading. So does an assignment to the charge
+  field of a `mut` parameter. Both are **exit 2**: the decision the entry made is
+  no longer the decision the loop applies, and no reading downstream can see it.
 
 The two readings are complementary and neither alone covers the hard-wire. A
 forwarded loop that writes `let charge = false;` is caught **twice**: by RULE 8,
@@ -554,7 +590,13 @@ only a count, where RULE 8 names the line.
 
 1. The token reader reports `?` for anything that is not a bare identifier, so
    `charged: cfg.charged` is unreadable today and would exit 2. It must read a
-   field access as a token.
+   field access as a token — and **keep the delimiter anchor it already has**:
+   `<ident>.<ident>` followed by `,`, `}` or the end of the line, and nothing
+   else. `cfg.charged()`, `cfg.charged.into()`, `cfg.charged as bool` and
+   `!cfg.charged` stay `?` and stay exit 2. The anchor is what stops the reader
+   turning a call, a cast or a negation into the field it resembles, which is
+   precisely how a decision gets inverted under a spelling the census still
+   counts as forwarded.
 2. The binding reader records **per binding**, keyed to the loop's own charge
    token. Today it sets one flag per function with a good binding outranking a
    bad one, so a shadow passes. **Measured on this tree**: a `mtp.rs` that binds
@@ -566,15 +608,36 @@ only a count, where RULE 8 names the line.
 
    Under the per-binding reading a token bound twice in one fn is **exit 1** for
    a forwarded loop, where RULE 8 has something exact to say about the second
-   binding, and **exit 2** for a classic loop, where RULE 1's same-token reading
-   has become vacuous: with a shadow, the token at the `rollback_round` argument
-   and the token in the `charged:` field can be two different values under one
-   spelling, and nothing in the scan can say which binding governs which site.
+   binding, and **exit 2** for a classic loop and **for an entry**, where the
+   same-token reading has become vacuous: with a shadow, the token at the
+   `rollback_round` argument and the token in the `charged:` field can be two
+   different values under one spelling, and nothing in the scan can say which
+   binding governs which site. The entry arm is not a corner: at the end state
+   all seven decisions live in entries, so an unread shadow there is the whole
+   census.
+
+   **What counts as a readable binding**, since a reader that guesses is worse
+   than one that refuses. The only readable form is a body-level
+   `let <token> = <rhs>;` whose statement closes on its own line. `let mut`, a
+   type annotation, a right-hand side spanning more than one line, a destructure
+   in the body or in the parameter list, and a binding introduced by `if let` or
+   `match` are each **exit 2** — a shape this gate cannot read, reported rather
+   than skipped. A fn with zero readable bindings whose sites name a bare
+   identifier is **exit 1**: the token means something the scan never saw.
+
+   Two hazards go with that. A right-hand side long enough for rustfmt to break
+   over two lines turns a readable binding into an unreadable one on a
+   reformatting commit, so the configuration field's name has to stay short
+   enough that it cannot happen — a constraint on the engine, not on the scanner.
+   And a destructure of the configuration in the parameter list —
+   `let RoundCfg { charged: charge, .. }` — registers a `charged:` site today,
+   which the census would count as an eighth decision; the exit-2 disposition
+   above is what keeps that from being a silent miscount.
 
 #### The fixture cases the re-key must pass
 
-None of these can run against today's scanner: populations (b) and (c) and
-RULE 8 do not exist in it, and a fixture root asserting them would fail
+Twenty-three cases. None can run against today's scanner: populations (b) and
+(c) and RULE 8 do not exist in it, and a fixture root asserting them would fail
 `make check-spec-charge-fixtures` today. They are stated here with the exit and
 the reason each must produce, and the re-key chunk turns each into a scan root.
 
@@ -590,7 +653,7 @@ that a loop is forwarded has a line to assert against.
 | 2 | the forwarded loop writes `let charge = false;` at both sites | 1 | RULE 8, the binding is not the configuration field — and the census reads eight sites, both readings on one tree |
 | 3 | the forwarded loop writes `let charge = cfg.charged \|\| x;` | 1 | RULE 8, the whole right-hand side |
 | 4 | the forwarded loop names `cfg.charged` at both sites, no binding | 0 | forwarded, read as one token |
-| 5 | one of the seven entries drops its `charged:` | 1 | census of six sites — excluding the loop must not hide a lost entry |
+| 5 | one of the seven entries drops its `charged:` | 1 | both reasons on one tree: RULE 5's zero-arm names the entry, and the census reads six sites — excluding the loop must not hide a lost decision |
 | 6 | an entry binds `charge_phases` to a literal | 1 | RULE 2, unchanged |
 | 7 | an entry moves a token from `false` to `phases_charged()` | 1 | RULE 3, census `charge_phases:4 false:3` |
 | 8 | a fn with no driver signature writes `charged:` | 1 | RULE 5, unchanged |
@@ -603,6 +666,12 @@ that a loop is forwarded has a line to assert against.
 | 15 | the forwarded loop calls `log_round` twice | 2 | RULE 7, unchanged |
 | 16 | the forwarded loop shadows its binding — `let charge = cfg.charged;` then `let charge = false;` | 1 | RULE 8 names the second binding; the same shape on a classic loop is exit 2 |
 | 17 | an entry states two `charged:` fields | 1 | RULE 5 over (b): an entry names one decision |
+| 18 | an entry shadows its binding — `charge_phases` bound to `phases_charged()` then rebound to `false` | 2 | a shape this gate cannot read, the entry arm of case 16 |
+| 19 | an entry stops constructing the configuration and calls the loop some other way | 1 | it leaves (b), so the census reads six sites — a dropped decision is a lost entry, not a clean scan |
+| 20 | the forwarded loop builds its own configuration — `let cfg = RoundCfg::uncharged();` — and forwards from that | 2 | the configuration handed over is read-only inside the loop; a rebinding of its name writes no site any reading can see |
+| 21 | the forwarded loop assigns `cfg.charged = false;` on a `mut` parameter | 2 | the same, by assignment rather than by rebinding |
+| 22 | the forwarded loop writes `charged: cfg.charged()` | 2 | the delimiter anchor holds: a call is not the field it resembles |
+| 23 | the forwarded loop writes `let mut charge = cfg.charged;` | 2 | not a readable binding form; a reader that guesses is worse than one that refuses |
 
 ### `make check-spec-sampling`
 
@@ -615,7 +684,12 @@ takes no sampler at all, and `emit_step`, `emit_round_tokens` and
 rule changes.
 
 Widen it to **any visibility, over the charge gate's populations (a) and (b)
-together** — the one loop and the seven entries. Narrowing to (a) alone is the
+and the fns that call one of them** — the one loop, the seven entries, and the
+two-model entry guard that routes a request to one of two loops by reading
+whether the sampler is active. That third clause is not tidiness: the guard is
+where a sampled request can be routed to the greedy arm, which is this gate's
+own defect class, and it is in the gate today only because it happens to be
+`pub`. Narrowing to (a) alone is the
 tempting move and it is wrong: at the end of the campaign the entries are the
 only place a request's sampler can be dropped, since each takes `sampler_cfg`
 and hands it to the loop's configuration, and a gate that stops reading them
@@ -633,12 +707,13 @@ and read by nobody is exactly the shape (b) exists to refuse, and so is a
 `sampler_cfg` an entry accepts and leaves out of the configuration it hands over.
 
 The census belongs on the success line for the same reason the charge gate's
-does: **one loop and seven entries**. A lost entry is then exit 2 — a scan that
-finds six drivers where the tree has seven has not passed, it has stopped
-looking.
+does: **one loop, seven entries, one guard**. A lost entry is then exit 2 — a
+scan that finds six drivers where the tree has seven has not passed, it has
+stopped looking.
 
-The three emit helpers are excluded by (a) ∪ (b) without an exception, since none
-carries a `RoundTotals` and none is an entry. `spec_generate_greedy_cached` is
+The three emit helpers are excluded without an exception: none constructs a
+`RoundTotals`, none constructs the loop's configuration, and none calls a fn that
+does — `emit_round_tokens` calls `emit_step`, which is in no population either. `spec_generate_greedy_cached` is
 the one real exception: it is the two-model greedy loop, it takes no sampler at
 all, and it runs only at temperature 0 where the verifier's argmax is the draw.
 Record it with that reason and delete the exception in migration chunk 6, where


### PR DESCRIPTION
Chunk 0 of the round skeleton for #548. No engine code.

**What this adds.** `docs/SPEC_ROUND_SKELETON.md`: the proposed one-loop-plus-drafter interface (`prefill`, `block`, `propose`, `verify`, `rollback`, `condition`; `RoundCtx`, `Verdict`, `RoundEmit`, `RoundOutcome`, paired `CacheSpan`/`Conditioning`), the eleven things the interface cannot express and the disposition for each, the migration order (Gemma4 assistant first, since its pair is the only one reproducible without an operator-named drafter), the oracle and what each reader is blind to, the "cannot move" list, the mutation table with its catchers and declared residuals, and the gate changes the collapse needs — `make check-spec-charge` populations derived by signature (loops forwarded/classic, entries, drafter rollbacks), RULE 8, a per-binding reader, a field-access token, 23 fixture cases written with their exit and reason; `make check-spec-sampling` over loops, entries and their callers.

Two CPU tests in `round_skeleton_tests.rs` pin, per loop, which exit skips the resident-KV report and how the loop refuses an empty chain, as a seven-row table read by a positional marker scan (`EWGRP` / `WGRERP`); each is mutation-checked and the two are complementary.

**Found while writing it.** `make check-spec-charge` on `main` has a live hole: a loop that binds `charge_phases` to `phases_charged()` and rebinds it to `false` on the next line passes with the census unchanged (the binding reader keeps one verdict per fn and a good binding outranks a bad one). Measured on a synthetic root. The gate chunk that follows closes it.

**Decisions taken as constraints for the skeleton chunks.** No behaviour change the oracle cannot see (per-loop exits, the resident-KV report's exit, the seed-exit block value all preserved per loop; unification later with its own chunk 0); no baseline cell moves (the verifier-offset basis stays two-valued).

**Duplication baseline** over the seven loop bodies at the merge base: 2032 matched lines summed over 21 pairs, 2326 lines of body, recorded in the doc.

## Removals

Nothing. This chunk adds a proposal and two tests; the deletions are named by the chunks that implement it.
